### PR TITLE
fix: hide Computer Use button behind feature flag

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { server } from "../../../mocks/server.ts";
@@ -23,9 +24,17 @@ function mockChatAPI() {
   server.use();
 }
 
-function renderChatPage() {
+function renderChatPage(options?: {
+  featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+}) {
   mockChatAPI();
-  detachedSetupPage({ context, path: "/" });
+  detachedSetupPage({
+    context,
+    path: "/",
+    ...(options?.featureSwitches
+      ? { featureSwitches: options.featureSwitches }
+      : {}),
+  });
 }
 
 describe("zero chat page - suggested prompts", () => {
@@ -136,6 +145,21 @@ describe("zero chat page - composer", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Connectors")).toBeInTheDocument();
     });
+  });
+
+  it("should hide Computer Use when the feature switch is disabled", async () => {
+    await renderChatPage({
+      featureSwitches: { [FeatureSwitchKey.ComputerUse]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(
+          "Ask me to automate workflows, manage tasks...",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Computer Use")).not.toBeInTheDocument();
   });
 
   it("should disable Send button when input is empty", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx
@@ -107,6 +107,22 @@ beforeEach(() => {
 });
 
 describe("zero chat thread page display - schedule menu", () => {
+  it("hides Computer Use when the feature switch is disabled", async () => {
+    const threadId = "d0000000-0000-4000-a000-000000000001";
+    mockChatLifecycle({ threadId });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ComputerUse]: false },
+    });
+
+    await expect(
+      screen.findByPlaceholderText(PLACEHOLDER),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByLabelText("Computer Use")).not.toBeInTheDocument();
+  });
+
   it("hides the schedule button when no schedules are linked to the thread", async () => {
     const threadId = "d0000000-0000-4000-a000-000000000001";
     let schedulesRequested = false;

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -11,6 +11,7 @@ import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -73,6 +74,7 @@ import {
 } from "../../signals/view-component-state.ts";
 import { modelFirstPersonalOauthState$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import { updateUserModelPreference$ } from "../../signals/external/user-model-preference.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   resolveChatComposerSubmitBlocker,
   usePersonalOauthConfigurationAction,
@@ -418,6 +420,8 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
 }
 
 function useNewThreadComputerUse() {
+  const features = useLastResolved(featureSwitch$);
+  const computerUseEnabled = features?.[FeatureSwitchKey.ComputerUse] ?? false;
   const computerUseHostsLoadable = useLastLoadable(onlineComputerUseHosts$);
   const computerUseHosts =
     computerUseHostsLoadable.state === "hasData"
@@ -431,17 +435,21 @@ function useNewThreadComputerUse() {
   const setComputerUseHostId = useSet(setNewThreadComputerUseHostId$);
 
   return {
-    selectedComputerUseHostId,
+    selectedComputerUseHostId: computerUseEnabled
+      ? selectedComputerUseHostId
+      : null,
     clearComputerUseHostId: () => {
       setComputerUseHostId(null);
     },
-    computerUse: {
-      hosts: computerUseHosts,
-      loading: computerUseHostsLoadable.state === "loading",
-      selectedHostId: selectedComputerUseHostId,
-      onChange: setComputerUseHostId,
-      downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
-    },
+    computerUse: computerUseEnabled
+      ? {
+          hosts: computerUseHosts,
+          loading: computerUseHostsLoadable.state === "loading",
+          selectedHostId: selectedComputerUseHostId,
+          onChange: setComputerUseHostId,
+          downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
+        }
+      : undefined,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2863,6 +2863,8 @@ function useChatThreadComposerSendState({
 }
 
 function useChatThreadComputerUse(thread: ChatThreadSignals) {
+  const features = useLastResolved(featureSwitch$);
+  const computerUseEnabled = features?.[FeatureSwitchKey.ComputerUse] ?? false;
   const computerUseHostsLoadable = useLastLoadable(onlineComputerUseHosts$);
   const computerUseHosts =
     computerUseHostsLoadable.state === "hasData"
@@ -2879,14 +2881,18 @@ function useChatThreadComputerUse(thread: ChatThreadSignals) {
   const setComputerUseHostId = useSet(thread.setComputerUseHostId$);
 
   return {
-    selectedComputerUseHostId,
-    computerUse: {
-      hosts: computerUseHosts,
-      loading: computerUseHostsLoadable.state === "loading",
-      selectedHostId: selectedComputerUseHostId,
-      onChange: setComputerUseHostId,
-      downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
-    },
+    selectedComputerUseHostId: computerUseEnabled
+      ? selectedComputerUseHostId
+      : null,
+    computerUse: computerUseEnabled
+      ? {
+          hosts: computerUseHosts,
+          loading: computerUseHostsLoadable.state === "loading",
+          selectedHostId: selectedComputerUseHostId,
+          onChange: setComputerUseHostId,
+          downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
+        }
+      : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- hide the Computer Use composer button unless the ComputerUse feature switch is enabled
- prevent new and existing chat sends from carrying a stale computerUseHostId while the feature is disabled
- add regression coverage for both the new chat page and existing chat thread page

## Validation
- pnpm format
- pnpm check-types
- pnpm turbo run lint
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-chat-page.test.tsx src/views/zero-page/__tests__/zero-chat-thread-page-display.test.tsx --no-file-parallelism --maxWorkers=1
