### PR TITLE
fix(guest-download): require instruction target files

### DIFF
--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -95,7 +95,12 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
             .copied()
             .filter(|candidate| *candidate != target_filename)
             .map(|candidate| mount_path.join(candidate.as_str()))
-            .find(|path| path.is_file());
+            .find(|path| {
+                matches!(
+                    lstat_instruction_path_state(path),
+                    InstructionPathState::RegularFile
+                )
+            });
 
         let Some(source_path) = source else {
             log_warn!(
@@ -362,6 +367,32 @@ mod tests {
         )]);
 
         assert!(mount.join("CLAUDE.md").symlink_metadata().is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_instruction_files_ignores_alternate_symlink_source() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        fs::create_dir_all(&mount).unwrap();
+        fs::write(mount.join("linked.md"), "runtime instructions").unwrap();
+        std::os::unix::fs::symlink(mount.join("linked.md"), mount.join("CLAUDE.md")).unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::new(
+            mount.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert!(mount.join("AGENTS.md").symlink_metadata().is_err());
+        assert!(
+            mount
+                .join("CLAUDE.md")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -1,6 +1,7 @@
 use crate::LOG_TAG;
 use guest_common::{log_info, log_warn};
 use std::fs;
+use std::io;
 use std::path::Path;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -22,6 +23,13 @@ impl InstructionNormalization {
 enum InstructionFilename {
     Claude,
     Agents,
+}
+
+enum InstructionPathState {
+    Missing,
+    RegularFile,
+    NonRegular,
+    MetadataError(io::Error),
 }
 
 impl InstructionFilename {
@@ -57,9 +65,29 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
 
         let mount_path = Path::new(&entry.mount_path);
         let target_path = mount_path.join(target_filename.as_str());
-        if target_path.exists() {
-            remove_alternate_instruction_files(mount_path, target_filename);
-            continue;
+        match lstat_instruction_path_state(&target_path) {
+            InstructionPathState::RegularFile => {
+                remove_alternate_instruction_files(mount_path, target_filename);
+                continue;
+            }
+            InstructionPathState::Missing => {}
+            InstructionPathState::NonRegular => {
+                log_warn!(
+                    LOG_TAG,
+                    "Skipping instructions normalization because target is not a regular file: {}",
+                    target_path.display()
+                );
+                continue;
+            }
+            InstructionPathState::MetadataError(e) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to inspect instructions target {}: {}",
+                    target_path.display(),
+                    e
+                );
+                continue;
+            }
         }
 
         let source = InstructionFilename::ALL
@@ -79,24 +107,86 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
         };
 
         match fs::copy(&source_path, &target_path) {
-            Ok(_) => log_info!(
-                LOG_TAG,
-                "Normalized instructions file {} -> {}",
-                source_path.display(),
-                target_path.display()
-            ),
-            Err(e) => log_warn!(
-                LOG_TAG,
-                "Failed to normalize instructions file {} -> {}: {}",
-                source_path.display(),
-                target_path.display(),
-                e
-            ),
+            Ok(_) => {
+                log_info!(
+                    LOG_TAG,
+                    "Normalized instructions file {} -> {}",
+                    source_path.display(),
+                    target_path.display()
+                );
+                remove_alternates_after_successful_copy(mount_path, target_filename, &target_path);
+            }
+            Err(e) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to normalize instructions file {} -> {}: {}",
+                    source_path.display(),
+                    target_path.display(),
+                    e
+                );
+                remove_failed_instruction_target(&target_path);
+            }
         }
+    }
+}
 
