### PR TITLE
fix(runner): redact command output before excerpting

### DIFF
--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -243,9 +243,17 @@ fn redact_url_query_strings(input: &str) -> String {
     let mut redacted = String::with_capacity(input.len());
     let mut cursor = 0;
 
-    while let Some((url_start, scheme)) = find_next_url_scheme(input, cursor) {
-        redacted.push_str(&input[cursor..url_start]);
+    while cursor < input.len() {
+        let Some(scheme) = url_scheme_at(input, cursor) else {
+            let Some(ch) = input[cursor..].chars().next() else {
+                break;
+            };
+            redacted.push(ch);
+            cursor += ch.len_utf8();
+            continue;
+        };
 
+        let url_start = cursor;
         let url_body_start = url_start + scheme.len();
         let url_end = find_url_token_end(input, url_body_start);
         let Some(query_offset) = input[url_body_start..url_end].find('?') else {
@@ -265,15 +273,10 @@ fn redact_url_query_strings(input: &str) -> String {
     redacted
 }
 
-fn find_next_url_scheme(input: &str, start: usize) -> Option<(usize, &'static str)> {
+fn url_scheme_at(input: &str, index: usize) -> Option<&'static str> {
     ["https://", "http://"]
         .into_iter()
-        .filter_map(|scheme| {
-            input[start..]
-                .find(scheme)
-                .map(|index| (start + index, scheme))
-        })
-        .min_by_key(|(index, _)| *index)
+        .find(|scheme| input[index..].starts_with(scheme))
 }
 
 fn find_url_token_end(input: &str, start: usize) -> usize {

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -274,9 +274,11 @@ fn redact_url_query_strings(input: &str) -> String {
 }
 
 fn url_scheme_at(input: &str, index: usize) -> Option<&'static str> {
-    ["https://", "http://"]
-        .into_iter()
-        .find(|scheme| input[index..].starts_with(scheme))
+    ["https://", "http://"].into_iter().find(|scheme| {
+        input[index..]
+            .get(..scheme.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(scheme))
+    })
 }
 
 fn find_url_token_end(input: &str, start: usize) -> usize {

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -200,15 +200,12 @@ pub(super) fn format_command_output_excerpt(
         return None;
     }
 
-    let omitted_prefix = bytes.len() > GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
-    let excerpt_start = if omitted_prefix {
-        bytes.len() - GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES
-    } else {
-        0
-    };
-    let excerpt_bytes = bytes.get(excerpt_start..)?;
-    let excerpt = String::from_utf8_lossy(excerpt_bytes);
-    let excerpt = redact_url_query_strings(excerpt.trim());
+    // Redact before excerpting so a suffix cannot start inside a URL query and expose it.
+    let output = String::from_utf8_lossy(bytes);
+    let output = sanitize_command_output_for_diagnostic(output.trim());
+    let output = output.trim();
+    let (excerpt, omitted_prefix) = diagnostic_output_excerpt(output);
+    let excerpt = excerpt.trim();
     if excerpt.is_empty() {
         return None;
     }
@@ -226,22 +223,62 @@ pub(super) fn format_command_output_excerpt(
     Some(format!("{label} ({}): {excerpt}", qualifiers.join(", ")))
 }
 
-pub(super) fn redact_url_query_strings(input: &str) -> String {
-    input
-        .split_whitespace()
-        .map(redact_url_query_token)
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-pub(super) fn redact_url_query_token(token: &str) -> String {
-    for scheme in ["https://", "http://"] {
-        if let Some((prefix, candidate)) = token.split_once(scheme)
-            && let Some((base_url, _)) = candidate.split_once('?')
-        {
-            return format!("{prefix}{scheme}{base_url}?<redacted>");
-        }
+fn diagnostic_output_excerpt(input: &str) -> (&str, bool) {
+    if input.len() <= GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES {
+        return (input, false);
     }
 
-    token.to_owned()
+    let mut start = input.len() - GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
+    while !input.is_char_boundary(start) {
+        start += 1;
+    }
+    (&input[start..], true)
+}
+
+fn sanitize_command_output_for_diagnostic(input: &str) -> String {
+    redact_url_query_strings(input)
+}
+
+fn redact_url_query_strings(input: &str) -> String {
+    let mut redacted = String::with_capacity(input.len());
+    let mut cursor = 0;
+
+    while let Some((url_start, scheme)) = find_next_url_scheme(input, cursor) {
+        redacted.push_str(&input[cursor..url_start]);
+
+        let url_body_start = url_start + scheme.len();
+        let url_end = find_url_token_end(input, url_body_start);
+        let Some(query_offset) = input[url_body_start..url_end].find('?') else {
+            redacted.push_str(&input[url_start..url_end]);
+            cursor = url_end;
+            continue;
+        };
+
+        let query_start = url_body_start + query_offset;
+        let query_value_start = query_start + '?'.len_utf8();
+        redacted.push_str(&input[url_start..query_value_start]);
+        redacted.push_str("<redacted>");
+        cursor = url_end;
+    }
+
+    redacted.push_str(&input[cursor..]);
+    redacted
+}
+
+fn find_next_url_scheme(input: &str, start: usize) -> Option<(usize, &'static str)> {
+    ["https://", "http://"]
+        .into_iter()
+        .filter_map(|scheme| {
+            input[start..]
+                .find(scheme)
+                .map(|index| (start + index, scheme))
+        })
+        .min_by_key(|(index, _)| *index)
+}
+
+fn find_url_token_end(input: &str, start: usize) -> usize {
+    input[start..]
+        .char_indices()
+        .find_map(|(index, ch)| ch.is_whitespace().then_some(start + index))
+        .unwrap_or(input.len())
 }

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -4,10 +4,11 @@ use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootP
 use sandbox::ExecResult;
 use sandbox_mock::MockSandbox;
 
+use super::super::GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
 use super::super::guest_runtime_dir;
 use super::super::storage::{
-    download_storages, filter_unchanged_storages, format_guest_download_failure,
-    guest_download_command, guest_download_env,
+    download_storages, filter_unchanged_storages, format_command_output_excerpt,
+    format_guest_download_failure, guest_download_command, guest_download_env,
 };
 use super::support::{minimal_context, sandbox_write_file_error};
 use crate::types::{GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry};
@@ -99,6 +100,51 @@ fn guest_download_failure_output_redacts_url_queries() {
     assert!(msg.contains("stderr (captured, sandbox-truncated)"));
     assert!(msg.contains("archiveUrl=https://storage.example/archive.tar.gz?<redacted>"));
     assert!(!msg.contains("secret"));
+}
+
+#[test]
+fn guest_download_failure_redacts_url_query_before_excerpting() {
+    let prefix = "HTTP transport error for archiveUrl=https://storage.example/archive.tar.gz?";
+    let query_key = "X-Amz-Signature=";
+    let secret_value = "secret-value-that-must-not-leak";
+    let suffix = " download failed";
+    let boundary_offset = "X-Amz-".len();
+    let padding_len = GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES + boundary_offset
+        - query_key.len()
+        - secret_value.len()
+        - suffix.len();
+    let query = format!("{query_key}{secret_value}{}", "a".repeat(padding_len));
+    let result = ExecResult {
+        exit_code: 1,
+        stdout: Vec::new(),
+        stderr: format!("{prefix}{query}{suffix}").into_bytes(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    };
+
+    let msg = format_guest_download_failure(&result);
+
+    assert!(msg.contains("storage download failed (exit code 1)"));
+    assert!(msg.contains("stderr ("));
+    assert!(msg.contains("archive.tar.gz?<redacted>"));
+    assert!(!msg.contains("X-Amz-Signature"));
+    assert!(!msg.contains(secret_value));
+}
+
+#[test]
+fn command_output_redaction_preserves_whitespace_between_urls() {
+    let msg = format_command_output_excerpt(
+        "stderr",
+        b"first=https://a.example/archive.tar.gz?token=secret\n\tsecond=http://b.example/logs?key=hidden plain=https://c.example/no-query",
+        false,
+    )
+    .unwrap();
+
+    assert!(msg.contains(
+        "first=https://a.example/archive.tar.gz?<redacted>\n\tsecond=http://b.example/logs?<redacted> plain=https://c.example/no-query"
+    ));
+    assert!(!msg.contains("secret"));
+    assert!(!msg.contains("hidden"));
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -147,6 +147,19 @@ fn command_output_redaction_preserves_whitespace_between_urls() {
     assert!(!msg.contains("hidden"));
 }
 
+#[test]
+fn command_output_redaction_handles_case_insensitive_url_schemes() {
+    let msg = format_command_output_excerpt(
+        "stderr",
+        b"archiveUrl=HTTPS://storage.example/archive.tar.gz?token=secret",
+        false,
+    )
+    .unwrap();
+
+    assert!(msg.contains("archiveUrl=HTTPS://storage.example/archive.tar.gz?<redacted>"));
+    assert!(!msg.contains("secret"));
+}
+
 #[tokio::test]
 async fn download_storages_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");


### PR DESCRIPTION
## Summary

- Sanitize captured runner command output before taking the final diagnostic excerpt
- Replace whitespace-token URL query redaction with a text scanner that preserves surrounding whitespace
- Redact URL queries for case-insensitive `http://` and `https://` schemes
- Add regression coverage for a truncated excerpt boundary inside a signed URL query

Closes #17040

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::storage_tests`
- `cargo fmt --manifest-path crates/Cargo.toml -p runner --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- Pre-commit: cargo-fmt, cargo-doc, cargo-clippy