### PR TITLE
ci: run stripe listener for platform prs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1397,6 +1397,7 @@ jobs:
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
+        needs.prepare.outputs.platform-changed == 'true' ||
         needs.prepare.outputs.ci-changed == 'true' ||
         needs.prepare.outputs.e2e-changed == 'true'
       )
@@ -1467,6 +1468,7 @@ jobs:
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
+        needs.prepare.outputs.platform-changed == 'true' ||
         needs.prepare.outputs.ci-changed == 'true' ||
         needs.prepare.outputs.e2e-changed == 'true'
       ) &&


### PR DESCRIPTION
## Summary
- include platform-only changes in the Stripe listener preview job condition
- keep the subscription Playwright E2E trigger aligned with listener startup

## Why
Platform-only PRs deploy the app/API preview and configure the API Stripe webhook secret, but previously skipped the persistent Stripe CLI listener. That leaves subscription checkout without forwarded webhooks on preview environments.

## Verification
- git diff --check
- actionlint unavailable locally

Full local vitest and dev server were intentionally not run per vm0 PR verification preference.