### PR TITLE
test: bound mitm forward-start wait

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -25,6 +25,7 @@ _MODEL_PROVIDER_RUN_ID = "run-model-1"
 _MODEL_PROVIDER_SANDBOX_MARKER = "tok-model"
 _MODEL_PROVIDER_PATH = "/v1/messages"
 _AUTH_URL_REWRITE_REQUEST_BODY = b'{"ok":true}'
+_FORWARD_START_TIMEOUT_SECONDS = 2.0
 
 
 class _ForwardProbe:
@@ -56,15 +57,38 @@ class _ForwardProbe:
         return self._response
 
 
-async def _wait_for_forward_start(probe: _ForwardProbe, request_task: asyncio.Task[None]) -> None:
+async def _wait_for_forward_start(
+    probe: _ForwardProbe,
+    request_task: asyncio.Task[None],
+    *,
+    timeout: float = _FORWARD_START_TIMEOUT_SECONDS,
+) -> None:
     started_task = asyncio.create_task(probe.started.wait())
     try:
         done, _ = await asyncio.wait(
             (started_task, request_task),
             return_when=asyncio.FIRST_COMPLETED,
+            timeout=timeout,
         )
-        if started_task in done:
+        if started_task in done or probe.started.is_set():
             return
+
+        if request_task not in done and not request_task.done():
+            request_pending_before_cancel = True
+            request_task.cancel()
+            await asyncio.wait((request_task,), timeout=timeout)
+
+            if request_task.done():
+                await asyncio.gather(request_task, return_exceptions=True)
+
+            raise AssertionError(
+                "forward_request did not start before timeout "
+                f"(timeout={timeout}, probe.calls={probe.calls}, "
+                "request_task_pending_before_cancel="
+                f"{request_pending_before_cancel}, "
+                f"request_task_done={request_task.done()}, "
+                f"request_task_cancelled={request_task.cancelled()})"
+            )
 
         try:
             await request_task
@@ -89,6 +113,23 @@ async def _await_request_task(request_task: asyncio.Task[None]) -> None:
     result = (await asyncio.gather(request_task, return_exceptions=True))[0]
     if isinstance(result, BaseException):
         raise result
+
+
+async def test_wait_for_forward_start_times_out_and_cancels_request_task():
+    probe = _ForwardProbe(response=(200, b"{}", {}))
+    never_released = asyncio.Event()
+
+    async def wait_forever() -> None:
+        await never_released.wait()
+
+    request_task = asyncio.create_task(wait_forever())
+
+    with pytest.raises(AssertionError, match="forward_request did not start before timeout"):
+        await _wait_for_forward_start(probe, request_task, timeout=0.01)
+
+    assert probe.calls == 0
+    assert request_task.done()
+    assert request_task.cancelled()
 
 
 @pytest.fixture

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -103,9 +103,16 @@ async def _wait_for_forward_start(
             await asyncio.gather(started_task, return_exceptions=True)
 
 
-async def _release_forward_probe(probe: _ForwardProbe, request_task: asyncio.Task[None]) -> None:
+async def _release_forward_probe(
+    probe: _ForwardProbe,
+    request_task: asyncio.Task[None],
+    *,
+    timeout: float = _FORWARD_START_TIMEOUT_SECONDS,
+) -> None:
     probe.release.set()
     if not request_task.done():
+        await asyncio.wait((request_task,), timeout=timeout)
+    if request_task.done():
         await asyncio.gather(request_task, return_exceptions=True)
 
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -74,7 +74,6 @@ async def _wait_for_forward_start(
             return
 
         if request_task not in done and not request_task.done():
-            request_pending_before_cancel = True
             request_task.cancel()
             await asyncio.wait((request_task,), timeout=timeout)
 
@@ -85,7 +84,7 @@ async def _wait_for_forward_start(
                 "forward_request did not start before timeout "
                 f"(timeout={timeout}, probe.calls={probe.calls}, "
                 "request_task_pending_before_cancel="
-                f"{request_pending_before_cancel}, "
+                "True, "
                 f"request_task_done={request_task.done()}, "
                 f"request_task_cancelled={request_task.cancelled()})"
             )
@@ -114,6 +113,19 @@ async def _release_forward_probe(
         await asyncio.wait((request_task,), timeout=timeout)
     if request_task.done():
         await asyncio.gather(request_task, return_exceptions=True)
+        return
+
+    request_task.cancel()
+    await asyncio.wait((request_task,), timeout=timeout)
+    if request_task.done():
+        await asyncio.gather(request_task, return_exceptions=True)
+
+    raise AssertionError(
+        "forward_request did not finish after release "
+        f"(timeout={timeout}, probe.calls={probe.calls}, "
+        f"request_task_done={request_task.done()}, "
+        f"request_task_cancelled={request_task.cancelled()})"
+    )
 
 
 async def _await_request_task(request_task: asyncio.Task[None]) -> None:
@@ -135,6 +147,23 @@ async def test_wait_for_forward_start_times_out_and_cancels_request_task():
         await _wait_for_forward_start(probe, request_task, timeout=0.01)
 
     assert probe.calls == 0
+    assert request_task.done()
+    assert request_task.cancelled()
+
+
+async def test_release_forward_probe_times_out_and_cancels_request_task():
+    probe = _ForwardProbe(response=(200, b"{}", {}))
+    never_finished = asyncio.Event()
+
+    async def wait_forever() -> None:
+        await never_finished.wait()
+
+    request_task = asyncio.create_task(wait_forever())
+
+    with pytest.raises(AssertionError, match="forward_request did not finish after release"):
+        await _release_forward_probe(probe, request_task, timeout=0.01)
+
+    assert probe.release.is_set()
     assert request_task.done()
     assert request_task.cancelled()
 


### PR DESCRIPTION
## Summary

- Bound the mitm-addon usage-tracking forward-start test helper with a local timeout.
- Cancel and drain the pending request task on timeout before raising a diagnostic assertion.
- Bound forward-probe release cleanup so timeout failures cannot hang again in caller `finally` blocks.
- Add a focused regression test for the timeout branch.

Closes #17100

## Tests

- `python3 -m pytest tests/test_request_handler_usage_tracking.py -v`
- `ruff check tests/test_request_handler_usage_tracking.py`
- `ruff format --check tests/test_request_handler_usage_tracking.py`
- `basedpyright -p .`
- `pnpm -F @vm0/firewalls-generator generate`
- `python3 -m pytest tests/test_x_billing.py -v`

Note: `python3 -m pytest tests/ -v` initially failed only in `tests/test_x_billing.py` because local generated firewall files were missing (`./aws.generated`). After materializing generated firewalls with the generator, the failed file passed.