### PR TITLE
test: guard builtin firewall base overlaps

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -2,10 +2,33 @@ import { describe, it, expect } from "vitest";
 import { connectorTypeSchema } from "../connectors";
 import { isFirewallConnectorType, getConnectorFirewall } from "../firewalls";
 import { collectAndValidatePermissions } from "../firewall-expander";
+import { matchFirewallBaseUrl } from "../firewall-rule-matcher";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallConfig,
 } from "../firewall-types";
+
+interface FirewallBaseEntry {
+  readonly connectorType: string;
+  readonly apiIndex: number;
+  readonly base: string;
+  readonly sampleUrls: readonly string[];
+}
+
+const FIREWALL_BASE_SAMPLE_VALUES = ["api", "foo", "bar", "v1", "me", "123"];
+const ALLOWED_FIREWALL_BASE_OVERLAPS = new Set([
+  // `{network}` currently also matches `api`; avoid adding more Alchemy overlaps.
+  "alchemy[0] https://{network}.g.alchemy.com <-> alchemy[1] https://api.g.alchemy.com",
+  // Meta and Instagram share the Facebook Graph API origin.
+  "instagram[1] https://graph.facebook.com <-> meta-ads[0] https://graph.facebook.com",
+  "instagram[1] https://graph.facebook.com <-> meta-ads[1] https://graph.facebook.com",
+  // Meta Ads has a same-origin page-token exception that intentionally skips auth injection.
+  "meta-ads[0] https://graph.facebook.com <-> meta-ads[1] https://graph.facebook.com",
+  // Outlook Mail and Calendar both use Microsoft Graph.
+  "outlook-calendar[0] https://graph.microsoft.com <-> outlook-mail[0] https://graph.microsoft.com",
+  // Railway account/workspace and project tokens hit the same public API origin.
+  "railway[0] https://backboard.railway.com <-> railway-project[0] https://backboard.railway.com",
+]);
 
 function firewallWithPermissionName(name: string): FirewallConfig {
   return {
@@ -29,6 +52,63 @@ function apiBases(firewall: FirewallConfig): string[] {
   return firewall.apis.map((api) => {
     return api.base;
   });
+}
+
+function baseSampleUrls(base: string): string[] {
+  if (base.includes("${{")) return [];
+  return FIREWALL_BASE_SAMPLE_VALUES.map((value) => {
+    return base.replace(/\{[^}]+\}/g, value);
+  });
+}
+
+function firewallBaseLabel(entry: FirewallBaseEntry): string {
+  return `${entry.connectorType}[${entry.apiIndex}] ${entry.base}`;
+}
+
+function collectBuiltinFirewallBaseEntries(): FirewallBaseEntry[] {
+  const entries: FirewallBaseEntry[] = [];
+  for (const connectorType of connectorTypeSchema.options) {
+    if (!isFirewallConnectorType(connectorType)) continue;
+    const firewall = getConnectorFirewall(connectorType);
+    firewall.apis.forEach((api, apiIndex) => {
+      const sampleUrls = baseSampleUrls(api.base);
+      if (sampleUrls.length === 0) return;
+      entries.push({
+        connectorType,
+        apiIndex,
+        base: api.base,
+        sampleUrls,
+      });
+    });
+  }
+  return entries;
+}
+
+function findBuiltinFirewallBaseOverlaps(): string[] {
+  const entries = collectBuiltinFirewallBaseEntries();
+  const overlaps = new Set<string>();
+  for (let leftIndex = 0; leftIndex < entries.length; leftIndex += 1) {
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < entries.length;
+      rightIndex += 1
+    ) {
+      const left = entries[leftIndex]!;
+      const right = entries[rightIndex]!;
+      const leftMatchesRight = left.sampleUrls.some((sampleUrl) => {
+        return matchFirewallBaseUrl(sampleUrl, right.base) !== null;
+      });
+      const rightMatchesLeft = right.sampleUrls.some((sampleUrl) => {
+        return matchFirewallBaseUrl(sampleUrl, left.base) !== null;
+      });
+      if (leftMatchesRight || rightMatchesLeft) {
+        overlaps.add(
+          `${firewallBaseLabel(left)} <-> ${firewallBaseLabel(right)}`,
+        );
+      }
+    }
+  }
+  return [...overlaps].sort();
 }
 
 /**
@@ -67,6 +147,29 @@ describe("reserved firewall permission names", () => {
       }).toThrow(`permission named "${name}"`);
     },
   );
+});
+
+describe("builtin firewall base overlap guard", () => {
+  it("does not introduce new builtin base overlaps", () => {
+    const overlaps = findBuiltinFirewallBaseOverlaps();
+    const unexpectedOverlaps = overlaps.filter((overlap) => {
+      return !ALLOWED_FIREWALL_BASE_OVERLAPS.has(overlap);
+    });
+    const staleAllowedOverlaps = [...ALLOWED_FIREWALL_BASE_OVERLAPS].filter(
+      (overlap) => {
+        return !overlaps.includes(overlap);
+      },
+    );
+
+    expect(
+      unexpectedOverlaps,
+      "New firewall base overlaps can make auth injection ambiguous. Narrow the new base, or add a justified allowlist entry only for an unavoidable shared API surface.",
+    ).toEqual([]);
+    expect(
+      staleAllowedOverlaps,
+      "Remove fixed firewall base overlaps from ALLOWED_FIREWALL_BASE_OVERLAPS.",
+    ).toEqual([]);
+  });
 });
 
 describe("known endpoint-scoped firewall bases", () => {


### PR DESCRIPTION
## Summary
- add a builtin firewall base overlap guard to `firewall-rule-validation.test.ts`
- allowlist the currently known overlapping bases with inline reasons
- fail the test for any new overlap so future connector/firewall changes must narrow their base or explicitly justify an unavoidable shared API surface

## Notes
- Runtime-template bases such as `${{ vars.* }}` are skipped because they do not have a single fixed URL to compare in this test.
- Parameterized bases are checked with multiple sample values through the existing `matchFirewallBaseUrl` matcher.

## Verification
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-rule-validation.test.ts --run`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- pre-commit: `prettier`, `knip`, `check-types`
