### PR TITLE
fix(cli): remove --no-timestamps toggle from zero video transcribe

### DIFF
--- a/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/zero/video/__tests__/transcribe.test.ts
@@ -64,7 +64,7 @@ describe("zero video transcribe command", () => {
     vi.unstubAllEnvs();
   });
 
-  describe("with timestamps (verbose mode)", () => {
+  describe("with --url", () => {
     it("outputs structured Markdown with timestamp blocks", async () => {
       server.use(
         http.post(STT_URL, () => {
@@ -87,27 +87,6 @@ describe("zero video transcribe command", () => {
       expect(output).toContain("## Transcript");
       expect(output).toContain("[00:02-00:05] Hello world.");
       expect(output).toContain("[00:06-00:07] Second sentence.");
-    });
-  });
-
-  describe("without timestamps (--no-timestamps)", () => {
-    it("outputs plain text transcript", async () => {
-      server.use(
-        http.post(STT_URL, ({ request }) => {
-          expect(new URL(request.url).searchParams.get("verbose")).toBeNull();
-          return HttpResponse.json({ text: "Hello world. Second sentence." });
-        }),
-      );
-
-      await transcribeCommand.parseAsync(
-        ["--url", "https://example.com/video.mp4", "--no-timestamps"],
-        { from: "user" },
-      );
-
-      const output = readStdout();
-      expect(output).toContain("## Transcript");
-      expect(output).toContain("Hello world. Second sentence.");
-      expect(output).not.toMatch(/\[\d{2}:\d{2}-\d{2}:\d{2}\]/);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/zero/video/transcribe.ts
@@ -46,10 +46,6 @@ export const transcribeCommand = new Command()
     "--file <path>",
     "Local file path (alternative to --url or --file-id)",
   )
-  .option(
-    "--no-timestamps",
-    "Output plain text only, without per-segment timestamps",
-  )
   .addHelpText(
     "after",
     `
@@ -57,7 +53,6 @@ Examples:
   Transcribe from URL:      zero video transcribe --url "https://..."
   Transcribe a web file:    zero video transcribe --file-id abc-123-def
   Transcribe a local file:  zero video transcribe --file /tmp/video.mp4
-  Plain text only:          zero video transcribe --url "https://..." --no-timestamps
 
 Output:
   Structured Markdown printed to stdout:
@@ -77,7 +72,6 @@ Notes:
         url?: string;
         fileId?: string;
         file?: string;
-        timestamps: boolean;
       }) => {
         if (!options.url && !options.fileId && !options.file) {
           process.stderr.write(
@@ -128,9 +122,7 @@ Notes:
             { stdio: ["ignore", "ignore", "pipe"] },
           );
 
-          const result = await transcribeAudio(tmpAudio, {
-            verbose: options.timestamps !== false,
-          });
+          const result = await transcribeAudio(tmpAudio, { verbose: true });
 
           process.stdout.write(
             formatTranscript(result.text, result.segments) + "\n",


### PR DESCRIPTION
## Summary

- Removes the `--no-timestamps` option from `zero video transcribe`
- `transcribeAudio` now always called with `verbose: true` — timestamps are always included in output
- Removes the corresponding `without timestamps` test block

## Test plan

- [ ] `zero video transcribe --url <url>` outputs timestamped Markdown as before
- [ ] `--no-timestamps` flag no longer accepted (unknown option error)
- [ ] Existing `--url`, `--file-id`, `--file` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)