### PR TITLE
feat: enable chat recommended followups

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -112,7 +112,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
-      false,
+      true,
     );
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -327,8 +327,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "linghan@vm0.ai",
     description:
       "Generate and show recommended follow-up prompts after completed chat runs.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.PresentationHtmlPptxDownload]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable `ChatRecommendedFollowups` globally in the feature switch registry.
- Update the feature switch matrix test so non-staff orgs now receive the follow-up recommendations feature.

## Validation
- `pnpm prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`

Note: local type-check initially needed generated firewall files from latest `main`; ran `pnpm -F @vm0/firewalls-generator generate`, which left no tracked diff.
