### PR TITLE
feat: promote computer-use to seed skill

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -3031,6 +3031,42 @@ describe("POST /api/zero/runs", () => {
     expect(volumes[customIndex]?.system).toBeUndefined();
   });
 
+  it("does not let custom skills override seed skill volumes", async () => {
+    const fx = await fixture();
+    const agent = await seedRunnableZeroAgent({
+      fixture: fx,
+      customSkills: ["computer-use"],
+    });
+
+    const response = await accept(
+      zeroRunsClient().create({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { prompt: "use computer use", agentId: agent.agentId },
+      }),
+      [201],
+    );
+
+    const db = store.set(writeDb$);
+    const [run] = await db
+      .select({ additionalVolumes: agentRuns.additionalVolumes })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId));
+    const volumes = run?.additionalVolumes ?? [];
+    const computerUseVolumes = volumes.filter((volume) => {
+      return volume.mountPath === "/home/user/.claude/skills/computer-use";
+    });
+
+    expect(computerUseVolumes).toHaveLength(1);
+    expect(computerUseVolumes[0]).toMatchObject({
+      system: true,
+    });
+    expect(
+      volumes.some((volume) => {
+        return volume.name === "custom-skill@computer-use";
+      }),
+    ).toBeFalsy();
+  });
+
   it("mounts skills using the model provider framework, not the compose framework", async () => {
     const fx = await fixture();
     await trackModelProviders(Promise.resolve({ orgId: fx.orgId }));

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -485,12 +485,16 @@ function buildCustomSkillVolumes(
   customSkills: readonly string[],
   framework: SupportedFramework,
 ): readonly AdditionalVolume[] {
-  return customSkills.map((name) => {
-    return {
-      name: getCustomSkillStorageName(name),
-      mountPath: skillMountPath(framework, name),
-    };
-  });
+  return customSkills
+    .filter((name) => {
+      return !SEED_SKILLS.includes(name);
+    })
+    .map((name) => {
+      return {
+        name: getCustomSkillStorageName(name),
+        mountPath: skillMountPath(framework, name),
+      };
+    });
 }
 
 function buildInjectedSkillVolumes(

--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -16,6 +16,7 @@ export const SEED_SKILLS: readonly string[] = [
   "audit-readiness",
   "brand-guidelines",
   "campaign-strategy",
+  "computer-use",
   "competitor-matrix",
   "contract-redline",
   "copywriting",


### PR DESCRIPTION
## Summary

- Add `computer-use` to the server-side `SEED_SKILLS` list.
- Filter custom skills whose names are already seed skills so an old org custom skill cannot override the seed volume at runtime.
- Add a regression test for the seed/custom collision behavior.

## Companion PR

- vm0-ai/vm0-skills#254 adds the `computer-use` seed skill content.

## Validation

- `pnpm exec prettier --write packages/core/src/zero-seed-skills.ts apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts` passed.
- `pnpm -F @vm0/core check-types` passed.
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts -t "does not let custom skills override seed skill volumes"` could not complete locally because the test fixture requires Postgres on `localhost:5432`, which is not running in this environment.
- `pnpm -F api check-types` exceeded local memory; retrying with `NODE_OPTIONS=--max-old-space-size=8192` was killed by the host. CI should be used as the authoritative API type/test validation.

Refs #17221.
