### PR TITLE
perf(mitm-addon): skip non-terminal responses websocket usage scans

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -47,6 +47,7 @@ _RESPONSES_EVENT_NON_TERMINAL: _ResponsesEventTypeClassification = "non_terminal
 _RESPONSES_EVENT_UNKNOWN: _ResponsesEventTypeClassification = "unknown"
 _JSON_CONTROL_CHAR_MAX = 0x20
 _JSON_PREFILTER_MAX_DEPTH = 256
+_JSON_PREFILTER_MAX_STRING_BYTES = 1024
 _JSON_HEX_BYTES = frozenset(b"0123456789abcdefABCDEF")
 
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (
@@ -76,23 +77,38 @@ def _skip_json_whitespace(body: bytes, i: int) -> int:
     return i
 
 
-def _scan_json_string_end(body: bytes, i: int) -> int | None:
+def _scan_json_string_end(
+    body: bytes,
+    i: int,
+    *,
+    max_string_bytes: int | None = None,
+) -> int | None:
     if i >= len(body) or body[i] != ord('"'):
         return None
     i += 1
+    raw_bytes = 0
     while i < len(body):
         b = body[i]
         if b == ord('"'):
             return i + 1
+        raw_bytes += 1
+        if max_string_bytes is not None and raw_bytes > max_string_bytes:
+            return None
         if b == ord("\\"):
             i += 1
             if i >= len(body):
                 return None
             escape = body[i]
+            raw_bytes += 1
+            if max_string_bytes is not None and raw_bytes > max_string_bytes:
+                return None
             if escape == ord("u"):
                 if i + 4 >= len(body):
                     return None
                 if any(hex_byte not in _JSON_HEX_BYTES for hex_byte in body[i + 1 : i + 5]):
+                    return None
+                raw_bytes += 4
+                if max_string_bytes is not None and raw_bytes > max_string_bytes:
                     return None
                 i += 5
                 continue
@@ -107,7 +123,11 @@ def _scan_json_string_end(body: bytes, i: int) -> int | None:
 
 
 def _read_json_string(body: bytes, i: int) -> tuple[str, int] | None:
-    end = _scan_json_string_end(body, i)
+    end = _scan_json_string_end(
+        body,
+        i,
+        max_string_bytes=_JSON_PREFILTER_MAX_STRING_BYTES,
+    )
     if end is None:
         return None
     try:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -18,8 +18,9 @@ model-provider usage billing:
   usage into a per-flow accumulator.
 """
 
+import json
 from collections.abc import Callable
-from typing import TypeGuard
+from typing import Literal, TypeGuard
 
 from mitmproxy import http
 
@@ -40,6 +41,13 @@ _RESPONSES_TERMINAL_USAGE_EVENTS = frozenset(
     ("response.completed", "response.done", "response.incomplete", "response.failed")
 )
 _SseUsageParseErrorCallback = Callable[[str, str], None]
+_ResponsesEventTypeClassification = Literal["terminal", "non_terminal", "unknown"]
+_RESPONSES_EVENT_TERMINAL: _ResponsesEventTypeClassification = "terminal"
+_RESPONSES_EVENT_NON_TERMINAL: _ResponsesEventTypeClassification = "non_terminal"
+_RESPONSES_EVENT_UNKNOWN: _ResponsesEventTypeClassification = "unknown"
+_JSON_CONTROL_CHAR_MAX = 0x20
+_JSON_PREFILTER_MAX_DEPTH = 256
+_JSON_HEX_BYTES = frozenset(b"0123456789abcdefABCDEF")
 
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_INPUT,
@@ -60,6 +68,208 @@ _RESPONSES_SSE_SCALAR_FIELDS = {
     **_RESPONSES_RESPONSE_SCALAR_FIELDS,
     **{("response", *path): field for path, field in _RESPONSES_RESPONSE_SCALAR_FIELDS.items()},
 }
+
+
+def _skip_json_whitespace(body: bytes, i: int) -> int:
+    while i < len(body) and body[i] in b" \t\r\n":
+        i += 1
+    return i
+
+
+def _scan_json_string_end(body: bytes, i: int) -> int | None:
+    if i >= len(body) or body[i] != ord('"'):
+        return None
+    i += 1
+    while i < len(body):
+        b = body[i]
+        if b == ord('"'):
+            return i + 1
+        if b == ord("\\"):
+            i += 1
+            if i >= len(body):
+                return None
+            escape = body[i]
+            if escape == ord("u"):
+                if i + 4 >= len(body):
+                    return None
+                if any(hex_byte not in _JSON_HEX_BYTES for hex_byte in body[i + 1 : i + 5]):
+                    return None
+                i += 5
+                continue
+            if escape not in b'"\\/bfnrt':
+                return None
+            i += 1
+            continue
+        if b < _JSON_CONTROL_CHAR_MAX:
+            return None
+        i += 1
+    return None
+
+
+def _read_json_string(body: bytes, i: int) -> tuple[str, int] | None:
+    end = _scan_json_string_end(body, i)
+    if end is None:
+        return None
+    try:
+        value = json.loads(body[i:end].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, str):
+        return None
+    return value, end
+
+
+def _skip_json_number(body: bytes, i: int) -> int | None:
+    if i < len(body) and body[i] == ord("-"):
+        i += 1
+    if i >= len(body):
+        return None
+
+    if body[i] == ord("0"):
+        i += 1
+        if i < len(body) and ord("0") <= body[i] <= ord("9"):
+            return None
+    elif ord("1") <= body[i] <= ord("9"):
+        i += 1
+        while i < len(body) and ord("0") <= body[i] <= ord("9"):
+            i += 1
+    else:
+        return None
+
+    if i < len(body) and body[i] == ord("."):
+        i += 1
+        if i >= len(body) or not ord("0") <= body[i] <= ord("9"):
+            return None
+        while i < len(body) and ord("0") <= body[i] <= ord("9"):
+            i += 1
+
+    if i < len(body) and body[i] in b"eE":
+        i += 1
+        if i < len(body) and body[i] in b"+-":
+            i += 1
+        if i >= len(body) or not ord("0") <= body[i] <= ord("9"):
+            return None
+        while i < len(body) and ord("0") <= body[i] <= ord("9"):
+            i += 1
+
+    return i
+
+
+def _skip_json_array(body: bytes, i: int, depth: int) -> int | None:
+    if depth >= _JSON_PREFILTER_MAX_DEPTH:
+        return None
+    i = _skip_json_whitespace(body, i + 1)
+    if i < len(body) and body[i] == ord("]"):
+        return i + 1
+
+    while i < len(body):
+        next_i = _skip_json_value(body, i, depth + 1)
+        if next_i is None:
+            return None
+        i = next_i
+        i = _skip_json_whitespace(body, i)
+        if i >= len(body):
+            return None
+        if body[i] == ord("]"):
+            return i + 1
+        if body[i] != ord(","):
+            return None
+        i = _skip_json_whitespace(body, i + 1)
+    return None
+
+
+def _skip_json_object(body: bytes, i: int, depth: int) -> int | None:
+    if depth >= _JSON_PREFILTER_MAX_DEPTH:
+        return None
+    i = _skip_json_whitespace(body, i + 1)
+    if i < len(body) and body[i] == ord("}"):
+        return i + 1
+
+    while i < len(body):
+        key = _scan_json_string_end(body, i)
+        if key is None:
+            return None
+        i = _skip_json_whitespace(body, key)
+        if i >= len(body) or body[i] != ord(":"):
+            return None
+        i = _skip_json_whitespace(body, i + 1)
+        next_i = _skip_json_value(body, i, depth + 1)
+        if next_i is None:
+            return None
+        i = next_i
+        i = _skip_json_whitespace(body, i)
+        if i >= len(body):
+            return None
+        if body[i] == ord("}"):
+            return i + 1
+        if body[i] != ord(","):
+            return None
+        i = _skip_json_whitespace(body, i + 1)
+    return None
+
+
+def _skip_json_value(body: bytes, i: int, depth: int = 0) -> int | None:
+    i = _skip_json_whitespace(body, i)
+    if i >= len(body):
+        return None
+    b = body[i]
+    if b == ord('"'):
+        return _scan_json_string_end(body, i)
+    if b == ord("{"):
+        return _skip_json_object(body, i, depth)
+    if b == ord("["):
+        return _skip_json_array(body, i, depth)
+    if b == ord("-") or ord("0") <= b <= ord("9"):
+        return _skip_json_number(body, i)
+    for literal in (b"true", b"false", b"null"):
+        if body.startswith(literal, i):
+            return i + len(literal)
+    return None
+
+
+def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
+    i = _skip_json_whitespace(body, 0)
+    if i >= len(body) or body[i] != ord("{"):
+        return _RESPONSES_EVENT_UNKNOWN
+    i = _skip_json_whitespace(body, i + 1)
+    if i < len(body) and body[i] == ord("}"):
+        return _RESPONSES_EVENT_UNKNOWN
+
+    while i < len(body):
+        key_result = _read_json_string(body, i)
+        if key_result is None:
+            return _RESPONSES_EVENT_UNKNOWN
+        key, i = key_result
+
+        i = _skip_json_whitespace(body, i)
+        if i >= len(body) or body[i] != ord(":"):
+            return _RESPONSES_EVENT_UNKNOWN
+        i = _skip_json_whitespace(body, i + 1)
+
+        if key == "type":
+            type_result = _read_json_string(body, i)
+            if type_result is None:
+                return _RESPONSES_EVENT_UNKNOWN
+            event_type, _end = type_result
+            # Responses event JSON is expected to have one top-level type. Stop
+            # at the first conforming type so common delta frames stay cheap.
+            if event_type in _RESPONSES_TERMINAL_USAGE_EVENTS:
+                return _RESPONSES_EVENT_TERMINAL
+            return _RESPONSES_EVENT_NON_TERMINAL
+
+        i = _skip_json_value(body, i)
+        if i is None:
+            return _RESPONSES_EVENT_UNKNOWN
+        i = _skip_json_whitespace(body, i)
+        if i >= len(body):
+            return _RESPONSES_EVENT_UNKNOWN
+        if body[i] == ord("}"):
+            return _RESPONSES_EVENT_UNKNOWN
+        if body[i] != ord(","):
+            return _RESPONSES_EVENT_UNKNOWN
+        i = _skip_json_whitespace(body, i + 1)
+
+    return _RESPONSES_EVENT_UNKNOWN
 
 
 def _is_usage_quantity(value: object) -> TypeGuard[int]:
@@ -348,6 +558,9 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
     ``event:`` / ``data:`` envelope, so reuse the SSE field map and event gate
     directly.
     """
+    if _classify_responses_event_type(body) == _RESPONSES_EVENT_NON_TERMINAL:
+        return None
+
     extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
     extractor.feed(body)
     result = extractor.finish()

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -2,10 +2,12 @@
 
 import json
 
+import usage.openai_responses as openai_responses
 from usage import (
     extract_openai_responses_usage_from_event_json,
     merge_openai_responses_usage_result,
 )
+from usage.json_selective import JsonExtractionResult
 
 
 def test_extracts_usage_from_wrapped_response_completed_event():
@@ -159,6 +161,115 @@ def test_returns_none_for_non_usage_event_type():
     ).encode()
 
     assert extract_openai_responses_usage_from_event_json(body) is None
