### PR TITLE
feat: enable expiring permission grants by default

### DIFF
--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -403,10 +403,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorPermissionReset]: true,
-        [FeatureSwitchKey.ExpiringPermissionGrants]: true,
-      },
+      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
     });
     await openPermissionsDrawer("Notion");
     await waitFor(() => {
@@ -555,7 +552,6 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Notion");
 
@@ -598,7 +594,6 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Notion");
 
@@ -653,7 +648,6 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Notion");
 
@@ -694,7 +688,6 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Notion");
 
@@ -722,7 +715,6 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Notion");
 
@@ -779,7 +771,6 @@ describe("permissions dialog - flat list connector (Notion)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Notion");
 
@@ -927,7 +918,6 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Slack");
 
@@ -957,7 +947,6 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     detachedSetupPage({
       context,
       path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
     await openPermissionsDrawer("Slack");
 

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { server } from "../../../mocks/server.ts";
 import { createMockApi } from "../../../mocks/msw-contract.ts";
@@ -96,7 +95,7 @@ describe("permission allow page", () => {
     });
   });
 
-  it("hides existing grant expiry when expiring grants are disabled", async () => {
+  it("shows existing grant expiry for matching allow grants", async () => {
     mockAgent();
     setMockUserPermissionGrants([
       createMockUserPermissionGrantResponse({
@@ -115,7 +114,7 @@ describe("permission allow page", () => {
     await waitFor(() => {
       expect(screen.getByText("Permissions updated")).toBeInTheDocument();
     });
-    expect(screen.queryByText(/Expires in/)).not.toBeInTheDocument();
+    expect(screen.getByText("Expires in 1 hour")).toBeInTheDocument();
   });
 
   it("ignores expired matching grants", async () => {
@@ -170,11 +169,11 @@ describe("permission allow page", () => {
       connectorRef: "slack",
       permission: "chat:write",
       action: "allow",
+      expiresIn: "1h",
     });
-    expect(grantBody).not.toMatchObject({ expiresIn: expect.any(String) });
   });
 
-  it("submits the default duration when expiring grants are enabled", async () => {
+  it("submits the default duration for allow grants", async () => {
     let grantBody: unknown;
     mockAgent();
     setMockUserPermissionGrants([]);
@@ -191,11 +190,9 @@ describe("permission allow page", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
-    });
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Research agent")).toBeInTheDocument();
@@ -237,11 +234,9 @@ describe("permission allow page", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=1h`,
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
-    });
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=1h`,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Research agent")).toBeInTheDocument();
@@ -271,11 +266,9 @@ describe("permission allow page", () => {
       }),
     ]);
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=always`,
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
-    });
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=always`,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Permissions updated")).toBeInTheDocument();
@@ -302,11 +295,9 @@ describe("permission allow page", () => {
       }),
     ]);
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=always`,
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
-    });
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow&expiresIn=always`,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Research agent")).toBeInTheDocument();
@@ -317,7 +308,7 @@ describe("permission allow page", () => {
     });
   });
 
-  it("submits the selected duration when expiring grants are enabled", async () => {
+  it("submits the selected duration for allow grants", async () => {
     let grantBody: unknown;
     mockAgent();
     setMockUserPermissionGrants([]);
@@ -328,11 +319,9 @@ describe("permission allow page", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
-    });
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=chat:write&action=allow`,
+    );
 
     const durationSelect = await screen.findByRole("combobox", {
       name: "Permission duration",
@@ -357,11 +346,9 @@ describe("permission allow page", () => {
       }),
     );
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=deny`,
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
-    });
+    setupPermissionPage(
+      `/agents/${AGENT_ID}/permissions?ref=slack&permission=channels:read&action=deny`,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Research agent")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -9,7 +9,6 @@ import {
 } from "@tabler/icons-react";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFirewallConnectorType } from "@vm0/connectors/firewalls";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
@@ -32,7 +31,6 @@ import {
   requestedUserPermissionGrantExpirationAlreadyApplies,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
@@ -219,7 +217,6 @@ function ConfirmGrantCard({
   connectorRef,
   permission,
   action,
-  expirationEnabled,
   initialExpiresIn,
   agentDisplayName,
   agentAvatarUrl,
@@ -229,7 +226,6 @@ function ConfirmGrantCard({
   connectorRef: string;
   permission: Permission;
   action: "allow" | "deny";
-  expirationEnabled: boolean;
   initialExpiresIn: UserPermissionGrantExpiresIn | null;
   agentDisplayName: string;
   agentAvatarUrl: string | null;
@@ -243,7 +239,7 @@ function ConfirmGrantCard({
     expiresInByScope[durationScope] ??
     initialExpiresIn ??
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
-  const expirationAvailable = expirationEnabled && action === "allow";
+  const expirationAvailable = action === "allow";
   const [grantLoadable, upsertGrant] = useLoadableSet(
     upsertUserPermissionGrant$,
   );
@@ -346,9 +342,6 @@ function PermissionAllowDoctorPage({
   const agentLoadable = useLastLoadable(permissionAllowAgent$);
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
-  const features = useGet(featureSwitch$);
-  const expirationEnabled =
-    features[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
 
   if (
     agentLoadable.state === "loading" ||
@@ -389,7 +382,6 @@ function PermissionAllowDoctorPage({
     );
   });
   const requestedExpirationAlreadyApplies =
-    !expirationEnabled ||
     action !== "allow" ||
     requestedUserPermissionGrantExpirationAlreadyApplies({
       expiresIn: initialExpiresIn,
@@ -400,7 +392,7 @@ function PermissionAllowDoctorPage({
       <ResultCard
         action={action}
         expiresAt={explicitGrant?.expiresAt}
-        showExpiry={expirationEnabled && action === "allow"}
+        showExpiry={action === "allow"}
       />
     );
   }
@@ -414,7 +406,6 @@ function PermissionAllowDoctorPage({
       connectorRef={ref}
       permission={focusedPermission}
       action={action}
-      expirationEnabled={expirationEnabled}
       initialExpiresIn={initialExpiresIn}
       agentDisplayName={agent.displayName ?? agentId}
       agentAvatarUrl={agent.avatarUrl}

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -460,12 +460,11 @@ interface ChangedUserGrantPolicy {
 }
 
 function selectedGrantExpiresIn(
-  expirationEnabled: boolean,
   expiresInByPermission: GrantExpirationSelections,
   permission: string,
   action: UserPermissionGrantAction,
 ): UserPermissionGrantExpiresIn | undefined {
-  if (!expirationEnabled || action !== "allow") {
+  if (action !== "allow") {
     return undefined;
   }
   return expiresInByPermission[permission];
@@ -488,13 +487,11 @@ function addNamedPolicyChanges({
   changes,
   initial,
   current,
-  expirationEnabled,
   expiresInByPermission,
 }: {
   changes: Map<string, ChangedUserGrantPolicy>;
   initial: FirewallPolicies[ConnectorType] | undefined;
   current: FirewallPolicies[ConnectorType] | undefined;
-  expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
 }): void {
   for (const [permission, action] of Object.entries(current?.policies ?? {})) {
@@ -504,12 +501,7 @@ function addNamedPolicyChanges({
         changes,
         permission,
         grantAction,
-        selectedGrantExpiresIn(
-          expirationEnabled,
-          expiresInByPermission,
-          permission,
-          grantAction,
-        ),
+        selectedGrantExpiresIn(expiresInByPermission, permission, grantAction),
       );
     }
   }
@@ -519,13 +511,11 @@ function addUnknownPolicyChange({
   changes,
   initial,
   current,
-  expirationEnabled,
   expiresInByPermission,
 }: {
   changes: Map<string, ChangedUserGrantPolicy>;
   initial: FirewallPolicies[ConnectorType] | undefined;
   current: FirewallPolicies[ConnectorType] | undefined;
-  expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
 }): void {
   const unknownPolicy = current?.unknownPolicy;
@@ -538,7 +528,6 @@ function addUnknownPolicyChange({
     UNKNOWN_PERMISSION_GRANT,
     grantAction,
     selectedGrantExpiresIn(
-      expirationEnabled,
       expiresInByPermission,
       UNKNOWN_PERMISSION_GRANT,
       grantAction,
@@ -637,14 +626,12 @@ function changedUserGrantPolicies({
   initialPolicies,
   initialGrants,
   policies,
-  expirationEnabled,
   expiresInByPermission,
 }: {
   connectorType: ConnectorType;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
-  expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
 }): ChangedUserGrantPolicy[] {
   const initial = resolveFirewallPolicies(initialPolicies, [connectorType])?.[
@@ -657,33 +644,29 @@ function changedUserGrantPolicies({
     changes,
     initial,
     current,
-    expirationEnabled,
     expiresInByPermission,
   });
   addUnknownPolicyChange({
     changes,
     initial,
     current,
-    expirationEnabled,
     expiresInByPermission,
   });
 
-  if (expirationEnabled) {
-    addExpirationOnlyChanges({
-      changes,
-      connectorType,
-      initialGrants,
-      current,
-      expiresInByPermission,
-    });
-    addDefaultAllowExpirationChanges({
-      changes,
-      connectorType,
-      initialGrants,
-      current,
-      expiresInByPermission,
-    });
-  }
+  addExpirationOnlyChanges({
+    changes,
+    connectorType,
+    initialGrants,
+    current,
+    expiresInByPermission,
+  });
+  addDefaultAllowExpirationChanges({
+    changes,
+    connectorType,
+    initialGrants,
+    current,
+    expiresInByPermission,
+  });
 
   return [...changes.values()];
 }
@@ -705,7 +688,6 @@ async function saveUserGrantPolicies({
   initialPolicies,
   initialGrants,
   policies,
-  expirationEnabled,
   expiresInByPermission,
   resetPending,
   pageSignal,
@@ -717,7 +699,6 @@ async function saveUserGrantPolicies({
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
-  expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
   resetPending: boolean;
   pageSignal: AbortSignal;
@@ -744,7 +725,6 @@ async function saveUserGrantPolicies({
     initialPolicies: basePolicies,
     initialGrants: baseGrants,
     policies,
-    expirationEnabled,
     expiresInByPermission,
   })) {
     await upsertGrant(
@@ -766,7 +746,6 @@ async function saveDrawerPolicies({
   initialPolicies,
   initialGrants,
   policies,
-  expirationEnabled,
   expiresInByPermission,
   resetPending,
   pageSignal,
@@ -778,7 +757,6 @@ async function saveDrawerPolicies({
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
-  expirationEnabled: boolean;
   expiresInByPermission: GrantExpirationSelections;
   resetPending: boolean;
   pageSignal: AbortSignal;
@@ -791,7 +769,6 @@ async function saveDrawerPolicies({
     initialPolicies,
     initialGrants,
     policies,
-    expirationEnabled,
     expiresInByPermission,
     resetPending,
     pageSignal,
@@ -989,7 +966,6 @@ function AgentPermissionsDrawer({
   displayName,
   initialPolicies,
   initialGrants,
-  expirationEnabled,
   resetEnabled,
   readOnly,
   onApply,
@@ -1000,7 +976,6 @@ function AgentPermissionsDrawer({
   displayName: string;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
-  expirationEnabled: boolean;
   resetEnabled: boolean;
   readOnly: boolean;
   onApply: (
@@ -1020,7 +995,6 @@ function AgentPermissionsDrawer({
       displayName={displayName}
       initialPolicies={initialPolicies}
       initialGrants={initialGrants}
-      expirationEnabled={expirationEnabled}
       resetEnabled={resetEnabled}
       readOnly={readOnly}
       onApply={onApply}
@@ -1064,8 +1038,6 @@ function JobPermissionsTab({
       : null;
   const drawerInitialPolicies = userGrantPolicies ?? {};
   const features = useLastResolved(featureSwitch$);
-  const expirationEnabled =
-    features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
   const resetEnabled =
     features?.[FeatureSwitchKey.ConnectorPermissionReset] ?? false;
   const [, upsertGrant] = useLoadableSet(upsertUserPermissionGrant$);
@@ -1148,7 +1120,6 @@ function JobPermissionsTab({
             displayName={displayName}
             initialPolicies={drawerInitialPolicies}
             initialGrants={userGrants}
-            expirationEnabled={expirationEnabled}
             resetEnabled={resetEnabled}
             readOnly={!canManagePermissions}
             onApply={async (
@@ -1165,7 +1136,6 @@ function JobPermissionsTab({
                 initialPolicies: drawerInitialPolicies,
                 initialGrants: userGrants,
                 policies,
-                expirationEnabled,
                 expiresInByPermission,
                 resetPending: resetConnectorGrants,
                 pageSignal,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -352,15 +352,15 @@ describe("zero chat thread page display - permission action card", () => {
         connectorRef: "slack",
         permission: "channels:write",
         action: "allow",
+        expiresIn: "1h",
       });
     });
-    expect(grantBody).not.toMatchObject({ expiresIn: expect.any(String) });
     const status = within(card).getByText("Permissions updated");
     expect(status).toBeInTheDocument();
     expect(status.closest("button")).toBeNull();
   });
 
-  it("submits the default duration from permission action cards when enabled", async () => {
+  it("submits the default duration from permission action cards", async () => {
     let grantBody: unknown;
     mockPermissionAgent();
     mockPermissionMessage();
@@ -375,7 +375,6 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
 
     const card = await waitFor(() => {
@@ -410,7 +409,6 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
 
     const card = await waitFor(() => {
@@ -480,7 +478,6 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
 
     const card = await waitFor(() => {
@@ -517,7 +514,6 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
 
     const card = await waitFor(() => {
@@ -550,7 +546,6 @@ describe("zero chat thread page display - permission action card", () => {
     detachedSetupPage({
       context,
       path: "/chats/thread-test-1",
-      featureSwitches: { [FeatureSwitchKey.ExpiringPermissionGrants]: true },
     });
 
     const card = await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permission-grant-reset-state.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permission-grant-reset-state.ts
@@ -61,13 +61,9 @@ function grantExpirationFingerprint(
 
 function selectedExpirationFingerprint(
   action: UserPermissionGrantResponse["action"],
-  expirationEnabled: boolean,
   selected: UserPermissionGrantExpiresIn | undefined,
 ): string {
-  return action === "allow" &&
-    expirationEnabled &&
-    selected !== undefined &&
-    selected !== "always"
+  return action === "allow" && selected !== undefined && selected !== "always"
     ? `duration:${selected}`
     : "always";
 }
@@ -106,13 +102,11 @@ function currentPermissionGrantFingerprint({
   currentPolicy,
   defaultPolicy,
   selected,
-  expirationEnabled,
 }: {
   permission: string;
   currentPolicy: FirewallPolicyValue;
   defaultPolicy: FirewallPolicyValue;
   selected: UserPermissionGrantExpiresIn | undefined;
-  expirationEnabled: boolean;
 }): PermissionGrantFingerprint | null {
   const currentAction = grantAction(currentPolicy);
   const defaultAction = grantAction(defaultPolicy);
@@ -122,7 +116,6 @@ function currentPermissionGrantFingerprint({
   const hasExpiringDefaultAllowGrant =
     currentAction === "allow" &&
     currentAction === defaultAction &&
-    expirationEnabled &&
     selected !== undefined &&
     selected !== "always";
   if (currentAction === defaultAction && !hasExpiringDefaultAllowGrant) {
@@ -131,11 +124,7 @@ function currentPermissionGrantFingerprint({
   return {
     permission,
     action: currentAction,
-    expiration: selectedExpirationFingerprint(
-      currentAction,
-      expirationEnabled,
-      selected,
-    ),
+    expiration: selectedExpirationFingerprint(currentAction, selected),
   };
 }
 
@@ -145,7 +134,6 @@ function currentConnectorGrantFingerprints({
   unknownPolicy,
   defaultPolicies,
   defaultUnknownPolicy,
-  expirationEnabled,
   selections,
 }: {
   permissionNames: readonly string[];
@@ -153,7 +141,6 @@ function currentConnectorGrantFingerprints({
   unknownPolicy: FirewallPolicyValue;
   defaultPolicies: Record<string, PermissionPolicy>;
   defaultUnknownPolicy: FirewallPolicyValue;
-  expirationEnabled: boolean;
   selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
 }): readonly PermissionGrantFingerprint[] {
   const fingerprints: PermissionGrantFingerprint[] = [];
@@ -163,7 +150,6 @@ function currentConnectorGrantFingerprints({
       currentPolicy: policies[name] ?? defaultPolicies[name] ?? "allow",
       defaultPolicy: defaultPolicies[name] ?? "allow",
       selected: selections[name],
-      expirationEnabled,
     });
     if (fingerprint) {
       fingerprints.push(fingerprint);
@@ -174,7 +160,6 @@ function currentConnectorGrantFingerprints({
     currentPolicy: unknownPolicy,
     defaultPolicy: defaultUnknownPolicy,
     selected: selections[UNKNOWN_PERMISSION_GRANT],
-    expirationEnabled,
   });
   if (unknownFingerprint) {
     fingerprints.push(unknownFingerprint);
@@ -221,7 +206,6 @@ export function hasConnectorResetPersistedEffect({
   unknownPolicy,
   defaultPolicies,
   defaultUnknownPolicy,
-  expirationEnabled,
   selections,
 }: {
   resetPending: boolean;
@@ -231,7 +215,6 @@ export function hasConnectorResetPersistedEffect({
   unknownPolicy: FirewallPolicyValue;
   defaultPolicies: Record<string, PermissionPolicy>;
   defaultUnknownPolicy: FirewallPolicyValue;
-  expirationEnabled: boolean;
   selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
 }): boolean {
   if (!resetPending) {
@@ -244,7 +227,6 @@ export function hasConnectorResetPersistedEffect({
     unknownPolicy,
     defaultPolicies,
     defaultUnknownPolicy,
-    expirationEnabled,
     selections,
   });
   return !permissionGrantFingerprintsEqual(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -91,7 +91,6 @@ interface PermissionsDrawerProps {
   displayName: string;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
-  expirationEnabled: boolean;
   resetEnabled?: boolean;
   readOnly?: boolean;
   onApply: (
@@ -397,21 +396,16 @@ function hasPermissionPolicyChanges({
 }
 
 function hasGrantExpirationChanges({
-  expirationEnabled,
   explicitGrants,
   policies,
   unknownPolicy,
   selections,
 }: {
-  expirationEnabled: boolean;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   policies: Record<string, PermissionPolicy>;
   unknownPolicy: FirewallPolicyValue;
   selections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
 }): boolean {
-  if (!expirationEnabled) {
-    return false;
-  }
   for (const permission of Object.keys(selections)) {
     const grant = explicitGrants.get(permission);
     const selected = selections[permission];
@@ -430,17 +424,15 @@ function hasGrantExpirationChanges({
 }
 
 function hasPendingGrantExpirationChange({
-  expirationEnabled,
   grant,
   policy,
   selected,
 }: {
-  expirationEnabled: boolean;
   grant: UserPermissionGrantResponse | undefined;
   policy: FirewallPolicyValue;
   selected: UserPermissionGrantExpiresIn | undefined;
 }): boolean {
-  if (!expirationEnabled || selected === undefined || policy !== "allow") {
+  if (selected === undefined || policy !== "allow") {
     return false;
   }
   if (grant?.action === "allow") {
@@ -450,13 +442,11 @@ function hasPendingGrantExpirationChange({
 }
 
 function hasPendingPermissionControlChange({
-  expirationEnabled,
   grant,
   initialPolicy,
   policy,
   selected,
 }: {
-  expirationEnabled: boolean;
   grant: UserPermissionGrantResponse | undefined;
   initialPolicy: PermissionPolicy;
   policy: FirewallPolicyValue;
@@ -465,7 +455,6 @@ function hasPendingPermissionControlChange({
   return (
     policy !== initialPolicy ||
     hasPendingGrantExpirationChange({
-      expirationEnabled,
       grant,
       policy,
       selected,
@@ -663,7 +652,6 @@ function PermissionGrantPolicyControl({
   grant,
   selected,
   hasPendingChange,
-  expirationEnabled,
   allowAlwaysActive,
   expirationStatusExpiresAt,
   readOnly,
@@ -679,7 +667,6 @@ function PermissionGrantPolicyControl({
   grant: UserPermissionGrantResponse | undefined;
   selected: UserPermissionGrantExpiresIn | undefined;
   hasPendingChange: boolean;
-  expirationEnabled: boolean;
   allowAlwaysActive: boolean;
   expirationStatusExpiresAt?: string | null;
   readOnly?: boolean;
@@ -692,10 +679,10 @@ function PermissionGrantPolicyControl({
 }) {
   const allowGrant = grant?.action === "allow" ? grant : undefined;
   const showExpirationStatus =
-    showCurrentExpirationStatus && expirationEnabled && policy === "allow";
+    showCurrentExpirationStatus && policy === "allow";
   const expirationStatusValue =
     expirationStatusExpiresAt ?? allowGrant?.expiresAt ?? null;
-  const showSplitPolicy = expirationEnabled && !readOnly;
+  const showSplitPolicy = !readOnly;
 
   return (
     <div className="flex shrink-0 items-center gap-2">
@@ -823,14 +810,12 @@ function groupExpirationSelection(
 }
 
 function hasPendingGroupControlChange({
-  expirationEnabled,
   explicitGrants,
   initialPolicies,
   permissions,
   policies,
   selections,
 }: {
-  expirationEnabled: boolean;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   initialPolicies: Record<string, PermissionPolicy>;
   permissions: readonly ConnectorPermission[];
@@ -840,7 +825,6 @@ function hasPendingGroupControlChange({
   return permissions.some((permission) => {
     const name = permission.name;
     return hasPendingPermissionControlChange({
-      expirationEnabled,
       grant: explicitGrants.get(name),
       initialPolicy: initialPolicies[name] ?? "allow",
       policy: policies[name] ?? "allow",
@@ -917,7 +901,6 @@ function PermissionRows({
   expandedGroups,
   explicitGrants,
   expirationSelections,
-  expirationEnabled,
   readOnly,
   saving,
   onToggleGroup,
@@ -933,7 +916,6 @@ function PermissionRows({
   expandedGroups: Set<string>;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
-  expirationEnabled: boolean;
   readOnly?: boolean;
   saving: boolean;
   onToggleGroup: (category: string) => void;
@@ -957,7 +939,6 @@ function PermissionRows({
         expirationSelections,
       );
       const groupHasPendingChange = hasPendingGroupControlChange({
-        expirationEnabled,
         explicitGrants,
         initialPolicies,
         permissions: group.permissions,
@@ -1000,7 +981,6 @@ function PermissionRows({
               grant={undefined}
               selected={groupSelectedExpiration}
               hasPendingChange={groupHasPendingChange}
-              expirationEnabled={expirationEnabled}
               allowAlwaysActive={groupAllowAlwaysActive}
               expirationStatusExpiresAt={groupExpirationStatus ?? null}
               readOnly={readOnly}
@@ -1045,7 +1025,6 @@ function PermissionRows({
                   policies={policies}
                   explicitGrants={explicitGrants}
                   expirationSelections={expirationSelections}
-                  expirationEnabled={expirationEnabled}
                   readOnly={readOnly}
                   saving={saving}
                   onPolicyChange={onPolicyChange}
@@ -1069,7 +1048,6 @@ function PermissionRows({
         policies={policies}
         explicitGrants={explicitGrants}
         expirationSelections={expirationSelections}
-        expirationEnabled={expirationEnabled}
         readOnly={readOnly}
         saving={saving}
         onPolicyChange={onPolicyChange}
@@ -1088,7 +1066,6 @@ function PermissionRow({
   policies,
   explicitGrants,
   expirationSelections,
-  expirationEnabled,
   readOnly,
   saving,
   onPolicyChange,
@@ -1102,7 +1079,6 @@ function PermissionRow({
   policies: Record<string, PermissionPolicy>;
   explicitGrants: Map<string, UserPermissionGrantResponse>;
   expirationSelections: Readonly<Record<string, UserPermissionGrantExpiresIn>>;
-  expirationEnabled: boolean;
   readOnly?: boolean;
   saving: boolean;
   onPolicyChange: (name: string, policy: PermissionPolicy) => void;
@@ -1116,7 +1092,6 @@ function PermissionRow({
   const grant = explicitGrants.get(permission.name);
   const selected = expirationSelections[permission.name];
   const hasPendingChange = hasPendingPermissionControlChange({
-    expirationEnabled,
     grant,
     initialPolicy,
     policy,
@@ -1144,7 +1119,6 @@ function PermissionRow({
           grant={grant}
           selected={selected}
           hasPendingChange={hasPendingChange}
-          expirationEnabled={expirationEnabled}
           allowAlwaysActive={hasAllowAlwaysPolicy(grant, policy)}
           readOnly={readOnly}
           saving={saving}
@@ -1231,7 +1205,6 @@ export function PermissionsDrawer({
   displayName,
   initialPolicies,
   initialGrants,
-  expirationEnabled,
   resetEnabled,
   readOnly,
   onApply,
@@ -1294,7 +1267,6 @@ export function PermissionsDrawer({
     defaultUnknownPolicy: defaultPolicyState.unknownPolicy,
   });
   const hasExpirationChanges = hasGrantExpirationChanges({
-    expirationEnabled,
     explicitGrants: effectiveExplicitGrants,
     policies,
     unknownPolicy,
@@ -1312,7 +1284,6 @@ export function PermissionsDrawer({
     unknownPolicy,
     defaultPolicies: defaultPolicyState.policies,
     defaultUnknownPolicy: defaultPolicyState.unknownPolicy,
-    expirationEnabled,
     selections: expirationSelections,
   });
   const resetAvailable =
@@ -1478,7 +1449,6 @@ export function PermissionsDrawer({
                 expandedGroups={expandedGroups}
                 explicitGrants={effectiveExplicitGrants}
                 expirationSelections={expirationSelections}
-                expirationEnabled={expirationEnabled}
                 readOnly={readOnly}
                 saving={saving}
                 onToggleGroup={toggleGroup}
@@ -1497,13 +1467,11 @@ export function PermissionsDrawer({
                   grant={unknownGrant}
                   selected={unknownSelectedExpiration}
                   hasPendingChange={hasPendingPermissionControlChange({
-                    expirationEnabled,
                     grant: unknownGrant,
                     initialPolicy: initialUnknownPolicy,
                     policy: unknownPolicy,
                     selected: unknownSelectedExpiration,
                   })}
-                  expirationEnabled={expirationEnabled}
                   allowAlwaysActive={hasAllowAlwaysPolicy(
                     unknownGrant,
                     unknownPolicy,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3829,10 +3829,7 @@ function PermissionActionCardContent({
 function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
   const pageSignal = useGet(pageSignal$);
   const config = CONNECTOR_TYPES[block.connectorRef];
-  const features = useLastResolved(featureSwitch$);
-  const expirationEnabled =
-    features?.[FeatureSwitchKey.ExpiringPermissionGrants] ?? false;
-  const expirationAvailable = expirationEnabled && block.action === "allow";
+  const expirationAvailable = block.action === "allow";
   const durationScope = `${block.id}\u0000${block.expiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
   const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -55,7 +55,6 @@ export enum FeatureSwitchKey {
   ChatRecommendedFollowups = "chatRecommendedFollowups",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",
-  ExpiringPermissionGrants = "expiringPermissionGrants",
   ConnectorPermissionReset = "connectorPermissionReset",
   ZeroAutomations = "zeroAutomations",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -316,13 +316,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ExpiringPermissionGrants]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Show duration controls for explicit current-user permission grants.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ConnectorPermissionReset]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the `expiringPermissionGrants` feature switch from the registry
- make permission grant duration controls available by default for allow grants
- simplify permission drawer/reset state code and update tests for the GA behavior

## Testing
- pnpm -F @vm0/app exec vitest run src/views/permission-allow/__tests__/permission-allow-page.test.tsx src/views/fw/__tests__/permissions-dialog.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/core lint
- pnpm -F @vm0/connectors lint
- git diff --check

Pre-commit also ran repository check-types through lefthook.