### PR TITLE
refactor(vsock-guest): reuse error response helper in quiesce tests

### DIFF
--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -1,11 +1,19 @@
 use std::io::Write;
 
 use vsock_proto::{
-    self, ExecOutputPolicy, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
+    self, ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_WRITE_FILE,
 };
 
 use super::support::*;
+
+fn assert_error_contains(stream: &mut impl std::io::Read, seq: u32, expected_fragment: &str) {
+    let error = read_error_response(stream, seq);
+    assert!(
+        error.contains(expected_fragment),
+        "expected error to contain {expected_fragment:?}, got {error:?}",
+    );
+}
 
 #[test]
 fn quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes() {
@@ -21,14 +29,7 @@ fn quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes() {
     );
 
     send_quiesce_operations(&mut host_stream, 202);
-    let busy = read_message(&mut host_stream);
-    assert_eq!(busy.msg_type, MSG_ERROR);
-    assert_eq!(busy.seq, 202);
-    assert!(
-        vsock_proto::decode_error(&busy.payload)
-            .unwrap()
-            .contains("guest operations still pending: 1")
-    );
+    assert_error_contains(&mut host_stream, 202, "guest operations still pending: 1");
 
     send_exec_start(
         &mut host_stream,
@@ -38,14 +39,7 @@ fn quiesce_busy_fences_new_exec_operations_until_pending_exec_finishes() {
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Discard,
     );
-    let fenced = read_message(&mut host_stream);
-    assert_eq!(fenced.msg_type, MSG_ERROR);
-    assert_eq!(fenced.seq, 203);
-    assert!(
-        vsock_proto::decode_error(&fenced.payload)
-            .unwrap()
-            .contains("guest operations are quiescing")
-    );
+    assert_error_contains(&mut host_stream, 203, "guest operations are quiescing");
 
     send_exec_cancel(&mut host_stream, 201);
     let (_chunks, cancelled) = read_exec_result(&mut host_stream, 201);
@@ -91,14 +85,7 @@ fn quiesced_connection_rejects_write_file_without_creating_file() {
     let msg = vsock_proto::encode(MSG_WRITE_FILE, 212, &payload).unwrap();
     host_stream.write_all(&msg).unwrap();
 
-    let fenced = read_message(&mut host_stream);
-    assert_eq!(fenced.msg_type, MSG_ERROR);
-    assert_eq!(fenced.seq, 212);
-    assert!(
-        vsock_proto::decode_error(&fenced.payload)
-            .unwrap()
-            .contains("guest operations are quiescing")
-    );
+    assert_error_contains(&mut host_stream, 212, "guest operations are quiescing");
     assert!(!std::path::Path::new(path.as_str()).exists());
 
     send_resume_operations(&mut host_stream, 213);
@@ -118,14 +105,7 @@ fn quiesced_connection_rejects_new_operation_without_decoding_payload() {
 
     let malformed_start = vsock_proto::encode(MSG_EXEC_START, 217, b"malformed").unwrap();
     host_stream.write_all(&malformed_start).unwrap();
-    let fenced = read_message(&mut host_stream);
-    assert_eq!(fenced.msg_type, MSG_ERROR);
-    assert_eq!(fenced.seq, 217);
-    assert!(
-        vsock_proto::decode_error(&fenced.payload)
-            .unwrap()
-            .contains("guest operations are quiescing")
-    );
+    assert_error_contains(&mut host_stream, 217, "guest operations are quiescing");
 
     send_resume_operations(&mut host_stream, 218);
     let resumed = read_message(&mut host_stream);
@@ -192,14 +172,7 @@ fn quiesce_operations_is_idempotent_while_quiesced() {
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Discard,
     );
-    let fenced = read_message(&mut host_stream);
-    assert_eq!(fenced.msg_type, MSG_ERROR);
-    assert_eq!(fenced.seq, 225);
-    assert!(
-        vsock_proto::decode_error(&fenced.payload)
-            .unwrap()
-            .contains("guest operations are quiescing")
-    );
+    assert_error_contains(&mut host_stream, 225, "guest operations are quiescing");
 
     send_resume_operations(&mut host_stream, 226);
     let resumed = read_message(&mut host_stream);
@@ -214,13 +187,10 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
     let (handle, mut host_stream) = start_guest_connection();
 
     send_control_payload(&mut host_stream, MSG_QUIESCE_OPERATIONS, 227, b"unexpected");
-    let quiesce_error = read_message(&mut host_stream);
-    assert_eq!(quiesce_error.msg_type, MSG_ERROR);
-    assert_eq!(quiesce_error.seq, 227);
-    assert!(
-        vsock_proto::decode_error(&quiesce_error.payload)
-            .unwrap()
-            .contains("quiesce_operations payload must be empty")
+    assert_error_contains(
+        &mut host_stream,
+        227,
+        "quiesce_operations payload must be empty",
     );
 
     send_exec_start(
@@ -244,13 +214,10 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
     assert_eq!(quiesced.seq, 229);
 
     send_control_payload(&mut host_stream, MSG_RESUME_OPERATIONS, 230, b"unexpected");
-    let resume_error = read_message(&mut host_stream);
-    assert_eq!(resume_error.msg_type, MSG_ERROR);
-    assert_eq!(resume_error.seq, 230);
-    assert!(
-        vsock_proto::decode_error(&resume_error.payload)
-            .unwrap()
-            .contains("resume_operations payload must be empty")
+    assert_error_contains(
+        &mut host_stream,
+        230,
+        "resume_operations payload must be empty",
     );
 
     send_exec_start(
@@ -261,14 +228,7 @@ fn malformed_quiesce_resume_payloads_do_not_change_state() {
         ExecOutputPolicy::Capture { limit_bytes: 64 },
         ExecOutputPolicy::Discard,
     );
-    let fenced = read_message(&mut host_stream);
-    assert_eq!(fenced.msg_type, MSG_ERROR);
-    assert_eq!(fenced.seq, 231);
-    assert!(
-        vsock_proto::decode_error(&fenced.payload)
-            .unwrap()
-            .contains("guest operations are quiescing")
-    );
+    assert_error_contains(&mut host_stream, 231, "guest operations are quiescing");
 
     send_resume_operations(&mut host_stream, 232);
     let resumed = read_message(&mut host_stream);
@@ -292,14 +252,7 @@ fn resume_operations_reopens_after_busy_quiesce_with_pending_operation() {
     );
 
     send_quiesce_operations(&mut host_stream, 242);
-    let busy = read_message(&mut host_stream);
-    assert_eq!(busy.msg_type, MSG_ERROR);
-    assert_eq!(busy.seq, 242);
-    assert!(
-        vsock_proto::decode_error(&busy.payload)
-            .unwrap()
-            .contains("guest operations still pending: 1")
-    );
+    assert_error_contains(&mut host_stream, 242, "guest operations still pending: 1");
 
     send_resume_operations(&mut host_stream, 243);
     let resumed = read_message(&mut host_stream);


### PR DESCRIPTION
## Summary

- Add a local `assert_error_contains` helper in the quiesce connection tests that delegates to `read_error_response`.
- Replace repeated manual `MSG_ERROR` / sequence / `decode_error` assertions in `quiesce.rs`.
- Remove the now-unused `MSG_ERROR` import from `quiesce.rs`.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest connection`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- pre-commit hook: crates `cargo-fmt`, `cargo-doc`, `cargo-clippy`, commitlint

Closes #17196
