### PR TITLE
fix(mitm-addon): validate X fallback query hints

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -549,7 +549,13 @@ def _slice_exceeds_query_hint_byte_limit(value: str, start: int, end: int, max_b
     size = 0
     for index in range(start, end):
         char = value[index]
-        size += 1 if ord(char) < _ASCII_CODEPOINT_LIMIT else len(char.encode("utf-8"))
+        if ord(char) < _ASCII_CODEPOINT_LIMIT:
+            size += 1
+        else:
+            try:
+                size += len(char.encode("utf-8"))
+            except UnicodeEncodeError:
+                return True
         if size > max_bytes:
             return True
     return False

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -131,6 +131,7 @@ _REQUEST_FALLBACK_HINT_POLICY_SPECS: tuple[tuple[str, _RequestFallbackHintPolicy
     ("/2/tweets/search/recent", _RequestFallbackHintPolicy(None, None, 10, 100)),
     ("/2/users/search", _RequestFallbackHintPolicy(None, None, 1, 1000)),
     ("/2/users/{id}/followers", _RequestFallbackHintPolicy(None, None, 1, 1000)),
+    ("/2/users/{id}/following", _RequestFallbackHintPolicy(None, None, 1, 1000)),
 )
 
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -121,17 +121,59 @@ class _RequestFallbackHintPolicy(NamedTuple):
     max_results_max: int | None
 
 
+_REQUEST_IDS_100_HINT_POLICY = _RequestFallbackHintPolicy("ids", 100, None, None)
+_REQUEST_USERNAMES_100_HINT_POLICY = _RequestFallbackHintPolicy("usernames", 100, None, None)
+_REQUEST_PAGE_1_TO_100_HINT_POLICY = _RequestFallbackHintPolicy(None, None, 1, 100)
+_REQUEST_PAGE_5_TO_100_HINT_POLICY = _RequestFallbackHintPolicy(None, None, 5, 100)
+_REQUEST_PAGE_10_TO_100_HINT_POLICY = _RequestFallbackHintPolicy(None, None, 10, 100)
+_REQUEST_PAGE_1_TO_1000_HINT_POLICY = _RequestFallbackHintPolicy(None, None, 1, 1000)
+
+
 _REQUEST_FALLBACK_HINT_POLICY_SPECS: tuple[tuple[str, _RequestFallbackHintPolicy], ...] = (
-    # X batch lookup selectors. Docs cap these selector lists at 100 entries.
-    ("/2/tweets", _RequestFallbackHintPolicy("ids", 100, None, None)),
-    ("/2/users", _RequestFallbackHintPolicy("ids", 100, None, None)),
-    ("/2/users/by", _RequestFallbackHintPolicy("usernames", 100, None, None)),
-    # X page-size hints. The bounds are endpoint-specific; unlisted paths do
-    # not get to use a same-named query parameter as fallback billing evidence.
-    ("/2/tweets/search/recent", _RequestFallbackHintPolicy(None, None, 10, 100)),
-    ("/2/users/search", _RequestFallbackHintPolicy(None, None, 1, 1000)),
-    ("/2/users/{id}/followers", _RequestFallbackHintPolicy(None, None, 1, 1000)),
-    ("/2/users/{id}/following", _RequestFallbackHintPolicy(None, None, 1, 1000)),
+    # X query hints are trusted only for documented count-source parameters on
+    # billable generated-firewall GET paths. App-only paths stay omitted because
+    # ``classify_bucket`` skips them before fallback parsing.
+    ("/2/spaces", _REQUEST_IDS_100_HINT_POLICY),
+    ("/2/tweets", _REQUEST_IDS_100_HINT_POLICY),
+    ("/2/tweets/analytics", _REQUEST_IDS_100_HINT_POLICY),
+    ("/2/users", _REQUEST_IDS_100_HINT_POLICY),
+    ("/2/users/by", _REQUEST_USERNAMES_100_HINT_POLICY),
+    ("/2/users/public_keys", _REQUEST_IDS_100_HINT_POLICY),
+    ("/2/chat/conversations", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/communities/search", _REQUEST_PAGE_10_TO_100_HINT_POLICY),
+    ("/2/dm_conversations/with/{participant_id}/dm_events", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/dm_conversations/{id}/dm_events", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/dm_events", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/lists/{id}/followers", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/lists/{id}/members", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/lists/{id}/tweets", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/news/search", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/notes/search/notes_written", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/notes/search/posts_eligible_for_notes", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/spaces/search", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/spaces/{id}/buyers", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/spaces/{id}/tweets", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/tweets/search/recent", _REQUEST_PAGE_10_TO_100_HINT_POLICY),
+    ("/2/tweets/{id}/liking_users", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/tweets/{id}/quote_tweets", _REQUEST_PAGE_10_TO_100_HINT_POLICY),
+    ("/2/tweets/{id}/retweeted_by", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/tweets/{id}/retweets", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/reposts_of_me", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/search", _REQUEST_PAGE_1_TO_1000_HINT_POLICY),
+    ("/2/users/{id}/affiliates", _REQUEST_PAGE_1_TO_1000_HINT_POLICY),
+    ("/2/users/{id}/blocking", _REQUEST_PAGE_1_TO_1000_HINT_POLICY),
+    ("/2/users/{id}/bookmarks", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/{id}/bookmarks/folders", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/{id}/followed_lists", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/{id}/followers", _REQUEST_PAGE_1_TO_1000_HINT_POLICY),
+    ("/2/users/{id}/following", _REQUEST_PAGE_1_TO_1000_HINT_POLICY),
+    ("/2/users/{id}/liked_tweets", _REQUEST_PAGE_5_TO_100_HINT_POLICY),
+    ("/2/users/{id}/list_memberships", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/{id}/mentions", _REQUEST_PAGE_5_TO_100_HINT_POLICY),
+    ("/2/users/{id}/muting", _REQUEST_PAGE_1_TO_1000_HINT_POLICY),
+    ("/2/users/{id}/owned_lists", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/{id}/timelines/reverse_chronological", _REQUEST_PAGE_1_TO_100_HINT_POLICY),
+    ("/2/users/{id}/tweets", _REQUEST_PAGE_5_TO_100_HINT_POLICY),
 )
 
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -612,36 +612,45 @@ def _parse_request_query_fallback_hints(original_url: str) -> dict:
             if separator and raw_value:
                 hint_key = _decode_request_query_hint_key(raw_key)
                 if hint_key is not None:
-                    if _exceeds_query_hint_byte_limit(
-                        raw_value, _REQUEST_QUERY_HINT_VALUE_MAX_BYTES
+                    id_count_max = policy.id_count_max if hint_key == policy.id_query_key else None
+                    max_results_min = (
+                        policy.max_results_min
+                        if hint_key == _REQUEST_MAX_RESULTS_QUERY_KEY and not max_results_seen
+                        else None
+                    )
+                    max_results_max = (
+                        policy.max_results_max
+                        if hint_key == _REQUEST_MAX_RESULTS_QUERY_KEY and not max_results_seen
+                        else None
+                    )
+                    if id_count_max is not None or (
+                        max_results_min is not None and max_results_max is not None
                     ):
-                        return _empty_request_query_fallback_hints()
+                        if _exceeds_query_hint_byte_limit(
+                            raw_value, _REQUEST_QUERY_HINT_VALUE_MAX_BYTES
+                        ):
+                            return _empty_request_query_fallback_hints()
 
-                    decoded_value = urllib.parse.unquote_plus(raw_value)
-                    if hint_key == policy.id_query_key and policy.id_count_max is not None:
-                        remaining = policy.id_count_max - ids_count
-                        if remaining < 1:
-                            ids_count = 0
-                            break
-                        value_count = _count_bounded_non_empty_comma_segments(
-                            decoded_value, remaining
-                        )
-                        if value_count is None:
-                            ids_count = 0
-                            break
-                        ids_count += value_count
-                    elif (
-                        hint_key == _REQUEST_MAX_RESULTS_QUERY_KEY
-                        and policy.max_results_min is not None
-                        and policy.max_results_max is not None
-                        and not max_results_seen
-                    ):
-                        max_results_seen = True
-                        max_results = _parse_bounded_positive_decimal(
-                            decoded_value,
-                            policy.max_results_min,
-                            policy.max_results_max,
-                        )
+                        decoded_value = urllib.parse.unquote_plus(raw_value)
+                        if id_count_max is not None:
+                            remaining = id_count_max - ids_count
+                            if remaining < 1:
+                                ids_count = 0
+                                break
+                            value_count = _count_bounded_non_empty_comma_segments(
+                                decoded_value, remaining
+                            )
+                            if value_count is None:
+                                ids_count = 0
+                                break
+                            ids_count += value_count
+                        elif max_results_min is not None and max_results_max is not None:
+                            max_results_seen = True
+                            max_results = _parse_bounded_positive_decimal(
+                                decoded_value,
+                                max_results_min,
+                                max_results_max,
+                            )
 
         if end == len(query):
             break

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -7,13 +7,14 @@ through the X firewall and buffers them for aggregate platform upload.
 import json
 import re
 import urllib.parse
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from typing import Literal, NamedTuple, TypedDict
 
 from mitmproxy import http
 
 import body_utils
 import flow_metadata_keys as metadata_keys
+import matching
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
@@ -111,6 +112,43 @@ _X_JSON_RESULT_COUNT_FIELDS = {
 class _IncludeBillingCategory(NamedTuple):
     category: str
     kind: Literal["known", "synthetic", "overflow"]
+
+
+class _RequestFallbackHintPolicy(NamedTuple):
+    id_query_key: str | None
+    id_count_max: int | None
+    max_results_min: int | None
+    max_results_max: int | None
+
+
+_REQUEST_FALLBACK_HINT_POLICY_SPECS: tuple[tuple[str, _RequestFallbackHintPolicy], ...] = (
+    # X batch lookup selectors. Docs cap these selector lists at 100 entries.
+    ("/2/tweets", _RequestFallbackHintPolicy("ids", 100, None, None)),
+    ("/2/users", _RequestFallbackHintPolicy("ids", 100, None, None)),
+    ("/2/users/by", _RequestFallbackHintPolicy("usernames", 100, None, None)),
+    # X page-size hints. The bounds are endpoint-specific; unlisted paths do
+    # not get to use a same-named query parameter as fallback billing evidence.
+    ("/2/tweets/search/recent", _RequestFallbackHintPolicy(None, None, 10, 100)),
+    ("/2/users/search", _RequestFallbackHintPolicy(None, None, 1, 1000)),
+    ("/2/users/{id}/followers", _RequestFallbackHintPolicy(None, None, 1, 1000)),
+)
+
+
+def _compile_request_fallback_hint_policies(
+    specs: tuple[tuple[str, _RequestFallbackHintPolicy], ...],
+) -> tuple[tuple[matching.CompiledPathPattern, _RequestFallbackHintPolicy], ...]:
+    compiled_policies: list[tuple[matching.CompiledPathPattern, _RequestFallbackHintPolicy]] = []
+    for path_pattern, policy in specs:
+        compiled_pattern = matching.compile_path_pattern(path_pattern)
+        if compiled_pattern is None:
+            raise ValueError(f"invalid X fallback hint path pattern: {path_pattern}")
+        compiled_policies.append((compiled_pattern, policy))
+    return tuple(compiled_policies)
+
+
+_REQUEST_FALLBACK_HINT_POLICIES = _compile_request_fallback_hint_policies(
+    _REQUEST_FALLBACK_HINT_POLICY_SPECS
+)
 
 
 def _as_non_bool_int(value: object) -> int | None:
@@ -394,8 +432,14 @@ def create_response_parser(
     return ConnectorResponseParser(feed=extractor.feed, finish=finish_json_state)
 
 
-def _count_non_empty_comma_segments(values: Iterable[str]) -> int | None:
-    count = sum(1 for value in values for segment in value.split(",") if segment.strip())
+def _count_bounded_non_empty_comma_segments(value: str, max_count: int) -> int | None:
+    count = 0
+    for segment in value.split(","):
+        if not segment.strip():
+            continue
+        count += 1
+        if count > max_count:
+            return None
     return count or None
 
 
@@ -431,6 +475,27 @@ def _decode_request_query_hint_key(raw_key: str) -> str | None:
     decoded_key = urllib.parse.unquote_plus(raw_key)
     if decoded_key in _REQUEST_ID_LIKE_QUERY_KEYS or decoded_key == _REQUEST_MAX_RESULTS_QUERY_KEY:
         return decoded_key
+    return None
+
+
+def _request_fallback_hint_policy_for_path(path: str) -> _RequestFallbackHintPolicy | None:
+    for pattern, policy in _REQUEST_FALLBACK_HINT_POLICIES:
+        if matching.match_compiled_path(path, pattern) is not None:
+            return policy
+    return None
+
+
+def _parse_bounded_positive_decimal(value: str, min_value: int, max_value: int) -> int | None:
+    if not value or any(char < "0" or char > "9" for char in value):
+        return None
+    if value.startswith("0"):
+        return None
+    if len(value) > len(str(max_value)):
+        return None
+
+    parsed = int(value)
+    if min_value <= parsed <= max_value:
+        return parsed
     return None
 
 
@@ -470,18 +535,22 @@ def _get_bounded_original_request_query(original_url: str) -> str | None:
 
 
 def _parse_request_query_fallback_hints(original_url: str) -> dict:
-    """Extract request-side count hints for unparseable non-count GET responses.
+    """Extract endpoint-scoped count hints for unparseable non-count GETs.
 
     This intentionally does not call ``parse_qs``.  Successful X responses
     normally bill from the parsed response body, so query hints are only a
     fallback for lost response visibility.  ``report_usage`` merges these
-    fields only when a non-count GET response was not parsed.  The scanner
-    therefore looks only for the small key set that can affect fallback billing,
-    preserves ``parse_qs``' blank-value and ``+`` behavior for those keys, and
-    caps work on hostile query strings instead of materializing every parameter.
+    fields only when a non-count GET response was not parsed.  Even then, the
+    scanner trusts a query hint only when the current endpoint documents that
+    hint as count visibility, and caps work on hostile query strings instead of
+    materializing every parameter.
 
     Returns ``request_ids_count`` and ``max_results``.
     """
+    policy = _request_fallback_hint_policy_for_path(urllib.parse.urlparse(original_url).path)
+    if policy is None:
+        return _empty_request_query_fallback_hints()
+
     query = _get_bounded_original_request_query(original_url)
     if query is None:
         return _empty_request_query_fallback_hints()
@@ -506,16 +575,30 @@ def _parse_request_query_fallback_hints(original_url: str) -> dict:
                         return _empty_request_query_fallback_hints()
 
                     decoded_value = urllib.parse.unquote_plus(raw_value)
-                    if hint_key in _REQUEST_ID_LIKE_QUERY_KEYS:
-                        value_count = _count_non_empty_comma_segments((decoded_value,))
-                        if value_count is not None:
-                            ids_count += value_count
-                    elif hint_key == _REQUEST_MAX_RESULTS_QUERY_KEY and not max_results_seen:
+                    if hint_key == policy.id_query_key and policy.id_count_max is not None:
+                        remaining = policy.id_count_max - ids_count
+                        if remaining < 1:
+                            ids_count = 0
+                            break
+                        value_count = _count_bounded_non_empty_comma_segments(
+                            decoded_value, remaining
+                        )
+                        if value_count is None:
+                            ids_count = 0
+                            break
+                        ids_count += value_count
+                    elif (
+                        hint_key == _REQUEST_MAX_RESULTS_QUERY_KEY
+                        and policy.max_results_min is not None
+                        and policy.max_results_max is not None
+                        and not max_results_seen
+                    ):
                         max_results_seen = True
-                        try:
-                            max_results = int(decoded_value)
-                        except ValueError:
-                            max_results = None
+                        max_results = _parse_bounded_positive_decimal(
+                            decoded_value,
+                            policy.max_results_min,
+                            policy.max_results_max,
+                        )
 
         if end == len(query):
             break
@@ -633,9 +716,9 @@ def _compute_billable_counts(
       trust the actual response.  Soft errors (HTTP 200 + ``errors`` array,
       no ``data``) and zero-result searches yield primary 0, which is skipped
       from the returned dict so no empty ``usage_event`` row is created.
-    - **Body NOT parsed**: fall back to request-side hints
-      ``max(request_ids_count, max_results, 1)``.  When the URL also carries
-      no hints we emit no ``usage_event`` row; :func:`report_usage`
+    - **Body NOT parsed**: fall back to endpoint-scoped request-side hints
+      ``max(request_ids_count, max_results, 1)``.  When the URL carries no
+      trusted hints we emit no ``usage_event`` row; :func:`report_usage`
       detects that state and writes an error log so ops can audit.
     - **Includes**: each ``includes.<key>`` is normalized to a billing
       bucket via :func:`classify_includes_bucket`, a bounded safe synthetic
@@ -828,9 +911,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     # Loud-but-zero billing path: GET with an unparseable response body and
     # no reliable count source.  We deliberately emit nothing rather than
     # blind-guess a quantity — the error log carries enough context for ops
-    # to audit and, if needed, back-charge manually.  Use ``is None`` so a
-    # legitimate ``?max_results=0`` (no-op query) is distinguished from the
-    # absent-field case.
+    # to audit and, if needed, back-charge manually.
     missing_count_visibility = bool(req_meta.get("is_count_endpoint")) or (
         req_meta.get("request_ids_count") is None and req_meta.get("max_results") is None
     )

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -79,6 +79,17 @@ class TestXConnectorUsage:
         assert len(payloads) == 1, f"expected 1 billing record, got {len(payloads)}"
         return payloads[0]
 
+    def _assert_lost_visibility_error(self, proxy_log):
+        assert proxy_log.exists()
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        matching_entries = [
+            entry
+            for entry in entries
+            if entry["level"] == "error" and "unparseable" in entry["message"].lower()
+        ]
+        assert len(matching_entries) == 1
+        return matching_entries[0]
+
     def test_logs_single_resource_get(self, tmp_path, real_flow):
         """GET /2/tweets/:id -> category=tweet.read, quantity=1."""
         body = json.dumps({"data": {"id": "1", "text": "hi"}}).encode()
@@ -1226,21 +1237,18 @@ class TestXConnectorUsage:
     def test_unparseable_response_accumulates_repeated_id_like_fallback_hints(
         self, tmp_path, real_flow
     ):
-        """Repeated ids/usernames keep the same aggregate count behavior as parse_qs."""
+        """Repeated allowed selector keys are accumulated on the matching path."""
         flow = self._make_x_flow(
             real_flow,
             tmp_path,
-            path="/2/users/by",
-            query="ids=1,2&ids=3&usernames=a,b",
+            query="ids=1,2&ids=3",
             body=b"not json",
-            permission="users.read",
-            rule="GET /2/users/by",
         )
 
         p = self._call_and_get_single_billing(flow)
 
-        assert p["category"] == "user.read"
-        assert p["quantity"] == 5
+        assert p["category"] == "posts.read"
+        assert p["quantity"] == 3
 
     def test_unparseable_response_does_not_treat_semicolon_as_query_separator(
         self, tmp_path, real_flow
@@ -1279,8 +1287,32 @@ class TestXConnectorUsage:
         ("path", "query", "permission", "rule", "expected_category", "expected_quantity"),
         [
             ("/2/tweets", "ids=1,2,3", "tweet.read", "GET /2/tweets", "posts.read", 3),
-            ("/2/tweets", "max_results=50", "tweet.read", "GET /2/tweets", "posts.read", 50),
+            (
+                "/2/tweets/search/recent",
+                "query=hello&max_results=50",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+                "posts.read",
+                50,
+            ),
+            (
+                "/2/users/search",
+                "query=alice&max_results=1000",
+                "users.read",
+                "GET /2/users/search",
+                "user.read",
+                1000,
+            ),
+            ("/2/users", "ids=1,2", "users.read", "GET /2/users", "user.read", 2),
             ("/2/users/by", "usernames=a,b", "users.read", "GET /2/users/by", "user.read", 2),
+            (
+                "/2/users/123/followers",
+                "max_results=1000",
+                "follows.read",
+                "GET /2/users/{id}/followers",
+                "following_followers.read",
+                1000,
+            ),
         ],
     )
     def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
@@ -1320,9 +1352,17 @@ class TestXConnectorUsage:
         assert all("unparseable" not in entry["message"].lower() for entry in entries)
         assert all("parse_error" not in entry for entry in entries)
 
-    def test_x_json_parse_error_with_zero_max_results_is_noop_hint(self, tmp_path, real_flow):
-        """A zero max_results hint should suppress lost-visibility logs without billing."""
-        flow = self._make_x_flow(real_flow, tmp_path, query="max_results=0")
+    def test_x_json_parse_error_with_zero_max_results_is_no_reliable_hint(
+        self, tmp_path, real_flow
+    ):
+        """A zero max_results hint should preserve lost-visibility logs."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=hello&max_results=0",
+            rule="GET /2/tweets/search/recent",
+        )
         flow.metadata["x_json_state"] = {
             "body_parsed": False,
             "body_truncated": False,
@@ -1331,12 +1371,110 @@ class TestXConnectorUsage:
         proxy_log = tmp_path / "proxy.jsonl"
 
         assert self._call_and_get_billing(flow) == []
+        entry = self._assert_lost_visibility_error(proxy_log)
+        assert entry["parse_error"] == "incomplete json"
 
-        if proxy_log.exists():
-            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
-            assert all(entry["level"] != "error" for entry in entries)
-            assert all("unparseable" not in entry["message"].lower() for entry in entries)
-            assert all("parse_error" not in entry for entry in entries)
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "query=hello&max_results=-5",
+            "query=hello&max_results=999999",
+            "query=hello&max_results=+50",
+            "query=hello&max_results=%2050",
+        ],
+    )
+    def test_x_json_parse_error_with_invalid_max_results_preserves_audit_log(
+        self, tmp_path, real_flow, query
+    ):
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query=query,
+            body=b"not json",
+            rule="GET /2/tweets/search/recent",
+        )
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+        self._assert_lost_visibility_error(proxy_log)
+
+    def test_x_json_parse_error_ignores_max_results_on_irrelevant_path(self, tmp_path, real_flow):
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/123",
+            query="max_results=1000",
+            body=b"not json",
+            rule="GET /2/tweets/{id}",
+        )
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+        self._assert_lost_visibility_error(proxy_log)
+
+    @pytest.mark.parametrize(
+        ("path", "query", "permission", "rule"),
+        [
+            ("/2/users/by", "ids=1,2", "users.read", "GET /2/users/by"),
+            (
+                "/2/tweets/search/recent",
+                "query=hello&ids=1,2",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+            ),
+        ],
+    )
+    def test_x_json_parse_error_ignores_id_like_hints_on_irrelevant_paths(
+        self, tmp_path, real_flow, path, query, permission, rule
+    ):
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path=path,
+            query=query,
+            body=b"not json",
+            permission=permission,
+            rule=rule,
+        )
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+        self._assert_lost_visibility_error(proxy_log)
+
+    @pytest.mark.parametrize(
+        ("path", "query", "permission", "rule"),
+        [
+            (
+                "/2/tweets",
+                f"ids={','.join(str(i) for i in range(101))}",
+                "tweet.read",
+                "GET /2/tweets",
+            ),
+            (
+                "/2/users/by",
+                f"usernames={','.join(f'user{i}' for i in range(101))}",
+                "users.read",
+                "GET /2/users/by",
+            ),
+        ],
+    )
+    def test_x_json_parse_error_ignores_excessive_selector_counts(
+        self, tmp_path, real_flow, path, query, permission, rule
+    ):
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path=path,
+            query=query,
+            body=b"not json",
+            permission=permission,
+            rule=rule,
+        )
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+        self._assert_lost_visibility_error(proxy_log)
 
     @pytest.mark.parametrize(
         ("query", "expected_quantity"),
@@ -1380,9 +1518,16 @@ class TestXConnectorUsage:
         assert "unparseable" in content.lower()
         assert '"level":"error"' in content or '"level": "error"' in content
 
-    def test_billable_counts_fallback_only_when_no_max_results(self, tmp_path, real_flow):
-        """body unparseable but ?max_results=50 present -> uses max_results."""
-        flow = self._make_x_flow(real_flow, tmp_path, query="max_results=50", body=b"not json")
+    def test_billable_counts_fallback_uses_path_scoped_max_results(self, tmp_path, real_flow):
+        """body unparseable on a max_results endpoint -> uses max_results."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=hello&max_results=50",
+            body=b"not json",
+            rule="GET /2/tweets/search/recent",
+        )
         p = self._call_and_get_single_billing(flow)
         assert p["category"] == "posts.read"
         assert p["quantity"] == 50

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -1313,6 +1313,14 @@ class TestXConnectorUsage:
                 "following_followers.read",
                 1000,
             ),
+            (
+                "/2/users/123/following",
+                "max_results=1000",
+                "follows.read",
+                "GET /2/users/{id}/following",
+                "following_followers.read",
+                1000,
+            ),
         ],
     )
     def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -1321,6 +1321,70 @@ class TestXConnectorUsage:
                 "following_followers.read",
                 1000,
             ),
+            (
+                "/2/spaces",
+                "ids=1,2",
+                "space.read",
+                "GET /2/spaces",
+                "space.read",
+                2,
+            ),
+            (
+                "/2/tweets/analytics",
+                "ids=1,2",
+                "tweet.read",
+                "GET /2/tweets/analytics",
+                "analytics.read",
+                2,
+            ),
+            (
+                "/2/tweets/123/quote_tweets",
+                "max_results=100",
+                "tweet.read",
+                "GET /2/tweets/{id}/quote_tweets",
+                "posts.read",
+                100,
+            ),
+            (
+                "/2/tweets/123/retweeted_by",
+                "max_results=100",
+                "tweet.read",
+                "GET /2/tweets/{id}/retweeted_by",
+                "user.read",
+                100,
+            ),
+            (
+                "/2/users/123/tweets",
+                "max_results=100",
+                "users.read",
+                "GET /2/users/{id}/tweets",
+                "posts.read",
+                100,
+            ),
+            (
+                "/2/users/123/liked_tweets",
+                "max_results=5",
+                "like.read",
+                "GET /2/users/{id}/liked_tweets",
+                "posts.read",
+                5,
+            ),
+            (
+                "/2/lists/123/members",
+                "max_results=100",
+                "list.read",
+                "GET /2/lists/{id}/members",
+                "list.read",
+                100,
+            ),
+            (
+                "/2/dm_events",
+                "max_results=100",
+                "dm.read",
+                "GET /2/dm_events",
+                "dm_event.read",
+                100,
+            ),
         ],
     )
     def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
@@ -1383,24 +1447,63 @@ class TestXConnectorUsage:
         assert entry["parse_error"] == "incomplete json"
 
     @pytest.mark.parametrize(
-        "query",
+        ("path", "query", "permission", "rule"),
         [
-            "query=hello&max_results=-5",
-            "query=hello&max_results=999999",
-            "query=hello&max_results=+50",
-            "query=hello&max_results=%2050",
+            (
+                "/2/tweets/search/recent",
+                "query=hello&max_results=-5",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+            ),
+            (
+                "/2/tweets/search/recent",
+                "query=hello&max_results=999999",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+            ),
+            (
+                "/2/tweets/search/recent",
+                "query=hello&max_results=+50",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+            ),
+            (
+                "/2/tweets/search/recent",
+                "query=hello&max_results=%2050",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+            ),
+            (
+                "/2/lists/123/members",
+                "max_results=101",
+                "list.read",
+                "GET /2/lists/{id}/members",
+            ),
+            (
+                "/2/users/123/tweets",
+                "max_results=4",
+                "users.read",
+                "GET /2/users/{id}/tweets",
+            ),
+            (
+                "/2/users/search",
+                "query=alice&max_results=1001",
+                "users.read",
+                "GET /2/users/search",
+            ),
         ],
     )
     def test_x_json_parse_error_with_invalid_max_results_preserves_audit_log(
-        self, tmp_path, real_flow, query
+        self, tmp_path, real_flow, path, query, permission, rule
     ):
         flow = self._make_x_flow(
             real_flow,
             tmp_path,
-            path="/2/tweets/search/recent",
+            path=path,
             query=query,
             body=b"not json",
-            rule="GET /2/tweets/search/recent",
+            permission=permission,
+            rule=rule,
         )
         proxy_log = tmp_path / "proxy.jsonl"
 

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -1283,6 +1283,19 @@ class TestXConnectorUsage:
         assert "unparseable" in content.lower()
         assert '"level":"error"' in content or '"level": "error"' in content
 
+    def test_unencodable_fallback_query_suppresses_request_hints(self, tmp_path, real_flow):
+        """Malformed Unicode in fallback queries should fail closed instead of crashing."""
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            query="noise=" + "\ud800" + "&ids=1",
+            body=b"not json",
+        )
+        proxy_log = tmp_path / "proxy.jsonl"
+
+        assert self._call_and_get_billing(flow) == []
+        self._assert_lost_visibility_error(proxy_log)
+
     @pytest.mark.parametrize(
         ("path", "query_template", "permission", "rule", "expected_quantity"),
         [

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -1284,6 +1284,58 @@ class TestXConnectorUsage:
         assert '"level":"error"' in content or '"level": "error"' in content
 
     @pytest.mark.parametrize(
+        ("path", "query_template", "permission", "rule", "expected_quantity"),
+        [
+            (
+                "/2/tweets/search/recent",
+                "ids={large}&query=hello&max_results=50",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+                50,
+            ),
+            (
+                "/2/tweets",
+                "max_results={large}&ids=1,2",
+                "tweet.read",
+                "GET /2/tweets",
+                2,
+            ),
+            (
+                "/2/tweets/search/recent",
+                "query=hello&max_results=50&max_results={large}",
+                "tweet.read",
+                "GET /2/tweets/search/recent",
+                50,
+            ),
+        ],
+    )
+    def test_unparseable_response_ignores_oversized_irrelevant_fallback_hint_values(
+        self,
+        tmp_path,
+        real_flow,
+        path,
+        query_template,
+        permission,
+        rule,
+        expected_quantity,
+    ):
+        """Oversized values only fail the hint that would actually be trusted."""
+        query = query_template.format(large="x" * 20_000)
+        flow = self._make_x_flow(
+            real_flow,
+            tmp_path,
+            path=path,
+            query=query,
+            body=b"not json",
+            permission=permission,
+            rule=rule,
+        )
+
+        p = self._call_and_get_single_billing(flow)
+
+        assert p["quantity"] == expected_quantity
+
+    @pytest.mark.parametrize(
         ("path", "query", "permission", "rule", "expected_category", "expected_quantity"),
         [
             ("/2/tweets", "ids=1,2,3", "tweet.read", "GET /2/tweets", "posts.read", 3),


### PR DESCRIPTION
## Summary
- scope X request fallback hints to documented endpoint/query-key pairs
- enforce selector and max_results bounds before using request hints for fallback billing
- preserve lost-visibility audit logs when hints are invalid, irrelevant, or excessive

Closes #17205

## Tests
- /tmp/mitm-addon-venv/bin/ruff format --check .
- /tmp/mitm-addon-venv/bin/ruff check .
- /tmp/mitm-addon-venv/bin/basedpyright -p . --pythonpath /tmp/mitm-addon-venv/bin/python
- /tmp/mitm-addon-venv/bin/pytest tests/test_x_connector_usage.py -q