### PR TITLE
fix: update garmin connect connector color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/garmin-connect.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/garmin-connect.svg
@@ -1,1 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Garmin</title><path d="M11.5 2.87Q12 2 12.5 2.87L22.5 20.13Q23 21 22 21H2Q1 21 1.5 20.13Z" fill="#007CC3"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <title>Garmin</title>
+  <path
+    d="M11.5 2.87Q12 2 12.5 2.87L22.5 20.13Q23 21 22 21H2Q1 21 1.5 20.13Z"
+    fill="#11A9ED"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- update the Garmin Connect connector icon fill from `#007CC3` to official Connect blue `#11A9ED`
- keep the existing Garmin triangle mark as an SVG-only asset
- confirm there is no redundant `garmin-connect.png` and no `currentColor` usage

Fixes #17057

## Testing
- `git diff --check`
- `cd turbo && pnpm exec prettier --check --parser html apps/platform/src/views/zero-page/components/settings/icons/garmin-connect.svg`

No runtime tests run; this is an icon-only asset update.