### PR TITLE
Add runner claim pickup telemetry

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -11,7 +11,7 @@ use api_contracts::generated::routes;
 use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::{Serialize, de::DeserializeOwned};
 
-use super::api_ably_supervisor::{AblySupervisor, PollOutcome, PollWakeups};
+use super::api_ably_supervisor::{AblySupervisor, PollOutcome, PollReason, PollWakeups};
 use super::{ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobProvider};
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
@@ -35,6 +35,8 @@ struct ClaimRequestTelemetry {
     job_discovered_to_claim_request_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     local_admission_to_claim_request_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    poll_reason: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -166,7 +168,10 @@ impl JobProvider for ApiProvider {
                         .experimental_profile
                         .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
                     info!(run_id = %job.run_id, %profile, poll_reason = ?reason, "poll: job found");
-                    return Some(JobCandidate::new(job.run_id, profile));
+                    return Some(
+                        JobCandidate::new(job.run_id, profile)
+                            .with_poll_reason(poll_reason_value(reason)),
+                    );
                 }
                 Ok(None) => {
                     self.poll_wakeups
@@ -431,7 +436,18 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             local_admission_to_claim_request_ms: candidate
                 .local_admission_elapsed()
                 .map(duration_ms),
+            poll_reason: candidate.poll_reason().map(String::from),
         },
+    }
+}
+
+fn poll_reason_value(reason: PollReason) -> &'static str {
+    match reason {
+        PollReason::Immediate => "immediate",
+        PollReason::Deferred => "deferred",
+        PollReason::WakeupRetry => "wakeup_retry",
+        PollReason::Slow => "slow",
+        PollReason::Fast => "fast",
     }
 }
 
@@ -631,7 +647,8 @@ mod tests {
             crate::profile::DEFAULT_PROFILE.to_string(),
             now.checked_sub(Duration::from_millis(25)).unwrap(),
             Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
-        );
+        )
+        .with_poll_reason("deferred");
 
         let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
 
@@ -645,6 +662,7 @@ mod tests {
                 .as_u64()
                 .is_some_and(|value| value >= 7)
         );
+        assert_eq!(body["telemetry"]["pollReason"], "deferred");
     }
 
     #[test]
@@ -669,6 +687,7 @@ mod tests {
                 .get("localAdmissionToClaimRequestMs")
                 .is_none()
         );
