### PR TITLE
fix: clear desktop computer use claim errors on idle

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -213,6 +213,45 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("keeps heartbeat deactivation when a late idle command poll resolves", async () => {
+    vi.useFakeTimers();
+    const heartbeat = deferred<Response>();
+    const commandPoll = deferred<Response>();
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return heartbeat.promise;
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        return commandPoll.promise;
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    heartbeat.resolve(new Response("{}", { status: 401 }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(runtime.getState()).toMatchObject({
+      status: "unauthenticated",
+      hostId: null,
+      lastError:
+        "Desktop host could not authenticate with the API session. Sign in and retry.",
+    });
+
+    commandPoll.resolve(jsonResponse({ status: "idle" }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(runtime.getState()).toMatchObject({
+      status: "unauthenticated",
+      hostId: null,
+      lastError:
+        "Desktop host could not authenticate with the API session. Sign in and retry.",
+    });
+  });
+
   it("records local native command payloads and results", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T08:00:00.000Z"));

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -173,6 +173,46 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("clears a command polling error when the next idle claim succeeds", async () => {
+    vi.useFakeTimers();
+    const heartbeat = deferred<Response>();
+    let nextCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return heartbeat.promise;
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? new Response("{}", { status: 500 })
+          : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/stop")) {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(runtime.getState()).toMatchObject({
+      status: "error",
+      lastError: "Computer Use command claim failed: 500",
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(nextCalls).toBe(2);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+    });
+
+    await runtime.stop();
+  });
+
   it("records local native command payloads and results", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T08:00:00.000Z"));

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -512,6 +512,9 @@ export class ComputerUseHostRuntime {
     }
     const body = (await next.json()) as ComputerUseHostNextResponse;
     if (body.status === "idle") {
+      if (!this.running || !this.hostToken) {
+        return;
+      }
       this.setState({
         status: "online",
         lastError: null,

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -512,6 +512,10 @@ export class ComputerUseHostRuntime {
     }
     const body = (await next.json()) as ComputerUseHostNextResponse;
     if (body.status === "idle") {
+      this.setState({
+        status: "online",
+        lastError: null,
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Clear stale Computer Use command polling errors after a successful idle claim response.
- Add a regression test for transient 500 claim failures recovering on the next idle poll.

## Tests
- pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm exec prettier --check apps/desktop/src/computer-use-host.ts apps/desktop/src/computer-use-host.test.ts
- git diff --check