-        if target_path.exists() {
+fn lstat_instruction_path_state(path: &Path) -> InstructionPathState {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => InstructionPathState::RegularFile,
+        Ok(_) => InstructionPathState::NonRegular,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => InstructionPathState::Missing,
+        Err(e) => InstructionPathState::MetadataError(e),
+    }
+}
+
+fn remove_alternates_after_successful_copy(
+    mount_path: &Path,
+    target_filename: InstructionFilename,
+    target_path: &Path,
+) {
+    match lstat_instruction_path_state(target_path) {
+        InstructionPathState::RegularFile => {
             remove_alternate_instruction_files(mount_path, target_filename);
         }
+        InstructionPathState::Missing => log_warn!(
+            LOG_TAG,
+            "Normalized instructions target is missing after copy: {}",
+            target_path.display()
+        ),
+        InstructionPathState::NonRegular => log_warn!(
+            LOG_TAG,
+            "Normalized instructions target is not a regular file after copy: {}",
+            target_path.display()
+        ),
+        InstructionPathState::MetadataError(e) => log_warn!(
+            LOG_TAG,
+            "Failed to inspect normalized instructions target {}: {}",
+            target_path.display(),
+            e
+        ),
+    }
+}
+
+fn remove_failed_instruction_target(target_path: &Path) {
+    if !matches!(
+        lstat_instruction_path_state(target_path),
+        InstructionPathState::RegularFile
+    ) {
+        return;
+    }
+
+    match fs::remove_file(target_path) {
+        Ok(_) => log_info!(
+            LOG_TAG,
+            "Removed failed instructions target {}",
+            target_path.display()
+        ),
+        Err(e) => log_warn!(
+            LOG_TAG,
+            "Failed to remove failed instructions target {}: {}",
+            target_path.display(),
+            e
+        ),
     }
 }
 
@@ -107,8 +197,18 @@ fn remove_alternate_instruction_files(mount_path: &Path, target_filename: Instru
         }
 
         let path = mount_path.join(candidate.as_str());
-        if !path.exists() {
-            continue;
+        match lstat_instruction_path_state(&path) {
+            InstructionPathState::Missing => continue,
+            InstructionPathState::RegularFile | InstructionPathState::NonRegular => {}
+            InstructionPathState::MetadataError(e) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to inspect non-runtime instructions file {}: {}",
+                    path.display(),
+                    e
+                );
+                continue;
+            }
         }
 
         match fs::remove_file(&path) {
@@ -194,6 +294,74 @@ mod tests {
             "canonical"
         );
         assert!(!mount.join("CLAUDE.md").exists());
+    }
+
+    #[test]
+    fn normalize_instruction_files_keeps_alternate_when_target_is_directory() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        fs::create_dir_all(mount.join("AGENTS.md")).unwrap();
+        fs::write(mount.join("CLAUDE.md"), "runtime instructions").unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::new(
+            mount.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(mount.join("CLAUDE.md")).unwrap(),
+            "runtime instructions"
+        );
+        assert!(mount.join("AGENTS.md").is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_instruction_files_keeps_alternate_when_target_is_symlink() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        fs::create_dir_all(&mount).unwrap();
+        fs::write(mount.join("target.md"), "linked target").unwrap();
+        fs::write(mount.join("CLAUDE.md"), "runtime instructions").unwrap();
+        std::os::unix::fs::symlink(mount.join("target.md"), mount.join("AGENTS.md")).unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::new(
+            mount.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(mount.join("CLAUDE.md")).unwrap(),
+            "runtime instructions"
+        );
+        assert!(
+            mount
+                .join("AGENTS.md")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_instruction_files_removes_dangling_alternate_symlink() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        fs::create_dir_all(&mount).unwrap();
+        fs::write(mount.join("AGENTS.md"), "runtime instructions").unwrap();
+        std::os::unix::fs::symlink(mount.join("missing.md"), mount.join("CLAUDE.md")).unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::new(
+            mount.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert!(mount.join("CLAUDE.md").symlink_metadata().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require instruction normalization targets to be lstat regular files before removing alternates
- require alternate instruction sources to be lstat regular files before copying
- preserve alternate instruction files when the runtime target path is a directory, symlink, or other non-file
- remove dangling alternate symlinks during cleanup and avoid alternate cleanup after failed copies

Fixes #17243

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download normalize_instruction_files`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy, commitlint
