### PR TITLE
fix: clarify static artifact delivery context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -636,6 +636,8 @@ describe("POST /api/zero/runs", () => {
       "`agent-browser` for browser automation and inspection",
       "Local dev servers are useful for agent-side verification",
       "For static web artifacts, Zero provides `zero host <dir> --site <slug> [--spa]` to publish a directory containing `index.html` to a public URL that users can open; for HTML presentations, include `--artifact-kind presentation-html`",
+      "For static HTML or site artifacts, a hosted URL is the user-accessible artifact view",
+      "`upload-file` commands provide file delivery, which is different from publishing a user-accessible artifact view",
       "For apps or services that require a long-running backend, database, worker, external service, or framework-specific runtime",
       "for HTML presentations, include `--artifact-kind presentation-html`; run `zero host --help`",
       "zero connector status <type>",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -176,7 +176,9 @@ function buildIntegrationToolsPrompt(
     "Local dev servers are useful for agent-side verification, but they are not by themselves a user-facing deliverable.",
     "For static web artifacts, Zero provides `zero host <dir> --site <slug> [--spa]` to publish a directory containing `index.html` to a public URL that users can open; for HTML presentations, include `--artifact-kind presentation-html`.",
     "For apps or services that require a long-running backend, database, worker, external service, or framework-specific runtime, `zero host` may not be sufficient; use the project's own deployment workflow or hosting platform to make the change visible to users.",
-    "A local file needs separate delivery only when it is the requested artifact or the only available user-accessible copy. If the artifact is already available through a hosted URL, email, cloud document, or another user-accessible destination, duplicate file upload is usually unnecessary unless the user asks for the file itself.",
+    "For static HTML or site artifacts, a hosted URL is the user-accessible artifact view; the local `index.html` is an implementation file inside the authored bundle.",
+    "`upload-file` commands provide file delivery, which is different from publishing a user-accessible artifact view. File delivery is useful when the user asks for the file itself, an artifact cannot be hosted, or no hosted, email, cloud document, or other destination already gives the user access.",
+    "Duplicate delivery channels give the user multiple copies of the same artifact; they are useful when they serve different user needs, such as sharing both a live view and a source file.",
   ];
   const localFileContextLines = localFileContext.map((line) => {
     return `- ${line}`;

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -85,6 +85,9 @@ describe("zero generate source-backed artifact commands", () => {
       expect(stdout).toContain(
         `zero host ./generated/mockups/${command}-demo --site ${command}-demo`,
       );
+      expect(stdout).toContain(
+        "The hosted URL is the preview and user-accessible view for this static HTML artifact.",
+      );
     },
   );
 

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -223,11 +223,14 @@ export function createHtmlArtifactAuthoringPacket(
     "- Run the final hosting command only after the artifact looks correct.",
     "",
     "## Publish",
+    "The hosted URL is the preview and user-accessible view for this static HTML artifact.",
     `When everything is OK, publish it with:`,
     "",
     "```bash",
     hostCommand,
     "```",
+    "",
+    "File upload is a separate delivery channel for when the user needs a local file copy, not another way to preview the same hosted artifact.",
   ].join("\n");
 
   return {


### PR DESCRIPTION
## Summary
- Replace the ambiguous local-file delivery prompt with contextual delivery semantics for hosted static artifacts.
- Clarify that `zero host` provides the user-accessible artifact view while `upload-file` is a separate file-delivery channel.
- Add assertions covering the new system prompt and HTML authoring packet context.

## Verification
- `pnpm exec prettier --write apps/api/src/signals/services/zero-runs-create.service.ts apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts apps/cli/src/commands/zero/shared/html-artifact-authoring.ts apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts`
- `pnpm exec vitest run apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F @vm0/cli lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/cli check-types`
- `NODE_OPTIONS="--max-old-space-size=6144" pnpm -F api check-types`