### PR TITLE
feat: enable connector permission reset by default

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -5,10 +5,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewalls";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -95,18 +93,6 @@ async function readStoredGrant(args: {
   return row ?? null;
 }
 
-async function enableConnectorPermissionReset(args: {
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<void> {
-  const db = store.set(writeDb$);
-  await db.insert(userFeatureSwitches).values({
-    orgId: args.orgId,
-    userId: args.userId,
-    switches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-  });
-}
-
 describe("zero user permission grants", () => {
   const fixtures: UsageInsightFixture[] = [];
   const trackedOrgIds: string[] = [];
@@ -136,9 +122,6 @@ describe("zero user permission grants", () => {
       await db
         .delete(userPermissionGrants)
         .where(inArray(userPermissionGrants.orgId, trackedOrgIds));
-      await db
-        .delete(userFeatureSwitches)
-        .where(inArray(userFeatureSwitches.orgId, trackedOrgIds));
       trackedOrgIds.length = 0;
     }
 
@@ -384,47 +367,12 @@ describe("zero user permission grants", () => {
     expect(askResponse.status).toBe(400);
   });
 
-  it("rejects connector reset when the feature switch is disabled", async () => {
-    const fixture = await createFixture();
-    const agentId = await seedAgent(fixture);
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-    const db = store.set(writeDb$);
-    await db.insert(userPermissionGrants).values({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      agentId,
-      connectorRef: SLACK_CONNECTOR,
-      permission: SLACK_READ_PERMISSION,
-      action: "deny",
-    });
-    const client = setupApp({ context })(zeroUserPermissionGrantsContract);
-
-    const response = await accept(
-      client.reset({
-        query: { agentId, connectorRef: SLACK_CONNECTOR },
-        headers: AUTH_HEADERS,
-      }),
-      [403],
-    );
-
-    expect(response.body.error.code).toBe("FORBIDDEN");
-    const stored = await readStoredGrant({
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      agentId,
-      connectorRef: SLACK_CONNECTOR,
-      permission: SLACK_READ_PERMISSION,
-    });
-    expect(stored?.action).toBe("deny");
-  });
-
   it("resets only the current user's selected connector grants", async () => {
     const fixture = await createFixture();
     const otherUserId = `user_${randomUUID()}`;
     await seedMember({ orgId: fixture.orgId, userId: otherUserId });
     const agentId = await seedAgent(fixture);
     const otherAgentId = await seedAgent(fixture);
-    await enableConnectorPermissionReset(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const db = store.set(writeDb$);
     await db.insert(userPermissionGrants).values([
@@ -529,7 +477,6 @@ describe("zero user permission grants", () => {
   it("validates connector refs for connector reset", async () => {
     const fixture = await createFixture();
     const agentId = await seedAgent(fixture);
-    await enableConnectorPermissionReset(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const client = setupApp({ context })(zeroUserPermissionGrantsContract);
 
@@ -552,10 +499,6 @@ describe("zero user permission grants", () => {
       orgId: owner.orgId,
       userId: owner.userId,
       visibility: "private",
-    });
-    await enableConnectorPermissionReset({
-      orgId: owner.orgId,
-      userId: sameOrgUserId,
     });
     mocks.clerk.session(sameOrgUserId, owner.orgId, "org:member");
     const client = setupApp({ context })(zeroUserPermissionGrantsContract);

--- a/turbo/apps/api/src/signals/routes/zero-user-permission-grants.ts
+++ b/turbo/apps/api/src/signals/routes/zero-user-permission-grants.ts
@@ -1,13 +1,10 @@
 import { command } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, queryOf } from "../context/request";
 import type { RouteEntry } from "../route";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   listUserPermissionGrants$,
   resetUserPermissionGrants$,
@@ -22,28 +19,6 @@ const userPermissionGrantAuthOptions = {
 const listQuery$ = queryOf(zeroUserPermissionGrantsContract.list);
 const upsertBody$ = bodyResultOf(zeroUserPermissionGrantsContract.upsert);
 const resetQuery$ = queryOf(zeroUserPermissionGrantsContract.reset);
-
-const connectorPermissionResetDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Connector permission reset is not enabled",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
-
-const connectorPermissionResetEnabled$ = command(async ({ get }) => {
-  const auth = get(organizationAuthContext$);
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  return isFeatureEnabled(FeatureSwitchKey.ConnectorPermissionReset, {
-    orgId: auth.orgId,
-    userId: auth.userId,
-    overrides,
-  });
-});
 
 const listUserPermissionGrantsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -96,11 +71,6 @@ const upsertUserPermissionGrantInner$ = command(
 
 const resetUserPermissionGrantsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!(await set(connectorPermissionResetEnabled$))) {
-      return connectorPermissionResetDisabled;
-    }
-    signal.throwIfAborted();
-
     const auth = get(organizationAuthContext$);
     const query = get(resetQuery$);
     const result = await set(

--- a/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/fw/__tests__/permissions-dialog.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import {
   zeroAgentsByIdContract,
@@ -240,21 +239,9 @@ async function selectAllowDuration(
 }
 
 describe("permissions dialog - flat list connector (Notion)", () => {
-  it("hides connector reset when the reset feature switch is disabled", async () => {
-    mockAPIs({ connectorType: "notion" });
-    detachedSetupPage({ context, path: "/agents/my-agent" });
-    await openPermissionsDrawer("Notion");
-
-    expect(queryButtonByText("Restore")).toBeUndefined();
-  });
-
   it("disables connector reset when there is no persisted or draft state to reset", async () => {
     mockAPIs({ connectorType: "notion" });
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
     expect(getButtonByText("Restore")).toBeDisabled();
@@ -278,11 +265,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
         return respond(200, createMockUserPermissionGrantResponse(body));
       }),
     );
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
     const row = getPermissionRow("insert_comments");
@@ -326,11 +309,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
         return respond(200, createMockUserPermissionGrantResponse(body));
       }),
     );
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
     const row = getPermissionRow("insert_comments");
@@ -366,11 +345,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       connectorType: "notion",
       userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
     });
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
     click(getButtonByText("Restore"));
@@ -400,11 +375,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
         }),
       ],
     });
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
     await waitFor(() => {
       expect(screen.getByText("< 1 hour")).toBeInTheDocument();
@@ -433,11 +404,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
         return respond(200, createMockUserPermissionGrantResponse(body));
       }),
     );
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
     click(getButtonByText("Restore"));
@@ -459,11 +426,7 @@ describe("permissions dialog - flat list connector (Notion)", () => {
       connectorType: "notion",
       userPermissionGrants: [mockGrant("notion", "insert_comments", "deny")],
     });
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Notion");
 
     click(getButtonByText("Restore"));
@@ -802,11 +765,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
       connectorType: "slack",
       userPermissionGrants: [mockGrant("slack", "admin", "allow")],
     });
-    detachedSetupPage({
-      context,
-      path: "/agents/my-agent",
-      featureSwitches: { [FeatureSwitchKey.ConnectorPermissionReset]: true },
-    });
+    detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer("Slack");
 
     click(screen.getByText(/Admin \(\d+\)/i));

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -22,7 +22,6 @@ import {
   IconWand,
 } from "@tabler/icons-react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Button,
   Tabs,
@@ -95,7 +94,6 @@ import {
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   allConnectorTypes$,
   matchesConnectorSearch,
@@ -1037,9 +1035,6 @@ function JobPermissionsTab({
       ? permissionGrantsToFirewallPolicies(userGrants)
       : null;
   const drawerInitialPolicies = userGrantPolicies ?? {};
-  const features = useLastResolved(featureSwitch$);
-  const resetEnabled =
-    features?.[FeatureSwitchKey.ConnectorPermissionReset] ?? false;
   const [, upsertGrant] = useLoadableSet(upsertUserPermissionGrant$);
   const [, resetGrantPolicies] = useLoadableSet(resetUserPermissionGrants$);
   const connectorType = useGet(permConnectorType$);
@@ -1120,7 +1115,7 @@ function JobPermissionsTab({
             displayName={displayName}
             initialPolicies={drawerInitialPolicies}
             initialGrants={userGrants}
-            resetEnabled={resetEnabled}
+            resetEnabled
             readOnly={!canManagePermissions}
             onApply={async (
               policies,

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -57,6 +57,5 @@ export enum FeatureSwitchKey {
   ChatRecommendedFollowups = "chatRecommendedFollowups",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",
-  ConnectorPermissionReset = "connectorPermissionReset",
   ZeroAutomations = "zeroAutomations",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -328,13 +328,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ConnectorPermissionReset]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Show staged connector-level reset controls for current-user permission grants.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ZeroAutomations]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the connectorPermissionReset feature switch from the registry and enum
- always expose connector permission reset in the job permissions drawer
- remove API/UI tests that only covered the disabled switch path while keeping reset behavior coverage

## Testing
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-permission-grants.test.ts
- pnpm -F @vm0/app exec vitest run src/views/fw/__tests__/permissions-dialog.test.tsx
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- git diff --check
- pre-commit: prettier, knip, full pnpm check-types