### PR TITLE
feat: add Transcript label to speaker notes button in presentation editor

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -3,7 +3,7 @@ import {
   IconDownload,
   IconLoader2,
   IconPresentation,
-  IconScript,
+  IconSparkles,
 } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
@@ -232,9 +232,10 @@ function PresentationEditorHeader({
         title="Generate PPT script"
         disabled={!onGenerateSpeakerNotes}
         onClick={onGenerateSpeakerNotes}
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+        className="inline-flex h-8 items-center gap-2 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
       >
-        <IconScript size={16} stroke={1.5} />
+        <IconSparkles size={16} stroke={1.5} />
+        Transcript
       </button>
       <button
         type="button"

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -3,7 +3,7 @@ import {
   IconDownload,
   IconLoader2,
   IconPresentation,
-  IconSparkles,
+  IconScript,
 } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
@@ -234,7 +234,7 @@ function PresentationEditorHeader({
         onClick={onGenerateSpeakerNotes}
         className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
       >
-        <IconSparkles size={16} stroke={1.5} />
+        <IconScript size={16} stroke={1.5} />
       </button>
       <button
         type="button"

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -235,7 +235,7 @@ function PresentationEditorHeader({
         className="inline-flex h-8 items-center gap-2 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
       >
         <IconSparkles size={16} stroke={1.5} />
-        Transcript
+        Script
       </button>
       <button
         type="button"


### PR DESCRIPTION
## Summary

- Keep the original `IconSparkles` icon on the speaker notes generation button
- Add a **"Transcript"** text label next to the icon, matching the style of the PPTX download button (icon + text)
- Button className updated from fixed-width icon-only style to accommodate the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)