### PR TITLE
fix: filter unsafe resolved auth headers

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -23,10 +23,11 @@ import matching
 from auth_base_forwarder import (
     MAX_AUTH_BASE_REQUEST_BODY_BYTES,
     ForwardedRequestTooLargeError,
+    InvalidResolvedAuthHeaderError,
     forward_request,
     forwarded_request_header_pairs,
     header_pairs,
-    trusted_request_header_pairs,
+    resolved_auth_header_pairs,
 )
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
 from logging_utils import log_proxy_entry
@@ -623,7 +624,7 @@ def _merge_auth_headers(
     auth_headers: dict[str, str],
 ) -> list[tuple[str, str]]:
     pairs = header_pairs(headers)
-    auth_pairs = trusted_request_header_pairs(auth_headers)
+    auth_pairs = resolved_auth_header_pairs(auth_headers)
     override_names = {name.lower() for name, _value in auth_pairs}
     return [
         (name, value) for name, value in pairs if name.lower() not in override_names
@@ -783,7 +784,7 @@ def _apply_header_query_injection(
     headers: dict[str, str],
     resolved_query: dict | None,
 ) -> None:
-    for header_name, header_value in headers.items():
+    for header_name, header_value in resolved_auth_header_pairs(headers):
         flow.request.headers[header_name] = header_value
     if resolved_query:
         for key, value in resolved_query.items():
@@ -1027,6 +1028,32 @@ def _set_firewall_auth_resolution_failure(
     return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
 
+def _set_invalid_resolved_auth_header_response(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+    error: InvalidResolvedAuthHeaderError,
+) -> None:
+    log_proxy_entry(
+        proxy_log_path,
+        "error",
+        "Invalid resolved auth header",
+        type="firewall",
+        firewall_base=firewall_base,
+        error_type=type(error).__name__,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=502,
+        action="ALLOW",
+        error_code="invalid_resolved_auth_header",
+        message=str(error),
+        permission=allow.name,
+    )
+
+
 async def _apply_url_rewrite(
     flow: http.HTTPFlow,
     *,
@@ -1131,23 +1158,34 @@ async def _apply_resolved_firewall_auth(
     resolved_base = token_meta.get("base")
     aws_sigv4 = token_meta.get("aws_sigv4")
 
-    if resolved_base:
-        return await _apply_url_rewrite(
+    try:
+        if resolved_base:
+            return await _apply_url_rewrite(
+                flow,
+                allow=allow,
+                resolved_base=resolved_base,
+                headers=headers,
+                resolved_query=resolved_query,
+                aws_sigv4=aws_sigv4,
+                firewall_base=firewall_base,
+                proxy_log_path=proxy_log_path,
+            )
+
+        _apply_header_query_injection(
             flow,
-            allow=allow,
-            resolved_base=resolved_base,
             headers=headers,
             resolved_query=resolved_query,
-            aws_sigv4=aws_sigv4,
-            firewall_base=firewall_base,
-            proxy_log_path=proxy_log_path,
         )
+    except InvalidResolvedAuthHeaderError as e:
+        _set_invalid_resolved_auth_header_response(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+            error=e,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    _apply_header_query_injection(
-        flow,
-        headers=headers,
-        resolved_query=resolved_query,
-    )
     if aws_sigv4 is not None:
         try:
             _sign_flow_request_with_aws_sigv4(flow, aws_sigv4)

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -32,6 +32,14 @@ HOP_BY_HOP: frozenset[str] = frozenset(
         "upgrade",
     )
 )
+_RESOLVED_AUTH_HEADER_EXCLUDED: frozenset[str] = HOP_BY_HOP | frozenset(
+    ("host", "content-length", "transfer-encoding")
+)
+_HTTP_TOKEN_CHARS: frozenset[str] = frozenset(
+    "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+_ASCII_CONTROL_MAX = 0x1F
+_ASCII_DELETE = 0x7F
 DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
@@ -77,6 +85,10 @@ class ForwardedRequestTooLargeError(Exception):
 
 class UnsafeAuthBaseDestinationError(Exception):
     """Raised when an auth.base upstream destination is not public internet."""
+
+
+class InvalidResolvedAuthHeaderError(Exception):
+    """Raised when resolved auth data contains an invalid HTTP header."""
 
 
 class _ValidatedAddress(NamedTuple):
@@ -204,11 +216,40 @@ def forwarded_request_header_pairs(headers) -> list[tuple[str, str]]:
     )
 
 
+def _validate_resolved_auth_header_pair(header_name: str, header_value: str) -> None:
+    if (
+        not isinstance(header_name, str)
+        or not header_name
+        or any(char not in _HTTP_TOKEN_CHARS for char in header_name)
+    ):
+        raise InvalidResolvedAuthHeaderError("Resolved auth header name is invalid")
+    if (
+        not isinstance(header_value, str)
+        or any(ord(char) <= _ASCII_CONTROL_MAX and char != "\t" for char in header_value)
+        or chr(_ASCII_DELETE) in header_value
+    ):
+        raise InvalidResolvedAuthHeaderError(f"Resolved auth header {header_name} value is invalid")
+    try:
+        header_value.encode("latin-1")
+    except UnicodeEncodeError as exc:
+        raise InvalidResolvedAuthHeaderError(
+            f"Resolved auth header {header_name} value is invalid"
+        ) from exc
+
+
+def resolved_auth_header_pairs(headers) -> list[tuple[str, str]]:
+    """Return resolved auth headers safe to inject into an outbound request."""
+    pairs = header_pairs(headers)
+    for name, value in pairs:
+        _validate_resolved_auth_header_pair(name, value)
+    return [
+        (name, value) for name, value in pairs if name.lower() not in _RESOLVED_AUTH_HEADER_EXCLUDED
+    ]
+
+
 def trusted_request_header_pairs(headers) -> list[tuple[str, str]]:
     """Return trusted injected request headers safe to append after client filtering."""
-    excluded = set(HOP_BY_HOP)
-    excluded.update({"host", "content-length", "transfer-encoding"})
-    return [(name, value) for name, value in header_pairs(headers) if name.lower() not in excluded]
+    return resolved_auth_header_pairs(headers)
 
 
 def _headers_from_pairs(pairs: list[tuple[str, str]]) -> http.Headers:

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -748,6 +748,113 @@ class TestHandleFirewallRequest:
         )
         assert "Firewall https://api.github.com: api.github.com" in log_text
 
+    async def test_standard_auth_filters_unsafe_resolved_headers(
+        self, real_flow, headers, mitm_ctx, tmp_path
+    ):
+        flow = _firewall_flow(
+            real_flow,
+            path="/repos?existing=1",
+        )
+        api_entry = _api_entry(
+            auth_config={"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry)
+        token_meta = _token_meta(
+            headers={
+                "Connection": "Authorization, X-Injected",
+                "Host": "evil.example.com",
+                "Content-Length": "999",
+                "Transfer-Encoding": "chunked",
+                "Keep-Alive": "timeout=5",
+                "Proxy-Authenticate": "Basic realm=proxy",
+                "Proxy-Authorization": "Basic secret",
+                "Proxy-Connection": "keep-alive",
+                "TE": "trailers",
+                "Trailer": "X-Trailer",
+                "Upgrade": "websocket",
+                "Authorization": "Bearer real-token",
+                "X-Injected": "trusted",
+            },
+        )
+        token_meta["query"] = {"api_key": "secret"}
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        header_names = {name.lower() for name, _value in flow.request.headers.items(multi=True)}
+        assert flow.request.headers["Host"] == "api.github.com"
+        assert "connection" not in header_names
+        assert "content-length" not in header_names
+        assert "transfer-encoding" not in header_names
+        assert "keep-alive" not in header_names
+        assert "proxy-authenticate" not in header_names
+        assert "proxy-authorization" not in header_names
+        assert "proxy-connection" not in header_names
+        assert "te" not in header_names
+        assert "trailer" not in header_names
+        assert "upgrade" not in header_names
+        assert flow.request.headers["Authorization"] == "Bearer real-token"
+        assert flow.request.headers["X-Injected"] == "trusted"
+        assert flow.request.query["existing"] == "1"
+        assert flow.request.query["api_key"] == "secret"
+
+    @pytest.mark.parametrize(
+        "resolved_headers",
+        [
+            pytest.param({"": "value"}, id="empty-name"),
+            pytest.param({"Bad\nName": "value"}, id="newline-name"),
+            pytest.param({":authority": "evil.example.com"}, id="pseudo-header-name"),
+            pytest.param({"X-Test": "bad\r\nX-Injected: value"}, id="newline-value"),
+        ],
+    )
+    async def test_standard_auth_rejects_malformed_resolved_headers(
+        self,
+        resolved_headers: dict[str, str],
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+    ):
+        flow = _firewall_flow(real_flow, path="/repos?existing=1")
+        api_entry = _api_entry(
+            auth_config={
+                "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
+                "query": {"api_key": "${{ secrets.GITHUB_TOKEN }}"},
+            },
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry)
+        token_meta = _token_meta(
+            headers={
+                **resolved_headers,
+                "Authorization": "Bearer real-token",
+            },
+        )
+        token_meta["query"] = {"api_key": "secret"}
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "invalid_resolved_auth_header"
+        assert "Authorization" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["existing"] == "1"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "invalid_resolved_auth_header"
+        assert body["permission"] == "github"
+        assert body["base"] == "https://api.github.com"
+
     async def test_missing_billable_firewalls_falls_back_to_empty(
         self, real_flow, headers, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -803,6 +803,70 @@ class TestHandleFirewallRequest:
         assert flow.request.query["existing"] == "1"
         assert flow.request.query["api_key"] == "secret"
 
+    async def test_standard_auth_filters_unsafe_headers_before_aws_sigv4_signing(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        placeholder_authorization = (
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=content-type;host;x-amz-date, "
+            "Signature=placeholder"
+        )
+        flow = real_flow(
+            with_response=False,
+            host="sts.amazonaws.com",
+            path="/",
+            method="POST",
+            request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+            request_headers=headers(
+                ("Host", "sts.amazonaws.com"),
+                ("Content-Type", "application/x-www-form-urlencoded"),
+                ("X-Amz-Date", "20260101T000000Z"),
+                ("Authorization", placeholder_authorization),
+            ),
+        )
+        flow.metadata["vm_run_id"] = "test-run"
+        api_entry = _api_entry(
+            base="https://sts.amazonaws.com",
+            auth_config={
+                "headers": {"Host": "${{ secrets.UNSAFE_HOST }}"},
+                "awsSigv4": {
+                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                },
+            },
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry, rule="POST /", rel_path="/")
+        token_meta = _token_meta(
+            headers={
+                "Host": "evil.example.com",
+                "X-Amz-Meta-Test": "trusted-meta",
+            },
+        )
+        token_meta["aws_sigv4"] = AwsSigV4Credentials(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            "real-session-token",
+        )
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        assert flow.request.headers["host"] == "sts.amazonaws.com"
+        assert flow.request.headers["x-amz-meta-test"] == "trusted-meta"
+        assert flow.request.headers["x-amz-security-token"] == "real-session-token"
+        assert (
+            "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
+            in flow.request.headers["authorization"]
+        )
+        assert "evil.example.com" not in flow.request.headers["authorization"]
+
     @pytest.mark.parametrize(
         "resolved_headers",
         [

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -154,6 +154,36 @@ class TestAuthBaseUrlRewriteForwarding:
         assert ("X-Injected", "trusted") in req_headers
         assert ("X-Keep", "client") in req_headers
 
+    async def test_forward_request_rejects_malformed_injected_header(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        """Malformed resolved auth headers fail before auth.base forwarding."""
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            resolved_base="https://discord.com/api/webhooks/123/abc",
+        )
+        token_meta["headers"] = {
+            "Authorization": "Bearer real-token",
+            "X-Test": "bad\r\nX-Injected: value",
+        }
+        mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        mock_forward.assert_not_called()
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == "invalid_resolved_auth_header"
+        body = json.loads(flow.response.content)
+        assert body["error"] == "invalid_resolved_auth_header"
+
     async def test_forward_request_signs_rewritten_aws_sigv4_request(
         self,
         headers,


### PR DESCRIPTION
## Summary

- add a shared resolved-auth header boundary in the mitm addon
- drop protocol-control resolved auth headers before standard or auth.base outbound use
- reject malformed resolved auth header names/values with a local firewall auth failure
- add standard-path and auth.base regression coverage

Closes #16976

## Tests

- `ruff format src/auth.py src/auth_base_forwarder.py tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py`
- `ruff check src/auth.py src/auth_base_forwarder.py tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py`
- `basedpyright src/auth.py src/auth_base_forwarder.py`
- `pytest tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py`
- `pytest tests/`