### PR TITLE
fix(api): measure STT WAV duration via RIFF chunk-walk, not fixed offset

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -151,6 +151,42 @@ function wavBytesWithOversizedDataChunk(
   return bytes;
 }
 
+// Canonical header with a correctly-sized data chunk, followed by a trailing
+// LIST chunk. Duration must come from the declared data size, not the whole
+// remaining buffer (which would count the trailing chunk as audio).
+function wavBytesWithTrailingChunk(
+  durationSeconds: number,
+): Uint8Array<ArrayBuffer> {
+  const sampleRate = 24_000;
+  const channels = 1;
+  const bitsPerSample = 16;
+  const bytesPerSample = channels * (bitsPerSample / 8);
+  const byteRate = sampleRate * bytesPerSample;
+  const dataSize = byteRate * durationSeconds;
+  const trailingSize = byteRate * 3; // 3s of bytes; over-count would add ~3s
+  const buffer = new ArrayBuffer(44 + dataSize + 8 + trailingSize);
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+
+  writeAscii(bytes, 0, "RIFF");
+  view.setUint32(4, bytes.byteLength - 8, true);
+  writeAscii(bytes, 8, "WAVE");
+  writeAscii(bytes, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, bitsPerSample, true);
+  writeAscii(bytes, 36, "data");
+  view.setUint32(40, dataSize, true);
+  writeAscii(bytes, 44 + dataSize, "LIST");
+  view.setUint32(44 + dataSize + 4, trailingSize, true);
+
+  return bytes;
+}
+
 function zeroToken(args: {
   readonly userId: string;
   readonly orgId: string;
@@ -774,6 +810,32 @@ describe("POST /api/zero/voice-io/*", () => {
     await expect(
       readBehaviorCount(fixture, sttDailyDurationKey()),
     ).resolves.toBe(120);
+  });
+
+  it("meters /stt WAV duration from the declared data size, ignoring trailing chunks", async () => {
+    // A well-formed WAV with a LIST chunk after data must be measured from the
+    // declared data size, not the whole remaining buffer (which would count the
+    // 3s-worth trailing chunk as audio and over-meter to 63s).
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, () => {
+        return HttpResponse.json({ text: "hello from voice" });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: authHeaders(),
+      body: sttForm(sttFile(wavBytesWithTrailingChunk(60))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      readBehaviorCount(fixture, sttDailyDurationKey()),
+    ).resolves.toBe(60);
   });
 
   it("uses whisper-1 and verbose_json when ?verbose=true, returns segments", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-voice-io-post.test.ts
@@ -750,6 +750,32 @@ describe("POST /api/zero/voice-io/*", () => {
     expect(counts.get(sttDailyDurationKey())).toBe(2);
   });
 
+  it("meters /stt WAV duration from the data chunk, not a fixed 44-byte offset", async () => {
+    // ffmpeg-produced WAV can carry chunks (LIST/INFO/JUNK) before the data
+    // chunk, so the data chunk is not at byte 44. A fixed-offset reader would
+    // mis-measure this clip; the RIFF chunk-walk must report its true length.
+    const fixture = await track(seedVoiceFixture({}));
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    server.use(
+      http.post(OPENAI_AUDIO_TRANSCRIPTIONS_URL, () => {
+        return HttpResponse.json({ text: "hello from voice" });
+      }),
+    );
+
+    const app = createApp({ signal: context.signal });
+    const response = await app.request("/api/zero/voice-io/stt", {
+      method: "POST",
+      headers: authHeaders(),
+      body: sttForm(sttFile(wavBytesWithOversizedDataChunk(120))),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      readBehaviorCount(fixture, sttDailyDurationKey()),
+    ).resolves.toBe(120);
+  });
+
   it("uses whisper-1 and verbose_json when ?verbose=true, returns segments", async () => {
     const fixture = await track(seedVoiceFixture({ audioInputEnabled: true }));
     mocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -341,35 +341,6 @@ export function parseSpeechWavDurationSeconds(
   return Math.max(1, Math.ceil(audioBytes / bytesPerSecond));
 }
 
-function sttWavDuration(buf: Uint8Array): number | null {
-  if (buf.length < 44) {
-    return null;
-  }
-  if (
-    buf[0] !== 0x52 ||
-    buf[1] !== 0x49 ||
-    buf[2] !== 0x46 ||
-    buf[3] !== 0x46
-  ) {
-    return null;
-  }
-
-  const view = new DataView(buf.buffer, buf.byteOffset, buf.length);
-  const sampleRate = view.getUint32(24, true);
-  const numChannels = view.getUint16(22, true);
-  const bitsPerSample = view.getUint16(34, true);
-  const dataSize = view.getUint32(40, true);
-
-  if (sampleRate === 0 || numChannels === 0 || bitsPerSample === 0) {
-    return null;
-  }
-  const bytesPerSecond = (sampleRate * numChannels * bitsPerSample) / 8;
-  if (bytesPerSecond === 0) {
-    return null;
-  }
-  return Math.ceil(dataSize / bytesPerSecond);
-}
-
 function estimateDurationFromSize(fileSize: number): number {
   return Math.ceil(fileSize / (MIN_SPEECH_BITRATE_BPS / 8));
 }
@@ -565,21 +536,26 @@ function parseWebmDuration(buf: Uint8Array): number | null {
 
 export async function getAudioDuration(file: File): Promise<number | null> {
   const mimeType = file.type.split(";")[0] ?? file.type;
-  const buf = new Uint8Array(
-    await file
-      .slice(0, Math.min(file.size, MAX_DURATION_READ_BYTES))
-      .arrayBuffer(),
-  );
 
-  if (mimeType === "audio/webm") {
-    return parseWebmDuration(buf);
-  }
   if (
     mimeType === "audio/wav" ||
     mimeType === "audio/wave" ||
     mimeType === "audio/x-wav"
   ) {
-    return sttWavDuration(buf);
+    // Walk the RIFF chunk chain over the whole file. ffmpeg-produced WAV is not
+    // guaranteed to place the data chunk at a fixed offset (it can insert
+    // LIST/INFO/JUNK chunks), so a fixed-offset header read mis-measures it.
+    return parseSpeechWavDurationSeconds(
+      new Uint8Array(await file.arrayBuffer()),
+    );
+  }
+  if (mimeType === "audio/webm") {
+    const head = new Uint8Array(
+      await file
+        .slice(0, Math.min(file.size, MAX_DURATION_READ_BYTES))
+        .arrayBuffer(),
+    );
+    return parseWebmDuration(head);
   }
   return estimateDurationFromSize(file.size);
 }

--- a/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts
@@ -300,6 +300,7 @@ export function parseSpeechWavDurationSeconds(
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   let format: WavFormat | null = null;
   let dataOffset: number | null = null;
+  let dataChunkSize: number | null = null;
   let offset = 12;
 
   while (offset + 8 <= bytes.byteLength) {
@@ -313,6 +314,7 @@ export function parseSpeechWavDurationSeconds(
         readSpeechWavFormat(view, chunkStart, bytes.byteLength) ?? format;
     } else if (chunkId === "data") {
       dataOffset = chunkStart;
+      dataChunkSize = chunkSize;
     }
 
     if (chunkEnd > bytes.byteLength) {
@@ -327,8 +329,15 @@ export function parseSpeechWavDurationSeconds(
     return null;
   }
 
-  const audioBytes =
+  const remaining =
     dataOffset !== null ? bytes.byteLength - dataOffset : bytes.byteLength - 44;
+  // Prefer the declared data-chunk size when it fits the buffer, so trailing
+  // chunks after `data` (LIST/INFO/JUNK) are not counted as audio. Fall back to
+  // the remaining bytes for oversized/placeholder/truncated sizes (streamed WAV).
+  const audioBytes =
+    dataChunkSize !== null && dataChunkSize > 0 && dataChunkSize <= remaining
+      ? dataChunkSize
+      : remaining;
   if (audioBytes <= 0) {
     return null;
   }

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -81,7 +81,7 @@ Notes:
         }
 
         const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
-        const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.mp3`);
+        const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.wav`);
 
         try {
           if (options.url) {
@@ -102,8 +102,10 @@ Notes:
               "16000",
               "-ac",
               "1",
-              "-b:a",
-              "64k",
+              "-c:a",
+              "pcm_s16le",
+              "-map_metadata",
+              "-1",
               tmpAudio,
               "-y",
               "-loglevel",


### PR DESCRIPTION
## Problem

`zero video transcribe` failed on a normal ~60s video with:

```
400 Audio duration (482s) exceeds maximum (300s)
```

The clip is genuinely 60s, but the STT endpoint measured it as 482s and rejected it.

## Root cause

`zero video transcribe` extracts audio as **64 kbps mp3** and posts it to `/api/zero/voice-io/stt`. For non-WAV/webm formats the server estimates duration via `estimateDurationFromSize`, which divides file size by an assumed **8 kbps** minimum speech bitrate. Real audio at 64 kbps is ~8x denser, so duration is inflated ~8x:

```
ceil(481_972 bytes / (8000/8)) = 482s   →  > 300s gate  →  400
error factor = 64 kbps / 8 kbps = 8      (matches 482 / 60 ≈ 8)
```

A second latent bug: `getAudioDuration`'s WAV branch used a fixed-offset reader (`sttWavDuration`, data size at byte 40). ffmpeg-produced WAV inserts a `LIST/INFO` chunk before the `data` chunk (encoder tag `Lavf...`), so `data` is **not** at byte 44 and the fixed-offset read mis-measures it — `-map_metadata -1` does not remove that chunk.

## Fix

Both ends, no new dependency:

- **CLI** ([transcribe.ts](../blob/fix/stt-duration-false-rejection/turbo/apps/cli/src/commands/zero/video/transcribe.ts)) — extract canonical 16 kHz mono **PCM WAV** (`pcm_s16le`, `-map_metadata -1`) instead of 64 kbps mp3, so the upload hits the accurate WAV path.
- **Server** ([zero-voice-io-post.service.ts](../blob/fix/stt-duration-false-rejection/turbo/apps/api/src/signals/services/zero-voice-io-post.service.ts)) — `getAudioDuration`'s WAV branch now uses the existing, chunk-walking `parseSpeechWavDurationSeconds` over the whole file (the parser already used by the `/speech` route and covered for extra-chunk headers). The broken fixed-offset `sttWavDuration` is deleted.

The `estimateDurationFromSize` fallback (mp3/mp4/m4a) is left as-is per scope: no current caller reaches it once the CLI sends WAV. It remains a latent over-estimate for any future caller that posts compressed audio directly.

## Test plan

- [x] New regression test: meters a WAV with a non-canonical header (JUNK chunk before `data`, oversized declared `data` size) at its **true** duration (120s) — fails on the old fixed-offset reader (~1s), passes with the chunk-walk.
- [x] `pnpm -F api exec vitest` voice-io suite — 31 passed
- [x] CLI `transcribe.test.ts` — 4 passed
- [x] check-types, lint, knip, format — clean (api + cli)
- [x] **End-to-end on the real 60.1s video**: new WAV path → `getAudioDuration` = **61s (accepted)**; old mp3 path → **482s (rejected)**. Confirmed ffmpeg writes a `LIST/INFO` chunk before `data`, which the chunk-walk handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)