### PR TITLE
fix: show usage range filter in credit balance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -80,6 +80,15 @@ async function enableCreditUsageRecords(fixture: UsageFixture): Promise<void> {
   });
 }
 
+async function disableCreditUsageRecords(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.CreditUsageRecords]: false },
+  });
+}
+
 describe("GET /api/zero/usage/record", () => {
   const track = createFixtureTracker<UsageFixture>((fixture) => {
     return store.set(deleteUsageFixture$, fixture, context.signal);
@@ -145,6 +154,7 @@ describe("GET /api/zero/usage/record", () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),
     );
+    await disableCreditUsageRecords(fixture);
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -3,7 +3,6 @@ import {
   zeroUsageRecordContract,
   type UsageRecordRange,
   type UsageRecordScope,
-  type UsageRecordSource,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
@@ -24,16 +23,10 @@ export const setCreditBalanceTab$ = command(
 
 const PAGE_STEP = 20;
 
-const legacyUsagePageSize$ = state(PAGE_STEP);
 const myUsagePageSize$ = state(PAGE_STEP);
 const teamUsagePageSize$ = state(PAGE_STEP);
-const sourceFilter$ = state<UsageRecordSource | null>(null);
 const myUsageRangeState$ = state<UsageRecordRange>("today");
 const teamUsageRangeState$ = state<UsageRecordRange>("billingPeriod");
-
-export const usageSourceFilter$ = computed((get) => {
-  return get(sourceFilter$);
-});
 
 export const myUsageRange$ = computed((get) => {
   return get(myUsageRangeState$);
@@ -47,13 +40,6 @@ export const setMyUsageRange$ = command(({ set }, range: UsageRecordRange) => {
   set(myUsageRangeState$, range);
   set(myUsagePageSize$, PAGE_STEP);
 });
-
-export const setUsageSourceFilter$ = command(
-  ({ set }, source: UsageRecordSource | null) => {
-    set(sourceFilter$, source);
-    set(legacyUsagePageSize$, PAGE_STEP);
-  },
-);
 
 export const setTeamUsageRange$ = command(
   ({ set }, range: UsageRecordRange) => {
@@ -72,28 +58,9 @@ export const loadMoreUsageRecord$ = command(
   },
 );
 
-export const loadMoreLegacyUsageRecord$ = command(({ get, set }) => {
-  set(legacyUsagePageSize$, get(legacyUsagePageSize$) + PAGE_STEP);
-});
-
 function currentTimeZone(): string {
   return new Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
-
-export const usageRecordAsync$ = computed(async (get) => {
-  const pageSize = get(legacyUsagePageSize$);
-  const source = get(sourceFilter$);
-  const createClient = get(zeroClient$);
-  const client = createClient(zeroUsageRecordContract);
-  const result = await accept(
-    client.get({
-      query: { page: 1, pageSize, ...(source ? { source } : {}) },
-    }),
-    [200],
-    { toast: false },
-  );
-  return result.body;
-});
 
 export const myUsageRecordAsync$ = computed(async (get) => {
   const pageSize = get(myUsagePageSize$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -63,8 +63,9 @@ function usageRows(): UsageRecordRow[] {
   ];
 }
 
-function mockPersonalUsageStory(): void {
+function mockPersonalUsageStory(): string[] {
   const rows = usageRows();
+  const requestedRanges: string[] = [];
 
   context.mocks.data.org({
     id: "org_1",
@@ -104,11 +105,7 @@ function mockPersonalUsageStory(): void {
     });
   });
   context.mocks.api(zeroUsageRecordContract.get, ({ query, respond }) => {
-    const filteredRows = query.source
-      ? rows.filter((row) => {
-          return row.source === query.source;
-        })
-      : rows;
+    requestedRanges.push(query.range);
     const offset = (query.page - 1) * query.pageSize;
 
     return respond(200, {
@@ -116,36 +113,38 @@ function mockPersonalUsageStory(): void {
         start: "2026-03-01T00:00:00.000Z",
         end: "2026-04-01T00:00:00.000Z",
       },
-      rows: filteredRows.slice(offset, offset + query.pageSize),
+      rows: rows.slice(offset, offset + query.pageSize),
       pagination: {
         page: query.page,
         pageSize: query.pageSize,
-        total: filteredRows.length,
+        total: rows.length,
       },
     });
   });
+  return requestedRanges;
 }
 
 async function openUsageSettings(): Promise<void> {
   detachedSetupPage({ context, path: "/?settings=usage" });
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-    expect(screen.getByTestId("credit-balance-info")).toBeInTheDocument();
+    expect(screen.getByText("Today")).toBeInTheDocument();
   });
 }
 
 describe("personal usage settings", () => {
-  it("shows personal usage, loads more, and filters by source", async () => {
-    mockPersonalUsageStory();
+  it("shows personal usage, loads more, and changes the usage range", async () => {
+    const requestedRanges = mockPersonalUsageStory();
     await openUsageSettings();
 
     await waitFor(() => {
-      expect(screen.getByText("12,500")).toBeInTheDocument();
       expect(screen.getByText("Quarterly planning chat")).toBeInTheDocument();
       expect(screen.getByText("Slack customer follow-up")).toBeInTheDocument();
     });
     expect(screen.getByText("980 credits")).toBeInTheDocument();
     expect(screen.queryByText("Extended CLI audit")).not.toBeInTheDocument();
+    expect(screen.queryByText("All sources")).not.toBeInTheDocument();
+    expect(requestedRanges).toContain("today");
 
     click(screen.getByText("Load more"));
 
@@ -153,24 +152,12 @@ describe("personal usage settings", () => {
       expect(screen.getByText("Extended CLI audit")).toBeInTheDocument();
     });
 
-    click(screen.getByText("All sources"));
-    click(await screen.findByText("Slack"));
+    click(screen.getByText("Today"));
+    click(await screen.findByText("Last 7 days"));
 
     await waitFor(() => {
-      expect(screen.getByText("Slack customer follow-up")).toBeInTheDocument();
-      expect(
-        screen.queryByText("Quarterly planning chat"),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText("Extended CLI audit")).not.toBeInTheDocument();
-    });
-
-    click(screen.getByText("Slack"));
-    click(await screen.findByText("Telegram"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("No usage from this source yet."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Last 7 days")).toBeInTheDocument();
+      expect(requestedRanges).toContain("7d");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -34,12 +34,9 @@ import {
   TooltipTrigger,
 } from "@vm0/ui/components/ui/tooltip";
 import {
-  loadMoreLegacyUsageRecord$,
   loadMoreUsageRecord$,
   myUsageRecordAsync$,
   teamUsageRecordAsync$,
-  usageRecordAsync$,
-  usageSourceFilter$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
 import { setSettingsDialogOpen$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
@@ -99,14 +96,6 @@ const RANGE_OPTIONS = [
   label: string;
 }[];
 
-const FILTER_OPTIONS = [
-  "chat",
-  "schedule",
-  "slack",
-  "telegram",
-  "other",
-] as const satisfies readonly UsageRecordSource[];
-
 const ROW_CLASS =
   "block px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50";
 
@@ -145,55 +134,6 @@ function rangeLabel(range: UsageRecordRange): string {
 
 function usageRowKey(row: UsageRecordRow): string {
   return `${row.source}:${row.threadId ?? row.runId ?? row.lastActivityAt}:${row.member?.userId ?? "mine"}`;
-}
-
-export function SourceFilter({
-  value,
-  onChange,
-}: {
-  value: UsageRecordSource | null;
-  onChange: (source: UsageRecordSource | null) => void;
-}) {
-  const label = value ? SOURCE_META[value].label : "All sources";
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="zero-btn-morandi h-9 shrink-0 rounded-lg border"
-        >
-          {label}
-          <IconChevronDown
-            size={14}
-            stroke={1.5}
-            className="ml-1.5 text-muted-foreground"
-          />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuItem
-          onClick={() => {
-            onChange(null);
-          }}
-        >
-          All sources
-        </DropdownMenuItem>
-        {FILTER_OPTIONS.map((source) => {
-          return (
-            <DropdownMenuItem
-              key={source}
-              onClick={() => {
-                onChange(source);
-              }}
-            >
-              {SOURCE_META[source].label}
-            </DropdownMenuItem>
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
 }
 
 export function UsageRangeSelect({
@@ -440,59 +380,6 @@ function UsageRecordContent({
                   className="h-9 rounded-lg text-muted-foreground hover:bg-[hsl(var(--gray-50))] hover:text-foreground"
                   onClick={() => {
                     loadMore(scope);
-                  }}
-                >
-                  Load more
-                </Button>
-              </div>
-            )}
-          </div>
-        ))}
-    </section>
-  );
-}
-
-export function LegacyPersonalUsageRecord() {
-  const loadable = useLastLoadable(usageRecordAsync$);
-  const loadMore = useSet(loadMoreLegacyUsageRecord$);
-  const filter = useGet(usageSourceFilter$);
-
-  return (
-    <section className="flex flex-col gap-4">
-      {loadable.state === "loading" && <UsageRecordSkeleton />}
-      {loadable.state === "hasError" && (
-        <p className="text-sm text-muted-foreground" role="alert">
-          Couldn&apos;t load your usage record. Please try again later.
-        </p>
-      )}
-      {loadable.state === "hasData" &&
-        (loadable.data.rows.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            {filter
-              ? "No usage from this source yet."
-              : "No usage yet. Your runs will show up here as you use credits."}
-          </p>
-        ) : (
-          <div className="flex flex-col gap-3">
-            <TooltipProvider delayDuration={100}>
-              <div
-                className="overflow-hidden rounded-xl bg-card"
-                style={{ border: CARD_BORDER }}
-              >
-                {loadable.data.rows.map((row) => {
-                  return <UsageRow key={usageRowKey(row)} row={row} />;
-                })}
-              </div>
-            </TooltipProvider>
-            {loadable.data.rows.length < loadable.data.pagination.total && (
-              <div className="flex justify-center">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-9 rounded-lg text-muted-foreground hover:bg-[hsl(var(--gray-50))] hover:text-foreground"
-                  onClick={() => {
-                    loadMore();
                   }}
                 >
                   Load more

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -1,19 +1,12 @@
-import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { CreditBalanceCard } from "../../org-manage/org-usage-tab.tsx";
 import {
-  CreditBalanceCard,
-  OrgUsageTab,
-} from "../../org-manage/org-usage-tab.tsx";
-import {
-  LegacyPersonalUsageRecord,
   PersonalUsageRecord,
-  SourceFilter,
   TeamUsageRecord,
   UsageRangeSelect,
 } from "../../preferences/personal-usage-record.tsx";
 import { isOrgAdmin$ } from "../../../../../signals/org.ts";
-import { featureSwitch$ } from "../../../../../signals/external/feature-switch.ts";
 import { setSettingsActiveSection$ } from "../../../../../signals/zero-page/settings/settings-dialog.ts";
 import { setBillingSubPage$ } from "../../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import {
@@ -21,10 +14,8 @@ import {
   myUsageRange$,
   setCreditBalanceTab$,
   setMyUsageRange$,
-  setUsageSourceFilter$,
   setTeamUsageRange$,
   teamUsageRange$,
-  usageSourceFilter$,
   type CreditBalanceTab,
 } from "../../../../../signals/zero-page/settings/personal-usage-record.ts";
 
@@ -36,11 +27,6 @@ export function CreditBalanceSection() {
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
   const tab = useGet(creditBalanceTab$);
   const setTab = useSet(setCreditBalanceTab$);
-  const features = useLastResolved(featureSwitch$);
-  const creditUsageRecordsEnabled =
-    features?.[FeatureSwitchKey.CreditUsageRecords] ?? false;
-  const sourceFilter = useGet(usageSourceFilter$);
-  const setSourceFilter = useSet(setUsageSourceFilter$);
   const myRange = useGet(myUsageRange$);
   const teamRange = useGet(teamUsageRange$);
   const setMyRange = useSet(setMyUsageRange$);
@@ -58,55 +44,6 @@ export function CreditBalanceSection() {
 
   const activeRange = tab === "team" ? teamRange : myRange;
   const setActiveRange = tab === "team" ? setTeamRange : setMyRange;
-  const legacyPersonalFilter = (
-    <SourceFilter value={sourceFilter} onChange={setSourceFilter} />
-  );
-
-  if (!creditUsageRecordsEnabled) {
-    if (!isAdmin) {
-      return (
-        <div className="flex flex-col gap-6">
-          {creditCard}
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-end">
-              {legacyPersonalFilter}
-            </div>
-            <LegacyPersonalUsageRecord />
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div className="flex flex-col gap-6">
-        {creditCard}
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between gap-3">
-            <Tabs
-              value={tab}
-              onValueChange={(value) => {
-                setTab(value as CreditBalanceTab);
-              }}
-            >
-              <TabsList>
-                <TabsTrigger value="mine">My usage</TabsTrigger>
-                <TabsTrigger value="team">Team usage</TabsTrigger>
-              </TabsList>
-            </Tabs>
-            {tab === "mine" ? legacyPersonalFilter : null}
-          </div>
-          {tab === "mine" ? (
-            <LegacyPersonalUsageRecord />
-          ) : (
-            <OrgUsageTab
-              showCreditBalance={false}
-              onComparePlans={goToComparePlans}
-            />
-          )}
-        </div>
-      </div>
-    );
-  }
 
   // Non-admins only have personal usage and cannot see the org credit balance.
   if (!isAdmin) {
@@ -124,7 +61,7 @@ export function CreditBalanceSection() {
     <div className="flex flex-col gap-6">
       {creditCard}
       <div className="flex flex-col gap-4">
-        {/* One compact header row: tabs on the left, source filter on the right. */}
+        {/* One compact header row: tabs on the left, range filter on the right. */}
         <div className="flex items-center justify-between gap-3">
           <Tabs
             value={tab}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -1,6 +1,6 @@
 // oxlint-disable max-lines-per-function
 import type { ReactNode } from "react";
-import { useGet, useLastResolved, useSet, useLoadable } from "ccstate-react";
+import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   Dialog,
   DialogContent,
@@ -24,10 +24,8 @@ import {
   IconKey,
   IconUsers,
 } from "@tabler/icons-react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
-import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import {
   isAdminOnlySettingsSection,
   settingsActiveSection$,
@@ -132,7 +130,7 @@ const MODELS_GROUP = {
 } as const satisfies SidebarGroup;
 
 // The usage section is visible to everyone; the label and detail UI depend on
-// org role and the credit usage records feature switch.
+// org role.
 const CREDIT_BALANCE_ITEM = {
   id: "usage",
   label: "Credit balance",
@@ -144,19 +142,13 @@ const BILLING_ADMIN_ITEMS = [
   { id: "invoices", label: "Invoices", icon: IconFileInvoice },
 ] as const satisfies readonly SidebarItem[];
 
-function billingGroup(
-  isAdmin: boolean,
-  creditUsageRecordsEnabled: boolean,
-): SidebarGroup {
+function billingGroup(isAdmin: boolean): SidebarGroup {
   return {
     label: "Billing & pricing",
     items: [
       {
         ...CREDIT_BALANCE_ITEM,
-        label:
-          !isAdmin && creditUsageRecordsEnabled
-            ? "Credit usage"
-            : "Credit balance",
+        label: !isAdmin ? "Credit usage" : "Credit balance",
       },
       ...(isAdmin ? BILLING_ADMIN_ITEMS : []),
     ],
@@ -221,15 +213,12 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
-  const features = useLastResolved(featureSwitch$);
-  const creditUsageRecordsEnabled =
-    features?.[FeatureSwitchKey.CreditUsageRecords] ?? false;
 
   const sidebarGroups: readonly SidebarGroup[] = [
     PERSONAL_GROUP,
     ...(isAdmin ? [WORKSPACE_GROUP] : []),
     MODELS_GROUP,
-    billingGroup(isAdmin, creditUsageRecordsEnabled),
+    billingGroup(isAdmin),
   ];
 
   // If the user lost admin while the dialog is open, fall back to a safe section
@@ -238,7 +227,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       ? "preference"
       : activeSection;
   const meta =
-    resolvedSection === "usage" && !isAdmin && creditUsageRecordsEnabled
+    resolvedSection === "usage" && !isAdmin
       ? {
           title: "Credit usage",
           description:

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -356,7 +356,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show ranged personal and team credit usage records in settings, and enable scoped/ranged /api/zero/usage/record queries.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ZeroAutomations]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary
- always show the usage range selector in the Credit Balance settings section
- remove the legacy source filter path from that dialog so `All sources` no longer appears
- keep the disabled API feature-switch path covered explicitly in tests

## Validation
- `git diff --check`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx --reporter=verbose --testTimeout=10000`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-usage-tab.test.tsx --reporter=verbose --testTimeout=10000`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`

## Notes
- API route test file could not complete locally because Postgres was unavailable (`ECONNREFUSED 127.0.0.1:5432`).
- Browser UI verification was blocked locally by the app browser-version check showing `Update Chrome to continue`.
