### PR TITLE
fix: update tripo connector icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/tripo.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/tripo.svg
@@ -1,5 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
-  <rect width="60" height="60" fill="#000000"/>
-  <path fill="#FFFFFF" d="M5 6 9 9 29 44 35 42 48 19H58L38 54 28 56 23 53 2 17V11Z"/>
-  <path fill="#F8CF00" d="M12 4H53L59 8 60 13H43L34 30 30 32 26 27V24L32 13H17Z"/>
+  <defs>
+    <clipPath id="tripo-icon-clip">
+      <rect width="60" height="60" rx="7.5"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#tripo-icon-clip)">
+    <rect width="60" height="60" fill="#000000"/>
+    <path fill="#FFFFFF" d="M5 6 9 9 29 44 35 42 48 19H58L38 54 28 56 23 53 2 17V11Z"/>
+    <path fill="#FFDE55" d="M12 4H53L59 8 60 13H43L34 30 30 32 26 27V24L32 13H17Z"/>
+  </g>
 </svg>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/tripo.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/tripo.svg
@@ -1,12 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
-  <defs>
-    <clipPath id="tripo-icon-clip">
-      <rect width="60" height="60" rx="7.5"/>
-    </clipPath>
-  </defs>
-  <g clip-path="url(#tripo-icon-clip)">
-    <rect width="60" height="60" fill="#000000"/>
-    <path fill="#FFFFFF" d="M5 6 9 9 29 44 35 42 48 19H58L38 54 28 56 23 53 2 17V11Z"/>
-    <path fill="#FFDE55" d="M12 4H53L59 8 60 13H43L34 30 30 32 26 27V24L32 13H17Z"/>
-  </g>
+  <rect width="60" height="60" fill="#000000"/>
+  <path fill="#FFFFFF" d="M5 6 9 9 29 44 35 42 48 19H58L38 54 28 56 23 53 2 17V11Z"/>
+  <path fill="#FFDE55" d="M12 4H53L59 8 60 13H43L34 30 30 32 26 27V24L32 13H17Z"/>
 </svg>


### PR DESCRIPTION
## Summary
- update the Tripo connector icon yellow to the current official logo PNG color
- keep the official square black tile treatment without adding rounded clipping
- keep the asset SVG-only with explicit colors and no duplicate PNG asset

Closes #17160

## Testing
- python3 XML parse/no currentColor/no image/no style/no duplicate PNG/no clipPath check for tripo.svg
- pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/icons/tripo.svg
