### PR TITLE
fix: align template icons between chat message flow and template picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -20,8 +20,8 @@ import {
   IconArrowUp,
   IconChevronLeft,
   IconChevronRight,
-  IconChartBar,
   IconDeviceDesktop,
+  IconPresentation,
   IconEye,
   IconLoader2,
   IconMicrophone,
@@ -1042,7 +1042,7 @@ function TemplatePickerDialog({
                           : "border-transparent text-muted-foreground hover:text-foreground",
                       )}
                     >
-                      <IconChartBar
+                      <IconPresentation
                         className={cn(
                           "h-5 w-5",
                           selectedCategory === "slides"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4757,7 +4757,11 @@ function UserMessageGenerationTemplate({
       className="mb-1.5 flex max-w-[85%] items-center gap-1.5 self-end text-xs font-medium text-muted-foreground"
       title={`${typeLabel} · ${label}`}
     >
-      <IconPresentation size={15} stroke={1.8} className="shrink-0" />
+      {generationTemplate?.type === "video" ? (
+        <IconVideo size={15} stroke={1.8} className="shrink-0" />
+      ) : (
+        <IconPresentation size={15} stroke={1.8} className="shrink-0" />
+      )}
       <span className="shrink-0">{typeLabel}</span>
       <span className="shrink-0">·</span>
       <span className="min-w-0 truncate">{label}</span>


### PR DESCRIPTION
## Summary

- Video template reference in chat message flow now shows `IconVideo` (video camera) instead of `IconPresentation`, consistent with the Video tab in the template picker
- PPT tab in the template picker now shows `IconPresentation` instead of `IconChartBar`, consistent with the icon shown in the chat message flow

## Test plan

- [ ] Send a message referencing a Video template → verify the chat chip shows the video camera icon
- [ ] Send a message referencing a PPT/Slides template → verify the chat chip shows the presentation icon
- [ ] Open the template picker → verify the PPT tab shows the presentation icon and Video tab shows the video camera icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)