### PR TITLE
fix(platform): replace presentation editor close icon with done button

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -4,7 +4,6 @@ import {
   IconLoader2,
   IconPresentation,
   IconSparkles,
-  IconX,
 } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
@@ -240,11 +239,11 @@ function PresentationEditorHeader({
       <button
         type="button"
         data-presentation-editor-action="true"
-        aria-label="Close presentation editor"
+        aria-label="Done editing presentation"
         onClick={onClose}
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+        className="inline-flex h-8 items-center justify-center rounded-md px-3 text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
       >
-        <IconX size={16} stroke={1.5} />
+        Done
       </button>
     </header>
   );


### PR DESCRIPTION
## Summary

- Replace the `×` (IconX) close button in the PPT editor header with a text **"Done"** button
- Update `aria-label` from "Close presentation editor" to "Done editing presentation"
- Adjust button styling from icon-sized square (`w-8 h-8`) to inline text button with horizontal padding (`px-3`)

## Background

The `×` button carries implicit "discard/cancel" semantics in most users' mental models, but its actual behavior is **save and exit**. Replacing it with "Done" aligns the label with the action — consistent with how Figma, Loom, and Notion handle inline editing sessions.

## Test plan

- [ ] Open a presentation in the editor — confirm "Done" button appears in the header toolbar
- [ ] Click "Done" — confirm changes are saved and editor closes
- [ ] Verify button is disabled while publishing is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)