### PR TITLE
feat: remove desktop setup guidance panels

### DIFF
--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -492,13 +492,6 @@ function AuthStepCard({
           )}
         </div>
       </div>
-      <aside className="step-guidance">
-        <strong>Next</strong>
-        <span>
-          After the account and workspace are ready, Zero will ask for the macOS
-          permissions needed by Computer Use.
-        </span>
-      </aside>
     </section>
   );
 }
@@ -669,13 +662,6 @@ function PermissionsStepCard({
           />
         </div>
       </div>
-      <aside className="step-guidance">
-        <strong>Runtime is hidden</strong>
-        <span>
-          Runtime status and command history appear after both permissions are
-          ready.
-        </span>
-      </aside>
     </section>
   );
 }

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -132,9 +132,9 @@ button {
 }
 
 .step-card-expanded {
-  min-height: 224px;
+  min-height: 168px;
   padding: 18px;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(0, 1fr);
   align-items: stretch;
 }
 
@@ -221,28 +221,6 @@ button {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-}
-
-.step-guidance {
-  border: 1px solid rgba(37, 99, 235, 0.16);
-  border-radius: 8px;
-  padding: 14px;
-  display: grid;
-  align-content: start;
-  gap: 10px;
-  background: #eff8ff;
-}
-
-.step-guidance strong {
-  color: #175cd3;
-  font-size: 13px;
-  line-height: 1.25;
-}
-
-.step-guidance span {
-  color: #475467;
-  font-size: 13px;
-  line-height: 1.4;
 }
 
 .compact-step-main {


### PR DESCRIPTION
## Summary
- remove the right-side guidance panels from the Account and Permissions setup cards
- make expanded setup cards single-column
- reduce expanded card height now that the guidance panel is gone

## Tests
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop build:renderer
- pnpm format