### PR TITLE
fix: update wandb connector icon color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/wandb.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/wandb.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 204 204" fill="none">
-  <g fill="#FAC13C">
+  <g fill="#FFCC33">
     <circle cx="28.52" cy="23.8" r="12"/>
     <circle cx="101.51" cy="41.48" r="12"/>
     <circle cx="174.52" cy="23.77" r="12"/>


### PR DESCRIPTION
## Summary
- update the W&B connector icon from the older `#FAC13C` yellow to the current official `#FFCC33` yellow
- keep the accepted W&B dots geometry and SVG-only asset
- keep colorful icon preservation with no duplicate PNG asset

Closes #17170

## Testing
- python3 XML parse/no currentColor/no image/no style/no duplicate PNG/colorful override check for wandb.svg
- pnpm exec prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/settings/icons/wandb.svg
- git diff --check
