### PR TITLE
fix: download hosted site clones from r2

### DIFF
--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -293,6 +293,20 @@ export function generateHostedSitesPresignedPutUrl(
   );
 }
 
+export function generateHostedSitesPresignedGetUrl(
+  bucket: string,
+  key: string,
+  expiresIn: number,
+  usePublicEndpoint = false,
+): Computed<Promise<string>> {
+  return generatePresignedGetUrlWithClient(
+    usePublicEndpoint ? hostedSitesPublicS3Client$ : hostedSitesS3Client$,
+    bucket,
+    key,
+    expiresIn,
+  );
+}
+
 export function generatePresignedGetUrl(
   bucket: string,
   key: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-host.test.ts
@@ -125,6 +125,18 @@ function mockUploadedKeys(keys: readonly string[]) {
   return puts;
 }
 
+function mockSignedUrlFromKey() {
+  context.mocks.s3.getSignedUrl.mockImplementation(
+    (_client: unknown, command: unknown) => {
+      const input =
+        typeof command === "object" && command !== null && "input" in command
+          ? (command.input as { Key?: string })
+          : {};
+      return Promise.resolve(`https://r2.example.com/${input.Key}?sig=test`);
+    },
+  );
+}
+
 describe("POST /api/zero/host/deployments/prepare", () => {
   it("returns 401 when unauthenticated", async () => {
     const client = setupApp({ context })(zeroHostContract);
@@ -610,6 +622,7 @@ describe("GET /api/zero/host/sites/:publicSlug/files", () => {
     );
 
     context.mocks.s3.getSignedUrl.mockClear();
+    mockSignedUrlFromKey();
 
     const response = await accept(
       client.files({
@@ -647,7 +660,23 @@ describe("GET /api/zero/host/sites/:publicSlug/files", () => {
         contentType: "text/html; charset=utf-8",
       },
     ]);
-    expect(context.mocks.s3.getSignedUrl).not.toHaveBeenCalled();
+    expect(
+      response.body.files.map((file) => {
+        return file.downloadUrl;
+      }),
+    ).toStrictEqual([
+      `https://r2.example.com/${prefix}/assets/index-a1b2c3d4.js?sig=test`,
+      `https://r2.example.com/${prefix}/index.html?sig=test`,
+    ]);
+    expect(context.mocks.s3.getSignedUrl).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.getSignedUrl.mock.calls[0]?.[1]).toHaveProperty(
+      "input.Bucket",
+      "test-hosted-sites",
+    );
+    expect(context.mocks.s3.getSignedUrl.mock.calls[0]?.[1]).toHaveProperty(
+      "input.Key",
+      `${prefix}/assets/index-a1b2c3d4.js`,
+    );
   });
 
   it("returns 404 for a hosted site owned by another org", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-host.ts
@@ -127,6 +127,9 @@ const filesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (result.status === "not_found") {
     return notFound(result.message);
   }
+  if (result.status === "config_error") {
+    return internalError(result.message);
+  }
 
   return { status: 200 as const, body: result.body };
 });

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -23,6 +23,7 @@ import { type Db, writeDb$ } from "../external/db";
 import { generateText } from "../external/openrouter";
 import {
   copyHostedSitesS3Object,
+  generateHostedSitesPresignedGetUrl,
   generateHostedSitesPresignedPutUrl,
   hostedSitesS3ObjectExists,
   putHostedSitesS3Object,
@@ -32,6 +33,7 @@ import { safeJsonParse } from "../utils";
 import { recordHostedSiteArtifact$ } from "./run-uploaded-files.service";
 
 const PUT_URL_TTL_SECONDS = 3600;
+const GET_URL_TTL_SECONDS = 3600;
 const MAX_HOSTED_SITE_TOTAL_BYTES = 512 * 1024 * 1024;
 const MAX_HOSTED_SITE_FILE_BYTES = 100 * 1024 * 1024;
 const MAX_PUBLIC_SLUG_ATTEMPTS = 5;
@@ -111,7 +113,8 @@ type GetHostedSiteFilesResult =
       readonly body: HostedSiteFilesResponse;
     }
   | { readonly status: "not_found"; readonly message: string }
-  | { readonly status: "conflict"; readonly message: string };
+  | { readonly status: "conflict"; readonly message: string }
+  | { readonly status: "config_error"; readonly message: string };
 
 type RedeployPresentationTargetResult =
   | {
@@ -793,7 +796,7 @@ export const completeHostedSiteDeployment$ = command(
 
 export const getHostedSiteFiles$ = command(
   async (
-    { set },
+    { get, set },
     args: GetHostedSiteFilesArgs,
     signal: AbortSignal,
   ): Promise<GetHostedSiteFilesResult> => {
@@ -847,9 +850,31 @@ export const getHostedSiteFiles$ = command(
       };
     }
 
-    const files = Object.values(deployment.manifest.files).sort((a, b) => {
-      return a.path.localeCompare(b.path);
-    });
+    const manifestFiles = Object.values(deployment.manifest.files).sort(
+      (a, b) => {
+        return a.path.localeCompare(b.path);
+      },
+    );
+    signal.throwIfAborted();
+
+    const hostedR2 = hostedR2Config();
+    if (hostedR2.status === "config_error") {
+      return hostedR2;
+    }
+
+    const files = await Promise.all(
+      manifestFiles.map(async (file) => {
+        const downloadUrl = await get(
+          generateHostedSitesPresignedGetUrl(
+            hostedR2.config.bucket,
+            fileKey(deployment.r2Prefix, file.path),
+            GET_URL_TTL_SECONDS,
+            true,
+          ),
+        );
+        return { ...file, downloadUrl };
+      }),
+    );
     signal.throwIfAborted();
 
     return {

--- a/turbo/apps/cli/src/commands/zero/host/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/zero/host/__tests__/clone.test.ts
@@ -19,6 +19,7 @@ import { zeroHostCommand } from "../index";
 const FILES_URL = "http://localhost:3000/api/zero/host/sites/:publicSlug/files";
 const HOSTED_SITE_URL =
   "https://demo-site-a1b2c3d4-release-01.sites.example.com";
+const R2_DOWNLOAD_URL = "https://r2.example.com/demo-site";
 
 function sha256(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
@@ -38,6 +39,7 @@ describe("zero host clone command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-token");
     vi.stubEnv("VM0_TOKEN", "test-token");
     tempDir = join(tmpdir(), `zero-host-clone-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
@@ -73,6 +75,7 @@ describe("zero host clone command", () => {
               size: index.byteLength,
               sha256: sha256(index),
               contentType: "text/html; charset=utf-8",
+              downloadUrl: `${R2_DOWNLOAD_URL}/index.html?sig=test`,
             },
             {
               path: "/assets/app.js",
@@ -80,14 +83,15 @@ describe("zero host clone command", () => {
               sha256: sha256(script),
               contentType: "application/javascript; charset=utf-8",
               immutable: true,
+              downloadUrl: `${R2_DOWNLOAD_URL}/assets/app.js?sig=test`,
             },
           ],
         });
       }),
-      http.get(`${HOSTED_SITE_URL}/index.html`, () => {
+      http.get(`${R2_DOWNLOAD_URL}/index.html`, () => {
         return new HttpResponse(index);
       }),
-      http.get(`${HOSTED_SITE_URL}/assets/app.js`, () => {
+      http.get(`${R2_DOWNLOAD_URL}/assets/app.js`, () => {
         return new HttpResponse(script);
       }),
     );
@@ -135,11 +139,12 @@ describe("zero host clone command", () => {
               size: index.byteLength,
               sha256: sha256(index),
               contentType: "text/html; charset=utf-8",
+              downloadUrl: `${R2_DOWNLOAD_URL}/index.html?sig=test`,
             },
           ],
         });
       }),
-      http.get(`${HOSTED_SITE_URL}/index.html`, () => {
+      http.get(`${R2_DOWNLOAD_URL}/index.html`, () => {
         return new HttpResponse(index);
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/host/clone.ts
+++ b/turbo/apps/cli/src/commands/zero/host/clone.ts
@@ -34,7 +34,7 @@ Examples:
 Notes:
   - Authenticates via ZERO_TOKEN (requires host:read capability)
   - Only hosted sites owned by the active org can be cloned
-  - Downloads files from the public hosted site URL and verifies size/hash
+  - Downloads files directly from R2 and verifies size/hash
   - The destination directory must be empty or not exist`,
   )
   .action(

--- a/turbo/apps/cli/src/lib/host/clone-hosted-site.ts
+++ b/turbo/apps/cli/src/lib/host/clone-hosted-site.ts
@@ -90,10 +90,9 @@ function sha256(bytes: Buffer): string {
 
 async function downloadHostedFile(
   file: HostedSiteFilesResponse["files"][number],
-  siteUrl: string,
   destination: string,
 ): Promise<void> {
-  const response = await fetch(new URL(file.path, siteUrl));
+  const response = await fetch(file.downloadUrl);
   if (!response.ok) {
     throw new Error(
       `Failed to download ${file.path} (HTTP ${response.status})`,
@@ -133,7 +132,7 @@ export async function cloneHostedSite(
 
   for (const file of hostedSite.files) {
     options.onProgress?.({ phase: "downloading", path: file.path });
-    await downloadHostedFile(file, hostedSite.url, options.destination);
+    await downloadHostedFile(file, options.destination);
   }
 
   return {

--- a/turbo/packages/api-contracts/src/contracts/zero-host.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-host.ts
@@ -53,6 +53,10 @@ export const hostedSiteFileSchema = z.object({
   immutable: z.boolean().optional(),
 });
 
+export const hostedSiteDownloadFileSchema = hostedSiteFileSchema.extend({
+  downloadUrl: z.string().url(),
+});
+
 export const hostedSitePrepareRequestSchema = z
   .object({
     site: hostedSiteSlugSchema,
@@ -130,7 +134,7 @@ export const hostedSiteFilesResponseSchema = z.object({
   url: z.string().url(),
   fileCount: z.number().int().nonnegative(),
   size: z.number().int().nonnegative(),
-  files: z.array(hostedSiteFileSchema),
+  files: z.array(hostedSiteDownloadFileSchema),
 });
 
 export const zeroHostContract = c.router({


### PR DESCRIPTION
## Summary
- add R2 presigned GET URLs to the hosted-site files API response
- update `zero host clone` to download via those R2 URLs instead of the public hosted site URL
- update API and CLI tests for the R2 clone path

## Verification
- `pnpm format`
- `pnpm turbo run lint --log-order grouped --concurrency=1`
- `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/zero-host.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/host/__tests__/clone.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api run check-types`

Note: `pnpm check-types` with the default Node heap completed preceding packages but OOMed in the API package; the API type check passed when rerun with a 4GB heap.