### PR TITLE
[codex] move keep awake tray menu item

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -138,6 +138,14 @@ describe("desktop tray menu", () => {
       trayActions(),
     );
 
+    expect(menu.map((item) => item.label).filter((label) => label)).toEqual([
+      "Show Main Window",
+      "Computer Use: Online",
+      "Keep Mac Awake",
+      "Workspace: Max & Zoe",
+      "No Recent Commands",
+      "Quit",
+    ]);
     expect(findItem(menu, "Show Main Window")).toBeDefined();
     expect(findItem(menu, "Keep Mac Awake")).toStrictEqual({
       label: "Keep Mac Awake",

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -334,6 +334,11 @@ export function buildDesktopTrayMenuItems(
 ): readonly DesktopTrayMenuItem[] {
   return [
     { label: "Show Main Window", click: actions.showMainWindow },
+    separator(),
+    {
+      label: `Computer Use: ${computerUseStatusLabel(state)}`,
+      submenu: buildComputerUseSubmenu(state, actions),
+    },
     {
       label: "Keep Mac Awake",
       type: "checkbox",
@@ -341,11 +346,6 @@ export function buildDesktopTrayMenuItems(
       click: () => {
         actions.setKeepAwakeEnabled(!state.computerUse.keepAwake.enabled);
       },
-    },
-    separator(),
-    {
-      label: `Computer Use: ${computerUseStatusLabel(state)}`,
-      submenu: buildComputerUseSubmenu(state, actions),
     },
     {
       label: authStatusLabel(state),


### PR DESCRIPTION
## Summary
- Move the `Keep Mac Awake` tray menu item below `Computer Use` and above `Workspace`
- Add a tray menu ordering assertion so the placement stays covered

## Validation
- `pnpm -F @vm0/desktop exec vitest run src/desktop-tray-menu.test.ts`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm exec prettier --check apps/desktop/src/desktop-tray-menu.ts apps/desktop/src/desktop-tray-menu.test.ts`
