### PR TITLE
fix(cli): add --file option to zero video transcribe

### DIFF
--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -147,13 +147,14 @@ describe("zero video transcribe command", () => {
         }),
       );
 
-      await transcribeCommand.parseAsync(
-        ["--file", "/tmp/some-video.mp4"],
-        { from: "user" },
-      );
+      await transcribeCommand.parseAsync(["--file", "/tmp/some-video.mp4"], {
+        from: "user",
+      });
 
       const execCalls = vi.mocked(execFileSync).mock.calls;
-      const curlCalls = execCalls.filter((c) => c[0] === "curl");
+      const curlCalls = execCalls.filter((c) => {
+        return c[0] === "curl";
+      });
       expect(curlCalls).toHaveLength(0);
     });
 
@@ -162,17 +163,14 @@ describe("zero video transcribe command", () => {
         http.post(STT_URL, () => {
           return HttpResponse.json({
             text: "Local file transcript.",
-            segments: [
-              { start: 0, end: 2, text: " Local file transcript." },
-            ],
+            segments: [{ start: 0, end: 2, text: " Local file transcript." }],
           });
         }),
       );
 
-      await transcribeCommand.parseAsync(
-        ["--file", "/tmp/some-video.mp4"],
-        { from: "user" },
-      );
+      await transcribeCommand.parseAsync(["--file", "/tmp/some-video.mp4"], {
+        from: "user",
+      });
 
       const output = readStdout();
       expect(output).toContain("## Transcript");

--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -138,8 +138,50 @@ describe("zero video transcribe command", () => {
     });
   });
 
