### PR TITLE
fix: only auto-name chat threads once

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts
@@ -65,7 +65,9 @@ function vm0Template(expression: string): string {
   return `$${expression}`;
 }
 
-async function seedChatCallbackFixture(): Promise<ChatCallbackFixture> {
+async function seedChatCallbackFixture(
+  options: { readonly title?: string | null } = {},
+): Promise<ChatCallbackFixture> {
   const userId = `user_${randomUUID()}`;
   const orgId = `org_${randomUUID()}`;
   const agentId = randomUUID();
@@ -116,7 +118,7 @@ async function seedChatCallbackFixture(): Promise<ChatCallbackFixture> {
     id: threadId,
     userId,
     agentComposeId: agentId,
-    title: "Test thread",
+    title: options.title !== undefined ? options.title : "Test thread",
   });
   await db.insert(agentSessions).values({
     id: sessionId,
@@ -950,7 +952,7 @@ describe("POST /api/internal/callbacks/chat", () => {
     const messages = await listMessages(fixture.threadId);
     expect(
       messages.find((message) => {
-        return message.role === "assistant";
+        return message.role === "assistant" && message.content !== null;
       }),
     ).toMatchObject({
       sequenceNumber: 1,
@@ -1757,7 +1759,7 @@ describe("POST /api/internal/callbacks/chat", () => {
   });
 
   it("generates a chat thread title from the completed callback exchange", async () => {
-    const fixture = await track(seedChatCallbackFixture());
+    const fixture = await track(seedChatCallbackFixture({ title: null }));
     completedOutputEvents([
       {
         eventType: "result",
@@ -1799,8 +1801,47 @@ describe("POST /api/internal/callbacks/chat", () => {
     await clearAllDetached();
   });
 
-  it("feeds prior rounds into the callback title prompt without duplicating the current run", async () => {
+  it("does not regenerate an existing chat thread title on completed callbacks", async () => {
     const fixture = await track(seedChatCallbackFixture());
+    completedOutputEvents([
+      {
+        eventType: "result",
+        sequenceNumber: 1,
+        eventData: { result: "Use --inspect for debugging." },
+      },
+    ]);
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    let titleRequestCount = 0;
+    mockOpenRouter((body) => {
+      const systemContent = body.messages[0]?.content ?? "";
+      if (systemContent.includes("Generate a short, descriptive title")) {
+        titleRequestCount += 1;
+        return "Replacement Title";
+      }
+      return "Generated summary";
+    });
+
+    const response = await postSignedCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: { threadId: fixture.threadId, agentId: fixture.agentId },
+    });
+
+    expect(response.status).toBe(200);
+    const [thread] = await store
+      .set(writeDb$)
+      .select({ title: chatThreads.title })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId))
+      .limit(1);
+    expect(titleRequestCount).toBe(0);
+    expect(thread?.title).toBe("Test thread");
+    await clearAllDetached();
+  });
+
+  it("feeds prior rounds into the callback title prompt without duplicating the current run", async () => {
+    const fixture = await track(seedChatCallbackFixture({ title: null }));
     const prior = await seedAdditionalRun(fixture, {
       prompt: "How do I parse JSON?",
       status: "completed",
@@ -1842,7 +1883,7 @@ describe("POST /api/internal/callbacks/chat", () => {
   });
 
   it("does not fail completed callbacks when title generation returns an upstream error", async () => {
-    const fixture = await track(seedChatCallbackFixture());
+    const fixture = await track(seedChatCallbackFixture({ title: null }));
     completedOutputEvents([
       {
         eventType: "result",
@@ -1871,7 +1912,7 @@ describe("POST /api/internal/callbacks/chat", () => {
       .from(chatThreads)
       .where(eq(chatThreads.id, fixture.threadId))
       .limit(1);
-    expect(thread?.title).toBe("Test thread");
+    expect(thread?.title).toBeNull();
     await clearAllDetached();
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -1384,6 +1384,107 @@ describe("POST /api/zero/chat/messages", () => {
     expect(thread?.title).toBe("Migration Plan");
   });
 
+  it("does not regenerate a chat thread title once one exists", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    const threadId = randomUUID();
+    await writeDb.insert(chatThreads).values({
+      id: threadId,
+      userId: fixture.userId,
+      agentComposeId: fixture.agentId,
+      title: "Existing Title",
+    });
+    mockOptionalEnv("OPENROUTER_API_KEY", "title-api-key");
+    let titleRequestCount = 0;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const body = (await request.json()) as {
+            readonly messages?: readonly { readonly content?: string }[];
+          };
+          if (
+            body.messages?.[0]?.content?.includes(
+              "Generate a short, descriptive title",
+            )
+          ) {
+            titleRequestCount += 1;
+          }
+          return HttpResponse.json({
+            choices: [{ message: { content: "Replacement Title" } }],
+          });
+        },
+      ),
+    );
+
+    await send({
+      agentId: fixture.agentId,
+      prompt: "rename this thread automatically",
+      threadId,
+    });
+    await clearAllDetached();
+
+    const [thread] = await writeDb
+      .select({ title: chatThreads.title })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, threadId))
+      .limit(1);
+    expect(titleRequestCount).toBe(0);
+    expect(thread?.title).toBe("Existing Title");
+  });
+
+  it("does not auto-name a manually renamed chat thread", async () => {
+    const fixture = await track(seedFixture());
+    const writeDb = store.set(writeDb$);
+    const threadId = randomUUID();
+    const renamedAt = new Date("2026-01-01T00:00:00.000Z");
+    await writeDb.insert(chatThreads).values({
+      id: threadId,
+      userId: fixture.userId,
+      agentComposeId: fixture.agentId,
+      title: "Manual Name",
+      renamedAt,
+    });
+    mockOptionalEnv("OPENROUTER_API_KEY", "title-api-key");
+    let titleRequestCount = 0;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const body = (await request.json()) as {
+            readonly messages?: readonly { readonly content?: string }[];
+          };
+          if (
+            body.messages?.[0]?.content?.includes(
+              "Generate a short, descriptive title",
+            )
+          ) {
+            titleRequestCount += 1;
+          }
+          return HttpResponse.json({
+            choices: [{ message: { content: "Replacement Title" } }],
+          });
+        },
+      ),
+    );
+
+    await send({
+      agentId: fixture.agentId,
+      prompt: "rename this thread automatically",
+      threadId,
+    });
+    await clearAllDetached();
+
+    const [thread] = await writeDb
+      .select({ title: chatThreads.title, renamedAt: chatThreads.renamedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, threadId))
+      .limit(1);
+    expect(titleRequestCount).toBe(0);
+    expect(thread?.title).toBe("Manual Name");
+    expect(thread?.renamedAt?.toISOString()).toBe(renamedAt.toISOString());
+  });
+
   it("queues an unassociated user message when the thread has an active run", async () => {
     const fixture = await track(seedFixture());
     const first = await send({ agentId: fixture.agentId, prompt: "first" });

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -6,7 +6,7 @@ import {
   type ChatMessageRecommendedFollowups,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
@@ -198,21 +198,36 @@ async function updateChatThreadTitle(
   userId: string,
   title: string,
 ): Promise<void> {
+  const updated = await db
+    .update(chatThreads)
+    .set({ title })
+    .where(
+      and(
+        eq(chatThreads.id, threadId),
+        isNull(chatThreads.title),
+        isNull(chatThreads.renamedAt),
+      ),
+    )
+    .returning({ id: chatThreads.id });
+
+  if (updated.length === 0) {
+    return;
+  }
+
+  await publishThreadListChanged(userId);
+}
+
+async function shouldGenerateChatThreadTitle(
+  db: SelectDb,
+  threadId: string,
+): Promise<boolean> {
   const [thread] = await db
-    .select({ renamedAt: chatThreads.renamedAt })
+    .select({ title: chatThreads.title, renamedAt: chatThreads.renamedAt })
     .from(chatThreads)
     .where(eq(chatThreads.id, threadId))
     .limit(1);
 
-  if (thread?.renamedAt) {
-    return;
-  }
-
-  await db
-    .update(chatThreads)
-    .set({ title })
-    .where(eq(chatThreads.id, threadId));
-  await publishThreadListChanged(userId);
+  return Boolean(thread && thread.title === null && thread.renamedAt === null);
 }
 
 export async function generateAndPersistChatThreadTitle(args: {
@@ -224,6 +239,10 @@ export async function generateAndPersistChatThreadTitle(args: {
 }): Promise<void> {
   const result = await settle(
     (async () => {
+      if (!(await shouldGenerateChatThreadTitle(args.db, args.threadId))) {
+        return;
+      }
+
       const priorRounds = args.includePriorRounds
         ? await getLatestTitleContextMessages(args.db, args.threadId)
         : [];
@@ -254,6 +273,10 @@ export async function generateAndPersistChatThreadTitleFromCallback(args: {
 }): Promise<void> {
   const result = await settle(
     (async () => {
+      if (!(await shouldGenerateChatThreadTitle(args.db, args.threadId))) {
+        return;
+      }
+
       const priorRounds = await getLatestTitleContextMessages(
         args.db,
         args.threadId,


### PR DESCRIPTION
## Summary
- only generate/persist an automatic chat thread title when the thread title is still null and it has not been manually renamed
- guard the database update with the same title/renamedAt conditions to avoid races
- add regression coverage for callback title generation, existing titles, and manually renamed threads

## Tests
- `pnpm vitest run apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `pnpm exec prettier --check apps/api/src/signals/services/zero-chat-title.service.ts apps/api/src/signals/routes/__tests__/internal-callbacks-chat.test.ts apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts`
- `git diff --check`