### PR TITLE
fix(runner): add live runner instances

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -568,7 +568,7 @@ async fn build_runner_report(
 }
 
 // ---------------------------------------------------------------------------
-// Config loading (lenient — no path validation)
+// Config loading (lenient parse, safe candidate read)
 // ---------------------------------------------------------------------------
 
 async fn load_config_lenient(path: &Path) -> Option<RunnerConfig> {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -572,7 +572,9 @@ async fn build_runner_report(
 // ---------------------------------------------------------------------------
 
 async fn load_config_lenient(path: &Path) -> Option<RunnerConfig> {
-    let content = tokio::fs::read_to_string(path).await.ok()?;
+    let content = crate::config::read_diagnostic_config_to_string(path)
+        .await
+        .ok()??;
     let mut config: RunnerConfig = serde_yaml_ng::from_str(&content).ok()?;
     if let Some(config_dir) = path.parent() {
         config.resolve_relative_paths(config_dir);

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -164,6 +164,20 @@ pub struct StartArgs {
     local: bool,
 }
 
+async fn publish_live_runner_or_shutdown_runtime(
+    home: &HomePaths,
+    metadata: crate::live_runner_registry::LiveRunnerRegistryMetadata,
+    runtime: &mut dyn SandboxRuntime,
+) -> RunnerResult<crate::live_runner_registry::LiveRunnerRegistryHandle> {
+    match crate::live_runner_registry::publish(home, metadata).await {
+        Ok(handle) => Ok(handle),
+        Err(e) => {
+            runtime.shutdown().await;
+            Err(e)
+        }
+    }
+}
+
 /// Load config and run the main poll loop.
 pub async fn run_start(
     args: StartArgs,
@@ -420,7 +434,7 @@ pub async fn run_start(
     };
 
     // Build sandbox runtime with shared resources (netns and NBD device pools).
-    let runtime = runtime_provider
+    let mut runtime = runtime_provider
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
             dns_port: Some(dns_handle.port()),
@@ -499,6 +513,10 @@ pub async fn run_start(
         runner_group: group_name.clone(),
     };
 
+    let live_runner_handle =
+        publish_live_runner_or_shutdown_runtime(&home, live_runner_metadata, runtime.as_mut())
+            .await?;
+
     let config = RunConfig {
         runner: RunnerInfo {
             id: runner_id,
@@ -555,8 +573,6 @@ pub async fn run_start(
         },
     };
 
-    let live_runner_handle =
-        crate::live_runner_registry::publish(&config.paths.home, live_runner_metadata).await?;
     let run_result = run(config).await;
     if let Err(e) = live_runner_handle.remove_if_current().await {
         tracing::warn!(error = %e, "failed to remove live runner registry record");

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -164,14 +164,16 @@ pub struct StartArgs {
     local: bool,
 }
 
-async fn publish_live_runner_or_shutdown_runtime(
+async fn publish_live_runner_or_shutdown_startup_resources(
     home: &HomePaths,
     metadata: crate::live_runner_registry::LiveRunnerRegistryMetadata,
+    provider: &dyn JobProvider,
     runtime: &mut dyn SandboxRuntime,
 ) -> RunnerResult<crate::live_runner_registry::LiveRunnerRegistryHandle> {
     match crate::live_runner_registry::publish(home, metadata).await {
         Ok(handle) => Ok(handle),
         Err(e) => {
+            provider.shutdown().await;
             runtime.shutdown().await;
             Err(e)
         }
@@ -513,9 +515,13 @@ pub async fn run_start(
         runner_group: group_name.clone(),
     };
 
-    let live_runner_handle =
-        publish_live_runner_or_shutdown_runtime(&home, live_runner_metadata, runtime.as_mut())
-            .await?;
+    let live_runner_handle = publish_live_runner_or_shutdown_startup_resources(
+        &home,
+        live_runner_metadata,
+        provider.as_ref(),
+        runtime.as_mut(),
+    )
+    .await?;
 
     let config = RunConfig {
         runner: RunnerInfo {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -164,13 +164,13 @@ pub struct StartArgs {
     local: bool,
 }
 
-async fn publish_live_runner_or_shutdown_startup_resources(
+async fn publish_live_runner_instance_or_shutdown_startup_resources(
     home: &HomePaths,
-    metadata: crate::live_runner_registry::LiveRunnerRegistryMetadata,
+    metadata: crate::live_runner_instances::LiveRunnerInstanceMetadata,
     provider: &dyn JobProvider,
     runtime: &mut dyn SandboxRuntime,
-) -> RunnerResult<crate::live_runner_registry::LiveRunnerRegistryHandle> {
-    match crate::live_runner_registry::publish(home, metadata).await {
+) -> RunnerResult<crate::live_runner_instances::LiveRunnerInstanceHandle> {
+    match crate::live_runner_instances::publish(home, metadata).await {
         Ok(handle) => Ok(handle),
         Err(e) => {
             provider.shutdown().await;
@@ -508,16 +508,16 @@ pub async fn run_start(
         )),
     });
 
-    let live_runner_metadata = crate::live_runner_registry::LiveRunnerRegistryMetadata {
+    let live_runner_instance_metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: args.config.clone(),
         base_dir: base_dir_canonical.clone(),
         runner_name: name.clone(),
         runner_group: group_name.clone(),
     };
 
-    let live_runner_handle = publish_live_runner_or_shutdown_startup_resources(
+    let live_runner_instance_handle = publish_live_runner_instance_or_shutdown_startup_resources(
         &home,
-        live_runner_metadata,
+        live_runner_instance_metadata,
         provider.as_ref(),
         runtime.as_mut(),
     )
@@ -580,8 +580,8 @@ pub async fn run_start(
     };
 
     let run_result = run(config).await;
-    if let Err(e) = live_runner_handle.remove_if_current().await {
-        tracing::warn!(error = %e, "failed to remove live runner registry record");
+    if let Err(e) = live_runner_instance_handle.remove_if_current().await {
+        tracing::warn!(error = %e, "failed to remove live runner instance record");
     }
     run_result
 }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -492,6 +492,13 @@ pub async fn run_start(
         )),
     });
 
+    let live_runner_metadata = crate::live_runner_registry::LiveRunnerRegistryMetadata {
+        config_path: args.config.clone(),
+        base_dir: base_dir_canonical.clone(),
+        runner_name: name.clone(),
+        runner_group: group_name.clone(),
+    };
+
     let config = RunConfig {
         runner: RunnerInfo {
             id: runner_id,
@@ -548,7 +555,13 @@ pub async fn run_start(
         },
     };
 
-    run(config).await
+    let live_runner_handle =
+        crate::live_runner_registry::publish(&config.paths.home, live_runner_metadata).await?;
+    let run_result = run(config).await;
+    if let Err(e) = live_runner_handle.remove_if_current().await {
+        tracing::warn!(error = %e, "failed to remove live runner registry record");
+    }
+    run_result
 }
 
 struct RunConfig {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -9,9 +9,46 @@ use super::support::{
 
 use super::super::signals::{SignalController, SignalHandlerTask, handle_resume_signal};
 use crate::idle_pool::ParkingState;
+use crate::provider::{ClaimedJob, CompletionAuth, JobCandidate};
+use crate::types::{HeartbeatState, HeldSessionState, SandboxReuseResult};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct ShutdownRecordingProvider {
+    shutdowns: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl crate::provider::JobProvider for ShutdownRecordingProvider {
+    async fn discover(&self) -> Option<JobCandidate> {
+        panic!("publish failure cleanup test does not discover jobs")
+    }
+
+    async fn claim(&self, _candidate: JobCandidate) -> Option<ClaimedJob> {
+        panic!("publish failure cleanup test does not claim jobs")
+    }
+
+    async fn complete(
+        &self,
+        _run_id: RunId,
+        _exit_code: i32,
+        _error: Option<&str>,
+        _sandbox_id: Option<sandbox::SandboxId>,
+        _reuse_result: Option<SandboxReuseResult>,
+        _completion_auth: CompletionAuth,
+    ) {
+        panic!("publish failure cleanup test does not complete jobs")
+    }
+
+    async fn heartbeat(&self, _state: &HeartbeatState) {}
+
+    async fn set_held_session_states(&self, _states: Vec<HeldSessionState>) {}
+
+    async fn shutdown(&self) {
+        self.shutdowns.fetch_add(1, Ordering::SeqCst);
+    }
+}
 
 struct ShutdownRecordingRuntime {
     shutdowns: Arc<AtomicUsize>,
@@ -67,15 +104,19 @@ fn write_usage_pending_state(
 }
 
 #[tokio::test]
-async fn live_registry_publish_failure_shuts_down_runtime() {
+async fn live_registry_publish_failure_shuts_down_startup_resources() {
     let dir = tempfile::tempdir().unwrap();
     let home = crate::paths::HomePaths::with_root(dir.path().join("vm0-runner"));
     std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
     std::fs::write(home.live_runners_dir(), b"not a directory").unwrap();
 
-    let shutdowns = Arc::new(AtomicUsize::new(0));
+    let provider_shutdowns = Arc::new(AtomicUsize::new(0));
+    let provider = ShutdownRecordingProvider {
+        shutdowns: Arc::clone(&provider_shutdowns),
+    };
+    let runtime_shutdowns = Arc::new(AtomicUsize::new(0));
     let mut runtime = ShutdownRecordingRuntime {
-        shutdowns: Arc::clone(&shutdowns),
+        shutdowns: Arc::clone(&runtime_shutdowns),
     };
     let metadata = crate::live_runner_registry::LiveRunnerRegistryMetadata {
         config_path: dir.path().join("runner.yaml"),
@@ -84,15 +125,17 @@ async fn live_registry_publish_failure_shuts_down_runtime() {
         runner_group: "vm0/test".into(),
     };
 
-    let error = publish_live_runner_or_shutdown_runtime(&home, metadata, &mut runtime)
-        .await
-        .unwrap_err();
+    let error =
+        publish_live_runner_or_shutdown_startup_resources(&home, metadata, &provider, &mut runtime)
+            .await
+            .unwrap_err();
 
     assert!(
         error.to_string().contains("ensure live runner registry"),
         "unexpected error: {error}"
     );
-    assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
+    assert_eq!(provider_shutdowns.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime_shutdowns.load(Ordering::SeqCst), 1);
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -9,6 +9,27 @@ use super::support::{
 
 use super::super::signals::{SignalController, SignalHandlerTask, handle_resume_signal};
 use crate::idle_pool::ParkingState;
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct ShutdownRecordingRuntime {
+    shutdowns: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl sandbox::SandboxRuntime for ShutdownRecordingRuntime {
+    async fn create_factory(
+        &self,
+        _config: sandbox::FactoryConfig,
+    ) -> sandbox::Result<Box<dyn sandbox::SandboxFactory>> {
+        panic!("publish failure cleanup test does not create factories")
+    }
+
+    async fn shutdown(&mut self) {
+        self.shutdowns.fetch_add(1, Ordering::SeqCst);
+    }
+}
 
 fn usage_pending_path(base_dir: &std::path::Path) -> std::path::PathBuf {
     base_dir.join("mitm-addon").join("usage-pending")
@@ -43,6 +64,35 @@ fn write_usage_pending_state(
         .to_string(),
     )
     .unwrap();
+}
+
+#[tokio::test]
+async fn live_registry_publish_failure_shuts_down_runtime() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = crate::paths::HomePaths::with_root(dir.path().join("vm0-runner"));
+    std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
+    std::fs::write(home.live_runners_dir(), b"not a directory").unwrap();
+
+    let shutdowns = Arc::new(AtomicUsize::new(0));
+    let mut runtime = ShutdownRecordingRuntime {
+        shutdowns: Arc::clone(&shutdowns),
+    };
+    let metadata = crate::live_runner_registry::LiveRunnerRegistryMetadata {
+        config_path: dir.path().join("runner.yaml"),
+        base_dir: dir.path().join("base"),
+        runner_name: "test-runner".into(),
+        runner_group: "vm0/test".into(),
+    };
+
+    let error = publish_live_runner_or_shutdown_runtime(&home, metadata, &mut runtime)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("ensure live runner registry"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -104,11 +104,11 @@ fn write_usage_pending_state(
 }
 
 #[tokio::test]
-async fn live_registry_publish_failure_shuts_down_startup_resources() {
+async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
     let dir = tempfile::tempdir().unwrap();
     let home = crate::paths::HomePaths::with_root(dir.path().join("vm0-runner"));
     std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
-    std::fs::write(home.live_runners_dir(), b"not a directory").unwrap();
+    std::fs::write(home.live_runner_instances_dir(), b"not a directory").unwrap();
 
     let provider_shutdowns = Arc::new(AtomicUsize::new(0));
     let provider = ShutdownRecordingProvider {
@@ -118,20 +118,24 @@ async fn live_registry_publish_failure_shuts_down_startup_resources() {
     let mut runtime = ShutdownRecordingRuntime {
         shutdowns: Arc::clone(&runtime_shutdowns),
     };
-    let metadata = crate::live_runner_registry::LiveRunnerRegistryMetadata {
+    let metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: dir.path().join("runner.yaml"),
         base_dir: dir.path().join("base"),
         runner_name: "test-runner".into(),
         runner_group: "vm0/test".into(),
     };
 
-    let error =
-        publish_live_runner_or_shutdown_startup_resources(&home, metadata, &provider, &mut runtime)
-            .await
-            .unwrap_err();
+    let error = publish_live_runner_instance_or_shutdown_startup_resources(
+        &home,
+        metadata,
+        &provider,
+        &mut runtime,
+    )
+    .await
+    .unwrap_err();
 
     assert!(
-        error.to_string().contains("ensure live runner registry"),
+        error.to_string().contains("ensure live runner instances"),
         "unexpected error: {error}"
     );
     assert_eq!(provider_shutdowns.load(Ordering::SeqCst), 1);

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -50,6 +50,7 @@ pub(crate) const DEFAULT_CONCURRENCY_FACTOR: f64 = 1.0;
 const MAX_VCPU: u32 = 1024;
 const MAX_MEMORY_MB: u32 = 1_048_576; // 1 TB
 const MAX_DISK_MB: u32 = 1_048_576; // 1 TB
+pub(crate) const DIAGNOSTIC_CONFIG_MAX_BYTES: u64 = 1024 * 1024;
 
 /// Top-level runner configuration, deserialized from `runner.yaml`.
 ///
@@ -167,6 +168,20 @@ pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
     // Image artifacts are mutable cache outputs. Runtime callers validate
     // them only after acquiring the matching shared rootfs/snapshot locks.
     load_with_home(path, &home, false).await
+}
+
+/// Read a runner config selected by diagnostic/discovery code.
+///
+/// This does not replace normal startup config loading. It is for candidate
+/// paths discovered from local process state, where the path itself is not a
+/// trusted operator-supplied argument.
+pub(crate) async fn read_diagnostic_config_to_string(path: &Path) -> RunnerResult<Option<String>> {
+    crate::state_file::read_to_string(
+        path,
+        DIAGNOSTIC_CONFIG_MAX_BYTES,
+        crate::state_file::OwnerCheck::CurrentEuid,
+    )
+    .await
 }
 
 async fn load_with_home(

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -163,6 +163,97 @@ fn mode_of(path: &std::path::Path) -> u32 {
 }
 
 #[tokio::test]
+async fn diagnostic_config_read_accepts_regular_yaml() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("runner.yaml");
+    tokio::fs::write(&config, "name: test\n").await.unwrap();
+
+    let content = read_diagnostic_config_to_string(&config).await.unwrap();
+
+    assert_eq!(content.as_deref(), Some("name: test\n"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn diagnostic_config_read_rejects_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.yaml");
+    let link = dir.path().join("runner.yaml");
+    tokio::fs::write(&target, "name: test\n").await.unwrap();
+    symlink(&target, &link).unwrap();
+
+    let error = read_diagnostic_config_to_string(&link).await.unwrap_err();
+
+    assert!(
+        error.to_string().contains("open state file"),
+        "unexpected error: {error}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn diagnostic_config_read_rejects_fifo_without_blocking() {
+    let dir = tempfile::tempdir().unwrap();
+    let fifo = dir.path().join("runner.yaml");
+    let c_path = std::ffi::CString::new(fifo.to_string_lossy().as_bytes()).unwrap();
+    // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
+    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+    assert_eq!(
+        result,
+        0,
+        "mkfifo failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let error = read_diagnostic_config_to_string(&fifo).await.unwrap_err();
+
+    assert!(
+        error.to_string().contains("not a regular state file"),
+        "unexpected error: {error}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn diagnostic_config_read_rejects_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_dir = dir.path().join("runner.yaml");
+    tokio::fs::create_dir(&config_dir).await.unwrap();
+
+    let error = read_diagnostic_config_to_string(&config_dir)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("not a regular state file"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn diagnostic_config_read_rejects_oversized_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = dir.path().join("runner.yaml");
+    tokio::fs::write(
+        &config,
+        vec![b'a'; (DIAGNOSTIC_CONFIG_MAX_BYTES + 1) as usize],
+    )
+    .await
+    .unwrap();
+
+    let error = read_diagnostic_config_to_string(&config).await.unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("exceeds {DIAGNOSTIC_CONFIG_MAX_BYTES} bytes")),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn load_config_with_profiles() {
     let fixture = ConfigFixture::new().await;
     let yaml = fixture.yaml_with_identity(

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -9,10 +9,10 @@ use crate::paths::HomePaths;
 use crate::process;
 use crate::state_file::OwnerCheck;
 
-const LIVE_RUNNER_RECORD_MAX_BYTES: u64 = 64 * 1024;
+const LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES: u64 = 64 * 1024;
 
 #[derive(Debug)]
-pub(crate) struct LiveRunnerRegistryMetadata {
+pub(crate) struct LiveRunnerInstanceMetadata {
     pub config_path: PathBuf,
     pub base_dir: PathBuf,
     pub runner_name: String,
@@ -20,7 +20,7 @@ pub(crate) struct LiveRunnerRegistryMetadata {
 }
 
 #[derive(Debug)]
-pub(crate) struct LiveRunnerRegistryHandle {
+pub(crate) struct LiveRunnerInstanceHandle {
     path: PathBuf,
     identity: ProcessIdentity,
 }
@@ -33,7 +33,7 @@ struct ProcessIdentity {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-struct LiveRunnerRegistryRecord {
+struct LiveRunnerInstanceRecord {
     pid: u32,
     starttime: u64,
     euid: u32,
@@ -46,11 +46,11 @@ struct LiveRunnerRegistryRecord {
 
 pub(crate) async fn publish(
     home: &HomePaths,
-    metadata: LiveRunnerRegistryMetadata,
-) -> RunnerResult<LiveRunnerRegistryHandle> {
+    metadata: LiveRunnerInstanceMetadata,
+) -> RunnerResult<LiveRunnerInstanceHandle> {
     let identity = current_process_identity().await?;
-    let path = home.live_runner_record_path(identity.pid, identity.starttime);
-    let record = LiveRunnerRegistryRecord {
+    let path = home.live_runner_instance_record_path(identity.pid, identity.starttime);
+    let record = LiveRunnerInstanceRecord {
         pid: identity.pid,
         starttime: identity.starttime,
         euid: identity.euid,
@@ -61,26 +61,26 @@ pub(crate) async fn publish(
         started_at: chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
     };
     let content = serde_json::to_vec_pretty(&record)
-        .map_err(|e| RunnerError::Internal(format!("serialize live runner registry: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("serialize live runner instance: {e}")))?;
 
     crate::host_file::ensure_dir(
-        &home.live_runners_dir(),
+        &home.live_runner_instances_dir(),
         crate::host_file::DirMode::Private,
-        "live runner registry",
+        "live runner instances",
     )
     .map_err(|e| {
         RunnerError::Internal(format!(
-            "ensure live runner registry {}: {e}",
-            home.live_runners_dir().display()
+            "ensure live runner instances {}: {e}",
+            home.live_runner_instances_dir().display()
         ))
     })?;
     remove_stale_records(home).await;
     crate::state_file::write_private_atomic(&path, &content).await?;
 
-    Ok(LiveRunnerRegistryHandle { path, identity })
+    Ok(LiveRunnerInstanceHandle { path, identity })
 }
 
-impl LiveRunnerRegistryHandle {
+impl LiveRunnerInstanceHandle {
     pub(crate) async fn remove_if_current(&self) -> RunnerResult<bool> {
         let Some(record) = read_valid_record(&self.path).await else {
             return Ok(false);
@@ -96,17 +96,17 @@ impl LiveRunnerRegistryHandle {
             Ok(()) => Ok(true),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(e) => Err(RunnerError::Internal(format!(
-                "remove live runner registry record {}: {e}",
+                "remove live runner instance record {}: {e}",
                 self.path.display()
             ))),
         }
     }
 }
 
-async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
+async fn read_valid_record(path: &Path) -> Option<LiveRunnerInstanceRecord> {
     let content = match crate::state_file::read_to_string(
         path,
-        LIVE_RUNNER_RECORD_MAX_BYTES,
+        LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES,
         OwnerCheck::CurrentEuid,
     )
     .await
@@ -114,14 +114,14 @@ async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
         Ok(Some(content)) => content,
         Ok(None) => return None,
         Err(e) => {
-            tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner registry record");
+            tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner instance record");
             return None;
         }
     };
-    let record: LiveRunnerRegistryRecord = match serde_json::from_str(&content) {
+    let record: LiveRunnerInstanceRecord = match serde_json::from_str(&content) {
         Ok(record) => record,
         Err(e) => {
-            tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner registry record");
+            tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner instance record");
             return None;
         }
     };
@@ -133,11 +133,11 @@ async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
 }
 
 async fn remove_stale_records(home: &HomePaths) {
-    let dir = home.live_runners_dir();
+    let dir = home.live_runner_instances_dir();
     let mut entries = match tokio::fs::read_dir(&dir).await {
         Ok(entries) => entries,
         Err(e) => {
-            tracing::debug!(path = %dir.display(), error = %e, "cannot scan live runner registry");
+            tracing::debug!(path = %dir.display(), error = %e, "cannot scan live runner instances");
             return;
         }
     };
@@ -147,7 +147,7 @@ async fn remove_stale_records(home: &HomePaths) {
             Ok(Some(entry)) => entry,
             Ok(None) => break,
             Err(e) => {
-                tracing::debug!(path = %dir.display(), error = %e, "cannot read live runner registry entry");
+                tracing::debug!(path = %dir.display(), error = %e, "cannot read live runner instance entry");
                 break;
             }
         };
@@ -156,14 +156,14 @@ async fn remove_stale_records(home: &HomePaths) {
         if stable_record_identity_from_file_name(&file_name).is_some()
             && read_valid_record(&path).await.is_none()
         {
-            remove_stale_file(&path, "stale live runner registry record").await;
+            remove_stale_file(&path, "stale live runner instance record").await;
             continue;
         }
         let Some(identity) = atomic_tmp_record_identity_from_file_name(&file_name) else {
             continue;
         };
         if !process_identity_is_live(identity).await {
-            remove_stale_file(&path, "stale live runner registry tmp file").await;
+            remove_stale_file(&path, "stale live runner instance tmp file").await;
         }
     }
 }
@@ -171,11 +171,11 @@ async fn remove_stale_records(home: &HomePaths) {
 async fn remove_stale_file(path: &Path, reason: &'static str) {
     match tokio::fs::remove_file(path).await {
         Ok(()) => {
-            tracing::debug!(path = %path.display(), reason, "removed stale live runner registry file");
+            tracing::debug!(path = %path.display(), reason, "removed stale live runner instance file");
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
-            tracing::debug!(path = %path.display(), reason, error = %e, "cannot remove stale live runner registry file");
+            tracing::debug!(path = %path.display(), reason, error = %e, "cannot remove stale live runner instance file");
         }
     }
 }
@@ -201,7 +201,7 @@ fn atomic_tmp_record_identity_from_file_name(name: &OsStr) -> Option<ProcessIden
     stable_record_identity_from_str(stable_name)
 }
 
-async fn record_is_live(record: &LiveRunnerRegistryRecord) -> bool {
+async fn record_is_live(record: &LiveRunnerInstanceRecord) -> bool {
     process_identity_is_live(ProcessIdentity {
         pid: record.pid,
         starttime: record.starttime,
@@ -276,8 +276,8 @@ fn current_euid() -> u32 {
 mod tests {
     use super::*;
 
-    fn test_metadata(root: &Path) -> LiveRunnerRegistryMetadata {
-        LiveRunnerRegistryMetadata {
+    fn test_metadata(root: &Path) -> LiveRunnerInstanceMetadata {
+        LiveRunnerInstanceMetadata {
             config_path: root.join("runner.yaml"),
             base_dir: root.join("base"),
             runner_name: "test-runner".into(),
@@ -285,7 +285,7 @@ mod tests {
         }
     }
 
-    async fn write_record(path: &Path, record: &LiveRunnerRegistryRecord) {
+    async fn write_record(path: &Path, record: &LiveRunnerInstanceRecord) {
         let content = serde_json::to_vec_pretty(record).unwrap();
         crate::state_file::write_private_atomic(path, &content)
             .await
@@ -303,7 +303,7 @@ mod tests {
         assert!(!content.contains("server"));
         assert!(!content.contains("token"));
         assert!(!content.contains("api_url"));
-        let record: LiveRunnerRegistryRecord = serde_json::from_str(&content).unwrap();
+        let record: LiveRunnerInstanceRecord = serde_json::from_str(&content).unwrap();
         assert_eq!(record.pid, std::process::id());
         assert_eq!(record.euid, current_euid());
         assert_eq!(record.base_dir, dir.path().join("base"));
@@ -317,7 +317,7 @@ mod tests {
             assert!(!metadata.file_type().is_symlink());
             assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
             assert_eq!(
-                std::fs::metadata(home.live_runners_dir())
+                std::fs::metadata(home.live_runner_instances_dir())
                     .unwrap()
                     .permissions()
                     .mode()
@@ -344,12 +344,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
-            &home.live_runners_dir(),
+            &home.live_runner_instances_dir(),
             crate::host_file::DirMode::Private,
-            "live runner registry",
+            "live runner instances",
         )
         .unwrap();
-        let record = LiveRunnerRegistryRecord {
+        let record = LiveRunnerInstanceRecord {
             pid: u32::MAX,
             starttime: 1,
             euid: current_euid(),
@@ -359,7 +359,7 @@ mod tests {
             runner_group: "vm0/test".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
-        let path = home.live_runner_record_path(record.pid, record.starttime);
+        let path = home.live_runner_instance_record_path(record.pid, record.starttime);
         write_record(&path, &record).await;
 
         let result = read_valid_record(&path).await;
@@ -386,12 +386,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
-            &home.live_runners_dir(),
+            &home.live_runner_instances_dir(),
             crate::host_file::DirMode::Private,
-            "live runner registry",
+            "live runner instances",
         )
         .unwrap();
-        let path = home.live_runners_dir().join("malformed.json");
+        let path = home.live_runner_instances_dir().join("malformed.json");
         crate::state_file::write_private_atomic(&path, b"{")
             .await
             .unwrap();
@@ -406,15 +406,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
-            &home.live_runners_dir(),
+            &home.live_runner_instances_dir(),
             crate::host_file::DirMode::Private,
-            "live runner registry",
+            "live runner instances",
         )
         .unwrap();
-        let path = home.live_runners_dir().join("oversized.json");
+        let path = home.live_runner_instances_dir().join("oversized.json");
         crate::state_file::write_private_atomic(
             &path,
-            &vec![b'a'; (LIVE_RUNNER_RECORD_MAX_BYTES + 1) as usize],
+            &vec![b'a'; (LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES + 1) as usize],
         )
         .await
         .unwrap();
@@ -429,12 +429,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
-            &home.live_runners_dir(),
+            &home.live_runner_instances_dir(),
             crate::host_file::DirMode::Private,
-            "live runner registry",
+            "live runner instances",
         )
         .unwrap();
-        let stale_record = LiveRunnerRegistryRecord {
+        let stale_record = LiveRunnerInstanceRecord {
             pid: u32::MAX,
             starttime: 1,
             euid: current_euid(),
@@ -444,9 +444,12 @@ mod tests {
             runner_group: "vm0/test".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
-        let stale_path = home.live_runner_record_path(stale_record.pid, stale_record.starttime);
+        let stale_path =
+            home.live_runner_instance_record_path(stale_record.pid, stale_record.starttime);
         write_record(&stale_path, &stale_record).await;
-        let stale_tmp_path = home.live_runners_dir().join(".4294967295-1.json.test.tmp");
+        let stale_tmp_path = home
+            .live_runner_instances_dir()
+            .join(".4294967295-1.json.test.tmp");
         tokio::fs::write(&stale_tmp_path, b"partial").await.unwrap();
 
         let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
@@ -457,7 +460,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn publish_keeps_other_live_runner_records() {
+    async fn publish_keeps_other_live_runner_instance_records() {
         struct ChildGuard(std::process::Child);
 
         impl Drop for ChildGuard {
@@ -477,13 +480,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
-            &home.live_runners_dir(),
+            &home.live_runner_instances_dir(),
             crate::host_file::DirMode::Private,
-            "live runner registry",
+            "live runner instances",
         )
         .unwrap();
         let child_stat = process::read_process_stat(child_pid).await.unwrap();
-        let live_record = LiveRunnerRegistryRecord {
+        let live_record = LiveRunnerInstanceRecord {
             pid: child_pid,
             starttime: child_stat.starttime,
             euid: current_euid(),
@@ -493,8 +496,9 @@ mod tests {
             runner_group: "vm0/test".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
-        let live_path = home.live_runner_record_path(live_record.pid, live_record.starttime);
-        let live_tmp_path = home.live_runners_dir().join(format!(
+        let live_path =
+            home.live_runner_instance_record_path(live_record.pid, live_record.starttime);
+        let live_tmp_path = home.live_runner_instances_dir().join(format!(
             ".{}-{}.json.test.tmp",
             child_pid, child_stat.starttime
         ));

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -25,15 +25,23 @@ pub(crate) struct LiveRunnerInstanceHandle {
     identity: ProcessIdentity,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ProcessIdentity {
+    boot_id: String,
     pid: u32,
     starttime: u64,
     euid: u32,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FileProcessIdentity {
+    pid: u32,
+    starttime: u64,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 struct LiveRunnerInstanceRecord {
+    boot_id: String,
     pid: u32,
     starttime: u64,
     euid: u32,
@@ -51,6 +59,7 @@ pub(crate) async fn publish(
     let identity = current_process_identity().await?;
     let path = home.live_runner_instance_record_path(identity.pid, identity.starttime);
     let record = LiveRunnerInstanceRecord {
+        boot_id: identity.boot_id.clone(),
         pid: identity.pid,
         starttime: identity.starttime,
         euid: identity.euid,
@@ -85,7 +94,8 @@ impl LiveRunnerInstanceHandle {
         let Some(record) = read_valid_record(&self.path).await else {
             return Ok(false);
         };
-        if record.pid != self.identity.pid
+        if record.boot_id != self.identity.boot_id
+            || record.pid != self.identity.pid
             || record.starttime != self.identity.starttime
             || record.euid != self.identity.euid
         {
@@ -162,7 +172,7 @@ async fn remove_stale_records(home: &HomePaths) {
         let Some(identity) = atomic_tmp_record_identity_from_file_name(&file_name) else {
             continue;
         };
-        if !process_identity_is_live(identity).await {
+        if !file_process_identity_is_live(identity).await {
             remove_stale_file(&path, "stale live runner instance tmp file").await;
         }
     }
@@ -180,21 +190,20 @@ async fn remove_stale_file(path: &Path, reason: &'static str) {
     }
 }
 
-fn stable_record_identity_from_file_name(name: &OsStr) -> Option<ProcessIdentity> {
+fn stable_record_identity_from_file_name(name: &OsStr) -> Option<FileProcessIdentity> {
     stable_record_identity_from_str(name.to_str()?)
 }
 
-fn stable_record_identity_from_str(name: &str) -> Option<ProcessIdentity> {
+fn stable_record_identity_from_str(name: &str) -> Option<FileProcessIdentity> {
     let stem = name.strip_suffix(".json")?;
     let (pid, starttime) = stem.split_once('-')?;
-    Some(ProcessIdentity {
+    Some(FileProcessIdentity {
         pid: pid.parse().ok()?,
         starttime: starttime.parse().ok()?,
-        euid: current_euid(),
     })
 }
 
-fn atomic_tmp_record_identity_from_file_name(name: &OsStr) -> Option<ProcessIdentity> {
+fn atomic_tmp_record_identity_from_file_name(name: &OsStr) -> Option<FileProcessIdentity> {
     let name = name.to_str()?;
     let tmp_body = name.strip_prefix('.')?.strip_suffix(".tmp")?;
     let (stable_name, _tmp_id) = tmp_body.rsplit_once('.')?;
@@ -203,6 +212,7 @@ fn atomic_tmp_record_identity_from_file_name(name: &OsStr) -> Option<ProcessIden
 
 async fn record_is_live(record: &LiveRunnerInstanceRecord) -> bool {
     process_identity_is_live(ProcessIdentity {
+        boot_id: record.boot_id.clone(),
         pid: record.pid,
         starttime: record.starttime,
         euid: record.euid,
@@ -210,7 +220,30 @@ async fn record_is_live(record: &LiveRunnerInstanceRecord) -> bool {
     .await
 }
 
+async fn file_process_identity_is_live(identity: FileProcessIdentity) -> bool {
+    let Ok(boot_id) = current_boot_id().await else {
+        return false;
+    };
+    let identity = ProcessIdentity {
+        boot_id: boot_id.clone(),
+        pid: identity.pid,
+        starttime: identity.starttime,
+        euid: current_euid(),
+    };
+    process_identity_is_live_for_boot(&identity, &boot_id).await
+}
+
 async fn process_identity_is_live(identity: ProcessIdentity) -> bool {
+    let Ok(boot_id) = current_boot_id().await else {
+        return false;
+    };
+    process_identity_is_live_for_boot(&identity, &boot_id).await
+}
+
+async fn process_identity_is_live_for_boot(identity: &ProcessIdentity, boot_id: &str) -> bool {
+    if identity.boot_id != boot_id {
+        return false;
+    }
     if identity.euid != current_euid() {
         return false;
     }
@@ -243,10 +276,22 @@ async fn current_process_identity() -> RunnerResult<ProcessIdentity> {
         )));
     }
     Ok(ProcessIdentity {
+        boot_id: current_boot_id().await?,
         pid,
         starttime: stat.starttime,
         euid: current_euid(),
     })
+}
+
+async fn current_boot_id() -> RunnerResult<String> {
+    let content = tokio::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .await
+        .map_err(|e| RunnerError::Internal(format!("read boot id: {e}")))?;
+    let boot_id = content.trim();
+    if boot_id.is_empty() || !boot_id.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+        return Err(RunnerError::Internal("read boot id: invalid format".into()));
+    }
+    Ok(boot_id.to_owned())
 }
 
 async fn read_process_euid(pid: u32) -> Option<u32> {
@@ -335,6 +380,7 @@ mod tests {
 
         let record = read_valid_record(&handle.path).await.unwrap();
 
+        assert_eq!(record.boot_id, handle.identity.boot_id);
         assert_eq!(record.pid, handle.identity.pid);
         assert_eq!(record.starttime, handle.identity.starttime);
     }
@@ -350,6 +396,7 @@ mod tests {
         )
         .unwrap();
         let record = LiveRunnerInstanceRecord {
+            boot_id: current_boot_id().await.unwrap(),
             pid: u32::MAX,
             starttime: 1,
             euid: current_euid(),
@@ -374,6 +421,20 @@ mod tests {
         let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
         let mut record = read_valid_record(&handle.path).await.unwrap();
         record.starttime += 1;
+        write_record(&handle.path, &record).await;
+
+        let result = read_valid_record(&handle.path).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_valid_record_ignores_boot_id_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let mut record = read_valid_record(&handle.path).await.unwrap();
+        record.boot_id = "00000000-0000-0000-0000-000000000000".into();
         write_record(&handle.path, &record).await;
 
         let result = read_valid_record(&handle.path).await;
@@ -435,6 +496,7 @@ mod tests {
         )
         .unwrap();
         let stale_record = LiveRunnerInstanceRecord {
+            boot_id: current_boot_id().await.unwrap(),
             pid: u32::MAX,
             starttime: 1,
             euid: current_euid(),
@@ -487,6 +549,7 @@ mod tests {
         .unwrap();
         let child_stat = process::read_process_stat(child_pid).await.unwrap();
         let live_record = LiveRunnerInstanceRecord {
+            boot_id: current_boot_id().await.unwrap(),
             pid: child_pid,
             starttime: child_stat.starttime,
             euid: current_euid(),

--- a/crates/runner/src/live_runner_registry.rs
+++ b/crates/runner/src/live_runner_registry.rs
@@ -32,15 +32,15 @@ struct ProcessIdentity {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub(crate) struct LiveRunnerRegistryRecord {
-    pub pid: u32,
-    pub starttime: u64,
-    pub euid: u32,
-    pub config_path: PathBuf,
-    pub base_dir: PathBuf,
-    pub runner_name: String,
-    pub runner_group: String,
-    pub started_at: String,
+struct LiveRunnerRegistryRecord {
+    pid: u32,
+    starttime: u64,
+    euid: u32,
+    config_path: PathBuf,
+    base_dir: PathBuf,
+    runner_name: String,
+    runner_group: String,
+    started_at: String,
 }
 
 pub(crate) async fn publish(
@@ -101,7 +101,7 @@ impl LiveRunnerRegistryHandle {
     }
 }
 
-pub(crate) async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
+async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
     let content = match crate::state_file::read_to_string(
         path,
         LIVE_RUNNER_RECORD_MAX_BYTES,

--- a/crates/runner/src/live_runner_registry.rs
+++ b/crates/runner/src/live_runner_registry.rs
@@ -1,0 +1,342 @@
+use std::path::{Path, PathBuf};
+
+use chrono::SecondsFormat;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
+use crate::process;
+use crate::state_file::OwnerCheck;
+
+const LIVE_RUNNER_RECORD_MAX_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct LiveRunnerRegistryMetadata {
+    pub config_path: PathBuf,
+    pub base_dir: PathBuf,
+    pub runner_name: String,
+    pub runner_group: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct LiveRunnerRegistryHandle {
+    path: PathBuf,
+    identity: ProcessIdentity,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ProcessIdentity {
+    pid: u32,
+    starttime: u64,
+    euid: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct LiveRunnerRegistryRecord {
+    pub pid: u32,
+    pub starttime: u64,
+    pub euid: u32,
+    pub config_path: PathBuf,
+    pub base_dir: PathBuf,
+    pub runner_name: String,
+    pub runner_group: String,
+    pub started_at: String,
+}
+
+pub(crate) async fn publish(
+    home: &HomePaths,
+    metadata: LiveRunnerRegistryMetadata,
+) -> RunnerResult<LiveRunnerRegistryHandle> {
+    let identity = current_process_identity().await?;
+    let path = home.live_runner_record_path(identity.pid, identity.starttime);
+    let record = LiveRunnerRegistryRecord {
+        pid: identity.pid,
+        starttime: identity.starttime,
+        euid: identity.euid,
+        config_path: metadata.config_path,
+        base_dir: metadata.base_dir,
+        runner_name: metadata.runner_name,
+        runner_group: metadata.runner_group,
+        started_at: chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+    };
+    let content = serde_json::to_vec_pretty(&record)
+        .map_err(|e| RunnerError::Internal(format!("serialize live runner registry: {e}")))?;
+
+    crate::host_file::ensure_dir(
+        &home.live_runners_dir(),
+        crate::host_file::DirMode::Private,
+        "live runner registry",
+    )
+    .map_err(|e| {
+        RunnerError::Internal(format!(
+            "ensure live runner registry {}: {e}",
+            home.live_runners_dir().display()
+        ))
+    })?;
+    crate::state_file::write_private_atomic(&path, &content).await?;
+
+    Ok(LiveRunnerRegistryHandle { path, identity })
+}
+
+impl LiveRunnerRegistryHandle {
+    pub(crate) async fn remove_if_current(&self) -> RunnerResult<bool> {
+        let Some(record) = read_valid_record(&self.path).await else {
+            return Ok(false);
+        };
+        if record.pid != self.identity.pid
+            || record.starttime != self.identity.starttime
+            || record.euid != self.identity.euid
+        {
+            return Ok(false);
+        }
+
+        match tokio::fs::remove_file(&self.path).await {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(RunnerError::Internal(format!(
+                "remove live runner registry record {}: {e}",
+                self.path.display()
+            ))),
+        }
+    }
+}
+
+pub(crate) async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
+    let content = match crate::state_file::read_to_string(
+        path,
+        LIVE_RUNNER_RECORD_MAX_BYTES,
+        OwnerCheck::CurrentEuid,
+    )
+    .await
+    {
+        Ok(Some(content)) => content,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner registry record");
+            return None;
+        }
+    };
+    let record: LiveRunnerRegistryRecord = match serde_json::from_str(&content) {
+        Ok(record) => record,
+        Err(e) => {
+            tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner registry record");
+            return None;
+        }
+    };
+    if record_is_live(&record).await {
+        Some(record)
+    } else {
+        None
+    }
+}
+
+async fn record_is_live(record: &LiveRunnerRegistryRecord) -> bool {
+    if record.euid != current_euid() {
+        return false;
+    }
+    let Some(before) = process::read_process_stat(record.pid).await else {
+        return false;
+    };
+    if !process::process_stat_is_live(&before) || before.starttime != record.starttime {
+        return false;
+    }
+    let Some(euid) = read_process_euid(record.pid).await else {
+        return false;
+    };
+    if euid != record.euid {
+        return false;
+    }
+    let Some(after) = process::read_process_stat(record.pid).await else {
+        return false;
+    };
+    process::process_stat_is_live(&after) && after.starttime == record.starttime
+}
+
+async fn current_process_identity() -> RunnerResult<ProcessIdentity> {
+    let pid = std::process::id();
+    let stat = process::read_process_stat(pid)
+        .await
+        .ok_or_else(|| RunnerError::Internal(format!("read current process stat for pid {pid}")))?;
+    if !process::process_stat_is_live(&stat) {
+        return Err(RunnerError::Internal(format!(
+            "current process pid {pid} is not live"
+        )));
+    }
+    Ok(ProcessIdentity {
+        pid,
+        starttime: stat.starttime,
+        euid: current_euid(),
+    })
+}
+
+async fn read_process_euid(pid: u32) -> Option<u32> {
+    let path = format!("/proc/{pid}/status");
+    let content = tokio::fs::read_to_string(path).await.ok()?;
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("Uid:") {
+            let mut parts = value.split_whitespace();
+            let _real_uid = parts.next()?;
+            return parts.next()?.parse().ok();
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn current_euid() -> u32 {
+    nix::unistd::geteuid().as_raw()
+}
+
+#[cfg(not(unix))]
+fn current_euid() -> u32 {
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_metadata(root: &Path) -> LiveRunnerRegistryMetadata {
+        LiveRunnerRegistryMetadata {
+            config_path: root.join("runner.yaml"),
+            base_dir: root.join("base"),
+            runner_name: "test-runner".into(),
+            runner_group: "vm0/test".into(),
+        }
+    }
+
+    async fn write_record(path: &Path, record: &LiveRunnerRegistryRecord) {
+        let content = serde_json::to_vec_pretty(record).unwrap();
+        crate::state_file::write_private_atomic(path, &content)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_writes_private_record_without_secret_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        let content = tokio::fs::read_to_string(&handle.path).await.unwrap();
+        assert!(!content.contains("server"));
+        assert!(!content.contains("token"));
+        assert!(!content.contains("api_url"));
+        let record: LiveRunnerRegistryRecord = serde_json::from_str(&content).unwrap();
+        assert_eq!(record.pid, std::process::id());
+        assert_eq!(record.euid, current_euid());
+        assert_eq!(record.base_dir, dir.path().join("base"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let metadata = std::fs::symlink_metadata(&handle.path).unwrap();
+            assert!(metadata.file_type().is_file());
+            assert!(!metadata.file_type().is_symlink());
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+        }
+    }
+
+    #[tokio::test]
+    async fn read_valid_record_accepts_matching_live_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        let record = read_valid_record(&handle.path).await.unwrap();
+
+        assert_eq!(record.pid, handle.identity.pid);
+        assert_eq!(record.starttime, handle.identity.starttime);
+    }
+
+    #[tokio::test]
+    async fn read_valid_record_ignores_stale_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runners_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner registry",
+        )
+        .unwrap();
+        let record = LiveRunnerRegistryRecord {
+            pid: u32::MAX,
+            starttime: 1,
+            euid: current_euid(),
+            config_path: dir.path().join("runner.yaml"),
+            base_dir: dir.path().join("base"),
+            runner_name: "test-runner".into(),
+            runner_group: "vm0/test".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
+        };
+        let path = home.live_runner_record_path(record.pid, record.starttime);
+        write_record(&path, &record).await;
+
+        let result = read_valid_record(&path).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_valid_record_ignores_starttime_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let mut record = read_valid_record(&handle.path).await.unwrap();
+        record.starttime += 1;
+        write_record(&handle.path, &record).await;
+
+        let result = read_valid_record(&handle.path).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_valid_record_ignores_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runners_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner registry",
+        )
+        .unwrap();
+        let path = home.live_runners_dir().join("malformed.json");
+        crate::state_file::write_private_atomic(&path, b"{")
+            .await
+            .unwrap();
+
+        let result = read_valid_record(&path).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_if_current_removes_matching_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        let removed = handle.remove_if_current().await.unwrap();
+
+        assert!(removed);
+        assert!(!handle.path.exists());
+    }
+
+    #[tokio::test]
+    async fn remove_if_current_preserves_mismatched_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let mut record = read_valid_record(&handle.path).await.unwrap();
+        record.starttime += 1;
+        write_record(&handle.path, &record).await;
+
+        let removed = handle.remove_if_current().await.unwrap();
+
+        assert!(!removed);
+        assert!(handle.path.exists());
+    }
+}

--- a/crates/runner/src/live_runner_registry.rs
+++ b/crates/runner/src/live_runner_registry.rs
@@ -151,60 +151,85 @@ async fn remove_stale_records(home: &HomePaths) {
                 break;
             }
         };
-        if !is_stable_record_file_name(&entry.file_name()) {
-            continue;
-        }
+        let file_name = entry.file_name();
         let path = entry.path();
-        if read_valid_record(&path).await.is_some() {
+        if stable_record_identity_from_file_name(&file_name).is_some()
+            && read_valid_record(&path).await.is_none()
+        {
+            remove_stale_file(&path, "stale live runner registry record").await;
             continue;
         }
-        match tokio::fs::remove_file(&path).await {
-            Ok(()) => {
-                tracing::debug!(path = %path.display(), "removed stale live runner registry record");
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => {
-                tracing::debug!(path = %path.display(), error = %e, "cannot remove stale live runner registry record");
-            }
+        let Some(identity) = atomic_tmp_record_identity_from_file_name(&file_name) else {
+            continue;
+        };
+        if !process_identity_is_live(identity).await {
+            remove_stale_file(&path, "stale live runner registry tmp file").await;
         }
     }
 }
 
-fn is_stable_record_file_name(name: &OsStr) -> bool {
-    let Some(name) = name.to_str() else {
-        return false;
-    };
-    let Some(stem) = name.strip_suffix(".json") else {
-        return false;
-    };
-    let Some((pid, starttime)) = stem.split_once('-') else {
-        return false;
-    };
-    [pid, starttime]
-        .into_iter()
-        .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
+async fn remove_stale_file(path: &Path, reason: &'static str) {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {
+            tracing::debug!(path = %path.display(), reason, "removed stale live runner registry file");
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::debug!(path = %path.display(), reason, error = %e, "cannot remove stale live runner registry file");
+        }
+    }
+}
+
+fn stable_record_identity_from_file_name(name: &OsStr) -> Option<ProcessIdentity> {
+    stable_record_identity_from_str(name.to_str()?)
+}
+
+fn stable_record_identity_from_str(name: &str) -> Option<ProcessIdentity> {
+    let stem = name.strip_suffix(".json")?;
+    let (pid, starttime) = stem.split_once('-')?;
+    Some(ProcessIdentity {
+        pid: pid.parse().ok()?,
+        starttime: starttime.parse().ok()?,
+        euid: current_euid(),
+    })
+}
+
+fn atomic_tmp_record_identity_from_file_name(name: &OsStr) -> Option<ProcessIdentity> {
+    let name = name.to_str()?;
+    let tmp_body = name.strip_prefix('.')?.strip_suffix(".tmp")?;
+    let (stable_name, _tmp_id) = tmp_body.rsplit_once('.')?;
+    stable_record_identity_from_str(stable_name)
 }
 
 async fn record_is_live(record: &LiveRunnerRegistryRecord) -> bool {
-    if record.euid != current_euid() {
+    process_identity_is_live(ProcessIdentity {
+        pid: record.pid,
+        starttime: record.starttime,
+        euid: record.euid,
+    })
+    .await
+}
+
+async fn process_identity_is_live(identity: ProcessIdentity) -> bool {
+    if identity.euid != current_euid() {
         return false;
     }
-    let Some(before) = process::read_process_stat(record.pid).await else {
+    let Some(before) = process::read_process_stat(identity.pid).await else {
         return false;
     };
-    if !process::process_stat_is_live(&before) || before.starttime != record.starttime {
+    if !process::process_stat_is_live(&before) || before.starttime != identity.starttime {
         return false;
     }
-    let Some(euid) = read_process_euid(record.pid).await else {
+    let Some(euid) = read_process_euid(identity.pid).await else {
         return false;
     };
-    if euid != record.euid {
+    if euid != identity.euid {
         return false;
     }
-    let Some(after) = process::read_process_stat(record.pid).await else {
+    let Some(after) = process::read_process_stat(identity.pid).await else {
         return false;
     };
-    process::process_stat_is_live(&after) && after.starttime == record.starttime
+    process::process_stat_is_live(&after) && after.starttime == identity.starttime
 }
 
 async fn current_process_identity() -> RunnerResult<ProcessIdentity> {
@@ -421,10 +446,13 @@ mod tests {
         };
         let stale_path = home.live_runner_record_path(stale_record.pid, stale_record.starttime);
         write_record(&stale_path, &stale_record).await;
+        let stale_tmp_path = home.live_runners_dir().join(".4294967295-1.json.test.tmp");
+        tokio::fs::write(&stale_tmp_path, b"partial").await.unwrap();
 
         let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
 
         assert!(!stale_path.exists());
+        assert!(!stale_tmp_path.exists());
     }
 
     #[cfg(unix)]
@@ -466,11 +494,17 @@ mod tests {
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
         let live_path = home.live_runner_record_path(live_record.pid, live_record.starttime);
+        let live_tmp_path = home.live_runners_dir().join(format!(
+            ".{}-{}.json.test.tmp",
+            child_pid, child_stat.starttime
+        ));
         write_record(&live_path, &live_record).await;
+        tokio::fs::write(&live_tmp_path, b"partial").await.unwrap();
 
         let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
 
         assert!(live_path.exists());
+        assert!(live_tmp_path.exists());
     }
 
     #[tokio::test]

--- a/crates/runner/src/live_runner_registry.rs
+++ b/crates/runner/src/live_runner_registry.rs
@@ -236,6 +236,14 @@ mod tests {
             assert!(metadata.file_type().is_file());
             assert!(!metadata.file_type().is_symlink());
             assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+            assert_eq!(
+                std::fs::metadata(home.live_runners_dir())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
         }
     }
 
@@ -307,6 +315,29 @@ mod tests {
         crate::state_file::write_private_atomic(&path, b"{")
             .await
             .unwrap();
+
+        let result = read_valid_record(&path).await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_valid_record_ignores_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runners_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner registry",
+        )
+        .unwrap();
+        let path = home.live_runners_dir().join("oversized.json");
+        crate::state_file::write_private_atomic(
+            &path,
+            &vec![b'a'; (LIVE_RUNNER_RECORD_MAX_BYTES + 1) as usize],
+        )
+        .await
+        .unwrap();
 
         let result = read_valid_record(&path).await;
 

--- a/crates/runner/src/live_runner_registry.rs
+++ b/crates/runner/src/live_runner_registry.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use chrono::SecondsFormat;
@@ -73,6 +74,7 @@ pub(crate) async fn publish(
             home.live_runners_dir().display()
         ))
     })?;
+    remove_stale_records(home).await;
     crate::state_file::write_private_atomic(&path, &content).await?;
 
     Ok(LiveRunnerRegistryHandle { path, identity })
@@ -128,6 +130,59 @@ async fn read_valid_record(path: &Path) -> Option<LiveRunnerRegistryRecord> {
     } else {
         None
     }
+}
+
+async fn remove_stale_records(home: &HomePaths) {
+    let dir = home.live_runners_dir();
+    let mut entries = match tokio::fs::read_dir(&dir).await {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::debug!(path = %dir.display(), error = %e, "cannot scan live runner registry");
+            return;
+        }
+    };
+
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::debug!(path = %dir.display(), error = %e, "cannot read live runner registry entry");
+                break;
+            }
+        };
+        if !is_stable_record_file_name(&entry.file_name()) {
+            continue;
+        }
+        let path = entry.path();
+        if read_valid_record(&path).await.is_some() {
+            continue;
+        }
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {
+                tracing::debug!(path = %path.display(), "removed stale live runner registry record");
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::debug!(path = %path.display(), error = %e, "cannot remove stale live runner registry record");
+            }
+        }
+    }
+}
+
+fn is_stable_record_file_name(name: &OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    let Some(stem) = name.strip_suffix(".json") else {
+        return false;
+    };
+    let Some((pid, starttime)) = stem.split_once('-') else {
+        return false;
+    };
+    [pid, starttime]
+        .into_iter()
+        .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit()))
 }
 
 async fn record_is_live(record: &LiveRunnerRegistryRecord) -> bool {
@@ -342,6 +397,80 @@ mod tests {
         let result = read_valid_record(&path).await;
 
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn publish_removes_stale_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runners_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner registry",
+        )
+        .unwrap();
+        let stale_record = LiveRunnerRegistryRecord {
+            pid: u32::MAX,
+            starttime: 1,
+            euid: current_euid(),
+            config_path: dir.path().join("stale-runner.yaml"),
+            base_dir: dir.path().join("stale-base"),
+            runner_name: "stale-runner".into(),
+            runner_group: "vm0/test".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
+        };
+        let stale_path = home.live_runner_record_path(stale_record.pid, stale_record.starttime);
+        write_record(&stale_path, &stale_record).await;
+
+        let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn publish_keeps_other_live_runner_records() {
+        struct ChildGuard(std::process::Child);
+
+        impl Drop for ChildGuard {
+            fn drop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+
+        let child = ChildGuard(
+            std::process::Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .unwrap(),
+        );
+        let child_pid = child.0.id();
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runners_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner registry",
+        )
+        .unwrap();
+        let child_stat = process::read_process_stat(child_pid).await.unwrap();
+        let live_record = LiveRunnerRegistryRecord {
+            pid: child_pid,
+            starttime: child_stat.starttime,
+            euid: current_euid(),
+            config_path: dir.path().join("other-runner.yaml"),
+            base_dir: dir.path().join("other-base"),
+            runner_name: "other-runner".into(),
+            runner_group: "vm0/test".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
+        };
+        let live_path = home.live_runner_record_path(live_record.pid, live_record.starttime);
+        write_record(&live_path, &live_record).await;
+
+        let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        assert!(live_path.exists());
     }
 
     #[tokio::test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -16,6 +16,7 @@ mod ids;
 mod image_hash;
 mod io_limits;
 mod kmsg_log;
+mod live_runner_registry;
 mod local_queue;
 mod lock;
 mod log_file;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -16,7 +16,7 @@ mod ids;
 mod image_hash;
 mod io_limits;
 mod kmsg_log;
-mod live_runner_registry;
+mod live_runner_instances;
 mod local_queue;
 mod lock;
 mod log_file;

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -544,6 +544,11 @@ mod tests {
         assert_eq!(home.bin_dir(), PathBuf::from("/test/bin"));
         assert_eq!(home.images_dir(), PathBuf::from("/test/images"));
         assert_eq!(home.logs_dir(), PathBuf::from("/test/logs"));
+        assert_eq!(home.live_runners_dir(), PathBuf::from("/test/live-runners"));
+        assert_eq!(
+            home.live_runner_record_path(123, 456),
+            PathBuf::from("/test/live-runners/123-456.json")
+        );
         assert_eq!(home.runners_dir(), PathBuf::from("/test/runners"));
         assert_eq!(home.groups_dir(), PathBuf::from("/test/groups"));
         assert_eq!(home.ca_dir(), PathBuf::from("/test/ca"));

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -223,6 +223,15 @@ impl HomePaths {
         self.root.join("logs")
     }
 
+    pub fn live_runners_dir(&self) -> PathBuf {
+        self.root.join("live-runners")
+    }
+
+    pub fn live_runner_record_path(&self, pid: u32, starttime: u64) -> PathBuf {
+        self.live_runners_dir()
+            .join(format!("{pid}-{starttime}.json"))
+    }
+
     pub fn runners_dir(&self) -> PathBuf {
         self.root.join("runners")
     }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -223,12 +223,12 @@ impl HomePaths {
         self.root.join("logs")
     }
 
-    pub fn live_runners_dir(&self) -> PathBuf {
-        self.root.join("live-runners")
+    pub fn live_runner_instances_dir(&self) -> PathBuf {
+        self.root.join("live-runner-instances")
     }
 
-    pub fn live_runner_record_path(&self, pid: u32, starttime: u64) -> PathBuf {
-        self.live_runners_dir()
+    pub fn live_runner_instance_record_path(&self, pid: u32, starttime: u64) -> PathBuf {
+        self.live_runner_instances_dir()
             .join(format!("{pid}-{starttime}.json"))
     }
 
@@ -544,10 +544,13 @@ mod tests {
         assert_eq!(home.bin_dir(), PathBuf::from("/test/bin"));
         assert_eq!(home.images_dir(), PathBuf::from("/test/images"));
         assert_eq!(home.logs_dir(), PathBuf::from("/test/logs"));
-        assert_eq!(home.live_runners_dir(), PathBuf::from("/test/live-runners"));
         assert_eq!(
-            home.live_runner_record_path(123, 456),
-            PathBuf::from("/test/live-runners/123-456.json")
+            home.live_runner_instances_dir(),
+            PathBuf::from("/test/live-runner-instances")
+        );
+        assert_eq!(
+            home.live_runner_instance_record_path(123, 456),
+            PathBuf::from("/test/live-runner-instances/123-456.json")
         );
         assert_eq!(home.runners_dir(), PathBuf::from("/test/runners"));
         assert_eq!(home.groups_dir(), PathBuf::from("/test/groups"));

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -42,6 +42,7 @@ const RESERVED_PRIVATE_DIR_SUBTREES: &[&str] = &[
     "/var/lib/vm0-runner/groups",
     "/var/lib/vm0-runner/images",
     "/var/lib/vm0-runner/locks",
+    "/var/lib/vm0-runner/live-runners",
     "/var/lib/vm0-runner/logs",
     "/var/lib/vm0-runner/mitmproxy",
     "/var/lib/vm0-runner/storages",

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -42,7 +42,7 @@ const RESERVED_PRIVATE_DIR_SUBTREES: &[&str] = &[
     "/var/lib/vm0-runner/groups",
     "/var/lib/vm0-runner/images",
     "/var/lib/vm0-runner/locks",
-    "/var/lib/vm0-runner/live-runners",
+    "/var/lib/vm0-runner/live-runner-instances",
     "/var/lib/vm0-runner/logs",
     "/var/lib/vm0-runner/mitmproxy",
     "/var/lib/vm0-runner/storages",

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -14,8 +14,12 @@ async fn load_base_dir(config_path: &Path) -> Option<PathBuf> {
     struct ConfigShape {
         base_dir: PathBuf,
     }
-    let content = match tokio::fs::read_to_string(config_path).await {
-        Ok(c) => c,
+    let content = match crate::config::read_diagnostic_config_to_string(config_path).await {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            tracing::warn!(path = %config_path.display(), "skipping runner: config is missing");
+            return None;
+        }
         Err(e) => {
             tracing::warn!(path = %config_path.display(), error = %e, "skipping runner: cannot read config");
             return None;


### PR DESCRIPTION
## Summary

- Add a bounded diagnostic config read path for runner discovery reads.
- Publish a private live runner instance record from `runner start` after startup state is ready.
- Validate live runner instance records by pid, process starttime, and euid.
- Clean stale live runner instance records and atomic tmp files without removing other live runner instances.

Closes #17266

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner diagnostic_config_read`
- `cargo test --manifest-path crates/Cargo.toml -p runner live_runner_instances`
- `cargo test --manifest-path crates/Cargo.toml -p runner live_runner_instance_publish_failure_shuts_down_startup_resources`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_resolution`
- `cargo test --manifest-path crates/Cargo.toml -p runner doctor`
- `cargo test --manifest-path crates/Cargo.toml -p runner state_file`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check`
