### PR TITLE
feat: enable meta ads and search console connectors

### DIFF
--- a/turbo/apps/platform/src/lib/google-security-warning.ts
+++ b/turbo/apps/platform/src/lib/google-security-warning.ts
@@ -19,3 +19,14 @@ export function shouldShowGoogleSecurityWarningNotice(
     }
   }
 }
+
+export function shouldShowMetaAdsReviewNotice(type: ConnectorType): boolean {
+  return type === "meta-ads";
+}
+
+export function shouldShowConnectorConnectNotice(type: ConnectorType): boolean {
+  return (
+    shouldShowGoogleSecurityWarningNotice(type) ||
+    shouldShowMetaAdsReviewNotice(type)
+  );
+}

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
@@ -6,7 +6,7 @@ import { allConnectorTypes$ } from "../connectors.ts";
 
 const context = testContext();
 
-describe("google ads connector", () => {
+describe("marketing connectors", () => {
   it("shows Google Ads by default", async () => {
     await setupPage({
       context,
@@ -23,10 +23,27 @@ describe("google ads connector", () => {
     expect(googleAds?.availableAuthMethods).toStrictEqual(["oauth"]);
   });
 
-  it("hides Meta Ads by default", async () => {
+  it("shows Meta Ads by default", async () => {
     await setupPage({
       context,
       path: "/",
+      withoutRender: true,
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const metaAds = connectors.find((connector) => {
+      return connector.type === "meta-ads";
+    });
+
+    expect(metaAds?.label).toBe("Meta Ads");
+    expect(metaAds?.availableAuthMethods).toStrictEqual(["oauth"]);
+  });
+
+  it("hides Meta Ads when its feature switch is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: false },
       withoutRender: true,
     });
 
@@ -38,20 +55,37 @@ describe("google ads connector", () => {
     expect(metaAds).toBeUndefined();
   });
 
-  it("shows Meta Ads when its feature switch is enabled", async () => {
+  it("shows Google Search Console by default without an experimental label", async () => {
     await setupPage({
       context,
       path: "/",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
       withoutRender: true,
     });
 
     const connectors = await context.store.get(allConnectorTypes$);
-    const metaAds = connectors.find((connector) => {
-      return connector.type === "meta-ads";
+    const googleSearchConsole = connectors.find((connector) => {
+      return connector.type === "google-search-console";
     });
 
-    expect(metaAds?.label).toBe("Meta Ads");
-    expect(metaAds?.availableAuthMethods).toStrictEqual(["oauth"]);
+    expect(googleSearchConsole?.label).toBe("Google Search Console");
+    expect(googleSearchConsole?.availableAuthMethods).toStrictEqual(["oauth"]);
+  });
+
+  it("hides Google Search Console when its feature switch is disabled", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: {
+        [FeatureSwitchKey.GoogleSearchConsoleConnector]: false,
+      },
+      withoutRender: true,
+    });
+
+    const connectors = await context.store.get(allConnectorTypes$);
+    const googleSearchConsole = connectors.find((connector) => {
+      return connector.type === "google-search-console";
+    });
+
+    expect(googleSearchConsole).toBeUndefined();
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -20,7 +20,7 @@ import {
   hasConnectorDeviceAuthGrant,
   hasConnectorExternalCodeGrant,
 } from "@vm0/connectors/connector-utils";
-import { shouldShowGoogleSecurityWarningNotice } from "../../../lib/google-security-warning.ts";
+import { shouldShowConnectorConnectNotice } from "../../../lib/google-security-warning.ts";
 import {
   zeroConnectorScopeDiffContract,
   zeroConnectorExternalCodeSessionContract,
@@ -135,11 +135,11 @@ function getAvailableConnectorConnectAuthMethods(
 export function getConnectorConnectLaunchMode({
   type,
   availableAuthMethods,
-  preferModalForGoogleSecurityWarning = false,
+  preferModalForConnectorNotice = false,
 }: {
   readonly type: ConnectorType;
   readonly availableAuthMethods: readonly ConnectorAuthMethodId[];
-  readonly preferModalForGoogleSecurityWarning?: boolean;
+  readonly preferModalForConnectorNotice?: boolean;
 }): ConnectorConnectLaunchMode {
   const [authMethod] = availableAuthMethods;
   if (availableAuthMethods.length !== 1 || !authMethod) {
@@ -148,10 +148,7 @@ export function getConnectorConnectLaunchMode({
   if (getConnectorAuthMethod(type, authMethod)?.grant.kind !== "auth-code") {
     return "modal";
   }
-  if (
-    preferModalForGoogleSecurityWarning &&
-    shouldShowGoogleSecurityWarningNotice(type)
-  ) {
+  if (preferModalForConnectorNotice && shouldShowConnectorConnectNotice(type)) {
     return "modal";
   }
   return "oauth-auth-code";

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -61,8 +61,14 @@ import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
-import { shouldShowGoogleSecurityWarningNotice } from "../../../../lib/google-security-warning.ts";
-import { GoogleSecurityWarningNotice } from "../../zero-directed-shared.tsx";
+import {
+  shouldShowGoogleSecurityWarningNotice,
+  shouldShowMetaAdsReviewNotice,
+} from "../../../../lib/google-security-warning.ts";
+import {
+  GoogleSecurityWarningNotice,
+  MetaAdsReviewNotice,
+} from "../../zero-directed-shared.tsx";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 
 // ---------------------------------------------------------------------------
@@ -1052,10 +1058,18 @@ function StandardConnectMethodsContent({
         return entry.authMethod;
       }),
     ) && shouldShowGoogleSecurityWarningNotice(item.type);
+  const showMetaAdsReviewNotice =
+    hasAuthCodeGrant(
+      item.type,
+      entries.map((entry) => {
+        return entry.authMethod;
+      }),
+    ) && shouldShowMetaAdsReviewNotice(item.type);
 
   return (
     <div className="flex flex-col gap-4">
       {showGoogleSecurityWarningNotice && <GoogleSecurityWarningNotice />}
+      {showMetaAdsReviewNotice && <MetaAdsReviewNotice />}
 
       <ConnectMethodsContent
         entries={entries}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -643,7 +643,7 @@ export function ZeroConnectorsPage() {
     const launchMode = getConnectorConnectLaunchMode({
       type,
       availableAuthMethods: ct.availableAuthMethods,
-      preferModalForGoogleSecurityWarning: true,
+      preferModalForConnectorNotice: true,
     });
     if (launchMode === "modal") {
       setSelected(type);

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -26,10 +26,14 @@ import {
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
+import {
+  shouldShowGoogleSecurityWarningNotice,
+  shouldShowMetaAdsReviewNotice,
+} from "../../lib/google-security-warning.ts";
 import {
   Vm0LogoLink,
   GoogleSecurityWarningNotice,
+  MetaAdsReviewNotice,
 } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
@@ -183,6 +187,10 @@ function DirectedAuthorizeCard() {
     !isAuthorized &&
     !isConnected &&
     shouldShowGoogleSecurityWarningNotice(connectorType);
+  const showMetaAdsReviewNotice =
+    !isAuthorized &&
+    !isConnected &&
+    shouldShowMetaAdsReviewNotice(connectorType);
 
   const handleAuthorize = () => {
     if (!canAuthorize) {
@@ -233,6 +241,7 @@ function DirectedAuthorizeCard() {
                   {showGoogleSecurityWarningNotice && (
                     <GoogleSecurityWarningNotice />
                   )}
+                  {showMetaAdsReviewNotice && <MetaAdsReviewNotice />}
                 </>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -50,10 +50,14 @@ import {
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
+import {
+  shouldShowGoogleSecurityWarningNotice,
+  shouldShowMetaAdsReviewNotice,
+} from "../../lib/google-security-warning.ts";
 import {
   Vm0LogoLink,
   GoogleSecurityWarningNotice,
+  MetaAdsReviewNotice,
 } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
@@ -536,6 +540,10 @@ function DirectedConnectCard() {
                   {!isConnected &&
                     shouldShowGoogleSecurityWarningNotice(connectorType) && (
                       <GoogleSecurityWarningNotice />
+                    )}
+                  {!isConnected &&
+                    shouldShowMetaAdsReviewNotice(connectorType) && (
+                      <MetaAdsReviewNotice />
                     )}
                 </>
               )}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -438,6 +438,25 @@ function useDirectedConnectConnectorType(): ConnectorType | null {
   return parsed.success ? parsed.data : null;
 }
 
+function ConnectorConnectNotices({
+  connectorType,
+  isConnected,
+}: {
+  readonly connectorType: ConnectorType;
+  readonly isConnected: boolean;
+}) {
+  if (isConnected) {
+    return null;
+  }
+  if (shouldShowGoogleSecurityWarningNotice(connectorType)) {
+    return <GoogleSecurityWarningNotice />;
+  }
+  if (shouldShowMetaAdsReviewNotice(connectorType)) {
+    return <MetaAdsReviewNotice />;
+  }
+  return null;
+}
+
 function DirectedConnectCard() {
   const connectorType = useDirectedConnectConnectorType();
   const agentId = useGet(directedConnectAgentId$);
@@ -537,14 +556,10 @@ function DirectedConnectCard() {
                   <p className="w-60 text-sm text-muted-foreground">
                     {config.helpText}
                   </p>
-                  {!isConnected &&
-                    shouldShowGoogleSecurityWarningNotice(connectorType) && (
-                      <GoogleSecurityWarningNotice />
-                    )}
-                  {!isConnected &&
-                    shouldShowMetaAdsReviewNotice(connectorType) && (
-                      <MetaAdsReviewNotice />
-                    )}
+                  <ConnectorConnectNotices
+                    connectorType={connectorType}
+                    isConnected={isConnected}
+                  />
                 </>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -114,3 +114,27 @@ export function GoogleSecurityWarningNotice() {
     </div>
   );
 }
+
+export function MetaAdsReviewNotice() {
+  return (
+    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
+      <AvatarSvgPreview
+        config={getAvatarPresets()[0]}
+        size={36}
+        className="h-9 w-9 rounded-full"
+        alt="Zero"
+      />
+      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
+        <p>
+          Meta Ads is currently in Meta&apos;s app review period. You can
+          connect now, but the connector may encounter rate limiting issues
+          until the review is complete.
+        </p>
+        <p>
+          We only request the permissions needed for ads workflows, and your
+          connection tokens are encrypted at rest.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -281,7 +281,7 @@ function ConnectStepContent() {
     const launchMode = getConnectorConnectLaunchMode({
       type,
       availableAuthMethods: connector.availableAuthMethods,
-      preferModalForGoogleSecurityWarning: true,
+      preferModalForConnectorNotice: true,
     });
     if (launchMode === "modal") {
       setSelectedConnector(type);

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/meta-ads.test.ts
@@ -46,6 +46,21 @@ describe("connector/providers/meta-ads", () => {
       expect(url).toContain("response_type=code");
       expect(url).toContain("scope=");
       expect(url).toContain("facebook.com/v22.0/dialog/oauth");
+      const scopes = new Set(
+        new URL(url).searchParams.get("scope")?.split(",") ?? [],
+      );
+      expect(scopes).toStrictEqual(
+        new Set([
+          "ads_management",
+          "ads_read",
+          "business_management",
+          "pages_manage_ads",
+          "pages_read_engagement",
+          "pages_show_list",
+          "public_profile",
+        ]),
+      );
+      expect(scopes.has("email")).toBe(false);
     });
   });
 

--- a/turbo/packages/connectors/src/connectors/google-search-console.ts
+++ b/turbo/packages/connectors/src/connectors/google-search-console.ts
@@ -18,6 +18,7 @@ export const googleSearchConsole = {
     authMethods: {
       oauth: {
         featureFlag: FeatureSwitchKey.GoogleSearchConsoleConnector,
+        showExperimentalLabel: false,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Search Console access.",
         client: {

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -25,7 +25,15 @@ export const metaAds = {
         },
         grant: {
           kind: "auth-code",
-          scopes: ["ads_management", "ads_read", "business_management"],
+          scopes: [
+            "ads_management",
+            "ads_read",
+            "business_management",
+            "pages_manage_ads",
+            "pages_read_engagement",
+            "pages_show_list",
+            "public_profile",
+          ],
           outputs: {
             accessToken: "$secrets.META_ADS_ACCESS_TOKEN",
             refreshToken: "$secrets.META_ADS_REFRESH_TOKEN",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -122,7 +122,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.MetaAdsConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Meta Ads Manager connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.StripeConnector]: {
     maintainer: "ethan@vm0.ai",
@@ -153,7 +153,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.GoogleSearchConsoleConnector]: {
     maintainer: "linghan@vm0.ai",
     description: "Enable the Google Search Console connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.SpotifyConnector]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable Meta Ads and Google Search Console connector switches by default
- remove the experimental label from Google Search Console
- show a Meta Ads app-review notice before OAuth connection, including directed connect/authorize flows
- update Meta Ads OAuth scopes and tests

## Tests
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/settings/__tests__/google-ads-connector.test.ts
- pnpm -F @vm0/app exec vitest run src/signals/zero-page/__tests__/zero-connectors.test.ts
- pnpm -F @vm0/connectors exec vitest run src/auth-providers/connectors/__tests__/meta-ads.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-list.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pre-commit: pnpm check-types via lefthook
