### PR TITLE
fix: store run context maps as Axiom entries

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -630,6 +630,8 @@ describe("POST /api/agent/runs", () => {
         { name: "USER_DEFINED_DYNAMIC_ENV_17220", value: "visible" },
       ]),
     );
+    expect(snapshot.networkPolicyEntries).toStrictEqual(expect.any(Array));
+    expect(snapshot.featureFlagEntries).toStrictEqual(expect.any(Array));
   });
 
   it("does not load unreferenced persisted secrets into runner secrets", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -1640,6 +1640,24 @@ describe("POST /api/agent/runs", () => {
       AWS_REGION: "us-west-2",
       AWS_DEFAULT_REGION: "us-west-2",
     });
+    const snapshot = runContextSnapshot(response.body.runId);
+    if (!snapshot) {
+      throw new Error("expected run context snapshot");
+    }
+    expect(snapshot).not.toHaveProperty("networkPolicies");
+    expect(snapshot.networkPolicyEntries).toStrictEqual(
+      expect.arrayContaining([
+        {
+          name: "aws",
+          policy: {
+            allow: [],
+            deny: [],
+            ask: [],
+            unknownPolicy: "allow",
+          },
+        },
+      ]),
+    );
   });
 
   it("injects an org model provider when the compose omits a framework API key", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts
@@ -548,6 +548,7 @@ describe("POST /api/agent/runs", () => {
           ANTHROPIC_API_KEY: "test-key",
           MY_VAR: vm0Template("{{ vars.MY_VAR }}"),
           API_KEY: vm0Template("{{ secrets.API_KEY }}"),
+          USER_DEFINED_DYNAMIC_ENV_17220: "visible",
         },
       },
     });
