### PR TITLE
fix(mitm-addon): handle malformed x tld sources

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -36,6 +36,10 @@ class TldFetchError(RuntimeError):
     """Raised when the live IANA TLD source cannot be fetched."""
 
 
+class TldSourceError(ValueError):
+    """Raised when an IANA TLD source cannot be read or parsed."""
+
+
 class SnapshotComparison(NamedTuple):
     checked_version: str
     source_version: str
@@ -74,6 +78,8 @@ def fetch_source() -> str:
     except urllib.error.HTTPError as exc:
         with exc:
             raise TldFetchError(f"failed to fetch {SOURCE_URL}: HTTP {exc.code}") from exc
+    except UnicodeDecodeError as exc:
+        raise TldFetchError(f"failed to fetch {SOURCE_URL}: invalid UTF-8 response body") from exc
     except (OSError, http.client.HTTPException) as exc:
         raise TldFetchError(f"failed to fetch {SOURCE_URL}: {exc}") from exc
 
@@ -81,11 +87,11 @@ def fetch_source() -> str:
 def parse_source(source: str) -> tuple[str, tuple[str, ...]]:
     lines = source.splitlines()
     if not lines:
-        raise ValueError("IANA TLD source is empty")
+        raise TldSourceError("IANA TLD source is empty")
 
     version_match = VERSION_RE.match(lines[0])
     if version_match is None:
-        raise ValueError("IANA TLD source is missing the version header")
+        raise TldSourceError("IANA TLD source is missing the version header")
     version = version_match.group("version")
 
     tlds: set[str] = set()
@@ -97,15 +103,26 @@ def parse_source(source: str) -> tuple[str, tuple[str, ...]]:
         try:
             tld.encode("ascii")
         except UnicodeEncodeError as exc:
-            raise ValueError(f"IANA TLD is not ASCII: {raw}") from exc
+            raise TldSourceError(f"IANA TLD is not ASCII: {raw}") from exc
         if TLD_RE.fullmatch(tld) is None or tld.startswith("-") or tld.endswith("-"):
-            raise ValueError(f"IANA TLD has invalid syntax: {raw}")
+            raise TldSourceError(f"IANA TLD has invalid syntax: {raw}")
         tlds.add(tld)
 
     if not tlds:
-        raise ValueError("IANA TLD source contains no TLD entries")
+        raise TldSourceError("IANA TLD source contains no TLD entries")
 
     return version, tuple(sorted(tlds))
+
+
+def read_source_file(source_file: Path) -> str:
+    try:
+        return source_file.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise TldSourceError(
+            f"failed to read IANA TLD source file {source_file}: invalid UTF-8"
+        ) from exc
+    except OSError as exc:
+        raise TldSourceError(f"failed to read IANA TLD source file {source_file}: {exc}") from exc
 
 
 def render_module(version: str, tlds: tuple[str, ...]) -> str:
@@ -190,7 +207,7 @@ def compare_snapshot_to_source(source: str) -> SnapshotComparison:
 
 
 def check_source(source_file: Path) -> int:
