### PR TITLE
test: avoid mitmproxy internals in x billing decode test

### DIFF
--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -722,11 +722,11 @@ class TestXConnectorUsage:
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
 
         with patch(
-            "mitmproxy.net.encoding.decode",
-            side_effect=AssertionError("request body should not be decoded"),
-        ):
+            "usage.providers.connectors.x.billing_body.decode_request_body_for_billing"
+        ) as decode_request_body:
             p = self._call_and_get_single_billing(flow)
 
+        decode_request_body.assert_not_called()
         assert p["category"] == "user.read"
         assert p["quantity"] == 1
 

--- a/crates/runner/mitm-addon/tests/test_x_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_usage.py
@@ -716,7 +716,7 @@ class TestXConnectorUsage:
             body=json.dumps({"data": [{"id": "u1"}]}).encode(),
             permission="tweet.read",
             rule="GET /2/tweets/{id}/retweeted_by",
-            request_body=gzip.compress(b'{"unused": true}'),
+            request_body=b"not gzip request content",
             request_encoding="gzip",
         )
         flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"


### PR DESCRIPTION
## Summary

- replace the X billing non-refinement test's `mitmproxy.net.encoding.decode` patch with a spy on the addon-owned billing decode call site
- keep the existing `user.read` and response-derived quantity assertions
- leave production behavior unchanged

Closes #17256

## Tests

- `pytest tests/test_x_connector_usage.py::TestXConnectorUsage::test_non_refinement_flow_does_not_decode_request_body`
- `pytest tests/test_x_connector_usage.py`
- `ruff check .`
- `ruff format --check .`

`basedpyright -p .` was not run locally because `basedpyright` is not installed in this environment.
