### PR TITLE
fix: block stale mitm tls admissions

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -22,10 +22,11 @@ import time
 import urllib.parse
 from collections.abc import Callable
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeVar
+from typing import Final, Literal, TypeVar
 
-from mitmproxy import ctx, http, tcp, tls
+from mitmproxy import connection, ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
@@ -89,6 +90,26 @@ _USAGE_FLOW_TRACKED = "_usage_flow_tracked"
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
 _MAX_SAFE_NETWORK_LOG_SIZE_DIGITS = len(str(_MAX_SAFE_NETWORK_LOG_SIZE))
+_TLS_ADMISSION_VALID_REGISTRY_VM: Final = "valid_registry_vm"
+_TLS_ADMISSION_INVALID_REGISTRY_VM: Final = "invalid_registry_vm"
+_TLS_ADMISSION_REGISTRY_UNAVAILABLE: Final = "registry_unavailable"
+_STALE_TLS_ADMISSION_ERROR: Final = "stale_tls_admission"
+
+_TlsAdmissionKind = Literal[
+    "valid_registry_vm",
+    "invalid_registry_vm",
+    "registry_unavailable",
+]
+
+
+@dataclass(frozen=True)
+class _TlsAdmission:
+    client_ip: str
+    kind: _TlsAdmissionKind
+    run_id: str | None = None
+
+
+_tls_admissions: dict[str, _TlsAdmission] = {}
 
 # Runner-triggered flush protocols:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
@@ -495,6 +516,55 @@ def _block_invalid_registry_vm(
     )
 
 