+        assert!(body["telemetry"].get("pollReason").is_none());
     }
 
     async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -22,7 +22,7 @@ type AblyConnectHandle =
     tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum PollReason {
+pub(crate) enum PollReason {
     Immediate,
     Deferred,
     WakeupRetry,

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -29,6 +29,7 @@ pub struct JobCandidate {
     local_job_path: Option<PathBuf>,
     discovered_at: Instant,
     local_admission_started_at: Option<Instant>,
+    poll_reason: Option<String>,
 }
 
 impl JobCandidate {
@@ -39,6 +40,7 @@ impl JobCandidate {
             local_job_path: None,
             discovered_at: Instant::now(),
             local_admission_started_at: None,
+            poll_reason: None,
         }
     }
 
@@ -49,6 +51,7 @@ impl JobCandidate {
             local_job_path: Some(job_path),
             discovered_at: Instant::now(),
             local_admission_started_at: None,
+            poll_reason: None,
         }
     }
 
@@ -77,6 +80,15 @@ impl JobCandidate {
             .map(|started| started.elapsed())
     }
 
+    pub(crate) fn poll_reason(&self) -> Option<&str> {
+        self.poll_reason.as_deref()
+    }
+
+    pub(crate) fn with_poll_reason(mut self, poll_reason: impl Into<String>) -> Self {
+        self.poll_reason = Some(poll_reason.into());
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn new_with_timing_for_test(
         run_id: RunId,
@@ -90,6 +102,7 @@ impl JobCandidate {
             local_job_path: None,
             discovered_at,
             local_admission_started_at,
+            poll_reason: None,
         }
     }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -775,6 +775,7 @@ describe("POST /api/runners/*", () => {
           telemetry: {
             jobDiscoveredToClaimRequestMs: 1234,
             localAdmissionToClaimRequestMs: 56,
+            pollReason: "deferred",
           },
         },
         headers: { authorization: `Bearer ${pat.token}` },
@@ -829,6 +830,38 @@ describe("POST /api/runners/*", () => {
       "vm0-sandbox-op-log-dev",
       [
         expect.objectContaining({
+          op_type: "api_to_runner_queue",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: expect.any(Number),
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+          poll_reason: "deferred",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          op_type: "runner_queue_to_claim_request",
+          sandbox_type: "runner",
+          run_id: queued.runId,
+          duration_ms: expect.any(Number),
+          success: true,
+          runner_group: "vm0/test",
+          profile: "vm0/default",
+          auth_type: "user",
+          poll_reason: "deferred",
+        }),
+      ],
+    );
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
           op_type: "api_to_claim_request",
           sandbox_type: "runner",
           run_id: queued.runId,
@@ -837,6 +870,7 @@ describe("POST /api/runners/*", () => {
           runner_group: "vm0/test",
           profile: "vm0/default",
           auth_type: "user",
+          poll_reason: "deferred",
         }),
       ],
     );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -535,11 +535,14 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly runnerGroup: string;
   readonly profile: string;
   readonly authType: RunnerAuthContext["type"];
+  readonly apiToRunnerQueueMs: number | undefined;
+  readonly runnerQueueToClaimRequestMs: number;
   readonly apiToClaimRequestMs: number | undefined;
   readonly apiToClaimMs: number | undefined;
   readonly claimRequestToRunningMs: number;
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
+  readonly pollReason: string | undefined;
 }): void {
   waitUntil(
     publishRunChangedForUserSafely(args.userId, args.runId, {
@@ -559,18 +562,36 @@ async function recordClaimTimingMetrics(args: {
   readonly runnerGroup: string;
   readonly profile: string;
   readonly authType: RunnerAuthContext["type"];
+  readonly apiToRunnerQueueMs: number | undefined;
+  readonly runnerQueueToClaimRequestMs: number;
   readonly apiToClaimRequestMs: number | undefined;
   readonly apiToClaimMs: number | undefined;
   readonly claimRequestToRunningMs: number;
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
+  readonly pollReason: string | undefined;
 }): Promise<void> {
   await Promise.resolve();
-  const dimensions = {
+  const dimensions: Record<string, string> = {
     runner_group: args.runnerGroup,
     profile: args.profile,
     auth_type: args.authType,
   };
+  if (args.pollReason) {
+    dimensions.poll_reason = args.pollReason;
+  }
+  recordClaimTimingOperation(
+    args.runId,
+    "api_to_runner_queue",
+    args.apiToRunnerQueueMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "runner_queue_to_claim_request",
+    args.runnerQueueToClaimRequestMs,
+    dimensions,
+  );
   recordClaimTimingOperation(
     args.runId,
     "api_to_claim_request",
@@ -756,12 +777,21 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Run not found");
   }
 
+  const queueCreatedAtMs = jobWithRun.job.createdAt.getTime();
   scheduleClaimSucceededSideEffects({
     runId,
     userId: run.userId,
     runnerGroup: jobWithRun.job.runnerGroup,
     profile: jobWithRun.job.profile,
     authType: auth.type,
+    apiToRunnerQueueMs: elapsedSinceApiStartMs(
+      storedContext.apiStartTime,
+      queueCreatedAtMs,
+    ),
+    runnerQueueToClaimRequestMs: Math.max(
+      0,
+      claimRequestStartedAtMs - queueCreatedAtMs,
+    ),
     apiToClaimRequestMs: elapsedSinceApiStartMs(
       storedContext.apiStartTime,
       claimRequestStartedAtMs,
@@ -778,6 +808,7 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       body.data.telemetry?.jobDiscoveredToClaimRequestMs,
     localAdmissionToClaimRequestMs:
       body.data.telemetry?.localAdmissionToClaimRequestMs,
+    pollReason: body.data.telemetry?.pollReason,
   });
 
   return {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -35,9 +35,18 @@ export function elapsedSinceApiStartMs(
   return Math.max(0, nowMs - apiStartTimeMs);
 }
 
+export const runnerClaimPollReasonSchema = z.enum([
+  "immediate",
+  "deferred",
+  "wakeup_retry",
+  "slow",
+  "fast",
+]);
+
 const runnerClaimTelemetrySchema = z.object({
   jobDiscoveredToClaimRequestMs: z.number().int().nonnegative().optional(),
   localAdmissionToClaimRequestMs: z.number().int().nonnegative().optional(),
+  pollReason: runnerClaimPollReasonSchema.optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- add claim timing spans for `api_to_runner_queue` and `runner_queue_to_claim_request`
- include runner `pollReason` in claim telemetry and Axiom dimensions
- cover the new spans and serialized claim telemetry in tests

## Context
This helps break down the current opaque `api_to_claim_request` latency window from #10796 into API dispatch-to-queue time and queue-visible-to-runner-claim time.

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `cargo test -p runner claim_request_body --manifest-path crates/Cargo.toml`
- `cargo check -p runner --manifest-path crates/Cargo.toml`
- `cargo clippy -p runner --manifest-path crates/Cargo.toml --all-targets -- -D warnings`
- pre-commit hook: prettier, cargo fmt/doc/clippy, knip, full `pnpm check-types`