### PR TITLE
fix: wait for workspace holders before unmount retry

### DIFF
--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -242,6 +242,22 @@ kill_workspace_holder_pids() {
   done
 }
 
+wait_for_workspace_holders_to_clear() {
+  grace_seconds=$1
+  attempts=$((grace_seconds * 10))
+  [ "$attempts" -gt 0 ] || attempts=1
+
+  while [ "$attempts" -gt 0 ]; do
+    if [ -z "$(workspace_holder_pids)" ]; then
+      return 0
+    fi
+    attempts=$((attempts - 1))
+    sleep 0.1
+  done
+
+  [ -z "$(workspace_holder_pids)" ]
+}
+
 echo "workspace drive unmount failed; diagnosing holders under $workspace_dir" >&2
 holder_pids="$(workspace_holder_pids)"
 if [ -z "$holder_pids" ]; then
@@ -249,14 +265,14 @@ if [ -z "$holder_pids" ]; then
 else
   log_workspace_holders
   term_workspace_holder_pids "$holder_pids"
-  sleep "$WORKSPACE_HOLDER_TERM_GRACE_SECONDS"
+  wait_for_workspace_holders_to_clear "$WORKSPACE_HOLDER_TERM_GRACE_SECONDS" || true
 
   remaining_holder_pids="$(workspace_holder_pids)"
   if [ -n "$remaining_holder_pids" ]; then
     echo "workspace holders remain after TERM; sending KILL" >&2
     log_workspace_holders
     kill_workspace_holder_pids "$remaining_holder_pids"
-    sleep "$WORKSPACE_HOLDER_KILL_GRACE_SECONDS"
+    wait_for_workspace_holders_to_clear "$WORKSPACE_HOLDER_KILL_GRACE_SECONDS" || true
   fi
 fi
 

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -629,6 +629,7 @@ exit 0
         assert!(cmd.contains("WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT=40"));
         assert!(cmd.contains("WORKSPACE_HOLDER_VALUE_LIMIT=240"));
         assert!(cmd.contains("WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1"));
+        assert!(cmd.contains("wait_for_workspace_holders_to_clear()"));
         assert!(cmd.contains("workspace holder diagnostics truncated"));
         assert!(cmd.contains("pid=%s uid=%s comm=%s ref=%s path=%s"));
         assert!(cmd.contains("comm=\"$(sanitize_log_value \"$comm\")\""));
@@ -646,14 +647,21 @@ exit 0
         let term = cmd
             .find("term_workspace_holder_pids \"$holder_pids\"")
             .expect("TERM holders");
+        let term_wait = cmd
+            .find("wait_for_workspace_holders_to_clear \"$WORKSPACE_HOLDER_TERM_GRACE_SECONDS\"")
+            .expect("TERM holder wait");
         let rescan = cmd
             .find("remaining_holder_pids=\"$(workspace_holder_pids)\"")
             .expect("holder rescan");
         let kill = cmd
             .find("kill_workspace_holder_pids \"$remaining_holder_pids\"")
             .expect("KILL remaining holders");
-        let kill_sleep = find_after(&cmd, "sleep \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"", kill);
-        let retry_sync = find_after(&cmd, "sync -f -- \"$workspace_dir\"", kill_sleep);
+        let kill_wait = find_after(
+            &cmd,
+            "wait_for_workspace_holders_to_clear \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"",
+            kill,
+        );
+        let retry_sync = find_after(&cmd, "sync -f -- \"$workspace_dir\"", kill_wait);
         let retry_unmount = find_after(&cmd, "umount -- \"$workspace_dir\"", retry_sync);
 
         assert!(
@@ -661,15 +669,19 @@ exit 0
             "holder diagnosis must only happen after clean unmount fails"
         );
         assert!(diagnose < term, "holders must be diagnosed before TERM");
-        assert!(term < rescan, "holders must be rescanned after TERM");
+        assert!(term < term_wait, "TERM must wait for holder refs to clear");
+        assert!(
+            term_wait < rescan,
+            "holders must be rescanned after TERM wait"
+        );
         assert!(
             rescan < kill,
             "KILL must only target holders confirmed by the rescan"
         );
         assert!(kill < retry_sync, "cleanup must happen before retry sync");
         assert!(
-            kill < kill_sleep,
-            "KILL must have a short grace period before retry sync"
+            kill < kill_wait,
+            "KILL must wait for holder refs to clear before retry sync"
         );
         assert!(
             retry_sync < retry_unmount,


### PR DESCRIPTION
## Summary
- wait for workspace holder references to clear after TERM/KILL before retrying workspace unmount
- keep the retry bounded by the existing grace windows while avoiding fixed sleeps when holders exit quickly
- update workspace mount script assertions to lock in the wait-before-retry behavior

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner workspace_mount::tests:: -- --nocapture
- repeated 20x: cargo test --manifest-path crates/Cargo.toml -p runner --bin runner workspace_mount::tests::unmount_script_terminates_workspace_exe_holder_before_retry -- --nocapture
- cargo clippy --manifest-path crates/Cargo.toml -p runner --bin runner --all-features
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner