### PR TITLE
fix: use system hostname for computer use hosts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -241,7 +241,7 @@ describe("desktop computer-use runtime", () => {
     const started = await accept(
       client.start({
         body: {
-          hostName: "Zero Desktop",
+          hostName: "lancy-macbook-pro.local",
           appVersion: "0.1.0",
           osVersion: "macOS 15",
           supportedCapabilities: [...supportedCapabilities],
@@ -261,7 +261,8 @@ describe("desktop computer-use runtime", () => {
     expect(listed.body.hosts).toHaveLength(1);
     expect(listed.body.hosts[0]).toMatchObject({
       id: started.body.hostId,
-      displayName: "Zero Desktop",
+      hostName: "lancy-macbook-pro.local",
+      displayName: "lancy-macbook-pro.local",
       status: "online",
       permissions: { accessibility: true, screenRecording: false },
     });

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -146,7 +146,7 @@ function generateOpaqueToken(prefix: string): string {
 }
 
 function normalizeHostName(hostName: string): string {
-  return hostName.trim().slice(0, 128);
+  return hostName.trim().slice(0, 253);
 }
 
 function normalizeVersion(version: string): string {
@@ -490,6 +490,7 @@ function timeoutErrorForCommand(
 function serializeHost(row: ComputerUseHostRow, now: Date) {
   return {
     id: row.id,
+    hostName: row.displayName,
     displayName: row.displayName,
     appVersion: row.appVersion,
     osVersion: row.osVersion,

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -1,6 +1,8 @@
+import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ComputerUseHostRuntime,
+  readSystemHostName,
   type ComputerUseHostFetch,
 } from "./computer-use-host";
 import type {
@@ -55,7 +57,7 @@ function createRuntime(
     });
   const runtime = new ComputerUseHostRuntime({
     platformUrl: new URL("https://app.vm0.ai"),
-    displayName: "Zero Desktop",
+    hostName: "lancy-macbook-pro.local",
     appVersion: "1.2.3",
     sessionFetch,
     hostFetch,
@@ -73,10 +75,24 @@ function createRuntime(
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
 describe("ComputerUseHostRuntime", () => {
+  it("reads the system hostname with an app-name fallback", () => {
+    const hostname = vi
+      .spyOn(os, "hostname")
+      .mockReturnValue(" lancy-macbook-pro.local ");
+
+    expect(readSystemHostName("Zero Computer Use")).toBe(
+      "lancy-macbook-pro.local",
+    );
+
+    hostname.mockReturnValue(" ");
+    expect(readSystemHostName("Zero Computer Use")).toBe("Zero Computer Use");
+  });
+
   it("does not register a host until manually started", async () => {
     vi.useFakeTimers();
     const { runtime, sessionFetch, hostFetch } = createRuntime();
@@ -105,7 +121,7 @@ describe("ComputerUseHostRuntime", () => {
     expect(url).toBe("https://api.vm0.ai/api/zero/computer-use/hosts/start");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      hostName: "Zero Desktop",
+      hostName: "lancy-macbook-pro.local",
       appVersion: "1.2.3",
       permissions: {
         accessibility: true,

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -32,7 +32,7 @@ type MaybePromise<T> = T | Promise<T>;
 
 interface ComputerUseHostRuntimeOptions {
   readonly platformUrl: URL;
-  readonly displayName: string;
+  readonly hostName: string;
   readonly appVersion: string;
   readonly sessionFetch: ComputerUseHostFetch;
   readonly hostFetch: ComputerUseHostFetch;
@@ -106,12 +106,12 @@ export function resolveComputerUseApiBaseUrl(platformUrl: URL): string {
 }
 
 export function buildComputerUseRuntimeBody(args: {
-  readonly displayName: string;
+  readonly hostName: string;
   readonly appVersion: string;
   readonly permissions: ComputerUsePermissionState;
 }): Record<string, unknown> {
   return {
-    hostName: args.displayName,
+    hostName: args.hostName,
     appVersion: args.appVersion,
     osVersion: `${os.type()} ${os.release()}`,
     supportedCapabilities: [...SUPPORTED_COMPUTER_USE_CAPABILITIES],
@@ -119,9 +119,14 @@ export function buildComputerUseRuntimeBody(args: {
   };
 }
 
+export function readSystemHostName(fallback: string): string {
+  const hostName = os.hostname().trim().replace(/\s+/g, " ");
+  return hostName || fallback;
+}
+
 export class ComputerUseHostRuntime {
   private readonly apiBaseUrl: string;
-  private readonly displayName: string;
+  private readonly hostName: string;
   private readonly appVersion: string;
   private readonly sessionFetch: ComputerUseHostFetch;
   private readonly hostFetchRequest: ComputerUseHostFetch;
@@ -149,7 +154,7 @@ export class ComputerUseHostRuntime {
 
   constructor(options: ComputerUseHostRuntimeOptions) {
     this.apiBaseUrl = resolveComputerUseApiBaseUrl(options.platformUrl);
-    this.displayName = options.displayName;
+    this.hostName = options.hostName;
     this.appVersion = options.appVersion;
     this.sessionFetch = options.sessionFetch;
     this.hostFetchRequest = options.hostFetch;
@@ -206,7 +211,7 @@ export class ComputerUseHostRuntime {
 
   private async runtimeBody(): Promise<Record<string, unknown>> {
     return buildComputerUseRuntimeBody({
-      displayName: this.displayName,
+      hostName: this.hostName,
       appVersion: this.appVersion,
       permissions: await this.getPermissions(),
     });

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -21,6 +21,7 @@ import {
 } from "./computer-use-electron";
 import {
   ComputerUseHostRuntime,
+  readSystemHostName,
   resolveComputerUseApiBaseUrl,
 } from "./computer-use-host";
 import {
@@ -341,7 +342,7 @@ async function startComputerUseRuntime(
   if (!computerUseRuntime) {
     computerUseRuntime = new ComputerUseHostRuntime({
       platformUrl: config.platformUrl,
-      displayName: config.identity.displayName,
+      hostName: readSystemHostName(config.identity.displayName),
       appVersion: app.getVersion(),
       sessionFetch: createDesktopComputerUseSessionFetch({
         platformUrl: config.platformUrl,

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -622,12 +622,12 @@ describe("computer use desktop runtime", () => {
   it("serializes the Desktop host runtime body", () => {
     expect(
       buildComputerUseRuntimeBody({
-        displayName: "Zero Desktop",
+        hostName: "lancy-macbook-pro.local",
         appVersion: "0.1.0",
         permissions: { accessibility: true, screenRecording: false },
       }),
     ).toMatchObject({
-      hostName: "Zero Desktop",
+      hostName: "lancy-macbook-pro.local",
       appVersion: "0.1.0",
       permissions: { accessibility: true, screenRecording: false },
     });

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -11,10 +11,12 @@ import { featureSwitch$ } from "../external/feature-switch.ts";
 export const ZERO_DESKTOP_DOWNLOAD_URL =
   "https://github.com/vm0-ai/vm0/releases/tag/desktop-updates";
 
-type OnlineComputerUseHost = Pick<
+interface OnlineComputerUseHost extends Pick<
   ComputerUseHost,
   "id" | "displayName" | "lastSeenAt"
->;
+> {
+  readonly hostName: string;
+}
 
 export function selectedOnlineComputerUseHostId(
   hosts: readonly { readonly id: string }[],
@@ -52,6 +54,7 @@ export const onlineComputerUseHosts$ = computed(
       .map((host) => {
         return {
           id: host.id,
+          hostName: host.hostName ?? host.displayName,
           displayName: host.displayName,
           lastSeenAt: host.lastSeenAt,
         };

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -286,6 +286,7 @@ export interface QueuedComposerItem {
 
 interface ComposerComputerUseHost {
   id: string;
+  hostName: string;
   displayName: string;
 }
 
@@ -1771,7 +1772,7 @@ function ComputerUsePopoverButton({
                       <IconDeviceDesktop size={16} stroke={1.5} />
                     </span>
                     <span className="text-sm flex-1 truncate text-foreground">
-                      {host.displayName}
+                      {host.hostName}
                     </span>
                     <LoadingSwitch
                       checked={checked}
@@ -1779,7 +1780,7 @@ function ComputerUsePopoverButton({
                         computerUse.onChange(nextChecked ? host.id : null);
                       }}
                       loading={false}
-                      ariaLabel={`${checked ? "Disable" : "Enable"} ${host.displayName}`}
+                      ariaLabel={`${checked ? "Disable" : "Enable"} ${host.hostName}`}
                       size="sm"
                     />
                   </div>

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -47,7 +47,7 @@ export const computerUseCommandErrorCodeSchema = z.enum([
   "timeout",
 ]);
 
-const hostNameSchema = z.string().trim().min(1).max(128);
+const hostNameSchema = z.string().trim().min(1).max(253);
 const hostVersionSchema = z.string().trim().min(1).max(64);
 const hostOsVersionSchema = z.string().trim().min(1).max(128);
 const hostIdPathParamsSchema = z.object({
@@ -319,6 +319,7 @@ export function isExpiredScreenshotPointer(
 
 export const computerUseHostSchema = z.object({
   id: z.string(),
+  hostName: z.string().optional(),
   displayName: z.string(),
   appVersion: z.string(),
   osVersion: z.string(),


### PR DESCRIPTION
## Summary
- Register desktop computer-use hosts with the system hostname instead of the desktop app display name.
- Expose `hostName` in the computer-use host list response while keeping `displayName` as a compatibility alias.
- Render `hostName` in the Zero chat computer-use picker.

## Notes
- The existing `computer_use_hosts.display_name` database column is kept for compatibility and stores the normalized hostname for now.
- Older desktop clients can still send the app display name until they upgrade; upgraded clients refresh the record through start/heartbeat.

## Tests
- `pnpm format`
- `pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts src/window-policy.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/zero-computer-use.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-computer-use.test.ts`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
