### PR TITLE
fix: filter slack agent switch options

### DIFF
--- a/turbo/apps/api/src/lib/slack-webhook-blocks.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-blocks.ts
@@ -133,13 +133,20 @@ function buildAppHomeAgentBlocks(options: AppHomeOptions): SlackBlocks {
     },
   ];
 
+  const settingsButton = {
+    type: "button" as const,
+    text: { type: "plain_text" as const, text: "Settings" },
+    url: `${appUrl()}/works`,
+    action_id: "home_environment_setup",
+  };
+  const switchButton = {
+    type: "button" as const,
+    text: { type: "plain_text" as const, text: "Switch" },
+    action_id: "home_switch_agent",
+    style: "primary" as const,
+  };
+
   if (options.agentName) {
-    const settingsButton = {
-      type: "button" as const,
-      text: { type: "plain_text" as const, text: "Settings" },
-      url: `${appUrl()}/works`,
-      action_id: "home_environment_setup",
-    };
     blocks.push({
       type: "section",
       text: {
@@ -151,15 +158,7 @@ function buildAppHomeAgentBlocks(options: AppHomeOptions): SlackBlocks {
     if (options.canSwitch) {
       blocks.push({
         type: "actions",
-        elements: [
-          {
-            type: "button",
-            text: { type: "plain_text", text: "Switch" },
-            action_id: "home_switch_agent",
-            style: "primary",
-          },
-          settingsButton,
-        ],
+        elements: [switchButton, settingsButton],
       });
     }
     return blocks;
@@ -169,6 +168,12 @@ function buildAppHomeAgentBlocks(options: AppHomeOptions): SlackBlocks {
     type: "section",
     text: { type: "mrkdwn", text: "_No agent configured yet._" },
   });
+  if (options.canSwitch) {
+    blocks.push({
+      type: "actions",
+      elements: [switchButton, settingsButton],
+    });
+  }
   return blocks;
 }
 
@@ -402,6 +407,7 @@ export function buildAgentResponseMessage(
 export function buildAgentPickerModal(args: {
   readonly options: readonly AgentPickerOption[];
   readonly currentSelectedId: string | null;
+  readonly includeOrgDefault: boolean;
   readonly orgDefaultName: string | null;
   readonly privateMetadata?: string;
 }): View {
@@ -409,10 +415,14 @@ export function buildAgentPickerModal(args: {
     ? `Use org default (${args.orgDefaultName})`
     : "Use org default";
   const selectOptions = [
-    {
-      text: { type: "plain_text" as const, text: orgDefaultLabel },
-      value: AGENT_PICKER_ORG_DEFAULT_VALUE,
-    },
+    ...(args.includeOrgDefault
+      ? [
+          {
+            text: { type: "plain_text" as const, text: orgDefaultLabel },
+            value: AGENT_PICKER_ORG_DEFAULT_VALUE,
+          },
+        ]
+      : []),
     ...args.options.map((option) => {
       return {
         text: {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-slack-webhooks.ts
@@ -17,7 +17,10 @@ import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session";
 import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
 import { userCache } from "@vm0/db/schema/user-cache";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import {
+  zeroAgents,
+  type ZeroAgentVisibility,
+} from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, inArray } from "drizzle-orm";
 
@@ -50,6 +53,7 @@ async function seedRunnableAgent(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly namePrefix: string;
+  readonly visibility?: ZeroAgentVisibility;
 }): Promise<string> {
   const name = `${args.namePrefix}-${randomUUID().slice(0, 8)}`;
   const [compose] = await args.db
@@ -90,12 +94,30 @@ async function seedRunnableAgent(args: {
     owner: args.userId,
     name,
     displayName: name,
-    visibility: "public",
+    visibility: args.visibility ?? "public",
     customSkills: [],
   });
 
   return compose.id;
 }
+
+export const seedSlackWebhookAgent$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly namePrefix: string;
+      readonly visibility?: ZeroAgentVisibility;
+    },
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const db = set(writeDb$);
+    const composeId = await seedRunnableAgent({ db, ...args });
+    signal.throwIfAborted();
+    return composeId;
+  },
+);
 
 export const seedSlackWebhookFixture$ = command(
   async (

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
@@ -13,6 +13,7 @@ import {
   deleteSlackWebhookFixture$,
   seedSlackWebhookAgent$,
   seedSlackWebhookFixture$,
+  setSlackWebhookDefaultAgent$,
   setSlackWebhookUserSelectedModel$,
   type SlackWebhookFixture,
 } from "./helpers/zero-slack-webhooks";
@@ -395,6 +396,70 @@ describe("POST /api/zero/slack/commands", () => {
     expect(values).not.toContain(fixture.defaultAgentId);
     expect(values).not.toContain(otherPrivateAgentId);
     expect(labels).toContainEqual(expect.stringContaining("Use org default"));
+  });
+
+  it("omits an inaccessible private org default from the switch picker", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: false,
+        },
+        context.signal,
+      ),
+    );
+    const hiddenDefaultAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "hidden-default-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookDefaultAgent$,
+      { orgId: fixture.orgId, composeId: hiddenDefaultAgentId },
+      context.signal,
+    );
+    const visibleAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "visible-agent",
+        visibility: "public",
+      },
+      context.signal,
+    );
+
+    const switchResponse = await postCommand(
+      buildCommandBody({
+        teamId: fixture.slackWorkspaceId,
+        userId: fixture.slackUserId,
+        text: "switch",
+      }),
+    );
+
+    expect(switchResponse.status).toBe(200);
+    const select = getStaticSelectElement(latestSlackViewOpenCall().view ?? {});
+    const values =
+      select.options?.map((option) => {
+        return option.value;
+      }) ?? [];
+    const labels =
+      select.options?.map((option) => {
+        return option.text?.text;
+      }) ?? [];
+
+    expect(values).not.toContain("__org_default__");
+    expect(values).toContain(visibleAgentId);
+    expect(values).not.toContain(hiddenDefaultAgentId);
+    expect(labels).not.toContainEqual(
+      expect.stringContaining("Use org default"),
+    );
   });
 
   it("returns a login prompt for switch when the Slack user is not connected", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-commands.test.ts
@@ -11,6 +11,7 @@ import { createFixtureTracker } from "./helpers/zero-route-test";
 import {
   countSlackWebhookConnections$,
   deleteSlackWebhookFixture$,
+  seedSlackWebhookAgent$,
   seedSlackWebhookFixture$,
   setSlackWebhookUserSelectedModel$,
   type SlackWebhookFixture,
@@ -330,6 +331,37 @@ describe("POST /api/zero/slack/commands", () => {
     if (!fixture.defaultAgentId || !fixture.switchAgentId) {
       throw new Error("Expected Slack fixture to include switchable agents");
     }
+    const otherUserId = `user_${randomBytes(4).toString("hex")}`;
+    const ownPrivateAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        namePrefix: "own-private-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const otherPublicAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        namePrefix: "other-public-agent",
+        visibility: "public",
+      },
+      context.signal,
+    );
+    const otherPrivateAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        namePrefix: "other-private-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
 
     const switchResponse = await postCommand(
       buildCommandBody({
@@ -358,7 +390,10 @@ describe("POST /api/zero/slack/commands", () => {
 
     expect(values).toContain("__org_default__");
     expect(values).toContain(fixture.switchAgentId);
+    expect(values).toContain(ownPrivateAgentId);
+    expect(values).toContain(otherPublicAgentId);
     expect(values).not.toContain(fixture.defaultAgentId);
+    expect(values).not.toContain(otherPrivateAgentId);
     expect(labels).toContainEqual(expect.stringContaining("Use org default"));
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -218,6 +218,14 @@ function latestPostEphemeralCall(): {
   };
 }
 
+function latestViewPublishCall(): { readonly view?: unknown } {
+  const call = context.mocks.slack.views.publish.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("Expected Slack views.publish to be called");
+  }
+  return call[0] as { readonly view?: unknown };
+}
+
 describe("POST /api/zero/slack/events", () => {
   const track = createFixtureTracker<SlackWebhookFixture>((fixture) => {
     return store.set(deleteSlackWebhookFixture$, fixture, context.signal);
@@ -655,6 +663,57 @@ describe("POST /api/zero/slack/events", () => {
         context.signal,
       ),
     ).resolves.toBe(0);
+  });
+
+  it("shows the App Home switch action when a visible agent exists without a visible default", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: false },
+        context.signal,
+      ),
+    );
+    const hiddenDefaultAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "home-hidden-default",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookDefaultAgent$,
+      { orgId: fixture.orgId, composeId: hiddenDefaultAgentId },
+      context.signal,
+    );
+    await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "home-visible-agent",
+        visibility: "public",
+      },
+      context.signal,
+    );
+
+    await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "app_home_opened",
+        user: fixture.slackUserId,
+        tab: "home",
+        channel: "D-home",
+      },
+    });
+    await clearAllDetached();
+
+    expect(JSON.stringify(latestViewPublishCall().view ?? "")).toContain(
+      "home_switch_agent",
+    );
   });
 
   it("handles App Home and Messages tab edge cases", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-events.test.ts
@@ -25,6 +25,7 @@ import {
   countSlackWebhookConnections$,
   countSlackWebhookInstallations$,
   deleteSlackWebhookFixture$,
+  seedSlackWebhookAgent$,
   seedSlackWebhookOrphanCompose$,
   seedSlackWebhookFixture$,
   seedSlackThreadSession$,
@@ -484,6 +485,51 @@ describe("POST /api/zero/slack/events", () => {
 
     expect(dm.status).toBe(200);
     expect(latestPostMessageCall().text).toContain("could not be found");
+  });
+
+  it("does not run a private default agent owned by another user", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        { withConnection: true, withDefaultAgent: false },
+        context.signal,
+      ),
+    );
+    const hiddenAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_other_${randomBytes(8).toString("hex")}`,
+        namePrefix: "hidden-default",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookDefaultAgent$,
+      { orgId: fixture.orgId, composeId: hiddenAgentId },
+      context.signal,
+    );
+
+    const dm = await postEvent({
+      type: "event_callback",
+      team_id: fixture.slackWorkspaceId,
+      event: {
+        type: "message",
+        channel_type: "im",
+        user: fixture.slackUserId,
+        text: "hello in dm",
+        ts: "1710000003.100000",
+        channel: "D-test",
+      },
+    });
+    await clearAllDetached();
+
+    expect(dm.status).toBe(200);
+    expect(latestPostMessageCall().text).toContain("not available");
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).not.toHaveBeenCalled();
   });
 
   it("filters direct message events by channel type, bot marker, and subtype", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
@@ -14,6 +14,7 @@ import {
   findUserSelectedModel$,
   seedSlackWebhookAgent$,
   seedSlackWebhookFixture$,
+  setSlackWebhookDefaultAgent$,
   setSlackWebhookUserAgentPreference$,
   setSlackWebhookUserSelectedModel$,
   type SlackWebhookFixture,
@@ -462,6 +463,50 @@ describe("POST /api/zero/slack/interactive", () => {
     );
   });
 
+  it("rejects org default submissions when the default agent is inaccessible", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: false,
+        },
+        context.signal,
+      ),
+    );
+    const hiddenDefaultAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "hidden-default-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookDefaultAgent$,
+      { orgId: fixture.orgId, composeId: hiddenDefaultAgentId },
+      context.signal,
+    );
+
+    const response = await postInteractive(
+      agentPickerSubmission({
+        workspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+        selectedValue: "__org_default__",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      response_action: "errors",
+      errors: {
+        agent_select_block: "You don't have access to that agent.",
+      },
+    });
+  });
+
   it("returns an inline error when no agent is selected", async () => {
     const response = await postInteractive(
       agentPickerSubmission({
@@ -605,6 +650,66 @@ describe("POST /api/zero/slack/interactive", () => {
     expect(values).toContain(otherPublicAgentId);
     expect(values).not.toContain(fixture.defaultAgentId);
     expect(values).not.toContain(otherPrivateAgentId);
+  });
+
+  it("omits an inaccessible private org default from the App Home switch picker", async () => {
+    const fixture = await track(
+      store.set(
+        seedSlackWebhookFixture$,
+        {
+          withConnection: true,
+          withDefaultAgent: false,
+        },
+        context.signal,
+      ),
+    );
+    const hiddenDefaultAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "home-hidden-default-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    await store.set(
+      setSlackWebhookDefaultAgent$,
+      { orgId: fixture.orgId, composeId: hiddenDefaultAgentId },
+      context.signal,
+    );
+    const visibleAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "home-visible-agent",
+        visibility: "public",
+      },
+      context.signal,
+    );
+
+    const response = await postInteractive({
+      type: "block_actions",
+      user: {
+        id: fixture.slackUserId,
+        username: "testuser",
+        team_id: fixture.slackWorkspaceId,
+      },
+      team: { id: fixture.slackWorkspaceId, domain: "test" },
+      trigger_id: "trigger-123",
+      actions: [{ action_id: "home_switch_agent", block_id: "home" }],
+    });
+
+    expect(response.status).toBe(200);
+    const select = getStaticSelectElement(latestSlackViewOpenCall().view ?? {});
+    const values =
+      select.options?.map((option) => {
+        return option.value;
+      }) ?? [];
+    expect(values).not.toContain("__org_default__");
+    expect(values).toContain(visibleAgentId);
+    expect(values).not.toContain(hiddenDefaultAgentId);
   });
 
   it("replaces an existing model preference with the workspace default", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-interactive.test.ts
@@ -12,6 +12,7 @@ import {
   deleteSlackWebhookFixture$,
   findSlackAgentPreference$,
   findUserSelectedModel$,
+  seedSlackWebhookAgent$,
   seedSlackWebhookFixture$,
   setSlackWebhookUserAgentPreference$,
   setSlackWebhookUserSelectedModel$,
@@ -146,6 +147,50 @@ function modelPickerSubmission(args: {
       },
     },
   };
+}
+
+interface SlackSelectOption {
+  readonly value: string;
+}
+
+interface SlackSelectElement {
+  readonly options?: readonly SlackSelectOption[];
+}
+
+interface SlackModalBlock {
+  readonly element?: SlackSelectElement;
+}
+
+interface SlackModalView {
+  readonly blocks?: readonly SlackModalBlock[];
+}
+
+interface SlackViewOpenCall {
+  readonly view?: SlackModalView;
+}
+
+function latestSlackViewOpenCall(): SlackViewOpenCall {
+  const call = context.mocks.slack.views.open.mock.calls.at(-1)?.[0] as
+    | SlackViewOpenCall
+    | undefined;
+  if (!call) {
+    throw new Error("Expected Slack views.open to have been called");
+  }
+  return call;
+}
+
+function getStaticSelectElement(view: SlackModalView): SlackSelectElement {
+  const select = view.blocks
+    ?.map((block) => {
+      return block.element;
+    })
+    .find((element) => {
+      return element?.options;
+    });
+  if (!select) {
+    throw new Error("Expected Slack modal to include a static select");
+  }
+  return select;
 }
 
 describe("POST /api/zero/slack/interactive", () => {
@@ -317,6 +362,32 @@ describe("POST /api/zero/slack/interactive", () => {
       }),
     );
 
+    const hiddenPrivateAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: `user_${randomBytes(4).toString("hex")}`,
+        namePrefix: "hidden-private-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const hiddenPrivateRejected = await postInteractive(
+      agentPickerSubmission({
+        workspaceId: fixture.slackWorkspaceId,
+        slackUserId: fixture.slackUserId,
+        selectedValue: hiddenPrivateAgentId,
+      }),
+    );
+
+    expect(hiddenPrivateRejected.status).toBe(200);
+    expect(hiddenPrivateRejected.body).toMatchObject({
+      response_action: "errors",
+      errors: {
+        agent_select_block: "You don't have access to that agent.",
+      },
+    });
+
     const other = await track(
       store.set(
         seedSlackWebhookFixture$,
@@ -455,6 +526,40 @@ describe("POST /api/zero/slack/interactive", () => {
         context.signal,
       ),
     );
+    if (!fixture.defaultAgentId || !fixture.switchAgentId) {
+      throw new Error("Expected Slack fixture to include switchable agents");
+    }
+    const otherUserId = `user_${randomBytes(4).toString("hex")}`;
+    const ownPrivateAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        namePrefix: "home-own-private-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const otherPublicAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        namePrefix: "home-other-public-agent",
+        visibility: "public",
+      },
+      context.signal,
+    );
+    const otherPrivateAgentId = await store.set(
+      seedSlackWebhookAgent$,
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        namePrefix: "home-other-private-agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
 
     const modelResponse = await postInteractive(
       modelPickerSubmission({
@@ -488,6 +593,18 @@ describe("POST /api/zero/slack/interactive", () => {
 
     expect(switchResponse.status).toBe(200);
     expect(context.mocks.slack.views.open).toHaveBeenCalledOnce();
+    const call = latestSlackViewOpenCall();
+    const select = getStaticSelectElement(call.view ?? {});
+    const values =
+      select.options?.map((option) => {
+        return option.value;
+      }) ?? [];
+    expect(values).toContain("__org_default__");
+    expect(values).toContain(fixture.switchAgentId);
+    expect(values).toContain(ownPrivateAgentId);
+    expect(values).toContain(otherPublicAgentId);
+    expect(values).not.toContain(fixture.defaultAgentId);
+    expect(values).not.toContain(otherPrivateAgentId);
   });
 
   it("replaces an existing model preference with the workspace default", async () => {

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -22,7 +22,7 @@ import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session"
 import { slackUserAgentPreferences } from "@vm0/db/schema/slack-user-agent-preference";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import type { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -75,7 +75,6 @@ import {
 } from "./integration-model-route.service";
 import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
 import { formatIntegrationRunError$ } from "./integration-run-errors.service";
-import { zeroComposeList } from "./zero-compose-data.service";
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import {
   updateUserModelPreference$,
@@ -224,6 +223,22 @@ interface RunAgentParams {
 
 type SlackChannelType = "channel" | "dm" | "group_dm";
 
+interface WorkspaceAgentSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string | null;
+}
+
+type EffectiveComposeResolution =
+  | {
+      readonly status: "resolved";
+      readonly composeId: string;
+      readonly agent: WorkspaceAgentSummary;
+    }
+  | {
+      readonly status: "not_configured" | "not_found" | "not_accessible";
+    };
+
 interface SlackAgentMessageArgs {
   readonly db: Db;
   readonly workspaceId: string;
@@ -254,11 +269,7 @@ interface ResolvedSlackAgentMessage {
   readonly client: ReturnType<typeof createSlackClient>;
   readonly threadTs: string;
   readonly composeId: string;
-  readonly agent: {
-    readonly id: string;
-    readonly name: string;
-    readonly displayName: string | null;
-  };
+  readonly agent: WorkspaceAgentSummary;
 }
 
 interface CommandModelResponseArgs {
@@ -528,14 +539,7 @@ async function getWorkspaceAgent(
   db: Db,
   composeId: string,
   orgId?: string,
-): Promise<
-  | {
-      readonly id: string;
-      readonly name: string;
-      readonly displayName: string | null;
-    }
-  | undefined
-> {
+): Promise<WorkspaceAgentSummary | undefined> {
   const [agent] = await db
     .select({
       id: zeroAgents.id,
@@ -552,23 +556,110 @@ async function getWorkspaceAgent(
   return agent;
 }
 
-async function resolveEffectiveComposeId(
+async function getVisibleWorkspaceAgent(
+  db: Db,
+  composeId: string,
+  orgId: string,
+  userId: string,
+): Promise<WorkspaceAgentSummary | undefined> {
+  const [agent] = await db
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      displayName: zeroAgents.displayName,
+    })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.id, composeId),
+        eq(zeroAgents.orgId, orgId),
+        or(eq(zeroAgents.visibility, "public"), eq(zeroAgents.owner, userId)),
+      ),
+    )
+    .limit(1);
+  return agent;
+}
+
+async function getVisibleAgentPickerOptions(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly defaultComposeId: string | null;
+}): Promise<
+  readonly {
+    readonly composeId: string;
+    readonly name: string;
+    readonly displayName: string | null;
+  }[]
+> {
+  const rows = await args.db
+    .select({
+      composeId: zeroAgents.id,
+      name: zeroAgents.name,
+      displayName: zeroAgents.displayName,
+    })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, args.orgId),
+        or(
+          eq(zeroAgents.visibility, "public"),
+          eq(zeroAgents.owner, args.userId),
+        ),
+      ),
+    )
+    .orderBy(desc(zeroAgents.updatedAt));
+
+  return rows
+    .filter((agent) => {
+      return agent.composeId !== args.defaultComposeId;
+    })
+    .slice(0, AGENT_PICKER_MAX_OPTIONS);
+}
+
+async function resolveEffectiveCompose(
   db: Db,
   vm0UserId: string,
   orgId: string,
-): Promise<string | null> {
+): Promise<EffectiveComposeResolution> {
   const override = await getUserAgentPreference(db, vm0UserId, orgId);
   if (override) {
-    const [row] = await db
-      .select({ id: zeroAgents.id })
-      .from(zeroAgents)
-      .where(and(eq(zeroAgents.id, override), eq(zeroAgents.orgId, orgId)))
-      .limit(1);
-    if (row?.id) {
-      return override;
+    const agent = await getVisibleWorkspaceAgent(
+      db,
+      override,
+      orgId,
+      vm0UserId,
+    );
+    if (agent) {
+      return { status: "resolved", composeId: override, agent };
     }
   }
-  return resolveDefaultComposeId(db, orgId);
+  const defaultComposeId = await resolveDefaultComposeId(db, orgId);
+  if (!defaultComposeId) {
+    return { status: "not_configured" };
+  }
+  const configuredDefaultAgent = await getWorkspaceAgent(
+    db,
+    defaultComposeId,
+    orgId,
+  );
+  if (!configuredDefaultAgent) {
+    return { status: "not_found" };
+  }
+  const visibleDefaultAgent = await getVisibleWorkspaceAgent(
+    db,
+    defaultComposeId,
+    orgId,
+    vm0UserId,
+  );
+  if (!visibleDefaultAgent) {
+    return { status: "not_accessible" };
+  }
+  return {
+    status: "resolved",
+    composeId: defaultComposeId,
+    agent: visibleDefaultAgent,
+  };
 }
 
 async function disconnect(db: Db, connectionId: string): Promise<void> {
@@ -707,20 +798,36 @@ const refreshOrgAppHome$ = command(
     let canSwitch = false;
     if (installation.orgId) {
       const orgId = installation.orgId;
-      const [effectiveComposeId, overrideComposeId, defaultComposeId] =
+      const [effectiveCompose, overrideComposeId, defaultComposeId] =
         await Promise.all([
-          resolveEffectiveComposeId(db, connection.vm0UserId, orgId),
+          resolveEffectiveCompose(db, connection.vm0UserId, orgId),
           getUserAgentPreference(db, connection.vm0UserId, orgId),
           resolveDefaultComposeId(db, orgId),
         ]);
-      if (effectiveComposeId) {
-        const agent = await getWorkspaceAgent(db, effectiveComposeId);
-        agentName = agent?.displayName ?? agent?.name;
+      const visibleOverrideAgent = overrideComposeId
+        ? await getVisibleWorkspaceAgent(
+            db,
+            overrideComposeId,
+            orgId,
+            connection.vm0UserId,
+          )
+        : undefined;
+      const visibleDefaultAgent = defaultComposeId
+        ? await getVisibleWorkspaceAgent(
+            db,
+            defaultComposeId,
+            orgId,
+            connection.vm0UserId,
+          )
+        : undefined;
+      if (effectiveCompose.status === "resolved") {
+        agentName =
+          effectiveCompose.agent.displayName ?? effectiveCompose.agent.name;
       }
       isOverrideActive = Boolean(
-        overrideComposeId && overrideComposeId !== defaultComposeId,
+        visibleOverrideAgent && overrideComposeId !== defaultComposeId,
       );
-      canSwitch = Boolean(defaultComposeId);
+      canSwitch = Boolean(visibleDefaultAgent);
     }
 
     const [metadata] = await db
@@ -766,23 +873,16 @@ const commandSwitchResponse$ = command(
         ),
       );
     }
-    const { composes } = await get(zeroComposeList(installation.orgId));
     const defaultComposeId = await resolveDefaultComposeId(
       db,
       installation.orgId,
     );
-    const options = composes
-      .filter((compose) => {
-        return compose.id !== defaultComposeId;
-      })
-      .slice(0, AGENT_PICKER_MAX_OPTIONS)
-      .map((compose) => {
-        return {
-          composeId: compose.id,
-          name: compose.name,
-          displayName: compose.displayName,
-        };
-      });
+    const options = await getVisibleAgentPickerOptions({
+      db,
+      orgId: installation.orgId,
+      userId: connection.vm0UserId,
+      defaultComposeId,
+    });
     const orgDefaultName = defaultComposeId
       ? ((await getWorkspaceAgent(db, defaultComposeId))?.displayName ??
         (await getWorkspaceAgent(db, defaultComposeId))?.name ??
@@ -1274,40 +1374,50 @@ const resolveSlackAgentMessage$ = command(
       return null;
     }
 
-    const composeId = await resolveEffectiveComposeId(
+    const effectiveCompose = await resolveEffectiveCompose(
       args.db,
       connection.vm0UserId,
       boundInstallation.orgId,
     );
-    if (!composeId) {
-      await postSlackUserNotice({
-        client,
-        channelId: args.channelId,
-        channelType: args.channelType,
-        slackUserId: args.slackUserId,
-        threadTs,
-        ephemeralThreadTs: args.threadTs ? threadTs : undefined,
-        text: "No agent is configured for this org. Please ask your org admin to set a default agent.",
-      });
-      return null;
-    }
-
-    const agent = await getWorkspaceAgent(
-      args.db,
-      composeId,
-      boundInstallation.orgId,
-    );
-    if (!agent) {
-      await postSlackUserNotice({
-        client,
-        channelId: args.channelId,
-        channelType: args.channelType,
-        slackUserId: args.slackUserId,
-        threadTs,
-        ephemeralThreadTs: args.threadTs ? threadTs : undefined,
-        text: "The configured agent could not be found. Please contact your org admin.",
-      });
-      return null;
+    if (effectiveCompose.status !== "resolved") {
+      switch (effectiveCompose.status) {
+        case "not_configured": {
+          await postSlackUserNotice({
+            client,
+            channelId: args.channelId,
+            channelType: args.channelType,
+            slackUserId: args.slackUserId,
+            threadTs,
+            ephemeralThreadTs: args.threadTs ? threadTs : undefined,
+            text: "No agent is configured for this org. Please ask your org admin to set a default agent.",
+          });
+          return null;
+        }
+        case "not_found": {
+          await postSlackUserNotice({
+            client,
+            channelId: args.channelId,
+            channelType: args.channelType,
+            slackUserId: args.slackUserId,
+            threadTs,
+            ephemeralThreadTs: args.threadTs ? threadTs : undefined,
+            text: "The configured agent could not be found. Please contact your org admin.",
+          });
+          return null;
+        }
+        case "not_accessible": {
+          await postSlackUserNotice({
+            client,
+            channelId: args.channelId,
+            channelType: args.channelType,
+            slackUserId: args.slackUserId,
+            threadTs,
+            ephemeralThreadTs: args.threadTs ? threadTs : undefined,
+            text: "The configured agent is not available to your Slack account. Use `/zero switch` to choose an accessible agent.",
+          });
+          return null;
+        }
+      }
     }
 
     return {
@@ -1315,8 +1425,8 @@ const resolveSlackAgentMessage$ = command(
       connection,
       client,
       threadTs,
-      composeId,
-      agent,
+      composeId: effectiveCompose.composeId,
+      agent: effectiveCompose.agent,
     };
   },
 );
@@ -1831,7 +1941,12 @@ const handleAgentPickerSubmit$ = command(
       return emptyResponse();
     }
 
-    const agent = await getWorkspaceAgent(db, selected, ctx.orgId);
+    const agent = await getVisibleWorkspaceAgent(
+      db,
+      selected,
+      ctx.orgId,
+      ctx.connection.vm0UserId,
+    );
     if (!agent || agent.id !== selected) {
       return jsonResponse({
         response_action: "errors",
@@ -1943,20 +2058,13 @@ const handleHomeSwitchAgent$ = command(
     if (!ctx) {
       return;
     }
-    const { composes } = await get(zeroComposeList(ctx.orgId));
     const defaultComposeId = await resolveDefaultComposeId(db, ctx.orgId);
-    const options = composes
-      .filter((compose) => {
-        return compose.id !== defaultComposeId;
-      })
-      .slice(0, AGENT_PICKER_MAX_OPTIONS)
-      .map((compose) => {
-        return {
-          composeId: compose.id,
-          name: compose.name,
-          displayName: compose.displayName,
-        };
-      });
+    const options = await getVisibleAgentPickerOptions({
+      db,
+      orgId: ctx.orgId,
+      userId: ctx.connection.vm0UserId,
+      defaultComposeId,
+    });
     const orgDefaultName = defaultComposeId
       ? ((await getWorkspaceAgent(db, defaultComposeId))?.displayName ??
         (await getWorkspaceAgent(db, defaultComposeId))?.name ??

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -820,6 +820,12 @@ const refreshOrgAppHome$ = command(
             connection.vm0UserId,
           )
         : undefined;
+      const visibleOptions = await getVisibleAgentPickerOptions({
+        db,
+        orgId,
+        userId: connection.vm0UserId,
+        defaultComposeId,
+      });
       if (effectiveCompose.status === "resolved") {
         agentName =
           effectiveCompose.agent.displayName ?? effectiveCompose.agent.name;
@@ -827,7 +833,7 @@ const refreshOrgAppHome$ = command(
       isOverrideActive = Boolean(
         visibleOverrideAgent && overrideComposeId !== defaultComposeId,
       );
-      canSwitch = Boolean(visibleDefaultAgent);
+      canSwitch = Boolean(visibleDefaultAgent || visibleOptions.length > 0);
     }
 
     const [metadata] = await db
@@ -883,10 +889,21 @@ const commandSwitchResponse$ = command(
       userId: connection.vm0UserId,
       defaultComposeId,
     });
-    const orgDefaultName = defaultComposeId
-      ? ((await getWorkspaceAgent(db, defaultComposeId))?.displayName ??
-        (await getWorkspaceAgent(db, defaultComposeId))?.name ??
-        null)
+    const visibleDefaultAgent = defaultComposeId
+      ? await getVisibleWorkspaceAgent(
+          db,
+          defaultComposeId,
+          installation.orgId,
+          connection.vm0UserId,
+        )
+      : undefined;
+    if (!visibleDefaultAgent && options.length === 0) {
+      return ephemeral(
+        buildErrorMessage("No agents are available to your Slack account."),
+      );
+    }
+    const orgDefaultName = visibleDefaultAgent
+      ? (visibleDefaultAgent.displayName ?? visibleDefaultAgent.name)
       : null;
     const currentOverride = await getUserAgentPreference(
       db,
@@ -908,6 +925,7 @@ const commandSwitchResponse$ = command(
         buildAgentPickerModal({
           options,
           currentSelectedId: currentOverride,
+          includeOrgDefault: Boolean(visibleDefaultAgent),
           orgDefaultName,
           privateMetadata: JSON.stringify({ channelId: payload.channel_id }),
         }),
@@ -1881,15 +1899,6 @@ async function postEphemeralMessage(args: {
   }
 }
 
-async function resolveOrgDefaultName(db: Db, orgId: string): Promise<string> {
-  const defaultComposeId = await resolveDefaultComposeId(db, orgId);
-  if (!defaultComposeId) {
-    return "the org default agent";
-  }
-  const agent = await getWorkspaceAgent(db, defaultComposeId);
-  return agent?.displayName ?? agent?.name ?? "the org default agent";
-}
-
 const handleAgentPickerSubmit$ = command(
   async (
     { get, set },
@@ -1922,7 +1931,25 @@ const handleAgentPickerSubmit$ = command(
     );
     const channelId = parseViewChannelId(payload.view?.private_metadata);
     if (selected === AGENT_PICKER_ORG_DEFAULT_VALUE) {
-      const defaultName = await resolveOrgDefaultName(db, ctx.orgId);
+      const defaultComposeId = await resolveDefaultComposeId(db, ctx.orgId);
+      const visibleDefaultAgent = defaultComposeId
+        ? await getVisibleWorkspaceAgent(
+            db,
+            defaultComposeId,
+            ctx.orgId,
+            ctx.connection.vm0UserId,
+          )
+        : undefined;
+      if (!visibleDefaultAgent) {
+        return jsonResponse({
+          response_action: "errors",
+          errors: {
+            [AGENT_PICKER_BLOCK_ID]: "You don't have access to that agent.",
+          },
+        });
+      }
+      const defaultName =
+        visibleDefaultAgent.displayName ?? visibleDefaultAgent.name;
       await setUserAgentPreference({
         db,
         vm0UserId: ctx.connection.vm0UserId,
@@ -2065,10 +2092,19 @@ const handleHomeSwitchAgent$ = command(
       userId: ctx.connection.vm0UserId,
       defaultComposeId,
     });
-    const orgDefaultName = defaultComposeId
-      ? ((await getWorkspaceAgent(db, defaultComposeId))?.displayName ??
-        (await getWorkspaceAgent(db, defaultComposeId))?.name ??
-        null)
+    const visibleDefaultAgent = defaultComposeId
+      ? await getVisibleWorkspaceAgent(
+          db,
+          defaultComposeId,
+          ctx.orgId,
+          ctx.connection.vm0UserId,
+        )
+      : undefined;
+    if (!visibleDefaultAgent && options.length === 0) {
+      return;
+    }
+    const orgDefaultName = visibleDefaultAgent
+      ? (visibleDefaultAgent.displayName ?? visibleDefaultAgent.name)
       : null;
     const currentOverride = await getUserAgentPreference(
       db,
@@ -2089,6 +2125,7 @@ const handleHomeSwitchAgent$ = command(
         buildAgentPickerModal({
           options,
           currentSelectedId: currentOverride,
+          includeOrgDefault: Boolean(visibleDefaultAgent),
           orgDefaultName,
         }),
       ),


### PR DESCRIPTION
## Summary
- filter Slack `/zero switch` and App Home switch options to public agents plus the current user's private agents
- reject hidden private agent IDs submitted through the Slack picker
- prevent Slack event dispatch from running a private default agent that is not visible to the connected user

## Validation
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-commands.test.ts src/signals/routes/__tests__/zero-slack-interactive.test.ts src/signals/routes/__tests__/zero-slack-events.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-third-party.test.ts -t "starts a new session for label triggers on a GitHub issue with an existing session"`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest` (Slack tests passed; local full run fails on `@vm0/desktop src/computer-use-native.test.ts` because this container is not macOS, and one unrelated GitHub webhook case passed when rerun directly)