-    comparison = compare_snapshot_to_source(source_file.read_text(encoding="utf-8"))
+    comparison = compare_snapshot_to_source(read_source_file(source_file))
     sys.stdout.write(
         f"checked-in IANA TLD version {comparison.checked_version} "
         f"({comparison.checked_count} TLDs)\n"
@@ -233,7 +250,7 @@ def write_generated_module(contents: str) -> None:
 
 
 def update_generated(source_file: Path | None) -> int:
-    source = source_file.read_text(encoding="utf-8") if source_file is not None else fetch_source()
+    source = read_source_file(source_file) if source_file is not None else fetch_source()
     version, tlds = parse_source(source)
     write_generated_module(render_module(version, tlds))
     sys.stdout.write(f"wrote {OUTPUT_PATH} with {len(tlds)} TLDs from IANA version {version}\n")
@@ -265,12 +282,12 @@ def main() -> int:
         if args.source_file is not None:
             parser.error("--check cannot be combined with --source-file")
         return check_generated()
-    if args.check_source:
-        if args.source_file is None:
-            parser.error("--check-source requires --source-file")
-        return check_source(args.source_file)
     try:
+        if args.check_source:
+            if args.source_file is None:
+                parser.error("--check-source requires --source-file")
+            return check_source(args.source_file)
         return update_generated(args.source_file)
-    except TldFetchError as exc:
+    except (TldFetchError, TldSourceError) as exc:
         sys.stderr.write(f"{exc}\n")
         return 1

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -259,6 +259,18 @@ def test_update_cli_reports_malformed_source_without_replacing_output(
     assert output.read_text(encoding="utf-8") == original
 
 
+def test_update_script_reports_malformed_source_without_traceback(tmp_path):
+    source = tmp_path / "tlds.txt"
+    source.write_text("COM\nORG\n", encoding="utf-8")
+
+    completed = _run_update_script("--source-file", str(source))
+
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert "IANA TLD source is missing the version header" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
 def test_update_cli_reports_invalid_utf8_source_without_replacing_output(
     tmp_path, monkeypatch, capsys
 ):

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -53,6 +53,24 @@ class _ReadFailureOpener:
         return _ReadFailureResponse()
 
 
+class _InvalidUtf8Response:
+    status = update_x_tlds.HTTPStatus.OK
+
+    def __enter__(self) -> _InvalidUtf8Response:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return b"\xff"
+
+
+class _InvalidUtf8Opener:
+    def open(self, request: object, timeout: int) -> _InvalidUtf8Response:
+        return _InvalidUtf8Response()
+
+
 def _build_failing_opener(*handlers: object) -> _FailingOpener:
     return _FailingOpener()
 
@@ -65,8 +83,19 @@ def _build_read_failure_opener(*handlers: object) -> _ReadFailureOpener:
     return _ReadFailureOpener()
 
 
+def _build_invalid_utf8_opener(*handlers: object) -> _InvalidUtf8Opener:
+    return _InvalidUtf8Opener()
+
+
 def _source_text(version: str, tlds: Iterable[str]) -> str:
     return f"# Version {version}, Last Updated test\n" + "\n".join(sorted(tlds)) + "\n"
+
+
+def _write_generated_snapshot(path: Path) -> None:
+    path.write_text(
+        update_x_tlds.render_module(IANA_TLD_VERSION, tuple(sorted(IANA_TLDS))),
+        encoding="utf-8",
+    )
 
 
 def _run_update_script(*args: str) -> subprocess.CompletedProcess[str]:
@@ -179,6 +208,17 @@ def test_fetch_source_reports_response_read_failure_as_fetch_error(monkeypatch):
     assert "IncompleteRead" in message
 
 
+def test_fetch_source_reports_invalid_utf8_body_as_fetch_error(monkeypatch):
+    monkeypatch.setattr(update_x_tlds.urllib.request, "build_opener", _build_invalid_utf8_opener)
+
+    with pytest.raises(update_x_tlds.TldFetchError) as exc_info:
+        update_x_tlds.fetch_source()
+
+    message = str(exc_info.value)
+    assert f"failed to fetch {update_x_tlds.SOURCE_URL}:" in message
+    assert "invalid UTF-8" in message
+
+
 def test_default_update_cli_reports_fetch_failure_without_replacing_output(
     tmp_path, monkeypatch, capsys
 ):
@@ -195,6 +235,67 @@ def test_default_update_cli_reports_fetch_failure_without_replacing_output(
     assert captured.out == ""
     assert f"failed to fetch {update_x_tlds.SOURCE_URL}:" in captured.err
     assert "dns failed" in captured.err
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_update_cli_reports_malformed_source_without_replacing_output(
+    tmp_path, monkeypatch, capsys
+):
+    source = tmp_path / "tlds.txt"
+    source.write_text("COM\nORG\n", encoding="utf-8")
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [str(_UPDATE_SCRIPT), "--source-file", str(source)])
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "IANA TLD source is missing the version header" in captured.err
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_update_cli_reports_invalid_utf8_source_without_replacing_output(
+    tmp_path, monkeypatch, capsys
+):
+    source = tmp_path / "tlds.txt"
+    source.write_bytes(b"\xff")
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [str(_UPDATE_SCRIPT), "--source-file", str(source)])
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(source) in captured.err
+    assert "invalid UTF-8" in captured.err
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_update_cli_reports_missing_source_file_without_replacing_output(
+    tmp_path, monkeypatch, capsys
+):
+    source = tmp_path / "missing-tlds.txt"
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [str(_UPDATE_SCRIPT), "--source-file", str(source)])
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(source) in captured.err
+    assert "failed to read IANA TLD source file" in captured.err
     assert "Traceback" not in captured.err
     assert output.read_text(encoding="utf-8") == original
 
