### PR TITLE
feat(desktop): silently install idle auto-updates

### DIFF
--- a/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS,
+  shouldNotifyUserForDesktopUpdate,
+} from "./desktop-auto-update-policy";
+import type {
+  ComputerUseHostRuntimeState,
+  ComputerUseLocalCommandLogEntry,
+} from "./computer-use-types";
+
+const now = Date.parse("2026-06-11T12:00:00.000Z");
+
+function isoAgo(ms: number): string {
+  return new Date(now - ms).toISOString();
+}
+
+function commandEntry(
+  overrides: Partial<ComputerUseLocalCommandLogEntry>,
+): ComputerUseLocalCommandLogEntry {
+  return {
+    commandId: "command-1",
+    kind: "click",
+    app: "Safari",
+    status: "succeeded",
+    payload: {},
+    result: null,
+    error: null,
+    startedAt: isoAgo(60 * 60 * 1000),
+    completedAt: isoAgo(60 * 60 * 1000),
+    durationMs: 100,
+    ...overrides,
+  };
+}
+
+function hostState(
+  overrides: Partial<ComputerUseHostRuntimeState>,
+): ComputerUseHostRuntimeState {
+  return {
+    status: "idle",
+    hostId: null,
+    lastHeartbeatAt: null,
+    lastCommandAt: null,
+    lastError: null,
+    errorLog: [],
+    recentAuditEvents: [],
+    localCommandLog: [],
+    ...overrides,
+  };
+}
+
+describe("desktop auto-update policy", () => {
+  it("allows silent restart when there is no command activity", () => {
+    expect(shouldNotifyUserForDesktopUpdate(hostState({}), now)).toBe(false);
+  });
+
+  it("allows silent restart when the last command is older than 30 minutes", () => {
+    expect(
+      shouldNotifyUserForDesktopUpdate(
+        hostState({
+          lastCommandAt: isoAgo(DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS + 1),
+        }),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("notifies when the last command completed within 30 minutes", () => {
+    expect(
+      shouldNotifyUserForDesktopUpdate(
+        hostState({
+          lastCommandAt: isoAgo(DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS - 1),
+        }),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("notifies when a local command log entry completed within 30 minutes", () => {
+    expect(
+      shouldNotifyUserForDesktopUpdate(
+        hostState({
+          localCommandLog: [
+            commandEntry({
+              startedAt: isoAgo(DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS + 1),
+              completedAt: isoAgo(DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS - 1),
+            }),
+          ],
+        }),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("notifies while a command is still running", () => {
+    expect(
+      shouldNotifyUserForDesktopUpdate(
+        hostState({
+          localCommandLog: [
+            commandEntry({
+              status: "running",
+              completedAt: null,
+              startedAt: isoAgo(2 * 60 * 60 * 1000),
+            }),
+          ],
+        }),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores malformed timestamps", () => {
+    expect(
+      shouldNotifyUserForDesktopUpdate(
+        hostState({
+          lastCommandAt: "not-a-date",
+          localCommandLog: [
+            commandEntry({
+              startedAt: "not-a-date",
+              completedAt: "not-a-date",
+            }),
+          ],
+        }),
+        now,
+      ),
+    ).toBe(false);
+  });
+});

--- a/turbo/apps/desktop/src/desktop-auto-update-policy.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.ts
@@ -1,0 +1,38 @@
+import type { ComputerUseHostRuntimeState } from "./computer-use-types";
+
+export const DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS = 30 * 60 * 1000;
+
+function timestampMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isRecentTimestamp(value: string | null, nowMs: number): boolean {
+  const parsed = timestampMs(value);
+  return (
+    parsed !== null && parsed >= nowMs - DESKTOP_UPDATE_SILENT_RESTART_IDLE_MS
+  );
+}
+
+export function shouldNotifyUserForDesktopUpdate(
+  hostState: ComputerUseHostRuntimeState,
+  nowMs = Date.now(),
+): boolean {
+  if (isRecentTimestamp(hostState.lastCommandAt, nowMs)) {
+    return true;
+  }
+
+  return hostState.localCommandLog.some((entry) => {
+    if (entry.status === "running") {
+      return true;
+    }
+    return (
+      isRecentTimestamp(entry.startedAt, nowMs) ||
+      isRecentTimestamp(entry.completedAt, nowMs)
+    );
+  });
+}

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DesktopConfig } from "./config";
+import { IDLE_COMPUTER_USE_HOST_STATE } from "./computer-use-types";
+import type { ComputerUseHostRuntimeState } from "./computer-use-types";
+import { installDesktopAutoUpdates } from "./desktop-auto-updates";
+
+const mocks = vi.hoisted(() => ({
+  app: { isPackaged: true },
+  autoUpdater: {
+    quitAndInstall: vi.fn(),
+  },
+  dialog: {
+    showMessageBox: vi.fn<() => Promise<{ response: number }>>(),
+  },
+  updateElectronApp: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: mocks.app,
+  autoUpdater: mocks.autoUpdater,
+  dialog: mocks.dialog,
+}));
+
+vi.mock("update-electron-app", () => ({
+  UpdateSourceType: {
+    StaticStorage: "staticStorage",
+  },
+  updateElectronApp: mocks.updateElectronApp,
+}));
+
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+const productionConfig: DesktopConfig = {
+  platformUrl: new URL("https://app.vm0.ai"),
+  webUrl: new URL("https://www.vm0.ai"),
+  environment: "production",
+  identity: {
+    displayName: "Zero Computer Use",
+    bundleId: "ai.vm0.desktop",
+    authProtocolName: "Zero Computer Use",
+    authScheme: "vm0",
+  },
+  sessionPartition: "persist:vm0-desktop-production",
+  allowedAppOrigins: new Set(["https://app.vm0.ai"]),
+};
+
+interface CapturedUpdateOptions {
+  readonly onNotifyUser: (info: { readonly releaseName: string }) => void;
+}
+
+function stubDesktopAutoUpdatePlatform(): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: "darwin",
+  });
+  Object.defineProperty(process, "arch", {
+    configurable: true,
+    value: "arm64",
+  });
+}
+
+function installAndCaptureUpdateOptions(
+  getComputerUseHostState: () => ComputerUseHostRuntimeState,
+): {
+  readonly updateOptions: CapturedUpdateOptions;
+  readonly prepareForQuitAndInstall: ReturnType<typeof vi.fn>;
+} {
+  const prepareForQuitAndInstall = vi.fn(async () => {});
+
+  expect(
+    installDesktopAutoUpdates({
+      config: productionConfig,
+      apiBaseUrl: "https://api.vm0.ai",
+      getComputerUseHostState,
+      prepareForQuitAndInstall,
+    }),
+  ).toBe(true);
+
+  expect(mocks.updateElectronApp).toHaveBeenCalledTimes(1);
+  const [updateOptions] = mocks.updateElectronApp.mock.calls[0] ?? [];
+  expect(updateOptions).toEqual(
+    expect.objectContaining({
+      notifyUser: true,
+      updateInterval: "30 minutes",
+      updateSource: expect.objectContaining({
+        baseUrl: "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+      }),
+    }),
+  );
+
+  return {
+    updateOptions: updateOptions as CapturedUpdateOptions,
+    prepareForQuitAndInstall,
+  };
+}
+
+async function flushDownloadedUpdateCallback(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await Promise.resolve();
+}
+
+describe("desktop auto-updates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.app.isPackaged = true;
+    mocks.dialog.showMessageBox.mockResolvedValue({ response: 1 });
+    stubDesktopAutoUpdatePlatform();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    Object.defineProperty(process, "arch", {
+      configurable: true,
+      value: originalArch,
+    });
+  });
+
+  it("silently restarts after a downloaded update when Computer Use is idle", async () => {
+    const { updateOptions, prepareForQuitAndInstall } =
+      installAndCaptureUpdateOptions(() => IDLE_COMPUTER_USE_HOST_STATE);
+
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+
+    await vi.waitFor(() => {
+      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("prompts instead of silently restarting during recent command activity", async () => {
+    const { updateOptions, prepareForQuitAndInstall } =
+      installAndCaptureUpdateOptions(() => ({
+        ...IDLE_COMPUTER_USE_HOST_STATE,
+        lastCommandAt: new Date().toISOString(),
+      }));
+
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    await flushDownloadedUpdateCallback();
+
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Zero 1.2.3",
+      }),
+    );
+    expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it("prompts when Computer Use activity inspection fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { updateOptions, prepareForQuitAndInstall } =
+      installAndCaptureUpdateOptions(() => {
+        throw new Error("state unavailable");
+      });
+
+    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    await flushDownloadedUpdateCallback();
+
+    expect(warn).toHaveBeenCalledWith(
+      "Unable to inspect Computer Use activity for update",
+      expect.any(Error),
+    );
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Zero 1.2.3",
+      }),
+    );
+    expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
+    expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -6,15 +6,25 @@ import {
 } from "update-electron-app";
 
 import type { DesktopConfig } from "./config";
+import { shouldNotifyUserForDesktopUpdate } from "./desktop-auto-update-policy";
 import {
   desktopUpdateFeedBaseUrl,
   shouldInstallDesktopAutoUpdates,
 } from "./desktop-update-feed";
+import type { ComputerUseHostRuntimeState } from "./computer-use-types";
 
 interface DesktopAutoUpdateOptions {
   readonly config: DesktopConfig;
   readonly apiBaseUrl: string;
+  readonly getComputerUseHostState: () => ComputerUseHostRuntimeState;
   readonly prepareForQuitAndInstall: () => Promise<void>;
+}
+
+async function restartForUpdate(
+  prepareForQuitAndInstall: () => Promise<void>,
+): Promise<void> {
+  await prepareForQuitAndInstall();
+  autoUpdater.quitAndInstall();
 }
 
 async function promptToRestartForUpdate(
@@ -36,8 +46,30 @@ async function promptToRestartForUpdate(
     return;
   }
 
-  await prepareForQuitAndInstall();
-  autoUpdater.quitAndInstall();
+  await restartForUpdate(prepareForQuitAndInstall);
+}
+
+function shouldPromptForDownloadedUpdate(
+  getComputerUseHostState: () => ComputerUseHostRuntimeState,
+): boolean {
+  try {
+    return shouldNotifyUserForDesktopUpdate(getComputerUseHostState());
+  } catch (error) {
+    console.warn("Unable to inspect Computer Use activity for update", error);
+    return true;
+  }
+}
+
+async function handleDownloadedUpdate(
+  info: IUpdateInfo,
+  options: DesktopAutoUpdateOptions,
+): Promise<void> {
+  if (shouldPromptForDownloadedUpdate(options.getComputerUseHostState)) {
+    await promptToRestartForUpdate(info, options.prepareForQuitAndInstall);
+    return;
+  }
+
+  await restartForUpdate(options.prepareForQuitAndInstall);
 }
 
 export function installDesktopAutoUpdates(
@@ -68,10 +100,7 @@ export function installDesktopAutoUpdates(
     updateInterval: "30 minutes",
     notifyUser: true,
     onNotifyUser: (info) => {
-      void promptToRestartForUpdate(
-        info,
-        options.prepareForQuitAndInstall,
-      ).catch((error) => {
+      void handleDownloadedUpdate(info, options).catch((error) => {
         console.error("Desktop update restart prompt failed", error);
       });
     },

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -997,6 +997,7 @@ if (!hasSingleInstanceLock) {
     installDesktopAutoUpdates({
       config,
       apiBaseUrl: desktopApiBaseUrl,
+      getComputerUseHostState: () => getComputerUseBridgeState().host,
       prepareForQuitAndInstall,
     });
     installKeepAwake();


### PR DESCRIPTION
## Summary
- add a desktop auto-update policy that prompts only when recent Computer Use command activity exists
- silently restart/install downloaded updates when no Computer Use command has started or completed in the last 30 minutes
- keep prompting while any local command is still running, and fail safe to prompting if activity inspection fails

## Tests
- pnpm exec prettier --check apps/desktop/src/desktop-auto-update-policy.ts apps/desktop/src/desktop-auto-update-policy.test.ts apps/desktop/src/desktop-auto-updates.ts apps/desktop/src/main.ts
- pnpm --filter @vm0/desktop exec oxlint src/desktop-auto-update-policy.ts src/desktop-auto-update-policy.test.ts src/desktop-auto-updates.ts src/main.ts --deny-warnings
- pnpm --filter @vm0/desktop check-types
- pnpm --filter @vm0/desktop exec vitest run src/desktop-auto-update-policy.test.ts