### PR TITLE
test: cover greedy host parameter casing

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -496,11 +496,13 @@ def match_host(host: str, pattern: str) -> dict | None:
     ({name+}, {name*}) must appear in the first (leftmost) position.
 
     - Literal segments must match exactly (case-insensitive).
-    - {name} matches a single host segment.
+    - {name} matches a single host segment, captured in lowercase.
     - prefix{name}suffix matches a host segment case-insensitively, with
-      the non-empty middle captured into `name` (case preserved from host).
+      the non-empty middle captured into `name` in lowercase.
     - {name+} matches one or more leading host segments. Must be first.
+      Captures preserve the input case supplied to match_host().
     - {name*} matches zero or more leading host segments. Must be first.
+      Non-empty captures preserve the input case supplied to match_host().
     """
     pattern_segs = _compile_segments(tuple(reversed(pattern.split("."))))
     if pattern_segs is None:

--- a/crates/runner/mitm-addon/tests/test_matching_base_url_parameterized.py
+++ b/crates/runner/mitm-addon/tests/test_matching_base_url_parameterized.py
@@ -26,6 +26,13 @@ class TestMatchBaseUrl:
         assert rel_path == "/api/v2/tickets"
         assert params == {"Subdomain": "acme"}
 
+    def test_parameterized_base_normalizes_runtime_host_before_params(self):
+        result = matching.match_base_url(
+            "https://Foo.Bar.example.com/api",
+            "https://{sub+}.example.com",
+        )
+        assert result == ("/api", {"sub": "foo.bar"})
+
     def test_parameterized_base_with_query_is_rejected(self):
         result = matching.match_base_url(
             "https://acme.zendesk.com/api/v2/tickets",

--- a/crates/runner/mitm-addon/tests/test_matching_host.py
+++ b/crates/runner/mitm-addon/tests/test_matching_host.py
@@ -22,6 +22,10 @@ class TestMatchHost:
         result = matching.match_host("a.b.c.example.com", "{sub+}.example.com")
         assert result == {"sub": "a.b.c"}
 
+    def test_greedy_plus_preserves_runtime_host_case(self):
+        result = matching.match_host("Foo.Bar.example.com", "{sub+}.example.com")
+        assert result == {"sub": "Foo.Bar"}
+
     def test_greedy_plus_matches_single(self):
         result = matching.match_host("x.example.com", "{sub+}.example.com")
         assert result == {"sub": "x"}
@@ -33,6 +37,10 @@ class TestMatchHost:
     def test_greedy_star_matches_multi(self):
         result = matching.match_host("a.b.example.com", "{sub*}.example.com")
         assert result == {"sub": "a.b"}
+
+    def test_greedy_star_preserves_runtime_host_case(self):
+        result = matching.match_host("Foo.Bar.example.com", "{sub*}.example.com")
+        assert result == {"sub": "Foo.Bar"}
 
     def test_greedy_star_matches_zero(self):
         result = matching.match_host("example.com", "{sub*}.example.com")

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
@@ -170,6 +170,12 @@ describe("matchFirewallHost", () => {
     ).toEqual({ deployment: "Foo.Bar" });
   });
 
+  it("preserves original case for star-greedy leading host params", () => {
+    expect(
+      matchFirewallHost("Foo.Bar.bentoml.ai", "{deployment*}.bentoml.ai"),
+    ).toEqual({ deployment: "Foo.Bar" });
+  });
+
   it("requires a non-empty leading host for plus greedy params", () => {
     expect(
       matchFirewallHost("bentoml.ai", "{deployment+}.bentoml.ai"),


### PR DESCRIPTION
## Summary

- Document Python `match_host()` host parameter casing semantics accurately.
- Add Python low-level coverage for uppercase `{sub+}` and `{sub*}` host captures.
- Add Python base URL coverage for normalized runtime host params.
- Add TypeScript low-level coverage for uppercase star-greedy host captures.

Closes #17206

## Testing

- `PYTHONPATH=/tmp/vm4-mitm-addon-pydeps python3 -m pytest tests/test_matching_host.py tests/test_matching_base_url_parameterized.py`
- `PYTHONPATH=/tmp/vm4-mitm-addon-pydeps PATH=/tmp/vm4-mitm-addon-pydeps/bin:$PATH ruff check .`
- `PYTHONPATH=/tmp/vm4-mitm-addon-pydeps PATH=/tmp/vm4-mitm-addon-pydeps/bin:$PATH ruff format --check .`
- `PYTHONPATH=/tmp/vm4-mitm-addon-pydeps PATH=/tmp/vm4-mitm-addon-pydeps/bin:$PATH basedpyright -p .`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-rule-matcher.test.ts`
- `pnpm -F @vm0/connectors run check-types`
- `pnpm check-types`
- `lefthook run pre-commit --jobs turbo`
- `lefthook run pre-commit --jobs check-file-size`
- `lefthook run pre-commit --jobs ensure-connector-firewalls-index-only`