### PR TITLE
feat: add video style template picker to chat composer

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -705,7 +705,9 @@ describe("POST /api/zero/chat/messages", () => {
       .where(eq(agentRuns.id, response.body.runId!))
       .limit(1);
 
-    expect(run?.appendSystemPrompt).toContain(`## Video Style: ${preset.nameEn}`);
+    expect(run?.appendSystemPrompt).toContain(
+      `## Video Style: ${preset.nameEn}`,
+    );
     expect(run?.appendSystemPrompt).toContain("- Visual Tone:");
     expect(run?.appendSystemPrompt).toContain("- Style Reference:");
     expect(run?.appendSystemPrompt).toContain(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -7,7 +7,7 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { PRESENTATION_TEMPLATE_ITEMS } from "@vm0/core";
+import { PRESENTATION_TEMPLATE_ITEMS, VIDEO_STYLE_PRESETS } from "@vm0/core";
 import {
   agentComposes,
   agentComposeVersions,
@@ -678,6 +678,61 @@ describe("POST /api/zero/chat/messages", () => {
     expect(response.body.error.message).toBe(
       "Generation template does not support the requested type",
     );
+  });
+
+  it("adds video style preset guidance to appendSystemPrompt", async () => {
+    const fixture = await track(seedFixture());
+    const preset = VIDEO_STYLE_PRESETS[0]!;
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "make a cinematic video",
+      generationTemplate: {
+        type: "video",
+        selection: {
+          stylePresetId: preset.id,
+        },
+      },
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+
+    expect(run?.appendSystemPrompt).toContain(`## Video Style: ${preset.nameEn}`);
+    expect(run?.appendSystemPrompt).toContain("- Visual Tone:");
+    expect(run?.appendSystemPrompt).toContain("- Style Reference:");
+    expect(run?.appendSystemPrompt).toContain(
+      "safe for all audiences, positive and uplifting, no violence, no explicit content",
+    );
+  });
+
+  it("rejects unknown video style preset", async () => {
+    const fixture = await track(seedFixture());
+
+    const response = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "make a video",
+          generationTemplate: {
+            type: "video",
+            selection: {
+              stylePresetId: "preset:missing",
+            },
+          },
+        },
+      }),
+      [400],
+    );
+    expect(response.body.error.message).toBe("Unknown video style preset");
   });
 
   it("queues generation template when the thread has an active run", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -606,6 +606,51 @@ describe("POST /api/zero/chat/messages", () => {
     );
   });
 
+  it("adds video generation template guidance to appendSystemPrompt", async () => {
+    const fixture = await track(seedFixture());
+    const item = VIDEO_STYLE_PRESETS.find((preset) => {
+      return preset.id === "tech-minimalist-reveal";
+    })!;
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "make a product video",
+      generationTemplate: {
+        type: "video",
+        selection: {
+          stylePresetId: item.id,
+        },
+      },
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+
+    expect(run?.prompt).toBe("make a product video");
+    expect(run?.appendSystemPrompt).toContain(`## Video Style: ${item.nameEn}`);
+    expect(run?.appendSystemPrompt).toContain(
+      `- Visual Tone: ${item.dimensions.visualTone}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      `- Camera Style: ${item.dimensions.cameraStyle}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      `- Style Reference: ${item.dimensions.styleReference}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      "safe for all audiences, positive and uplifting, no violence, no explicit content",
+    );
+    expect(run?.appendSystemPrompt).not.toContain(item.scene);
+  });
+
   it("rejects unknown generation template resources", async () => {
     const fixture = await track(seedFixture());
     const item = PRESENTATION_TEMPLATE_ITEMS[0]!;
@@ -650,6 +695,26 @@ describe("POST /api/zero/chat/messages", () => {
     );
     expect(unknownDesignSystem.body.error.message).toBe(
       "Unknown generation template design system",
+    );
+
+    const unknownVideoStyle = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "make a product video",
+          generationTemplate: {
+            type: "video",
+            selection: {
+              stylePresetId: "video-style:missing",
+            },
+          },
+        },
+      }),
+      [400],
+    );
+    expect(unknownVideoStyle.body.error.message).toBe(
+      "Unknown video style preset",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -38,36 +38,15 @@ export function buildGenerationTemplatePrompt(
   }
 
   if (generationTemplate.type === "video") {
-    const preset = VIDEO_STYLE_PRESETS.find((p) => {
-      return p.id === generationTemplate.selection.stylePresetId;
-    });
-    if (!preset) {
-      return { status: "invalid", message: "Unknown video style preset" };
-    }
-    const describeSlug = (slug: string): string => {
-      const desc = VIDEO_DIMENSION_DESCRIPTIONS[slug];
-      return desc ? `${slug} — ${desc}` : slug;
-    };
-    return {
-      status: "resolved",
-      prompt: [
-        `## Video Style: ${preset.nameEn}`,
-        "",
-        "Apply these style constraints to the user's scene:",
-        `- Visual Tone: ${describeSlug(preset.dimensions.visualTone)}`,
-        `- Camera Style: ${describeSlug(preset.dimensions.cameraStyle)}`,
-        `- Editing Pace: ${describeSlug(preset.dimensions.editingPace)}`,
-        `- Narrative Mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
-        `- Production Type: ${describeSlug(preset.dimensions.productionType)}`,
-        `- Emotional Tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
-        `- Style Reference: ${describeSlug(preset.dimensions.styleReference)}`,
-        "",
-        "Generate a single video prompt (2–3 sentences) that applies the above style to the user's scene.",
-        "End with: safe for all audiences, positive and uplifting, no violence, no explicit content",
-      ].join("\n"),
-    };
+    return buildVideoGenerationTemplatePrompt(generationTemplate);
   }
 
+  return buildPresentationGenerationTemplatePrompt(generationTemplate);
+}
+
+function buildPresentationGenerationTemplatePrompt(
+  generationTemplate: PresentationGenerationTemplateInput,
+): GenerationTemplatePromptResult {
   const template = findTemplate(generationTemplate.selection.templateId);
   if (!template) {
     return { status: "invalid", message: "Unknown generation template" };
@@ -104,6 +83,41 @@ export function buildGenerationTemplatePrompt(
       "- Resolve the design system and template from the resource registry.",
       "- Apply them as generation constraints for the artifact.",
       "- Keep the user's prompt as the source of the requested content.",
+    ].join("\n"),
+  };
+}
+
+function buildVideoGenerationTemplatePrompt(
+  generationTemplate: VideoGenerationTemplateInput,
+): GenerationTemplatePromptResult {
+  const preset = VIDEO_STYLE_PRESETS.find((p) => {
+    return p.id === generationTemplate.selection.stylePresetId;
+  });
+  if (!preset) {
+    return { status: "invalid", message: "Unknown video style preset" };
+  }
+
+  const describeSlug = (slug: string): string => {
+    const desc = VIDEO_DIMENSION_DESCRIPTIONS[slug];
+    return desc ? `${slug} — ${desc}` : slug;
+  };
+
+  return {
+    status: "resolved",
+    prompt: [
+      `## Video Style: ${preset.nameEn}`,
+      "",
+      "Apply these style constraints to the user's scene:",
+      `- Visual Tone: ${describeSlug(preset.dimensions.visualTone)}`,
+      `- Camera Style: ${describeSlug(preset.dimensions.cameraStyle)}`,
+      `- Editing Pace: ${describeSlug(preset.dimensions.editingPace)}`,
+      `- Narrative Mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
+      `- Production Type: ${describeSlug(preset.dimensions.productionType)}`,
+      `- Emotional Tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
+      `- Style Reference: ${describeSlug(preset.dimensions.styleReference)}`,
+      "",
+      "Generate a single video prompt (2–3 sentences) that applies the above style to the user's scene.",
+      "End with: safe for all audiences, positive and uplifting, no violence, no explicit content",
     ].join("\n"),
   };
 }

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -1,4 +1,5 @@
 import { findDesignSystem, findTemplate } from "@vm0/core/resource-registry";
+import { VIDEO_STYLE_PRESETS, VIDEO_DIMENSION_DESCRIPTIONS } from "@vm0/core";
 
 interface PresentationGenerationTemplateInput {
   readonly type: "presentation";
@@ -8,7 +9,16 @@ interface PresentationGenerationTemplateInput {
   };
 }
 
