### PR TITLE
refactor: move storage fingerprints out of idle pool

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -232,7 +232,7 @@ mod tests {
             device_rate_limits: None,
             budget_lease: ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
             source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
         })
     }
 
@@ -267,7 +267,7 @@ mod tests {
                     None,
                     WorkspaceCacheTerminalStatus::Success,
                     completed_at.into(),
-                    &crate::idle_pool::StorageFingerprints::default(),
+                    &crate::storage_fingerprints::StorageFingerprints::default(),
                 )
                 .await
                 .unwrap()

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -193,11 +193,12 @@ mod tests {
 
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult,
-        ParkedIdleCandidate, StorageFingerprints, SyntheticParkedIdleCandidateParts,
+        ParkedIdleCandidate, SyntheticParkedIdleCandidateParts,
     };
     use crate::ids::RunId;
     use crate::paths::RunnerPaths;
     use crate::resource_budget::ResourceBudget;
+    use crate::storage_fingerprints::StorageFingerprints;
     use crate::workspace_image_cache::{
         SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImagePrepareRequest,
         WorkspaceImagePromotionRequest,
@@ -345,7 +346,7 @@ mod tests {
                 device_rate_limits: None,
                 budget_lease: lease,
                 source_ip: "10.0.0.1".into(),
-                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             });
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),
@@ -392,7 +393,7 @@ mod tests {
                 device_rate_limits: None,
                 budget_lease: lease,
                 source_ip: "10.0.0.1".into(),
-                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             });
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),
@@ -441,7 +442,7 @@ mod tests {
                 device_rate_limits: None,
                 budget_lease: lease,
                 source_ip: "10.0.0.1".into(),
-                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             });
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -27,7 +27,7 @@ use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completi
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{self, ExecutionFailureKind, ExecutorConfig};
-use crate::idle_pool::{ParkingGate, ReusableIdleSandbox, StorageFingerprints};
+use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_logs;
@@ -35,6 +35,7 @@ use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
 use crate::resource_budget::BudgetLease;
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::StatusTracker;
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
@@ -448,7 +449,7 @@ pub(super) fn spawn_job(
     let storage_fingerprints = context
         .storage_manifest
         .as_ref()
-        .map(crate::idle_pool::StorageFingerprints::from_manifest)
+        .map(crate::storage_fingerprints::StorageFingerprints::from_manifest)
         .unwrap_or_default();
 
     let provider = Arc::clone(&ctx.provider);
@@ -1316,7 +1317,7 @@ mod tests {
                 device_rate_limits: None,
                 budget_lease: lease,
                 source_ip: "10.0.0.1".into(),
-                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             });
         assert!(matches!(
             fixture.idle_pool.lock().await.park(candidate),

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -314,10 +314,11 @@ async fn reap_orphaned_active_runs_with_firecrackers(
 mod tests {
     use super::*;
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate, StorageFingerprints,
+        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
         SyntheticParkedIdleCandidateParts,
     };
     use crate::resource_budget::ResourceBudget;
+    use crate::storage_fingerprints::StorageFingerprints;
     use sandbox::SandboxFactory;
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
     use std::time::Duration;

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -23,7 +23,7 @@ use super::ownership::OwnershipTransitions;
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkRequest, IdleParkRequestParts,
-    ParkResult, ParkingGate, StorageFingerprints,
+    ParkResult, ParkingGate,
 };
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -33,6 +33,7 @@ use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
 use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionRequest,
 };
@@ -671,7 +672,7 @@ mod tests {
                 network_log_session: Some(network_log_session),
                 workspace_image: None,
                 workspace_promotable: false,
-                storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
                 device_rate_limits: None,
                 factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
                 idle_pool: Arc::clone(&self.idle_pool),
@@ -721,7 +722,7 @@ mod tests {
         sandbox_id: SandboxId,
         session_id: &str,
         terminal_status: WorkspaceCacheTerminalStatus,
-        storage_fingerprints: crate::idle_pool::StorageFingerprints,
+        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints,
     ) -> WorkspaceImagePromotionContext {
         lease
             .into_promotion_context(WorkspaceImagePromotionRequest {
@@ -869,7 +870,7 @@ mod tests {
             sandbox_id,
             "sess-promote",
             WorkspaceCacheTerminalStatus::Success,
-            crate::idle_pool::StorageFingerprints::default(),
+            crate::storage_fingerprints::StorageFingerprints::default(),
         );
 
         let promoted =
@@ -903,7 +904,7 @@ mod tests {
                 prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, session_id)
                     .await;
             let sandbox = MockSandbox::new(format!("workspace-promotion-{session_id}"));
-            let storage_fingerprints = crate::idle_pool::StorageFingerprints {
+            let storage_fingerprints = crate::storage_fingerprints::StorageFingerprints {
                 storages: std::collections::HashMap::from([(
                     CANONICAL_WORKING_DIR.to_owned(),
                     ("repo".to_owned(), "v1".to_owned()),
@@ -978,7 +979,7 @@ mod tests {
             sandbox_id,
             "sess-failed",
             WorkspaceCacheTerminalStatus::Success,
-            crate::idle_pool::StorageFingerprints::default(),
+            crate::storage_fingerprints::StorageFingerprints::default(),
         );
 
         let promoted =
@@ -1071,7 +1072,7 @@ mod tests {
             device_rate_limits: None,
             budget_lease: existing_lease,
             source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
         })
         .with_last_completed_at(local_completed_at());
         assert!(matches!(
@@ -1162,7 +1163,7 @@ mod tests {
             old_sandbox_id,
             session_id,
             WorkspaceCacheTerminalStatus::Success,
-            crate::idle_pool::StorageFingerprints::default(),
+            crate::storage_fingerprints::StorageFingerprints::default(),
         );
         let destroy_gate = MockLifecycleGate::new();
         let existing_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -1192,7 +1193,7 @@ mod tests {
             profile_name: "vm0/default".into(),
             device_rate_limits: None,
             budget_lease: existing_lease,
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
             workspace_promotion: Some(old_promotion),
         })
         .park_for_idle()

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -20,7 +20,7 @@ fn make_synthetic_parked_candidate(
         device_rate_limits: None,
         budget_lease,
         source_ip: "10.0.0.1".into(),
-        storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
     })
 }
 
@@ -94,7 +94,7 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
             device_rate_limits: None,
             budget_lease,
             source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
         })
         .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string()),
     );

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -106,7 +106,7 @@ fn wait_process_timed_out(error: &sandbox::SandboxError) -> bool {
 pub(super) struct RunStart<'a> {
     pub(super) restore_guest_state: bool,
     pub(super) reuse_result: SandboxReuseResult,
-    pub(super) prev_storage: Option<&'a crate::idle_pool::StorageFingerprints>,
+    pub(super) prev_storage: Option<&'a crate::storage_fingerprints::StorageFingerprints>,
 }
 
 pub(super) async fn run_in_sandbox(

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -311,7 +311,7 @@ pub(super) async fn execute_reused_sandbox(
     source_ip: &str,
     context: &ExecutionContext,
     config: &ExecutorConfig,
-    prev_storage: &crate::idle_pool::StorageFingerprints,
+    prev_storage: &crate::storage_fingerprints::StorageFingerprints,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> ExecuteOutcome {

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -7,8 +7,8 @@ use super::{
     DEFAULT_EXEC_TIMEOUT, GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES, RunnerError, RunnerResult,
     guest_runtime_dir,
 };
-use crate::idle_pool::StorageFingerprints;
 use crate::paths::guest;
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{
     ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
 };

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -102,7 +102,7 @@ async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_ag
     let source_ip = sandbox.source_ip().to_string();
     let ctx = minimal_context();
     let mut telemetry = test_telemetry(&config, &ctx);
-    let prev_storage = crate::idle_pool::StorageFingerprints::default();
+    let prev_storage = crate::storage_fingerprints::StorageFingerprints::default();
 
     let outcome = execute_reused_sandbox(
         sandbox,
@@ -1665,8 +1665,9 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
 ) {
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, IdleUnparkResult,
-        ParkResult, StorageFingerprints,
+        ParkResult,
     };
+    use crate::storage_fingerprints::StorageFingerprints;
 
     let current_image =
         seed_workspace_image_cache(cache, runner_paths, session_id, params.workspace_disk_mb).await;
@@ -1763,8 +1764,9 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
 ) {
     use crate::idle_pool::{
         IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, IdleUnparkResult,
-        ParkResult, StorageFingerprints,
+        ParkResult,
     };
+    use crate::storage_fingerprints::StorageFingerprints;
 
     let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
@@ -2034,7 +2036,7 @@ async fn idle_pool_park_and_reuse_cycle() {
         device_rate_limits: None,
         budget_lease: test_budget_lease(),
         source_ip: outcome.source_ip,
-        storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
     });
 
     let result = pool.park(entry);
@@ -2092,7 +2094,7 @@ async fn idle_pool_profile_mismatch_returns_none() {
         device_rate_limits: None,
         budget_lease: test_budget_lease(),
         source_ip: "10.0.0.1".into(),
-        storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
     });
     let _ = pool.park(entry);
 

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -171,7 +171,7 @@ fn filter_same_artifact_version_keeps_url_for_mount_repair() {
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -191,7 +191,7 @@ fn filter_different_artifact_version_keeps_url() {
         artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -209,7 +209,7 @@ fn filter_different_artifact_name_keeps_url() {
         artifacts: vec![guest_art("other-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -224,7 +224,7 @@ fn filter_new_artifact_not_in_prev_keeps_url() {
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints::default();
+    let prev = crate::storage_fingerprints::StorageFingerprints::default();
     let result = filter_unchanged_storages(&manifest, &prev);
     assert!(result.artifacts[0].archive_url.is_some());
 }
@@ -241,7 +241,7 @@ fn filter_empty_prev_downloads_everything() {
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints::default();
+    let prev = crate::storage_fingerprints::StorageFingerprints::default();
     let result = filter_unchanged_storages(&manifest, &prev);
     assert!(result.storages[0].archive_url.is_some());
     assert!(result.artifacts[0].archive_url.is_some());
@@ -261,7 +261,7 @@ fn filter_all_unchanged_nulls_storage_urls_and_keeps_artifact_urls() {
     };
     let mut storages = HashMap::new();
     storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages,
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -304,7 +304,7 @@ fn filter_two_artifacts_at_different_mount_paths() {
     let mut artifacts = HashMap::new();
     artifacts.insert("/workspace".into(), ("art-a".into(), "v1".into()));
     artifacts.insert("/data".into(), ("art-b".into(), "v1".into()));
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts,
     };
@@ -333,7 +333,7 @@ fn filter_detects_removed_artifacts() {
     let mut artifacts = HashMap::new();
     artifacts.insert("/workspace".into(), ("kept".into(), "v1".into()));
     artifacts.insert("/old".into(), ("removed".into(), "v1".into()));
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts,
     };
@@ -371,7 +371,7 @@ fn filter_computes_cleanup_for_changed_storages() {
         "/home/user/.claude/skills/foo".into(),
         ("skill-foo".into(), "v1".into()),
     );
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -406,7 +406,7 @@ fn filter_detects_removed_storages() {
         "/home/user/.claude/skills/old-skill".into(),
         ("old-skill".into(), "v1".into()),
     );
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -427,7 +427,7 @@ fn filter_changed_artifact_adds_cleanup_path() {
         artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -447,7 +447,7 @@ fn filter_changed_artifact_with_null_url_adds_cleanup_path() {
         artifacts: vec![guest_art("my-art", "v2", None)],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -469,7 +469,7 @@ fn filter_unchanged_artifact_policy_does_not_force_redownload() {
         )],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "memory", "v1"),
     };
@@ -493,7 +493,7 @@ fn filter_changed_storage_with_null_url_adds_cleanup_path() {
     };
     let mut storages = HashMap::new();
     storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -517,7 +517,7 @@ fn filter_unchanged_storage_sets_cached_true() {
     };
     let mut storages = HashMap::new();
     storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -546,7 +546,7 @@ fn filter_tainted_paths_force_download_even_when_versions_match() {
         }],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::from([("/workspace/repo".into(), ("repo".into(), "v1".into()))]),
         artifacts: HashMap::from([(
             "/workspace/artifact".into(),
@@ -586,7 +586,7 @@ fn filter_tainted_removed_paths_are_cleaned() {
         artifacts: vec![],
         cleanup_paths: vec![],
     };
-    let prev = crate::idle_pool::StorageFingerprints {
+    let prev = crate::storage_fingerprints::StorageFingerprints {
         storages: HashMap::from([(
             "/workspace/removed-storage".into(),
             ("repo".into(), "v1".into()),

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -93,7 +93,7 @@ pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
         device_rate_limits: None,
         budget_lease: test_budget_lease(),
         source_ip,
-        storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
+        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
     });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(session_id).expect("idle entry should exist");

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -48,7 +48,7 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
                 None,
                 WorkspaceCacheTerminalStatus::Success,
                 "2026-06-01T00:00:00.000Z".into(),
-                &crate::idle_pool::StorageFingerprints::default(),
+                &crate::storage_fingerprints::StorageFingerprints::default(),
             )
             .await
             .unwrap()

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -6,13 +6,12 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
-use api_contracts::generated::types::runners::storage::StorageManifest;
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
-use serde::{Deserialize, Serialize};
 
 use crate::resource_budget::BudgetLease;
 use crate::status::IdleVm;
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::HeldSessionState;
 use crate::workspace_image_cache::WorkspaceImagePromotionContext;
 use crate::workspace_promotion::promote_workspace_image_from_parked_sandbox;
@@ -22,70 +21,6 @@ use crate::workspace_promotion::promote_workspace_image_from_parked_sandbox;
 /// Re-exported via `SandboxConfig::default()` so the YAML default and
 /// the in-process fallback stay locked together.
 pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
-
-/// Compact version fingerprints for storage manifest entries.
-/// Used to skip re-downloading unchanged storages on VM reuse.
-///
-/// All comparisons use `(vas_storage_name, vas_version_id)` tuples.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StorageFingerprints {
-    /// mount_path → (vas_storage_name, vas_version_id) for regular storages.
-    pub storages: HashMap<String, (String, String)>,
-    /// mount_path → (vas_storage_name, vas_version_id) for artifacts.
-    pub artifacts: HashMap<String, (String, String)>,
-}
-
-const TAINTED_STORAGE_FINGERPRINT_NAME: &str = "\0vm0-tainted-storage\0";
-const TAINTED_STORAGE_FINGERPRINT_VERSION: &str = "\0vm0-tainted-storage\0";
-
-impl StorageFingerprints {
-    pub fn from_manifest(manifest: &StorageManifest) -> Self {
-        let mut storages = HashMap::new();
-        for s in &manifest.storages {
-            storages.insert(
-                s.mount_path.clone(),
-                (s.vas_storage_name.clone(), s.vas_version_id.clone()),
-            );
-        }
-        let mut artifacts = HashMap::new();
-        for a in &manifest.artifacts {
-            artifacts.insert(
-                a.mount_path.clone(),
-                (a.vas_storage_name.clone(), a.vas_version_id.clone()),
-            );
-        }
-        Self {
-            storages,
-            artifacts,
-        }
-    }
-
-    pub(crate) fn tainted_paths(&self) -> Self {
-        let tainted = || {
-            (
-                TAINTED_STORAGE_FINGERPRINT_NAME.to_owned(),
-                TAINTED_STORAGE_FINGERPRINT_VERSION.to_owned(),
-            )
-        };
-        Self {
-            storages: self
-                .storages
-                .keys()
-                .map(|path| (path.clone(), tainted()))
-                .collect(),
-            artifacts: self
-                .artifacts
-                .keys()
-                .map(|path| (path.clone(), tainted()))
-                .collect(),
-        }
-    }
-
-    pub(crate) fn fingerprint_is_tainted(fingerprint: &(String, String)) -> bool {
-        fingerprint.0 == TAINTED_STORAGE_FINGERPRINT_NAME
-            && fingerprint.1 == TAINTED_STORAGE_FINGERPRINT_VERSION
-    }
-}
 
 /// Configuration for the idle sandbox pool.
 #[derive(Debug, Clone)]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -39,6 +39,7 @@ mod runtime_overrides;
 mod state_file;
 mod status;
 mod storage_cache;
+mod storage_fingerprints;
 mod telemetry;
 mod types;
 mod workspace_image_cache;

--- a/crates/runner/src/storage_fingerprints.rs
+++ b/crates/runner/src/storage_fingerprints.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use api_contracts::generated::types::runners::storage::StorageManifest;
+use serde::{Deserialize, Serialize};
+
+/// Compact version fingerprints for storage manifest entries.
+/// Used to skip re-downloading unchanged storages on VM reuse.
+///
+/// All comparisons use `(vas_storage_name, vas_version_id)` tuples.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageFingerprints {
+    /// mount_path → (vas_storage_name, vas_version_id) for regular storages.
+    pub storages: HashMap<String, (String, String)>,
+    /// mount_path → (vas_storage_name, vas_version_id) for artifacts.
+    pub artifacts: HashMap<String, (String, String)>,
+}
+
+const TAINTED_STORAGE_FINGERPRINT_NAME: &str = "\0vm0-tainted-storage\0";
+const TAINTED_STORAGE_FINGERPRINT_VERSION: &str = "\0vm0-tainted-storage\0";
+
+impl StorageFingerprints {
+    pub fn from_manifest(manifest: &StorageManifest) -> Self {
+        let mut storages = HashMap::new();
+        for s in &manifest.storages {
+            storages.insert(
+                s.mount_path.clone(),
+                (s.vas_storage_name.clone(), s.vas_version_id.clone()),
+            );
+        }
+        let mut artifacts = HashMap::new();
+        for a in &manifest.artifacts {
+            artifacts.insert(
+                a.mount_path.clone(),
+                (a.vas_storage_name.clone(), a.vas_version_id.clone()),
+            );
+        }
+        Self {
+            storages,
+            artifacts,
+        }
+    }
+
+    pub(crate) fn tainted_paths(&self) -> Self {
+        let tainted = || {
+            (
+                TAINTED_STORAGE_FINGERPRINT_NAME.to_owned(),
+                TAINTED_STORAGE_FINGERPRINT_VERSION.to_owned(),
+            )
+        };
+        Self {
+            storages: self
+                .storages
+                .keys()
+                .map(|path| (path.clone(), tainted()))
+                .collect(),
+            artifacts: self
+                .artifacts
+                .keys()
+                .map(|path| (path.clone(), tainted()))
+                .collect(),
+        }
+    }
+
+    pub(crate) fn fingerprint_is_tainted(fingerprint: &(String, String)) -> bool {
+        fingerprint.0 == TAINTED_STORAGE_FINGERPRINT_NAME
+            && fingerprint.1 == TAINTED_STORAGE_FINGERPRINT_VERSION
+    }
+}

--- a/crates/runner/src/storage_fingerprints.rs
+++ b/crates/runner/src/storage_fingerprints.rs
@@ -8,18 +8,18 @@ use serde::{Deserialize, Serialize};
 ///
 /// All comparisons use `(vas_storage_name, vas_version_id)` tuples.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StorageFingerprints {
+pub(crate) struct StorageFingerprints {
     /// mount_path → (vas_storage_name, vas_version_id) for regular storages.
-    pub storages: HashMap<String, (String, String)>,
+    pub(crate) storages: HashMap<String, (String, String)>,
     /// mount_path → (vas_storage_name, vas_version_id) for artifacts.
-    pub artifacts: HashMap<String, (String, String)>,
+    pub(crate) artifacts: HashMap<String, (String, String)>,
 }
 
 const TAINTED_STORAGE_FINGERPRINT_NAME: &str = "\0vm0-tainted-storage\0";
 const TAINTED_STORAGE_FINGERPRINT_VERSION: &str = "\0vm0-tainted-storage\0";
 
 impl StorageFingerprints {
-    pub fn from_manifest(manifest: &StorageManifest) -> Self {
+    pub(crate) fn from_manifest(manifest: &StorageManifest) -> Self {
         let mut storages = HashMap::new();
         for s in &manifest.storages {
             storages.insert(

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -17,13 +17,13 @@ use tracing::debug;
 use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::idle_pool::StorageFingerprints;
 use crate::ids::RunId;
 #[cfg(test)]
 use crate::paths::session_workspace_cache_key;
 use crate::paths::{
     HomePaths, RunnerPaths, scoped_session_workspace_cache_key, workspace_image_cache_lock_path,
 };
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES};
 
 const CACHE_FORMAT_VERSION: u32 = 1;


### PR DESCRIPTION
## Summary

- Move `StorageFingerprints` and its direct taint/from-manifest helpers from `idle_pool.rs` into `storage_fingerprints.rs`.
- Update runner production code and tests to import the type from `crate::storage_fingerprints`.
- Keep the fingerprint data shape, serde fields, storage filtering behavior, workspace cache metadata, and archive cache policy unchanged.

Fixes #17036.

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::storage_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner idle_pool`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- pre-commit: cargo fmt, cargo doc, cargo clippy