+def _block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = _STALE_TLS_ADMISSION_ERROR
+    flow.response = http.Response.make(
+        503,
+        json.dumps(
+            {
+                "error": _STALE_TLS_ADMISSION_ERROR,
+                "message": (
+                    "Request blocked: TLS admission is no longer backed by a valid "
+                    "proxy registry VM"
+                ),
+                "reason": reason,
+            }
+        ).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
+def _client_connection_id(client: object) -> str | None:
+    client_id = getattr(client, "id", None)
+    if isinstance(client_id, str) and client_id:
+        return client_id
+    return None
+
+
+def _record_tls_admission(client: object, admission: _TlsAdmission) -> None:
+    client_id = _client_connection_id(client)
+    if client_id is not None:
+        _tls_admissions[client_id] = admission
+
+
+def _tls_admission_for_client(client: object) -> _TlsAdmission | None:
+    client_id = _client_connection_id(client)
+    if client_id is None:
+        return None
+    return _tls_admissions.get(client_id)
+
+
+def _forget_tls_admission(client: object) -> None:
+    client_id = _client_connection_id(client)
+    if client_id is not None:
+        _tls_admissions.pop(client_id, None)
+
+
+def reset_tls_admission_state_for_tests() -> None:
+    _tls_admissions.clear()
+
+
 # ============================================================================
 # TLS ClientHello Handler
 # ============================================================================
@@ -512,15 +582,45 @@ def tls_clienthello(data: tls.ClientHelloData) -> None:
 
     registry_state = registry.load_registry_state(get_registry_path())
     if isinstance(registry_state, registry.RegistryUnavailable):
+        _record_tls_admission(
+            data.context.client,
+            _TlsAdmission(
+                client_ip=client_ip,
+                kind=_TLS_ADMISSION_REGISTRY_UNAVAILABLE,
+            ),
+        )
         return
 
-    if client_ip not in registry_state.vms and client_ip not in registry_state.invalid_vms:
-        # Not a registered VM - pass through without MITM interception
-        # This is critical for CIDR-based rules where all VM traffic is redirected
-        data.ignore_connection = True
+    vm_info = registry_state.vms.get(client_ip)
+    if vm_info is not None:
+        _record_tls_admission(
+            data.context.client,
+            _TlsAdmission(
+                client_ip=client_ip,
+                kind=_TLS_ADMISSION_VALID_REGISTRY_VM,
+                run_id=vm_info.get("runId", ""),
+            ),
+        )
         return
 
-    # Registered VM: let mitmproxy perform MITM interception
+    if client_ip in registry_state.invalid_vms:
+        _record_tls_admission(
+            data.context.client,
+            _TlsAdmission(
+                client_ip=client_ip,
+                kind=_TLS_ADMISSION_INVALID_REGISTRY_VM,
+            ),
+        )
+        return
+
+    # Not a registered VM - pass through without MITM interception.
+    # This is critical for CIDR-based rules where all VM traffic is redirected.
+    _forget_tls_admission(data.context.client)
+    data.ignore_connection = True
+
+
+def client_disconnected(client: connection.Client) -> None:
+    _forget_tls_admission(client)
 
 
 # ============================================================================
@@ -539,14 +639,22 @@ async def request(flow: http.HTTPFlow) -> None:
     """
     # Get client IP (source VM)
     client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+    tls_admission = _tls_admission_for_client(flow.client_conn)
 
     if not client_ip:
+        if tls_admission is not None:
+            _block_stale_tls_admission(flow, reason="client_ip_missing")
+            return
         ctx.log.warn("No client IP available, passing through")
         return
 
     registry_state = registry.load_registry_state(get_registry_path())
     if isinstance(registry_state, registry.RegistryUnavailable):
         _block_registry_unavailable(flow, registry_state)
+        return
+
+    if tls_admission is not None and tls_admission.client_ip != client_ip:
+        _block_stale_tls_admission(flow, reason="client_ip_mismatch")
         return
 
     # Look up VM info from registry. This pass-through path is valid only after
@@ -557,12 +665,22 @@ async def request(flow: http.HTTPFlow) -> None:
         if invalid_vm is not None:
             _block_invalid_registry_vm(flow, invalid_vm)
             return
+        if tls_admission is not None:
+            _block_stale_tls_admission(flow, reason="registry_entry_missing")
+            return
         # Not a registered VM, pass through without proxying
+        return
+
+    run_id = vm_info.get("runId", "")
+    if (
+        tls_admission is not None
+        and tls_admission.run_id is not None
+        and tls_admission.run_id != run_id
+    ):
+        _block_stale_tls_admission(flow, reason="run_id_mismatch")
         return
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
     compiled_network_policies = registry_state.compiled_network_policies[client_ip]
-
-    run_id = vm_info.get("runId", "")
 
     # Track request start time after early returns so unregistered flows do not carry it.
     flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
@@ -1275,6 +1393,7 @@ def _log_tcp(flow: tcp.TCPFlow) -> None:
 # mitmproxy addon registration
 addons = [
     tls_clienthello,
+    client_disconnected,
     request,
     responseheaders,
     websocket_message,

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -15,6 +15,7 @@ Fixtures here exist for two reasons:
 
 import contextlib
 import json
+import uuid
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from pathlib import Path
@@ -49,6 +50,7 @@ def _reset_module_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """
     auth_base_forwarder.reset_forward_request_state_for_tests()
     registry.reset_cache_for_tests()
+    mitm_addon.reset_tls_admission_state_for_tests()
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters.reset_for_tests()
@@ -78,6 +80,7 @@ def _reset_module_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     yield
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    mitm_addon.reset_tls_admission_state_for_tests()
     usage.reset_usage_buffer_for_tests()
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.counters.reset_for_tests()
@@ -176,7 +179,13 @@ def real_flow():
 class _StubTLSClient:
     """Minimal stand-in for ``mitmproxy.connection.Client`` in TLS tests."""
 
-    def __init__(self, peername: tuple[str, int] | None, sni: str) -> None:
+    def __init__(
+        self,
+        peername: tuple[str, int] | None,
+        sni: str,
+        client_id: str | None,
+    ) -> None:
+        self.id = client_id or str(uuid.uuid4())
         self.peername = peername
         self.sni = sni
 
@@ -197,15 +206,25 @@ class _StubClientHelloData:
     that surface without pulling in MagicMock's attribute-proliferation.
     """
 
-    def __init__(self, peername: tuple[str, int] | None, sni: str) -> None:
-        self.context = _StubTLSContext(_StubTLSClient(peername, sni))
+    def __init__(
+        self,
+        peername: tuple[str, int] | None,
+        sni: str,
+        client_id: str | None,
+    ) -> None:
+        self.context = _StubTLSContext(_StubTLSClient(peername, sni, client_id))
         self.ignore_connection = False
 
 
 @pytest.fixture
 def make_tls_data():
-    def _make(*, client_ip: str = "10.200.0.1", sni: str = "example.com") -> _StubClientHelloData:
-        return _StubClientHelloData(peername=(client_ip, 12345), sni=sni)
+    def _make(
+        *,
+        client_ip: str = "10.200.0.1",
+        sni: str = "example.com",
+        client_id: str | None = None,
+    ) -> _StubClientHelloData:
+        return _StubClientHelloData(peername=(client_ip, 12345), sni=sni, client_id=client_id)
 
     return _make
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -284,6 +284,59 @@ async def test_valid_tls_admission_blocks_when_request_client_ip_is_missing(
     _assert_stale_tls_admission_block(flow, reason="client_ip_missing")
 
 
+async def test_valid_tls_admission_blocks_when_request_client_ip_changes(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    tls_client_ip = "10.200.0.5"
+    request_client_ip = "10.200.0.6"
+    api_entry = {
+        "base": "https://api.github.com",
+        "auth": {"headers": {}},
+        "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+    }
+    network_policy = {
+        "allow": ["full-access"],
+        "deny": [],
+        "ask": [],
+        "unknownPolicy": "allow",
+    }
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip=tls_client_ip,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry=api_entry,
+            network_policy=network_policy,
+        ),
+    )
+    flow, tls_data = _bind_tls_admission_flow(
+        real_flow,
+        make_tls_data,
+        client_ip=tls_client_ip,
+    )
+    flow.client_conn.peername = (request_client_ip, 12345)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        _write_registry(
+            tmp_path,
+            client_ip=request_client_ip,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                api_entry=api_entry,
+                network_policy=network_policy,
+            ),
+        )
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(flow, reason="client_ip_mismatch")
+
+
 async def test_invalid_tls_admission_blocks_when_registry_entry_disappears(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -11,6 +11,42 @@ from tests.auth_state_helpers import has_auth_state
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
 
+def _bind_tls_admission_flow(
+    real_flow,
+    make_tls_data,
+    *,
+    client_ip: str = "10.200.0.5",
+    host: str = "api.github.com",
+):
+    client_id = f"client-{client_ip}-{host}"
+    flow = real_flow(with_response=False, client_ip=client_ip, host=host)
+    flow.client_conn.id = client_id
+    data = make_tls_data(client_ip=client_ip, sni=host, client_id=client_id)
+    return flow, data
+
+
+def _write_empty_registry(reg_path) -> None:
+    reg_path.write_text(json.dumps({"vms": {}, "updatedAt": 1}))
+
+
+def _assert_stale_tls_admission_block(flow, *, reason: str) -> None:
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "stale_tls_admission",
+        "message": (
+            "Request blocked: TLS admission is no longer backed by a valid proxy registry VM"
+        ),
+        "reason": reason,
+    }
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "stale_tls_admission"
+    assert "vm_run_id" not in flow.metadata
+    assert "vm_network_log_path" not in flow.metadata
+    assert "firewall_base" not in flow.metadata
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
+
+
 async def test_allowed_domain_passes_through(registry_file, real_flow, mitm_ctx):
     flow = real_flow(with_response=False, host="api.anthropic.com")
 
@@ -123,6 +159,270 @@ async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_
     assert flow.metadata["firewall_action"] == "BLOCK"
     assert flow.metadata["firewall_error"] == "registry_unavailable"
     assert "firewall_base" not in flow.metadata
+
+
+async def test_valid_tls_admission_blocks_when_registry_entry_disappears(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip=client_ip,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    flow, tls_data = _bind_tls_admission_flow(real_flow, make_tls_data, client_ip=client_ip)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        _write_empty_registry(reg_path)
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(flow, reason="registry_entry_missing")
+
+
+async def test_valid_tls_admission_blocks_when_run_id_changes(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    api_entry = {
+        "base": "https://api.github.com",
+        "auth": {"headers": {}},
+        "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+    }
+    network_policy = {
+        "allow": ["full-access"],
+        "deny": [],
+        "ask": [],
+        "unknownPolicy": "allow",
+    }
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip=client_ip,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            run_id="run-before",
+            api_entry=api_entry,
+            network_policy=network_policy,
+        ),
+    )
+    flow, tls_data = _bind_tls_admission_flow(real_flow, make_tls_data, client_ip=client_ip)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        _write_registry(
+            tmp_path,
+            client_ip=client_ip,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                run_id="run-after",
+                api_entry=api_entry,
+                network_policy=network_policy,
+            ),
+        )
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(flow, reason="run_id_mismatch")
+
+
+async def test_valid_tls_admission_blocks_when_request_client_ip_is_missing(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip=client_ip,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    flow, tls_data = _bind_tls_admission_flow(real_flow, make_tls_data, client_ip=client_ip)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        flow.client_conn.peername = None
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(flow, reason="client_ip_missing")
+
+
+async def test_invalid_tls_admission_blocks_when_registry_entry_disappears(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    reg_path = tmp_path / "registry.json"
+    reg_path.write_text(json.dumps({"vms": {client_ip: "broken"}, "updatedAt": 0}))
+    flow, tls_data = _bind_tls_admission_flow(real_flow, make_tls_data, client_ip=client_ip)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        _write_empty_registry(reg_path)
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(flow, reason="registry_entry_missing")
+
+
+async def test_registry_unavailable_tls_admission_blocks_when_registry_lacks_ip(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    reg_path = tmp_path / "registry.json"
+    flow, tls_data = _bind_tls_admission_flow(real_flow, make_tls_data, client_ip=client_ip)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        _write_empty_registry(reg_path)
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(flow, reason="registry_entry_missing")
+
+
+async def test_missing_registry_entry_without_tls_admission_passes_through(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    reg_path = tmp_path / "registry.json"
+    _write_empty_registry(reg_path)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert "firewall_action" not in flow.metadata
+
+
+async def test_tls_admission_keeps_guarding_multiple_requests(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip=client_ip,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    first_flow, tls_data = _bind_tls_admission_flow(
+        real_flow,
+        make_tls_data,
+        client_ip=client_ip,
+    )
+    second_flow = real_flow(with_response=False, client_ip=client_ip, host="api.github.com")
+    second_flow.client_conn.id = first_flow.client_conn.id
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        _write_empty_registry(reg_path)
+
+        await mitm_addon.request(first_flow)
+        await mitm_addon.request(second_flow)
+
+    assert tls_data.ignore_connection is False
+    _assert_stale_tls_admission_block(first_flow, reason="registry_entry_missing")
+    _assert_stale_tls_admission_block(second_flow, reason="registry_entry_missing")
+
+
+async def test_client_disconnected_removes_tls_admission(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+):
+    client_ip = "10.200.0.5"
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip=client_ip,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    flow, tls_data = _bind_tls_admission_flow(real_flow, make_tls_data, client_ip=client_ip)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        mitm_addon.client_disconnected(tls_data.context.client)
+        _write_empty_registry(reg_path)
+
+        await mitm_addon.request(flow)
+
+    assert tls_data.ignore_connection is False
+    assert flow.response is None
+    assert "firewall_action" not in flow.metadata
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- carry TLS-time MITM admission state by mitmproxy client connection id
- fail closed when an admitted connection loses its registry VM or changes runId before request handling
- clean admission state on client disconnect and reset it between tests

## Tests
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff check src/mitm_addon.py tests/conftest.py tests/test_connection_hooks.py tests/test_request_handler_passthrough.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m basedpyright src/mitm_addon.py tests/conftest.py tests/test_connection_hooks.py tests/test_request_handler_passthrough.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_connection_hooks.py tests/test_request_handler_passthrough.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_x_billing.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/`

Closes #17103