### PR TITLE
fix: narrow endpoint-scoped firewall bases

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -25,6 +25,12 @@ function firewallWithPermissionName(name: string): FirewallConfig {
   };
 }
 
+function apiBases(firewall: FirewallConfig): string[] {
+  return firewall.apis.map((api) => {
+    return api.base;
+  });
+}
+
 /**
  * Validate that every builtin connector firewall passes the same full
  * validation pipeline as custom (user-supplied) firewalls: base URLs,
@@ -61,4 +67,30 @@ describe("reserved firewall permission names", () => {
       }).toThrow(`permission named "${name}"`);
     },
   );
+});
+
+describe("known endpoint-scoped firewall bases", () => {
+  it("keeps Google Search Console off the shared www.googleapis.com root", () => {
+    const bases = apiBases(getConnectorFirewall("google-search-console"));
+
+    expect(bases).toContain("https://searchconsole.googleapis.com");
+    expect(bases).not.toContain("https://www.googleapis.com");
+  });
+
+  it("narrows Xero tenant discovery to the Connections endpoint", () => {
+    const firewall = getConnectorFirewall("xero");
+    const bases = apiBases(firewall);
+    const connectionsApi = firewall.apis.find((api) => {
+      return api.base === "https://api.xero.com/Connections";
+    });
+
+    expect(bases).toContain("https://api.xero.com/Connections");
+    expect(bases).not.toContain("https://api.xero.com");
+    expect(connectionsApi?.permissions).toEqual([
+      {
+        name: "connections",
+        rules: ["GET /", "DELETE /{id}"],
+      },
+    ]);
+  });
 });

--- a/turbo/packages/firewalls-generator/src/google.ts
+++ b/turbo/packages/firewalls-generator/src/google.ts
@@ -625,7 +625,6 @@ const CONFIGS: Record<string, GoogleFirewallConfig> = {
       "https://searchconsole.googleapis.com/$discovery/rest?version=v1",
     ],
     baseUrl: "https://searchconsole.googleapis.com",
-    additionalBaseUrls: ["https://www.googleapis.com"],
     stripPrefix: "",
     serviceName: "google-search-console",
     serviceDescription: "Google Search Console API",

--- a/turbo/packages/firewalls-generator/src/xero.ts
+++ b/turbo/packages/firewalls-generator/src/xero.ts
@@ -66,13 +66,54 @@ interface XeroSpec {
 // Unknown scopeless endpoints cause a build error — add them here or
 // investigate why they lack scopes.
 
-const INCLUDED_SCOPELESS = new Map<string, string>([
+interface IncludedScopelessEndpoint {
+  readonly permissionName: string;
+  readonly basePath?: string;
+}
+
+interface NarrowedRule {
+  readonly baseUrl: string;
+  readonly rule: string;
+}
+
+const INCLUDED_SCOPELESS = new Map<string, IncludedScopelessEndpoint>([
   // Identity endpoints use openid scopes (not OAuth2) but still need
   // Bearer token auth. Required to retrieve tenant IDs before any
   // accounting API call.
-  ["GET /Connections", "connections"],
-  ["DELETE /Connections/{id}", "connections"],
+  [
+    "GET /Connections",
+    { permissionName: "connections", basePath: "/Connections" },
+  ],
+  [
+    "DELETE /Connections/{id}",
+    { permissionName: "connections", basePath: "/Connections" },
+  ],
 ]);
+
+function narrowRuleToBasePath(
+  baseUrl: string,
+  rule: string,
+  basePath: string | undefined,
+): NarrowedRule {
+  if (basePath === undefined) {
+    return { baseUrl, rule };
+  }
+
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (!path.startsWith(basePath)) {
+    throw new Error(`${rule} cannot be narrowed to base path ${basePath}`);
+  }
+  const relativePath = path.slice(basePath.length);
+  if (relativePath !== "" && !relativePath.startsWith("/")) {
+    throw new Error(`${rule} does not align with base path ${basePath}`);
+  }
+  return {
+    baseUrl: `${baseUrl}${basePath}`,
+    rule: `${method} ${relativePath === "" ? "/" : relativePath}`,
+  };
+}
 
 // ── Grouping ─────────────────────────────────────────────────────────────
 
@@ -130,9 +171,19 @@ function buildGroups(specs: ParsedSpec[]): {
         }
 
         if (scopes.length === 0) {
-          const permName = INCLUDED_SCOPELESS.get(rule);
-          if (permName) {
-            addRule(groups, permName, spec.baseUrl, rule);
+          const includedEndpoint = INCLUDED_SCOPELESS.get(rule);
+          if (includedEndpoint) {
+            const narrowed = narrowRuleToBasePath(
+              spec.baseUrl,
+              rule,
+              includedEndpoint.basePath,
+            );
+            addRule(
+              groups,
+              includedEndpoint.permissionName,
+              narrowed.baseUrl,
+              narrowed.rule,
+            );
           } else {
             unknownScopeless.push(`${rule} (${spec.baseUrl})`);
           }


### PR DESCRIPTION
## Summary
- remove the extra Google Search Console `https://www.googleapis.com` firewall base so it only covers `https://searchconsole.googleapis.com`
- narrow Xero tenant discovery from `https://api.xero.com` to `https://api.xero.com/Connections` and rewrite the relative rules accordingly
- add regression coverage for these known endpoint-scoped bases

Split out from the firewall base overlap investigation for #17165. This does not try to solve same-endpoint/different-auth surfaces such as Railway account vs project tokens or Meta/Instagram Graph API.

## Verification
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-rule-validation.test.ts --run`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors lint`
- pre-commit: `knip`, `prettier`, `check-types`