@@ -292,6 +393,49 @@ def test_check_source_cli_reports_set_drift(tmp_path):
     assert "IANA TLD set drift detected" in completed.stderr
     assert f"added: {added_tld}" in completed.stderr
     assert f"removed: {removed_tld}" in completed.stderr
+
+
+def test_check_source_cli_reports_malformed_source_without_traceback(tmp_path, monkeypatch, capsys):
+    source = tmp_path / "tlds.txt"
+    source.write_text("COM\nORG\n", encoding="utf-8")
+    output = tmp_path / "x_tlds.py"
+    _write_generated_snapshot(output)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(_UPDATE_SCRIPT), "--check-source", "--source-file", str(source)],
+    )
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "IANA TLD source is missing the version header" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_check_source_cli_reports_invalid_utf8_source_without_traceback(
+    tmp_path, monkeypatch, capsys
+):
+    source = tmp_path / "tlds.txt"
+    source.write_bytes(b"\xff")
+    output = tmp_path / "x_tlds.py"
+    _write_generated_snapshot(output)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(_UPDATE_SCRIPT), "--check-source", "--source-file", str(source)],
+    )
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(source) in captured.err
+    assert "invalid UTF-8" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_check_source_cli_requires_source_file():

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -438,6 +438,47 @@ def test_check_source_cli_reports_invalid_utf8_source_without_traceback(
     assert "Traceback" not in captured.err
 
 
+def test_check_source_cli_reports_missing_source_file_without_traceback(
+    tmp_path, monkeypatch, capsys
+):
+    source = tmp_path / "missing-tlds.txt"
+    output = tmp_path / "x_tlds.py"
+    _write_generated_snapshot(output)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(_UPDATE_SCRIPT), "--check-source", "--source-file", str(source)],
+    )
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(source) in captured.err
+    assert "failed to read IANA TLD source file" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_check_source_cli_does_not_hide_invalid_generated_snapshot(tmp_path, monkeypatch):
+    source = tmp_path / "tlds.txt"
+    source.write_text(_source_text("1", {"com"}), encoding="utf-8")
+    output = tmp_path / "x_tlds.py"
+    output.write_text(
+        'IANA_TLD_VERSION = ""\nIANA_TLDS = frozenset({"com"})\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(_UPDATE_SCRIPT), "--check-source", "--source-file", str(source)],
+    )
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+
+    with pytest.raises(ValueError, match="invalid IANA_TLD_VERSION"):
+        update_x_tlds.main()
+
+
 def test_check_source_cli_requires_source_file():
     completed = _run_update_script("--check-source")
 


### PR DESCRIPTION
## Summary

- Add a `TldSourceError` boundary for malformed or unreadable local IANA TLD sources.
- Report malformed `--source-file`, invalid UTF-8, and missing source files as clean one-line CLI failures without traceback.
- Keep live fetch decode failures on the `TldFetchError` path.
- Add regression coverage for update and `--check-source` CLI error paths.

## Tests

- `pytest tests/test_update_x_tlds.py`
- `ruff check scripts/update_x_tlds.py tests/test_update_x_tlds.py`
- `ruff format --check scripts/update_x_tlds.py tests/test_update_x_tlds.py`
- `basedpyright scripts/update_x_tlds.py tests/test_update_x_tlds.py`

Closes #17101