+
+
+def test_non_terminal_event_skips_full_usage_extractor(monkeypatch):
+    def fail_extractor(**_kwargs):
+        raise AssertionError("full extractor should not run for non-terminal events")
+
+    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", fail_extractor)
+    body = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "delta": "x" * 4096,
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) is None
+
+
+def test_non_terminal_prefilter_ignores_nested_types_and_payload_text(monkeypatch):
+    def fail_extractor(**_kwargs):
+        raise AssertionError("full extractor should not run for non-terminal events")
+
+    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", fail_extractor)
+    body = json.dumps(
+        {
+            "metadata": {
+                "type": "response.completed",
+                "items": [True, None, {"type": "response.failed"}],
+            },
+            "index": 3,
+            "text": 'payload mentions "type":"response.completed"',
+            "type": "response.output_text.delta",
+            "delta": "ignored",
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) is None
+
+
+def test_duplicate_top_level_type_uses_first_type_boundary(monkeypatch):
+    def fail_extractor(**_kwargs):
+        raise AssertionError("duplicate type boundary should not scan beyond first type")
+
+    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", fail_extractor)
+
+    assert (
+        extract_openai_responses_usage_from_event_json(
+            b'{"type":"response.output_text.delta",'
+            b'"type":"response.completed",'
+            b'"response":{"usage":{"input_tokens":1,"output_tokens":1}}}'
+        )
+        is None
+    )
+
+
+def test_terminal_event_type_after_skipped_fields_still_extracts_usage():
+    body = json.dumps(
+        {
+            "metadata": {
+                "type": "response.output_text.delta",
+                "items": [1, {"type": "response.failed"}],
+            },
+            "ready": True,
+            "note": None,
+            "type": "response.completed",
+            "response": {
+                "id": "resp_after_fields",
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 12,
+                    "output_tokens": 5,
+                    "input_tokens_details": {"cached_tokens": 2},
+                },
+            },
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "message_id": "resp_after_fields",
+        "model": "gpt-5.5",
+        "tokens.input": 10,
+        "tokens.output": 5,
+        "tokens.cache_read": 2,
+    }
+
+
+def test_non_string_type_falls_back_to_full_extractor(monkeypatch):
+    class FakeExtractor:
+        def __init__(self, **_kwargs):
+            pass
+
+        def feed(self, _body):
+            pass
+
+        def finish(self):
+            return JsonExtractionResult(
+                complete=True,
+                values={
+                    ("type",): "response.completed",
+                    ("usage", "input_tokens"): 3,
+                    ("usage", "output_tokens"): 2,
+                },
+            )
+
+    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", FakeExtractor)
+
+    assert extract_openai_responses_usage_from_event_json(b'{"type":123}') == {
+        "tokens.input": 3,
+        "tokens.output": 2,
+    }
 
 
 def test_returns_none_for_malformed_json():

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -272,6 +272,34 @@ def test_non_string_type_falls_back_to_full_extractor(monkeypatch):
     }
 
 
