### PR TITLE
perf: avoid cloning mock codex prompt parts

### DIFF
--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -18,7 +18,7 @@ mod session;
 
 pub use events::build_events;
 pub use fixtures::{lookup_fixture, run_fixture};
-pub use prompt::join_prompt;
+pub use prompt::{join_prompt, join_prompt_cow};
 pub use session::{
     append_session_file, build_session_path, codex_home, emit_events, find_session_file,
     read_session_file, session_artifacts, session_files, write_session_file,

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -29,7 +29,7 @@
 //! codex-event-parser branches that the synthetic sequence cannot reach.
 
 use clap::{Parser, Subcommand};
-use guest_mock_codex::{join_prompt, lookup_fixture, run_fixture, run_new, run_resume};
+use guest_mock_codex::{join_prompt_cow, lookup_fixture, run_fixture, run_new, run_resume};
 use std::io;
 use std::path::PathBuf;
 
@@ -125,7 +125,13 @@ fn main() -> io::Result<()> {
         Cmd::Exec(ExecArgs {
             sub: Some(ExecSub::Resume { thread_id, prompt }),
             ..
-        }) => run_resume(&thread_id, &join_prompt(&prompt)),
-        Cmd::Exec(ExecArgs { prompt, .. }) => run_new(&join_prompt(&prompt)),
+        }) => {
+            let joined_prompt = join_prompt_cow(&prompt);
+            run_resume(&thread_id, joined_prompt.as_ref())
+        }
+        Cmd::Exec(ExecArgs { prompt, .. }) => {
+            let joined_prompt = join_prompt_cow(&prompt);
+            run_new(joined_prompt.as_ref())
+        }
     }
 }

--- a/crates/guest-mock-codex/src/prompt.rs
+++ b/crates/guest-mock-codex/src/prompt.rs
@@ -1,24 +1,48 @@
+use std::borrow::Cow;
+
 /// Join trailing positional args into a single prompt string. A leading `--`
 /// separator (sometimes left in by clap when `trailing_var_arg` is set) is
 /// dropped.
 pub fn join_prompt(parts: &[String]) -> String {
-    let mut iter = parts.iter().peekable();
-    if let Some(first) = iter.peek()
-        && first.as_str() == "--"
-    {
-        iter.next();
+    join_prompt_cow(parts).into_owned()
+}
+
+/// Join trailing positional args with the same separator handling as
+/// `join_prompt`, but without allocating when no owned output is needed.
+pub fn join_prompt_cow(parts: &[String]) -> Cow<'_, str> {
+    let parts = match parts {
+        [first, rest @ ..] if first.as_str() == "--" => rest,
+        _ => parts,
+    };
+
+    match parts {
+        [] => Cow::Borrowed(""),
+        [single] => Cow::Borrowed(single.as_str()),
+        _ => Cow::Owned(parts.join(" ")),
     }
-    iter.cloned().collect::<Vec<_>>().join(" ")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn parts(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
     #[test]
     fn join_prompt_joins_words() {
-        let parts = vec!["hello".to_string(), "world".to_string()];
+        let parts = parts(&["hello", "world"]);
         assert_eq!(join_prompt(&parts), "hello world");
+    }
+
+    #[test]
+    fn join_prompt_cow_owns_joined_words() {
+        let parts = parts(&["hello", "world"]);
+        match join_prompt_cow(&parts) {
+            Cow::Owned(prompt) => assert_eq!(prompt, "hello world"),
+            Cow::Borrowed(prompt) => panic!("expected owned joined prompt, got {prompt:?}"),
+        }
     }
 
     #[test]
@@ -27,14 +51,52 @@ mod tests {
     }
 
     #[test]
+    fn join_prompt_cow_borrows_empty_prompt() {
+        assert!(matches!(join_prompt_cow(&[]), Cow::Borrowed("")));
+    }
+
+    #[test]
+    fn join_prompt_cow_borrows_single_word() {
+        let parts = parts(&["hello"]);
+        assert!(matches!(join_prompt_cow(&parts), Cow::Borrowed("hello")));
+    }
+
+    #[test]
     fn join_prompt_strips_leading_double_dash() {
-        let parts = vec!["--".to_string(), "hi".to_string()];
+        let parts = parts(&["--", "hi"]);
         assert_eq!(join_prompt(&parts), "hi");
     }
 
     #[test]
+    fn join_prompt_strips_only_double_dash_to_empty_prompt() {
+        let parts = parts(&["--"]);
+        assert_eq!(join_prompt(&parts), "");
+        assert!(matches!(join_prompt_cow(&parts), Cow::Borrowed("")));
+    }
+
+    #[test]
+    fn join_prompt_strips_only_one_leading_double_dash() {
+        let parts = parts(&["--", "--"]);
+        assert_eq!(join_prompt(&parts), "--");
+        assert!(matches!(join_prompt_cow(&parts), Cow::Borrowed("--")));
+    }
+
+    #[test]
     fn join_prompt_keeps_internal_double_dash() {
-        let parts = vec!["foo".to_string(), "--".to_string(), "bar".to_string()];
+        let parts = parts(&["foo", "--", "bar"]);
         assert_eq!(join_prompt(&parts), "foo -- bar");
+    }
+
+    #[test]
+    fn join_prompt_preserves_empty_prompt_parts() {
+        for (values, expected) in [
+            (&["", "tail"][..], " tail"),
+            (&["head", ""][..], "head "),
+            (&["--", "", "tail"][..], " tail"),
+            (&["", ""][..], " "),
+        ] {
+            let parts = parts(values);
+            assert_eq!(join_prompt(&parts), expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Preserve the existing `join_prompt(parts) -> String` public API.
- Add a `join_prompt_cow` path for the mock Codex binary so empty and single-part prompts can be borrowed.
- Preserve multi-part prompt joining behavior while removing the cloned temporary `Vec<String>`.
- Keep `run_new`, `run_resume`, and event/session APIs unchanged.
- Add coverage for separator-only prompts and the borrowed/owned prompt boundary.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex prompt`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `cargo fmt --manifest-path crates/Cargo.toml -p guest-mock-codex --check`
- `git diff --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex --all-targets -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy, commitlint

Closes #17194