-type GenerationTemplateInput = PresentationGenerationTemplateInput;
+interface VideoGenerationTemplateInput {
+  readonly type: "video";
+  readonly selection: {
+    readonly stylePresetId: string;
+  };
+}
+
+type GenerationTemplateInput =
+  | PresentationGenerationTemplateInput
+  | VideoGenerationTemplateInput;
 
 type GenerationTemplatePromptResult =
   | {
@@ -25,6 +35,37 @@ export function buildGenerationTemplatePrompt(
 ): GenerationTemplatePromptResult {
   if (!generationTemplate) {
     return { status: "resolved", prompt: "" };
+  }
+
+  if (generationTemplate.type === "video") {
+    const preset = VIDEO_STYLE_PRESETS.find(
+      (p) => p.id === generationTemplate.selection.stylePresetId,
+    );
+    if (!preset) {
+      return { status: "invalid", message: "Unknown video style preset" };
+    }
+    const describeSlug = (slug: string): string => {
+      const desc = VIDEO_DIMENSION_DESCRIPTIONS[slug];
+      return desc ? `${slug} — ${desc}` : slug;
+    };
+    return {
+      status: "resolved",
+      prompt: [
+        `## Video Style: ${preset.nameEn}`,
+        "",
+        "Apply these style constraints to the user's scene:",
+        `- Visual Tone: ${describeSlug(preset.dimensions.visualTone)}`,
+        `- Camera Style: ${describeSlug(preset.dimensions.cameraStyle)}`,
+        `- Editing Pace: ${describeSlug(preset.dimensions.editingPace)}`,
+        `- Narrative Mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
+        `- Production Type: ${describeSlug(preset.dimensions.productionType)}`,
+        `- Emotional Tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
+        `- Style Reference: ${describeSlug(preset.dimensions.styleReference)}`,
+        "",
+        "Generate a single video prompt (2–3 sentences) that applies the above style to the user's scene.",
+        "End with: safe for all audiences, positive and uplifting, no violence, no explicit content",
+      ].join("\n"),
+    };
   }
 
   const template = findTemplate(generationTemplate.selection.templateId);

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -38,9 +38,9 @@ export function buildGenerationTemplatePrompt(
   }
 
   if (generationTemplate.type === "video") {
-    const preset = VIDEO_STYLE_PRESETS.find(
-      (p) => p.id === generationTemplate.selection.stylePresetId,
-    );
+    const preset = VIDEO_STYLE_PRESETS.find((p) => {
+      return p.id === generationTemplate.selection.stylePresetId;
+    });
     if (!preset) {
       return { status: "invalid", message: "Unknown video style preset" };
     }

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
-import type { VideoStyleGroupTag } from "@vm0/core";
+import type { VideoStyleCategory } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
 // Composer UI state — search, dialogs, loading indicators
@@ -110,7 +110,7 @@ export const setTemplatePickerSearch$ = command(({ set }, value: string) => {
   set(internalTemplatePickerSearch$, value);
 });
 
-export type TemplatePickerVideoGroup = VideoStyleGroupTag | "all";
+export type TemplatePickerVideoGroup = VideoStyleCategory | "all";
 
 const internalTemplatePickerVideoGroup$ =
   state<TemplatePickerVideoGroup>("all");

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import type { VideoStyleGroupTag } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
 // Composer UI state — search, dialogs, loading indicators
@@ -108,6 +109,19 @@ export const templatePickerSearch$ = computed((get) => {
 export const setTemplatePickerSearch$ = command(({ set }, value: string) => {
   set(internalTemplatePickerSearch$, value);
 });
+
+export type TemplatePickerVideoGroup = VideoStyleGroupTag | "all";
+
+const internalTemplatePickerVideoGroup$ =
+  state<TemplatePickerVideoGroup>("all");
+export const templatePickerVideoGroup$ = computed((get) => {
+  return get(internalTemplatePickerVideoGroup$);
+});
+export const setTemplatePickerVideoGroup$ = command(
+  ({ set }, value: TemplatePickerVideoGroup) => {
+    set(internalTemplatePickerVideoGroup$, value);
+  },
+);
 
 const internalTemplatePickerPreviewSlug$ = state<string | null>(null);
 export const templatePickerPreviewSlug$ = computed((get) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
@@ -28,6 +28,9 @@ const mockApi = createMockApi(context);
 const THREAD_ID = "thread-template-picker";
 const template = PRESENTATION_TEMPLATE_ITEMS[0]!;
 const nextTemplate = PRESENTATION_TEMPLATE_ITEMS[1]!;
+const videoStyle = VIDEO_STYLE_PRESETS.find((item) => {
+  return item.id === "tech-minimalist-reveal";
+})!;
 
 beforeEach(() => {
   const values = new Map<string, string>();
@@ -131,6 +134,35 @@ async function openPickerAndSelectTemplate(
   ).toBeInTheDocument();
 }
 
+async function openPickerAndSelectVideoStyle(
+  user: ReturnType<typeof userEvent.setup>,
+  item = videoStyle,
+) {
+  const templateButton = await waitFor(() => {
+    return screen.getByLabelText("Template");
+  });
+  click(templateButton);
+
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByLabelText(`Select video style ${item.nameEn}`));
+
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+  await waitFor(() => {
+    expect(screen.getByLabelText("Template")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+  expect(
+    screen.getByLabelText(`Remove video style ${item.nameEn}`),
+  ).toBeInTheDocument();
+}
+
 function expectPresentationTemplate(
   style: GenerationTemplateRequest | undefined,
 ) {
@@ -139,6 +171,15 @@ function expectPresentationTemplate(
     selection: {
       designSystemId: template.designSystemId,
       templateId: template.templateId,
+    },
+  });
+}
+
+function expectVideoTemplate(style: GenerationTemplateRequest | undefined) {
+  expect(style).toStrictEqual({
+    type: "video",
+    selection: {
+      stylePresetId: videoStyle.id,
     },
   });
 }
@@ -294,11 +335,10 @@ describe("zero chat template picker", () => {
     expect(screen.queryByText("Tech Minimalist Reveal")).toBeNull();
   });
 
-  it("selects a video style, shows chip, and sends with generation template", async () => {
+  it("selects, clears, and sends a video style", async () => {
     const user = userEvent.setup();
     mockChatLifecycle();
     const sendCapture = captureSendGenerationTemplate();
-    const preset = VIDEO_STYLE_PRESETS[0]!;
 
     await setupPage({
       context,
@@ -306,33 +346,35 @@ describe("zero chat template picker", () => {
       featureSwitches: { [FeatureSwitchKey.VideoTemplatePicker]: true },
     });
 
-    click(await screen.findByLabelText("Template"));
-
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    });
-
+    await openPickerAndSelectVideoStyle(user);
     await user.click(
-      screen.getByLabelText(`Select video style ${preset.nameEn}`),
+      screen.getByLabelText(`Remove video style ${videoStyle.nameEn}`),
     );
 
     await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(`Remove video style ${videoStyle.nameEn}`),
+      ).toBeNull();
     });
-    expect(
-      screen.getByLabelText(`Remove video style ${preset.nameEn}`),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Template")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    await openPickerAndSelectVideoStyle(user);
 
     const textarea = await waitFor(() => {
       return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
     });
-    await sendMessageInUI(user, textarea, "Create a cinematic video");
+    await sendMessageInUI(user, textarea, "Create a cinematic product video");
 
     await waitFor(() => {
-      expect(sendCapture.generationTemplate()).toStrictEqual({
-        type: "video",
-        selection: { stylePresetId: preset.id },
-      });
+      expectVideoTemplate(sendCapture.generationTemplate());
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(`Message template ${videoStyle.nameEn}`),
+      ).toBeInTheDocument();
     });
     await waitFor(() => {
       expect(screen.getByLabelText("Template")).toHaveAttribute(
@@ -340,46 +382,6 @@ describe("zero chat template picker", () => {
         "false",
       );
     });
-  });
-
-  it("clears the selected video style from the chip", async () => {
-    const user = userEvent.setup();
-    mockChatLifecycle();
-    const preset = VIDEO_STYLE_PRESETS[0]!;
-
-    await setupPage({
-      context,
-      path: "/",
-      featureSwitches: { [FeatureSwitchKey.VideoTemplatePicker]: true },
-    });
-
-    click(await screen.findByLabelText("Template"));
-
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    });
-
-    await user.click(
-      screen.getByLabelText(`Select video style ${preset.nameEn}`),
-    );
-
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
-
-    await user.click(
-      screen.getByLabelText(`Remove video style ${preset.nameEn}`),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByLabelText(`Remove video style ${preset.nameEn}`),
-      ).toBeNull();
-    });
-    expect(screen.getByLabelText("Template")).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
   });
 
   it("opens a PPT preview page from the template eye button", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
@@ -321,13 +321,13 @@ describe("zero chat template picker", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
     expect(tabWithText("Video")).toBeDefined();
-    expect(screen.getByText("Brand & Product")).toBeInTheDocument();
-    expect(screen.getByText("Story & Emotion")).toBeInTheDocument();
-    expect(screen.getByText("Energy & Sports")).toBeInTheDocument();
-    expect(screen.getByText("Fantasy & Art")).toBeInTheDocument();
+    expect(screen.getByText("Brand & Commercial")).toBeInTheDocument();
+    expect(screen.getByText("Cinematic")).toBeInTheDocument();
+    expect(screen.getByText("Energy & Music")).toBeInTheDocument();
+    expect(screen.getByText("Art & Creative")).toBeInTheDocument();
     expect(screen.getByText("Anime")).toBeInTheDocument();
 
-    await user.click(screen.getByText("Fantasy & Art"));
+    await user.click(screen.getByText("Art & Creative"));
 
     await waitFor(() => {
       expect(screen.getByText("Chinese Ink Painting")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
@@ -264,6 +264,36 @@ describe("zero chat template picker", () => {
     expect(screen.queryByText("Nothing saved yet")).toBeNull();
   });
 
+  it("filters video styles by group", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.VideoTemplatePicker]: true },
+    });
+
+    click(await screen.findByLabelText("Template"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(tabWithText("Video")).toBeDefined();
+    expect(screen.getByText("Brand & Product")).toBeInTheDocument();
+    expect(screen.getByText("Story & Emotion")).toBeInTheDocument();
+    expect(screen.getByText("Energy & Sports")).toBeInTheDocument();
+    expect(screen.getByText("Fantasy & Art")).toBeInTheDocument();
+    expect(screen.getByText("Anime")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Fantasy & Art"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Chinese Ink Painting")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Tech Minimalist Reveal")).toBeNull();
+  });
+
   it("opens a PPT preview page from the template eye button", async () => {
     const user = userEvent.setup();
     mockChatLifecycle();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-template-picker.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { PRESENTATION_TEMPLATE_ITEMS } from "@vm0/core";
+import { PRESENTATION_TEMPLATE_ITEMS, VIDEO_STYLE_PRESETS } from "@vm0/core";
 import {
   chatMessagesContract,
   type GenerationTemplateRequest,
@@ -292,6 +292,94 @@ describe("zero chat template picker", () => {
       expect(screen.getByText("Chinese Ink Painting")).toBeInTheDocument();
     });
     expect(screen.queryByText("Tech Minimalist Reveal")).toBeNull();
+  });
+
+  it("selects a video style, shows chip, and sends with generation template", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+    const sendCapture = captureSendGenerationTemplate();
+    const preset = VIDEO_STYLE_PRESETS[0]!;
+
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.VideoTemplatePicker]: true },
+    });
+
+    click(await screen.findByLabelText("Template"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByLabelText(`Select video style ${preset.nameEn}`),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByLabelText(`Remove video style ${preset.nameEn}`),
+    ).toBeInTheDocument();
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, "Create a cinematic video");
+
+    await waitFor(() => {
+      expect(sendCapture.generationTemplate()).toStrictEqual({
+        type: "video",
+        selection: { stylePresetId: preset.id },
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Template")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+  });
+
+  it("clears the selected video style from the chip", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+    const preset = VIDEO_STYLE_PRESETS[0]!;
+
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.VideoTemplatePicker]: true },
+    });
+
+    click(await screen.findByLabelText("Template"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByLabelText(`Select video style ${preset.nameEn}`),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByLabelText(`Remove video style ${preset.nameEn}`),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText(`Remove video style ${preset.nameEn}`),
+      ).toBeNull();
+    });
+    expect(screen.getByLabelText("Template")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 
   it("opens a PPT preview page from the template eye button", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -552,7 +552,13 @@ function videoTemplateMatchesSearch(
   if (!normalizedQuery) {
     return true;
   }
-  const searchable = [item.nameEn, item.category, ...item.tags].join(" ");
+  const searchable = [
+    item.nameEn,
+    item.nameZh,
+    item.category,
+    item.scene,
+    item.dimensions.styleReference,
+  ].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
 }
 
@@ -560,7 +566,7 @@ function videoTemplateMatchesGroup(
   item: VideoStylePreset,
   group: TemplatePickerVideoGroup,
 ): boolean {
-  return group === "all" || item.tags.includes(group);
+  return group === "all" || item.category === group;
 }
 
 function VideoTemplateCard({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -92,6 +92,8 @@ import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import {
   PRESENTATION_TEMPLATE_ITEMS,
   type PresentationTemplateItem,
+  VIDEO_STYLE_PRESETS,
+  type VideoStylePreset,
 } from "@vm0/core";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -468,6 +470,9 @@ function toPresentationGenerationTemplate(
 function selectedTemplateTitle(
   value: GenerationTemplateRequest | undefined,
 ): string | undefined {
+  if (value?.type === "video") {
+    return selectedVideoTemplateItem(value)?.nameEn;
+  }
   return selectedPresentationTemplateItem(value)?.title;
 }
 
@@ -505,6 +510,123 @@ function presentationTemplateMatchesSearch(
     formatPresentationTemplateKind(item.templateId),
   ].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
+}
+
+function isSelectedVideoTemplate(
+  item: VideoStylePreset,
+  value: GenerationTemplateRequest | undefined,
+): boolean {
+  return value?.type === "video" && value.selection.stylePresetId === item.id;
+}
+
+function toVideoGenerationTemplate(
+  item: VideoStylePreset,
+): GenerationTemplateRequest {
+  return {
+    type: "video",
+    selection: { stylePresetId: item.id },
+  };
+}
+
+function selectedVideoTemplateItem(
+  value: GenerationTemplateRequest | undefined,
+): VideoStylePreset | undefined {
+  if (value?.type !== "video") {
+    return undefined;
+  }
+  return VIDEO_STYLE_PRESETS.find((item) => {
+    return item.id === value.selection.stylePresetId;
+  });
+}
+
+function videoTemplateMatchesSearch(
+  item: VideoStylePreset,
+  query: string,
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+  const searchable = [
+    item.nameEn,
+    item.nameZh,
+    item.category,
+    ...item.tags,
+  ].join(" ");
+  return searchable.toLowerCase().includes(normalizedQuery);
+}
+
+function VideoTemplateCard({
+  item,
+  selected,
+  onSelect,
+}: {
+  item: VideoStylePreset;
+  selected: boolean;
+  onSelect: (item: VideoStylePreset) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "group overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+        selected ? "border-primary ring-1 ring-primary" : "border-border",
+      )}
+    >
+      <div className="relative aspect-[16/9] overflow-hidden bg-muted">
+        {item.sampleVideoUrl ? (
+          <video
+            src={item.sampleVideoUrl}
+            className="h-full w-full object-cover"
+            preload="metadata"
+            playsInline
+            muted
+            loop
+            onMouseEnter={(e) => {
+              const video = e.currentTarget as HTMLVideoElement;
+              detach(video.play(), Reason.DomCallback);
+            }}
+            onMouseLeave={(e) => {
+              const v = e.currentTarget as HTMLVideoElement;
+              v.pause();
+              v.currentTime = 0;
+            }}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-muted-foreground">
+            <IconTemplate size={28} stroke={1.5} />
+          </div>
+        )}
+      </div>
+      <div className="flex items-start justify-between gap-3 px-3.5 py-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {item.nameEn}
+          </p>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {item.nameZh}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center">
+          <button
+            type="button"
+            aria-label={`Select video style ${item.nameEn}`}
+            aria-pressed={selected}
+            onClick={() => {
+              onSelect(item);
+            }}
+            className={cn(
+              "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? "border-primary/40 bg-primary/10 text-primary"
+                : "border-border bg-background text-foreground hover:bg-muted",
+            )}
+          >
+            Use
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function TemplateSectionHeader({
@@ -787,10 +909,14 @@ function TemplatePickerDialog({
   value,
   onChange,
   onClose,
+  hasPptTab,
+  hasVideoTab,
 }: {
   value: GenerationTemplateRequest | undefined;
   onChange: (value: GenerationTemplateRequest | undefined) => void;
   onClose: () => void;
+  hasPptTab: boolean;
+  hasVideoTab: boolean;
 }) {
   const category = useGet(templatePickerCategory$);
   const setCategory = useSet(setTemplatePickerCategory$);
@@ -804,12 +930,20 @@ function TemplatePickerDialog({
     PRESENTATION_TEMPLATE_ITEMS.find((item) => {
       return item.slug === previewSlug;
     }) ?? null;
-  const filteredItems = PRESENTATION_TEMPLATE_ITEMS.filter((item) => {
+  const filteredPptItems = PRESENTATION_TEMPLATE_ITEMS.filter((item) => {
     return presentationTemplateMatchesSearch(item, search);
   });
+  const filteredVideoItems = VIDEO_STYLE_PRESETS.filter((item) => {
+    return videoTemplateMatchesSearch(item, search);
+  });
 
-  const handleSelect = (item: PresentationTemplateItem) => {
+  const handleSelectPresentation = (item: PresentationTemplateItem) => {
     onChange(toPresentationGenerationTemplate(item));
+    onClose();
+  };
+
+  const handleSelectVideo = (item: VideoStylePreset) => {
+    onChange(toVideoGenerationTemplate(item));
     onClose();
   };
 
@@ -817,6 +951,10 @@ function TemplatePickerDialog({
     setSelectedSlideIndex(0);
     setPreviewSlug(item.slug);
   };
+
+  const defaultCategory = hasPptTab ? "slides" : "video";
+  const effectiveCategory =
+    category === "slides" && !hasPptTab ? "video" : category;
 
   return (
     <Dialog
@@ -846,7 +984,7 @@ function TemplatePickerDialog({
             onBack={() => {
               setPreviewSlug(null);
             }}
-            onSelect={handleSelect}
+            onSelect={handleSelectPresentation}
           />
         ) : (
           <>
@@ -854,18 +992,35 @@ function TemplatePickerDialog({
               <DialogTitle>Templates</DialogTitle>
             </DialogHeader>
             <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
-              <Tabs value={category} onValueChange={setCategory}>
+              <Tabs
+                value={effectiveCategory || defaultCategory}
+                onValueChange={setCategory}
+              >
                 <TabsList className="h-auto rounded-none bg-transparent p-0">
-                  <TabsTrigger
-                    value="slides"
-                    className="h-11 gap-2 rounded-none border-b-2 border-foreground bg-transparent px-1 pb-3 pt-2 text-base font-semibold text-foreground shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-                  >
-                    <IconChartBar
-                      className="h-5 w-5 text-blue-500"
-                      stroke={1.8}
-                    />
-                    PPT
-                  </TabsTrigger>
+                  {hasPptTab && (
+                    <TabsTrigger
+                      value="slides"
+                      className="h-11 gap-2 rounded-none border-b-2 border-foreground bg-transparent px-1 pb-3 pt-2 text-base font-semibold text-foreground shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    >
+                      <IconChartBar
+                        className="h-5 w-5 text-blue-500"
+                        stroke={1.8}
+                      />
+                      PPT
+                    </TabsTrigger>
+                  )}
+                  {hasVideoTab && (
+                    <TabsTrigger
+                      value="video"
+                      className="h-11 gap-2 rounded-none border-b-2 border-foreground bg-transparent px-1 pb-3 pt-2 text-base font-semibold text-foreground shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                    >
+                      <IconTemplate
+                        className="h-5 w-5 text-purple-500"
+                        stroke={1.8}
+                      />
+                      Video
+                    </TabsTrigger>
+                  )}
                 </TabsList>
               </Tabs>
               <div className="relative w-full sm:w-64">
@@ -884,75 +1039,104 @@ function TemplatePickerDialog({
                 />
               </div>
             </div>
-            {category === "slides" && (
-              <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
-                <TemplateSectionHeader
-                  label="VM0 templates"
-                  count={filteredItems.length}
-                />
-                {filteredItems.length > 0 ? (
-                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {filteredItems.map((item) => {
-                      const selected = isSelectedPresentationTemplate(
-                        item,
-                        value,
-                      );
-                      return (
-                        <div
-                          key={item.slug}
-                          className={cn(
-                            "group overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
-                            selected
-                              ? "border-primary ring-1 ring-primary"
-                              : "border-border",
-                          )}
-                        >
-                          <TemplatePreview
-                            item={item}
-                            onPreview={handlePreview}
-                          />
-                          <div className="flex items-start justify-between gap-3 px-3.5 py-3">
-                            <div className="min-w-0">
-                              <p className="truncate text-sm font-semibold text-foreground">
-                                {item.title}
-                              </p>
-                              <p className="mt-1 truncate text-xs text-muted-foreground">
-                                {formatPresentationTemplateKind(
-                                  item.templateId,
-                                )}
-                              </p>
-                            </div>
-                            <div className="flex shrink-0 items-center">
-                              <button
-                                type="button"
-                                aria-label={`Select template ${item.title}`}
-                                aria-pressed={selected}
-                                onClick={() => {
-                                  handleSelect(item);
-                                }}
-                                className={cn(
-                                  "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                                  selected
-                                    ? "border-primary/40 bg-primary/10 text-primary"
-                                    : "border-border bg-background text-foreground hover:bg-muted",
-                                )}
-                              >
-                                Use
-                              </button>
+            {(effectiveCategory || defaultCategory) === "slides" &&
+              hasPptTab && (
+                <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
+                  <TemplateSectionHeader
+                    label="VM0 templates"
+                    count={filteredPptItems.length}
+                  />
+                  {filteredPptItems.length > 0 ? (
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                      {filteredPptItems.map((item) => {
+                        const selected = isSelectedPresentationTemplate(
+                          item,
+                          value,
+                        );
+                        return (
+                          <div
+                            key={item.slug}
+                            className={cn(
+                              "group overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+                              selected
+                                ? "border-primary ring-1 ring-primary"
+                                : "border-border",
+                            )}
+                          >
+                            <TemplatePreview
+                              item={item}
+                              onPreview={handlePreview}
+                            />
+                            <div className="flex items-start justify-between gap-3 px-3.5 py-3">
+                              <div className="min-w-0">
+                                <p className="truncate text-sm font-semibold text-foreground">
+                                  {item.title}
+                                </p>
+                                <p className="mt-1 truncate text-xs text-muted-foreground">
+                                  {formatPresentationTemplateKind(
+                                    item.templateId,
+                                  )}
+                                </p>
+                              </div>
+                              <div className="flex shrink-0 items-center">
+                                <button
+                                  type="button"
+                                  aria-label={`Select template ${item.title}`}
+                                  aria-pressed={selected}
+                                  onClick={() => {
+                                    handleSelectPresentation(item);
+                                  }}
+                                  className={cn(
+                                    "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                                    selected
+                                      ? "border-primary/40 bg-primary/10 text-primary"
+                                      : "border-border bg-background text-foreground hover:bg-muted",
+                                  )}
+                                >
+                                  Use
+                                </button>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <TemplateEmptyPanel
-                    title="No matches"
-                    description="Try a different search."
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <TemplateEmptyPanel
+                      title="No matches"
+                      description="Try a different search."
+                    />
+                  )}
+                </div>
+              )}
+            {(effectiveCategory || defaultCategory) === "video" &&
+              hasVideoTab && (
+                <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
+                  <TemplateSectionHeader
+                    label="VM0 video styles"
+                    count={filteredVideoItems.length}
                   />
-                )}
-              </div>
-            )}
+                  {filteredVideoItems.length > 0 ? (
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                      {filteredVideoItems.map((item) => {
+                        return (
+                          <VideoTemplateCard
+                            key={item.id}
+                            item={item}
+                            selected={isSelectedVideoTemplate(item, value)}
+                            onSelect={handleSelectVideo}
+                          />
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <TemplateEmptyPanel
+                      title="No matches"
+                      description="Try a different search."
+                    />
+                  )}
+                </div>
+              )}
           </>
         )}
       </DialogContent>
@@ -1000,6 +1184,46 @@ function SelectedTemplateChip({
   );
 }
 
+function SelectedVideoTemplateChip({
+  item,
+  onRemove,
+}: {
+  item: VideoStylePreset;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="px-4 pt-3">
+      <div className="flex">
+        <div className="inline-flex h-8 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/90 pl-1.5 pr-1 text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+            <IconTemplate
+              size={12}
+              stroke={1.5}
+              className="text-muted-foreground"
+            />
+          </span>
+          <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+            Video
+          </span>
+          <span className="h-3.5 w-px shrink-0 bg-border/70" />
+          <span className="min-w-0 truncate text-xs font-medium">
+            {item.nameEn}
+          </span>
+          <button
+            type="button"
+            aria-label={`Remove video style ${item.nameEn}`}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={onRemove}
+          >
+            <IconX size={14} stroke={1.8} />
+          </button>
+        </div>
+      </div>
+      <div className="mt-3 h-px bg-border/50" />
+    </div>
+  );
+}
+
 function SelectedTemplateChipSlot({
   picker,
   onDraftChange,
@@ -1007,22 +1231,45 @@ function SelectedTemplateChipSlot({
   picker: ComposerTemplatePicker | undefined;
   onDraftChange: (() => void) | undefined;
 }) {
-  const selectedItem = selectedPresentationTemplateItem(picker?.value);
-  if (!selectedItem || !picker) {
+  const presentationItem = selectedPresentationTemplateItem(picker?.value);
+  const videoItem = selectedVideoTemplateItem(picker?.value);
+  if (!picker) {
     return null;
   }
-  return (
-    <SelectedTemplateChip
-      item={selectedItem}
-      onRemove={() => {
-        picker.onChange(undefined);
-        onDraftChange?.();
-      }}
-    />
-  );
+  if (presentationItem) {
+    return (
+      <SelectedTemplateChip
+        item={presentationItem}
+        onRemove={() => {
+          picker.onChange(undefined);
+          onDraftChange?.();
+        }}
+      />
+    );
+  }
+  if (videoItem) {
+    return (
+      <SelectedVideoTemplateChip
+        item={videoItem}
+        onRemove={() => {
+          picker.onChange(undefined);
+          onDraftChange?.();
+        }}
+      />
+    );
+  }
+  return null;
 }
 
-function TemplatePickerButton({ picker }: { picker: ComposerTemplatePicker }) {
+function TemplatePickerButton({
+  picker,
+  hasPptTab,
+  hasVideoTab,
+}: {
+  picker: ComposerTemplatePicker;
+  hasPptTab: boolean;
+  hasVideoTab: boolean;
+}) {
   const open = useGet(templatePickerOpen$);
   const setOpen = useSet(setTemplatePickerOpen$);
   const setSearch = useSet(setTemplatePickerSearch$);
@@ -1065,6 +1312,8 @@ function TemplatePickerButton({ picker }: { picker: ComposerTemplatePicker }) {
           onClose={() => {
             setOpen(false);
           }}
+          hasPptTab={hasPptTab}
+          hasVideoTab={hasVideoTab}
         />
       )}
     </>
@@ -1077,10 +1326,18 @@ function ComposerTemplatePickerSlot({
   picker: ComposerTemplatePicker | undefined;
 }) {
   const features = useLastResolved(featureSwitch$);
-  if (!picker || !features?.[FeatureSwitchKey.ChatTemplatePicker]) {
+  const hasPptTab = Boolean(features?.[FeatureSwitchKey.ChatTemplatePicker]);
+  const hasVideoTab = Boolean(features?.[FeatureSwitchKey.VideoTemplatePicker]);
+  if (!picker || (!hasPptTab && !hasVideoTab)) {
     return null;
   }
-  return <TemplatePickerButton picker={picker} />;
+  return (
+    <TemplatePickerButton
+      picker={picker}
+      hasPptTab={hasPptTab}
+      hasVideoTab={hasVideoTab}
+    />
+  );
 }
 
 function ConnectorTriggerIcons({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -30,6 +30,7 @@ import {
   IconPlus,
   IconSearch,
   IconTemplate,
+  IconVideo,
   IconX,
 } from "@tabler/icons-react";
 import {
@@ -92,6 +93,7 @@ import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import {
   PRESENTATION_TEMPLATE_ITEMS,
   type PresentationTemplateItem,
+  VIDEO_STYLE_GROUPS,
   VIDEO_STYLE_PRESETS,
   type VideoStylePreset,
 } from "@vm0/core";
@@ -148,12 +150,15 @@ import {
   setTemplatePickerCategory$,
   templatePickerSearch$,
   setTemplatePickerSearch$,
+  templatePickerVideoGroup$,
+  setTemplatePickerVideoGroup$,
   templatePickerPreviewSlug$,
   setTemplatePickerPreviewSlug$,
   templatePickerPreviewSlideIndex$,
   setTemplatePickerPreviewSlideIndex$,
   templateCardHover$,
   setTemplateCardHover$,
+  type TemplatePickerVideoGroup,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
   audioInputAvailable$,
@@ -547,13 +552,15 @@ function videoTemplateMatchesSearch(
   if (!normalizedQuery) {
     return true;
   }
-  const searchable = [
-    item.nameEn,
-    item.nameZh,
-    item.category,
-    ...item.tags,
-  ].join(" ");
+  const searchable = [item.nameEn, item.category, ...item.tags].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
+}
+
+function videoTemplateMatchesGroup(
+  item: VideoStylePreset,
+  group: TemplatePickerVideoGroup,
+): boolean {
+  return group === "all" || item.tags.includes(group);
 }
 
 function VideoTemplateCard({
@@ -597,13 +604,10 @@ function VideoTemplateCard({
           </div>
         )}
       </div>
-      <div className="flex items-start justify-between gap-3 px-3.5 py-3">
+      <div className="flex items-center justify-between gap-3 px-3.5 py-3">
         <div className="min-w-0">
           <p className="truncate text-sm font-semibold text-foreground">
             {item.nameEn}
-          </p>
-          <p className="mt-1 truncate text-xs text-muted-foreground">
-            {item.nameZh}
           </p>
         </div>
         <div className="flex shrink-0 items-center">
@@ -922,6 +926,8 @@ function TemplatePickerDialog({
   const setCategory = useSet(setTemplatePickerCategory$);
   const search = useGet(templatePickerSearch$);
   const setSearch = useSet(setTemplatePickerSearch$);
+  const videoGroup = useGet(templatePickerVideoGroup$);
+  const setVideoGroup = useSet(setTemplatePickerVideoGroup$);
   const previewSlug = useGet(templatePickerPreviewSlug$);
   const setPreviewSlug = useSet(setTemplatePickerPreviewSlug$);
   const selectedSlideIndex = useGet(templatePickerPreviewSlideIndex$);
@@ -934,8 +940,15 @@ function TemplatePickerDialog({
     return presentationTemplateMatchesSearch(item, search);
   });
   const filteredVideoItems = VIDEO_STYLE_PRESETS.filter((item) => {
-    return videoTemplateMatchesSearch(item, search);
+    return (
+      videoTemplateMatchesGroup(item, videoGroup) &&
+      videoTemplateMatchesSearch(item, search)
+    );
   });
+  const videoGroupFilters: readonly {
+    readonly tag: TemplatePickerVideoGroup;
+    readonly label: string;
+  }[] = [{ tag: "all", label: "All" }, ...VIDEO_STYLE_GROUPS];
 
   const handleSelectPresentation = (item: PresentationTemplateItem) => {
     onChange(toPresentationGenerationTemplate(item));
@@ -955,6 +968,7 @@ function TemplatePickerDialog({
   const defaultCategory = hasPptTab ? "slides" : "video";
   const effectiveCategory =
     category === "slides" && !hasPptTab ? "video" : category;
+  const selectedCategory = effectiveCategory || defaultCategory;
 
   return (
     <Dialog
@@ -991,19 +1005,30 @@ function TemplatePickerDialog({
             <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
               <DialogTitle>Templates</DialogTitle>
             </DialogHeader>
-            <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 pt-3 sm:flex-row sm:items-start sm:justify-between">
               <Tabs
-                value={effectiveCategory || defaultCategory}
+                value={selectedCategory}
                 onValueChange={setCategory}
+                className="-mb-px"
               >
-                <TabsList className="h-auto rounded-none bg-transparent p-0">
+                <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
                   {hasPptTab && (
                     <TabsTrigger
                       value="slides"
-                      className="h-11 gap-2 rounded-none border-b-2 border-foreground bg-transparent px-1 pb-3 pt-2 text-base font-semibold text-foreground shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                      className={cn(
+                        "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+                        selectedCategory === "slides"
+                          ? "border-foreground text-foreground"
+                          : "border-transparent text-muted-foreground hover:text-foreground",
+                      )}
                     >
                       <IconChartBar
-                        className="h-5 w-5 text-blue-500"
+                        className={cn(
+                          "h-5 w-5",
+                          selectedCategory === "slides"
+                            ? "text-blue-500"
+                            : "text-muted-foreground",
+                        )}
                         stroke={1.8}
                       />
                       PPT
@@ -1012,10 +1037,20 @@ function TemplatePickerDialog({
                   {hasVideoTab && (
                     <TabsTrigger
                       value="video"
-                      className="h-11 gap-2 rounded-none border-b-2 border-foreground bg-transparent px-1 pb-3 pt-2 text-base font-semibold text-foreground shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                      className={cn(
+                        "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+                        selectedCategory === "video"
+                          ? "border-foreground text-foreground"
+                          : "border-transparent text-muted-foreground hover:text-foreground",
+                      )}
                     >
-                      <IconTemplate
-                        className="h-5 w-5 text-purple-500"
+                      <IconVideo
+                        className={cn(
+                          "h-5 w-5",
+                          selectedCategory === "video"
+                            ? "text-purple-500"
+                            : "text-muted-foreground",
+                        )}
                         stroke={1.8}
                       />
                       Video
@@ -1023,120 +1058,143 @@ function TemplatePickerDialog({
                   )}
                 </TabsList>
               </Tabs>
-              <div className="relative w-full sm:w-64">
-                <IconSearch
-                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                  stroke={1.8}
-                />
-                <Input
-                  aria-label="Search templates"
-                  className="h-8 pl-9 text-sm"
-                  value={search}
-                  onChange={(event) => {
-                    setSearch(event.target.value);
-                  }}
-                  placeholder="Search templates"
-                />
+              <div className="w-full pb-3 sm:w-64">
+                <div className="relative">
+                  <IconSearch
+                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                    stroke={1.8}
+                  />
+                  <Input
+                    aria-label="Search templates"
+                    className="h-8 pl-9 text-sm"
+                    value={search}
+                    onChange={(event) => {
+                      setSearch(event.target.value);
+                    }}
+                    placeholder="Search templates"
+                  />
+                </div>
               </div>
             </div>
-            {(effectiveCategory || defaultCategory) === "slides" &&
-              hasPptTab && (
-                <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
-                  <TemplateSectionHeader
-                    label="VM0 templates"
-                    count={filteredPptItems.length}
-                  />
-                  {filteredPptItems.length > 0 ? (
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                      {filteredPptItems.map((item) => {
-                        const selected = isSelectedPresentationTemplate(
-                          item,
-                          value,
-                        );
-                        return (
-                          <div
-                            key={item.slug}
-                            className={cn(
-                              "group overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
-                              selected
-                                ? "border-primary ring-1 ring-primary"
-                                : "border-border",
-                            )}
-                          >
-                            <TemplatePreview
-                              item={item}
-                              onPreview={handlePreview}
-                            />
-                            <div className="flex items-start justify-between gap-3 px-3.5 py-3">
-                              <div className="min-w-0">
-                                <p className="truncate text-sm font-semibold text-foreground">
-                                  {item.title}
-                                </p>
-                                <p className="mt-1 truncate text-xs text-muted-foreground">
-                                  {formatPresentationTemplateKind(
-                                    item.templateId,
-                                  )}
-                                </p>
-                              </div>
-                              <div className="flex shrink-0 items-center">
-                                <button
-                                  type="button"
-                                  aria-label={`Select template ${item.title}`}
-                                  aria-pressed={selected}
-                                  onClick={() => {
-                                    handleSelectPresentation(item);
-                                  }}
-                                  className={cn(
-                                    "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                                    selected
-                                      ? "border-primary/40 bg-primary/10 text-primary"
-                                      : "border-border bg-background text-foreground hover:bg-muted",
-                                  )}
-                                >
-                                  Use
-                                </button>
-                              </div>
+            {selectedCategory === "slides" && hasPptTab && (
+              <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
+                <TemplateSectionHeader
+                  label="VM0 templates"
+                  count={filteredPptItems.length}
+                />
+                {filteredPptItems.length > 0 ? (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {filteredPptItems.map((item) => {
+                      const selected = isSelectedPresentationTemplate(
+                        item,
+                        value,
+                      );
+                      return (
+                        <div
+                          key={item.slug}
+                          className={cn(
+                            "group overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+                            selected
+                              ? "border-primary ring-1 ring-primary"
+                              : "border-border",
+                          )}
+                        >
+                          <TemplatePreview
+                            item={item}
+                            onPreview={handlePreview}
+                          />
+                          <div className="flex items-start justify-between gap-3 px-3.5 py-3">
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-semibold text-foreground">
+                                {item.title}
+                              </p>
+                              <p className="mt-1 truncate text-xs text-muted-foreground">
+                                {formatPresentationTemplateKind(
+                                  item.templateId,
+                                )}
+                              </p>
+                            </div>
+                            <div className="flex shrink-0 items-center">
+                              <button
+                                type="button"
+                                aria-label={`Select template ${item.title}`}
+                                aria-pressed={selected}
+                                onClick={() => {
+                                  handleSelectPresentation(item);
+                                }}
+                                className={cn(
+                                  "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                                  selected
+                                    ? "border-primary/40 bg-primary/10 text-primary"
+                                    : "border-border bg-background text-foreground hover:bg-muted",
+                                )}
+                              >
+                                Use
+                              </button>
                             </div>
                           </div>
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <TemplateEmptyPanel
-                      title="No matches"
-                      description="Try a different search."
-                    />
-                  )}
-                </div>
-              )}
-            {(effectiveCategory || defaultCategory) === "video" &&
-              hasVideoTab && (
-                <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
-                  <TemplateSectionHeader
-                    label="VM0 video styles"
-                    count={filteredVideoItems.length}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <TemplateEmptyPanel
+                    title="No matches"
+                    description="Try a different search."
                   />
-                  {filteredVideoItems.length > 0 ? (
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                      {filteredVideoItems.map((item) => {
-                        return (
-                          <VideoTemplateCard
-                            key={item.id}
-                            item={item}
-                            selected={isSelectedVideoTemplate(item, value)}
-                            onSelect={handleSelectVideo}
-                          />
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <TemplateEmptyPanel
-                      title="No matches"
-                      description="Try a different search."
-                    />
-                  )}
+                )}
+              </div>
+            )}
+            {selectedCategory === "video" && hasVideoTab && (
+              <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
+                <TemplateSectionHeader
+                  label="VM0 video styles"
+                  count={filteredVideoItems.length}
+                />
+                <div className="mb-4 flex flex-wrap gap-2">
+                  {videoGroupFilters.map((group) => {
+                    const selected = videoGroup === group.tag;
+                    return (
+                      <button
+                        key={group.tag}
+                        type="button"
+                        aria-pressed={selected}
+                        className={cn(
+                          "h-7 rounded-full border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          selected
+                            ? "border-foreground bg-foreground text-background"
+                            : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+                        )}
+                        onClick={() => {
+                          setVideoGroup(group.tag);
+                        }}
+                      >
+                        {group.label}
+                      </button>
+                    );
+                  })}
                 </div>
-              )}
+                {filteredVideoItems.length > 0 ? (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {filteredVideoItems.map((item) => {
+                      return (
+                        <VideoTemplateCard
+                          key={item.id}
+                          item={item}
+                          selected={isSelectedVideoTemplate(item, value)}
+                          onSelect={handleSelectVideo}
+                        />
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <TemplateEmptyPanel
+                    title="No matches"
+                    description="Try a different search."
+                  />
+                )}
+              </div>
+            )}
           </>
         )}
       </DialogContent>
@@ -1165,7 +1223,7 @@ function SelectedTemplateChip({
             />
           </span>
           <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
-            Template
+            Presentation
           </span>
           <span className="h-3.5 w-px shrink-0 bg-border/70" />
           <span className="min-w-0 truncate text-xs font-medium">{label}</span>
@@ -1196,7 +1254,7 @@ function SelectedVideoTemplateChip({
       <div className="flex">
         <div className="inline-flex h-8 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/90 pl-1.5 pr-1 text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
           <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
-            <IconTemplate
+            <IconVideo
               size={12}
               stroke={1.5}
               className="text-muted-foreground"
@@ -1273,6 +1331,7 @@ function TemplatePickerButton({
   const open = useGet(templatePickerOpen$);
   const setOpen = useSet(setTemplatePickerOpen$);
   const setSearch = useSet(setTemplatePickerSearch$);
+  const setVideoGroup = useSet(setTemplatePickerVideoGroup$);
   const setPreviewSlug = useSet(setTemplatePickerPreviewSlug$);
   const setSelectedSlideIndex = useSet(setTemplatePickerPreviewSlideIndex$);
   const selectedTitle = selectedTemplateTitle(picker.value);
@@ -1292,6 +1351,7 @@ function TemplatePickerButton({
               aria-pressed={picker.value !== undefined}
               onClick={() => {
                 setSearch("");
+                setVideoGroup("all");
                 setPreviewSlug(null);
                 setSelectedSlideIndex(0);
                 setOpen(true);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -61,7 +61,7 @@ import type {
   GenerationTemplateRequest,
   ChatThreadGithubPr,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { PRESENTATION_TEMPLATE_ITEMS } from "@vm0/core";
+import { PRESENTATION_TEMPLATE_ITEMS, VIDEO_STYLE_PRESETS } from "@vm0/core";
 import type {
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
@@ -4663,7 +4663,10 @@ function generationTemplateLabel(
     return null;
   }
   if (value.type === "video") {
-    return value.selection.stylePresetId;
+    const item = VIDEO_STYLE_PRESETS.find((candidate) => {
+      return candidate.id === value.selection.stylePresetId;
+    });
+    return item?.nameEn ?? formatTemplateIdLabel(value.selection.stylePresetId);
   }
   const item = PRESENTATION_TEMPLATE_ITEMS.find((candidate) => {
     return (
@@ -4693,7 +4696,9 @@ function UserMessageGenerationTemplate({
 }) {
   const features = useLastResolved(featureSwitch$);
   const templateLabelEnabled =
-    features?.[FeatureSwitchKey.ChatTemplatePicker] ?? false;
+    generationTemplate?.type === "video"
+      ? (features?.[FeatureSwitchKey.VideoTemplatePicker] ?? false)
+      : (features?.[FeatureSwitchKey.ChatTemplatePicker] ?? false);
   if (!templateLabelEnabled) {
     return null;
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4662,6 +4662,9 @@ function generationTemplateLabel(
   if (!value) {
     return null;
   }
+  if (value.type === "video") {
+    return value.selection.stylePresetId;
+  }
   const item = PRESENTATION_TEMPLATE_ITEMS.find((candidate) => {
     return (
       candidate.designSystemId === value.selection.designSystemId &&
@@ -4676,6 +4679,9 @@ function generationTemplateTypeLabel(
 ): string | null {
   if (!value) {
     return null;
+  }
+  if (value.type === "video") {
+    return "Video";
   }
   return "Slides";
 }

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -167,8 +167,16 @@ const presentationGenerationTemplateRequestSchema = z.object({
   }),
 });
 
+const videoGenerationTemplateRequestSchema = z.object({
+  type: z.literal("video"),
+  selection: z.object({
+    stylePresetId: z.string().min(1),
+  }),
+});
+
 const generationTemplateRequestSchema = z.discriminatedUnion("type", [
   presentationGenerationTemplateRequestSchema,
+  videoGenerationTemplateRequestSchema,
 ]);
 
 const pagedChatMessageBaseSchema = z.object({
@@ -833,6 +841,7 @@ export {
   modelSelectionRequestSchema,
   generationTemplateRequestSchema,
   presentationGenerationTemplateRequestSchema,
+  videoGenerationTemplateRequestSchema,
   pagedChatMessageSchema,
   summaryEntrySchema,
   persistedAttachmentSchema,
@@ -851,6 +860,9 @@ export type GenerationTemplateRequest = z.infer<
 >;
 export type PresentationGenerationTemplateRequest = z.infer<
   typeof presentationGenerationTemplateRequestSchema
+>;
+export type VideoGenerationTemplateRequest = z.infer<
+  typeof videoGenerationTemplateRequestSchema
 >;
 
 export type SummaryEntry = z.infer<typeof summaryEntrySchema>;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -50,6 +50,7 @@ export enum FeatureSwitchKey {
   SandboxIoLimiters = "sandboxIoLimiters",
   ChatGithubPrTracking = "chatGithubPrTracking",
   ChatTemplatePicker = "chatTemplatePicker",
+  VideoTemplatePicker = "videoTemplatePicker",
   MemoryViewer = "memoryViewer",
   MemoryDevRefresh = "memoryDevRefresh",
   ChatRecommendedFollowups = "chatRecommendedFollowups",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -282,6 +282,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.VideoTemplatePicker]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Show the Video style picker tab in the Zero chat composer for AI video generation with curated style presets.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.MemoryViewer]: {
     maintainer: "lancy@vm0.ai",
     description:

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -26,7 +26,6 @@ export {
   VIDEO_STYLE_PRESETS,
   VIDEO_DIMENSION_DESCRIPTIONS,
   type VideoStyleGroup,
-  type VideoStyleGroupTag,
   type VideoStylePreset,
   type VideoStyleDimensions,
   type VideoStyleCategory,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -22,6 +22,13 @@ export {
   type PresentationTemplateItem,
 } from "./presentation-template-items";
 export {
+  VIDEO_STYLE_PRESETS,
+  VIDEO_DIMENSION_DESCRIPTIONS,
+  type VideoStylePreset,
+  type VideoStyleDimensions,
+  type VideoStyleCategory,
+} from "./video-style-preset-items";
+export {
   initContract,
   apiErrorSchema,
   ApiError,

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -22,8 +22,11 @@ export {
   type PresentationTemplateItem,
 } from "./presentation-template-items";
 export {
+  VIDEO_STYLE_GROUPS,
   VIDEO_STYLE_PRESETS,
   VIDEO_DIMENSION_DESCRIPTIONS,
+  type VideoStyleGroup,
+  type VideoStyleGroupTag,
   type VideoStylePreset,
   type VideoStyleDimensions,
   type VideoStyleCategory,

--- a/turbo/packages/core/src/video-style-preset-items.ts
+++ b/turbo/packages/core/src/video-style-preset-items.ts
@@ -265,8 +265,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
   },
   {
     id: "tech-minimalist-reveal",
-    nameZh: "极简科技·产品展示",
-    nameEn: "Tech Minimalist Reveal",
+    nameZh: "手机产品展示",
+    nameEn: "Phone Product Showcase",
     category: "brand_commercial",
     dimensions: {
       visualTone: "cold_desaturated",
@@ -277,9 +277,9 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       emotionalTone: "inspiring",
       styleReference: "tech_minimalist_reveal",
     },
-    scene: "laptop-open",
+    scene: "phone-product-showcase",
     sampleVideoUrl:
-      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6f1e98ef-7fc1-48b0-b1db-cd1ee58a0bd4/video-6f1e98ef.mp4",
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/95946706-2280-4938-9ec1-f824816f5105/video-95946706.mp4",
   },
   {
     id: "luxury-watch-product",

--- a/turbo/packages/core/src/video-style-preset-items.ts
+++ b/turbo/packages/core/src/video-style-preset-items.ts
@@ -201,7 +201,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "symmetrical_pastel_quirky",
     },
     scene: "grand-hotel-lobby",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6126d21a-1a19-4b2a-914a-0eec6335bf1f/video-6126d21a.mp4",
     tags: ["story-emotion", "quirky", "pastel", "symmetry", "deadpan", "retro"],
   },
   {
@@ -219,7 +220,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "imax_epic_cinematic",
     },
     scene: "mountain-horizon",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/df99de74-8eea-420c-86d1-c104ba5ba6b6/video-df99de74.mp4",
     tags: ["story-emotion", "epic", "imax", "dramatic", "cinematic", "grand"],
   },
   {
@@ -237,7 +239,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "slowburn_moody_romance",
     },
     scene: "rain-on-window",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/feda268d-7b6c-4c5d-b3c8-89ab1dcc29cd/video-feda268d.mp4",
     tags: [
       "story-emotion",
       "moody",
@@ -262,7 +265,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "indie_naturalistic",
     },
     scene: "forest-clearing",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e4fbe51f-45c9-4689-8681-1e102af0a55e/video-e4fbe51f.mp4",
     tags: [
       "story-emotion",
       "indie",
@@ -287,7 +291,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "film_noir",
     },
     scene: "rain-on-window",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/dc649267-41d8-4fbc-b253-29e407791ac6/video-dc649267.mp4",
     tags: [
       "story-emotion",
       "noir",
@@ -312,7 +317,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "tech_minimalist_reveal",
     },
     scene: "laptop-open",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6f1e98ef-7fc1-48b0-b1db-cd1ee58a0bd4/video-6f1e98ef.mp4",
     tags: ["brand-product", "minimalist", "product", "tech", "clean", "white"],
   },
   {
@@ -357,7 +363,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "athletic_motivation_ad",
     },
     scene: "extreme-sports",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/104ad36a-4d0c-472b-8416-d04cc2f06e75/video-104ad36a.mp4",
     tags: ["energy-sports", "sports", "motivation", "fast", "energy", "ad"],
   },
   {
@@ -375,7 +382,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "nature_documentary",
     },
     scene: "mountain-horizon",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/75e08761-7cdf-42ea-b8f3-eadb31586de6/video-75e08761.mp4",
     tags: [
       "story-emotion",
       "nature",
@@ -400,7 +408,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "shortform_viral",
     },
     scene: "summer-beach-crew",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/4bac1319-dba7-47a0-bc1b-4d1e932f71fd/video-4bac1319.mp4",
     tags: ["energy-sports", "viral", "shortform", "trending", "fast", "social"],
   },
   {
@@ -418,7 +427,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "hand_drawn_fantasy_anime",
     },
     scene: "forest-spirit-path",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/da7c7c2d-3383-4796-8e83-b0e112127387/video-da7c7c2d.mp4",
     tags: [
       "fantasy-art",
       "anime",
@@ -443,7 +453,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "chinese_ink",
     },
     scene: "mountain-horizon",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8314b0ae-6051-4daa-b789-51bec466ba66/video-8314b0ae.mp4",
     tags: ["fantasy-art", "ink", "chinese", "zen", "minimalist", "eastern"],
   },
   {
@@ -461,7 +472,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
       styleReference: "pop_art",
     },
     scene: "abstract-color-burst",
-    sampleVideoUrl: "",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/92c22511-a22e-4c9c-9489-b452eabaa16b/video-92c22511.mp4",
     tags: ["fantasy-art", "pop-art", "bold", "colorful", "graphic", "retro"],
   },
   {

--- a/turbo/packages/core/src/video-style-preset-items.ts
+++ b/turbo/packages/core/src/video-style-preset-items.ts
@@ -13,10 +13,12 @@ export type VideoStyleCategory =
   | "urban_social";
 
 export type VideoStyleGroupTag =
-  | "brand-product"
-  | "story-emotion"
-  | "energy-sports"
-  | "fantasy-art"
+  | "cinematic"
+  | "documentary"
+  | "lifestyle"
+  | "brand-commercial"
+  | "energy-music"
+  | "art-creative"
   | "anime-2d";
 
 export interface VideoStyleGroup {
@@ -25,10 +27,12 @@ export interface VideoStyleGroup {
 }
 
 export const VIDEO_STYLE_GROUPS: readonly VideoStyleGroup[] = [
-  { tag: "brand-product", label: "Brand & Product" },
-  { tag: "story-emotion", label: "Story & Emotion" },
-  { tag: "energy-sports", label: "Energy & Sports" },
-  { tag: "fantasy-art", label: "Fantasy & Art" },
+  { tag: "cinematic", label: "Cinematic" },
+  { tag: "documentary", label: "Documentary" },
+  { tag: "lifestyle", label: "Lifestyle" },
+  { tag: "brand-commercial", label: "Brand & Commercial" },
+  { tag: "energy-music", label: "Energy & Music" },
+  { tag: "art-creative", label: "Art & Creative" },
   { tag: "anime-2d", label: "Anime" },
 ];
 
@@ -203,7 +207,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "grand-hotel-lobby",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6126d21a-1a19-4b2a-914a-0eec6335bf1f/video-6126d21a.mp4",
-    tags: ["story-emotion", "quirky", "pastel", "symmetry", "deadpan", "retro"],
+    tags: ["cinematic", "quirky", "pastel", "symmetry", "deadpan", "retro"],
   },
   {
     id: "imax-epic-cinematic",
@@ -222,7 +226,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "mountain-horizon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/df99de74-8eea-420c-86d1-c104ba5ba6b6/video-df99de74.mp4",
-    tags: ["story-emotion", "epic", "imax", "dramatic", "cinematic", "grand"],
+    tags: ["cinematic", "epic", "imax", "dramatic", "cinematic", "grand"],
   },
   {
     id: "slowburn-moody-romance",
@@ -242,7 +246,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/feda268d-7b6c-4c5d-b3c8-89ab1dcc29cd/video-feda268d.mp4",
     tags: [
-      "story-emotion",
+      "cinematic",
       "moody",
       "romance",
       "handheld",
@@ -268,7 +272,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e4fbe51f-45c9-4689-8681-1e102af0a55e/video-e4fbe51f.mp4",
     tags: [
-      "story-emotion",
+      "cinematic",
       "indie",
       "arthouse",
       "naturalistic",
@@ -293,14 +297,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "rain-on-window",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/dc649267-41d8-4fbc-b253-29e407791ac6/video-dc649267.mp4",
-    tags: [
-      "story-emotion",
-      "noir",
-      "black-white",
-      "mystery",
-      "shadows",
-      "1950s",
-    ],
+    tags: ["cinematic", "noir", "black-white", "mystery", "shadows", "1950s"],
   },
   {
     id: "tech-minimalist-reveal",
@@ -319,7 +316,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "laptop-open",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6f1e98ef-7fc1-48b0-b1db-cd1ee58a0bd4/video-6f1e98ef.mp4",
-    tags: ["brand-product", "minimalist", "product", "tech", "clean", "white"],
+    tags: [
+      "brand-commercial",
+      "minimalist",
+      "product",
+      "tech",
+      "clean",
+      "white",
+    ],
   },
   {
     id: "luxury-watch-product",
@@ -339,7 +343,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/9e20abbb-a630-4523-857f-8350eba2ea4f/video-9e20abbb.mp4",
     tags: [
-      "brand-product",
+      "brand-commercial",
       "product",
       "watch",
       "luxury",
@@ -365,7 +369,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "extreme-sports",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/104ad36a-4d0c-472b-8416-d04cc2f06e75/video-104ad36a.mp4",
-    tags: ["energy-sports", "sports", "motivation", "fast", "energy", "ad"],
+    tags: ["energy-music", "sports", "motivation", "fast", "energy", "ad"],
   },
   {
     id: "nature-documentary",
@@ -385,7 +389,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/75e08761-7cdf-42ea-b8f3-eadb31586de6/video-75e08761.mp4",
     tags: [
-      "story-emotion",
+      "documentary",
       "nature",
       "documentary",
       "wildlife",
@@ -410,7 +414,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "summer-beach-crew",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/4bac1319-dba7-47a0-bc1b-4d1e932f71fd/video-4bac1319.mp4",
-    tags: ["energy-sports", "viral", "shortform", "trending", "fast", "social"],
+    tags: ["energy-music", "viral", "shortform", "trending", "fast", "social"],
   },
   {
     id: "hand-drawn-fantasy-anime",
@@ -430,7 +434,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/da7c7c2d-3383-4796-8e83-b0e112127387/video-da7c7c2d.mp4",
     tags: [
-      "fantasy-art",
+      "art-creative",
       "anime",
       "hand-drawn",
       "fantasy",
@@ -455,7 +459,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "mountain-horizon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8314b0ae-6051-4daa-b789-51bec466ba66/video-8314b0ae.mp4",
-    tags: ["fantasy-art", "ink", "chinese", "zen", "minimalist", "eastern"],
+    tags: ["art-creative", "ink", "chinese", "zen", "minimalist", "eastern"],
   },
   {
     id: "pop-art",
@@ -474,7 +478,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "abstract-color-burst",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/92c22511-a22e-4c9c-9489-b452eabaa16b/video-92c22511.mp4",
-    tags: ["fantasy-art", "pop-art", "bold", "colorful", "graphic", "retro"],
+    tags: ["art-creative", "pop-art", "bold", "colorful", "graphic", "retro"],
   },
   {
     id: "japanese-wabi-sabi",
@@ -492,9 +496,9 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "tokyo-alley-morning",
     sampleVideoUrl:
-      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f06bf43d-4820-466f-bc1d-716dec01e3cc/video-f06bf43d.mp4",
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/72b754cf-f76d-4fa9-9015-ab5082b49608/video-72b754cf.mp4",
     tags: [
-      "story-emotion",
+      "lifestyle",
       "japanese",
       "wabi-sabi",
       "calm",
@@ -520,7 +524,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8ea3c41f-8e80-4c70-aae6-a492b9eb264e/video-8ea3c41f.mp4",
     tags: [
-      "story-emotion",
+      "cinematic",
       "europe",
       "romance",
       "castle",
@@ -545,7 +549,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "food-plating",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3f0dd8d7-bfc3-4443-9b95-b58faf0d4f64/video-3f0dd8d7.mp4",
-    tags: ["brand-product", "food", "macro", "sensory", "chef", "documentary"],
+    tags: ["documentary", "food", "macro", "sensory", "chef", "documentary"],
   },
   {
     id: "fashion-editorial",
@@ -563,9 +567,9 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "model-editorial",
     sampleVideoUrl:
-      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6024a53b-fe0c-45dc-b5df-0ae14ad883ed/video-6024a53b.mp4",
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6d5822ff-d0ef-485e-b4e4-2eb0a46414d5/video-6d5822ff.mp4",
     tags: [
-      "brand-product",
+      "brand-commercial",
       "fashion",
       "luxury",
       "editorial",
@@ -590,7 +594,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "summer-beach-crew",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3d44e690-d838-49c6-89f8-946bcffee10b/video-3d44e690.mp4",
-    tags: ["energy-sports", "summer", "beach", "youth", "vibrant", "friends"],
+    tags: ["lifestyle", "summer", "beach", "youth", "vibrant", "friends"],
   },
   {
     id: "super8-home-film",
@@ -610,7 +614,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/29ddb4de-8aef-42a7-aac4-ee013c9272a5/video-29ddb4de.mp4",
     tags: [
-      "story-emotion",
+      "cinematic",
       "retro",
       "70s",
       "super8",
@@ -637,7 +641,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c28fd30a-d735-4c67-97d4-0567fd375a8d/video-c28fd30a.mp4",
     tags: [
-      "story-emotion",
+      "lifestyle",
       "cottagecore",
       "garden",
       "handmade",
@@ -664,7 +668,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b629a3f5-c644-4d96-81f5-834fe1a31da1/video-b629a3f5.mp4",
     tags: [
-      "brand-product",
+      "lifestyle",
       "wellness",
       "yoga",
       "meditation",
@@ -691,7 +695,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/76c1cf86-cb76-4a9b-817f-15597bcc8481/video-76c1cf86.mp4",
     tags: [
-      "brand-product",
+      "lifestyle",
       "diy",
       "maker",
       "craft",
@@ -716,9 +720,9 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "extreme-sports",
     sampleVideoUrl:
-      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/305b6781-280a-4f07-927a-1191bd8ece9b/video-305b6781.mp4",
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/637ca413-fd3e-4b6e-9b8c-42f2a6c63816/video-637ca413.mp4",
     tags: [
-      "energy-sports",
+      "energy-music",
       "extreme-sports",
       "action",
       "adrenaline",
@@ -744,7 +748,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f7d288e2-9d81-43b7-ae1b-1702a11686a8/video-f7d288e2.mp4",
     tags: [
-      "energy-sports",
+      "energy-music",
       "music",
       "concert",
       "stage",
@@ -770,7 +774,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "impossible-room",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b7b0d289-9e05-4f93-9795-d5d19263435c/video-b7b0d289.mp4",
-    tags: ["fantasy-art", "surreal", "dream", "impossible", "dali", "ethereal"],
+    tags: [
+      "art-creative",
+      "surreal",
+      "dream",
+      "impossible",
+      "dali",
+      "ethereal",
+    ],
   },
   {
     id: "ai-digital-art",
@@ -790,7 +801,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/629cab0a-fead-4c9c-ac9b-d5ef6df0782f/video-629cab0a.mp4",
     tags: [
-      "fantasy-art",
+      "art-creative",
       "ai",
       "digital",
       "neural-network",
@@ -817,7 +828,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/273d9673-9ed2-426b-8516-0102fbdd8622/video-273d9673.mp4",
     tags: [
-      "story-emotion",
+      "documentary",
       "space",
       "cosmos",
       "nasa",
@@ -844,7 +855,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/54c271a6-d2da-4134-a812-679fd0fc8810/video-54c271a6.mp4",
     tags: [
-      "story-emotion",
+      "documentary",
       "street",
       "nyc",
       "urban",
@@ -871,7 +882,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c227b1aa-7876-4fe3-8869-4d2b996d418f/video-c227b1aa.mp4",
     tags: [
-      "fantasy-art",
+      "art-creative",
       "synthwave",
       "80s",
       "retro",
@@ -898,7 +909,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e93201b0-90d2-42f1-9db7-19441315c4bc/video-e93201b0.mp4",
     tags: [
-      "fantasy-art",
+      "art-creative",
       "comedy",
       "absurdist",
       "quirky",

--- a/turbo/packages/core/src/video-style-preset-items.ts
+++ b/turbo/packages/core/src/video-style-preset-items.ts
@@ -1,28 +1,14 @@
 export type VideoStyleCategory =
-  | "anime_2d"
-  | "art_culture"
-  | "classic_cinematic"
-  | "fashion_luxury"
-  | "lifestyle"
-  | "music_entertainment"
-  | "nostalgic"
-  | "product_brand"
-  | "sci_fi_tech"
-  | "sports_energy"
-  | "surreal_creative"
-  | "urban_social";
-
-export type VideoStyleGroupTag =
+  | "art_creative"
+  | "anime"
+  | "brand_commercial"
   | "cinematic"
   | "documentary"
-  | "lifestyle"
-  | "brand-commercial"
-  | "energy-music"
-  | "art-creative"
-  | "anime-2d";
+  | "energy_music"
+  | "lifestyle";
 
 export interface VideoStyleGroup {
-  readonly tag: VideoStyleGroupTag;
+  readonly tag: VideoStyleCategory;
   readonly label: string;
 }
 
@@ -30,10 +16,10 @@ export const VIDEO_STYLE_GROUPS: readonly VideoStyleGroup[] = [
   { tag: "cinematic", label: "Cinematic" },
   { tag: "documentary", label: "Documentary" },
   { tag: "lifestyle", label: "Lifestyle" },
-  { tag: "brand-commercial", label: "Brand & Commercial" },
-  { tag: "energy-music", label: "Energy & Music" },
-  { tag: "art-creative", label: "Art & Creative" },
-  { tag: "anime-2d", label: "Anime" },
+  { tag: "brand_commercial", label: "Brand & Commercial" },
+  { tag: "energy_music", label: "Energy & Music" },
+  { tag: "art_creative", label: "Art & Creative" },
+  { tag: "anime", label: "Anime" },
 ];
 
 export interface VideoStyleDimensions {
@@ -54,7 +40,6 @@ export interface VideoStylePreset {
   readonly dimensions: VideoStyleDimensions;
   readonly scene: string;
   readonly sampleVideoUrl: string;
-  readonly tags: readonly string[];
 }
 
 export const VIDEO_DIMENSION_DESCRIPTIONS: Readonly<Record<string, string>> = {
@@ -175,8 +160,6 @@ export const VIDEO_DIMENSION_DESCRIPTIONS: Readonly<Record<string, string>> = {
     "street documentary — city pulse, candid portraits, social texture",
   synthwave_retro:
     "80s synthwave retro — grid horizons, neon glow, nostalgic retrofuturism",
-  absurdist_comedy:
-    "absurdist comedy — deadpan escalation, mundane surrealism, dry British wit",
   magical_girl_anime:
     "magical girl anime — sparkle transforms, friendship bonds, bright courage",
   shonen_battle_anime:
@@ -194,7 +177,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     id: "symmetrical-pastel-quirky",
     nameZh: "对称粉彩·怪诞优雅",
     nameEn: "Symmetrical Pastel Quirky",
-    category: "classic_cinematic",
+    category: "cinematic",
     dimensions: {
       visualTone: "dreamy_pastel",
       cameraStyle: "steady_locked",
@@ -207,13 +190,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "grand-hotel-lobby",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6126d21a-1a19-4b2a-914a-0eec6335bf1f/video-6126d21a.mp4",
-    tags: ["cinematic", "quirky", "pastel", "symmetry", "deadpan", "retro"],
   },
   {
     id: "imax-epic-cinematic",
     nameZh: "史诗叙事·宏大电影",
     nameEn: "IMAX Epic Cinematic",
-    category: "classic_cinematic",
+    category: "cinematic",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "drone_aerial",
@@ -226,13 +208,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "mountain-horizon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/df99de74-8eea-420c-86d1-c104ba5ba6b6/video-df99de74.mp4",
-    tags: ["cinematic", "epic", "imax", "dramatic", "cinematic", "grand"],
   },
   {
     id: "slowburn-moody-romance",
     nameZh: "情绪诗意·慢燃暖光",
     nameEn: "Slow Burn Moody Romance",
-    category: "classic_cinematic",
+    category: "cinematic",
     dimensions: {
       visualTone: "warm_natural",
       cameraStyle: "handheld_raw",
@@ -245,20 +226,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "rain-on-window",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/feda268d-7b6c-4c5d-b3c8-89ab1dcc29cd/video-feda268d.mp4",
-    tags: [
-      "cinematic",
-      "moody",
-      "romance",
-      "handheld",
-      "nostalgic",
-      "atmospheric",
-    ],
   },
   {
     id: "indie-naturalistic",
     nameZh: "文艺独立·自然光",
     nameEn: "Indie Naturalistic",
-    category: "classic_cinematic",
+    category: "cinematic",
     dimensions: {
       visualTone: "cold_desaturated",
       cameraStyle: "handheld_raw",
@@ -271,20 +244,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "forest-clearing",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e4fbe51f-45c9-4689-8681-1e102af0a55e/video-e4fbe51f.mp4",
-    tags: [
-      "cinematic",
-      "indie",
-      "arthouse",
-      "naturalistic",
-      "quiet",
-      "character-driven",
-    ],
   },
   {
     id: "film-noir",
     nameZh: "黑白悬疑·Film Noir",
     nameEn: "Film Noir",
-    category: "classic_cinematic",
+    category: "cinematic",
     dimensions: {
       visualTone: "cold_desaturated",
       cameraStyle: "steady_locked",
@@ -297,13 +262,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "rain-on-window",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/dc649267-41d8-4fbc-b253-29e407791ac6/video-dc649267.mp4",
-    tags: ["cinematic", "noir", "black-white", "mystery", "shadows", "1950s"],
   },
   {
     id: "tech-minimalist-reveal",
     nameZh: "极简科技·产品展示",
     nameEn: "Tech Minimalist Reveal",
-    category: "product_brand",
+    category: "brand_commercial",
     dimensions: {
       visualTone: "cold_desaturated",
       cameraStyle: "slow_push_in",
@@ -316,20 +280,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "laptop-open",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6f1e98ef-7fc1-48b0-b1db-cd1ee58a0bd4/video-6f1e98ef.mp4",
-    tags: [
-      "brand-commercial",
-      "minimalist",
-      "product",
-      "tech",
-      "clean",
-      "white",
-    ],
   },
   {
     id: "luxury-watch-product",
     nameZh: "Luxury Watch Product",
     nameEn: "Luxury Watch Product",
-    category: "product_brand",
+    category: "brand_commercial",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "steady_locked",
@@ -342,21 +298,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "luxury-watch-dial",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/9e20abbb-a630-4523-857f-8350eba2ea4f/video-9e20abbb.mp4",
-    tags: [
-      "brand-commercial",
-      "product",
-      "watch",
-      "luxury",
-      "mechanical-watch",
-      "apple-product",
-      "cinematic",
-    ],
   },
   {
     id: "athletic-motivation",
     nameZh: "运动励志·广告风",
     nameEn: "Athletic Motivation Ad",
-    category: "sports_energy",
+    category: "energy_music",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "extreme_closeup",
@@ -369,13 +316,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "extreme-sports",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/104ad36a-4d0c-472b-8416-d04cc2f06e75/video-104ad36a.mp4",
-    tags: ["energy-music", "sports", "motivation", "fast", "energy", "ad"],
   },
   {
     id: "nature-documentary",
     nameZh: "自然纪录·BBC风",
     nameEn: "Nature Documentary",
-    category: "sci_fi_tech",
+    category: "documentary",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "drone_aerial",
@@ -388,20 +334,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "mountain-horizon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/75e08761-7cdf-42ea-b8f3-eadb31586de6/video-75e08761.mp4",
-    tags: [
-      "documentary",
-      "nature",
-      "documentary",
-      "wildlife",
-      "slow",
-      "cinematic",
-    ],
   },
   {
     id: "shortform-viral",
     nameZh: "短视频·病毒传播",
     nameEn: "Shortform Viral",
-    category: "urban_social",
+    category: "energy_music",
     dimensions: {
       visualTone: "warm_natural",
       cameraStyle: "handheld_raw",
@@ -414,13 +352,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "summer-beach-crew",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/4bac1319-dba7-47a0-bc1b-4d1e932f71fd/video-4bac1319.mp4",
-    tags: ["energy-music", "viral", "shortform", "trending", "fast", "social"],
   },
   {
     id: "hand-drawn-fantasy-anime",
     nameZh: "手绘奇幻·动漫美学",
     nameEn: "Hand Drawn Fantasy Anime",
-    category: "anime_2d",
+    category: "art_creative",
     dimensions: {
       visualTone: "warm_natural",
       cameraStyle: "slow_push_in",
@@ -433,20 +370,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "forest-spirit-path",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/da7c7c2d-3383-4796-8e83-b0e112127387/video-da7c7c2d.mp4",
-    tags: [
-      "art-creative",
-      "anime",
-      "hand-drawn",
-      "fantasy",
-      "nature",
-      "whimsical",
-    ],
   },
   {
     id: "chinese-ink-art",
     nameZh: "水墨·东方禅意",
     nameEn: "Chinese Ink Painting",
-    category: "art_culture",
+    category: "art_creative",
     dimensions: {
       visualTone: "cold_desaturated",
       cameraStyle: "slow_push_in",
@@ -459,13 +388,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "mountain-horizon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8314b0ae-6051-4daa-b789-51bec466ba66/video-8314b0ae.mp4",
-    tags: ["art-creative", "ink", "chinese", "zen", "minimalist", "eastern"],
   },
   {
     id: "pop-art",
     nameZh: "波普·安迪沃霍尔风",
     nameEn: "Pop Art",
-    category: "art_culture",
+    category: "art_creative",
     dimensions: {
       visualTone: "neon_cyberpunk",
       cameraStyle: "steady_locked",
@@ -478,13 +406,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "abstract-color-burst",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/92c22511-a22e-4c9c-9489-b452eabaa16b/video-92c22511.mp4",
-    tags: ["art-creative", "pop-art", "bold", "colorful", "graphic", "retro"],
   },
   {
     id: "japanese-wabi-sabi",
     nameZh: "日系·小清新",
     nameEn: "Japanese Wabi-Sabi",
-    category: "art_culture",
+    category: "lifestyle",
     dimensions: {
       visualTone: "warm_natural",
       cameraStyle: "slow_push_in",
@@ -497,20 +424,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "tokyo-alley-morning",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/72b754cf-f76d-4fa9-9015-ab5082b49608/video-72b754cf.mp4",
-    tags: [
-      "lifestyle",
-      "japanese",
-      "wabi-sabi",
-      "calm",
-      "everyday",
-      "aesthetic",
-    ],
   },
   {
     id: "european-romance",
     nameZh: "欧洲·古典浪漫",
     nameEn: "European Classical Romance",
-    category: "art_culture",
+    category: "cinematic",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "steady_locked",
@@ -523,20 +442,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "castle-garden-dusk",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8ea3c41f-8e80-4c70-aae6-a492b9eb264e/video-8ea3c41f.mp4",
-    tags: [
-      "cinematic",
-      "europe",
-      "romance",
-      "castle",
-      "golden-hour",
-      "elegant",
-    ],
   },
   {
     id: "gourmet-documentary",
     nameZh: "美食纪录·感官系",
     nameEn: "Gourmet Documentary",
-    category: "lifestyle",
+    category: "documentary",
     dimensions: {
       visualTone: "warm_natural",
       cameraStyle: "extreme_closeup",
@@ -549,13 +460,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "food-plating",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3f0dd8d7-bfc3-4443-9b95-b58faf0d4f64/video-3f0dd8d7.mp4",
-    tags: ["documentary", "food", "macro", "sensory", "chef", "documentary"],
   },
   {
     id: "fashion-editorial",
     nameZh: "奢侈品·时尚大片",
     nameEn: "Fashion Editorial",
-    category: "fashion_luxury",
+    category: "brand_commercial",
     dimensions: {
       visualTone: "cold_desaturated",
       cameraStyle: "steady_locked",
@@ -567,15 +477,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "model-editorial",
     sampleVideoUrl:
-      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6d5822ff-d0ef-485e-b4e4-2eb0a46414d5/video-6d5822ff.mp4",
-    tags: [
-      "brand-commercial",
-      "fashion",
-      "luxury",
-      "editorial",
-      "high-contrast",
-      "model",
-    ],
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8bf8b826-2517-435b-8882-7f071c683e46/video-8bf8b826.mp4",
   },
   {
     id: "summer-indie",
@@ -594,13 +496,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "summer-beach-crew",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3d44e690-d838-49c6-89f8-946bcffee10b/video-3d44e690.mp4",
-    tags: ["lifestyle", "summer", "beach", "youth", "vibrant", "friends"],
   },
   {
     id: "super8-home-film",
     nameZh: "复古暖调·70s胶片",
     nameEn: "Super 8 Home Film",
-    category: "nostalgic",
+    category: "cinematic",
     dimensions: {
       visualTone: "vintage_film",
       cameraStyle: "handheld_raw",
@@ -613,15 +514,6 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "family-backyard-70s",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/29ddb4de-8aef-42a7-aac4-ee013c9272a5/video-29ddb4de.mp4",
-    tags: [
-      "cinematic",
-      "retro",
-      "70s",
-      "super8",
-      "family",
-      "nostalgic",
-      "film-grain",
-    ],
   },
   {
     id: "cottagecore",
@@ -640,15 +532,6 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "cottage-garden-morning",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c28fd30a-d735-4c67-97d4-0567fd375a8d/video-c28fd30a.mp4",
-    tags: [
-      "lifestyle",
-      "cottagecore",
-      "garden",
-      "handmade",
-      "nature",
-      "cozy",
-      "slow-living",
-    ],
   },
   {
     id: "wellness-yoga",
@@ -667,15 +550,6 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "yoga-sunrise-studio",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b629a3f5-c644-4d96-81f5-834fe1a31da1/video-b629a3f5.mp4",
-    tags: [
-      "lifestyle",
-      "wellness",
-      "yoga",
-      "meditation",
-      "mindfulness",
-      "morning",
-      "calm",
-    ],
   },
   {
     id: "diy-maker",
@@ -694,21 +568,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "workshop-maker-build",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/76c1cf86-cb76-4a9b-817f-15597bcc8481/video-76c1cf86.mp4",
-    tags: [
-      "lifestyle",
-      "diy",
-      "maker",
-      "craft",
-      "woodwork",
-      "handmade",
-      "satisfying",
-    ],
   },
   {
     id: "extreme-sports",
     nameZh: "运动·高燃热血",
     nameEn: "Extreme Sports Ad",
-    category: "sports_energy",
+    category: "energy_music",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "extreme_closeup",
@@ -721,20 +586,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "extreme-sports",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/637ca413-fd3e-4b6e-9b8c-42f2a6c63816/video-637ca413.mp4",
-    tags: [
-      "energy-music",
-      "extreme-sports",
-      "action",
-      "adrenaline",
-      "slow-motion",
-      "athlete",
-    ],
   },
   {
     id: "music-video",
     nameZh: "音乐MV风",
     nameEn: "Music Video",
-    category: "music_entertainment",
+    category: "energy_music",
     dimensions: {
       visualTone: "neon_cyberpunk",
       cameraStyle: "dutch_angle",
@@ -747,21 +604,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "concert-stage",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f7d288e2-9d81-43b7-ae1b-1702a11686a8/video-f7d288e2.mp4",
-    tags: [
-      "energy-music",
-      "music",
-      "concert",
-      "stage",
-      "neon",
-      "performance",
-      "rhythm",
-    ],
   },
   {
     id: "surrealist-dream",
     nameZh: "超现实·梦境",
     nameEn: "Surrealist Dream",
-    category: "surreal_creative",
+    category: "art_creative",
     dimensions: {
       visualTone: "dreamy_pastel",
       cameraStyle: "slow_push_in",
@@ -774,20 +622,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "impossible-room",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b7b0d289-9e05-4f93-9795-d5d19263435c/video-b7b0d289.mp4",
-    tags: [
-      "art-creative",
-      "surreal",
-      "dream",
-      "impossible",
-      "dali",
-      "ethereal",
-    ],
   },
   {
     id: "ai-digital-art",
     nameZh: "AI·数字宇宙",
     nameEn: "AI Digital Universe",
-    category: "sci_fi_tech",
+    category: "art_creative",
     dimensions: {
       visualTone: "neon_cyberpunk",
       cameraStyle: "pov_firstperson",
@@ -800,21 +640,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "neural-network-viz",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/629cab0a-fead-4c9c-ac9b-d5ef6df0782f/video-629cab0a.mp4",
-    tags: [
-      "art-creative",
-      "ai",
-      "digital",
-      "neural-network",
-      "futuristic",
-      "code",
-      "tech",
-    ],
   },
   {
     id: "space-documentary",
     nameZh: "太空·宇宙探索",
     nameEn: "Space Documentary",
-    category: "sci_fi_tech",
+    category: "documentary",
     dimensions: {
       visualTone: "cold_desaturated",
       cameraStyle: "drone_aerial",
@@ -827,21 +658,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "astronaut-spacewalk",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/273d9673-9ed2-426b-8516-0102fbdd8622/video-273d9673.mp4",
-    tags: [
-      "documentary",
-      "space",
-      "cosmos",
-      "nasa",
-      "astronaut",
-      "epic",
-      "documentary",
-    ],
   },
   {
     id: "street-documentary",
     nameZh: "街头纪实·都市",
     nameEn: "Street Documentary",
-    category: "urban_social",
+    category: "documentary",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "handheld_raw",
@@ -854,21 +676,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "nyc-street-corner",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/54c271a6-d2da-4134-a812-679fd0fc8810/video-54c271a6.mp4",
-    tags: [
-      "documentary",
-      "street",
-      "nyc",
-      "urban",
-      "documentary",
-      "people",
-      "authentic",
-    ],
   },
   {
     id: "synthwave-retro",
     nameZh: "80s Synthwave·复古科技",
     nameEn: "Synthwave Retro",
-    category: "nostalgic",
+    category: "art_creative",
     dimensions: {
       visualTone: "neon_cyberpunk",
       cameraStyle: "steady_locked",
@@ -881,48 +694,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "neon-highway-night",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c227b1aa-7876-4fe3-8869-4d2b996d418f/video-c227b1aa.mp4",
-    tags: [
-      "art-creative",
-      "synthwave",
-      "80s",
-      "retro",
-      "neon",
-      "vhs",
-      "cyberpunk-nostalgic",
-    ],
-  },
-  {
-    id: "absurdist-comedy",
-    nameZh: "怪诞喜剧·冷面幽默",
-    nameEn: "Absurdist Comedy",
-    category: "surreal_creative",
-    dimensions: {
-      visualTone: "warm_natural",
-      cameraStyle: "handheld_raw",
-      editingPace: "fast_cut",
-      narrativeMode: "observational",
-      productionType: "live_action",
-      emotionalTone: "humorous_quirky",
-      styleReference: "absurdist_comedy",
-    },
-    scene: "mundane-surreal-office",
-    sampleVideoUrl:
-      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e93201b0-90d2-42f1-9db7-19441315c4bc/video-e93201b0.mp4",
-    tags: [
-      "art-creative",
-      "comedy",
-      "absurdist",
-      "quirky",
-      "deadpan",
-      "office",
-      "humor",
-    ],
   },
   {
     id: "magical-girl",
     nameZh: "魔法少女·粉彩变身",
     nameEn: "Magical Girl",
-    category: "anime_2d",
+    category: "anime",
     dimensions: {
       visualTone: "dreamy_pastel",
       cameraStyle: "slow_push_in",
@@ -935,20 +712,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "magical-girl-transform",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f0b7f984-4d85-432f-bf41-a53d89e262bd/video-f0b7f984.mp4",
-    tags: [
-      "anime-2d",
-      "anime",
-      "magical-girl",
-      "transformation",
-      "pastel",
-      "sparkle",
-    ],
   },
   {
     id: "shonen-battle",
     nameZh: "热血少年·觉醒爆发",
     nameEn: "Shonen Battle",
-    category: "anime_2d",
+    category: "anime",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "extreme_closeup",
@@ -961,21 +730,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "hero-power-awakening",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d07d39ed-d2fe-4bee-a148-501d96ead5a2/video-d07d39ed.mp4",
-    tags: [
-      "anime-2d",
-      "anime",
-      "shonen",
-      "battle",
-      "power-up",
-      "energy",
-      "hero",
-    ],
   },
   {
     id: "cyberpunk-anime",
     nameZh: "赛博朋克·动漫都市",
     nameEn: "Cyberpunk Anime",
-    category: "anime_2d",
+    category: "anime",
     dimensions: {
       visualTone: "neon_cyberpunk",
       cameraStyle: "dutch_angle",
@@ -988,21 +748,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "cyberpunk-hacker-alley",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e1cfe984-3bfc-4ba1-acb3-9b40b7b76771/video-e1cfe984.mp4",
-    tags: [
-      "anime-2d",
-      "anime",
-      "cyberpunk",
-      "neon",
-      "hacker",
-      "dystopian",
-      "futuristic",
-    ],
   },
   {
     id: "slice-of-life-anime",
     nameZh: "日常系·校园治愈",
     nameEn: "Slice of Life Anime",
-    category: "anime_2d",
+    category: "anime",
     dimensions: {
       visualTone: "warm_natural",
       cameraStyle: "slow_push_in",
@@ -1015,21 +766,12 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "school-summer-afternoon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a477b387-f156-4826-9112-3258fcaec339/video-a477b387.mp4",
-    tags: [
-      "anime-2d",
-      "anime",
-      "slice-of-life",
-      "school",
-      "healing",
-      "summer",
-      "friends",
-    ],
   },
   {
     id: "wuxia-anime",
     nameZh: "古风仙侠·国漫",
     nameEn: "Wuxia Anime",
-    category: "anime_2d",
+    category: "anime",
     dimensions: {
       visualTone: "cinematic",
       cameraStyle: "drone_aerial",
@@ -1042,15 +784,5 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "wuxia-sword-flight",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/939b77ca-c2f2-4379-abfa-1bb2a904288b/video-939b77ca.mp4",
-    tags: [
-      "anime-2d",
-      "anime",
-      "wuxia",
-      "chinese-animation",
-      "sword",
-      "ancient",
-      "epic",
-      "ink-wash",
-    ],
   },
 ];

--- a/turbo/packages/core/src/video-style-preset-items.ts
+++ b/turbo/packages/core/src/video-style-preset-items.ts
@@ -1,0 +1,812 @@
+export type VideoStyleCategory =
+  | "anime_2d"
+  | "art_culture"
+  | "classic_cinematic"
+  | "fashion_luxury"
+  | "lifestyle"
+  | "music_entertainment"
+  | "nostalgic"
+  | "product_brand"
+  | "sci_fi_tech"
+  | "sports_energy"
+  | "surreal_creative"
+  | "urban_social";
+
+export interface VideoStyleDimensions {
+  readonly visualTone: string;
+  readonly cameraStyle: string;
+  readonly editingPace: string;
+  readonly narrativeMode: string;
+  readonly productionType: string;
+  readonly emotionalTone: string;
+  readonly styleReference: string;
+}
+
+export interface VideoStylePreset {
+  readonly id: string;
+  readonly nameZh: string;
+  readonly nameEn: string;
+  readonly category: VideoStyleCategory;
+  readonly dimensions: VideoStyleDimensions;
+  readonly scene: string;
+  readonly sampleVideoUrl: string;
+  readonly tags: readonly string[];
+}
+
+export const VIDEO_DIMENSION_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  warm_natural: "soft, amber-toned naturalistic lighting",
+  dreamy_pastel: "soft pastel palette with ethereal haze",
+  cinematic: "high-contrast wide-format cinematic look",
+  neon_cyberpunk: "electric neon glow against dark urban backdrops",
+  muted_film_grain: "desaturated tones with visible film grain",
+  high_contrast_bw: "stark black-and-white high-contrast monochrome",
+  saturated_vivid: "punchy oversaturated color palette",
+  vintage_warm: "golden-tinted warm vintage color grading",
+  cool_blue: "cool-toned blue-grey cinematic palette",
+  ink_wash: "Chinese ink wash monochrome aesthetic",
+  flat_design: "flat minimalist graphic color palette",
+  digital_glitch: "digital artifacts, scan lines, glitch aesthetics",
+  anime_vibrant: "bright saturated anime-style color palette",
+  pastel_soft: "gentle pastel tones, soft diffused light",
+  earth_tones: "warm earthy browns, greens, ochres",
+  steady_locked: "perfectly still, symmetrically composed locked frame",
+  drone_aerial: "slow sweeping aerial drone shot",
+  handheld_raw: "slightly shaky authentic handheld camera feel",
+  dolly_smooth: "smooth cinematic dolly or slider movement",
+  extreme_closeup: "tight macro shots emphasizing texture and detail",
+  wide_establishing: "wide establishing shot, subjects small in environment",
+  tracking_shot: "camera follows subject in smooth tracking motion",
+  tilt_shift: "miniature effect with selective focus blur",
+  fixed_medium: "fixed medium shot, subjects fill the frame",
+  pov_firstperson: "immersive first-person point-of-view perspective",
+  orbit_360: "360-degree orbital camera movement around subject",
+  slow_meditative: "unhurried, contemplative long takes",
+  fast_cut: "rapid rhythmic cuts synced to music",
+  kinetic_energy: "high-energy quick cuts with motion blur",
+  rhythmic_moderate: "moderate pacing with rhythmic editorial flow",
+  jump_cut: "jump cuts creating energetic discontinuity",
+  continuous_take: "long uninterrupted single-take sequence",
+  montage_flow: "seamless montage with thematic flow",
+  observational:
+    "passive cinematic observation, no narrator, let visuals speak",
+  voiceover_driven: "narrative driven by off-screen voice or text",
+  character_driven: "story told through character reactions and behavior",
+  product_showcase: "direct showcase of product features and details",
+  documentary_interview: "talking-head interview style documentary",
+  abstract_visual: "pure visual storytelling without literal narrative",
+  tutorial_guide: "step-by-step instructional or how-to format",
+  live_action: "real-world live-action footage",
+  "2d_animation": "hand-drawn or digital 2D animation",
+  "3d_cgi": "computer-generated 3D imagery",
+  stop_motion: "frame-by-frame stop-motion animation",
+  mixed_media: "combination of live action and animation",
+  screen_capture: "digital screen recording or UI demonstration",
+  warm_nostalgic: "evokes comfort, memory, and warm nostalgia",
+  epic_grand: "sweeping, awe-inspiring, grand emotional scale",
+  playful_fun: "lighthearted, joyful, playful energy",
+  inspiring: "motivational, uplifting, aspirational feeling",
+  melancholic: "bittersweet longing, poetic sadness",
+  serene_calm: "peaceful, meditative, tranquil atmosphere",
+  euphoric_energy: "high-energy excitement and euphoric rush",
+  mysterious: "enigmatic tension and atmospheric intrigue",
+  cozy_intimate: "warm, close, domestic intimacy",
+  wonder_awe: "childlike wonder and sense of discovery",
+  intense_dramatic: "high-stakes emotional intensity",
+  whimsical: "quirky, imaginative, fairy-tale whimsy",
+  symmetrical_pastel_quirky:
+    "Wes Anderson-esque deadpan symmetry with pastel palette",
+  imax_epic_cinematic: "IMAX-scale epic with sweeping aerial scope",
+  slowburn_moody_romance:
+    "slow-burn atmospheric romance in the manner of arthouse cinema",
+  indie_naturalistic:
+    "indie naturalistic — raw handheld authenticity, available light",
+  film_noir: "classic film noir — shadow, silhouette, moral ambiguity",
+  tech_minimalist_reveal:
+    "clean tech product reveal — white space, precision camera",
+  athletic_motivation_ad:
+    "athletic motivation ad — kinetic energy, raw sweat, triumph",
+  nature_documentary:
+    "nature documentary — patient observation, macro detail, vast scale",
+  shortform_viral:
+    "short-form viral — fast hook, trending audio, authentic creator energy",
+  hand_drawn_fantasy_anime:
+    "hand-drawn fantasy anime — lush painterly backgrounds, expressive characters",
+  chinese_ink_art:
+    "Chinese ink wash — brushstroke elegance, negative space, classical poetry",
+  pop_art: "pop art — bold flat colors, comic dots, graphic impact",
+  japanese_wabi_sabi:
+    "Japanese wabi-sabi — imperfection, aging, quiet beauty in impermanence",
+  european_romance:
+    "European arthouse romance — long glances, muted palettes, urban poetry",
+  gourmet_documentary:
+    "sensory-focused culinary documentary — texture, steam, artisan craft",
+  fashion_editorial:
+    "high fashion editorial — dramatic silhouettes, luxury materials",
+  summer_indie:
+    "golden hour indie summer — carefree golden light, handheld spontaneity",
+  super8_home_film:
+    "Super 8 home film — light leaks, dust grain, family nostalgia",
+  cottagecore:
+    "cottagecore pastoral — wildflower light, linen textures, rural idyll",
+  wellness_yoga:
+    "wellness lifestyle — clean white space, breath, mindful movement",
+  diy_maker:
+    "DIY maker — hands-on craft, workshop grit, creative problem-solving",
+  extreme_sports_ad:
+    "extreme sports ad — first-person rush, natural terrain, peak performance",
+  music_video_narrative:
+    "music video narrative — choreography, color story, artist performance",
+  surrealist_dream:
+    "surrealist dream — impossible gravity, melting forms, subconscious logic",
+  ai_digital_art:
+    "AI generative art — morphing geometry, luminous particles, data aesthetics",
+  space_documentary:
+    "space documentary — cosmic scale, hard science, human wonder",
+  street_documentary:
+    "street documentary — city pulse, candid portraits, social texture",
+  synthwave_retro:
+    "80s synthwave retro — grid horizons, neon glow, nostalgic retrofuturism",
+  absurdist_comedy:
+    "absurdist comedy — deadpan escalation, mundane surrealism, dry British wit",
+  magical_girl_anime:
+    "magical girl anime — sparkle transforms, friendship bonds, bright courage",
+  shonen_battle_anime:
+    "shonen battle anime — power-up determination, training montages, triumph",
+  cyberpunk_anime:
+    "cyberpunk anime — neon megacity, tech-augmented characters, dystopian beauty",
+  slice_of_life_anime:
+    "slice-of-life anime — everyday moments, soft season light, quiet emotion",
+  wuxia_anime:
+    "wuxia anime — wire-fu elegance, bamboo forests, honor and mastery",
+};
+
+export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
+  {
+    id: "symmetrical-pastel-quirky",
+    nameZh: "对称粉彩·怪诞优雅",
+    nameEn: "Symmetrical Pastel Quirky",
+    category: "classic_cinematic",
+    dimensions: {
+      visualTone: "dreamy_pastel",
+      cameraStyle: "steady_locked",
+      editingPace: "slow_meditative",
+      narrativeMode: "voiceover_driven",
+      productionType: "live_action",
+      emotionalTone: "playful_fun",
+      styleReference: "symmetrical_pastel_quirky",
+    },
+    scene: "grand-hotel-lobby",
+    sampleVideoUrl: "",
+    tags: ["quirky", "pastel", "symmetry", "deadpan", "retro"],
+  },
+  {
+    id: "imax-epic-cinematic",
+    nameZh: "史诗叙事·宏大电影",
+    nameEn: "IMAX Epic Cinematic",
+    category: "classic_cinematic",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "drone_aerial",
+      editingPace: "slow_meditative",
+      narrativeMode: "voiceover_driven",
+      productionType: "live_action",
+      emotionalTone: "epic_grand",
+      styleReference: "imax_epic_cinematic",
+    },
+    scene: "mountain-horizon",
+    sampleVideoUrl: "",
+    tags: ["epic", "imax", "dramatic", "cinematic", "grand"],
+  },
+  {
+    id: "slowburn-moody-romance",
+    nameZh: "情绪诗意·慢燃暖光",
+    nameEn: "Slow Burn Moody Romance",
+    category: "classic_cinematic",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "handheld_raw",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "melancholic",
+      styleReference: "slowburn_moody_romance",
+    },
+    scene: "rain-on-window",
+    sampleVideoUrl: "",
+    tags: ["moody", "romance", "handheld", "nostalgic", "atmospheric"],
+  },
+  {
+    id: "indie-naturalistic",
+    nameZh: "文艺独立·自然光",
+    nameEn: "Indie Naturalistic",
+    category: "classic_cinematic",
+    dimensions: {
+      visualTone: "cold_desaturated",
+      cameraStyle: "handheld_raw",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "melancholic",
+      styleReference: "indie_naturalistic",
+    },
+    scene: "forest-clearing",
+    sampleVideoUrl: "",
+    tags: ["indie", "arthouse", "naturalistic", "quiet", "character-driven"],
+  },
+  {
+    id: "film-noir",
+    nameZh: "黑白悬疑·Film Noir",
+    nameEn: "Film Noir",
+    category: "classic_cinematic",
+    dimensions: {
+      visualTone: "cold_desaturated",
+      cameraStyle: "steady_locked",
+      editingPace: "slow_meditative",
+      narrativeMode: "voiceover_driven",
+      productionType: "live_action",
+      emotionalTone: "melancholic",
+      styleReference: "film_noir",
+    },
+    scene: "rain-on-window",
+    sampleVideoUrl: "",
+    tags: ["noir", "black-white", "mystery", "shadows", "1950s"],
+  },
+  {
+    id: "tech-minimalist-reveal",
+    nameZh: "极简科技·产品展示",
+    nameEn: "Tech Minimalist Reveal",
+    category: "product_brand",
+    dimensions: {
+      visualTone: "cold_desaturated",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "abstract_mood",
+      productionType: "live_action",
+      emotionalTone: "inspiring",
+      styleReference: "tech_minimalist_reveal",
+    },
+    scene: "laptop-open",
+    sampleVideoUrl: "",
+    tags: ["minimalist", "product", "tech", "clean", "white"],
+  },
+  {
+    id: "athletic-motivation",
+    nameZh: "运动励志·广告风",
+    nameEn: "Athletic Motivation Ad",
+    category: "sports_energy",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "extreme_closeup",
+      editingPace: "fast_cut",
+      narrativeMode: "linear_story",
+      productionType: "live_action",
+      emotionalTone: "inspiring",
+      styleReference: "athletic_motivation_ad",
+    },
+    scene: "extreme-sports",
+    sampleVideoUrl: "",
+    tags: ["sports", "motivation", "fast", "energy", "ad"],
+  },
+  {
+    id: "nature-documentary",
+    nameZh: "自然纪录·BBC风",
+    nameEn: "Nature Documentary",
+    category: "sci_fi_tech",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "drone_aerial",
+      editingPace: "slow_meditative",
+      narrativeMode: "voiceover_driven",
+      productionType: "live_action",
+      emotionalTone: "calm_meditative",
+      styleReference: "nature_documentary",
+    },
+    scene: "mountain-horizon",
+    sampleVideoUrl: "",
+    tags: ["nature", "documentary", "wildlife", "slow", "cinematic"],
+  },
+  {
+    id: "shortform-viral",
+    nameZh: "短视频·病毒传播",
+    nameEn: "Shortform Viral",
+    category: "urban_social",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "handheld_raw",
+      editingPace: "fast_cut",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "playful_fun",
+      styleReference: "shortform_viral",
+    },
+    scene: "summer-beach-crew",
+    sampleVideoUrl: "",
+    tags: ["viral", "shortform", "trending", "fast", "social"],
+  },
+  {
+    id: "hand-drawn-fantasy-anime",
+    nameZh: "手绘奇幻·动漫美学",
+    nameEn: "Hand Drawn Fantasy Anime",
+    category: "anime_2d",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "linear_story",
+      productionType: "2d_animation",
+      emotionalTone: "playful_fun",
+      styleReference: "hand_drawn_fantasy_anime",
+    },
+    scene: "forest-spirit-path",
+    sampleVideoUrl: "",
+    tags: ["anime", "hand-drawn", "fantasy", "nature", "whimsical"],
+  },
+  {
+    id: "chinese-ink-art",
+    nameZh: "水墨·东方禅意",
+    nameEn: "Chinese Ink Painting",
+    category: "art_culture",
+    dimensions: {
+      visualTone: "cold_desaturated",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "abstract_mood",
+      productionType: "live_action",
+      emotionalTone: "calm_meditative",
+      styleReference: "chinese_ink",
+    },
+    scene: "mountain-horizon",
+    sampleVideoUrl: "",
+    tags: ["ink", "chinese", "zen", "minimalist", "eastern"],
+  },
+  {
+    id: "pop-art",
+    nameZh: "波普·安迪沃霍尔风",
+    nameEn: "Pop Art",
+    category: "art_culture",
+    dimensions: {
+      visualTone: "neon_cyberpunk",
+      cameraStyle: "steady_locked",
+      editingPace: "fast_cut",
+      narrativeMode: "abstract_mood",
+      productionType: "live_action",
+      emotionalTone: "playful_fun",
+      styleReference: "pop_art",
+    },
+    scene: "abstract-color-burst",
+    sampleVideoUrl: "",
+    tags: ["pop-art", "bold", "colorful", "graphic", "retro"],
+  },
+  {
+    id: "japanese-wabi-sabi",
+    nameZh: "日系·小清新",
+    nameEn: "Japanese Wabi-Sabi",
+    category: "art_culture",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "calm_meditative",
+      styleReference: "japanese_wabi_sabi",
+    },
+    scene: "tokyo-alley-morning",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f06bf43d-4820-466f-bc1d-716dec01e3cc/video-f06bf43d.mp4",
+    tags: ["japanese", "wabi-sabi", "calm", "everyday", "aesthetic"],
+  },
+  {
+    id: "european-romance",
+    nameZh: "欧洲·古典浪漫",
+    nameEn: "European Classical Romance",
+    category: "art_culture",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "steady_locked",
+      editingPace: "slow_meditative",
+      narrativeMode: "voiceover_driven",
+      productionType: "live_action",
+      emotionalTone: "warm_nostalgic",
+      styleReference: "european_romance",
+    },
+    scene: "castle-garden-dusk",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8ea3c41f-8e80-4c70-aae6-a492b9eb264e/video-8ea3c41f.mp4",
+    tags: ["europe", "romance", "castle", "golden-hour", "elegant"],
+  },
+  {
+    id: "gourmet-documentary",
+    nameZh: "美食纪录·感官系",
+    nameEn: "Gourmet Documentary",
+    category: "lifestyle",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "extreme_closeup",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "warm_nostalgic",
+      styleReference: "gourmet_documentary",
+    },
+    scene: "food-plating",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3f0dd8d7-bfc3-4443-9b95-b58faf0d4f64/video-3f0dd8d7.mp4",
+    tags: ["food", "macro", "sensory", "chef", "documentary"],
+  },
+  {
+    id: "fashion-editorial",
+    nameZh: "奢侈品·时尚大片",
+    nameEn: "Fashion Editorial",
+    category: "fashion_luxury",
+    dimensions: {
+      visualTone: "cold_desaturated",
+      cameraStyle: "steady_locked",
+      editingPace: "slow_meditative",
+      narrativeMode: "abstract_mood",
+      productionType: "live_action",
+      emotionalTone: "epic_grand",
+      styleReference: "fashion_editorial",
+    },
+    scene: "model-editorial",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6024a53b-fe0c-45dc-b5df-0ae14ad883ed/video-6024a53b.mp4",
+    tags: ["fashion", "luxury", "editorial", "high-contrast", "model"],
+  },
+  {
+    id: "summer-indie",
+    nameZh: "夏日·清新活力",
+    nameEn: "Summer Indie",
+    category: "lifestyle",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "handheld_raw",
+      editingPace: "fast_cut",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "playful_fun",
+      styleReference: "summer_indie",
+    },
+    scene: "summer-beach-crew",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3d44e690-d838-49c6-89f8-946bcffee10b/video-3d44e690.mp4",
+    tags: ["summer", "beach", "youth", "vibrant", "friends"],
+  },
+  {
+    id: "super8-home-film",
+    nameZh: "复古暖调·70s胶片",
+    nameEn: "Super 8 Home Film",
+    category: "nostalgic",
+    dimensions: {
+      visualTone: "vintage_film",
+      cameraStyle: "handheld_raw",
+      editingPace: "slow_meditative",
+      narrativeMode: "voiceover_driven",
+      productionType: "live_action",
+      emotionalTone: "warm_nostalgic",
+      styleReference: "super8_home_film",
+    },
+    scene: "family-backyard-70s",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/29ddb4de-8aef-42a7-aac4-ee013c9272a5/video-29ddb4de.mp4",
+    tags: ["retro", "70s", "super8", "family", "nostalgic", "film-grain"],
+  },
+  {
+    id: "cottagecore",
+    nameZh: "Cottagecore 田园乡村",
+    nameEn: "Cottagecore",
+    category: "lifestyle",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "warm_nostalgic",
+      styleReference: "cottagecore",
+    },
+    scene: "cottage-garden-morning",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c28fd30a-d735-4c67-97d4-0567fd375a8d/video-c28fd30a.mp4",
+    tags: [
+      "cottagecore",
+      "garden",
+      "handmade",
+      "nature",
+      "cozy",
+      "slow-living",
+    ],
+  },
+  {
+    id: "wellness-yoga",
+    nameZh: "Wellness 瑜伽冥想",
+    nameEn: "Wellness & Yoga",
+    category: "lifestyle",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "calm_meditative",
+      styleReference: "wellness_yoga",
+    },
+    scene: "yoga-sunrise-studio",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b629a3f5-c644-4d96-81f5-834fe1a31da1/video-b629a3f5.mp4",
+    tags: ["wellness", "yoga", "meditation", "mindfulness", "morning", "calm"],
+  },
+  {
+    id: "diy-maker",
+    nameZh: "DIY Maker 手作文化",
+    nameEn: "DIY Maker Culture",
+    category: "lifestyle",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "extreme_closeup",
+      editingPace: "rhythmic_beat",
+      narrativeMode: "linear_story",
+      productionType: "live_action",
+      emotionalTone: "inspiring",
+      styleReference: "diy_maker",
+    },
+    scene: "workshop-maker-build",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/76c1cf86-cb76-4a9b-817f-15597bcc8481/video-76c1cf86.mp4",
+    tags: ["diy", "maker", "craft", "woodwork", "handmade", "satisfying"],
+  },
+  {
+    id: "extreme-sports",
+    nameZh: "运动·高燃热血",
+    nameEn: "Extreme Sports Ad",
+    category: "sports_energy",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "extreme_closeup",
+      editingPace: "rhythmic_beat",
+      narrativeMode: "linear_story",
+      productionType: "live_action",
+      emotionalTone: "inspiring",
+      styleReference: "extreme_sports_ad",
+    },
+    scene: "extreme-sports",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/305b6781-280a-4f07-927a-1191bd8ece9b/video-305b6781.mp4",
+    tags: ["extreme-sports", "action", "adrenaline", "slow-motion", "athlete"],
+  },
+  {
+    id: "music-video",
+    nameZh: "音乐MV风",
+    nameEn: "Music Video",
+    category: "music_entertainment",
+    dimensions: {
+      visualTone: "neon_cyberpunk",
+      cameraStyle: "dutch_angle",
+      editingPace: "rhythmic_beat",
+      narrativeMode: "abstract_mood",
+      productionType: "live_action",
+      emotionalTone: "playful_fun",
+      styleReference: "music_video_mv",
+    },
+    scene: "concert-stage",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f7d288e2-9d81-43b7-ae1b-1702a11686a8/video-f7d288e2.mp4",
+    tags: ["music", "concert", "stage", "neon", "performance", "rhythm"],
+  },
+  {
+    id: "surrealist-dream",
+    nameZh: "超现实·梦境",
+    nameEn: "Surrealist Dream",
+    category: "surreal_creative",
+    dimensions: {
+      visualTone: "dreamy_pastel",
+      cameraStyle: "slow_push_in",
+      editingPace: "seamless_flow",
+      narrativeMode: "abstract_mood",
+      productionType: "mixed_media",
+      emotionalTone: "melancholic",
+      styleReference: "surrealist_dream",
+    },
+    scene: "impossible-room",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b7b0d289-9e05-4f93-9795-d5d19263435c/video-b7b0d289.mp4",
+    tags: ["surreal", "dream", "impossible", "dali", "ethereal"],
+  },
+  {
+    id: "ai-digital-art",
+    nameZh: "AI·数字宇宙",
+    nameEn: "AI Digital Universe",
+    category: "sci_fi_tech",
+    dimensions: {
+      visualTone: "neon_cyberpunk",
+      cameraStyle: "pov_firstperson",
+      editingPace: "fast_cut",
+      narrativeMode: "abstract_mood",
+      productionType: "3d_cgi",
+      emotionalTone: "inspiring",
+      styleReference: "ai_digital_art",
+    },
+    scene: "neural-network-viz",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/629cab0a-fead-4c9c-ac9b-d5ef6df0782f/video-629cab0a.mp4",
+    tags: ["ai", "digital", "neural-network", "futuristic", "code", "tech"],
+  },
+  {
+    id: "space-documentary",
+    nameZh: "太空·宇宙探索",
+    nameEn: "Space Documentary",
+    category: "sci_fi_tech",
+    dimensions: {
+      visualTone: "cold_desaturated",
+      cameraStyle: "drone_aerial",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "epic_grand",
+      styleReference: "space_documentary",
+    },
+    scene: "astronaut-spacewalk",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/273d9673-9ed2-426b-8516-0102fbdd8622/video-273d9673.mp4",
+    tags: ["space", "cosmos", "nasa", "astronaut", "epic", "documentary"],
+  },
+  {
+    id: "street-documentary",
+    nameZh: "街头纪实·都市",
+    nameEn: "Street Documentary",
+    category: "urban_social",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "handheld_raw",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "melancholic",
+      styleReference: "street_documentary",
+    },
+    scene: "nyc-street-corner",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/54c271a6-d2da-4134-a812-679fd0fc8810/video-54c271a6.mp4",
+    tags: ["street", "nyc", "urban", "documentary", "people", "authentic"],
+  },
+  {
+    id: "synthwave-retro",
+    nameZh: "80s Synthwave·复古科技",
+    nameEn: "Synthwave Retro",
+    category: "nostalgic",
+    dimensions: {
+      visualTone: "neon_cyberpunk",
+      cameraStyle: "steady_locked",
+      editingPace: "rhythmic_beat",
+      narrativeMode: "abstract_mood",
+      productionType: "live_action",
+      emotionalTone: "warm_nostalgic",
+      styleReference: "synthwave_retro",
+    },
+    scene: "neon-highway-night",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c227b1aa-7876-4fe3-8869-4d2b996d418f/video-c227b1aa.mp4",
+    tags: ["synthwave", "80s", "retro", "neon", "vhs", "cyberpunk-nostalgic"],
+  },
+  {
+    id: "absurdist-comedy",
+    nameZh: "怪诞喜剧·冷面幽默",
+    nameEn: "Absurdist Comedy",
+    category: "surreal_creative",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "handheld_raw",
+      editingPace: "fast_cut",
+      narrativeMode: "observational",
+      productionType: "live_action",
+      emotionalTone: "humorous_quirky",
+      styleReference: "absurdist_comedy",
+    },
+    scene: "mundane-surreal-office",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e93201b0-90d2-42f1-9db7-19441315c4bc/video-e93201b0.mp4",
+    tags: ["comedy", "absurdist", "quirky", "deadpan", "office", "humor"],
+  },
+  {
+    id: "magical-girl",
+    nameZh: "魔法少女·粉彩变身",
+    nameEn: "Magical Girl",
+    category: "anime_2d",
+    dimensions: {
+      visualTone: "dreamy_pastel",
+      cameraStyle: "slow_push_in",
+      editingPace: "seamless_flow",
+      narrativeMode: "linear_story",
+      productionType: "2d_animation",
+      emotionalTone: "playful_fun",
+      styleReference: "magical_girl",
+    },
+    scene: "magical-girl-transform",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f0b7f984-4d85-432f-bf41-a53d89e262bd/video-f0b7f984.mp4",
+    tags: ["anime", "magical-girl", "transformation", "pastel", "sparkle"],
+  },
+  {
+    id: "shonen-battle",
+    nameZh: "热血少年·觉醒爆发",
+    nameEn: "Shonen Battle",
+    category: "anime_2d",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "extreme_closeup",
+      editingPace: "rhythmic_beat",
+      narrativeMode: "linear_story",
+      productionType: "2d_animation",
+      emotionalTone: "inspiring",
+      styleReference: "shonen_battle",
+    },
+    scene: "hero-power-awakening",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d07d39ed-d2fe-4bee-a148-501d96ead5a2/video-d07d39ed.mp4",
+    tags: ["anime", "shonen", "battle", "power-up", "energy", "hero"],
+  },
+  {
+    id: "cyberpunk-anime",
+    nameZh: "赛博朋克·动漫都市",
+    nameEn: "Cyberpunk Anime",
+    category: "anime_2d",
+    dimensions: {
+      visualTone: "neon_cyberpunk",
+      cameraStyle: "dutch_angle",
+      editingPace: "fast_cut",
+      narrativeMode: "abstract_mood",
+      productionType: "2d_animation",
+      emotionalTone: "melancholic",
+      styleReference: "cyberpunk_anime",
+    },
+    scene: "cyberpunk-hacker-alley",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e1cfe984-3bfc-4ba1-acb3-9b40b7b76771/video-e1cfe984.mp4",
+    tags: ["cyberpunk", "anime", "neon", "hacker", "dystopian", "futuristic"],
+  },
+  {
+    id: "slice-of-life-anime",
+    nameZh: "日常系·校园治愈",
+    nameEn: "Slice of Life Anime",
+    category: "anime_2d",
+    dimensions: {
+      visualTone: "warm_natural",
+      cameraStyle: "slow_push_in",
+      editingPace: "slow_meditative",
+      narrativeMode: "observational",
+      productionType: "2d_animation",
+      emotionalTone: "playful_fun",
+      styleReference: "slice_of_life_anime",
+    },
+    scene: "school-summer-afternoon",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a477b387-f156-4826-9112-3258fcaec339/video-a477b387.mp4",
+    tags: ["anime", "slice-of-life", "school", "healing", "summer", "friends"],
+  },
+  {
+    id: "wuxia-anime",
+    nameZh: "古风仙侠·国漫",
+    nameEn: "Wuxia Anime",
+    category: "anime_2d",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "drone_aerial",
+      editingPace: "seamless_flow",
+      narrativeMode: "linear_story",
+      productionType: "2d_animation",
+      emotionalTone: "epic_grand",
+      styleReference: "wuxia_anime",
+    },
+    scene: "wuxia-sword-flight",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/939b77ca-c2f2-4379-abfa-1bb2a904288b/video-939b77ca.mp4",
+    tags: [
+      "wuxia",
+      "chinese-animation",
+      "sword",
+      "ancient",
+      "epic",
+      "ink-wash",
+    ],
+  },
+];

--- a/turbo/packages/core/src/video-style-preset-items.ts
+++ b/turbo/packages/core/src/video-style-preset-items.ts
@@ -12,6 +12,26 @@ export type VideoStyleCategory =
   | "surreal_creative"
   | "urban_social";
 
+export type VideoStyleGroupTag =
+  | "brand-product"
+  | "story-emotion"
+  | "energy-sports"
+  | "fantasy-art"
+  | "anime-2d";
+
+export interface VideoStyleGroup {
+  readonly tag: VideoStyleGroupTag;
+  readonly label: string;
+}
+
+export const VIDEO_STYLE_GROUPS: readonly VideoStyleGroup[] = [
+  { tag: "brand-product", label: "Brand & Product" },
+  { tag: "story-emotion", label: "Story & Emotion" },
+  { tag: "energy-sports", label: "Energy & Sports" },
+  { tag: "fantasy-art", label: "Fantasy & Art" },
+  { tag: "anime-2d", label: "Anime" },
+];
+
 export interface VideoStyleDimensions {
   readonly visualTone: string;
   readonly cameraStyle: string;
@@ -63,6 +83,7 @@ export const VIDEO_DIMENSION_DESCRIPTIONS: Readonly<Record<string, string>> = {
   slow_meditative: "unhurried, contemplative long takes",
   fast_cut: "rapid rhythmic cuts synced to music",
   kinetic_energy: "high-energy quick cuts with motion blur",
+  rhythmic_beat: "paced to a steady rhythmic beat with polished reveal moments",
   rhythmic_moderate: "moderate pacing with rhythmic editorial flow",
   jump_cut: "jump cuts creating energetic discontinuity",
   continuous_take: "long uninterrupted single-take sequence",
@@ -71,6 +92,8 @@ export const VIDEO_DIMENSION_DESCRIPTIONS: Readonly<Record<string, string>> = {
     "passive cinematic observation, no narrator, let visuals speak",
   voiceover_driven: "narrative driven by off-screen voice or text",
   character_driven: "story told through character reactions and behavior",
+  problem_solution:
+    "problem-solution structure that reveals a product as the answer",
   product_showcase: "direct showcase of product features and details",
   documentary_interview: "talking-head interview style documentary",
   abstract_visual: "pure visual storytelling without literal narrative",
@@ -103,6 +126,8 @@ export const VIDEO_DIMENSION_DESCRIPTIONS: Readonly<Record<string, string>> = {
   film_noir: "classic film noir — shadow, silhouette, moral ambiguity",
   tech_minimalist_reveal:
     "clean tech product reveal — white space, precision camera",
+  apple_product:
+    "Apple-style product commercial — premium materials, restrained motion, precise lighting",
   athletic_motivation_ad:
     "athletic motivation ad — kinetic energy, raw sweat, triumph",
   nature_documentary:
@@ -177,7 +202,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "grand-hotel-lobby",
     sampleVideoUrl: "",
-    tags: ["quirky", "pastel", "symmetry", "deadpan", "retro"],
+    tags: ["story-emotion", "quirky", "pastel", "symmetry", "deadpan", "retro"],
   },
   {
     id: "imax-epic-cinematic",
@@ -195,7 +220,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "mountain-horizon",
     sampleVideoUrl: "",
-    tags: ["epic", "imax", "dramatic", "cinematic", "grand"],
+    tags: ["story-emotion", "epic", "imax", "dramatic", "cinematic", "grand"],
   },
   {
     id: "slowburn-moody-romance",
@@ -213,7 +238,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "rain-on-window",
     sampleVideoUrl: "",
-    tags: ["moody", "romance", "handheld", "nostalgic", "atmospheric"],
+    tags: [
+      "story-emotion",
+      "moody",
+      "romance",
+      "handheld",
+      "nostalgic",
+      "atmospheric",
+    ],
   },
   {
     id: "indie-naturalistic",
@@ -231,7 +263,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "forest-clearing",
     sampleVideoUrl: "",
-    tags: ["indie", "arthouse", "naturalistic", "quiet", "character-driven"],
+    tags: [
+      "story-emotion",
+      "indie",
+      "arthouse",
+      "naturalistic",
+      "quiet",
+      "character-driven",
+    ],
   },
   {
     id: "film-noir",
@@ -249,7 +288,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "rain-on-window",
     sampleVideoUrl: "",
-    tags: ["noir", "black-white", "mystery", "shadows", "1950s"],
+    tags: [
+      "story-emotion",
+      "noir",
+      "black-white",
+      "mystery",
+      "shadows",
+      "1950s",
+    ],
   },
   {
     id: "tech-minimalist-reveal",
@@ -267,7 +313,34 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "laptop-open",
     sampleVideoUrl: "",
-    tags: ["minimalist", "product", "tech", "clean", "white"],
+    tags: ["brand-product", "minimalist", "product", "tech", "clean", "white"],
+  },
+  {
+    id: "luxury-watch-product",
+    nameZh: "Luxury Watch Product",
+    nameEn: "Luxury Watch Product",
+    category: "product_brand",
+    dimensions: {
+      visualTone: "cinematic",
+      cameraStyle: "steady_locked",
+      editingPace: "rhythmic_beat",
+      narrativeMode: "problem_solution",
+      productionType: "live_action",
+      emotionalTone: "inspiring",
+      styleReference: "apple_product",
+    },
+    scene: "luxury-watch-dial",
+    sampleVideoUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/9e20abbb-a630-4523-857f-8350eba2ea4f/video-9e20abbb.mp4",
+    tags: [
+      "brand-product",
+      "product",
+      "watch",
+      "luxury",
+      "mechanical-watch",
+      "apple-product",
+      "cinematic",
+    ],
   },
   {
     id: "athletic-motivation",
@@ -285,7 +358,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "extreme-sports",
     sampleVideoUrl: "",
-    tags: ["sports", "motivation", "fast", "energy", "ad"],
+    tags: ["energy-sports", "sports", "motivation", "fast", "energy", "ad"],
   },
   {
     id: "nature-documentary",
@@ -303,7 +376,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "mountain-horizon",
     sampleVideoUrl: "",
-    tags: ["nature", "documentary", "wildlife", "slow", "cinematic"],
+    tags: [
+      "story-emotion",
+      "nature",
+      "documentary",
+      "wildlife",
+      "slow",
+      "cinematic",
+    ],
   },
   {
     id: "shortform-viral",
@@ -321,7 +401,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "summer-beach-crew",
     sampleVideoUrl: "",
-    tags: ["viral", "shortform", "trending", "fast", "social"],
+    tags: ["energy-sports", "viral", "shortform", "trending", "fast", "social"],
   },
   {
     id: "hand-drawn-fantasy-anime",
@@ -339,7 +419,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "forest-spirit-path",
     sampleVideoUrl: "",
-    tags: ["anime", "hand-drawn", "fantasy", "nature", "whimsical"],
+    tags: [
+      "fantasy-art",
+      "anime",
+      "hand-drawn",
+      "fantasy",
+      "nature",
+      "whimsical",
+    ],
   },
   {
     id: "chinese-ink-art",
@@ -357,7 +444,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "mountain-horizon",
     sampleVideoUrl: "",
-    tags: ["ink", "chinese", "zen", "minimalist", "eastern"],
+    tags: ["fantasy-art", "ink", "chinese", "zen", "minimalist", "eastern"],
   },
   {
     id: "pop-art",
@@ -375,7 +462,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     },
     scene: "abstract-color-burst",
     sampleVideoUrl: "",
-    tags: ["pop-art", "bold", "colorful", "graphic", "retro"],
+    tags: ["fantasy-art", "pop-art", "bold", "colorful", "graphic", "retro"],
   },
   {
     id: "japanese-wabi-sabi",
@@ -394,7 +481,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "tokyo-alley-morning",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f06bf43d-4820-466f-bc1d-716dec01e3cc/video-f06bf43d.mp4",
-    tags: ["japanese", "wabi-sabi", "calm", "everyday", "aesthetic"],
+    tags: [
+      "story-emotion",
+      "japanese",
+      "wabi-sabi",
+      "calm",
+      "everyday",
+      "aesthetic",
+    ],
   },
   {
     id: "european-romance",
@@ -413,7 +507,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "castle-garden-dusk",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8ea3c41f-8e80-4c70-aae6-a492b9eb264e/video-8ea3c41f.mp4",
-    tags: ["europe", "romance", "castle", "golden-hour", "elegant"],
+    tags: [
+      "story-emotion",
+      "europe",
+      "romance",
+      "castle",
+      "golden-hour",
+      "elegant",
+    ],
   },
   {
     id: "gourmet-documentary",
@@ -432,7 +533,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "food-plating",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3f0dd8d7-bfc3-4443-9b95-b58faf0d4f64/video-3f0dd8d7.mp4",
-    tags: ["food", "macro", "sensory", "chef", "documentary"],
+    tags: ["brand-product", "food", "macro", "sensory", "chef", "documentary"],
   },
   {
     id: "fashion-editorial",
@@ -451,7 +552,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "model-editorial",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6024a53b-fe0c-45dc-b5df-0ae14ad883ed/video-6024a53b.mp4",
-    tags: ["fashion", "luxury", "editorial", "high-contrast", "model"],
+    tags: [
+      "brand-product",
+      "fashion",
+      "luxury",
+      "editorial",
+      "high-contrast",
+      "model",
+    ],
   },
   {
     id: "summer-indie",
@@ -470,7 +578,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "summer-beach-crew",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3d44e690-d838-49c6-89f8-946bcffee10b/video-3d44e690.mp4",
-    tags: ["summer", "beach", "youth", "vibrant", "friends"],
+    tags: ["energy-sports", "summer", "beach", "youth", "vibrant", "friends"],
   },
   {
     id: "super8-home-film",
@@ -489,7 +597,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "family-backyard-70s",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/29ddb4de-8aef-42a7-aac4-ee013c9272a5/video-29ddb4de.mp4",
-    tags: ["retro", "70s", "super8", "family", "nostalgic", "film-grain"],
+    tags: [
+      "story-emotion",
+      "retro",
+      "70s",
+      "super8",
+      "family",
+      "nostalgic",
+      "film-grain",
+    ],
   },
   {
     id: "cottagecore",
@@ -509,6 +625,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c28fd30a-d735-4c67-97d4-0567fd375a8d/video-c28fd30a.mp4",
     tags: [
+      "story-emotion",
       "cottagecore",
       "garden",
       "handmade",
@@ -534,7 +651,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "yoga-sunrise-studio",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b629a3f5-c644-4d96-81f5-834fe1a31da1/video-b629a3f5.mp4",
-    tags: ["wellness", "yoga", "meditation", "mindfulness", "morning", "calm"],
+    tags: [
+      "brand-product",
+      "wellness",
+      "yoga",
+      "meditation",
+      "mindfulness",
+      "morning",
+      "calm",
+    ],
   },
   {
     id: "diy-maker",
@@ -553,7 +678,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "workshop-maker-build",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/76c1cf86-cb76-4a9b-817f-15597bcc8481/video-76c1cf86.mp4",
-    tags: ["diy", "maker", "craft", "woodwork", "handmade", "satisfying"],
+    tags: [
+      "brand-product",
+      "diy",
+      "maker",
+      "craft",
+      "woodwork",
+      "handmade",
+      "satisfying",
+    ],
   },
   {
     id: "extreme-sports",
@@ -572,7 +705,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "extreme-sports",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/305b6781-280a-4f07-927a-1191bd8ece9b/video-305b6781.mp4",
-    tags: ["extreme-sports", "action", "adrenaline", "slow-motion", "athlete"],
+    tags: [
+      "energy-sports",
+      "extreme-sports",
+      "action",
+      "adrenaline",
+      "slow-motion",
+      "athlete",
+    ],
   },
   {
     id: "music-video",
@@ -591,7 +731,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "concert-stage",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f7d288e2-9d81-43b7-ae1b-1702a11686a8/video-f7d288e2.mp4",
-    tags: ["music", "concert", "stage", "neon", "performance", "rhythm"],
+    tags: [
+      "energy-sports",
+      "music",
+      "concert",
+      "stage",
+      "neon",
+      "performance",
+      "rhythm",
+    ],
   },
   {
     id: "surrealist-dream",
@@ -610,7 +758,7 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "impossible-room",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b7b0d289-9e05-4f93-9795-d5d19263435c/video-b7b0d289.mp4",
-    tags: ["surreal", "dream", "impossible", "dali", "ethereal"],
+    tags: ["fantasy-art", "surreal", "dream", "impossible", "dali", "ethereal"],
   },
   {
     id: "ai-digital-art",
@@ -629,7 +777,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "neural-network-viz",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/629cab0a-fead-4c9c-ac9b-d5ef6df0782f/video-629cab0a.mp4",
-    tags: ["ai", "digital", "neural-network", "futuristic", "code", "tech"],
+    tags: [
+      "fantasy-art",
+      "ai",
+      "digital",
+      "neural-network",
+      "futuristic",
+      "code",
+      "tech",
+    ],
   },
   {
     id: "space-documentary",
@@ -648,7 +804,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "astronaut-spacewalk",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/273d9673-9ed2-426b-8516-0102fbdd8622/video-273d9673.mp4",
-    tags: ["space", "cosmos", "nasa", "astronaut", "epic", "documentary"],
+    tags: [
+      "story-emotion",
+      "space",
+      "cosmos",
+      "nasa",
+      "astronaut",
+      "epic",
+      "documentary",
+    ],
   },
   {
     id: "street-documentary",
@@ -667,7 +831,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "nyc-street-corner",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/54c271a6-d2da-4134-a812-679fd0fc8810/video-54c271a6.mp4",
-    tags: ["street", "nyc", "urban", "documentary", "people", "authentic"],
+    tags: [
+      "story-emotion",
+      "street",
+      "nyc",
+      "urban",
+      "documentary",
+      "people",
+      "authentic",
+    ],
   },
   {
     id: "synthwave-retro",
@@ -686,7 +858,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "neon-highway-night",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c227b1aa-7876-4fe3-8869-4d2b996d418f/video-c227b1aa.mp4",
-    tags: ["synthwave", "80s", "retro", "neon", "vhs", "cyberpunk-nostalgic"],
+    tags: [
+      "fantasy-art",
+      "synthwave",
+      "80s",
+      "retro",
+      "neon",
+      "vhs",
+      "cyberpunk-nostalgic",
+    ],
   },
   {
     id: "absurdist-comedy",
@@ -705,7 +885,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "mundane-surreal-office",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e93201b0-90d2-42f1-9db7-19441315c4bc/video-e93201b0.mp4",
-    tags: ["comedy", "absurdist", "quirky", "deadpan", "office", "humor"],
+    tags: [
+      "fantasy-art",
+      "comedy",
+      "absurdist",
+      "quirky",
+      "deadpan",
+      "office",
+      "humor",
+    ],
   },
   {
     id: "magical-girl",
@@ -724,7 +912,14 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "magical-girl-transform",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f0b7f984-4d85-432f-bf41-a53d89e262bd/video-f0b7f984.mp4",
-    tags: ["anime", "magical-girl", "transformation", "pastel", "sparkle"],
+    tags: [
+      "anime-2d",
+      "anime",
+      "magical-girl",
+      "transformation",
+      "pastel",
+      "sparkle",
+    ],
   },
   {
     id: "shonen-battle",
@@ -743,7 +938,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "hero-power-awakening",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d07d39ed-d2fe-4bee-a148-501d96ead5a2/video-d07d39ed.mp4",
-    tags: ["anime", "shonen", "battle", "power-up", "energy", "hero"],
+    tags: [
+      "anime-2d",
+      "anime",
+      "shonen",
+      "battle",
+      "power-up",
+      "energy",
+      "hero",
+    ],
   },
   {
     id: "cyberpunk-anime",
@@ -762,7 +965,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "cyberpunk-hacker-alley",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e1cfe984-3bfc-4ba1-acb3-9b40b7b76771/video-e1cfe984.mp4",
-    tags: ["cyberpunk", "anime", "neon", "hacker", "dystopian", "futuristic"],
+    tags: [
+      "anime-2d",
+      "anime",
+      "cyberpunk",
+      "neon",
+      "hacker",
+      "dystopian",
+      "futuristic",
+    ],
   },
   {
     id: "slice-of-life-anime",
@@ -781,7 +992,15 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     scene: "school-summer-afternoon",
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a477b387-f156-4826-9112-3258fcaec339/video-a477b387.mp4",
-    tags: ["anime", "slice-of-life", "school", "healing", "summer", "friends"],
+    tags: [
+      "anime-2d",
+      "anime",
+      "slice-of-life",
+      "school",
+      "healing",
+      "summer",
+      "friends",
+    ],
   },
   {
     id: "wuxia-anime",
@@ -801,6 +1020,8 @@ export const VIDEO_STYLE_PRESETS: readonly VideoStylePreset[] = [
     sampleVideoUrl:
       "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/939b77ca-c2f2-4379-abfa-1bb2a904288b/video-939b77ca.mp4",
     tags: [
+      "anime-2d",
+      "anime",
       "wuxia",
       "chinese-animation",
       "sword",

--- a/turbo/packages/db/src/schema/chat-message.ts
+++ b/turbo/packages/db/src/schema/chat-message.ts
@@ -24,8 +24,16 @@ export interface ChatMessagePresentationGenerationTemplate {
   };
 }
 
+export interface ChatMessageVideoGenerationTemplate {
+  readonly type: "video";
+  readonly selection: {
+    readonly stylePresetId: string;
+  };
+}
+
 export type ChatMessageGenerationTemplate =
-  ChatMessagePresentationGenerationTemplate;
+  | ChatMessagePresentationGenerationTemplate
+  | ChatMessageVideoGenerationTemplate;
 
 export type ChatMessageRecommendedFollowupKind = "talk" | "generate";
 export type ChatMessageRecommendedFollowupGenerationType =


### PR DESCRIPTION
## Summary

- Adds a **Video** tab to the template picker dialog, gated behind a new `VideoTemplatePicker` feature switch
- 34 curated video style presets across 12 categories, each with 7 semantic dimensions (visualTone, cameraStyle, editingPace, narrativeMode, productionType, emotionalTone, styleReference)
- Video cards show static thumbnail with hover-to-play preview; selected style appears as a chip above the composer textarea
- Prompt builder injects dimensions with human-readable descriptions — no scene-specific reference prompt contamination
- All output constrained to safe, positive, uplifting content (safety suffix enforced in prompt builder)

## Files changed

- `packages/connectors/src/feature-switch-key.ts` — new `VideoTemplatePicker` key
- `packages/core/src/video-style-preset-items.ts` — new: 34 `VideoStylePreset` records + `VIDEO_DIMENSION_DESCRIPTIONS` map
- `packages/core/src/index.ts` — export new types
- `packages/api-contracts/src/contracts/chat-threads.ts` — `videoGenerationTemplateRequestSchema` added to discriminated union
- `packages/db/src/schema/chat-message.ts` — `ChatMessageGenerationTemplate` union extended with video variant
- `apps/api/src/signals/routes/generation-template-prompt.ts` — `type:"video"` branch builds dimension-only style prompt
- `apps/platform/src/views/zero-page/zero-chat-composer.tsx` — Video tab, VideoTemplateCard, SelectedVideoTemplateChip, feature-flag wiring
- `apps/platform/src/views/zero-page/zero-chat-thread-page.tsx` — type-narrow generationTemplate.selection for video variant

## Test plan

- [ ] Enable `videoTemplatePicker` feature flag for test org
- [ ] Open Template picker — Video tab appears
- [ ] Select a video style — chip appears above textarea
- [ ] Send message — agent receives structured dimension prompt
- [ ] Deselect via chip ✕ — chip clears
- [ ] PPT tab still works unchanged when `chatTemplatePicker` enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)