+  describe("with --file", () => {
+    it("does not call curl when --file is provided", async () => {
+      const { execFileSync } = await import("child_process");
+      server.use(
+        http.post(STT_URL, () => {
+          return HttpResponse.json({ text: "Local file transcript." });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(
+        ["--file", "/tmp/some-video.mp4"],
+        { from: "user" },
+      );
+
+      const execCalls = vi.mocked(execFileSync).mock.calls;
+      const curlCalls = execCalls.filter((c) => c[0] === "curl");
+      expect(curlCalls).toHaveLength(0);
+    });
+
+    it("transcribes the local file and outputs the result", async () => {
+      server.use(
+        http.post(STT_URL, () => {
+          return HttpResponse.json({
+            text: "Local file transcript.",
+            segments: [
+              { start: 0, end: 2, text: " Local file transcript." },
+            ],
+          });
+        }),
+      );
+
+      await transcribeCommand.parseAsync(
+        ["--file", "/tmp/some-video.mp4"],
+        { from: "user" },
+      );
+
+      const output = readStdout();
+      expect(output).toContain("## Transcript");
+      expect(output).toContain("Local file transcript.");
+    });
+  });
+
   describe("missing arguments", () => {
-    it("exits with error when neither --url nor --file-id provided", async () => {
+    it("exits with error when neither --url nor --file-id nor --file provided", async () => {
       const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
         throw new Error("process.exit called");
       }) as never);

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -84,50 +84,15 @@ Notes:
         }
 
         const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.wav`);
+        let tmpVideo: string | undefined;
 
-        if (options.file) {
-          // Use local file directly — no download needed
-          const videoPath = options.file;
-          try {
-            execFileSync(
-              "ffmpeg",
-              [
-                "-i",
-                videoPath,
-                "-vn",
-                "-ar",
-                "16000",
-                "-ac",
-                "1",
-                "-c:a",
-                "pcm_s16le",
-                "-map_metadata",
-                "-1",
-                tmpAudio,
-                "-y",
-                "-loglevel",
-                "error",
-              ],
-              { stdio: ["ignore", "ignore", "pipe"] },
-            );
+        try {
+          let videoPath: string;
 
-            const result = await transcribeAudio(tmpAudio, {
-              verbose: options.timestamps !== false,
-            });
-
-            process.stdout.write(
-              formatTranscript(result.text, result.segments) + "\n",
-            );
-          } finally {
-            try {
-              unlinkSync(tmpAudio);
-            } catch {
-              // best-effort cleanup
-            }
-          }
-        } else {
-          const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
-          try {
+          if (options.file) {
+            videoPath = options.file;
+          } else {
+            tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
             if (options.url) {
               execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
                 stdio: ["ignore", "ignore", "pipe"],
@@ -135,43 +100,45 @@ Notes:
             } else {
               await downloadWebFile(options.fileId as string, tmpVideo);
             }
+            videoPath = tmpVideo;
+          }
 
-            execFileSync(
-              "ffmpeg",
-              [
-                "-i",
-                tmpVideo,
-                "-vn",
-                "-ar",
-                "16000",
-                "-ac",
-                "1",
-                "-c:a",
-                "pcm_s16le",
-                "-map_metadata",
-                "-1",
-                tmpAudio,
-                "-y",
-                "-loglevel",
-                "error",
-              ],
-              { stdio: ["ignore", "ignore", "pipe"] },
-            );
+          execFileSync(
+            "ffmpeg",
+            [
+              "-i",
+              videoPath,
+              "-vn",
+              "-ar",
+              "16000",
+              "-ac",
+              "1",
+              "-c:a",
+              "pcm_s16le",
+              "-map_metadata",
+              "-1",
+              tmpAudio,
+              "-y",
+              "-loglevel",
+              "error",
+            ],
+            { stdio: ["ignore", "ignore", "pipe"] },
+          );
 
-            const result = await transcribeAudio(tmpAudio, {
-              verbose: options.timestamps !== false,
-            });
+          const result = await transcribeAudio(tmpAudio, {
+            verbose: options.timestamps !== false,
+          });
 
-            process.stdout.write(
-              formatTranscript(result.text, result.segments) + "\n",
-            );
-          } finally {
-            for (const path of [tmpVideo, tmpAudio]) {
-              try {
-                unlinkSync(path);
-              } catch {
-                // best-effort cleanup
-              }
+          process.stdout.write(
+            formatTranscript(result.text, result.segments) + "\n",
+          );
+        } finally {
+          for (const path of [tmpAudio, tmpVideo]) {
+            if (!path) continue;
+            try {
+              unlinkSync(path);
+            } catch {
+              // best-effort cleanup
             }
           }
         }

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -42,6 +42,7 @@ export const transcribeCommand = new Command()
   )
   .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
   .option("--file-id <id>", "Web file ID (alternative to --url)")
+  .option("--file <path>", "Local file path (alternative to --url or --file-id)")
   .option(
     "--no-timestamps",
     "Output plain text only, without per-segment timestamps",
@@ -52,6 +53,7 @@ export const transcribeCommand = new Command()
 Examples:
   Transcribe from URL:      zero video transcribe --url "https://..."
   Transcribe a web file:    zero video transcribe --file-id abc-123-def
+  Transcribe a local file:  zero video transcribe --file /tmp/video.mp4
   Plain text only:          zero video transcribe --url "https://..." --no-timestamps
 
 Output:
@@ -71,62 +73,105 @@ Notes:
       async (options: {
         url?: string;
         fileId?: string;
+        file?: string;
         timestamps: boolean;
       }) => {
-        if (!options.url && !options.fileId) {
+        if (!options.url && !options.fileId && !options.file) {
           process.stderr.write(
-            "Error: provide --url <presigned-url> or --file-id <id>\n",
+            "Error: provide --url <presigned-url>, --file-id <id>, or --file <path>\n",
           );
           process.exit(1);
         }
 
-        const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
         const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.wav`);
 
-        try {
-          if (options.url) {
-            execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
-              stdio: ["ignore", "ignore", "pipe"],
+        if (options.file) {
+          // Use local file directly — no download needed
+          const videoPath = options.file;
+          try {
+            execFileSync(
+              "ffmpeg",
+              [
+                "-i",
+                videoPath,
+                "-vn",
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                "-c:a",
+                "pcm_s16le",
+                "-map_metadata",
+                "-1",
+                tmpAudio,
+                "-y",
+                "-loglevel",
+                "error",
+              ],
+              { stdio: ["ignore", "ignore", "pipe"] },
+            );
+
+            const result = await transcribeAudio(tmpAudio, {
+              verbose: options.timestamps !== false,
             });
-          } else {
-            await downloadWebFile(options.fileId as string, tmpVideo);
-          }
 
-          execFileSync(
-            "ffmpeg",
-            [
-              "-i",
-              tmpVideo,
-              "-vn",
-              "-ar",
-              "16000",
-              "-ac",
-              "1",
-              "-c:a",
-              "pcm_s16le",
-              "-map_metadata",
-              "-1",
-              tmpAudio,
-              "-y",
-              "-loglevel",
-              "error",
-            ],
-            { stdio: ["ignore", "ignore", "pipe"] },
-          );
-
-          const result = await transcribeAudio(tmpAudio, {
-            verbose: options.timestamps !== false,
-          });
-
-          process.stdout.write(
-            formatTranscript(result.text, result.segments) + "\n",
-          );
-        } finally {
-          for (const path of [tmpVideo, tmpAudio]) {
+            process.stdout.write(
+              formatTranscript(result.text, result.segments) + "\n",
+            );
+          } finally {
             try {
-              unlinkSync(path);
+              unlinkSync(tmpAudio);
             } catch {
               // best-effort cleanup
+            }
+          }
+        } else {
+          const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+          try {
+            if (options.url) {
+              execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
+                stdio: ["ignore", "ignore", "pipe"],
+              });
+            } else {
+              await downloadWebFile(options.fileId as string, tmpVideo);
+            }
+
+            execFileSync(
+              "ffmpeg",
+              [
+                "-i",
+                tmpVideo,
+                "-vn",
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                "-c:a",
+                "pcm_s16le",
+                "-map_metadata",
+                "-1",
+                tmpAudio,
+                "-y",
+                "-loglevel",
+                "error",
+              ],
+              { stdio: ["ignore", "ignore", "pipe"] },
+            );
+
+            const result = await transcribeAudio(tmpAudio, {
+              verbose: options.timestamps !== false,
+            });
+
+            process.stdout.write(
+              formatTranscript(result.text, result.segments) + "\n",
+            );
+          } finally {
+            for (const path of [tmpVideo, tmpAudio]) {
+              try {
+                unlinkSync(path);
+              } catch {
+                // best-effort cleanup
+              }
             }
           }
         }

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -42,7 +42,10 @@ export const transcribeCommand = new Command()
   )
   .option("--url <presigned-url>", "Pre-signed or public URL of the video file")
   .option("--file-id <id>", "Web file ID (alternative to --url)")
-  .option("--file <path>", "Local file path (alternative to --url or --file-id)")
+  .option(
+    "--file <path>",
+    "Local file path (alternative to --url or --file-id)",
+  )
   .option(
     "--no-timestamps",
     "Output plain text only, without per-segment timestamps",


### PR DESCRIPTION
## Summary

- Adds `--file <path>` option to `zero video transcribe` as a third input method alongside `--url` and `--file-id`
- When `--file` is provided, the download step (curl/downloadWebFile) is skipped entirely and the local path is used directly as the video input for ffmpeg
- Refactors temp-file lifecycle: `tmpVideo` is only created and cleaned up in the download path; the `--file` path uses only `tmpAudio` as a temp file
- Updates validation error message to mention all three options
- Updates help text examples to include the new `--file` usage

## Test plan

- [ ] New `describe("with --file")` block covers two cases:
  - `execFileSync` is NOT called with `curl` when `--file` is passed
  - Transcription output is correct (ffmpeg mock writes fake audio, STT mock returns text)
- [ ] `missing arguments` test updated to expect the new three-option error message
- [ ] Existing `--url`, `--file-id`, and `--no-timestamps` tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)