### PR TITLE
fix: preserve model websocket usage sources

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -89,9 +89,15 @@ Response streaming
 
 Model-provider usage
 --------------------
-- ``MODEL_PROVIDER_USAGE``: ``dict`` of normalized token usage. Written by
-  streaming/JSON/WebSocket extractors or fallback extraction, then read by
-  model usage-event and observation reporters.
+- ``MODEL_PROVIDER_USAGE``: ``dict`` of normalized token usage for one
+  flow-level model response source. Written by streaming/JSON extractors,
+  WebSocket missing-response-id fallback extraction, or fallback extraction,
+  then read by model usage-event and observation reporters.
+- ``MODEL_PROVIDER_USAGE_SOURCES``: ``dict`` keyed by WebSocket response id,
+  with normalized token usage dict values. Written by WebSocket model-provider
+  usage extraction and read by model usage-event and observation reporters.
+  Retained after terminal reporting for diagnostics, like
+  ``MODEL_PROVIDER_USAGE``.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` model id from registry VM info.
   Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization
@@ -144,6 +150,7 @@ TRUSTED_AUTHORITY_HOST: Final = "trusted_authority_host"
 
 # Usage and streaming metadata
 MODEL_PROVIDER_USAGE: Final = "model_provider_usage"
+MODEL_PROVIDER_USAGE_SOURCES: Final = "model_provider_usage_sources"
 MODEL_USAGE_PROVIDER: Final = "model_usage_provider"
 MODEL_JSON_USAGE_FINALIZED: Final = "_model_json_usage_finalized"
 STREAM_BUFFER: Final = "stream_buffer"

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -105,6 +105,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         and uses_openai_responses_usage_protocol(flow)
     ):
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {}
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return None
     if is_observable_model_provider:
@@ -260,8 +261,10 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
 
     Called from ``websocket_message()`` only for server-originated frames. Reads
     ``_MODEL_WEBSOCKET_USAGE_ENABLED`` via ``is_model_websocket_usage_enabled()``
-    and writes or updates ``metadata_keys.MODEL_PROVIDER_USAGE``. This helper is
-    not idempotent for the same frame; callers must feed each server frame once.
+    and writes per-response sources to
+    ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES``. Frames without a response id
+    fall back to ``metadata_keys.MODEL_PROVIDER_USAGE``. This helper is not
+    idempotent for the same frame; callers must feed each server frame once.
     """
     if not is_model_websocket_usage_enabled(flow):
         return
@@ -269,6 +272,19 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     usage_result = usage.extract_openai_responses_usage_from_event_json(body)
     if not usage_result:
         return
+    message_id = usage_result.get("message_id")
+    if isinstance(message_id, str) and message_id:
+        usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
+        if not isinstance(usage_sources, dict):
+            usage_sources = {}
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = usage_sources
+        usage_target = usage_sources.get(message_id)
+        if not isinstance(usage_target, dict):
+            usage_target = {}
+            usage_sources[message_id] = usage_target
+        usage.merge_openai_responses_usage_result(usage_target, usage_result)
+        return
+
     usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
     if not isinstance(usage_target, dict):
         usage_target = {}

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -1,8 +1,9 @@
 """Model-provider usage reporting entry point.
 
 Buffers token counts already normalized by an addon-side provider extractor
-(stored in ``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]``) for aggregate upload to
-the platform usage webhook endpoints.
+(stored in ``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]`` or
+``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES]``) for aggregate
+upload to the platform usage webhook endpoints.
 
 Model-provider usage reporting is separate from platform billing. New run
 contexts set ``flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER]`` to the
@@ -14,6 +15,7 @@ field existed can still report usage.
 """
 
 import uuid
+from collections.abc import Iterator
 from typing import TypeGuard
 
 from mitmproxy import http
@@ -53,7 +55,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     - ``firewall_name`` starts with ``model-provider:``.
     - ``run_id`` is non-empty.
     - ``firewall_billable`` is truthy.
-    - ``model_provider_usage`` is a non-empty dict.
+    - At least one model-provider usage source is available.
     - At least one ``MODEL_USAGE_CATEGORIES`` value has a positive integer
       quantity.
     - ``vm_sandbox_token`` and ``get_api_url()`` are both non-empty.
@@ -70,11 +72,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
         return False
     if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
         return False
-    usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
-    if not usage or not isinstance(usage, dict):
-        return False
-    provider = _reported_model(flow, usage)
-    events = _build_usage_events(run_id, flow.id, provider, usage, USAGE_EVENT_NAMESPACE_MODEL)
+    events = _build_model_provider_usage_events(flow, run_id, USAGE_EVENT_NAMESPACE_MODEL)
     if not events:
         return False
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
@@ -105,17 +103,7 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
         return False
     if not is_model_provider_usage_observable(flow):
         return False
-    usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
-    if not usage or not isinstance(usage, dict):
-        return False
-    model = _reported_model(flow, usage)
-    events = _build_usage_events(
-        run_id,
-        flow.id,
-        model,
-        usage,
-        USAGE_OBSERVATION_NAMESPACE_MODEL,
-    )
+    events = _build_model_provider_usage_events(flow, run_id, USAGE_OBSERVATION_NAMESPACE_MODEL)
     if not events:
         return False
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
@@ -138,6 +126,32 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
         proxy_log_path,
     )
     return True
+
+
+def _build_model_provider_usage_events(
+    flow: http.HTTPFlow, run_id: str, namespace: uuid.UUID
+) -> list[UsageEvent]:
+    events: list[UsageEvent] = []
+    for source_id, usage in _iter_model_provider_usage_sources(flow):
+        provider = _reported_model(flow, usage)
+        events.extend(_build_usage_events(run_id, source_id, provider, usage, namespace))
+    return events
+
+
+def _iter_model_provider_usage_sources(flow: http.HTTPFlow) -> Iterator[tuple[str, dict]]:
+    usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
+    if isinstance(usage_sources, dict):
+        valid_sources = (
+            (message_id, source_usage)
+            for message_id, source_usage in usage_sources.items()
+            if isinstance(message_id, str) and message_id and isinstance(source_usage, dict)
+        )
+        for message_id, source_usage in sorted(valid_sources):
+            yield f"{flow.id}:{message_id}", source_usage
+
+    usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
+    if usage and isinstance(usage, dict):
+        yield flow.id, usage
 
 
 def _build_usage_events(

--- a/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py
@@ -205,6 +205,12 @@ def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
     mitm_addon.websocket_message(flow)
 
 
+def _model_websocket_usage_sources(flow: http.HTTPFlow) -> dict:
+    sources = flow.metadata["model_provider_usage_sources"]
+    assert isinstance(sources, dict)
+    return sources
+
+
 def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
     proxy_log = Path(flow.metadata["vm_proxy_log_path"])
     if not proxy_log.exists():
@@ -555,11 +561,147 @@ class TestModelProviderStreamUsage:
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
-        assert flow.metadata["model_provider_usage"]["message_id"] == "resp_ws_1"
+        assert flow.metadata["model_provider_usage"] == {}
+        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 40,
+            "tokens.output": 20,
+            "tokens.cache_read": 10,
+        }
         assert by_category == {
             "tokens.input": 40,
             "tokens.output": 20,
             "tokens.cache_read": 10,
+        }
+
+    def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_1",
+                input_tokens=10,
+                output_tokens=4,
+            ),
+        )
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_2",
+                input_tokens=3,
+                output_tokens=2,
+            ),
+        )
+
+        webhook = self._run_websocket_end(flow)
+
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 13,
+            "tokens.output": 6,
+        }
+        assert {
+            event["category"]: event["quantity"]
+            for event in webhook.model_usage_observation_events()
+        } == {
+            "tokens.input": 13,
+            "tokens.output": 6,
+        }
+
+    def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_1",
+                input_tokens=10,
+                output_tokens=4,
+                model="gpt-5.5",
+            ),
+        )
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_2",
+                input_tokens=3,
+                output_tokens=2,
+                model="gpt-5.4",
+            ),
+        )
+
+        webhook = self._run_websocket_end(flow)
+
+        assert {
+            (event["provider"], event["category"]): event["quantity"]
+            for event in webhook.usage_events()
+        } == {
+            ("gpt-5.5", "tokens.input"): 10,
+            ("gpt-5.5", "tokens.output"): 4,
+            ("gpt-5.4", "tokens.input"): 3,
+            ("gpt-5.4", "tokens.output"): 2,
+        }
+        assert {
+            (event["model"], event["category"]): event["quantity"]
+            for event in webhook.model_usage_observation_events()
+        } == {
+            ("gpt-5.5", "tokens.input"): 10,
+            ("gpt-5.5", "tokens.output"): 4,
+            ("gpt-5.4", "tokens.input"): 3,
+            ("gpt-5.4", "tokens.output"): 2,
+        }
+
+    def test_full_pipeline_model_websocket_reports_id_and_missing_id_usage(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        _feed_websocket_server_message(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 7, "output_tokens": 1},
+                    },
+                }
+            ).encode(),
+        )
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_1",
+                input_tokens=10,
+                output_tokens=4,
+                model="gpt-5.5",
+            ),
+        )
+
+        webhook = self._run_websocket_end(flow)
+
+        assert flow.metadata["model_provider_usage"] == {
+            "model": "gpt-5.5",
+            "tokens.input": 7,
+            "tokens.output": 1,
+        }
+        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
+            "message_id": "resp_ws_1",
+            "model": "gpt-5.5",
+            "tokens.input": 10,
+            "tokens.output": 4,
+        }
+        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+            "tokens.input": 17,
+            "tokens.output": 5,
+        }
+        assert {
+            event["category"]: event["quantity"]
+            for event in webhook.model_usage_observation_events()
+        } == {
+            "tokens.input": 17,
+            "tokens.output": 5,
         }
 
     async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
@@ -796,6 +938,7 @@ class TestModelProviderStreamUsage:
 
         assert webhook.request_count == 0
         assert flow.metadata["model_provider_usage"] == {}
+        assert _model_websocket_usage_sources(flow) == {}
 
     def test_model_websocket_deferred_trim_keeps_latest_server_message(
         self,
@@ -817,12 +960,15 @@ class TestModelProviderStreamUsage:
         mitm_addon.websocket_message(flow)
 
         assert messages == [old_client, old_server, latest_server]
-        assert flow.metadata["model_provider_usage"] == {
-            "message_id": "resp_ws_latest",
-            "model": "gpt-5.5",
-            "tokens.input": 10,
-            "tokens.output": 4,
+        assert _model_websocket_usage_sources(flow) == {
+            "resp_ws_latest": {
+                "message_id": "resp_ws_latest",
+                "model": "gpt-5.5",
+                "tokens.input": 10,
+                "tokens.output": 4,
+            }
         }
+        assert flow.metadata["model_provider_usage"] == {}
         assert len(deferred_websocket_trim_scheduler) == 1
 
         _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
@@ -847,6 +993,7 @@ class TestModelProviderStreamUsage:
         mitm_addon.websocket_message(flow)
 
         assert flow.metadata["model_provider_usage"] == {}
+        assert _model_websocket_usage_sources(flow) == {}
         assert len(deferred_websocket_trim_scheduler) == 1
 
         _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
@@ -888,12 +1035,21 @@ class TestModelProviderStreamUsage:
         _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
 
         assert flow.websocket.messages == [latest_server]
-        assert flow.metadata["model_provider_usage"] == {
-            "message_id": "resp_ws_latest",
-            "model": "gpt-5.5",
-            "tokens.input": 10,
-            "tokens.output": 4,
+        assert _model_websocket_usage_sources(flow) == {
+            "resp_ws_first": {
+                "message_id": "resp_ws_first",
+                "model": "gpt-5.5",
+                "tokens.input": 1,
+                "tokens.output": 1,
+            },
+            "resp_ws_latest": {
+                "message_id": "resp_ws_latest",
+                "model": "gpt-5.5",
+                "tokens.input": 10,
+                "tokens.output": 4,
+            },
         }
+        assert flow.metadata["model_provider_usage"] == {}
 
     def test_non_model_websocket_message_retention_is_unchanged(
         self,
@@ -1008,7 +1164,7 @@ class TestModelProviderWebSocketUsageMetadata:
             ).encode(),
         )
 
-        assert flow.metadata["model_provider_usage"] == {
+        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
             "tokens.input": 75,
@@ -1046,7 +1202,7 @@ class TestModelProviderWebSocketUsageMetadata:
             ).encode(),
         )
 
-        assert flow.metadata["model_provider_usage"] == {
+        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
             "tokens.input": 10,
@@ -1087,7 +1243,7 @@ class TestModelProviderWebSocketUsageMetadata:
             ).encode(),
         )
 
-        assert flow.metadata["model_provider_usage"] == {
+        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
             "tokens.input": 75,
@@ -1112,7 +1268,7 @@ class TestModelProviderWebSocketUsageMetadata:
             ),
         )
 
-        assert flow.metadata["model_provider_usage"] == {
+        assert _model_websocket_usage_sources(flow)["resp_ws_text"] == {
             "message_id": "resp_ws_text",
             "model": "gpt-5.4",
             "tokens.input": 3,
@@ -1137,11 +1293,11 @@ class TestModelProviderWebSocketUsageMetadata:
             "tokens.output": 4,
         }
 
-    def test_model_websocket_valid_usage_replaces_non_dict_usage_metadata(
+    def test_model_websocket_valid_id_usage_replaces_non_dict_usage_sources_metadata(
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
-        flow.metadata["model_provider_usage"] = "invalid"
+        flow.metadata["model_provider_usage_sources"] = "invalid"
 
         _feed_websocket_server_message(
             flow,
@@ -1157,18 +1313,22 @@ class TestModelProviderWebSocketUsageMetadata:
             ).encode(),
         )
 
-        assert flow.metadata["model_provider_usage"] == {
-            "message_id": "resp_ws_1",
-            "model": "gpt-5.5",
-            "tokens.input": 10,
-            "tokens.output": 4,
+        assert _model_websocket_usage_sources(flow) == {
+            "resp_ws_1": {
+                "message_id": "resp_ws_1",
+                "model": "gpt-5.5",
+                "tokens.input": 10,
+                "tokens.output": 4,
+            }
         }
+        assert flow.metadata["model_provider_usage"] == {}
 
     def test_model_websocket_ignores_invalid_frames_with_non_dict_usage_metadata(
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
         flow.metadata["model_provider_usage"] = "invalid"
+        flow.metadata["model_provider_usage_sources"] = "invalid"
 
         _feed_websocket_server_message(
             flow,
@@ -1180,6 +1340,8 @@ class TestModelProviderWebSocketUsageMetadata:
             ).encode(),
         )
         assert flow.metadata["model_provider_usage"] == "invalid"
+        assert flow.metadata["model_provider_usage_sources"] == "invalid"
 
         _feed_websocket_server_message(flow, b'{"type":"response.completed"')
         assert flow.metadata["model_provider_usage"] == "invalid"
+        assert flow.metadata["model_provider_usage_sources"] == "invalid"

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -372,6 +372,139 @@ class TestReportModelProviderUsage:
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
 
+    def test_source_dedupe_aggregates_model_provider_usage_sources(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.id = "flow-uuid-xyz-123"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage_sources"] = {
+            "resp_ws_1": {
+                "model": "gpt-5.5",
+                "message_id": "resp_ws_1",
+                "tokens.input": 10,
+            },
+            "resp_ws_2": {
+                "model": "gpt-5.5",
+                "message_id": "resp_ws_2",
+                "tokens.input": 3,
+            },
+        }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage(flow, "run-websocket")
+            usage.report_model_provider_usage(flow, "run-websocket")
+            usage.report_model_provider_usage_observation(flow, "run-websocket")
+            usage.report_model_provider_usage_observation(flow, "run-websocket")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        requests_by_path = {request.path: request for request in webhook.requests}
+        assert set(requests_by_path) == {
+            "/api/webhooks/agent/usage-event",
+            "/api/webhooks/agent/model-usage-observation",
+        }
+        usage_body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
+        observation_body = requests_by_path[
+            "/api/webhooks/agent/model-usage-observation"
+        ].json_body()
+        assert [
+            {key: value for key, value in event.items() if key != "idempotencyKey"}
+            for event in usage_body["events"]
+        ] == [
+            {
+                "kind": "model",
+                "provider": "gpt-5.5",
+                "category": "tokens.input",
+                "quantity": 13,
+            }
+        ]
+        assert [
+            {key: value for key, value in event.items() if key != "idempotencyKey"}
+            for event in observation_body["events"]
+        ] == [
+            {
+                "model": "gpt-5.5",
+                "category": "tokens.input",
+                "quantity": 13,
+            }
+        ]
+        uuid.UUID(usage_body["events"][0]["idempotencyKey"])
+        uuid.UUID(observation_body["events"][0]["idempotencyKey"])
+
+    def test_source_dedupe_separates_model_provider_usage_sources_by_model(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.id = "flow-uuid-xyz-123"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage_sources"] = {
+            "resp_ws_1": {
+                "model": "gpt-5.5",
+                "message_id": "resp_ws_1",
+                "tokens.input": 10,
+            },
+            "resp_ws_2": {
+                "model": "gpt-5.4",
+                "message_id": "resp_ws_2",
+                "tokens.input": 3,
+            },
+        }
+
+        with usage_webhook_api() as webhook:
+            usage.report_model_provider_usage(flow, "run-websocket")
+            usage.report_model_provider_usage_observation(flow, "run-websocket")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        requests_by_path = {request.path: request for request in webhook.requests}
+        usage_body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
+        observation_body = requests_by_path[
+            "/api/webhooks/agent/model-usage-observation"
+        ].json_body()
+        assert {
+            (event["provider"], event["category"]): event["quantity"]
+            for event in usage_body["events"]
+        } == {
+            ("gpt-5.5", "tokens.input"): 10,
+            ("gpt-5.4", "tokens.input"): 3,
+        }
+        assert {
+            (event["model"], event["category"]): event["quantity"]
+            for event in observation_body["events"]
+        } == {
+            ("gpt-5.5", "tokens.input"): 10,
+            ("gpt-5.4", "tokens.input"): 3,
+        }
+
+    def test_source_dedupe_skips_malformed_model_provider_usage_sources(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        flow = real_flow(with_response=False, host="api.openai.com")
+        flow.id = "flow-uuid-xyz-123"
+        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
+        flow.metadata["firewall_billable"] = True
+        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata["model_provider_usage_sources"] = {
+            "resp_invalid": "invalid",
+            "": {"model": "gpt-5.5", "tokens.input": 10},
+            42: {"model": "gpt-5.4", "tokens.input": 3},
+        }
+
+        with usage_webhook_api() as webhook:
+            accepted = usage.report_model_provider_usage(flow, "run-websocket")
+            observed = usage.report_model_provider_usage_observation(flow, "run-websocket")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        assert accepted is False
+        assert observed is False
+        assert webhook.request_count == 0
+
     def test_source_dedupe_separates_flows_when_message_id_missing(
         self, real_flow, fresh_usage_executor, usage_webhook_api
     ):


### PR DESCRIPTION
## Summary
- store OpenAI Responses WebSocket usage in per-response metadata buckets keyed by response id
- report source buckets with `flow.id:response_id` idempotency sources while preserving the existing flow-level fallback for missing ids
- add regression coverage for multiple response ids, mixed models, missing-id fallback, malformed source metadata, and billing/observation aggregation

## Tests
- `pytest crates/runner/mitm-addon/tests/test_model_provider_stream_usage.py crates/runner/mitm-addon/tests/test_model_provider_usage.py`
- `pytest crates/runner/mitm-addon/tests/test_model_provider_*.py crates/runner/mitm-addon/tests/test_response_streaming.py`
- `ruff check src/flow_metadata_keys.py src/response_streaming.py src/usage/providers/model_provider.py tests/test_model_provider_stream_usage.py tests/test_model_provider_usage.py`
- `ruff format --check src/flow_metadata_keys.py src/response_streaming.py src/usage/providers/model_provider.py tests/test_model_provider_stream_usage.py tests/test_model_provider_usage.py`
- `basedpyright src/flow_metadata_keys.py src/response_streaming.py src/usage/providers/model_provider.py tests/test_model_provider_stream_usage.py tests/test_model_provider_usage.py`

Closes #17099