### PR TITLE
test: stabilize vsock writer peer close test

### DIFF
--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn write_frame_fails_when_peer_is_closed() {
         let (guest, peer) = UnixStream::pair().unwrap();
-        drop(peer);
+        peer.shutdown(Shutdown::Read).unwrap();
         let writer = GuestWriter::new(guest);
 
         let err = writer


### PR DESCRIPTION
## Summary
- make the closed-peer writer test explicitly close the peer read half before writing
- avoid relying on immediate visibility of a dropped Unix socket peer for a tiny write

## Tests
- 
running 1 test
test writer::tests::write_frame_fails_when_peer_is_closed ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 124 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 57 filtered out; finished in 0.00s
- target test repeated 50 times
- 
running 125 tests
test connection::tests::retry_closed_failure_returns_connection_reset_when_exhausted ... ok
test drain::tests::bounded_drain_exact_capture_limit_is_not_truncated ... ok
test drain::tests::bounded_drain_discard_capture_stores_no_output ... ok
test drain::tests::bounded_drain_splits_stream_chunks_and_marks_stream_truncation ... ok
test drain::tests::drain_exits_on_eof_without_chunks ... ok
test drain::tests::bounded_drain_exact_stream_limit_has_no_truncation_marker ... ok
test drain::tests::bounded_drain_zero_capture_limit_stores_empty_and_truncates_on_data ... ok
test drain::tests::bounded_drain_retains_limit_and_reports_truncation ... ok
test drain::tests::bounded_drain_zero_stream_limit_emits_truncation_marker_on_data ... ok
test drain::tests::bounded_drain_stream_callback_failure_stops_stream_but_keeps_draining ... ok
test drain::tests::bounded_drain_zero_chunk_limit_emits_truncation_marker_on_data ... ok
test connection::tests::retry_error_failure_returns_original_error_when_exhausted ... ok
test exec_control::tests::close_does_not_wait_for_busy_control_stream_lock ... ok
test exec_control::tests::control_sink_registration_exports_bootstrap_endpoint ... ok
test exec_control::tests::dropped_operation_closes_connected_control_sink ... ok
test exec_control::tests::dropped_operation_closes_control_sink ... ok
test exec_control::tests::dropped_operation_allows_sequence_reuse ... ok
test exec_control::tests::duplicate_active_sequence_is_rejected_until_guard_releases ... ok
test exec_control::tests::exec_control_queue_full_rejects_without_leaking_pending_slots ... ok
test exec_control::tests::duplicate_control_sink_sequence_is_rejected_without_rebinding_endpoint ... ok
test exec_control::tests::close_interrupts_inflight_control_request ... ok
test exec_control::tests::failed_control_sink_handshake_returns_sink_error ... ok
test exec_control::tests::pending_control_slot_holds_existing_slot_until_drop ... ok
test exec_control::tests::operation_release_interrupts_control_sink_handshake ... ok
test exec_control::tests::mismatched_control_response_message_id_marks_sink_failed ... ok
test exec_control::tests::handle_exec_control_forwards_to_connected_sink ... ok
test exec_control::tests::expired_connected_control_request_is_not_delivered ... ok
test exec_control::tests::pending_exec_control_timeout_before_sink_connection_releases_slot ... ok
test exec_control::tests::pending_exec_control_returns_inactive_when_operation_releases ... ok
test exec_control::tests::handle_exec_control_waits_for_sink_connection ... ok
test exec_control::tests::pending_control_slot_releases_when_result_send_fails ... ok
test exec_control::tests::operation_drop_interrupts_control_sink_handshake ... ok
test exec_control::tests::registered_operation_rejects_nonce_mismatch ... ok
test exec_control::tests::released_operation_is_inactive ... ok
test exec_control::tests::released_guard_drop_does_not_remove_reused_sequence ... ok
test exec_control::tests::pending_exec_control_returns_inactive_when_operation_drops ... ok
test exec_control::tests::second_release_does_not_remove_reused_sequence ... ok
test exec_control::tests::non_terminal_control_responses_do_not_close_sink ... ok
test exec_control::tests::valid_operation_without_sink_is_unsupported ... ok
test exec_operation::tests::exec_termination_notable_tracks_nonzero_exit ... ok
test exec_operation::tests::duplicate_active_exec_operation_returns_error ... ok
test exec_operation::tests::registry_cancel_returns_truncated_label_preview ... ok
test exec_operation::tests::exec_operation_worker_spawn_failure_returns_start_failed_and_cleans_registry ... ok
test exec_operation::tests::registry_cancel_sets_token_and_unknown_cancel_is_noop ... ok
test exec_control::tests::fail_does_not_wait_for_busy_control_stream_lock ... ok
test exec_operation::tests::registry_rejects_duplicate_active_sequence_and_cleans_on_drop ... ok
test exec_operation::tests::stdin_cancel_pipe_is_nonblocking_and_close_on_exec ... ok
test exec_operation::tests::stdin_writer_cancel_unblocks_full_pipe ... ok
test exec_control::tests::queued_control_request_is_not_delivered_after_close ... ok
test exec_control::tests::timeout_before_sink_connection_does_not_poison_later_delivery ... ok
test exec_operation::tests::stdout_drain_spawn_failure_returns_wait_failed_and_cleans_registry ... ok
test exec_operation::tests::output_writer_spawn_failure_returns_wait_failed_and_cleans_registry ... ok
test exec_operation::tests::stdin_writer_spawn_failure_returns_wait_failed_and_cleans_registry ... ok
test process::tests::child_pgid_to_signal_skips_reserved_and_self_targets ... ok
test process::tests::extract_exit_code_failure ... ok
test exec_operation::tests::stderr_drain_spawn_failure_returns_wait_failed_and_cleans_registry ... ok
test process::tests::parse_stat_ppid_pgid_comm_with_spaces ... ok
test handlers::tests::write_file_child_starts_as_process_group_leader ... ok
test exec_operation::tests::supervised_exec_started_send_failure_releases_without_result ... ok
test process::tests::parse_stat_ppid_pgid_empty ... ok
test process::tests::extract_exit_code_signal_kill ... ok
test process::tests::parse_stat_ppid_pgid_no_closing_paren ... ok
test process::tests::parse_stat_ppid_pgid_empty_comm ... ok
test process::tests::parse_stat_ppid_pgid_normal ... ok
test process::tests::parse_stat_ppid_pgid_not_enough_fields ... ok
test process::tests::extract_exit_code_specific ... ok
test process::tests::parse_stat_ppid_pgid_setsid_child ... ok
test process::tests::parse_stat_ppid_pgid_truncated ... ok
test quiesce::tests::acquire_counts_one_operation_until_last_guard_clone_drops ... ok
test quiesce::tests::explicit_release_drops_pending_before_guard_clones_drop ... ok
test quiesce::tests::quiesce_fences_new_operations_even_when_busy ... ok
test quiesce::tests::resume_allows_operations_after_quiesce ... ok
test shell_command::tests::build_shell_command_normal ... ok
test shell_command::tests::build_shell_command_sudo ... ok
test shell_command::tests::env_diagnostics_do_not_include_values ... ok
test shell_command::tests::create_env_script_cleans_dir_on_script_build_failure ... ok
test shell_command::tests::env_diagnostics_reports_largest_five_in_stable_order ... ok
test shell_command::tests::env_script_content_rejects_invalid_env_key ... ok
test shell_command::tests::env_script_content_rejects_nul_command ... ok
test process::tests::extract_exit_code_success ... ok
test shell_command::tests::env_script_dir_rejects_existing_file ... ok
test shell_command::tests::env_script_content_rejects_nul_env_value ... ok
test shell_command::tests::env_script_content_self_removes_before_exports ... ok
test shell_command::tests::env_script_directory_uses_lowercase_hex_suffix ... ok
test shell_command::tests::env_script_dir_rejects_group_or_world_writable_directory ... ok
test shell_command::tests::env_script_guard_cleanup_is_idempotent ... ok
test handlers::tests::write_file_kills_lingering_process_group_after_parent_exit ... ok
test shell_command::tests::env_script_guard_drop_removes_file_and_directory ... ok
test shell_command::tests::shell_escape_empty ... ok
test shell_command::tests::shell_escape_simple ... ok
test shell_command::tests::shell_escape_with_single_quotes ... ok
test shell_command::tests::env_script_invocation_keeps_secret_out_of_argv ... ok
test shell_command::tests::env_script_dir_creation_tolerates_concurrent_first_use ... ok
test shell_command::tests::stale_env_script_cleanup_preserves_recent_directories ... ok
test shell_command::tests::stale_env_script_cleanup_only_removes_matching_entries ... ok
test shell_command::tests::stale_env_script_cleanup_removes_matching_directories ... ok
test shell_command::tests::truncate_command_preview_exact_limit ... ok
test shell_command::tests::truncate_command_preview_multibyte_utf8 ... ok
test shell_command::tests::stale_env_script_cleanup_removes_symlink_without_following_it ... ok
test shell_command::tests::truncate_command_preview_over_limit ... ok
test shell_command::tests::truncate_command_preview_short_string ... ok
test user::tests::parse_user_credentials_fails_on_invalid_uid ... ok
test user::tests::parse_user_credentials_fails_on_invalid_gid ... ok
test user::tests::parse_user_credentials_fails_when_user_missing ... ok
test user::tests::parse_user_credentials_includes_primary_and_supplementary_groups ... ok
test user::tests::parse_user_credentials_uses_passwd_primary_gid_without_group_entry ... ok
test user::tests::sandbox_user_gid_is_unavailable_in_local_builds ... ok
test handlers::tests::write_file_stderr_drain_spawn_failure_kills_and_reaps_child ... ok
test process::tests::snapshotted_process_tree_target_kills_setsid_child_after_parent_exit ... ok
test wait::tests::watchdog_done_signal_wins_over_pre_signalled_cancel ... ok
test wait::tests::watchdog_done_signal_wins_over_elapsed_deadline ... ok
test writer::tests::write_frame_after_lock_runs_hook_before_frame_and_blocks_other_writers ... ok
test writer::tests::write_frame_fails_when_peer_is_closed ... ok
test shell_command::tests::env_script_removes_file_and_directory_when_started ... ok
test wait::tests::timeout_zero_child_is_cancelled_by_external_cancel ... ok
test wait::tests::nonzero_timeout_child_is_cancelled_by_pre_signalled_cancel ... ok
test writer::tests::write_frame_sends_complete_frame ... ok
test process::tests::kill_and_reap_child_kills_group_after_direct_child_exits ... ok
test handlers::tests::write_file_timeout_kills_child_while_stdin_writer_is_blocked ... ok
test wait::tests::watchdog_kill_refreshes_stale_process_tree_target_before_signal ... ok
test wait::tests::fast_exit_wait_does_not_pay_cancel_poll_interval_per_child ... ok
test drain::tests::drain_cancel_closes_reader_while_writer_fd_remains_open ... ok
test writer::tests::write_frame_times_out_when_peer_stops_reading ... ok
test process::tests::spawn_in_own_process_group_timeout_kills_background_child ... ok
test exec_control::tests::timed_out_control_sink_is_marked_failed ... ok

test result: ok. 125 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s


running 57 tests
test basic::basic_messages_route_through_connection ... ok
test exec_operation::exec_operation_connection_close_cancels_child ... ok
test exec_operation::exec_operation_child_can_exit_without_reading_stdin ... ok
test exec_operation::exec_operation_captures_grandchild_output_before_drain_deadline ... ok
test exec_operation::exec_operation_expected_nonzero_exit_still_returns_result ... ok
test exec_operation::exec_operation_explicit_cancel_kills_child_and_returns_cancelled ... ok
test exec_operation::exec_operation_empty_stdin_is_immediate_eof ... ok
test exec_operation::exec_operation_duplicate_start_returns_error_without_cancelling_active_exec_operation ... ok
test exec_operation::exec_operation_capture_only_stdout_stderr_success ... ok
test exec_operation::exec_operation_rejects_output_policies_that_cannot_fit_protocol_frames_without_running ... ok
test exec_operation::exec_operation_explicit_cancel_with_stdin_kills_child ... ok
test exec_operation::exec_operation_capture_limits_track_exact_and_one_byte_over ... ok
test exec_operation::exec_operation_invalid_env_returns_start_failed_without_leaking_value ... ok
test exec_operation::exec_operation_seq_zero_start_cancel_and_control_return_error ... ok
test exec_operation::exec_operation_rejects_invalid_one_shot_start_policies ... ok
test exec_operation::exec_operation_capture_and_stream_success ... ok
test exec_operation::exec_operation_stream_only_stdout_stderr_success ... ok
test exec_operation::exec_operation_returns_when_grandchild_holds_stdin_without_reading ... ok
test exec_operation::exec_operation_large_stdout_stderr_capture_soak ... ok
test exec_operation::exec_operation_writes_stdin_and_closes_pipe ... ok
test exec_operation::exec_operation_stream_handles_more_chunks_than_output_queue_capacity ... ok
test exec_operation::malformed_exec_control_payload_returns_error_and_keeps_connection_open ... ok
test exec_operation::exec_operation_unknown_cancel_is_ignored ... ok
test exec_operation::malformed_exec_cancel_payload_still_cancels_and_keeps_connection_open ... ok
test exec_operation::exec_operation_large_env_payload_succeeds ... ok
test exec_operation::supervised_exec_control_after_exit_returns_inactive ... ok
test exec_operation::supervised_exec_control_registries_are_isolated_per_connection ... ok
test exec_operation::supervised_exec_control_reports_unsupported_without_sink ... ok
test exec_operation::supervised_exec_control_forwards_to_bootstrap_sink ... ok
test exec_operation::supervised_exec_control_spawn_failure_releases_registration ... ok
test exec_operation::supervised_exec_spawn_failure_returns_start_failed_without_started_ack ... ok
test exec_operation::supervised_exec_none_timeout_runs_until_cancelled ... ok
test exec_operation::exec_operation_stream_limits_track_exact_over_and_zero_budget ... ok
test exec_operation::supervised_exec_writes_stdin_and_closes_pipe ... ok
test exec_operation::supervised_exec_sends_started_before_output ... ok
test quiesce::malformed_quiesce_resume_payloads_do_not_change_state ... ok
test quiesce::quiesced_connection_rejects_write_file_without_creating_file ... ok
test quiesce::quiesce_operations_is_idempotent_while_quiesced ... ok
test quiesce::quiesced_connection_rejects_new_operation_without_decoding_payload ... ok
test shutdown::run_exits_after_shutdown_even_when_ack_write_fails ... ok
test shutdown::run_sends_shutdown_ack_and_exits_without_waiting_for_disconnect ... ok
test shutdown::shutdown_rejects_non_empty_payload_without_exiting ... ok
test support::tests::parse_proc_stat_handles_process_names_with_parentheses ... ok
test quiesce::resume_operations_is_idempotent ... ok
test write_file::malformed_write_file_payload_returns_error_and_keeps_connection_open ... ok
test support::tests::pid_alive_detects_live_group_after_leader_is_reaped ... ok
test write_file::write_file_seq_zero_is_not_rejected_as_invalid_sequence ... ok
test exec_operation::exec_operation_repeated_short_operations_soak ... ok
test quiesce::quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes ... ok
test exec_operation::exec_operation_different_sequences_run_concurrently_and_cancel_independently ... ok
test exec_operation::exec_operation_stream_disconnect_cancels_child ... ok
test exec_operation::supervised_exec_control_duplicate_start_preserves_active_nonce ... ok
test exec_operation::supervised_exec_duplicate_start_with_control_does_not_leak_registration ... ok
test quiesce::resume_operations_reopens_after_busy_quiesce_with_pending_operation ... ok
test exec_operation::exec_operation_timeout_returns_timed_out_with_partial_capture ... ok
test exec_operation::exec_operation_timeout_with_stdin_kills_child ... ok
test exec_operation::exec_operation_returns_when_orphaned_grandchild_holds_stdout ... ok

test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.09s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
- 
- pre-commit: Rust fmt/clippy/doc