### PR TITLE
docs: clarify video style prompt guidance

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -201,6 +201,17 @@ describe("zero generate video command", () => {
     expect(helpOutput).toContain("--image-url");
     expect(helpOutput).toContain("--first-frame-image-url");
     expect(helpOutput).toContain("--last-frame-image-url");
+    expect(helpOutput).toContain(
+      "If no explicit video style template is provided",
+    );
+    expect(helpOutput).toContain("visual");
+    expect(helpOutput).toContain("camera style");
+    expect(helpOutput).toContain("editing pace");
+    expect(helpOutput).toContain("narrative mode");
+    expect(helpOutput).toContain("production type");
+    expect(helpOutput).toContain(
+      "decisions naturally into the --prompt text passed to this command",
+    );
     expect(helpOutput).not.toContain("--json");
   });
 

--- a/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-generate.ts
@@ -367,6 +367,10 @@ Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
   - Charges org credits after successful video generation
   - Uses BytePlus ModelArk and fal.ai video models with configured usage pricing
+  - If no explicit video style template is provided, decide the video's visual
+    tone, camera style, editing pace, narrative mode, production type,
+    emotional tone, and style reference from the user's prompt, then write those
+    decisions naturally into the --prompt text passed to this command
 
 Models:
   - Dreamina Seedance 2.0: dreamina-seedance-2.0,


### PR DESCRIPTION
## Summary
- Add video-specific CLI help guidance for choosing style cues when no explicit template is provided
- Cover the new help text in the zero generate video test

## Tests
- pnpm -F @vm0/cli exec vitest src/commands/zero/generate/__tests__/video.test.ts --run
- pnpm format
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/cli lint