### PR TITLE
fix: move desktop workspace menu below main window

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -140,9 +140,9 @@ describe("desktop tray menu", () => {
 
     expect(menu.map((item) => item.label).filter((label) => label)).toEqual([
       "Show Main Window",
+      "Workspace: Max & Zoe",
       "Computer Use: Online",
       "Keep Mac Awake",
-      "Workspace: Max & Zoe",
       "No Recent Commands",
       "Quit",
     ]);

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -334,6 +334,10 @@ export function buildDesktopTrayMenuItems(
 ): readonly DesktopTrayMenuItem[] {
   return [
     { label: "Show Main Window", click: actions.showMainWindow },
+    {
+      label: authStatusLabel(state),
+      submenu: buildAuthSubmenu(state, actions),
+    },
     separator(),
     {
       label: `Computer Use: ${computerUseStatusLabel(state)}`,
@@ -346,10 +350,6 @@ export function buildDesktopTrayMenuItems(
       click: () => {
         actions.setKeepAwakeEnabled(!state.computerUse.keepAwake.enabled);
       },
-    },
-    {
-      label: authStatusLabel(state),
-      submenu: buildAuthSubmenu(state, actions),
     },
     separator(),
     ...buildRecentCommandSection(state, actions),


### PR DESCRIPTION
## Summary
- Move the desktop tray workspace/account submenu directly below `Show Main Window`
- Update the tray menu order test to match the new placement

## Validation
- `pnpm exec prettier --write apps/desktop/src/desktop-tray-menu.ts apps/desktop/src/desktop-tray-menu.test.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- `pnpm exec vitest run src/desktop-tray-menu.test.ts`