### PR TITLE
fix: keep desktop display awake

### DIFF
--- a/turbo/apps/desktop/src/desktop-keep-awake.test.ts
+++ b/turbo/apps/desktop/src/desktop-keep-awake.test.ts
@@ -68,7 +68,7 @@ describe("DesktopKeepAwakeController", () => {
     }
   });
 
-  it("starts the system sleep blocker and persists the setting", async () => {
+  it("starts the display sleep blocker and persists the setting", async () => {
     const { directory, preferencesPath } = await createPreferencesPath();
     const { blocker, start } = createBlocker();
     const onChange = vi.fn();
@@ -84,7 +84,7 @@ describe("DesktopKeepAwakeController", () => {
         enabled: true,
         active: true,
       });
-      expect(start).toHaveBeenCalledWith("prevent-app-suspension");
+      expect(start).toHaveBeenCalledWith("prevent-display-sleep");
       expect(JSON.parse(await readFile(preferencesPath, "utf8"))).toMatchObject(
         {
           keepAwakeEnabled: true,

--- a/turbo/apps/desktop/src/desktop-keep-awake.ts
+++ b/turbo/apps/desktop/src/desktop-keep-awake.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { DesktopKeepAwakeState } from "./computer-use-types";
 
-const KEEP_AWAKE_BLOCKER_TYPE = "prevent-app-suspension";
+const KEEP_AWAKE_BLOCKER_TYPE = "prevent-display-sleep";
 
 export interface DesktopKeepAwakeBlocker {
   readonly start: (type: typeof KEEP_AWAKE_BLOCKER_TYPE) => number;

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -703,7 +703,7 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
       </div>
       <CheckboxRow
         title="Keep Mac awake"
-        subtitle="Prevents automatic system sleep. Display may still turn off."
+        subtitle="Prevents automatic system sleep and display sleep."
         meta={state.keepAwake.active ? "Active" : "Off"}
         checked={state.keepAwake.enabled}
         disabled={keepAwakeLoadable.state === "loading"}


### PR DESCRIPTION
## Summary
- switch Desktop Keep Mac Awake to prevent display sleep
- update the runtime copy to say the display stays awake
- update the keep-awake controller test expectation

## Testing
- pnpm -F @vm0/desktop exec vitest run src/desktop-keep-awake.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test