### PR TITLE
ci: use larger runner for runner image build

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -198,7 +198,7 @@ jobs:
         run: .github/scripts/runner-image-context.sh artifact-name
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:


### PR DESCRIPTION
## Summary
- Move the runner-image build job from ubuntu-latest to the repo's existing ubuntu-latest-8-cores runner label.
- Keep prepare and downstream metal-host image build behavior unchanged.

## Validation
- git diff --check
- YAML parse via Ruby
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/runner-image.yml