### PR TITLE
docs: document ably session state invariants

### DIFF
--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -29,20 +29,21 @@ pub(crate) struct SessionState {
     /// connected reconnects reset this counter; reaching the configured max
     /// marks the lifecycle failed.
     token_renewal_failures: u32,
-    /// Next suspended-channel reattach attempt. This is only scheduled while
-    /// the channel is suspended and the connection can send events.
+    /// Next suspended-channel reattach attempt. It is scheduled from a
+    /// suspended channel while the connection can send events, then cleared by
+    /// retry, reconnect, suspend, or terminal cleanup.
     channel_retry_at: Option<Instant>,
     /// Backoff counter used when scheduling suspended-channel retries. It
-    /// resets after a successful channel attach or committed connected
-    /// transport state.
+    /// resets after a successful channel attach, and reconnect commits reset it
+    /// before scheduling any suspended retry on the new transport.
     channel_retry_count: u32,
     /// Deadline for the current in-flight channel attach operation. This is
     /// separate from `channel_retry_at`: operation deadlines time out active
     /// attaches, while retry deadlines start the next attach attempt.
     channel_operation_deadline: Option<Instant>,
     /// A reconnect can restore the transport while channel attach is still
-    /// suspended. In that case `Event::Connected` is deferred until a later
-    /// `ATTACHED` message confirms the channel is ready again.
+    /// suspended. In that case `Event::Connected` is held for a later `ATTACHED`
+    /// message unless failed or suspended cleanup clears the pending marker.
     connected_event_pending: bool,
 }
 
