### PR TITLE
feat: add desktop runtime error details

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -402,6 +402,15 @@ describe("ComputerUseHostRuntime", () => {
       hostId: null,
       lastError:
         "Computer Use is already active in another Zero Desktop session.",
+      errorLog: [
+        {
+          source: "heartbeat",
+          hostId: null,
+          message:
+            "Computer Use is already active in another Zero Desktop session.",
+          status: "error",
+        },
+      ],
     });
   });
 
@@ -468,6 +477,15 @@ describe("ComputerUseHostRuntime", () => {
       hostId: null,
       lastError:
         "Computer Use is already active in another Zero Desktop session.",
+      errorLog: [
+        {
+          source: "start",
+          hostId: null,
+          message:
+            "Computer Use is already active in another Zero Desktop session.",
+          status: "error",
+        },
+      ],
     });
   });
 });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -9,6 +9,8 @@ import type {
   ComputerUseLocalCommandLogEntry,
   ComputerUsePermissionState,
   ComputerUseRuntimeAuditEvent,
+  ComputerUseRuntimeErrorLogEntry,
+  ComputerUseRuntimeErrorSource,
 } from "./computer-use-types";
 import {
   COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
@@ -19,6 +21,7 @@ const ONLINE_POLL_MS = 2_000;
 const COMMAND_COMPLETION_RETRY_DELAY_MS = 2_000;
 const COMMAND_COMPLETION_MAX_ATTEMPTS = 3;
 const AUTH_ME_PATH = "/api/auth/me";
+const ERROR_LOG_LIMIT = 20;
 
 export type ComputerUseHostFetch = (
   input: string,
@@ -65,6 +68,21 @@ type ComputerUseHostNextResponse =
   | ComputerUseHostNextIdleResponse
   | ComputerUseHostNextCommandResponse;
 
+type RuntimeErrorStateUpdate = Partial<
+  Pick<
+    ComputerUseHostRuntimeState,
+    | "hostId"
+    | "lastHeartbeatAt"
+    | "lastCommandAt"
+    | "recentAuditEvents"
+    | "localCommandLog"
+  >
+>;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function commandFailureFromError(
   error: unknown,
 ): ComputerUseCommandExecutionResult {
@@ -72,7 +90,7 @@ function commandFailureFromError(
     status: "failed",
     error: {
       code: "accessibility_unavailable",
-      message: error instanceof Error ? error.message : String(error),
+      message: errorMessage(error),
     },
   };
 }
@@ -117,12 +135,14 @@ export class ComputerUseHostRuntime {
   private commandTimer: NodeJS.Timeout | null = null;
   private commandExecutionRunning = false;
   private hostToken: string | null = null;
+  private nextErrorLogId = 0;
   private state: ComputerUseHostRuntimeState = {
     status: "idle",
     hostId: null,
     lastHeartbeatAt: null,
     lastCommandAt: null,
     lastError: null,
+    errorLog: [],
     recentAuditEvents: [],
     localCommandLog: [],
   };
@@ -154,10 +174,7 @@ export class ComputerUseHostRuntime {
       this.scheduleHeartbeat(nextDelay);
       this.scheduleCommandPoll(nextDelay);
     } catch (error) {
-      this.setState({
-        status: "error",
-        lastError: error instanceof Error ? error.message : String(error),
-      });
+      this.setRuntimeErrorState("start", error);
       this.running = false;
     }
   }
@@ -179,10 +196,7 @@ export class ComputerUseHostRuntime {
     try {
       await this.stopHost(hostToken);
     } catch (error) {
-      this.setState({
-        status: "error",
-        lastError: error instanceof Error ? error.message : String(error),
-      });
+      this.setRuntimeErrorState("stop", error);
     }
   }
 
@@ -201,6 +215,31 @@ export class ComputerUseHostRuntime {
   private setState(update: Partial<ComputerUseHostRuntimeState>): void {
     this.state = { ...this.state, ...update };
     this.onChange();
+  }
+
+  private setRuntimeErrorState(
+    source: ComputerUseRuntimeErrorSource,
+    error: unknown,
+    update: RuntimeErrorStateUpdate = {},
+  ): void {
+    const message = errorMessage(error);
+    const occurredAt = new Date().toISOString();
+    const hostId =
+      "hostId" in update ? (update.hostId ?? null) : this.state.hostId;
+    const entry: ComputerUseRuntimeErrorLogEntry = {
+      id: `${occurredAt}-${this.nextErrorLogId++}`,
+      source,
+      message,
+      occurredAt,
+      hostId,
+      status: "error",
+    };
+    this.setState({
+      ...update,
+      status: "error",
+      lastError: message,
+      errorLog: [entry, ...this.state.errorLog].slice(0, ERROR_LOG_LIMIT),
+    });
   }
 
   private startLocalCommandLogEntry(
@@ -300,10 +339,7 @@ export class ComputerUseHostRuntime {
       }
       this.scheduleHeartbeat(ONLINE_POLL_MS);
     } catch (error) {
-      this.setState({
-        status: "error",
-        lastError: error instanceof Error ? error.message : String(error),
-      });
+      this.setRuntimeErrorState("heartbeat", error);
       this.running = false;
       this.clearCommandTimer();
     }
@@ -318,10 +354,7 @@ export class ComputerUseHostRuntime {
       await this.claimAndExecuteCommand();
     } catch (error) {
       if (this.running) {
-        this.setState({
-          status: "error",
-          lastError: error instanceof Error ? error.message : String(error),
-        });
+        this.setRuntimeErrorState("command_poll", error);
       }
     } finally {
       this.commandExecutionRunning = false;
@@ -363,12 +396,11 @@ export class ComputerUseHostRuntime {
       return null;
     }
     if (response.status === 409) {
-      this.setState({
-        status: "error",
-        hostId: null,
-        lastError:
-          "Computer Use is already active in another Zero Desktop session.",
-      });
+      this.setRuntimeErrorState(
+        "start",
+        "Computer Use is already active in another Zero Desktop session.",
+        { hostId: null },
+      );
       return null;
     }
     if (!response.ok) {
@@ -412,12 +444,11 @@ export class ComputerUseHostRuntime {
     }
     if (response.status === 409) {
       this.hostToken = null;
-      this.setState({
-        status: "error",
-        hostId: null,
-        lastError:
-          "Computer Use is already active in another Zero Desktop session.",
-      });
+      this.setRuntimeErrorState(
+        "heartbeat",
+        "Computer Use is already active in another Zero Desktop session.",
+        { hostId: null },
+      );
       return false;
     }
     if (!response.ok) {

--- a/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
@@ -51,6 +51,7 @@ describe("resolveComputerUseStartupGate", () => {
         lastHeartbeatAt: null,
         lastCommandAt: null,
         lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
+        errorLog: [],
         recentAuditEvents: [],
         localCommandLog: [],
       },

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -42,12 +42,28 @@ export interface ComputerUseLocalCommandLogEntry {
   readonly durationMs: number | null;
 }
 
+export type ComputerUseRuntimeErrorSource =
+  | "start"
+  | "stop"
+  | "heartbeat"
+  | "command_poll";
+
+export interface ComputerUseRuntimeErrorLogEntry {
+  readonly id: string;
+  readonly source: ComputerUseRuntimeErrorSource;
+  readonly message: string;
+  readonly occurredAt: string;
+  readonly hostId: string | null;
+  readonly status: Extract<ComputerUseHostRuntimeStatus, "error">;
+}
+
 export interface ComputerUseHostRuntimeState {
   readonly status: ComputerUseHostRuntimeStatus;
   readonly hostId: string | null;
   readonly lastHeartbeatAt: string | null;
   readonly lastCommandAt: string | null;
   readonly lastError: string | null;
+  readonly errorLog: readonly ComputerUseRuntimeErrorLogEntry[];
   readonly recentAuditEvents: readonly ComputerUseRuntimeAuditEvent[];
   readonly localCommandLog: readonly ComputerUseLocalCommandLogEntry[];
 }
@@ -79,6 +95,7 @@ export const IDLE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =
     lastHeartbeatAt: null,
     lastCommandAt: null,
     lastError: null,
+    errorLog: [],
     recentAuditEvents: [],
     localCommandLog: [],
   });

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -16,6 +16,7 @@ const baseHostState: ComputerUseHostRuntimeState = {
   lastHeartbeatAt: null,
   lastCommandAt: null,
   lastError: null,
+  errorLog: [],
   recentAuditEvents: [],
   localCommandLog: [],
 };

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -51,6 +51,7 @@ import {
 type HostStatus = DesktopComputerUseState["host"]["status"];
 type CommandLogEntry =
   DesktopComputerUseState["host"]["localCommandLog"][number];
+type RuntimeErrorEntry = DesktopComputerUseState["host"]["errorLog"][number];
 
 interface ScreenshotPreview {
   readonly src: string;
@@ -73,6 +74,13 @@ const COMMAND_STATUS_LABELS = {
   succeeded: "Succeeded",
   failed: "Failed",
 } as const satisfies Record<CommandLogEntry["status"], string>;
+
+const RUNTIME_ERROR_SOURCE_LABELS = {
+  start: "Start",
+  stop: "Stop",
+  heartbeat: "Heartbeat",
+  command_poll: "Command poll",
+} as const satisfies Record<RuntimeErrorEntry["source"], string>;
 
 const RESULT_SUMMARY_KEYS_TO_SKIP = new Set([
   "appState",
@@ -672,20 +680,37 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   const [refreshLoadable, refresh] = useLoadableSet(refreshComputerUse$);
   const [keepAwakeLoadable, setKeepAwakeEnabled] =
     useLoadableSet(setKeepAwakeEnabled$);
+  const [errorDetailsOpen, setErrorDetailsOpen] = useState(false);
   const startDisabled =
     state.host.status === "connecting" ||
     state.host.status === "online" ||
     startLoadable.state === "loading";
   const stopDisabled =
     state.host.status !== "online" || stopLoadable.state === "loading";
+  const hasErrorDetails =
+    state.host.status === "error" &&
+    (state.host.lastError !== null || state.host.errorLog.length > 0);
 
   return (
     <Panel title="Runtime" icon={<IconActivityHeartbeat size={18} />}>
       <div className="runtime-grid">
         <div>
           <span>Status</span>
-          <strong>
+          <strong className="runtime-status-value">
             <StatusBadge status={state.host.status} />
+            {hasErrorDetails && (
+              <button
+                type="button"
+                className="status-error-button"
+                aria-label="Show error details"
+                title="Show error details"
+                onClick={() => {
+                  setErrorDetailsOpen(true);
+                }}
+              >
+                <IconAlertCircle size={15} />
+              </button>
+            )}
           </strong>
         </div>
         <div>
@@ -711,12 +736,6 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
           void setKeepAwakeEnabled(enabled);
         }}
       />
-      {state.host.lastError && (
-        <div className="inline-alert">
-          <IconAlertCircle size={16} />
-          <span>{state.host.lastError}</span>
-        </div>
-      )}
       <div className="panel-actions">
         <IconButton
           tone="primary"
@@ -748,7 +767,126 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
           Refresh
         </IconButton>
       </div>
+      {errorDetailsOpen && hasErrorDetails && (
+        <RuntimeErrorDetailsModal
+          state={state}
+          onClose={() => {
+            setErrorDetailsOpen(false);
+          }}
+        />
+      )}
     </Panel>
+  );
+}
+
+function RuntimeErrorDetailsModal({
+  onClose,
+  state,
+}: {
+  readonly onClose: () => void;
+  readonly state: DesktopComputerUseState;
+}) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const latestError =
+    state.host.lastError ?? state.host.errorLog[0]?.message ?? "Unknown error";
+  const rawDiagnostics = {
+    status: state.host.status,
+    hostId: state.host.hostId,
+    lastHeartbeatAt: state.host.lastHeartbeatAt,
+    lastCommandAt: state.host.lastCommandAt,
+    lastError: state.host.lastError,
+    errorLog: state.host.errorLog,
+  };
+
+  return (
+    <div className="runtime-error-modal" role="presentation" onClick={onClose}>
+      <div
+        className="runtime-error-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Error details"
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <div className="runtime-error-header">
+          <div>
+            <strong>Error details</strong>
+            <span>Local Computer Use runtime logs</span>
+          </div>
+          <button
+            type="button"
+            className="icon-only-button"
+            aria-label="Close error details"
+            onClick={onClose}
+          >
+            <IconX size={18} />
+          </button>
+        </div>
+        <div className="runtime-error-body">
+          <section className="runtime-error-section">
+            <h3>Summary</h3>
+            <KeyValueList
+              emptyLabel="No runtime summary available."
+              value={{
+                Status: STATUS_LABELS[state.host.status],
+                "Host ID": state.host.hostId ?? "Not registered",
+                "Last heartbeat": formatTimestamp(state.host.lastHeartbeatAt),
+                "Last command": formatTimestamp(state.host.lastCommandAt),
+                "Captured errors": state.host.errorLog.length,
+              }}
+            />
+          </section>
+          <section className="runtime-error-section">
+            <h3>Latest error</h3>
+            <div className="runtime-error-message">{latestError}</div>
+          </section>
+          <section className="runtime-error-section">
+            <h3>Recent error log</h3>
+            {state.host.errorLog.length === 0 ? (
+              <div className="compact-empty">
+                No local error log entries were captured.
+              </div>
+            ) : (
+              <div className="runtime-error-log-list">
+                {state.host.errorLog.map((entry) => {
+                  return <RuntimeErrorLogRow key={entry.id} entry={entry} />;
+                })}
+              </div>
+            )}
+          </section>
+          <details className="raw-log-details">
+            <summary>Raw diagnostics</summary>
+            <pre className="json-block">{formatJson(rawDiagnostics)}</pre>
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RuntimeErrorLogRow({ entry }: { readonly entry: RuntimeErrorEntry }) {
+  return (
+    <div className="runtime-error-log-row">
+      <div>
+        <strong>{RUNTIME_ERROR_SOURCE_LABELS[entry.source]}</strong>
+        <span>
+          {formatTimestamp(entry.occurredAt)} - {entry.hostId ?? "No host id"}
+        </span>
+      </div>
+      <p>{entry.message}</p>
+    </div>
   );
 }
 

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -24,6 +24,7 @@ function computerUseState(
       lastHeartbeatAt: null,
       lastCommandAt: null,
       lastError: null,
+      errorLog: [],
       recentAuditEvents: [],
       localCommandLog: [],
     },

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -268,6 +268,30 @@ button {
   overflow-wrap: anywhere;
 }
 
+.runtime-status-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.status-error-button {
+  width: 24px;
+  height: 24px;
+  border: 1px solid rgba(180, 35, 24, 0.22);
+  border-radius: 999px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #b42318;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.status-error-button:hover {
+  background: #fef3f2;
+}
+
 .panel {
   border-radius: 8px;
   padding: 14px 16px;
@@ -731,6 +755,139 @@ button {
   line-height: 1.4;
 }
 
+.runtime-error-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  padding: 28px;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.runtime-error-dialog {
+  width: min(680px, 100%);
+  max-height: min(760px, 100%);
+  border-radius: 8px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: #ffffff;
+  box-shadow: 0 24px 72px rgba(15, 23, 42, 0.34);
+  overflow: hidden;
+}
+
+.runtime-error-header {
+  min-height: 48px;
+  border-bottom: 1px solid rgba(30, 38, 52, 0.1);
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.runtime-error-header div {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.runtime-error-header strong {
+  color: #202631;
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+.runtime-error-header span {
+  color: #667085;
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.runtime-error-body {
+  min-height: 0;
+  padding: 14px;
+  display: grid;
+  gap: 14px;
+  overflow: auto;
+}
+
+.runtime-error-section {
+  display: grid;
+  gap: 8px;
+}
+
+.runtime-error-section h3 {
+  margin: 0;
+  color: #3d4a5c;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.runtime-error-message {
+  border: 1px solid rgba(180, 35, 24, 0.14);
+  border-radius: 7px;
+  padding: 10px;
+  color: #7a271a;
+  background: #fef3f2;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.runtime-error-log-list {
+  display: grid;
+  gap: 8px;
+}
+
+.runtime-error-log-row {
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 7px;
+  padding: 9px 10px;
+  display: grid;
+  gap: 6px;
+  background: #f8fafc;
+}
+
+.runtime-error-log-row div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.runtime-error-log-row strong {
+  color: #202631;
+  font-size: 12px;
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.runtime-error-log-row span {
+  color: #667085;
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.runtime-error-log-row p {
+  margin: 0;
+  color: #3d4a5c;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 .empty-state {
   min-height: 58px;
   border: 1px dashed rgba(30, 38, 52, 0.16);
@@ -929,5 +1086,18 @@ button {
 
   .screenshot-lightbox {
     padding: 12px;
+  }
+
+  .runtime-error-modal {
+    padding: 12px;
+  }
+
+  .runtime-error-log-row div {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .runtime-error-log-row span {
+    text-align: left;
   }
 }


### PR DESCRIPTION
## Summary
- Capture local Computer Use runtime errors in a bounded host `errorLog`.
- Show the warning icon next to the Runtime status only when host status is `Error`.
- Add an error details modal with summary, latest error, recent local error log, and raw diagnostics.

## Testing
- `pnpm --dir turbo exec prettier --check apps/desktop/src/computer-use-host.ts apps/desktop/src/computer-use-types.ts apps/desktop/src/renderer/App.tsx apps/desktop/src/renderer/styles.css apps/desktop/src/computer-use-host.test.ts apps/desktop/src/computer-use-startup-gate.test.ts apps/desktop/src/desktop-tray-menu.test.ts apps/desktop/src/renderer/computer-use-state.test.ts`
- `pnpm --dir turbo --filter @vm0/desktop lint`
- `pnpm --dir turbo --filter @vm0/desktop check-types`
- `pnpm --dir turbo --filter @vm0/desktop exec vitest run src/computer-use-host.test.ts src/computer-use-startup-gate.test.ts src/desktop-tray-menu.test.ts src/renderer/computer-use-state.test.ts`

## Notes
- Full `pnpm --dir turbo --filter @vm0/desktop test` was attempted on Linux and failed only in macOS native CLI coverage (`computer-use-native.test.ts`) because Desktop Computer Use native backend is implemented for macOS.
