### PR TITLE
fix: reject malformed zstd usage bodies

### DIFF
--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -533,6 +533,38 @@ def _decompress_zlib_json_usage_body(
     return bytes(out), None
 
 
+def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[bytes, str | None]:
+    if max_output <= 0:
+        return b"", None
+
+    try:
+        with zstandard.ZstdDecompressor().stream_reader(data, read_across_frames=True) as reader:
+            body = reader.read(max_output)
+            # Force validation of any trailing frame without accumulating it.
+            extra = reader.read(1)
+    except zstandard.ZstdError as exc:
+        with contextlib.suppress(AttributeError):
+            # ctx.log unavailable outside mitmproxy runtime
+            ctx.log.debug(f"Decompression failed (zstd): {exc}")
+        return b"", "invalid compressed body"
+
+    if extra:
+        return body, None
+    if data and not body:
+        try:
+            # A fresh decompressobj exposes eof, which distinguishes a
+            # complete empty zstd frame from an incomplete prefix. The
+            # gzip/deflate and brotli branches already get equivalent
+            # completion signals through their codec-specific helpers.
+            obj = zstandard.ZstdDecompressor().decompressobj()
+            obj.decompress(data)
+        except zstandard.ZstdError:
+            return body, "incomplete compressed body"
+        if not obj.eof:
+            return body, "incomplete compressed body"
+    return body, None
+
+
 def decompress_json_usage_body(
     data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
 ) -> tuple[bytes, str | None]:
@@ -559,31 +591,7 @@ def decompress_json_usage_body(
             return body, "incomplete compressed body"
         return body, None
     if encoding == "zstd":
-        try:
-            # First use stream_reader().read(max_output) as the bounded-output
-            # primary path. For zstd, an incomplete frame can read as empty
-            # without proving whether the frame is a valid empty payload, so
-            # only the empty-output case needs a second state check below.
-            with zstandard.ZstdDecompressor().stream_reader(data) as reader:
-                body = reader.read(max_output)
-        except zstandard.ZstdError as exc:
-            with contextlib.suppress(AttributeError):
-                # ctx.log unavailable outside mitmproxy runtime
-                ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return b"", "invalid compressed body"
-        if data and not body:
-            try:
-                # A fresh decompressobj exposes eof, which distinguishes a
-                # complete empty zstd frame from an incomplete prefix. The
-                # gzip/deflate and brotli branches already get equivalent
-                # completion signals through their codec-specific helpers.
-                obj = zstandard.ZstdDecompressor().decompressobj()
-                obj.decompress(data)
-            except zstandard.ZstdError:
-                return body, "incomplete compressed body"
-            if not obj.eof:
-                return body, "incomplete compressed body"
-        return body, None
+        return _decompress_zstd_json_usage_body(data, max_output)
     if encoding and encoding != "identity" and data:
         return b"", "unsupported content encoding"
     return decompress_body(data, headers, max_output=max_output), None

--- a/crates/runner/mitm-addon/src/body_utils.py
+++ b/crates/runner/mitm-addon/src/body_utils.py
@@ -533,6 +533,20 @@ def _decompress_zlib_json_usage_body(
     return bytes(out), None
 
 
+def _validate_complete_zstd_frames(data: bytes) -> str | None:
+    remaining_data = data
+    while remaining_data:
+        obj = zstandard.ZstdDecompressor().decompressobj()
+        try:
+            obj.decompress(remaining_data)
+        except zstandard.ZstdError:
+            return "invalid compressed body"
+        if not obj.eof:
+            return "incomplete compressed body"
+        remaining_data = obj.unused_data
+    return None
+
+
 def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[bytes, str | None]:
     if max_output <= 0:
         return b"", None
@@ -550,19 +564,7 @@ def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[byte
 
     if extra:
         return body, None
-    if data and not body:
-        try:
-            # A fresh decompressobj exposes eof, which distinguishes a
-            # complete empty zstd frame from an incomplete prefix. The
-            # gzip/deflate and brotli branches already get equivalent
-            # completion signals through their codec-specific helpers.
-            obj = zstandard.ZstdDecompressor().decompressobj()
-            obj.decompress(data)
-        except zstandard.ZstdError:
-            return body, "incomplete compressed body"
-        if not obj.eof:
-            return body, "incomplete compressed body"
-    return body, None
+    return body, _validate_complete_zstd_frames(data)
 
 
 def decompress_json_usage_body(

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -120,6 +120,11 @@ def _zstd_frame_before_garbage(payload: bytes) -> bytes:
     return zstandard.ZstdCompressor().compress(payload) + b"garbage"
 
 
+def _zstd_frame_before_truncated_frame(payload: bytes) -> bytes:
+    trailing_frame = zstandard.ZstdCompressor().compress(b"{}")
+    return zstandard.ZstdCompressor().compress(payload) + trailing_frame[:5]
+
+
 JSON_COMPRESSION_FAILURE_CASES = (
     JsonCompressionFailureCase(
         id="chained-gzip",
@@ -192,6 +197,12 @@ JSON_COMPRESSION_FAILURE_CASES = (
         make_body=_zstd_frame_before_garbage,
         content_encoding="zstd",
         expected_error="invalid compressed body",
+    ),
+    JsonCompressionFailureCase(
+        id="zstd-frame-before-truncated-frame",
+        make_body=_zstd_frame_before_truncated_frame,
+        content_encoding="zstd",
+        expected_error="incomplete compressed body",
     ),
 )
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -116,6 +116,10 @@ def _truncated_zstd_prefix(payload: bytes) -> bytes:
     return zstandard.ZstdCompressor().compress(payload)[:5]
 
 
+def _zstd_frame_before_garbage(payload: bytes) -> bytes:
+    return zstandard.ZstdCompressor().compress(payload) + b"garbage"
+
+
 JSON_COMPRESSION_FAILURE_CASES = (
     JsonCompressionFailureCase(
         id="chained-gzip",
@@ -182,6 +186,12 @@ JSON_COMPRESSION_FAILURE_CASES = (
         make_body=_truncated_zstd_prefix,
         content_encoding="zstd",
         expected_error="incomplete compressed body",
+    ),
+    JsonCompressionFailureCase(
+        id="zstd-frame-before-garbage",
+        make_body=_zstd_frame_before_garbage,
+        content_encoding="zstd",
+        expected_error="invalid compressed body",
     ),
 )
 


### PR DESCRIPTION
## Summary

- add a zstd-specific JSON usage decompression helper that validates trailing frames through bounded streaming reads
- reject zstd usage bodies where a valid frame is followed by invalid garbage
- add a model-provider regression case covering malformed zstd usage responses

Closes #16977

## Tests

- `cd crates/runner/mitm-addon && pytest tests/test_model_provider_response_usage.py -k 'zstd-frame-before-garbage'`
- `cd crates/runner/mitm-addon && pytest tests/test_model_provider_response_usage.py`
- `cd crates/runner/mitm-addon && pytest tests/test_body_capture.py -k zstd`
- `cd crates/runner/mitm-addon && ruff check src/body_utils.py tests/test_model_provider_response_usage.py`
- `cd crates/runner/mitm-addon && ruff format --check src/body_utils.py tests/test_model_provider_response_usage.py`
- `git diff --check`
