### PR TITLE
docs: clarify exec-control payload rustdoc

### DIFF
--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -171,20 +171,57 @@ pub struct DecodedExecStarted {
 /// Decoded exec_control payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedExecControl<'a> {
+    /// Non-zero sequence number of the active exec operation being controlled.
+    ///
+    /// This is distinct from the outer frame `seq` used to correlate the
+    /// `exec_control` request message with its `exec_control_result` response.
     pub target_seq: u32,
+    /// Caller-visible local sink budget in milliseconds after guest receipt.
+    ///
+    /// The guest applies this budget across local sink connection, request
+    /// write, and response read. A value of `0` is valid and means no remaining
+    /// local sink budget, not an unbounded timeout.
     pub request_timeout_ms: u32,
+    /// Per-operation nonce registered with the target exec operation.
+    ///
+    /// Peers echo this value in results and use it to reject stale or
+    /// mismatched control messages.
     pub control_nonce: ExecControlNonce,
+    /// Non-empty payload-level correlation id for the local sink exchange.
+    ///
+    /// This identifies the local control request/response payload exchange and
+    /// does not replace the outer frame `seq` correlation.
     pub message_id: &'a str,
+    /// Local sink request bytes.
+    ///
+    /// This may be empty and is bounded by
+    /// [`crate::EXEC_CONTROL_MAX_PAYLOAD_BYTES`].
     pub payload: &'a [u8],
 }
 
 /// Decoded exec_control_result payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedExecControlResult<'a> {
+    /// Sequence number of the exec operation that the result refers to.
+    ///
+    /// This echoes the control request payload's `target_seq` and is distinct
+    /// from the outer frame `seq` used for the control request/result exchange.
     pub target_seq: u32,
+    /// Per-operation nonce echoed from the control request.
+    ///
+    /// Peers use this value to reject results that do not match the pending
+    /// control request.
     pub control_nonce: ExecControlNonce,
+    /// Payload-level correlation id echoed from the local sink exchange.
+    ///
+    /// This must match the pending control request's `message_id`.
     pub message_id: &'a str,
+    /// Terminal delivery outcome for the control request.
     pub status: ExecControlStatus,
+    /// UTF-8 diagnostic string for the terminal delivery outcome.
+    ///
+    /// This may be empty and is bounded by the result payload's `u16`
+    /// diagnostic length field.
     pub diagnostic: &'a str,
 }
 
@@ -466,7 +503,26 @@ pub fn encode_exec_started(pid: u32) -> Result<Vec<u8>, ProtocolError> {
     Ok(pid.to_be_bytes().to_vec())
 }
 
-/// Encode exec_control payload.
+/// Encode an exec_control payload.
+///
+/// `target_seq` is the non-zero sequence number of the active exec operation
+/// being controlled. It is separate from the outer frame `seq` that carries the
+/// control request itself.
+///
+/// `control_nonce` is the per-operation nonce registered with the target exec
+/// operation and later echoed by the result. `message_id` is the non-empty
+/// payload-level correlation id for the local sink request/response exchange.
+/// `payload` contains the local sink request bytes and may be empty.
+///
+/// `request_timeout_ms` is the caller-visible local sink budget in milliseconds
+/// after guest receipt. A value of `0` is valid and means no remaining local
+/// sink budget, not an unbounded timeout.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `target_seq` is zero, `message_id` is empty or
+/// too long, `payload` exceeds [`crate::EXEC_CONTROL_MAX_PAYLOAD_BYTES`], or
+/// the encoded payload would exceed the maximum message size.
 pub fn encode_exec_control(
     target_seq: u32,
     control_nonce: ExecControlNonce,
@@ -484,7 +540,21 @@ pub fn encode_exec_control(
     )
 }
 
-/// Encode exec_control_result payload.
+/// Encode an exec_control_result payload.
+///
+/// `target_seq`, `control_nonce`, and `message_id` echo the corresponding
+/// control request payload fields so the peer can match the result to the
+/// pending control request. The outer frame `seq` still carries the
+/// request/response correlation for the control message itself.
+///
+/// `status` carries the terminal delivery outcome as an [`ExecControlStatus`].
+/// `diagnostic` is a UTF-8 diagnostic string for that outcome and may be empty.
+///
+/// # Errors
+///
+/// Returns [`ProtocolError`] if `target_seq` is zero, `message_id` is empty or
+/// too long, `diagnostic` is too long, or the encoded payload would exceed the
+/// maximum message size.
 pub fn encode_exec_control_result(
     target_seq: u32,
     control_nonce: ExecControlNonce,


### PR DESCRIPTION
## Summary

- Add field-level rustdoc for decoded exec-control request/result payloads.
- Document public exec-control encoder argument semantics for target sequence, nonce, message id, timeout, status, and diagnostics.
- Keep the change documentation-only with no wire format or runtime behavior changes.

## Verification

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo doc -p vsock-proto --no-deps`
- Pre-commit: crates cargo-doc and cargo-clippy

Closes #17246
