### PR TITLE
fix(mitm-addon): block runner usage flush ownership

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -365,7 +365,8 @@ class UsageEventBuffer:
     ) -> None:
         self._lock = threading.Lock()
         # Serializes snapshot/enqueue ownership. Ordinary flushes defer if busy;
-        # shutdown waits so daemon timer work cannot outlive process teardown.
+        # lifecycle drains wait so their acknowledgement snapshots follow drain
+        # ownership instead of only recording signal receipt.
         self._flush_owner_lock: _FlushOwnerLock = (
             flush_owner_lock if flush_owner_lock is not None else threading.Lock()
         )
@@ -446,7 +447,7 @@ class UsageEventBuffer:
             self._flush_owner_lock.release()
 
     def _acquire_flush_ownership(self, trigger: UsageFlushTrigger) -> bool:
-        return self._flush_owner_lock.acquire(blocking=trigger == "shutdown")
+        return self._flush_owner_lock.acquire(blocking=trigger in ("runner", "shutdown"))
 
     def _defer_unowned_flush(self, trigger: UsageFlushTrigger) -> None:
         timer_to_cancel: _TimerHandle | None = None

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -603,7 +603,6 @@ class TestRunnerUsageFlushSignal:
             timer_thread.start()
             timer_thread_started = True
             assert timer_enqueue_started.wait(timeout=1)
-            assert usage.counters._buffered_usage_events == 1
 
             mitm_addon._handle_runner_usage_flush_signal(0, None)
             assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -19,6 +19,8 @@ import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
+from tests.usage_buffer_helpers import RecordingEnqueue, event
+from tests.usage_helpers import install_recording_usage_timer
 
 
 def wait_for_usage_flush_worker_to_stop(timeout: float = 1.0) -> None:
@@ -31,6 +33,20 @@ def reset_runner_usage_flush_state() -> None:
     mitm_addon._usage_flush_requested.clear()
     mitm_addon._last_jsonl_flush_request_id = None
     wait_for_usage_flush_worker_to_stop()
+
+
+class _InstrumentedFlushOwnerLock:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.blocking_acquire_started = threading.Event()
+
+    def acquire(self, blocking: bool = True) -> bool:
+        if blocking:
+            self.blocking_acquire_started.set()
+        return self._lock.acquire(blocking)
+
+    def release(self) -> None:
+        self._lock.release()
 
 
 _ScheduledTcpDrain = tuple[Callable[[tcp.TCPFlow], None], tcp.TCPFlow]
@@ -537,6 +553,91 @@ class TestRunnerUsageFlushSignal:
                 flush_request_id="request-1",
             )
         finally:
