### PR TITLE
feat: add runner claim timing telemetry

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -163,12 +163,14 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
 }
 
 async fn claim_with_local_admission(
-    candidate: JobCandidate,
+    mut candidate: JobCandidate,
     run_id: RunId,
     job_vcpu: u32,
     job_memory: u32,
     ctx: &DiscoveredJobContext<'_>,
 ) -> Option<AdmittedClaim> {
+    candidate.mark_local_admission_started();
+
     // Reserve resources before claiming so we don't waste a job that another
     // runner could handle.
     let job_lease = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)?;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -9,7 +9,7 @@ use tracing::{error, info, warn};
 
 use api_contracts::generated::routes;
 use reqwest::{RequestBuilder, Response, StatusCode};
-use serde::de::DeserializeOwned;
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::api_ably_supervisor::{AblySupervisor, PollOutcome, PollWakeups};
 use super::{ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobProvider};
@@ -22,6 +22,20 @@ use crate::types::{
     MAX_HELD_SESSION_STATES, PollResponse, SandboxReuseResult,
 };
 use sandbox::SandboxId;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaimRequestBody {
+    telemetry: ClaimRequestTelemetry,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaimRequestTelemetry {
+    job_discovered_to_claim_request_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_admission_to_claim_request_ms: Option<u64>,
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -171,7 +185,7 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        match self.api.claim(run_id).await {
+        match self.api.claim(&candidate).await {
             Ok(ctx) => {
                 let claimed = match ClaimedJob::api(run_id, ctx) {
                     Ok(claimed) => claimed,
@@ -328,7 +342,9 @@ impl ApiClient {
     /// row already dequeued by the winner) so callers can continue gracefully.
     /// Both outcomes are normal contention signals when multiple runners race
     /// for the same job.
-    async fn claim(&self, run_id: RunId) -> RunnerResult<ExecutionContext> {
+    async fn claim(&self, candidate: &JobCandidate) -> RunnerResult<ExecutionContext> {
+        let run_id = candidate.run_id();
+        let body = claim_request_body(candidate);
         let run_id = run_id.to_string();
         let resp = send_api(
             self.http
@@ -340,7 +356,7 @@ impl ApiClient {
                     ),
                     &self.token,
                 )
-                .json(&serde_json::json!({})),
+                .json(&body),
             "claim",
         )
         .await?;
@@ -406,6 +422,21 @@ impl ApiClient {
         let resp = check_api_status(resp, "realtime token").await?;
         decode_api_json(resp, "realtime token").await
     }
+}
+
+fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
+    ClaimRequestBody {
+        telemetry: ClaimRequestTelemetry {
+            job_discovered_to_claim_request_ms: duration_ms(candidate.job_discovered_elapsed()),
+            local_admission_to_claim_request_ms: candidate
+                .local_admission_elapsed()
+                .map(duration_ms),
+        },
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 async fn send_api(req: RequestBuilder, label: &str) -> RunnerResult<Response> {
@@ -589,6 +620,54 @@ mod tests {
                 .lines()
                 .any(|line| line.eq_ignore_ascii_case(&expected)),
             "completion request should use sandbox auth; request was:\n{request}",
+        );
+    }
+
+    #[test]
+    fn claim_request_body_serializes_runner_timing() {
+        let now = std::time::Instant::now();
+        let candidate = JobCandidate::new_with_timing_for_test(
+            RunId::nil(),
+            crate::profile::DEFAULT_PROFILE.to_string(),
+            now.checked_sub(Duration::from_millis(25)).unwrap(),
+            Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
+        );
+
+        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+
+        assert!(
+            body["telemetry"]["jobDiscoveredToClaimRequestMs"]
+                .as_u64()
+                .is_some_and(|value| value >= 25)
+        );
+        assert!(
+            body["telemetry"]["localAdmissionToClaimRequestMs"]
+                .as_u64()
+                .is_some_and(|value| value >= 7)
+        );
+    }
+
+    #[test]
+    fn claim_request_body_omits_missing_local_admission_timing() {
+        let now = std::time::Instant::now();
+        let candidate = JobCandidate::new_with_timing_for_test(
+            RunId::nil(),
+            crate::profile::DEFAULT_PROFILE.to_string(),
+            now.checked_sub(Duration::from_millis(25)).unwrap(),
+            None,
+        );
+
+        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+
+        assert!(
+            body["telemetry"]["jobDiscoveredToClaimRequestMs"]
+                .as_u64()
+                .is_some_and(|value| value >= 25)
+        );
+        assert!(
+            body["telemetry"]
+                .get("localAdmissionToClaimRequestMs")
+                .is_none()
         );
     }
 
@@ -839,7 +918,8 @@ mod tests {
                 .await;
             let api = api_client_for_server(&server);
 
-            let err = api.claim(run_id).await.unwrap_err();
+            let candidate = JobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string());
+            let err = api.claim(&candidate).await.unwrap_err();
 
             assert!(matches!(err, RunnerError::AlreadyClaimed));
             mock.assert_async().await;

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -16,6 +16,7 @@ pub use local::LocalProvider;
 
 use sandbox::SandboxId;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
@@ -26,6 +27,8 @@ pub struct JobCandidate {
     run_id: RunId,
     profile_name: String,
     local_job_path: Option<PathBuf>,
+    discovered_at: Instant,
+    local_admission_started_at: Option<Instant>,
 }
 
 impl JobCandidate {
@@ -34,6 +37,8 @@ impl JobCandidate {
             run_id,
             profile_name,
             local_job_path: None,
+            discovered_at: Instant::now(),
+            local_admission_started_at: None,
         }
     }
 
@@ -42,6 +47,8 @@ impl JobCandidate {
             run_id,
             profile_name,
             local_job_path: Some(job_path),
+            discovered_at: Instant::now(),
+            local_admission_started_at: None,
         }
     }
 
@@ -55,6 +62,35 @@ impl JobCandidate {
 
     pub(crate) fn local_job_path(&self) -> Option<&Path> {
         self.local_job_path.as_deref()
+    }
+
+    pub(crate) fn mark_local_admission_started(&mut self) {
+        self.local_admission_started_at = Some(Instant::now());
+    }
+
+    pub(crate) fn job_discovered_elapsed(&self) -> Duration {
+        self.discovered_at.elapsed()
+    }
+
+    pub(crate) fn local_admission_elapsed(&self) -> Option<Duration> {
+        self.local_admission_started_at
+            .map(|started| started.elapsed())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_timing_for_test(
+        run_id: RunId,
+        profile_name: String,
+        discovered_at: Instant,
+        local_admission_started_at: Option<Instant>,
+    ) -> Self {
+        Self {
+            run_id,
+            profile_name,
+            local_job_path: None,
+            discovered_at,
+            local_admission_started_at,
+        }
     }
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -771,7 +771,12 @@ describe("POST /api/runners/*", () => {
     const response = await accept(
       client.claim({
         params: { id: queued.runId },
-        body: {},
+        body: {
+          telemetry: {
+            jobDiscoveredToClaimRequestMs: 1234,
+            localAdmissionToClaimRequestMs: 56,
+          },
+        },
         headers: { authorization: `Bearer ${pat.token}` },
       }),
       [200],
@@ -858,6 +863,36 @@ describe("POST /api/runners/*", () => {
           sandbox_type: "runner",
           run_id: queued.runId,
           duration_ms: expect.any(Number),
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "job_discovered_to_claim_request",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: 1234,
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "local_admission_to_claim_request",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: 56,
           success: true,
           runner_group: "vm0/test",
           profile: "vm0/default",

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -538,6 +538,8 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly apiToClaimRequestMs: number | undefined;
   readonly apiToClaimMs: number | undefined;
   readonly claimRequestToRunningMs: number;
+  readonly jobDiscoveredToClaimRequestMs: number | undefined;
+  readonly localAdmissionToClaimRequestMs: number | undefined;
 }): void {
   waitUntil(
     publishRunChangedForUserSafely(args.userId, args.runId, {
@@ -560,6 +562,8 @@ async function recordClaimTimingMetrics(args: {
   readonly apiToClaimRequestMs: number | undefined;
   readonly apiToClaimMs: number | undefined;
   readonly claimRequestToRunningMs: number;
+  readonly jobDiscoveredToClaimRequestMs: number | undefined;
+  readonly localAdmissionToClaimRequestMs: number | undefined;
 }): Promise<void> {
   await Promise.resolve();
   const dimensions = {
@@ -567,32 +571,53 @@ async function recordClaimTimingMetrics(args: {
     profile: args.profile,
     auth_type: args.authType,
   };
-  if (args.apiToClaimRequestMs !== undefined) {
-    recordSandboxOperation({
-      sandboxType: "runner",
-      actionType: "api_to_claim_request",
-      durationMs: args.apiToClaimRequestMs,
-      success: true,
-      runId: args.runId,
-      dimensions,
-    });
-  }
-  if (args.apiToClaimMs !== undefined) {
-    recordSandboxOperation({
-      sandboxType: "runner",
-      actionType: "api_to_claim",
-      durationMs: args.apiToClaimMs,
-      success: true,
-      runId: args.runId,
-      dimensions,
-    });
+  recordClaimTimingOperation(
+    args.runId,
+    "api_to_claim_request",
+    args.apiToClaimRequestMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "api_to_claim",
+    args.apiToClaimMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "claim_request_to_running",
+    args.claimRequestToRunningMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "job_discovered_to_claim_request",
+    args.jobDiscoveredToClaimRequestMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "local_admission_to_claim_request",
+    args.localAdmissionToClaimRequestMs,
+    dimensions,
+  );
+}
+
+function recordClaimTimingOperation(
+  runId: string,
+  actionType: string,
+  durationMs: number | undefined,
+  dimensions: Record<string, string>,
+): void {
+  if (durationMs === undefined) {
+    return;
   }
   recordSandboxOperation({
     sandboxType: "runner",
-    actionType: "claim_request_to_running",
-    durationMs: args.claimRequestToRunningMs,
+    actionType,
+    durationMs,
     success: true,
-    runId: args.runId,
+    runId,
     dimensions,
   });
 }
@@ -749,6 +774,10 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       0,
       claimResult.claimedAt.getTime() - claimRequestStartedAtMs,
     ),
+    jobDiscoveredToClaimRequestMs:
+      body.data.telemetry?.jobDiscoveredToClaimRequestMs,
+    localAdmissionToClaimRequestMs:
+      body.data.telemetry?.localAdmissionToClaimRequestMs,
   });
 
   return {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -35,6 +35,11 @@ export function elapsedSinceApiStartMs(
   return Math.max(0, nowMs - apiStartTimeMs);
 }
 
+const runnerClaimTelemetrySchema = z.object({
+  jobDiscoveredToClaimRequestMs: z.number().int().nonnegative().optional(),
+  localAdmissionToClaimRequestMs: z.number().int().nonnegative().optional(),
+});
+
 /**
  * Default profile when none is specified.
  * Must stay in sync with Rust: crates/runner/src/profile.rs → DEFAULT_PROFILE
@@ -290,7 +295,9 @@ export const runnersJobClaimContract = c.router({
     pathParams: z.object({
       id: z.uuid(),
     }),
-    body: z.object({}),
+    body: z.object({
+      telemetry: runnerClaimTelemetrySchema.optional(),
+    }),
     responses: {
       200: executionContextSchema,
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary
- Add an optional runner claim telemetry payload for `jobDiscoveredToClaimRequestMs` and `localAdmissionToClaimRequestMs`.
- Record the two runner-side timings as sandbox Axiom operation rows: `job_discovered_to_claim_request` and `local_admission_to_claim_request`.
- Include the timings from the runner's claim request without changing claim semantics.

Part of #16254.

## Validation
- `pnpm -F @vm0/api-contracts generate:rust`
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `pnpm format`
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `git diff --check`
- pre-commit hook: `cargo clippy`, `cargo doc`, `cargo fmt`, `prettier`, `knip`, `pnpm check-types`
