### PR TITLE
chore: update amadeus icon colors

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/icons/amadeus.svg
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/icons/amadeus.svg
@@ -1,6 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="connector logo">
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  role="img"
+  aria-label="connector logo"
+>
   <!-- Official sources: https://developers.amadeus.com/favicon.ico and /assets/images/wordmark/Amadeus-Logo.svg -->
-  <rect width="24" height="24" rx="5" fill="#0C66E1"/>
+  <circle cx="12" cy="12" r="12" fill="#000835" />
   <path
     d="M6.7095 0.479095H1.66079V2.97362C4.06642 2.87905 4.74427 2.84753 5.79486 2.84753C7.45499 2.84753 8.43793 3.41554 8.43793 4.93165V5.91066H5.79486C1.35569 5.91066 0 7.58439 0 9.76307C0 12.5734 2.2365 13.5209 4.473 13.5209C6.7095 13.5209 8.06519 12.5419 8.50559 12.2576V13.3627H11.4199V4.55217C11.4199 1.5842 9.69149 0.479095 6.7095 0.479095ZM8.43793 10.6154C7.69244 10.8682 6.33675 11.3101 5.04936 11.3101C3.82963 11.3101 2.84669 10.8051 2.84669 9.57333C2.84669 8.46762 3.59219 7.89961 5.2185 7.83657L8.43793 7.70987V10.6154Z"
     fill="white"


### PR DESCRIPTION
## Summary
- update the Amadeus connector icon to use the official Developers favicon dark navy background color
- keep the official wordmark-derived white `a` glyph and SVG-only asset

## Verification
- parsed the SVG with Python XML parser
- checked there is no duplicate PNG asset
- ran targeted SVG prettier check via pre-commit

Closes #17184
