### PR TITLE
perf(mitm-addon): cache unsafe path scans

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1763,6 +1763,7 @@ def match_compiled_firewall_request(
     upper_method = method.upper()
 
     decision = _FirewallDecisionState()
+    unsafe_path: bool | None = True if url_has_backslash else None
 
     for fw_entry in compiled_firewalls.firewalls:
         policy = compiled_network_policies.policies.get(fw_entry.name)
@@ -1774,7 +1775,10 @@ def match_compiled_firewall_request(
 
             rel_path, base_params = base_result
 
-            if url_has_backslash or has_unsafe_path(url_parts.path):
+            if unsafe_path is None:
+                unsafe_path = has_unsafe_path(url_parts.path)
+
+            if unsafe_path:
                 return FirewallBlock(
                     api_entry.base.raw,
                     fw_entry.name,

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
@@ -147,6 +147,49 @@ def test_compiled_blocks_unsafe_path_consumed_by_parameterized_base():
     assert compiled.path == "/admin"
 
 
+def test_compiled_reuses_safe_path_scan_for_multiple_base_matches(monkeypatch):
+    first_api_entry = {
+        "base": "https://api.example.com",
+        "auth": {"headers": {"Authorization": "Bearer first"}},
+        "permissions": [{"name": "read", "rules": ["GET /items/{id}"]}],
+    }
+    second_api_entry = {
+        "base": "https://api.example.com",
+        "auth": {"headers": {"Authorization": "Bearer second"}},
+        "permissions": [{"name": "write", "rules": ["POST /items/{id}"]}],
+    }
+    third_api_entry = {
+        "base": "https://api.example.com",
+        "auth": {"headers": {"Authorization": "Bearer third"}},
+        "permissions": [],
+    }
+    fws = wrap_firewalls(
+        [first_api_entry, second_api_entry, third_api_entry],
+        name="example",
+    )
+    policies = {"example": {"allow": ["read", "write"], "deny": [], "unknownPolicy": "allow"}}
+    calls: list[str] = []
+    original_has_unsafe_path = matching.has_unsafe_path
+
+    def counting_has_unsafe_path(path: str) -> bool:
+        calls.append(path)
+        return original_has_unsafe_path(path)
+
+    monkeypatch.setattr(matching, "has_unsafe_path", counting_has_unsafe_path)
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com/items/123",
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.api_entry is first_api_entry
+    assert result.permission == "read"
+    assert calls == ["/items/123"]
+
+
 def test_compiled_matches_unknown_policy_when_permissions_are_omitted():
     fws = wrap_firewalls(
         [


### PR DESCRIPTION
## Summary

- Cache the request unsafe-path boolean after the first compiled firewall base match.
- Preserve existing unsafe_path block construction at the active matched base.
- Add a regression test proving multiple safe matching bases scan the path once.

Closes #17198

## Tests

- .venv/bin/python -m pytest tests/test_compiled_firewall_unknown_policy.py
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/basedpyright -p .