### PR TITLE
refactor(runner): name storage fingerprint entries

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -595,6 +595,7 @@ mod tests {
     use crate::paths::RunnerPaths;
     use crate::resource_budget::{BudgetLease, ResourceBudget};
     use crate::status::StatusTracker;
+    use crate::storage_fingerprints::StorageFingerprint;
     use crate::types::SandboxReuseResult;
     use crate::workspace_image_cache::{
         SessionWorkspaceCache, WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext,
@@ -904,14 +905,14 @@ mod tests {
                 prepare_test_workspace_image_lease(&paths, &cache, run_id, sandbox_id, session_id)
                     .await;
             let sandbox = MockSandbox::new(format!("workspace-promotion-{session_id}"));
-            let storage_fingerprints = crate::storage_fingerprints::StorageFingerprints {
+            let storage_fingerprints = StorageFingerprints {
                 storages: std::collections::HashMap::from([(
                     CANONICAL_WORKING_DIR.to_owned(),
-                    ("repo".to_owned(), "v1".to_owned()),
+                    StorageFingerprint::new("repo", "v1"),
                 )]),
                 artifacts: std::collections::HashMap::from([(
                     format!("{CANONICAL_WORKING_DIR}/artifact"),
-                    ("artifact".to_owned(), "v1".to_owned()),
+                    StorageFingerprint::new("artifact", "v1"),
                 )]),
             };
             let promotion = test_promotion_context(
@@ -945,18 +946,20 @@ mod tests {
             let previous_storage = checkout
                 .previous_storage()
                 .expect("cache hit should expose previous storage fingerprints");
-            assert!(StorageFingerprints::fingerprint_is_tainted(
+            assert!(
                 previous_storage
                     .storages
                     .get(CANONICAL_WORKING_DIR)
                     .expect("storage path should be retained for cleanup")
-            ));
-            assert!(StorageFingerprints::fingerprint_is_tainted(
+                    .is_tainted()
+            );
+            assert!(
                 previous_storage
                     .artifacts
                     .get(&format!("{CANONICAL_WORKING_DIR}/artifact"))
                     .expect("artifact path should be retained for cleanup")
-            ));
+                    .is_tainted()
+            );
         }
     }
 

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -8,7 +8,7 @@ use super::{
     guest_runtime_dir,
 };
 use crate::paths::guest;
-use crate::storage_fingerprints::StorageFingerprints;
+use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
     ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
 };
@@ -25,9 +25,7 @@ pub(super) fn filter_unchanged_storages(
         .iter()
         .map(|s| {
             let unchanged = prev.storages.get(&s.mount_path).is_some_and(|fingerprint| {
-                !StorageFingerprints::fingerprint_is_tainted(fingerprint)
-                    && fingerprint.0.as_str() == s.vas_storage_name.as_str()
-                    && fingerprint.1.as_str() == s.vas_version_id.as_str()
+                fingerprint.matches(&s.vas_storage_name, &s.vas_version_id)
             });
             if unchanged {
                 skipped += 1;
@@ -60,14 +58,11 @@ pub(super) fn filter_unchanged_storages(
     }
 
     let filter_artifact = |a: &GuestDownloadArtifactEntry,
-                           prev_ver: Option<&(String, String)>,
+                           prev_ver: Option<&StorageFingerprint>,
                            skipped: &mut usize,
                            cleanup: &mut Vec<String>| {
-        let same = prev_ver.is_some_and(|fingerprint| {
-            !StorageFingerprints::fingerprint_is_tainted(fingerprint)
-                && fingerprint.0.as_str() == a.vas_storage_name.as_str()
-                && fingerprint.1.as_str() == a.vas_version_id.as_str()
-        });
+        let same = prev_ver
+            .is_some_and(|fingerprint| fingerprint.matches(&a.vas_storage_name, &a.vas_version_id));
         if same {
             *skipped += 1;
         } else {

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -11,6 +11,7 @@ use super::super::storage::{
     format_guest_download_failure, guest_download_command, guest_download_env,
 };
 use super::support::{minimal_context, sandbox_write_file_error};
+use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry};
 
 #[tokio::test]
@@ -217,9 +218,13 @@ fn guest_storage(
     }
 }
 
-fn art_fp(mount: &str, name: &str, ver: &str) -> HashMap<String, (String, String)> {
+fn fp(name: &str, ver: &str) -> StorageFingerprint {
+    StorageFingerprint::new(name, ver)
+}
+
+fn art_fp(mount: &str, name: &str, ver: &str) -> HashMap<String, StorageFingerprint> {
     let mut m = HashMap::new();
-    m.insert(mount.into(), (name.into(), ver.into()));
+    m.insert(mount.into(), fp(name, ver));
     m
 }
 
@@ -230,7 +235,7 @@ fn filter_same_artifact_version_keeps_url_for_mount_repair() {
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -250,7 +255,7 @@ fn filter_different_artifact_version_keeps_url() {
         artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -268,7 +273,7 @@ fn filter_different_artifact_name_keeps_url() {
         artifacts: vec![guest_art("other-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -283,7 +288,7 @@ fn filter_new_artifact_not_in_prev_keeps_url() {
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints::default();
+    let prev = StorageFingerprints::default();
     let result = filter_unchanged_storages(&manifest, &prev);
     assert!(result.artifacts[0].archive_url.is_some());
 }
@@ -300,7 +305,7 @@ fn filter_empty_prev_downloads_everything() {
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints::default();
+    let prev = StorageFingerprints::default();
     let result = filter_unchanged_storages(&manifest, &prev);
     assert!(result.storages[0].archive_url.is_some());
     assert!(result.artifacts[0].archive_url.is_some());
@@ -319,8 +324,8 @@ fn filter_all_unchanged_nulls_storage_urls_and_keeps_artifact_urls() {
         cleanup_paths: vec![],
     };
     let mut storages = HashMap::new();
-    storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    storages.insert("/data".into(), fp("vol-1", "v1"));
+    let prev = StorageFingerprints {
         storages,
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -361,9 +366,9 @@ fn filter_two_artifacts_at_different_mount_paths() {
     };
     // Previous fingerprints: art-a was v1 (changed), art-b was v1 (unchanged).
     let mut artifacts = HashMap::new();
-    artifacts.insert("/workspace".into(), ("art-a".into(), "v1".into()));
-    artifacts.insert("/data".into(), ("art-b".into(), "v1".into()));
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    artifacts.insert("/workspace".into(), fp("art-a", "v1"));
+    artifacts.insert("/data".into(), fp("art-b", "v1"));
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts,
     };
@@ -390,9 +395,9 @@ fn filter_detects_removed_artifacts() {
         cleanup_paths: vec![],
     };
     let mut artifacts = HashMap::new();
-    artifacts.insert("/workspace".into(), ("kept".into(), "v1".into()));
-    artifacts.insert("/old".into(), ("removed".into(), "v1".into()));
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    artifacts.insert("/workspace".into(), fp("kept", "v1"));
+    artifacts.insert("/old".into(), fp("removed", "v1"));
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts,
     };
@@ -422,15 +427,12 @@ fn filter_computes_cleanup_for_changed_storages() {
         cleanup_paths: vec![],
     };
     let mut storages = HashMap::new();
-    storages.insert(
-        "/home/user/.claude".into(),
-        ("instructions".into(), "v1".into()),
-    );
+    storages.insert("/home/user/.claude".into(), fp("instructions", "v1"));
     storages.insert(
         "/home/user/.claude/skills/foo".into(),
-        ("skill-foo".into(), "v1".into()),
+        fp("skill-foo", "v1"),
     );
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -457,15 +459,12 @@ fn filter_detects_removed_storages() {
         cleanup_paths: vec![],
     };
     let mut storages = HashMap::new();
-    storages.insert(
-        "/home/user/.claude".into(),
-        ("instructions".into(), "v1".into()),
-    );
+    storages.insert("/home/user/.claude".into(), fp("instructions", "v1"));
     storages.insert(
         "/home/user/.claude/skills/old-skill".into(),
-        ("old-skill".into(), "v1".into()),
+        fp("old-skill", "v1"),
     );
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -486,7 +485,7 @@ fn filter_changed_artifact_adds_cleanup_path() {
         artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -506,7 +505,7 @@ fn filter_changed_artifact_with_null_url_adds_cleanup_path() {
         artifacts: vec![guest_art("my-art", "v2", None)],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
@@ -528,7 +527,7 @@ fn filter_unchanged_artifact_policy_does_not_force_redownload() {
         )],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    let prev = StorageFingerprints {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "memory", "v1"),
     };
@@ -551,8 +550,8 @@ fn filter_changed_storage_with_null_url_adds_cleanup_path() {
         cleanup_paths: vec![],
     };
     let mut storages = HashMap::new();
-    storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    storages.insert("/data".into(), fp("vol-1", "v1"));
+    let prev = StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -575,8 +574,8 @@ fn filter_unchanged_storage_sets_cached_true() {
         cleanup_paths: vec![],
     };
     let mut storages = HashMap::new();
-    storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
-    let prev = crate::storage_fingerprints::StorageFingerprints {
+    storages.insert("/data".into(), fp("vol-1", "v1"));
+    let prev = StorageFingerprints {
         storages,
         artifacts: HashMap::new(),
     };
@@ -605,12 +604,9 @@ fn filter_tainted_paths_force_download_even_when_versions_match() {
         }],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
-        storages: HashMap::from([("/workspace/repo".into(), ("repo".into(), "v1".into()))]),
-        artifacts: HashMap::from([(
-            "/workspace/artifact".into(),
-            ("artifact".into(), "v1".into()),
-        )]),
+    let prev = StorageFingerprints {
+        storages: HashMap::from([("/workspace/repo".into(), fp("repo", "v1"))]),
+        artifacts: HashMap::from([("/workspace/artifact".into(), fp("artifact", "v1"))]),
     }
     .tainted_paths();
 
@@ -645,15 +641,9 @@ fn filter_tainted_removed_paths_are_cleaned() {
         artifacts: vec![],
         cleanup_paths: vec![],
     };
-    let prev = crate::storage_fingerprints::StorageFingerprints {
-        storages: HashMap::from([(
-            "/workspace/removed-storage".into(),
-            ("repo".into(), "v1".into()),
-        )]),
-        artifacts: HashMap::from([(
-            "/workspace/removed-artifact".into(),
-            ("artifact".into(), "v1".into()),
-        )]),
+    let prev = StorageFingerprints {
+        storages: HashMap::from([("/workspace/removed-storage".into(), fp("repo", "v1"))]),
+        artifacts: HashMap::from([("/workspace/removed-artifact".into(), fp("artifact", "v1"))]),
     }
     .tainted_paths();
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -999,6 +999,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::resource_budget::ResourceBudget;
+    use crate::storage_fingerprints::StorageFingerprint;
 
     use sandbox::{ResourceLimits, SandboxConfig};
     use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
@@ -1179,11 +1180,11 @@ mod tests {
         let storage_fingerprints = StorageFingerprints {
             storages: HashMap::from([(
                 "/mnt/storage".into(),
-                ("storage-a".into(), "storage-version-2".into()),
+                StorageFingerprint::new("storage-a", "storage-version-2"),
             )]),
             artifacts: HashMap::from([(
                 "/workspace".into(),
-                ("artifact-a".into(), "artifact-version-3".into()),
+                StorageFingerprint::new("artifact-a", "artifact-version-3"),
             )]),
         };
         let expected_storage_fingerprints = storage_fingerprints.clone();

--- a/crates/runner/src/storage_fingerprints.rs
+++ b/crates/runner/src/storage_fingerprints.rs
@@ -1,22 +1,107 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::types::runners::storage::StorageManifest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Compact version fingerprints for storage manifest entries.
 /// Used to skip re-downloading unchanged storages on VM reuse.
-///
-/// All comparisons use `(vas_storage_name, vas_version_id)` tuples.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct StorageFingerprints {
-    /// mount_path → (vas_storage_name, vas_version_id) for regular storages.
-    pub(crate) storages: HashMap<String, (String, String)>,
-    /// mount_path → (vas_storage_name, vas_version_id) for artifacts.
-    pub(crate) artifacts: HashMap<String, (String, String)>,
+    /// mount_path to version fingerprint for regular storages.
+    pub(crate) storages: HashMap<String, StorageFingerprint>,
+    /// mount_path to version fingerprint for artifacts.
+    pub(crate) artifacts: HashMap<String, StorageFingerprint>,
 }
 
 const TAINTED_STORAGE_FINGERPRINT_NAME: &str = "\0vm0-tainted-storage\0";
 const TAINTED_STORAGE_FINGERPRINT_VERSION: &str = "\0vm0-tainted-storage\0";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StorageFingerprint {
+    kind: StorageFingerprintKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StorageFingerprintKind {
+    Known {
+        vas_storage_name: String,
+        vas_version_id: String,
+    },
+    Tainted,
+}
+
+impl StorageFingerprint {
+    pub(crate) fn new(
+        vas_storage_name: impl Into<String>,
+        vas_version_id: impl Into<String>,
+    ) -> Self {
+        let vas_storage_name = vas_storage_name.into();
+        let vas_version_id = vas_version_id.into();
+        if vas_storage_name == TAINTED_STORAGE_FINGERPRINT_NAME
+            && vas_version_id == TAINTED_STORAGE_FINGERPRINT_VERSION
+        {
+            return Self::tainted();
+        }
+        Self {
+            kind: StorageFingerprintKind::Known {
+                vas_storage_name,
+                vas_version_id,
+            },
+        }
+    }
+
+    pub(crate) fn tainted() -> Self {
+        Self {
+            kind: StorageFingerprintKind::Tainted,
+        }
+    }
+
+    pub(crate) fn is_tainted(&self) -> bool {
+        matches!(self.kind, StorageFingerprintKind::Tainted)
+    }
+
+    pub(crate) fn matches(&self, vas_storage_name: &str, vas_version_id: &str) -> bool {
+        if self.is_tainted() {
+            return false;
+        }
+        match &self.kind {
+            StorageFingerprintKind::Known {
+                vas_storage_name: known_name,
+                vas_version_id: known_version,
+            } => known_name == vas_storage_name && known_version == vas_version_id,
+            StorageFingerprintKind::Tainted => false,
+        }
+    }
+}
+
+impl Serialize for StorageFingerprint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.kind {
+            StorageFingerprintKind::Known {
+                vas_storage_name,
+                vas_version_id,
+            } => (vas_storage_name, vas_version_id).serialize(serializer),
+            StorageFingerprintKind::Tainted => (
+                TAINTED_STORAGE_FINGERPRINT_NAME,
+                TAINTED_STORAGE_FINGERPRINT_VERSION,
+            )
+                .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StorageFingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (vas_storage_name, vas_version_id) = <(String, String)>::deserialize(deserializer)?;
+        Ok(Self::new(vas_storage_name, vas_version_id))
+    }
+}
 
 impl StorageFingerprints {
     pub(crate) fn from_manifest(manifest: &StorageManifest) -> Self {
@@ -24,14 +109,14 @@ impl StorageFingerprints {
         for s in &manifest.storages {
             storages.insert(
                 s.mount_path.clone(),
-                (s.vas_storage_name.clone(), s.vas_version_id.clone()),
+                StorageFingerprint::new(s.vas_storage_name.clone(), s.vas_version_id.clone()),
             );
         }
         let mut artifacts = HashMap::new();
         for a in &manifest.artifacts {
             artifacts.insert(
                 a.mount_path.clone(),
-                (a.vas_storage_name.clone(), a.vas_version_id.clone()),
+                StorageFingerprint::new(a.vas_storage_name.clone(), a.vas_version_id.clone()),
             );
         }
         Self {
@@ -41,28 +126,116 @@ impl StorageFingerprints {
     }
 
     pub(crate) fn tainted_paths(&self) -> Self {
-        let tainted = || {
-            (
-                TAINTED_STORAGE_FINGERPRINT_NAME.to_owned(),
-                TAINTED_STORAGE_FINGERPRINT_VERSION.to_owned(),
-            )
-        };
         Self {
             storages: self
                 .storages
                 .keys()
-                .map(|path| (path.clone(), tainted()))
+                .map(|path| (path.clone(), StorageFingerprint::tainted()))
                 .collect(),
             artifacts: self
                 .artifacts
                 .keys()
-                .map(|path| (path.clone(), tainted()))
+                .map(|path| (path.clone(), StorageFingerprint::tainted()))
                 .collect(),
         }
     }
+}
 
-    pub(crate) fn fingerprint_is_tainted(fingerprint: &(String, String)) -> bool {
-        fingerprint.0 == TAINTED_STORAGE_FINGERPRINT_NAME
-            && fingerprint.1 == TAINTED_STORAGE_FINGERPRINT_VERSION
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn known_fingerprint_deserializes_from_legacy_tuple() {
+        let fingerprint: StorageFingerprint = serde_json::from_value(json!(["repo", "v1"]))
+            .expect("legacy tuple fingerprint should deserialize");
+
+        assert!(!fingerprint.is_tainted());
+        assert!(fingerprint.matches("repo", "v1"));
+        assert!(!fingerprint.matches("repo", "v2"));
+        assert!(!fingerprint.matches("other", "v1"));
+    }
+
+    #[test]
+    fn known_fingerprint_serializes_to_legacy_tuple() {
+        let value = serde_json::to_value(StorageFingerprint::new("repo", "v1"))
+            .expect("known fingerprint should serialize");
+
+        assert_eq!(value, json!(["repo", "v1"]));
+    }
+
+    #[test]
+    fn tainted_fingerprint_deserializes_from_legacy_sentinel_tuple() {
+        let fingerprint: StorageFingerprint = serde_json::from_value(json!([
+            TAINTED_STORAGE_FINGERPRINT_NAME,
+            TAINTED_STORAGE_FINGERPRINT_VERSION
+        ]))
+        .expect("legacy tainted tuple should deserialize");
+
+        assert!(fingerprint.is_tainted());
+        assert!(!fingerprint.matches(
+            TAINTED_STORAGE_FINGERPRINT_NAME,
+            TAINTED_STORAGE_FINGERPRINT_VERSION
+        ));
+        assert!(!fingerprint.matches("repo", "v1"));
+    }
+
+    #[test]
+    fn tainted_fingerprint_serializes_to_legacy_sentinel_tuple() {
+        let value = serde_json::to_value(StorageFingerprint::tainted())
+            .expect("tainted fingerprint should serialize");
+
+        assert_eq!(
+            value,
+            json!([
+                TAINTED_STORAGE_FINGERPRINT_NAME,
+                TAINTED_STORAGE_FINGERPRINT_VERSION
+            ])
+        );
+    }
+
+    #[test]
+    fn storage_fingerprints_preserve_legacy_map_value_shape() {
+        let fingerprints = StorageFingerprints {
+            storages: HashMap::from([(
+                "/workspace/repo".to_owned(),
+                StorageFingerprint::new("repo", "v1"),
+            )]),
+            artifacts: HashMap::from([(
+                "/workspace/artifact".to_owned(),
+                StorageFingerprint::tainted(),
+            )]),
+        };
+
+        let value =
+            serde_json::to_value(&fingerprints).expect("storage fingerprints should serialize");
+
+        assert_eq!(value["storages"]["/workspace/repo"], json!(["repo", "v1"]));
+        assert_eq!(
+            value["artifacts"]["/workspace/artifact"],
+            json!([
+                TAINTED_STORAGE_FINGERPRINT_NAME,
+                TAINTED_STORAGE_FINGERPRINT_VERSION
+            ])
+        );
+
+        let parsed: StorageFingerprints =
+            serde_json::from_value(value).expect("legacy map value shape should deserialize");
+        assert!(
+            parsed
+                .storages
+                .get("/workspace/repo")
+                .expect("storage fingerprint should exist")
+                .matches("repo", "v1")
+        );
+        assert!(
+            parsed
+                .artifacts
+                .get("/workspace/artifact")
+                .expect("artifact fingerprint should exist")
+                .is_tainted()
+        );
     }
 }

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -2797,6 +2797,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::storage_fingerprints::StorageFingerprint;
 
     const TEST_PROFILE_NAME: &str = "vm0/default";
 
@@ -3198,12 +3199,15 @@ mod tests {
                     drive_layout: WORKSPACE_DRIVE_LAYOUT.into(),
                     storage_fingerprints: StorageFingerprints {
                         storages: HashMap::from([
-                            ("/workspace".into(), ("repo".into(), "v1".into())),
-                            ("/workspace/cache".into(), ("cache".into(), "v2".into())),
+                            ("/workspace".into(), StorageFingerprint::new("repo", "v1")),
+                            (
+                                "/workspace/cache".into(),
+                                StorageFingerprint::new("cache", "v2"),
+                            ),
                         ]),
                         artifacts: HashMap::from([(
                             "/workspace/artifact".into(),
-                            ("artifact".into(), "v1".into()),
+                            StorageFingerprint::new("artifact", "v1"),
                         )]),
                     },
                     state: WorkspaceCacheState::Current,
@@ -3769,19 +3773,31 @@ mod tests {
     fn workspace_scoped_fingerprints_do_not_match_prefix_traps() {
         let fingerprints = StorageFingerprints {
             storages: HashMap::from([
-                ("/workspace".into(), ("repo".into(), "v1".into())),
-                ("/workspace/sub".into(), ("sub".into(), "v1".into())),
-                ("/workspace//sub2".into(), ("sub2".into(), "v1".into())),
-                ("/workspace2".into(), ("trap".into(), "v1".into())),
+                ("/workspace".into(), StorageFingerprint::new("repo", "v1")),
+                (
+                    "/workspace/sub".into(),
+                    StorageFingerprint::new("sub", "v1"),
+                ),
+                (
+                    "/workspace//sub2".into(),
+                    StorageFingerprint::new("sub2", "v1"),
+                ),
+                ("/workspace2".into(), StorageFingerprint::new("trap", "v1")),
                 (
                     "/workspace/../outside".into(),
-                    ("escape".into(), "v1".into()),
+                    StorageFingerprint::new("escape", "v1"),
                 ),
-                ("/tmp/cache".into(), ("tmp".into(), "v1".into())),
+                ("/tmp/cache".into(), StorageFingerprint::new("tmp", "v1")),
             ]),
             artifacts: HashMap::from([
-                ("/workspace/art".into(), ("art".into(), "v1".into())),
-                ("/home/user/.codex".into(), ("codex".into(), "v1".into())),
+                (
+                    "/workspace/art".into(),
+                    StorageFingerprint::new("art", "v1"),
+                ),
+                (
+                    "/home/user/.codex".into(),
+                    StorageFingerprint::new("codex", "v1"),
+                ),
             ]),
         };
 


### PR DESCRIPTION
## Summary

- introduce a `StorageFingerprint` domain value with explicit known and tainted states
- preserve the existing tuple/array serde shape for workspace cache metadata
- update storage filtering and tests to use fingerprint behavior instead of tuple indexes

Closes #17199

## Tests

- `cd crates && cargo test -p runner storage_fingerprints`
- `cd crates && cargo test -p runner filter_`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo test -p runner`