### PR TITLE
fix: bound runner dirname length

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -199,6 +199,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_config_rejects_overlong_runner_dirname() {
+        let dirname = "a".repeat(crate::runner_dirname::MAX_NAME_BYTES + 1);
+        let err = run_config(args_with_dirname(&dirname)).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid runner-dirname"), "got: {msg}");
+        assert!(
+            msg.contains(&format!(
+                "at most {} bytes",
+                crate::runner_dirname::MAX_NAME_BYTES
+            )),
+            "got: {msg}"
+        );
+        assert!(
+            !msg.contains(&dirname),
+            "overlong dirname should be previewed, not echoed in full: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn run_config_rejects_mismatched_profile_arg_lengths() {
         let cases = [
             (

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -146,12 +146,14 @@ static UNIT_STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
 ///
 /// Validates the suffix with [`crate::runner_dirname::validate_name`] so
 /// that runner directory names and service name suffixes follow the same
-/// rules (lowercase alphanumeric, hyphens, dots; no leading `.` or `-`).
+/// rules (bounded length, lowercase alphanumeric, hyphens, dots; no
+/// leading `.` or `-`).
 pub(crate) fn unit_name(suffix: &str) -> RunnerResult<String> {
     if !crate::runner_dirname::validate_name(suffix) {
+        let diagnostic = crate::runner_dirname::invalid_name_diagnostic(suffix);
+        let rules = crate::runner_dirname::validation_rules();
         return Err(RunnerError::Config(format!(
-            "invalid service name suffix '{suffix}': must be non-empty, \
-             lowercase alphanumeric, hyphens, and dots; cannot start with '.' or '-'"
+            "invalid service name suffix {diagnostic}: {rules}"
         )));
     }
     Ok(format!("{UNIT_PREFIX}{suffix}"))
@@ -1424,6 +1426,12 @@ mod tests {
     }
 
     #[test]
+    fn test_unit_name_accepts_max_length_suffix() {
+        let suffix = "a".repeat(crate::runner_dirname::MAX_NAME_BYTES);
+        assert_eq!(unit_name(&suffix).unwrap(), format!("vm0-runner-{suffix}"));
+    }
+
+    #[test]
     fn test_unit_name_rejects_invalid() {
         assert!(unit_name("").is_err());
         assert!(unit_name("../evil").is_err());
@@ -1434,6 +1442,61 @@ mod tests {
         assert!(unit_name("my_name-1.0").is_err());
         assert!(unit_name(".hidden").is_err());
         assert!(unit_name("-flag").is_err());
+    }
+
+    #[test]
+    fn test_unit_name_rejects_over_max_length_suffix() {
+        let suffix = "a".repeat(crate::runner_dirname::MAX_NAME_BYTES + 1);
+        let msg = unit_name(&suffix).unwrap_err().to_string();
+        assert!(msg.contains("service name suffix"), "got: {msg}");
+        assert!(
+            msg.contains(&format!(
+                "at most {} bytes",
+                crate::runner_dirname::MAX_NAME_BYTES
+            )),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains(&format!(
+                "{} bytes",
+                crate::runner_dirname::MAX_NAME_BYTES + 1
+            )),
+            "got: {msg}"
+        );
+        assert!(
+            !msg.contains(&suffix),
+            "overlong suffix should be previewed, not echoed in full: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_max_length_suffix_derived_basenames_fit_name_max() {
+        const COMMON_LINUX_NAME_MAX: usize = 255;
+
+        let suffix = "a".repeat(crate::runner_dirname::MAX_NAME_BYTES);
+        let unit = unit_name(&suffix).unwrap();
+        let unit_file = format!("{unit}.service");
+        let service_lock = format!("service-{unit}.lock");
+        let current_staging = format!(
+            "{unit_file}{UNIT_STAGING_MARKER}{}.{}.{}",
+            u32::MAX,
+            u128::MAX,
+            u64::MAX
+        );
+        let legacy_staging = format!(".{unit_file}.tmp.{}", "0".repeat(36));
+
+        for (label, basename) in [
+            ("unit file", unit_file),
+            ("service lock", service_lock),
+            ("current unit staging", current_staging),
+            ("legacy unit staging", legacy_staging),
+        ] {
+            assert!(
+                basename.len() <= COMMON_LINUX_NAME_MAX,
+                "{label} basename is {} bytes: {basename}",
+                basename.len()
+            );
+        }
     }
 
     /// Guard against someone replacing the call with `validate_or_err`

--- a/crates/runner/src/runner_dirname.rs
+++ b/crates/runner/src/runner_dirname.rs
@@ -2,8 +2,9 @@
 //!
 //! The same name is used as both a directory name (joined against
 //! `HomePaths::runners_dir()`) and a systemd service name suffix
-//! (e.g. `vm0-runner-<name>`). This module is the single source of
-//! truth for what counts as a valid runner instance name.
+//! (e.g. `vm0-runner-<name>`). Service locks and unit staging files also
+//! derive filenames from the service name, so this module is the single
+//! source of truth for what counts as a valid runner instance name.
 //!
 //! Without validation, an absolute path (`/etc`) replaces the base via
 //! `Path::join`, and a bare `..` segment escapes once the kernel resolves
@@ -19,18 +20,49 @@
 
 use crate::error::{RunnerError, RunnerResult};
 
+/// Maximum byte length for a runner instance name.
+///
+/// The limit is deliberately below common Linux `NAME_MAX` values after
+/// adding runner/service prefixes and staging suffixes.
+pub(crate) const MAX_NAME_BYTES: usize = 128;
+const INVALID_NAME_PREVIEW_CHARS: usize = 64;
+
 /// Validate `name` and return a `RunnerError::Config` with a uniform
 /// message if it fails. Use this at every callsite that takes a runner
 /// directory name from the user (currently only the `--runner-dirname`
 /// flag of `runner config`) so the error wording stays consistent.
 pub fn validate_or_err(name: &str) -> RunnerResult<()> {
     if !validate_name(name) {
+        let diagnostic = invalid_name_diagnostic(name);
+        let rules = validation_rules();
         return Err(RunnerError::Config(format!(
-            "invalid runner-dirname: {name} (must be a non-empty single path segment \
-             of lowercase alphanumeric, hyphens, and dots; cannot start with `.` or `-`)"
+            "invalid runner-dirname: {diagnostic} ({rules})"
         )));
     }
     Ok(())
+}
+
+pub(crate) fn validation_rules() -> String {
+    format!(
+        "must be a non-empty single path segment of at most {MAX_NAME_BYTES} bytes, \
+         lowercase alphanumeric, hyphens, and dots; cannot start with `.` or `-`"
+    )
+}
+
+pub(crate) fn invalid_name_diagnostic(name: &str) -> String {
+    let mut preview = String::new();
+    let mut chars = name.chars();
+    for _ in 0..INVALID_NAME_PREVIEW_CHARS {
+        let Some(c) = chars.next() else {
+            return format!("{name:?} ({} bytes)", name.len());
+        };
+        preview.push(c);
+    }
+    if chars.next().is_some() {
+        format!("{preview:?}... ({} bytes)", name.len())
+    } else {
+        format!("{name:?} ({} bytes)", name.len())
+    }
 }
 
 /// Validate that `name` is a safe runner instance identifier.
@@ -40,6 +72,7 @@ pub fn validate_or_err(name: &str) -> RunnerResult<()> {
 ///
 /// Accepts `[a-z0-9.-]+` with these guards:
 /// - non-empty
+/// - at most [`MAX_NAME_BYTES`] bytes
 /// - does not start with `.` (rejects `.`, `..`, and hidden-file forms)
 /// - does not start with `-` (avoids being parsed as a flag downstream)
 ///
@@ -48,7 +81,11 @@ pub fn validate_or_err(name: &str) -> RunnerResult<()> {
 /// conventions. The dot allowance exists for production semver dirnames
 /// produced by `ansible/playbooks/build-runner.yml` (e.g. `v0.3.0`).
 pub(crate) fn validate_name(name: &str) -> bool {
-    if name.is_empty() || name.starts_with('.') || name.starts_with('-') {
+    if name.is_empty()
+        || name.len() > MAX_NAME_BYTES
+        || name.starts_with('.')
+        || name.starts_with('-')
+    {
         return false;
     }
     name.chars()
@@ -85,6 +122,18 @@ mod tests {
         assert!(validate_name("foo..bar")); // consecutive dots (NOT traversal — no `/`)
         assert!(validate_name("vm0..0")); // near-traversal shape, still safe
         assert!(validate_name("0")); // single digit
+    }
+
+    #[test]
+    fn validate_name_accepts_max_length() {
+        let name = "a".repeat(MAX_NAME_BYTES);
+        assert!(validate_name(&name));
+    }
+
+    #[test]
+    fn validate_name_rejects_over_max_length() {
+        let name = "a".repeat(MAX_NAME_BYTES + 1);
+        assert!(!validate_name(&name));
     }
 
     #[test]
@@ -153,10 +202,28 @@ mod tests {
         assert!(msg.contains("/etc"), "got: {msg}");
     }
 
-    /// Empty input renders the `{name}` placeholder as blank in the error
-    /// message, so the generic "cannot start with `.` or `-`" hint does
-    /// not apply. Lock in that the message explicitly calls out the
-    /// non-empty requirement so empty-string bugs surface clearly.
+    #[test]
+    fn validate_or_err_overlong_message_reports_limit() {
+        let name = "a".repeat(MAX_NAME_BYTES + 1);
+        let err = validate_or_err(&name).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid runner-dirname"), "got: {msg}");
+        assert!(
+            msg.contains(&format!("at most {MAX_NAME_BYTES} bytes")),
+            "got: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("{} bytes", MAX_NAME_BYTES + 1)),
+            "got: {msg}"
+        );
+        assert!(
+            !msg.contains(&name),
+            "overlong input should be previewed, not echoed in full: {msg}"
+        );
+    }
+
+    /// Empty string is reported as a zero-byte value, so lock in that the
+    /// message explicitly calls out the non-empty requirement.
     #[test]
     fn validate_or_err_empty_message_hints_non_empty() {
         let err = validate_or_err("").unwrap_err();


### PR DESCRIPTION
## Summary

- Add a shared 128-byte runner instance name limit in `runner_dirname`.
- Reuse the same bound for `runner config --runner-dirname` and `runner service --name`.
- Report overlong invalid names with bounded previews and actual byte lengths.
- Cover validator, service suffix, derived basename, and config fail-fast behavior with tests.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner runner_dirname`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::tests::test_unit_name`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::tests::test_max_length_suffix_derived_basenames_fit_name_max`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::config::tests::run_config_rejects_overlong_runner_dirname`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --package runner --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`

Closes #17041
