### PR TITLE
fix: update strapi connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/strapi.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/strapi.svg
@@ -1,1 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" fill="none"><path fill="#4945FF" d="M42.6 0H21.4v21.3h14.9c1 0 1.8.8 1.8 1.8v14.8H59.4V3.6A3.6 3.6 0 0 0 55.8 0h-13.2Z"/><path fill="#4945FF" fill-opacity=".4" d="M21.4 0v21.3H4.6l-.1-.1V21c0-.2.1-.3.2-.4L21 .3c.1-.1.2-.2.4-.2l.1-.1h-.1Z"/><path fill="#4945FF" fill-opacity=".4" d="M38.1 42.7H21.4V25.9c0-1.3 1-2.3 2.3-2.3h14.4v19.1Z"/><path fill="#4945FF" fill-opacity=".4" d="M21.4 42.7v16.7h.1l.1-.1L38 43.1c.1-.1.2-.2.2-.4V42.6l-.1.1H21.4Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0.299805 31.6997 31.6997">
+  <rect y="0.299805" width="31.6997" height="31.6997" rx="5.65311" fill="#4945FF" />
+  <path
+    fill="#FFFFFF"
+    fill-rule="evenodd"
+    d="M21.9792 9.86237H11.1619V15.2657H16.576C16.6632 15.2657 16.734 15.3364 16.734 15.4237V20.8374H22.1372V10.0204C22.1372 9.93311 22.0665 9.86237 21.9792 9.86237Z"
+    clip-rule="evenodd"
+  />
+  <path
+    fill="#FFFFFF"
+    fill-rule="evenodd"
+    d="M11.1629 9.86224V15.2654H5.95038C5.87999 15.2654 5.84474 15.1803 5.89452 15.1305L11.1629 9.86224Z"
+    clip-rule="evenodd"
+    opacity="0.42"
+  />
+  <path
+    fill="#FFFFFF"
+    fill-rule="evenodd"
+    d="M16.8694 26.1055C16.8197 26.1553 16.7346 26.1201 16.7346 26.0497V20.8373H22.1378L16.8694 26.1055Z"
+    clip-rule="evenodd"
+    opacity="0.42"
+  />
+  <path
+    fill="#FFFFFF"
+    d="M11.1642 15.2656H16.6573C16.7009 15.2656 16.7363 15.3009 16.7363 15.3446V20.8375H11.3222C11.2349 20.8375 11.1642 20.7668 11.1642 20.6795V15.2656Z"
+    opacity="0.42"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- replace the detached transparent Strapi monogram with the official blue rounded-square container treatment
- crop the official website logo SVG to the square icon portion so the connector slot does not include the wordmark
- keep explicit colors and SVG-only with no duplicate PNG asset

Closes #17146

## Testing
- python3 XML parse/no currentColor/no image/no style/no duplicate PNG check for strapi.svg
- pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/icons/strapi.svg