### PR TITLE
test: use session checkpoint guard consistently

### DIFF
--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -266,12 +266,10 @@ async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
 async fn send_event_extracts_claude_session_id() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
 
-    // Clean up session files from any prior run
     let sid_file = guest_agent::paths::session_id_file();
     let hist_file = guest_agent::paths::session_history_path_file();
-    let _ = std::fs::remove_file(sid_file);
-    let _ = std::fs::remove_file(hist_file);
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");
@@ -307,8 +305,6 @@ async fn send_event_extracts_claude_session_id() {
     );
 
     mock.delete_async().await;
-    let _ = std::fs::remove_file(sid_file);
-    let _ = std::fs::remove_file(hist_file);
 }
 
 #[tokio::test]
@@ -357,10 +353,9 @@ async fn send_event_rejects_unsafe_claude_session_id() {
 async fn send_event_skips_session_id_for_non_init() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
 
-    // Ensure no leftover session file
     let sid_file = guest_agent::paths::session_id_file();
-    let _ = std::fs::remove_file(sid_file);
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");


### PR DESCRIPTION
## Summary

- use `SessionCheckpointFilesGuard` in the two remaining event integration tests that touch session checkpoint files
- remove duplicated manual `remove_file` cleanup already covered by the guard
- keep production code and the guard implementation unchanged

Closes #17197

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration send_event_extracts_claude_session_id`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration send_event_skips_session_id_for_non_init`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings`

Note: an initial `cargo fmt --manifest-path crates/Cargo.toml --check` invocation failed because the Rust workspace manifest is virtual and requires `--all`; the corrected `cargo fmt --manifest-path crates/Cargo.toml --all --check` command passed.
