### PR TITLE
fix: add illustration template preview

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_ITEMS,
+} from "@vm0/core";
+import { buildGenerationTemplatePrompt } from "../generation-template-prompt";
+
+describe("buildGenerationTemplatePrompt", () => {
+  it("builds presentation template guidance", () => {
+    const item = PRESENTATION_TEMPLATE_ITEMS[0]!;
+
+    const result = buildGenerationTemplatePrompt({
+      type: "presentation",
+      selection: {
+        designSystemId: item.designSystemId,
+        templateId: item.templateId,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      status: "resolved",
+      prompt: expect.stringContaining(`Template ID: ${item.templateId}`),
+    });
+  });
+
+  it("builds illustration template guidance", () => {
+    const item = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+
+    const result = buildGenerationTemplatePrompt({
+      type: "illustration",
+      selection: {
+        illustrationStyleId: item.illustrationStyleId,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      status: "resolved",
+      prompt: expect.stringContaining(
+        `Image style ID: ${item.illustrationStyleId}`,
+      ),
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -46,6 +46,7 @@ import { generateZeroToken, verifyZeroToken } from "../../auth/tokens";
 import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
+import { clearAllDetached } from "../../utils";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
   createFixtureTracker,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -46,7 +46,6 @@ import { generateZeroToken, verifyZeroToken } from "../../auth/tokens";
 import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
-import { clearAllDetached } from "../../utils";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import {
   createFixtureTracker,
@@ -703,7 +702,7 @@ describe("POST /api/zero/chat/messages", () => {
         },
       },
     });
-    await clearAllDetached();
+    await flushWaitUntilForTest();
 
     const [run] = await store
       .set(writeDb$)
@@ -791,6 +790,26 @@ describe("POST /api/zero/chat/messages", () => {
     );
     expect(unknownVideoStyle.body.error.message).toBe(
       "Unknown video style preset",
+    );
+
+    const unknownIllustrationStyle = await accept(
+      client().send({
+        headers: authHeaders(),
+        body: {
+          agentId: fixture.agentId,
+          prompt: "make an illustration",
+          generationTemplate: {
+            type: "illustration",
+            selection: {
+              illustrationStyleId: "image-style:missing",
+            },
+          },
+        },
+      }),
+      [400],
+    );
+    expect(unknownIllustrationStyle.body.error.message).toBe(
+      "Unknown generation image style",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -7,7 +7,11 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { PRESENTATION_TEMPLATE_ITEMS, VIDEO_STYLE_PRESETS } from "@vm0/core";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_ITEMS,
+  VIDEO_STYLE_PRESETS,
+} from "@vm0/core";
 import {
   agentComposes,
   agentComposeVersions,
@@ -682,6 +686,44 @@ describe("POST /api/zero/chat/messages", () => {
       "safe for all audiences, positive and uplifting, no violence, no explicit content",
     );
     expect(run?.appendSystemPrompt).not.toContain(item.scene);
+  });
+
+  it("adds illustration generation template guidance to appendSystemPrompt", async () => {
+    const fixture = await track(seedFixture());
+    const item = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: "make an illustrated launch card",
+      generationTemplate: {
+        type: "illustration",
+        selection: {
+          illustrationStyleId: item.illustrationStyleId,
+        },
+      },
+    });
+    await clearAllDetached();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({
+        prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+
+    expect(run?.prompt).toBe("make an illustrated launch card");
+    expect(run?.appendSystemPrompt).toContain("Type: illustration");
+    expect(run?.appendSystemPrompt).toContain("Tag: illustration");
+    expect(run?.appendSystemPrompt).toContain(
+      `Image style ID: ${item.illustrationStyleId}`,
+    );
+    expect(run?.appendSystemPrompt).toContain("Instructions:");
+    expect(run?.appendSystemPrompt).toContain(
+      "- Keep the user's prompt as the source of the requested content.",
+    );
   });
 
   it("rejects unknown generation template resources", async () => {

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -1,4 +1,8 @@
-import { findDesignSystem, findTemplate } from "@vm0/core/resource-registry";
+import {
+  findDesignSystem,
+  findImageStyle,
+  findTemplate,
+} from "@vm0/core/resource-registry";
 import { VIDEO_STYLE_PRESETS, VIDEO_DIMENSION_DESCRIPTIONS } from "@vm0/core";
 
 interface PresentationGenerationTemplateInput {
@@ -16,9 +20,17 @@ interface VideoGenerationTemplateInput {
   };
 }
 
+interface IllustrationGenerationTemplateInput {
+  readonly type: "illustration";
+  readonly selection: {
+    readonly illustrationStyleId: string;
+  };
+}
+
 type GenerationTemplateInput =
   | PresentationGenerationTemplateInput
-  | VideoGenerationTemplateInput;
+  | VideoGenerationTemplateInput
+  | IllustrationGenerationTemplateInput;
 
 type GenerationTemplatePromptResult =
   | {
@@ -39,6 +51,9 @@ export function buildGenerationTemplatePrompt(
 
   if (generationTemplate.type === "video") {
     return buildVideoGenerationTemplatePrompt(generationTemplate);
+  }
+  if (generationTemplate.type === "illustration") {
+    return buildIllustrationGenerationTemplatePrompt(generationTemplate);
   }
 
   return buildPresentationGenerationTemplatePrompt(generationTemplate);
@@ -118,6 +133,34 @@ function buildVideoGenerationTemplatePrompt(
       "",
       "Generate a single video prompt (2–3 sentences) that applies the above style to the user's scene.",
       "End with: safe for all audiences, positive and uplifting, no violence, no explicit content",
+    ].join("\n"),
+  };
+}
+
+function buildIllustrationGenerationTemplatePrompt(
+  generationTemplate: IllustrationGenerationTemplateInput,
+): GenerationTemplatePromptResult {
+  const imageStyle = findImageStyle(
+    generationTemplate.selection.illustrationStyleId,
+  );
+  if (!imageStyle) {
+    return { status: "invalid", message: "Unknown generation image style" };
+  }
+
+  return {
+    status: "resolved",
+    prompt: [
+      "# Generation Template",
+      "Use the following registered resources for this run.",
+      `Type: ${generationTemplate.type}`,
+      "Tag: illustration",
+      `Image style ID: ${imageStyle.id}`,
+      `Image style name: ${imageStyle.name}`,
+      "",
+      "Instructions:",
+      "- Resolve the image style from the resource registry.",
+      "- Apply it as a generation constraint for the artifact.",
+      "- Keep the user's prompt as the source of the requested content.",
     ].join("\n"),
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1216,6 +1216,45 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("keeps historical illustration labels behind the template picker feature switch", async () => {
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-illustration-template-history",
+          role: "user",
+          content: "Make an illustrated launch card",
+          runId: "run-illustration-template-history",
+          generationTemplate: {
+            type: "illustration",
+            selection: {
+              illustrationStyleId: illustrationTemplate.illustrationStyleId,
+            },
+          },
+          createdAt: NOW,
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatTemplatePicker]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Make an illustrated launch card"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(
+          `Message template ${illustrationTemplate.title}`,
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("queues a selected template during an active run and clears the picker state", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -7,7 +7,11 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { PRESENTATION_TEMPLATE_ITEMS, VIDEO_STYLE_PRESETS } from "@vm0/core";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_ITEMS,
+  VIDEO_STYLE_PRESETS,
+} from "@vm0/core";
 import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
@@ -1116,6 +1120,75 @@ describe("chat composer templates", () => {
       );
       expect(
         screen.queryByLabelText(`Remove template ${templateLabel(template)}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("selects and removes an illustration style from the picker", async () => {
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatTemplatePicker]: true },
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    await waitFor(() => {
+      expect(tabByText("Illustration")).toBeInTheDocument();
+    });
+    click(tabByText("Illustration"));
+
+    await waitFor(() => {
+      expect(screen.getByText("VM0 illustration styles")).toBeInTheDocument();
+      expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${illustrationTemplate.title} illustration preview`),
+      ).toHaveAttribute("src", illustrationTemplate.previewImage);
+      expect(screen.getAllByTitle(/ illustration preview$/u)).toHaveLength(
+        ILLUSTRATION_TEMPLATE_ITEMS.length,
+      );
+    });
+
+    await fill(screen.getByLabelText("Search templates"), "no matching style");
+    await waitFor(() => {
+      expect(screen.getByText("No matches")).toBeInTheDocument();
+    });
+
+    await fill(screen.getByLabelText("Search templates"), "ink");
+    click(
+      screen.getByLabelText(`Select template ${illustrationTemplate.title}`),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Template")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(
+        screen.getByLabelText(`Remove template ${illustrationTemplate.title}`),
+      ).toBeInTheDocument();
+    });
+
+    click(
+      screen.getByLabelText(`Remove template ${illustrationTemplate.title}`),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Template")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+      expect(
+        screen.queryByLabelText(
+          `Remove template ${illustrationTemplate.title}`,
+        ),
       ).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1155,6 +1155,29 @@ describe("chat composer templates", () => {
       );
     });
 
+    click(screen.getByLabelText(`View template ${illustrationTemplate.title}`));
+    await waitFor(() => {
+      expect(
+        screen.getByTitle(`${illustrationTemplate.title} preview variant 1`),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Show variant 2"));
+    await waitFor(() => {
+      expect(
+        screen.getByTitle(`${illustrationTemplate.title} preview variant 2`),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Show variant 1"));
+    await waitFor(() => {
+      expect(
+        screen.getByTitle(`${illustrationTemplate.title} preview variant 1`),
+      ).toBeInTheDocument();
+    });
+    click(buttonByText("Templates"));
+    await waitFor(() => {
+      expect(screen.getByText("VM0 illustration styles")).toBeInTheDocument();
+    });
+
     await fill(screen.getByLabelText("Search templates"), "no matching style");
     await waitFor(() => {
       expect(screen.getByText("No matches")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -12,6 +12,11 @@ import {
   type PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_ITEMS,
+  VIDEO_STYLE_PRESETS,
+} from "@vm0/core";
+import {
   zeroBillingCheckoutContract,
   zeroBillingCreditCheckoutContract,
   zeroBillingStatusContract,
@@ -1822,6 +1827,10 @@ describe("chat lifecycle", () => {
 
   it("shows template labels on historical user messages", async () => {
     const threadId = "template-message-history";
+    const presentationTemplate = PRESENTATION_TEMPLATE_ITEMS[0]!;
+    const videoTemplate = VIDEO_STYLE_PRESETS[0]!;
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Template labels",
@@ -1834,8 +1843,8 @@ describe("chat lifecycle", () => {
           generationTemplate: {
             type: "presentation",
             selection: {
-              designSystemId: "retired-design-system",
-              templateId: "template:html-ppt-quarterly-business-review",
+              designSystemId: presentationTemplate.designSystemId,
+              templateId: presentationTemplate.templateId,
             },
           },
           createdAt: "2026-06-09T10:00:00Z",
@@ -1847,9 +1856,22 @@ describe("chat lifecycle", () => {
           runId: "run-template-video",
           generationTemplate: {
             type: "video",
-            selection: { stylePresetId: "template:phone-demo" },
+            selection: { stylePresetId: videoTemplate.id },
           },
           createdAt: "2026-06-09T10:01:00Z",
+        },
+        {
+          id: "msg-template-illustration",
+          role: "user",
+          content: "Create an illustrated launch card",
+          runId: "run-template-illustration",
+          generationTemplate: {
+            type: "illustration",
+            selection: {
+              illustrationStyleId: illustrationTemplate.illustrationStyleId,
+            },
+          },
+          createdAt: "2026-06-09T10:02:00Z",
         },
       ],
     });
@@ -1865,11 +1887,76 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText("Message template Quarterly business review"),
+        screen.getByLabelText(`Message template ${presentationTemplate.title}`),
       ).toHaveTextContent("Slides");
       expect(
-        screen.getByLabelText("Message template Phone demo"),
+        screen.getByLabelText(`Message template ${videoTemplate.nameEn}`),
       ).toHaveTextContent("Video");
+      expect(
+        screen.getByLabelText(`Message template ${illustrationTemplate.title}`),
+      ).toHaveTextContent("Illustration");
+    });
+  });
+
+  it("hides historical template labels behind picker feature switches", async () => {
+    const threadId = "template-message-history-gated";
+    const presentationTemplate = PRESENTATION_TEMPLATE_ITEMS[0]!;
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Template labels gated",
+      chatMessages: [
+        {
+          id: "msg-template-presentation-gated",
+          role: "user",
+          content: "Create the business review deck",
+          runId: "run-template-presentation-gated",
+          generationTemplate: {
+            type: "presentation",
+            selection: {
+              designSystemId: presentationTemplate.designSystemId,
+              templateId: presentationTemplate.templateId,
+            },
+          },
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-template-illustration-gated",
+          role: "user",
+          content: "Create an illustrated launch card",
+          runId: "run-template-illustration-gated",
+          generationTemplate: {
+            type: "illustration",
+            selection: {
+              illustrationStyleId: illustrationTemplate.illustrationStyleId,
+            },
+          },
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatTemplatePicker]: false,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Create the business review deck")).toBeVisible();
+      expect(
+        screen.queryByLabelText(
+          `Message template ${presentationTemplate.title}`,
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(
+          `Message template ${illustrationTemplate.title}`,
+        ),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -992,8 +992,10 @@ function TemplatePreviewPage({
 
 function IllustrationTemplatePreview({
   item,
+  onPreview,
 }: {
   item: IllustrationTemplateItem;
+  onPreview: (item: IllustrationTemplateItem) => void;
 }) {
   return (
     <div className="relative aspect-[4/3] overflow-hidden bg-muted">
@@ -1004,8 +1006,163 @@ function IllustrationTemplatePreview({
         className="h-full w-full object-cover"
         loading="lazy"
       />
+      <button
+        type="button"
+        aria-label={`View template ${item.title}`}
+        className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md bg-[rgba(0,0,0,.3)] text-white opacity-0 shadow-sm transition-colors hover:bg-[rgba(0,0,0,.45)] hover:text-white group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={(event) => {
+          event.stopPropagation();
+          onPreview(item);
+        }}
+      >
+        <IconEye size={16} stroke={1.8} />
+      </button>
     </div>
   );
+}
+
+function IllustrationPreviewPage({
+  item,
+  selectedImageIndex,
+  onImageChange,
+  onBack,
+  onSelect,
+}: {
+  item: IllustrationTemplateItem;
+  selectedImageIndex: number;
+  onImageChange: (index: number) => void;
+  onBack: () => void;
+  onSelect: (item: IllustrationTemplateItem) => void;
+}) {
+  const images =
+    item.previewImages.length > 0 ? item.previewImages : [item.previewImage];
+  const safeImageIndex = Math.max(
+    0,
+    Math.min(selectedImageIndex, images.length - 1),
+  );
+  const selectedImage = images[safeImageIndex] ?? item.previewImage;
+
+  return (
+    <>
+      <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
+        <DialogTitle className="flex min-w-0 items-center gap-2 text-base">
+          <button
+            type="button"
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={onBack}
+          >
+            Templates
+          </button>
+          <span className="shrink-0 text-muted-foreground">/</span>
+          <span className="shrink-0 text-muted-foreground">Illustration</span>
+          <span className="shrink-0 text-muted-foreground">/</span>
+          <span className="min-w-0 truncate">{item.title}</span>
+        </DialogTitle>
+      </DialogHeader>
+      <div className="grid h-[min(72vh,680px)] min-h-0 gap-4 overflow-hidden bg-muted/20 p-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="flex min-h-0 flex-col rounded-lg border border-border bg-background p-3">
+          <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-muted">
+            <img
+              key={selectedImage}
+              src={selectedImage}
+              title={`${item.title} preview variant ${safeImageIndex + 1}`}
+              alt=""
+              className="h-full w-full object-contain"
+              loading="lazy"
+            />
+          </div>
+          <div className="mt-3 flex shrink-0 max-w-full items-center gap-2 overflow-x-auto pb-1">
+            {images.map((image, index) => {
+              const selected = index === safeImageIndex;
+              return (
+                <button
+                  key={image}
+                  type="button"
+                  aria-label={`Show variant ${index + 1}`}
+                  aria-pressed={selected}
+                  className={cn(
+                    "relative h-14 w-20 shrink-0 overflow-hidden rounded-md border-2 bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    selected ? "border-orange-500" : "border-border",
+                  )}
+                  onClick={() => {
+                    onImageChange(index);
+                  }}
+                >
+                  <img
+                    src={image}
+                    alt=""
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <div className="rounded-lg border border-border bg-background p-4">
+            <h3 className="text-lg font-semibold text-foreground">
+              {item.title}
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {formatIllustrationTemplateKind(item)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-background p-4">
+            <h3 className="text-sm font-semibold text-muted-foreground">
+              Variants
+            </h3>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <span className="rounded-full bg-muted px-3 py-1 text-sm text-muted-foreground">
+                {images.length} reference images
+              </span>
+              <span className="rounded-full bg-muted px-3 py-1 text-sm text-muted-foreground">
+                Illustration style
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label={`Select template ${item.title}`}
+            className="h-10 rounded-md bg-foreground px-4 text-sm font-semibold text-background transition-colors hover:bg-foreground/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => {
+              onSelect(item);
+            }}
+          >
+            Use this template
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function resolveTemplatePickerCategory({
+  category,
+  hasPptTab,
+  hasIllustrationTab,
+  hasVideoTab,
+}: {
+  category: string;
+  hasPptTab: boolean;
+  hasIllustrationTab: boolean;
+  hasVideoTab: boolean;
+}): string {
+  const categories: string[] = [];
+  if (hasPptTab) {
+    categories.push("slides");
+  }
+  if (hasIllustrationTab) {
+    categories.push("illustration");
+  }
+  if (hasVideoTab) {
+    categories.push("video");
+  }
+  const defaultCategory = categories[0] ?? "slides";
+  if (category === "video" && !hasVideoTab) {
+    return defaultCategory;
+  }
+  return categories.includes(category) ? category : defaultCategory;
 }
 
 function TemplatePickerTabs({
@@ -1124,6 +1281,15 @@ function TemplatePickerDialog({
     PRESENTATION_TEMPLATE_ITEMS.find((item) => {
       return item.slug === previewSlug;
     }) ?? null;
+  const illustrationPreviewItem =
+    ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
+      return item.slug === previewSlug;
+    }) ?? null;
+  const isPreviewing = Boolean(previewItem ?? illustrationPreviewItem);
+  const dialogContentClassName = cn(
+    "p-0 gap-0 overflow-hidden",
+    isPreviewing ? "max-w-6xl" : "max-w-4xl",
+  );
   const filteredPptItems = PRESENTATION_TEMPLATE_ITEMS.filter((item) => {
     return presentationTemplateMatchesSearch(item, search);
   });
@@ -1163,23 +1329,24 @@ function TemplatePickerDialog({
     setPreviewSlug(item.slug);
   };
 
-  const defaultCategory = "slides";
-  const effectiveCategory =
-    category === "video" && !hasVideoTab ? defaultCategory : category;
-  const selectedCategory = [
-    ...(hasPptTab ? ["slides"] : []),
-    ...(hasIllustrationTab ? ["illustration"] : []),
-    ...(hasVideoTab ? ["video"] : []),
-  ].includes(effectiveCategory)
-    ? effectiveCategory
-    : defaultCategory;
+  const handleIllustrationPreview = (item: IllustrationTemplateItem) => {
+    setSelectedSlideIndex(0);
+    setPreviewSlug(item.slug);
+  };
+
+  const selectedCategory = resolveTemplatePickerCategory({
+    category,
+    hasPptTab,
+    hasIllustrationTab,
+    hasVideoTab,
+  });
 
   return (
     <Dialog
       open
       onOpenChange={(open) => {
         if (!open) {
-          if (previewItem) {
+          if (isPreviewing) {
             setPreviewSlug(null);
             return;
           }
@@ -1188,10 +1355,7 @@ function TemplatePickerDialog({
       }}
     >
       <DialogContent
-        className={cn(
-          "p-0 gap-0 overflow-hidden",
-          previewItem ? "max-w-6xl" : "max-w-4xl",
-        )}
+        className={dialogContentClassName}
         aria-describedby={undefined}
       >
         {previewItem ? (
@@ -1203,6 +1367,16 @@ function TemplatePickerDialog({
               setPreviewSlug(null);
             }}
             onSelect={handleSelectPresentation}
+          />
+        ) : illustrationPreviewItem ? (
+          <IllustrationPreviewPage
+            item={illustrationPreviewItem}
+            selectedImageIndex={selectedSlideIndex}
+            onImageChange={setSelectedSlideIndex}
+            onBack={() => {
+              setPreviewSlug(null);
+            }}
+            onSelect={handleSelectIllustration}
           />
         ) : (
           <>
@@ -1327,7 +1501,10 @@ function TemplatePickerDialog({
                               : "border-border",
                           )}
                         >
-                          <IllustrationTemplatePreview item={item} />
+                          <IllustrationTemplatePreview
+                            item={item}
+                            onPreview={handleIllustrationPreview}
+                          />
                           <div className="flex items-start justify-between gap-3 px-3.5 py-3">
                             <div className="min-w-0">
                               <p className="truncate text-sm font-semibold text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -28,6 +28,7 @@ import {
   IconPaperclip,
   IconPlayerStop,
   IconPlug,
+  IconPhoto,
   IconPlus,
   IconSearch,
   IconTemplate,
@@ -92,7 +93,9 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
+  type IllustrationTemplateItem,
   type PresentationTemplateItem,
   VIDEO_STYLE_GROUPS,
   VIDEO_STYLE_PRESETS,
@@ -493,7 +496,10 @@ function selectedTemplateTitle(
   if (value?.type === "video") {
     return selectedVideoTemplateItem(value)?.nameEn;
   }
-  return selectedPresentationTemplateItem(value)?.title;
+  return (
+    selectedPresentationTemplateItem(value)?.title ??
+    selectedIllustrationTemplateItem(value)?.title
+  );
 }
 
 function selectedPresentationTemplateItem(
@@ -507,12 +513,50 @@ function selectedPresentationTemplateItem(
   });
 }
 
+function isSelectedIllustrationTemplate(
+  item: IllustrationTemplateItem,
+  value: GenerationTemplateRequest | undefined,
+): boolean {
+  return (
+    value?.type === "illustration" &&
+    value.selection.illustrationStyleId === item.illustrationStyleId
+  );
+}
+
+function toIllustrationGenerationTemplate(
+  item: IllustrationTemplateItem,
+): GenerationTemplateRequest {
+  return {
+    type: "illustration",
+    selection: {
+      illustrationStyleId: item.illustrationStyleId,
+    },
+  };
+}
+
+function selectedIllustrationTemplateItem(
+  value: GenerationTemplateRequest | undefined,
+): IllustrationTemplateItem | undefined {
+  if (value?.type !== "illustration") {
+    return undefined;
+  }
+  return ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
+    return isSelectedIllustrationTemplate(item, value);
+  });
+}
+
 function formatPresentationTemplateKind(templateId: string): string {
   const label = templateId
     .replace(/^template:/, "")
     .replace(/^html-ppt-/, "")
     .replace(/-/g, " ");
   return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function formatIllustrationTemplateKind(
+  item: IllustrationTemplateItem,
+): string {
+  return `${item.variationCount} variations`;
 }
 
 function presentationTemplateMatchesSearch(
@@ -528,6 +572,22 @@ function presentationTemplateMatchesSearch(
     item.designSystemId,
     item.templateId,
     formatPresentationTemplateKind(item.templateId),
+  ].join(" ");
+  return searchable.toLowerCase().includes(normalizedQuery);
+}
+
+function illustrationTemplateMatchesSearch(
+  item: IllustrationTemplateItem,
+  query: string,
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+  const searchable = [
+    item.title,
+    item.illustrationStyleId,
+    formatIllustrationTemplateKind(item),
   ].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
 }
@@ -930,17 +990,124 @@ function TemplatePreviewPage({
   );
 }
 
+function IllustrationTemplatePreview({
+  item,
+}: {
+  item: IllustrationTemplateItem;
+}) {
+  return (
+    <div className="relative aspect-[4/3] overflow-hidden bg-muted">
+      <img
+        src={item.previewImage}
+        alt=""
+        title={`${item.title} illustration preview`}
+        className="h-full w-full object-cover"
+        loading="lazy"
+      />
+    </div>
+  );
+}
+
+function TemplatePickerTabs({
+  selectedCategory,
+  hasPptTab,
+  hasIllustrationTab,
+  hasVideoTab,
+  onChange,
+}: {
+  selectedCategory: string;
+  hasPptTab: boolean;
+  hasIllustrationTab: boolean;
+  hasVideoTab: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <Tabs value={selectedCategory} onValueChange={onChange} className="-mb-px">
+      <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
+        {hasPptTab && (
+          <TabsTrigger
+            value="slides"
+            className={cn(
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              selectedCategory === "slides"
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <IconPresentation
+              className={cn(
+                "h-5 w-5",
+                selectedCategory === "slides"
+                  ? "text-blue-500"
+                  : "text-muted-foreground",
+              )}
+              stroke={1.8}
+            />
+            PPT
+          </TabsTrigger>
+        )}
+        {hasIllustrationTab && (
+          <TabsTrigger
+            value="illustration"
+            className={cn(
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              selectedCategory === "illustration"
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <IconPhoto
+              className={cn(
+                "h-5 w-5",
+                selectedCategory === "illustration"
+                  ? "text-emerald-500"
+                  : "text-muted-foreground",
+              )}
+              stroke={1.8}
+            />
+            Illustration
+          </TabsTrigger>
+        )}
+        {hasVideoTab && (
+          <TabsTrigger
+            value="video"
+            className={cn(
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              selectedCategory === "video"
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <IconVideo
+              className={cn(
+                "h-5 w-5",
+                selectedCategory === "video"
+                  ? "text-purple-500"
+                  : "text-muted-foreground",
+              )}
+              stroke={1.8}
+            />
+            Video
+          </TabsTrigger>
+        )}
+      </TabsList>
+    </Tabs>
+  );
+}
+
 function TemplatePickerDialog({
   value,
   onChange,
   onClose,
   hasPptTab,
+  hasIllustrationTab,
   hasVideoTab,
 }: {
   value: GenerationTemplateRequest | undefined;
   onChange: (value: GenerationTemplateRequest | undefined) => void;
   onClose: () => void;
   hasPptTab: boolean;
+  hasIllustrationTab: boolean;
   hasVideoTab: boolean;
 }) {
   const category = useGet(templatePickerCategory$);
@@ -960,6 +1127,11 @@ function TemplatePickerDialog({
   const filteredPptItems = PRESENTATION_TEMPLATE_ITEMS.filter((item) => {
     return presentationTemplateMatchesSearch(item, search);
   });
+  const filteredIllustrationItems = ILLUSTRATION_TEMPLATE_ITEMS.filter(
+    (item) => {
+      return illustrationTemplateMatchesSearch(item, search);
+    },
+  );
   const filteredVideoItems = VIDEO_STYLE_PRESETS.filter((item) => {
     return (
       videoTemplateMatchesGroup(item, videoGroup) &&
@@ -981,15 +1153,26 @@ function TemplatePickerDialog({
     onClose();
   };
 
+  const handleSelectIllustration = (item: IllustrationTemplateItem) => {
+    onChange(toIllustrationGenerationTemplate(item));
+    onClose();
+  };
+
   const handlePreview = (item: PresentationTemplateItem) => {
     setSelectedSlideIndex(0);
     setPreviewSlug(item.slug);
   };
 
-  const defaultCategory = hasPptTab ? "slides" : "video";
+  const defaultCategory = "slides";
   const effectiveCategory =
-    category === "slides" && !hasPptTab ? "video" : category;
-  const selectedCategory = effectiveCategory || defaultCategory;
+    category === "video" && !hasVideoTab ? defaultCategory : category;
+  const selectedCategory = [
+    ...(hasPptTab ? ["slides"] : []),
+    ...(hasIllustrationTab ? ["illustration"] : []),
+    ...(hasVideoTab ? ["video"] : []),
+  ].includes(effectiveCategory)
+    ? effectiveCategory
+    : defaultCategory;
 
   return (
     <Dialog
@@ -1027,58 +1210,13 @@ function TemplatePickerDialog({
               <DialogTitle>Templates</DialogTitle>
             </DialogHeader>
             <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 pt-3 sm:flex-row sm:items-start sm:justify-between">
-              <Tabs
-                value={selectedCategory}
-                onValueChange={setCategory}
-                className="-mb-px"
-              >
-                <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
-                  {hasPptTab && (
-                    <TabsTrigger
-                      value="slides"
-                      className={cn(
-                        "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
-                        selectedCategory === "slides"
-                          ? "border-foreground text-foreground"
-                          : "border-transparent text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      <IconPresentation
-                        className={cn(
-                          "h-5 w-5",
-                          selectedCategory === "slides"
-                            ? "text-blue-500"
-                            : "text-muted-foreground",
-                        )}
-                        stroke={1.8}
-                      />
-                      PPT
-                    </TabsTrigger>
-                  )}
-                  {hasVideoTab && (
-                    <TabsTrigger
-                      value="video"
-                      className={cn(
-                        "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
-                        selectedCategory === "video"
-                          ? "border-foreground text-foreground"
-                          : "border-transparent text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      <IconVideo
-                        className={cn(
-                          "h-5 w-5",
-                          selectedCategory === "video"
-                            ? "text-purple-500"
-                            : "text-muted-foreground",
-                        )}
-                        stroke={1.8}
-                      />
-                      Video
-                    </TabsTrigger>
-                  )}
-                </TabsList>
-              </Tabs>
+              <TemplatePickerTabs
+                selectedCategory={selectedCategory}
+                hasPptTab={hasPptTab}
+                hasIllustrationTab={hasIllustrationTab}
+                hasVideoTab={hasVideoTab}
+                onChange={setCategory}
+              />
               <div className="w-full pb-3 sm:w-64">
                 <div className="relative">
                   <IconSearch
@@ -1142,6 +1280,70 @@ function TemplatePickerDialog({
                                 aria-pressed={selected}
                                 onClick={() => {
                                   handleSelectPresentation(item);
+                                }}
+                                className={cn(
+                                  "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                                  selected
+                                    ? "border-primary/40 bg-primary/10 text-primary"
+                                    : "border-border bg-background text-foreground hover:bg-muted",
+                                )}
+                              >
+                                Use
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <TemplateEmptyPanel
+                    title="No matches"
+                    description="Try a different search."
+                  />
+                )}
+              </div>
+            )}
+            {selectedCategory === "illustration" && (
+              <div className="max-h-[66vh] overflow-y-auto px-5 py-4">
+                <TemplateSectionHeader
+                  label="VM0 illustration styles"
+                  count={filteredIllustrationItems.length}
+                />
+                {filteredIllustrationItems.length > 0 ? (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {filteredIllustrationItems.map((item) => {
+                      const selected = isSelectedIllustrationTemplate(
+                        item,
+                        value,
+                      );
+                      return (
+                        <div
+                          key={item.illustrationStyleId}
+                          className={cn(
+                            "group overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+                            selected
+                              ? "border-primary ring-1 ring-primary"
+                              : "border-border",
+                          )}
+                        >
+                          <IllustrationTemplatePreview item={item} />
+                          <div className="flex items-start justify-between gap-3 px-3.5 py-3">
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-semibold text-foreground">
+                                {item.title}
+                              </p>
+                              <p className="mt-1 truncate text-xs text-muted-foreground">
+                                {formatIllustrationTemplateKind(item)}
+                              </p>
+                            </div>
+                            <div className="flex shrink-0 items-center">
+                              <button
+                                type="button"
+                                aria-label={`Select template ${item.title}`}
+                                aria-pressed={selected}
+                                onClick={() => {
+                                  handleSelectIllustration(item);
                                 }}
                                 className={cn(
                                   "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -1303,6 +1505,47 @@ function SelectedVideoTemplateChip({
   );
 }
 
+function SelectedIllustrationTemplateChip({
+  item,
+  onRemove,
+}: {
+  item: IllustrationTemplateItem;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="px-4 pt-3">
+      <div className="flex">
+        <div className="inline-flex h-8 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/90 pl-1.5 pr-1 text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+            <img
+              src={item.previewImage}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          </span>
+          <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+            Illustration
+          </span>
+          <span className="h-3.5 w-px shrink-0 bg-border/70" />
+          <span className="min-w-0 truncate text-xs font-medium">
+            {item.title}
+          </span>
+          <button
+            type="button"
+            aria-label={`Remove template ${item.title}`}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={onRemove}
+          >
+            <IconX size={14} stroke={1.8} />
+          </button>
+        </div>
+      </div>
+      <div className="mt-3 h-px bg-border/50" />
+    </div>
+  );
+}
+
 function SelectedTemplateChipSlot({
   picker,
   onDraftChange,
@@ -1311,6 +1554,7 @@ function SelectedTemplateChipSlot({
   onDraftChange: (() => void) | undefined;
 }) {
   const presentationItem = selectedPresentationTemplateItem(picker?.value);
+  const illustrationItem = selectedIllustrationTemplateItem(picker?.value);
   const videoItem = selectedVideoTemplateItem(picker?.value);
   if (!picker) {
     return null;
@@ -1337,16 +1581,29 @@ function SelectedTemplateChipSlot({
       />
     );
   }
+  if (illustrationItem) {
+    return (
+      <SelectedIllustrationTemplateChip
+        item={illustrationItem}
+        onRemove={() => {
+          picker.onChange(undefined);
+          onDraftChange?.();
+        }}
+      />
+    );
+  }
   return null;
 }
 
 function TemplatePickerButton({
   picker,
   hasPptTab,
+  hasIllustrationTab,
   hasVideoTab,
 }: {
   picker: ComposerTemplatePicker;
   hasPptTab: boolean;
+  hasIllustrationTab: boolean;
   hasVideoTab: boolean;
 }) {
   const open = useGet(templatePickerOpen$);
@@ -1394,6 +1651,7 @@ function TemplatePickerButton({
             setOpen(false);
           }}
           hasPptTab={hasPptTab}
+          hasIllustrationTab={hasIllustrationTab}
           hasVideoTab={hasVideoTab}
         />
       )}
@@ -1407,15 +1665,20 @@ function ComposerTemplatePickerSlot({
   picker: ComposerTemplatePicker | undefined;
 }) {
   const features = useLastResolved(featureSwitch$);
-  const hasPptTab = Boolean(features?.[FeatureSwitchKey.ChatTemplatePicker]);
+  const hasChatTemplatePicker = Boolean(
+    features?.[FeatureSwitchKey.ChatTemplatePicker],
+  );
+  const hasPptTab = hasChatTemplatePicker;
+  const hasIllustrationTab = hasChatTemplatePicker;
   const hasVideoTab = Boolean(features?.[FeatureSwitchKey.VideoTemplatePicker]);
-  if (!picker || (!hasPptTab && !hasVideoTab)) {
+  if (!picker || (!hasChatTemplatePicker && !hasVideoTab)) {
     return null;
   }
   return (
     <TemplatePickerButton
       picker={picker}
       hasPptTab={hasPptTab}
+      hasIllustrationTab={hasIllustrationTab}
       hasVideoTab={hasVideoTab}
     />
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -61,7 +61,11 @@ import type {
   GenerationTemplateRequest,
   ChatThreadGithubPr,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { PRESENTATION_TEMPLATE_ITEMS, VIDEO_STYLE_PRESETS } from "@vm0/core";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_ITEMS,
+  VIDEO_STYLE_PRESETS,
+} from "@vm0/core";
 import type {
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
@@ -4720,6 +4724,16 @@ function generationTemplateLabel(
     });
     return item?.nameEn ?? formatTemplateIdLabel(value.selection.stylePresetId);
   }
+  if (value.type === "illustration") {
+    const item = ILLUSTRATION_TEMPLATE_ITEMS.find((candidate) => {
+      return (
+        candidate.illustrationStyleId === value.selection.illustrationStyleId
+      );
+    });
+    return (
+      item?.title ?? formatTemplateIdLabel(value.selection.illustrationStyleId)
+    );
+  }
   const item = PRESENTATION_TEMPLATE_ITEMS.find((candidate) => {
     return (
       candidate.designSystemId === value.selection.designSystemId &&
@@ -4738,6 +4752,9 @@ function generationTemplateTypeLabel(
   if (value.type === "video") {
     return "Video";
   }
+  if (value.type === "illustration") {
+    return "Illustration";
+  }
   return "Slides";
 }
 
@@ -4750,7 +4767,7 @@ function UserMessageGenerationTemplate({
   const templateLabelEnabled =
     generationTemplate?.type === "video"
       ? (features?.[FeatureSwitchKey.VideoTemplatePicker] ?? false)
-      : (features?.[FeatureSwitchKey.ChatTemplatePicker] ?? false);
+      : true;
   if (!templateLabelEnabled) {
     return null;
   }
@@ -4767,6 +4784,8 @@ function UserMessageGenerationTemplate({
     >
       {generationTemplate?.type === "video" ? (
         <IconVideo size={15} stroke={1.8} className="shrink-0" />
+      ) : generationTemplate?.type === "illustration" ? (
+        <IconPhoto size={15} stroke={1.8} className="shrink-0" />
       ) : (
         <IconPresentation size={15} stroke={1.8} className="shrink-0" />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4767,7 +4767,7 @@ function UserMessageGenerationTemplate({
   const templateLabelEnabled =
     generationTemplate?.type === "video"
       ? (features?.[FeatureSwitchKey.VideoTemplatePicker] ?? false)
-      : true;
+      : (features?.[FeatureSwitchKey.ChatTemplatePicker] ?? false);
   if (!templateLabelEnabled) {
     return null;
   }

--- a/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Footer } from "../../components/Footer";
-import { ILLUSTRATION_STYLES, type IllustrationStyle } from "./data";
-
-const ASSET_BASE = "https://quiet-moments-gallery-715f6d07.sites.vm0.io";
+import {
+  ILLUSTRATION_ASSET_BASE,
+  ILLUSTRATION_STYLES,
+  type IllustrationStyle,
+} from "@vm0/core";
 
 interface LightboxState {
   style: IllustrationStyle;
@@ -115,8 +117,8 @@ interface CardProps {
 
 function IllustrationCard({ style, onOpen }: CardProps) {
   const coverSrc = style.cover
-    ? `${ASSET_BASE}/${style.cover}`
-    : `${ASSET_BASE}/images/${style.image}`;
+    ? `${ILLUSTRATION_ASSET_BASE}/${style.cover}`
+    : `${ILLUSTRATION_ASSET_BASE}/images/${style.image}`;
 
   return (
     <article className="illu-tile">
@@ -162,7 +164,7 @@ function IllustrationCard({ style, onOpen }: CardProps) {
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={`${ASSET_BASE}/refs/${style.slug}/${ref}`}
+                src={`${ILLUSTRATION_ASSET_BASE}/refs/${style.slug}/${ref}`}
                 loading="lazy"
                 alt=""
               />
@@ -188,7 +190,7 @@ function Lightbox({ state, onClose, onSelectRef }: LightboxProps) {
 
   const { style, activeRef } = state;
   const refCount = style.refs.length;
-  const activeSrc = `${ASSET_BASE}/refs/${style.slug}/${activeRef}`;
+  const activeSrc = `${ILLUSTRATION_ASSET_BASE}/refs/${style.slug}/${activeRef}`;
 
   if (!mounted) {
     return null;
@@ -238,7 +240,7 @@ function Lightbox({ state, onClose, onSelectRef }: LightboxProps) {
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={`${ASSET_BASE}/refs/${style.slug}/${ref}`}
+                src={`${ILLUSTRATION_ASSET_BASE}/refs/${style.slug}/${ref}`}
                 loading="lazy"
                 alt=""
               />

--- a/turbo/apps/web/app/[locale]/illustration/page.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/page.tsx
@@ -2,11 +2,10 @@ import type { Metadata } from "next";
 import { Fraunces } from "next/font/google";
 import type { Locale } from "../../../i18n";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
+import { ILLUSTRATION_ASSET_BASE, ILLUSTRATION_STYLES } from "@vm0/core";
 import { IllustrationGalleryClient } from "./IllustrationGalleryClient";
-import { ILLUSTRATION_STYLES } from "./data";
 
 const BASE_URL = "https://www.vm0.ai";
-const ASSET_BASE = "https://quiet-moments-gallery-715f6d07.sites.vm0.io";
 
 const fraunces = Fraunces({
   subsets: ["latin"],
@@ -73,7 +72,7 @@ export default async function IllustrationPage({ params }: PageProps) {
         "@type": "ListItem",
         position: i + 1,
         name: style.title,
-        image: `${ASSET_BASE}/images/${style.image}`,
+        image: `${ILLUSTRATION_ASSET_BASE}/images/${style.image}`,
       };
     }),
   };

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -174,9 +174,17 @@ const videoGenerationTemplateRequestSchema = z.object({
   }),
 });
 
+const illustrationGenerationTemplateRequestSchema = z.object({
+  type: z.literal("illustration"),
+  selection: z.object({
+    illustrationStyleId: z.string().min(1),
+  }),
+});
+
 const generationTemplateRequestSchema = z.discriminatedUnion("type", [
   presentationGenerationTemplateRequestSchema,
   videoGenerationTemplateRequestSchema,
+  illustrationGenerationTemplateRequestSchema,
 ]);
 
 const pagedChatMessageBaseSchema = z.object({
@@ -847,6 +855,7 @@ export {
   generationTemplateRequestSchema,
   presentationGenerationTemplateRequestSchema,
   videoGenerationTemplateRequestSchema,
+  illustrationGenerationTemplateRequestSchema,
   pagedChatMessageSchema,
   summaryEntrySchema,
   persistedAttachmentSchema,
@@ -868,6 +877,9 @@ export type PresentationGenerationTemplateRequest = z.infer<
 >;
 export type VideoGenerationTemplateRequest = z.infer<
   typeof videoGenerationTemplateRequestSchema
+>;
+export type IllustrationGenerationTemplateRequest = z.infer<
+  typeof illustrationGenerationTemplateRequestSchema
 >;
 
 export type SummaryEntry = z.infer<typeof summaryEntrySchema>;

--- a/turbo/packages/core/src/__tests__/illustration-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/illustration-template-items.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  ILLUSTRATION_ASSET_BASE,
+  ILLUSTRATION_TEMPLATE_ITEMS,
+} from "../illustration-template-items";
+import { findImageStyle } from "../resource-registry";
+
+describe("illustration template items", () => {
+  it("resolve every image style against the resource registry", () => {
+    for (const item of ILLUSTRATION_TEMPLATE_ITEMS) {
+      const style = findImageStyle(item.illustrationStyleId);
+
+      expect(style, item.illustrationStyleId).toBeDefined();
+      expect(item.tag).toBe("illustration");
+    }
+  });
+
+  it("defines preview image arrays", () => {
+    for (const item of ILLUSTRATION_TEMPLATE_ITEMS) {
+      expect(item.previewImage).toContain(ILLUSTRATION_ASSET_BASE);
+      expect(item.previewImages.length).toBe(item.variationCount);
+    }
+  });
+});

--- a/turbo/packages/core/src/illustration-template-items.ts
+++ b/turbo/packages/core/src/illustration-template-items.ts
@@ -1,3 +1,6 @@
+export const ILLUSTRATION_ASSET_BASE =
+  "https://quiet-moments-gallery-715f6d07.sites.vm0.io";
+
 export interface IllustrationStyle {
   slug: string;
   title: string;
@@ -468,3 +471,33 @@ export const ILLUSTRATION_STYLES: readonly IllustrationStyle[] = [
     ],
   },
 ];
+
+export interface IllustrationTemplateItem {
+  readonly slug: string;
+  readonly title: string;
+  readonly illustrationStyleId: string;
+  readonly previewImage: string;
+  readonly previewImages: readonly string[];
+  readonly variationCount: number;
+  readonly tag: "illustration";
+}
+
+function illustrationPreviewImage(style: IllustrationStyle): string {
+  const cover = style.cover ?? `images/${style.image}`;
+  return `${ILLUSTRATION_ASSET_BASE}/${cover}`;
+}
+
+export const ILLUSTRATION_TEMPLATE_ITEMS: readonly IllustrationTemplateItem[] =
+  ILLUSTRATION_STYLES.map((style) => {
+    return {
+      slug: style.slug,
+      title: style.title,
+      illustrationStyleId: `image-style:${style.slug}`,
+      previewImage: illustrationPreviewImage(style),
+      previewImages: style.refs.map((ref) => {
+        return `${ILLUSTRATION_ASSET_BASE}/refs/${style.slug}/${ref}`;
+      }),
+      variationCount: style.refs.length,
+      tag: "illustration",
+    };
+  });

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -22,6 +22,13 @@ export {
   type PresentationTemplateItem,
 } from "./presentation-template-items";
 export {
+  ILLUSTRATION_ASSET_BASE,
+  ILLUSTRATION_STYLES,
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  type IllustrationStyle,
+  type IllustrationTemplateItem,
+} from "./illustration-template-items";
+export {
   VIDEO_STYLE_GROUPS,
   VIDEO_STYLE_PRESETS,
   VIDEO_DIMENSION_DESCRIPTIONS,

--- a/turbo/packages/db/src/schema/chat-message.ts
+++ b/turbo/packages/db/src/schema/chat-message.ts
@@ -30,9 +30,17 @@ export interface ChatMessageVideoGenerationTemplate {
   };
 }
 
+export interface ChatMessageIllustrationGenerationTemplate {
+  readonly type: "illustration";
+  readonly selection: {
+    readonly illustrationStyleId: string;
+  };
+}
+
 export type ChatMessageGenerationTemplate =
   | ChatMessagePresentationGenerationTemplate
-  | ChatMessageVideoGenerationTemplate;
+  | ChatMessageVideoGenerationTemplate
+  | ChatMessageIllustrationGenerationTemplate;
 
 export type ChatMessageRecommendedFollowupKind = "talk" | "generate";
 export type ChatMessageRecommendedFollowupGenerationType =


### PR DESCRIPTION
## Summary
- add a second-level Illustration preview in the template picker with large image and variant thumbnails
- keep the preview inside the template dialog flow, matching the PPT preview pattern
- fix the zero chat message test import for detached async cleanup

## Verification
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx

## Notes
- pnpm test was run, but local full-suite tests fail because the local environment is missing the vm0_test database and the web test environment has localStorage unavailable.