+def test_oversized_type_falls_back_to_full_extractor(monkeypatch):
+    class FakeExtractor:
+        def __init__(self, **_kwargs):
+            pass
+
+        def feed(self, _body):
+            pass
+
+        def finish(self):
+            return JsonExtractionResult(
+                complete=True,
+                values={
+                    ("type",): "response.completed",
+                    ("usage", "input_tokens"): 5,
+                    ("usage", "output_tokens"): 1,
+                },
+            )
+
+    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", FakeExtractor)
+
+    assert extract_openai_responses_usage_from_event_json(
+        json.dumps({"type": "x" * 2048}).encode()
+    ) == {
+        "tokens.input": 5,
+        "tokens.output": 1,
+    }
+
+
 def test_returns_none_for_malformed_json():
     assert extract_openai_responses_usage_from_event_json(b'{"type":"response.completed"') is None
 


### PR DESCRIPTION
## Summary

- add a narrow top-level Responses event `type` prefilter for WebSocket event JSON
- skip the full selective usage extractor for confidently non-terminal WebSocket frames
- keep terminal and unknown frames on the existing full extraction path

## Notes

- This does not change SSE usage extraction, non-streaming JSON usage extraction, WebSocket trimming, or usage aggregation.
- Duplicate top-level `type` remains treated as non-conforming input; the prefilter stops at the first conforming top-level `type` to preserve the hot-path win.

Closes #17255

## Tests

- `./.venv/bin/python -m pytest tests/test_openai_responses_event_json.py tests/test_model_provider_stream_usage.py`
- `./.venv/bin/python -m ruff check src tests`
- `./.venv/bin/python -m basedpyright`
