### PR TITLE
fix(schedule): apply UTC→local conversion in job-detail and fix once-schedule timezone display

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/cron.ts
+++ b/turbo/apps/platform/src/signals/zero-page/cron.ts
@@ -128,6 +128,65 @@ export function getTimezoneLabel(iana: string): string {
   return `(${offset}) ${name}`;
 }
 
+export function cronUtcToLocalTime(
+  utcHour: number,
+  utcMinute: number,
+  timezone: string,
+): { hour: number; minute: number } {
+  if (timezone === "UTC" || timezone === "Etc/UTC") {
+    return { hour: utcHour, minute: utcMinute };
+  }
+  const d = new Date();
+  d.setUTCHours(utcHour, utcMinute, 0, 0);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: timezone,
+  }).formatToParts(d);
+  return {
+    hour: Number(
+      parts.find((p) => {
+        return p.type === "hour";
+      })?.value ?? utcHour,
+    ),
+    minute: Number(
+      parts.find((p) => {
+        return p.type === "minute";
+      })?.value ?? utcMinute,
+    ),
+  };
+}
+
+export function atTimeInTimezone(
+  isoTime: string,
+  timezone: string,
+): { date: string; hour: number; minute: number } {
+  const d = new Date(isoTime);
+  const tz = timezone || "UTC";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: tz,
+  }).formatToParts(d);
+  const get = (type: string) => {
+    return (
+      parts.find((p) => {
+        return p.type === type;
+      })?.value ?? "00"
+    );
+  };
+  return {
+    date: `${get("year")}-${get("month")}-${get("day")}`,
+    hour: Number(get("hour")),
+    minute: Number(get("minute")),
+  };
+}
+
 export function buildCronExpression(opts: {
   timeOption: CronTimeOption;
   hour: string;

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
@@ -6,6 +6,8 @@ import {
   buildCronExpression,
   buildAtTime,
   isAtTimePast,
+  cronUtcToLocalTime,
+  atTimeInTimezone,
   type ScheduleBody,
   type CronTimeOption,
 } from "../cron.ts";
@@ -40,36 +42,6 @@ interface ScheduleItem {
 // ---------------------------------------------------------------------------
 // Schedule time string conversion
 // ---------------------------------------------------------------------------
-
-function cronUtcToLocalTime(
-  utcHour: number,
-  utcMinute: number,
-  timezone: string,
-): { hour: number; minute: number } {
-  if (timezone === "UTC" || timezone === "Etc/UTC") {
-    return { hour: utcHour, minute: utcMinute };
-  }
-  const d = new Date();
-  d.setUTCHours(utcHour, utcMinute, 0, 0);
-  const parts = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: timezone,
-  }).formatToParts(d);
-  return {
-    hour: Number(
-      parts.find((p) => {
-        return p.type === "hour";
-      })?.value ?? utcHour,
-    ),
-    minute: Number(
-      parts.find((p) => {
-        return p.type === "minute";
-      })?.value ?? utcMinute,
-    ),
-  };
-}
 
 function cronToTimeString(cron: string, timezone = "UTC"): string {
   const parts = cron.split(" ");
@@ -112,35 +84,6 @@ function cronToTimeString(cron: string, timezone = "UTC"): string {
     return `Every week at ${timeStr}`;
   }
   return `Every day at ${timeStr}`;
-}
-
-function atTimeInTimezone(
-  isoTime: string,
-  timezone: string,
-): { date: string; hour: number; minute: number } {
-  const d = new Date(isoTime);
-  const tz = timezone || "UTC";
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: tz,
-  }).formatToParts(d);
-  const get = (type: string) => {
-    return (
-      parts.find((p) => {
-        return p.type === type;
-      })?.value ?? "00"
-    );
-  };
-  return {
-    date: `${get("year")}-${get("month")}-${get("day")}`,
-    hour: Number(get("hour")),
-    minute: Number(get("minute")),
-  };
 }
 
 function scheduleToTimeString(s: ScheduleItem): string {

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
@@ -41,12 +41,44 @@ interface ScheduleItem {
 // Schedule time string conversion
 // ---------------------------------------------------------------------------
 
-function cronToTimeString(cron: string): string {
+function cronUtcToLocalTime(
+  utcHour: number,
+  utcMinute: number,
+  timezone: string,
+): { hour: number; minute: number } {
+  if (timezone === "UTC" || timezone === "Etc/UTC") {
+    return { hour: utcHour, minute: utcMinute };
+  }
+  const d = new Date();
+  d.setUTCHours(utcHour, utcMinute, 0, 0);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: timezone,
+  }).formatToParts(d);
+  return {
+    hour: Number(
+      parts.find((p) => {
+        return p.type === "hour";
+      })?.value ?? utcHour,
+    ),
+    minute: Number(
+      parts.find((p) => {
+        return p.type === "minute";
+      })?.value ?? utcMinute,
+    ),
+  };
+}
+
+function cronToTimeString(cron: string, timezone = "UTC"): string {
   const parts = cron.split(" ");
-  const minute = Number(parts[0]);
-  const hour = Number(parts[1]);
+  const rawMinute = Number(parts[0]);
+  const rawHour = Number(parts[1]);
   const dayOfMonth = parts[2] ?? "*";
   const dayOfWeek = parts[4] ?? "*";
+
+  const { hour, minute } = cronUtcToLocalTime(rawHour, rawMinute, timezone);
 
   const ampm = hour >= 12 ? "PM" : "AM";
   const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
@@ -82,6 +114,35 @@ function cronToTimeString(cron: string): string {
   return `Every day at ${timeStr}`;
 }
 
+function atTimeInTimezone(
+  isoTime: string,
+  timezone: string,
+): { date: string; hour: number; minute: number } {
+  const d = new Date(isoTime);
+  const tz = timezone || "UTC";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: tz,
+  }).formatToParts(d);
+  const get = (type: string) => {
+    return (
+      parts.find((p) => {
+        return p.type === type;
+      })?.value ?? "00"
+    );
+  };
+  return {
+    date: `${get("year")}-${get("month")}-${get("day")}`,
+    hour: Number(get("hour")),
+    minute: Number(get("minute")),
+  };
+}
+
 function scheduleToTimeString(s: ScheduleItem): string {
   if (s.triggerType === "loop" && s.intervalSeconds !== null) {
     if (s.intervalSeconds % 60 === 0) {
@@ -90,16 +151,16 @@ function scheduleToTimeString(s: ScheduleItem): string {
     return `Every ${s.intervalSeconds} seconds`;
   }
   if (s.triggerType === "once" && s.atTime) {
-    const at = new Date(s.atTime);
-    const date = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
-    const hour = at.getHours();
-    const minute = at.getMinutes();
+    const { date, hour, minute } = atTimeInTimezone(
+      s.atTime,
+      s.timezone ?? "UTC",
+    );
     const ampm = hour >= 12 ? "PM" : "AM";
     const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
     return `Once on ${date} at ${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
   }
   if (s.cronExpression) {
-    return cronToTimeString(s.cronExpression);
+    return cronToTimeString(s.cronExpression, s.timezone);
   }
   return "Scheduled";
 }

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -13,6 +13,8 @@ import {
   buildCronExpression,
   buildAtTime,
   isAtTimePast,
+  cronUtcToLocalTime,
+  atTimeInTimezone,
   type ScheduleBody,
   type CronTimeOption,
 } from "./cron.ts";
@@ -51,35 +53,6 @@ export const setScheduleTabSaving$ = command(({ set }, value: boolean) => {
 // Convert ScheduleResponse to display time string
 // ---------------------------------------------------------------------------
 
-function atTimeInTimezone(
-  isoTime: string,
-  timezone: string,
-): { date: string; hour: number; minute: number } {
-  const d = new Date(isoTime);
-  const tz = timezone || "UTC";
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: tz,
-  }).formatToParts(d);
-  const get = (type: string) => {
-    return (
-      parts.find((p) => {
-        return p.type === type;
-      })?.value ?? "00"
-    );
-  };
-  return {
-    date: `${get("year")}-${get("month")}-${get("day")}`,
-    hour: Number(get("hour")),
-    minute: Number(get("minute")),
-  };
-}
-
 function scheduleToTimeString(s: ScheduleResponse): string {
   if (s.triggerType === "loop" && s.intervalSeconds !== null) {
     if (s.intervalSeconds % 60 === 0) {
@@ -104,36 +77,6 @@ function scheduleToTimeString(s: ScheduleResponse): string {
   }
 
   return "Scheduled";
-}
-
-function cronUtcToLocalTime(
-  utcHour: number,
-  utcMinute: number,
-  timezone: string,
-): { hour: number; minute: number } {
-  if (timezone === "UTC" || timezone === "Etc/UTC") {
-    return { hour: utcHour, minute: utcMinute };
-  }
-  const d = new Date();
-  d.setUTCHours(utcHour, utcMinute, 0, 0);
-  const parts = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: timezone,
-  }).formatToParts(d);
-  return {
-    hour: Number(
-      parts.find((p) => {
-        return p.type === "hour";
-      })?.value ?? utcHour,
-    ),
-    minute: Number(
-      parts.find((p) => {
-        return p.type === "minute";
-      })?.value ?? utcMinute,
-    ),
-  };
 }
 
 function cronToTimeString(cron: string, timezone = "UTC"): string {

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -51,6 +51,35 @@ export const setScheduleTabSaving$ = command(({ set }, value: boolean) => {
 // Convert ScheduleResponse to display time string
 // ---------------------------------------------------------------------------
 
+function atTimeInTimezone(
+  isoTime: string,
+  timezone: string,
+): { date: string; hour: number; minute: number } {
+  const d = new Date(isoTime);
+  const tz = timezone || "UTC";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: tz,
+  }).formatToParts(d);
+  const get = (type: string) => {
+    return (
+      parts.find((p) => {
+        return p.type === type;
+      })?.value ?? "00"
+    );
+  };
+  return {
+    date: `${get("year")}-${get("month")}-${get("day")}`,
+    hour: Number(get("hour")),
+    minute: Number(get("minute")),
+  };
+}
+
 function scheduleToTimeString(s: ScheduleResponse): string {
   if (s.triggerType === "loop" && s.intervalSeconds !== null) {
     if (s.intervalSeconds % 60 === 0) {
@@ -61,10 +90,10 @@ function scheduleToTimeString(s: ScheduleResponse): string {
   }
 
   if (s.triggerType === "once" && s.atTime) {
-    const at = new Date(s.atTime);
-    const date = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, "0")}-${String(at.getDate()).padStart(2, "0")}`;
-    const hour = at.getHours();
-    const minute = at.getMinutes();
+    const { date, hour, minute } = atTimeInTimezone(
+      s.atTime,
+      s.timezone ?? "UTC",
+    );
     const ampm = hour >= 12 ? "PM" : "AM";
     const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
     return `Once on ${date} at ${h12}:${String(minute).padStart(2, "0")} ${ampm}`;


### PR DESCRIPTION
## Summary

Follow-up to #17028, which fixed `cronToTimeString` in `zero-schedule.ts` but left two gaps:

- **`job-detail/schedule.ts` missed** — this file has its own copy of `cronToTimeString` and `scheduleToTimeString` that power `agentScheduleEntries$` (the schedule tab on the agent job-detail page). It was not updated by #17028, so it still showed raw UTC cron hours without timezone conversion.
- **`once` schedule displayed in browser timezone** — both files used `at.getHours()` / `at.getMinutes()` (browser local time) to format one-time schedules, instead of the schedule's stored timezone.

## Changes

**`job-detail/schedule.ts`**
- Adds `cronUtcToLocalTime` helper (identical to the one in `zero-schedule.ts`)
- Updates `cronToTimeString` to accept `timezone = "UTC"` and convert UTC cron hours to local timezone
- Updates `scheduleToTimeString` to pass `s.timezone` to `cronToTimeString`
- Adds `atTimeInTimezone` helper and uses it in the `once` branch

**`zero-schedule.ts`**
- Adds `atTimeInTimezone` helper and uses it in the `once` branch to replace `at.getHours()` / `at.getMinutes()` with timezone-aware formatting

## Test plan

- [ ] Schedule tab on agent job-detail page now shows correct local times (e.g. `9:00 AM · Asia/Shanghai` instead of `1:00 AM · Asia/Shanghai`)
- [ ] Once-schedules display time in the schedule's stored timezone, not the browser's local timezone
- [ ] Existing unit tests pass: `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/schedule-list-view.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)