+            usage.set_pending_path("")
+
+    def test_signal_waits_for_active_timer_flush_before_ack_snapshot(self, tmp_path):
+        reset_runner_usage_flush_state()
+        flush_owner_lock = _InstrumentedFlushOwnerLock()
+        timer_enqueue_started = threading.Event()
+        release_timer_enqueue = threading.Event()
+        enqueued_runs: list[str] = []
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "usage-flush-request"
+        proxy_log_path = str(tmp_path / "proxy.jsonl")
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                }
+            )
+        )
+
+        def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+            del url, sandbox_token
+            assert log_type == "usage_event"
+            assert path == proxy_log_path
+            enqueued_runs.append(payload["runId"])
+            if payload["runId"] == "run-1":
+                timer_enqueue_started.set()
+                assert release_timer_enqueue.wait(timeout=2)
+
+        enqueue = RecordingEnqueue(side_effect=enqueue_webhook)
+        timers = install_recording_usage_timer(
+            enqueue_webhook=enqueue,
+            flush_owner_lock=flush_owner_lock,
+        )
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1")],
+            proxy_log_path,
+        )
+        timer_thread = threading.Thread(target=timers[0].callback)
+        timer_thread_started = False
+
+        try:
+            timer_thread.start()
+            timer_thread_started = True
+            assert timer_enqueue_started.wait(timeout=1)
+            assert usage.counters._buffered_usage_events == 1
+
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+            state_before_release = json.loads(pending_path.read_text())
+            assert "flushRequestId" not in state_before_release
+
+            usage.buffer_usage_events(
+                "https://api.test/api/webhooks/agent/usage-event",
+                "token-a",
+                "run-2",
+                [event(source_key="source-2")],
+                proxy_log_path,
+            )
+            assert len(timers) == 2
+
+            release_timer_enqueue.set()
+            timer_thread.join(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+            assert not timer_thread.is_alive()
+            assert enqueued_runs == ["run-1", "run-2"]
+            assert timers[1].cancelled is True
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=0,
+                flush_request_id="request-1",
+            )
+        finally:
+            release_timer_enqueue.set()
+            if timer_thread_started:
+                timer_thread.join(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
             usage.set_pending_path("")
 
     def test_signal_during_active_flush_runs_follow_up_flush(self):

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -639,6 +639,95 @@ class TestRunnerUsageFlushSignal:
             wait_for_usage_flush_worker_to_stop()
             usage.set_pending_path("")
 
+    def test_signal_retries_failed_active_timer_flush_before_ack_snapshot(self, tmp_path):
+        reset_runner_usage_flush_state()
+        flush_owner_lock = _InstrumentedFlushOwnerLock()
+        first_enqueue_started = threading.Event()
+        release_first_enqueue = threading.Event()
+        enqueued_run_ids: list[str] = []
+        enqueued_idempotency_keys: list[str] = []
+        timer_errors: list[str] = []
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "usage-flush-request"
+        proxy_log_path = str(tmp_path / "proxy.jsonl")
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                }
+            )
+        )
+
+        def enqueue_webhook(url, sandbox_token, payload, path, log_type):
+            del url, sandbox_token, path
+            assert log_type == "usage_event"
+            enqueued_run_ids.append(payload["runId"])
+            enqueued_idempotency_keys.append(payload["events"][0]["idempotencyKey"])
+            if len(enqueued_run_ids) == 1:
+                first_enqueue_started.set()
+                assert release_first_enqueue.wait(timeout=2)
+                raise OSError("timer failed")
+
+        enqueue = RecordingEnqueue(side_effect=enqueue_webhook)
+        timers = install_recording_usage_timer(
+            enqueue_webhook=enqueue,
+            flush_owner_lock=flush_owner_lock,
+        )
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1")],
+            proxy_log_path,
+        )
+
+        def timer_flush():
+            try:
+                timers[0].callback()
+            except OSError as exc:
+                timer_errors.append(str(exc))
+
+        timer_thread = threading.Thread(target=timer_flush)
+        timer_thread_started = False
+
+        try:
+            timer_thread.start()
+            timer_thread_started = True
+            assert first_enqueue_started.wait(timeout=1)
+
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+            state_before_release = json.loads(pending_path.read_text())
+            assert "flushRequestId" not in state_before_release
+
+            release_first_enqueue.set()
+            timer_thread.join(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+
+            assert not timer_thread.is_alive()
+            assert timer_errors == ["timer failed"]
+            assert enqueued_run_ids == ["run-1", "run-1"]
+            assert enqueued_idempotency_keys[0] == enqueued_idempotency_keys[1]
+            assert len(timers) == 2
+            assert timers[0].cancelled is True
+            assert timers[1].cancelled is True
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=0,
+                flush_request_id="request-1",
+            )
+        finally:
+            release_first_enqueue.set()
+            if timer_thread_started:
+                timer_thread.join(timeout=1)
+            wait_for_usage_flush_worker_to_stop()
+            usage.set_pending_path("")
+
     def test_signal_during_active_flush_runs_follow_up_flush(self):
         reset_runner_usage_flush_state()
         first_flush_started = threading.Event()

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -199,7 +199,7 @@ def test_overlapping_flush_defers_live_snapshot_while_enqueueing(tmp_path):
             [event(source_key="source-2")],
             path,
         )
-        assert usage.flush_usage_events(trigger="runner") == 0
+        assert usage.flush_usage_events(trigger="test") == 0
         assert payload["runId"] == "run-1"
         assert usage.counters._buffered_usage_events == 2
         assert log_type == "usage_event"

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -96,7 +96,6 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
         enqueued_runs.append(payload["runId"])
         if payload["runId"] == "run-1":
             timer_enqueue_started.set()
-            assert usage.flush_usage_events(trigger="runner") == 0
             usage.buffer_usage_events(
                 url,
                 sandbox_token,


### PR DESCRIPTION
## Summary

- make runner-triggered usage flushes wait for usage buffer ownership like shutdown flushes
- add a SIGUSR1 regression test that verifies no `flushRequestId` snapshot is acknowledged while a timer flush still owns the buffer
- remove the old test assertion that runner flushes return immediately while another flush is active

Closes #17203

## Tests

- `pytest tests/test_connection_hooks.py::TestRunnerUsageFlushSignal -q`
- `pytest tests/test_usage_buffer_timer_shutdown.py -q`
- `python3 -m compileall src/usage/buffer.py src/mitm_addon.py`
- `pytest tests/test_connection_hooks.py tests/test_usage_buffer_timer_shutdown.py -q`
- `git diff --check`