@@ -599,6 +600,7 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.environment).toMatchObject({
       MY_VAR: "value",
       API_KEY: "secret-value",
+      USER_DEFINED_DYNAMIC_ENV_17220: "visible",
     });
     expect(
       decryptSecretsMapForTests(executionContext.encryptedSecrets),
@@ -608,16 +610,26 @@ describe("POST /api/agent/runs", () => {
     expect(executionContext.storageManifest.storages).toMatchObject([
       { name: "docs", mountPath: "/mnt/docs", vasVersionId: docsVersion },
     ]);
-    expect(runContextSnapshot(response.body.runId)).toMatchObject({
+    const snapshot = runContextSnapshot(response.body.runId);
+    if (!snapshot) {
+      throw new Error("expected run context snapshot");
+    }
+    expect(snapshot).toMatchObject({
       secretNames: ["API_KEY"],
-      environment: {
-        MY_VAR: "value",
-        API_KEY: "***",
-      },
       volumes: [
         { name: "docs", mountPath: "/mnt/docs", vasVersionId: docsVersion },
       ],
     });
+    expect(snapshot).not.toHaveProperty("environment");
+    expect(snapshot).not.toHaveProperty("networkPolicies");
+    expect(snapshot).not.toHaveProperty("featureFlags");
+    expect(snapshot.environmentEntries).toStrictEqual(
+      expect.arrayContaining([
+        { name: "MY_VAR", value: "value" },
+        { name: "API_KEY", value: "***" },
+        { name: "USER_DEFINED_DYNAMIC_ENV_17220", value: "visible" },
+      ]),
+    );
   });
 
   it("does not load unreferenced persisted secrets into runner secrets", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
@@ -6,10 +6,13 @@ import { HttpResponse, http } from "msw";
 import { beforeEach, expect } from "vitest";
 import type { AxiomNetworkEvent } from "@vm0/api-contracts/contracts/runs";
 import { zeroReportErrorContract } from "@vm0/api-contracts/contracts/zero-report-error";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -534,6 +537,11 @@ describe("POST /api/zero/report-error", () => {
   it("includes run context when a same-org non-owner submits the report", async () => {
     const fixture = await seedReportRun({ prompt: "Inspect deployment" });
     mocks.clerk.session(randomUUID(), fixture.orgId);
+    await store
+      .set(writeDb$)
+      .update(agentRuns)
+      .set({ appendSystemPrompt: "database append prompt" })
+      .where(eq(agentRuns.id, fixture.runId));
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = String(args[0]);
@@ -541,6 +549,7 @@ describe("POST /api/zero/report-error", () => {
         return Promise.resolve([
           {
             runId: fixture.runId,
+            appendSystemPrompt: null,
             sessionId: "session-123",
             environmentEntries: [{ name: "NODE_ENV", value: "production" }],
             networkPolicyEntries: [
@@ -574,6 +583,7 @@ describe("POST /api/zero/report-error", () => {
     >;
     expect(activityContext).toMatchObject({
       runId: fixture.runId,
+      appendSystemPrompt: null,
       sessionId: "session-123",
       environment: { NODE_ENV: "production" },
       networkPolicies: {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-report-error.test.ts
@@ -542,7 +542,19 @@ describe("POST /api/zero/report-error", () => {
           {
             runId: fixture.runId,
             sessionId: "session-123",
-            environment: { NODE_ENV: "production" },
+            environmentEntries: [{ name: "NODE_ENV", value: "production" }],
+            networkPolicyEntries: [
+              {
+                name: "github",
+                policy: {
+                  allow: ["repo-read"],
+                  deny: [],
+                  ask: [],
+                  unknownPolicy: "allow",
+                },
+              },
+            ],
+            featureFlagEntries: [{ name: "apiBackend", enabled: true }],
             firewalls: [],
             volumes: [],
           },
@@ -556,11 +568,27 @@ describe("POST /api/zero/report-error", () => {
       [200],
     );
 
-    expect(activityLogJson(uploadedZip()).context).toMatchObject({
+    const activityContext = activityLogJson(uploadedZip()).context as Record<
+      string,
+      unknown
+    >;
+    expect(activityContext).toMatchObject({
       runId: fixture.runId,
       sessionId: "session-123",
       environment: { NODE_ENV: "production" },
+      networkPolicies: {
+        github: {
+          allow: ["repo-read"],
+          deny: [],
+          ask: [],
+          unknownPolicy: "allow",
+        },
+      },
+      featureFlags: { apiBackend: true },
     });
+    expect(activityContext).not.toHaveProperty("environmentEntries");
+    expect(activityContext).not.toHaveProperty("networkPolicyEntries");
+    expect(activityContext).not.toHaveProperty("featureFlagEntries");
   });
 
   it("collects prompts from all runs in a multi-run session", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
@@ -313,6 +313,109 @@ describe("GET /api/zero/runs/:id/context", () => {
     });
   });
 
+  it("omits malformed collection fields before response validation", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        ...makeEntriesSnapshot(runId),
+        firewalls: [
+          {
+            name: "valid-fw",
+            apis: [
+              {
+                base: "https://api.example.com",
+                permissions: [
+                  {
+                    name: "read",
+                    description: "Read records",
+                    rules: ["GET /records/*"],
+                  },
+                  { name: "bad-permission", rules: [null] },
+                ],
+              },
+              { base: null, permissions: [] },
+            ],
+          },
+          { name: "bad-fw", apis: null },
+        ],
+        volumes: [
+          {
+            name: "data",
+            mountPath: "/data",
+            vasStorageName: "vol-1",
+            vasVersionId: "ver-1",
+          },
+          {
+            name: "broken",
+            mountPath: "/broken",
+            vasStorageName: null,
+            vasVersionId: "ver-broken",
+          },
+        ],
+        artifact: {
+          mountPath: "/artifacts",
+          vasStorageName: null,
+          vasVersionId: "art-ver-1",
+        },
+      },
+    ]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.firewalls).toStrictEqual([
+      {
+        name: "valid-fw",
+        apis: [
+          {
+            base: "https://api.example.com",
+            permissions: [
+              {
+                name: "read",
+                description: "Read records",
+                rules: ["GET /records/*"],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(response.body.volumes).toStrictEqual([
+      {
+        name: "data",
+        mountPath: "/data",
+        vasStorageName: "vol-1",
+        vasVersionId: "ver-1",
+      },
+    ]);
+    expect(response.body.artifact).toBeNull();
+  });
+
   it("prefers entries over legacy map fields", async () => {
     const fixture = await track(
       store.set(seedUsageInsightFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
@@ -28,7 +28,59 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function makeSnapshot(runId: string): Record<string, unknown> {
+function makeEntriesSnapshot(runId: string): Record<string, unknown> {
+  return {
+    runId,
+    prompt: "test prompt",
+    appendSystemPrompt: null,
+    sessionId: null,
+    environmentEntries: [
+      { name: "NODE_ENV", value: "production" },
+      { name: "API_KEY", value: "***" },
+    ],
+    firewalls: [
+      {
+        name: "test-fw",
+        apis: [
+          {
+            base: "https://api.example.com",
+            permissions: [{ name: "read", rules: ["GET /users/*"] }],
+          },
+        ],
+      },
+    ],
+    volumes: [
+      {
+        name: "data",
+        mountPath: "/data",
+        vasStorageName: "vol-1",
+        vasVersionId: "ver-1",
+      },
+    ],
+    artifact: {
+      mountPath: "/artifacts",
+      vasStorageName: "art-1",
+      vasVersionId: "art-ver-1",
+    },
+    networkPolicyEntries: [
+      {
+        name: "github",
+        policy: {
+          allow: ["repo-read"],
+          deny: [],
+          ask: [],
+          unknownPolicy: "allow",
+        },
+      },
+    ],
+    featureFlagEntries: [
+      { name: "computerUse", enabled: true },
+      { name: "dummy", enabled: false },
+    ],
+  };
+}
+
+function makeLegacySnapshot(runId: string): Record<string, unknown> {
   return {
     runId,
     prompt: "test prompt",
@@ -223,7 +275,7 @@ describe("GET /api/zero/runs/:id/context", () => {
       },
       context.signal,
     );
-    context.mocks.axiom.query.mockResolvedValue([makeSnapshot(runId)]);
+    context.mocks.axiom.query.mockResolvedValue([makeEntriesSnapshot(runId)]);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context })(zeroRunContextContract);
@@ -247,14 +299,21 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(response.body.firewalls[0]?.name).toBe("test-fw");
     expect(response.body.volumes).toHaveLength(1);
     expect(response.body.artifact).toBeDefined();
-    expect(response.body.networkPolicies).toBeNull();
+    expect(response.body.networkPolicies).toStrictEqual({
+      github: {
+        allow: ["repo-read"],
+        deny: [],
+        ask: [],
+        unknownPolicy: "allow",
+      },
+    });
     expect(response.body.featureFlags).toStrictEqual({
       computerUse: true,
       dummy: false,
     });
   });
 
-  it("omits sparse null Axiom fields before response validation", async () => {
+  it("prefers entries over legacy map fields", async () => {
     const fixture = await track(
       store.set(seedUsageInsightFixture$, undefined, context.signal),
     );
@@ -275,7 +334,81 @@ describe("GET /api/zero/runs/:id/context", () => {
     );
     context.mocks.axiom.query.mockResolvedValue([
       {
-        ...makeSnapshot(runId),
+        ...makeEntriesSnapshot(runId),
+        environment: { LEGACY_ENV: "legacy" },
+        environmentEntries: [{ name: "ENTRY_ENV", value: "entry" }],
+        networkPolicies: {
+          legacy: {
+            allow: ["legacy-read"],
+            deny: [],
+            ask: [],
+            unknownPolicy: "allow",
+          },
+        },
+        networkPolicyEntries: [
+          {
+            name: "entry",
+            policy: {
+              allow: ["entry-read"],
+              deny: [],
+              ask: [],
+              unknownPolicy: "deny",
+            },
+          },
+        ],
+        featureFlags: { legacyFlag: true },
+        featureFlagEntries: [{ name: "entryFlag", enabled: false }],
+      },
+    ]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.environment).toStrictEqual({ ENTRY_ENV: "entry" });
+    expect(response.body.networkPolicies).toStrictEqual({
+      entry: {
+        allow: ["entry-read"],
+        deny: [],
+        ask: [],
+        unknownPolicy: "deny",
+      },
+    });
+    expect(response.body.featureFlags).toStrictEqual({ entryFlag: false });
+  });
+
+  it("falls back to legacy map fields and omits sparse null values", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        ...makeLegacySnapshot(runId),
+        environmentEntries: null,
+        networkPolicyEntries: null,
+        featureFlagEntries: null,
         environment: {
           OPENAI_API_KEY: null,
           ZERO_TOKEN: "***",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
@@ -384,6 +384,70 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(response.body.featureFlags).toStrictEqual({ entryFlag: false });
   });
 
+  it("does not fall back to legacy maps when entries are present but invalid", async () => {
+    const fixture = await track(
+      store.set(seedUsageInsightFixture$, undefined, context.signal),
+    );
+    const compose = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: compose.composeId,
+        status: "running",
+      },
+      context.signal,
+    );
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        ...makeEntriesSnapshot(runId),
+        environment: { LEGACY_ENV: "legacy" },
+        environmentEntries: [{ name: null, value: "invalid" }],
+        networkPolicies: {
+          legacy: {
+            allow: ["legacy-read"],
+            deny: [],
+            ask: [],
+            unknownPolicy: "allow",
+          },
+        },
+        networkPolicyEntries: [
+          {
+            name: "invalid",
+            policy: {
+              allow: ["entry-read"],
+              deny: [],
+              ask: [],
+              unknownPolicy: null,
+            },
+          },
+        ],
+        featureFlags: { legacyFlag: true },
+        featureFlagEntries: [{ name: "invalid", enabled: null }],
+      },
+    ]);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context })(zeroRunContextContract);
+
+    const response = await accept(
+      client.getContext({
+        params: { id: runId },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body.environment).toStrictEqual({});
+    expect(response.body.networkPolicies).toBeNull();
+    expect(response.body.featureFlags).toBeNull();
+  });
+
   it("falls back to legacy map fields and omits sparse null values", async () => {
     const fixture = await track(
       store.set(seedUsageInsightFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -119,6 +119,12 @@ import { now, nowDate } from "../external/time";
 import { generateZeroToken } from "../auth/tokens";
 import { settle, tapError } from "../utils";
 import {
+  environmentRecordToEntries,
+  featureFlagsRecordToEntries,
+  networkPoliciesRecordToEntries,
+  type RunContextAxiomSnapshot,
+} from "./run-context-snapshot.service";
+import {
   decryptStoredSecretValue,
   encryptPersistentSecretValue,
   encryptPersistentSecretsMap,
@@ -310,10 +316,6 @@ interface BuiltStoredExecutionContext {
   // Plain secret values used for run-context redaction; values, not names.
   readonly secretValues: readonly string[];
 }
-
-type RunContextSnapshot = Omit<RunContextResponse, "vars"> & {
-  readonly userId: string;
-};
 
 type ApiErrorResponse<Status extends number, Code extends string> = {
   readonly status: Status;
@@ -3082,7 +3084,11 @@ function ingestRunContextSnapshot(args: {
 }): void {
   const storedContext = args.builtContext.context;
   const manifest = storedContext.storageManifest;
-  const snapshot: RunContextSnapshot & { readonly _time: string } = {
+  const sanitizedEnvironment = sanitizeEnvironment(
+    storedContext.environment,
+    args.builtContext.secretValues,
+  );
+  const snapshot: RunContextAxiomSnapshot = {
     _time: nowDate().toISOString(),
     runId: args.runId,
     userId: args.userId,
@@ -3090,12 +3096,11 @@ function ingestRunContextSnapshot(args: {
     appendSystemPrompt: args.body.appendSystemPrompt ?? null,
     sessionId: storedContext.resumeSession?.sessionId ?? null,
     secretNames: [...args.builtContext.secretNames],
-    environment: sanitizeEnvironment(
-      storedContext.environment,
-      args.builtContext.secretValues,
-    ),
+    environmentEntries: environmentRecordToEntries(sanitizedEnvironment),
     firewalls: sanitizeFirewalls(storedContext.firewalls),
-    networkPolicies: storedContext.networkPolicies ?? null,
+    networkPolicyEntries: networkPoliciesRecordToEntries(
+      storedContext.networkPolicies,
+    ),
     volumes: (manifest?.storages ?? []).map((storage) => {
       return {
         name: storage.name,
@@ -3112,7 +3117,7 @@ function ingestRunContextSnapshot(args: {
             vasVersionId: manifest.artifacts[0]!.vasVersionId,
           }
         : null,
-    featureFlags: storedContext.featureFlags ?? null,
+    featureFlagEntries: featureFlagsRecordToEntries(storedContext.featureFlags),
   };
 
   ingestToAxiom(getDatasetName("run-context"), [snapshot]);

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -882,7 +882,9 @@ function queryRunContext(
       runId: normalizedSnapshot.runId ?? run.id,
       prompt: normalizedSnapshot.prompt ?? run.prompt,
       appendSystemPrompt:
-        normalizedSnapshot.appendSystemPrompt ?? run.appendSystemPrompt ?? null,
+        normalizedSnapshot.appendSystemPrompt !== undefined
+          ? normalizedSnapshot.appendSystemPrompt
+          : (run.appendSystemPrompt ?? null),
     };
   });
 }

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -23,6 +23,7 @@ import { db$, type Db } from "../external/db";
 import { settle, tapError } from "../utils";
 import { zeroConnectorList } from "./zero-connector-data.service";
 import { createPlainSupportThread } from "./plain-support.service";
+import { normalizeRunContextSnapshot } from "./run-context-snapshot.service";
 
 const log = logger("service:diagnostic-bundle");
 
@@ -684,7 +685,7 @@ function assembleActivityLog(
         ),
       ),
       get(queryNetworkLogs(run.id)),
-      tapError(get(queryRunContext(run.id)), (error) => {
+      tapError(get(queryRunContext(run)), (error) => {
         log.warn("Failed to collect run context", { error: String(error) });
       }),
     ]);
@@ -862,16 +863,27 @@ function queryNetworkLogs(
 }
 
 function queryRunContext(
-  runId: string,
+  run: RunMeta,
 ): Computed<Promise<Record<string, unknown> | null>> {
   return computed(async (get): Promise<Record<string, unknown> | null> => {
     const dataset = getDatasetName("run-context");
     const apl = `['${dataset}']
-| where runId == "${escapeAplString(runId)}"
+| where runId == "${escapeAplString(run.id)}"
 | limit 1`;
 
     const results = (await get(queryAxiom(apl))) as Record<string, unknown>[];
-    return results[0] ?? null;
+    const snapshot = results[0];
+    if (!snapshot) {
+      return null;
+    }
+    const normalizedSnapshot = normalizeRunContextSnapshot(snapshot);
+    return {
+      ...normalizedSnapshot,
+      runId: normalizedSnapshot.runId ?? run.id,
+      prompt: normalizedSnapshot.prompt ?? run.prompt,
+      appendSystemPrompt:
+        normalizedSnapshot.appendSystemPrompt ?? run.appendSystemPrompt ?? null,
+    };
   });
 }
 

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -230,6 +230,7 @@ export function featureFlagsRecordToEntries(
 export function normalizeRunContextSnapshot(
   snapshot: Record<string, unknown>,
 ): NormalizedRunContextSnapshot {
+  // Temporary legacy map fallback for #17222; remove after June 18, 2026.
   const environment = Array.isArray(snapshot.environmentEntries)
     ? environmentFromEntries(snapshot.environmentEntries)
     : (stringRecordValue(snapshot.environment) ?? {});

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -4,6 +4,12 @@ import type { NetworkPolicies } from "@vm0/connectors/firewall-types";
 type UnknownRecord = Record<string, unknown>;
 type NetworkPolicy = NetworkPolicies[string];
 type NetworkPolicyValue = "allow" | "deny" | "ask";
+type RunContextFirewall = RunContextResponse["firewalls"][number];
+type RunContextFirewallApi = RunContextFirewall["apis"][number];
+type RunContextFirewallPermission = NonNullable<
+  RunContextFirewallApi["permissions"]
+>[number];
+type RunContextVolume = RunContextResponse["volumes"][number];
 
 export interface RunContextEnvironmentEntry {
   readonly name: string;
@@ -174,6 +180,104 @@ function networkPoliciesFromEntries(
   return Object.keys(policies).length > 0 ? policies : null;
 }
 
+function firewallPermissionFromUnknown(
+  value: unknown,
+): RunContextFirewallPermission | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const name = stringValue(value.name);
+  const rules = stringArrayValue(value.rules);
+  if (!name || !rules) {
+    return undefined;
+  }
+  const description = stringValue(value.description);
+  return description === undefined
+    ? { name, rules }
+    : { name, description, rules };
+}
+
+function firewallApiFromUnknown(
+  value: unknown,
+): RunContextFirewallApi | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const base = stringValue(value.base);
+  if (!base) {
+    return undefined;
+  }
+  if (!Array.isArray(value.permissions)) {
+    return { base };
+  }
+  return {
+    base,
+    permissions: value.permissions.flatMap((permission) => {
+      const normalized = firewallPermissionFromUnknown(permission);
+      return normalized ? [normalized] : [];
+    }),
+  };
+}
+
+function firewallsFromUnknown(value: unknown): RunContextResponse["firewalls"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+    const name = stringValue(item.name);
+    if (!name || !Array.isArray(item.apis)) {
+      return [];
+    }
+    return [
+      {
+        name,
+        apis: item.apis.flatMap((api) => {
+          const normalized = firewallApiFromUnknown(api);
+          return normalized ? [normalized] : [];
+        }),
+      },
+    ];
+  });
+}
+
+function volumeFromUnknown(value: unknown): RunContextVolume | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const name = stringValue(value.name);
+  const mountPath = stringValue(value.mountPath);
+  const vasStorageName = stringValue(value.vasStorageName);
+  const vasVersionId = stringValue(value.vasVersionId);
+  return name && mountPath && vasStorageName && vasVersionId
+    ? { name, mountPath, vasStorageName, vasVersionId }
+    : undefined;
+}
+
+function volumesFromUnknown(value: unknown): RunContextResponse["volumes"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((item) => {
+    const normalized = volumeFromUnknown(item);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function artifactFromUnknown(value: unknown): RunContextResponse["artifact"] {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const mountPath = stringValue(value.mountPath);
+  const vasStorageName = stringValue(value.vasStorageName);
+  const vasVersionId = stringValue(value.vasVersionId);
+  return mountPath && vasStorageName && vasVersionId
+    ? { mountPath, vasStorageName, vasVersionId }
+    : null;
+}
+
 function featureFlagsFromEntries(
   value: unknown,
 ): Record<string, boolean> | null {
@@ -253,16 +357,10 @@ export function normalizeRunContextSnapshot(
     sessionId: stringValue(snapshot.sessionId) ?? null,
     secretNames: stringArrayFromUnknown(snapshot.secretNames),
     environment,
-    firewalls: Array.isArray(snapshot.firewalls)
-      ? (snapshot.firewalls as RunContextResponse["firewalls"])
-      : [],
+    firewalls: firewallsFromUnknown(snapshot.firewalls),
     networkPolicies,
-    volumes: Array.isArray(snapshot.volumes)
-      ? (snapshot.volumes as RunContextResponse["volumes"])
-      : [],
-    artifact: isRecord(snapshot.artifact)
-      ? (snapshot.artifact as RunContextResponse["artifact"])
-      : null,
+    volumes: volumesFromUnknown(snapshot.volumes),
+    artifact: artifactFromUnknown(snapshot.artifact),
     featureFlags,
   };
 }

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -1,0 +1,267 @@
+import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
+import type { NetworkPolicies } from "@vm0/connectors/firewall-types";
+
+type UnknownRecord = Record<string, unknown>;
+type NetworkPolicy = NetworkPolicies[string];
+type NetworkPolicyValue = "allow" | "deny" | "ask";
+
+export interface RunContextEnvironmentEntry {
+  readonly name: string;
+  readonly value: string;
+}
+
+export interface RunContextNetworkPolicyEntry {
+  readonly name: string;
+  readonly policy: NetworkPolicy;
+}
+
+export interface RunContextFeatureFlagEntry {
+  readonly name: string;
+  readonly enabled: boolean;
+}
+
+export type RunContextAxiomSnapshot = Omit<
+  RunContextResponse,
+  "vars" | "environment" | "networkPolicies" | "featureFlags"
+> & {
+  readonly _time: string;
+  readonly userId: string;
+  readonly environmentEntries: readonly RunContextEnvironmentEntry[];
+  readonly networkPolicyEntries: readonly RunContextNetworkPolicyEntry[];
+  readonly featureFlagEntries: readonly RunContextFeatureFlagEntry[];
+};
+
+interface NormalizedRunContextSnapshot {
+  readonly runId?: string;
+  readonly userId?: string;
+  readonly prompt?: string;
+  readonly appendSystemPrompt?: string | null;
+  readonly sessionId: string | null;
+  readonly secretNames: readonly string[];
+  readonly environment: Record<string, string>;
+  readonly firewalls: RunContextResponse["firewalls"];
+  readonly networkPolicies: RunContextResponse["networkPolicies"];
+  readonly volumes: RunContextResponse["volumes"];
+  readonly artifact: RunContextResponse["artifact"];
+  readonly featureFlags: Record<string, boolean> | null;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function stringArrayValue(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = value.filter((item): item is string => {
+    return typeof item === "string";
+  });
+  return strings.length === value.length ? strings : undefined;
+}
+
+function stringRecordValue(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => {
+      return typeof entry[1] === "string";
+    },
+  );
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(entries);
+}
+
+function booleanRecordValue(
+  value: unknown,
+): Record<string, boolean> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, boolean] => {
+      return typeof entry[1] === "boolean";
+    },
+  );
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(entries);
+}
+
+function networkPolicyValue(value: unknown): NetworkPolicyValue | undefined {
+  return value === "allow" || value === "deny" || value === "ask"
+    ? value
+    : undefined;
+}
+
+function networkPolicyFromUnknown(value: unknown): NetworkPolicy | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const unknownPolicy = networkPolicyValue(value.unknownPolicy);
+  if (!unknownPolicy) {
+    return undefined;
+  }
+  return {
+    allow: stringArrayValue(value.allow) ?? [],
+    deny: stringArrayValue(value.deny) ?? [],
+    ask: stringArrayValue(value.ask) ?? [],
+    unknownPolicy,
+  };
+}
+
+function networkPoliciesFromUnknown(
+  value: unknown,
+): RunContextResponse["networkPolicies"] {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const policies: NetworkPolicies = {};
+  for (const [name, rawPolicy] of Object.entries(value)) {
+    const policy = networkPolicyFromUnknown(rawPolicy);
+    if (policy) {
+      policies[name] = policy;
+    }
+  }
+
+  return Object.keys(policies).length > 0 ? policies : null;
+}
+
+function environmentFromEntries(value: unknown): Record<string, string> {
+  if (!Array.isArray(value)) {
+    return {};
+  }
+  const entries: [string, string][] = [];
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const name = stringValue(item.name);
+    const entryValue = stringValue(item.value);
+    if (name && entryValue !== undefined) {
+      entries.push([name, entryValue]);
+    }
+  }
+  return Object.fromEntries(entries);
+}
+
+function networkPoliciesFromEntries(
+  value: unknown,
+): RunContextResponse["networkPolicies"] {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const policies: NetworkPolicies = {};
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const name = stringValue(item.name);
+    const policy = networkPolicyFromUnknown(item.policy);
+    if (name && policy) {
+      policies[name] = policy;
+    }
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
+}
+
+function featureFlagsFromEntries(
+  value: unknown,
+): Record<string, boolean> | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const entries: [string, boolean][] = [];
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const name = stringValue(item.name);
+    if (name && typeof item.enabled === "boolean") {
+      entries.push([name, item.enabled]);
+    }
+  }
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+function stringArrayFromUnknown(value: unknown): string[] {
+  return stringArrayValue(value) ?? [];
+}
+
+export function environmentRecordToEntries(
+  environment: Record<string, string>,
+): RunContextEnvironmentEntry[] {
+  return Object.entries(environment).map(([name, value]) => {
+    return { name, value };
+  });
+}
+
+export function networkPoliciesRecordToEntries(
+  networkPolicies: NetworkPolicies | null | undefined,
+): RunContextNetworkPolicyEntry[] {
+  if (!networkPolicies) {
+    return [];
+  }
+  return Object.entries(networkPolicies).map(([name, policy]) => {
+    return { name, policy };
+  });
+}
+
+export function featureFlagsRecordToEntries(
+  featureFlags: Record<string, boolean> | null | undefined,
+): RunContextFeatureFlagEntry[] {
+  if (!featureFlags) {
+    return [];
+  }
+  return Object.entries(featureFlags).map(([name, enabled]) => {
+    return { name, enabled };
+  });
+}
+
+export function normalizeRunContextSnapshot(
+  snapshot: Record<string, unknown>,
+): NormalizedRunContextSnapshot {
+  const environment = Array.isArray(snapshot.environmentEntries)
+    ? environmentFromEntries(snapshot.environmentEntries)
+    : (stringRecordValue(snapshot.environment) ?? {});
+  const networkPolicies = Array.isArray(snapshot.networkPolicyEntries)
+    ? networkPoliciesFromEntries(snapshot.networkPolicyEntries)
+    : networkPoliciesFromUnknown(snapshot.networkPolicies);
+  const featureFlags = Array.isArray(snapshot.featureFlagEntries)
+    ? featureFlagsFromEntries(snapshot.featureFlagEntries)
+    : (booleanRecordValue(snapshot.featureFlags) ?? null);
+
+  return {
+    runId: stringValue(snapshot.runId),
+    userId: stringValue(snapshot.userId),
+    prompt: stringValue(snapshot.prompt),
+    appendSystemPrompt:
+      typeof snapshot.appendSystemPrompt === "string" ||
+      snapshot.appendSystemPrompt === null
+        ? snapshot.appendSystemPrompt
+        : undefined,
+    sessionId: stringValue(snapshot.sessionId) ?? null,
+    secretNames: stringArrayFromUnknown(snapshot.secretNames),
+    environment,
+    firewalls: Array.isArray(snapshot.firewalls)
+      ? (snapshot.firewalls as RunContextResponse["firewalls"])
+      : [],
+    networkPolicies,
+    volumes: Array.isArray(snapshot.volumes)
+      ? (snapshot.volumes as RunContextResponse["volumes"])
+      : [],
+    artifact: isRecord(snapshot.artifact)
+      ? (snapshot.artifact as RunContextResponse["artifact"])
+      : null,
+    featureFlags,
+  };
+}

--- a/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
@@ -18,10 +18,10 @@ import {
   waitForRunEventWatermarkVisible,
 } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
+import { normalizeRunContextSnapshot } from "./run-context-snapshot.service";
 
 type ServiceDb = Pick<Db, "select">;
 type UnknownRecord = Record<string, unknown>;
-type NetworkPolicyValue = "allow" | "deny" | "ask";
 
 interface AgentComposeContent {
   agent?: { framework?: string };
@@ -113,56 +113,6 @@ function stringRecordValue(value: unknown): Record<string, string> | undefined {
     return undefined;
   }
   return Object.fromEntries(entries);
-}
-
-function booleanRecordValue(
-  value: unknown,
-): Record<string, boolean> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const entries = Object.entries(value).filter(
-    (entry): entry is [string, boolean] => {
-      return typeof entry[1] === "boolean";
-    },
-  );
-  if (entries.length === 0) {
-    return undefined;
-  }
-  return Object.fromEntries(entries);
-}
-
-function networkPolicyValue(value: unknown): NetworkPolicyValue | undefined {
-  return value === "allow" || value === "deny" || value === "ask"
-    ? value
-    : undefined;
-}
-
-function sanitizeNetworkPolicies(
-  value: unknown,
-): RunContextResponse["networkPolicies"] {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const policies: NonNullable<RunContextResponse["networkPolicies"]> = {};
-  for (const [name, rawPolicy] of Object.entries(value)) {
-    if (!isRecord(rawPolicy)) {
-      continue;
-    }
-    const unknownPolicy = networkPolicyValue(rawPolicy.unknownPolicy);
-    if (!unknownPolicy) {
-      continue;
-    }
-    policies[name] = {
-      allow: stringArrayValue(rawPolicy.allow) ?? [],
-      deny: stringArrayValue(rawPolicy.deny) ?? [],
-      ask: stringArrayValue(rawPolicy.ask) ?? [],
-      unknownPolicy,
-    };
-  }
-
-  return Object.keys(policies).length > 0 ? policies : null;
 }
 
 function networkActionValue(
@@ -284,24 +234,12 @@ export function zeroRunContext(
 | limit 1`;
 
     const results = (await get(queryAxiom(apl))) as Record<string, unknown>[];
-    const snapshot = results[0] as
-      | (Omit<
-          RunContextResponse,
-          "vars" | "prompt" | "appendSystemPrompt" | "runId" | "secretNames"
-        > & {
-          sessionId?: string;
-          environment?: UnknownRecord;
-          firewalls?: RunContextResponse["firewalls"];
-          networkPolicies?: unknown;
-          volumes?: RunContextResponse["volumes"];
-          artifact?: RunContextResponse["artifact"];
-          featureFlags?: UnknownRecord;
-        })
-      | undefined;
+    const snapshot = results[0];
 
     if (!snapshot) {
       return { kind: "no-snapshot" };
     }
+    const normalizedSnapshot = normalizeRunContextSnapshot(snapshot);
 
     return {
       kind: "ok",
@@ -309,16 +247,15 @@ export function zeroRunContext(
         prompt: run.prompt,
         appendSystemPrompt: run.appendSystemPrompt ?? null,
         runId,
-        sessionId: (snapshot.sessionId as string) ?? null,
+        sessionId: normalizedSnapshot.sessionId,
         secretNames: (run.secretNames as string[]) ?? [],
         vars: (run.vars as Record<string, string> | undefined) ?? null,
-        environment: stringRecordValue(snapshot.environment) ?? {},
-        firewalls:
-          (snapshot.firewalls as RunContextResponse["firewalls"]) ?? [],
-        networkPolicies: sanitizeNetworkPolicies(snapshot.networkPolicies),
-        volumes: (snapshot.volumes as RunContextResponse["volumes"]) ?? [],
-        artifact: (snapshot.artifact as RunContextResponse["artifact"]) ?? null,
-        featureFlags: booleanRecordValue(snapshot.featureFlags) ?? null,
+        environment: normalizedSnapshot.environment,
+        firewalls: normalizedSnapshot.firewalls,
+        networkPolicies: normalizedSnapshot.networkPolicies,
+        volumes: normalizedSnapshot.volumes,
+        artifact: normalizedSnapshot.artifact,
+        featureFlags: normalizedSnapshot.featureFlags,
       },
     };
   });


### PR DESCRIPTION
Closes #17220

## Summary
- Store dynamic run context maps as `environmentEntries`, `networkPolicyEntries`, and `featureFlagEntries` before sending them to Axiom.
- Normalize entry snapshots back to the existing map-shaped API and diagnostic bundle contract.
- Keep temporary legacy map-field read compatibility for previously ingested run context events.

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agent-runs-create.test.ts src/signals/routes/__tests__/zero-run-context.test.ts src/signals/routes/__tests__/zero-report-error.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/agent-runs-create.test.ts apps/api/src/signals/routes/__tests__/zero-report-error.test.ts apps/api/src/signals/routes/__tests__/zero-run-context.test.ts apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/services/diagnostic-bundle.service.ts apps/api/src/signals/services/run-context-snapshot.service.ts apps/api/src/signals/services/zero-run-detail.service.ts`
- `git diff --check`