@@ -284,7 +285,8 @@ impl SessionState {
     // Reconnect commit outcomes separate transport recovery from subscription
     // readiness. If the channel reattaches during reconnect, the caller can
     // emit `Event::Connected` immediately. If the transport reconnects but the
-    // channel is suspended, delay that event until a later ATTACHED message.
+    // channel is suspended, hold that event for a later ATTACHED message unless
+    // cleanup clears the pending marker first.
     pub(super) fn commit_reconnect_attached(
         &mut self,
         connected_msg: &ProtocolMessage,

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -32,7 +32,7 @@ pub(crate) struct SessionState {
     /// Next suspended-channel reattach attempt. It is scheduled from a
     /// suspended channel while the connection can send events, then cleared
     /// when consumed, superseded by a new attach, reset by reconnect/suspended
-    /// retry, or dropped on failure.
+    /// retry, or dropped by explicit channel/connection failure cleanup.
     channel_retry_at: Option<Instant>,
     /// Backoff counter used when scheduling suspended-channel retries. It
     /// resets after a successful channel attach, and reconnect commits reset it
@@ -41,12 +41,13 @@ pub(crate) struct SessionState {
     /// Optional deadline tracked for a started channel attach operation. This
     /// is separate from `channel_retry_at`: operation deadlines time out active
     /// attaches, while retry deadlines start the next attach attempt.
-    /// Reconnect, suspended retry, and failure cleanup clear stale attach
-    /// deadlines.
+    /// Reconnect, suspended retry, and explicit channel/connection failure
+    /// cleanup clear stale attach deadlines.
     channel_operation_deadline: Option<Instant>,
     /// A reconnect can restore the transport while channel attach is still
     /// suspended. In that case `Event::Connected` is held for a later `ATTACHED`
-    /// message unless failed or suspended cleanup clears the pending marker.
+    /// message unless channel failure or suspended cleanup clears the pending
+    /// marker.
     connected_event_pending: bool,
 }
 
@@ -289,7 +290,7 @@ impl SessionState {
     // readiness. If the channel reattaches during reconnect, the caller can
     // emit `Event::Connected` immediately. If the transport reconnects but the
     // channel is suspended, hold that event for a later ATTACHED message unless
-    // cleanup clears the pending marker first.
+    // channel failure or suspended cleanup clears the pending marker first.
     pub(super) fn commit_reconnect_attached(
         &mut self,
         connected_msg: &ProtocolMessage,

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -38,10 +38,11 @@ pub(crate) struct SessionState {
     /// resets after a successful channel attach, and reconnect commits reset it
     /// before scheduling any suspended retry on the new transport.
     channel_retry_count: u32,
-    /// Deadline set for a sent channel attach operation. This is separate from
-    /// `channel_retry_at`: operation deadlines time out active attaches, while
-    /// retry deadlines start the next attach attempt. Reconnect, suspended
-    /// retry, and failure cleanup clear stale attach deadlines.
+    /// Optional deadline tracked for a started channel attach operation. This
+    /// is separate from `channel_retry_at`: operation deadlines time out active
+    /// attaches, while retry deadlines start the next attach attempt.
+    /// Reconnect, suspended retry, and failure cleanup clear stale attach
+    /// deadlines.
     channel_operation_deadline: Option<Instant>,
     /// A reconnect can restore the transport while channel attach is still
     /// suspended. In that case `Event::Connected` is held for a later `ATTACHED`
@@ -112,9 +113,9 @@ impl SessionState {
         self.conn_state.can_resume()
     }
 
-    // Channel attach has two scheduled states: an operation deadline while an
-    // ATTACH is in flight, then a retry deadline if that attach is suspended
-    // by timeout or DETACHED response.
+    // Channel attach tracks separate timers: an operation deadline may be set
+    // when ATTACH starts, and a retry deadline is scheduled if that attach is
+    // suspended by timeout or DETACHED response.
     pub(super) fn begin_channel_attach(&mut self, realtime_request_timeout: Duration) -> bool {
         self.lifecycle.request_channel_attaching();
         if self.lifecycle.channel != ChannelLifecycleState::Attaching

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -30,16 +30,18 @@ pub(crate) struct SessionState {
     /// marks the lifecycle failed.
     token_renewal_failures: u32,
     /// Next suspended-channel reattach attempt. It is scheduled from a
-    /// suspended channel while the connection can send events, then cleared by
-    /// retry, reconnect, suspend, or terminal cleanup.
+    /// suspended channel while the connection can send events, then cleared
+    /// when consumed, superseded by a new attach, reset by reconnect/suspended
+    /// retry, or dropped on failure.
     channel_retry_at: Option<Instant>,
     /// Backoff counter used when scheduling suspended-channel retries. It
     /// resets after a successful channel attach, and reconnect commits reset it
     /// before scheduling any suspended retry on the new transport.
     channel_retry_count: u32,
-    /// Deadline for the current in-flight channel attach operation. This is
-    /// separate from `channel_retry_at`: operation deadlines time out active
-    /// attaches, while retry deadlines start the next attach attempt.
+    /// Deadline set for a sent channel attach operation. This is separate from
+    /// `channel_retry_at`: operation deadlines time out active attaches, while
+    /// retry deadlines start the next attach attempt. Reconnect, suspended
+    /// retry, and failure cleanup clear stale attach deadlines.
     channel_operation_deadline: Option<Instant>,
     /// A reconnect can restore the transport while channel attach is still
     /// suspended. In that case `Event::Connected` is held for a later `ATTACHED`
@@ -211,8 +213,8 @@ impl SessionState {
     // Suspended retry means the session can no longer resume the previous
     // connection, either because the resumable window expired or because no
     // resume key is available. Clear resume metadata, channel serial, pending
-    // channel work, and deferred connected emission before future attempts use
-    // a fresh connection.
+    // channel deadlines, and deferred connected emission before future attempts
+    // use a fresh connection.
     pub(super) fn enter_suspended_retry_state(&mut self) {
         self.conn_state.clear_resume_state();
         self.lifecycle.notify_suspended();

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -26,8 +26,8 @@ pub(crate) struct SessionState {
     conn_state: ConnState,
     lifecycle: RealtimeStateMachine,
     /// Consecutive token renewal failures. Successful renewal and committed
-    /// reconnects reset this counter; reaching the configured max marks the
-    /// lifecycle failed.
+    /// connected reconnects reset this counter; reaching the configured max
+    /// marks the lifecycle failed.
     token_renewal_failures: u32,
     /// Next suspended-channel reattach attempt. This is only scheduled while
     /// the channel is suspended and the connection can send events.
@@ -207,9 +207,11 @@ impl SessionState {
             && !self.conn_state.can_resume()
     }
 
-    // Suspended retry means the resumable connection window has expired. Clear
-    // resume metadata, channel serial, pending channel work, and deferred
-    // connected emission before future attempts use a fresh connection.
+    // Suspended retry means the session can no longer resume the previous
+    // connection, either because the resumable window expired or because no
+    // resume key is available. Clear resume metadata, channel serial, pending
+    // channel work, and deferred connected emission before future attempts use
+    // a fresh connection.
     pub(super) fn enter_suspended_retry_state(&mut self) {
         self.conn_state.clear_resume_state();
         self.lifecycle.notify_suspended();
@@ -245,8 +247,9 @@ impl SessionState {
     }
 
     // Token renewal failures are consecutive. A successful renewal or
-    // committed reconnect establishes valid token/transport state and resets
-    // the count; reaching max_failures makes the session fail terminally.
+    // committed connected reconnect establishes valid token/transport state and
+    // resets the count; reaching max_failures makes the session fail
+    // terminally.
     pub(super) fn record_successful_token_renewal(&mut self) {
         self.token_renewal_failures = 0;
     }

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -1,3 +1,9 @@
+//! Session bookkeeping for the realtime event loop.
+//!
+//! `EventLoopState` drives this module while it owns the WebSocket transport.
+//! The state here is private implementation detail, but it determines
+//! externally visible subscription events and reconnect behavior.
+
 use std::time::Duration;
 
 use tokio::time::Instant;
@@ -9,13 +15,34 @@ use super::state::{
 use crate::protocol::ProtocolMessage;
 use crate::types::TokenDetails;
 
+/// Mutable session state owned by the realtime event loop.
+///
+/// `ConnState` stores transport metadata such as connection keys, channel
+/// serials, TTLs, and token renewal deadlines. `RealtimeStateMachine` stores
+/// the current connection and channel lifecycle phases. `SessionState` owns the
+/// timers, counters, and pending event markers that coordinate those two state
+/// models with event-loop behavior.
 pub(crate) struct SessionState {
     conn_state: ConnState,
     lifecycle: RealtimeStateMachine,
+    /// Consecutive token renewal failures. Successful renewal and committed
+    /// reconnects reset this counter; reaching the configured max marks the
+    /// lifecycle failed.
     token_renewal_failures: u32,
+    /// Next suspended-channel reattach attempt. This is only scheduled while
+    /// the channel is suspended and the connection can send events.
     channel_retry_at: Option<Instant>,
+    /// Backoff counter used when scheduling suspended-channel retries. It
+    /// resets after a successful channel attach or committed connected
+    /// transport state.
     channel_retry_count: u32,
+    /// Deadline for the current in-flight channel attach operation. This is
+    /// separate from `channel_retry_at`: operation deadlines time out active
+    /// attaches, while retry deadlines start the next attach attempt.
     channel_operation_deadline: Option<Instant>,
+    /// A reconnect can restore the transport while channel attach is still
+    /// suspended. In that case `Event::Connected` is deferred until a later
+    /// `ATTACHED` message confirms the channel is ready again.
     connected_event_pending: bool,
 }
 
@@ -82,6 +109,9 @@ impl SessionState {
         self.conn_state.can_resume()
     }
 
+    // Channel attach has two scheduled states: an operation deadline while an
+    // ATTACH is in flight, then a retry deadline if that attach times out into
+    // suspended channel retry.
     pub(super) fn begin_channel_attach(&mut self, realtime_request_timeout: Duration) -> bool {
         self.lifecycle.request_channel_attaching();
         if self.lifecycle.channel != ChannelLifecycleState::Attaching
@@ -130,6 +160,8 @@ impl SessionState {
         self.schedule_channel_retry(channel_retry_timeout);
     }
 
+    // A successful attach resolves pending channel work and restarts retry
+    // backoff from zero for the next suspension.
     pub(super) fn mark_channel_attached(&mut self) {
         self.lifecycle.notify_channel_attached();
         self.channel_retry_at = None;
@@ -175,6 +207,9 @@ impl SessionState {
             && !self.conn_state.can_resume()
     }
 
+    // Suspended retry means the resumable connection window has expired. Clear
+    // resume metadata, channel serial, pending channel work, and deferred
+    // connected emission before future attempts use a fresh connection.
     pub(super) fn enter_suspended_retry_state(&mut self) {
         self.conn_state.clear_resume_state();
         self.lifecycle.notify_suspended();
@@ -209,6 +244,9 @@ impl SessionState {
         pending
     }
 
+    // Token renewal failures are consecutive. A successful renewal or
+    // committed reconnect establishes valid token/transport state and resets
+    // the count; reaching max_failures makes the session fail terminally.
     pub(super) fn record_successful_token_renewal(&mut self) {
         self.token_renewal_failures = 0;
     }
@@ -240,6 +278,10 @@ impl SessionState {
         self.lifecycle.request_connecting();
     }
 
+    // Reconnect commit outcomes separate transport recovery from subscription
+    // readiness. If the channel reattaches during reconnect, the caller can
+    // emit `Event::Connected` immediately. If the transport reconnects but the
+    // channel is suspended, delay that event until a later ATTACHED message.
     pub(super) fn commit_reconnect_attached(
         &mut self,
         connected_msg: &ProtocolMessage,
@@ -283,6 +325,7 @@ impl SessionState {
     }
 
     fn schedule_channel_retry(&mut self, channel_retry_timeout: Duration) {
+        // A retry supersedes any in-flight attach deadline.
         self.channel_operation_deadline = None;
         if self.lifecycle.channel == ChannelLifecycleState::Suspended
             && self.lifecycle.connection.send_events()

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -110,8 +110,8 @@ impl SessionState {
     }
 
     // Channel attach has two scheduled states: an operation deadline while an
-    // ATTACH is in flight, then a retry deadline if that attach times out into
-    // suspended channel retry.
+    // ATTACH is in flight, then a retry deadline if that attach is suspended
+    // by timeout or DETACHED response.
     pub(super) fn begin_channel_attach(&mut self, realtime_request_timeout: Duration) -> bool {
         self.lifecycle.request_channel_attaching();
         if self.lifecycle.channel != ChannelLifecycleState::Attaching


### PR DESCRIPTION
## Summary
- document `SessionState` ownership boundaries for Ably realtime session bookkeeping
- add field-level invariants for token renewal failures, channel retry/deadline state, and deferred connected events
- document channel attach/retry, suspended retry, token renewal, and reconnect commit behavior

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo check -p ably-subscriber --manifest-path crates/Cargo.toml
- cargo test -p ably-subscriber --manifest-path crates/Cargo.toml connection::session

Closes #17037