### PR TITLE
fix: aggregate team credit usage by member

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-members.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-members.test.ts
@@ -78,10 +78,54 @@ describe("GET /api/zero/usage/members", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const response = await accept(apiClient().get({ headers: {} }), [401]);
+    const response = await accept(
+      apiClient().get({ query: {}, headers: {} }),
+      [401],
+    );
 
     expect(response.body).toStrictEqual({
       error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+    });
+  });
+
+  it("returns 403 when a non-admin requests member usage", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, { currentPeriodEnd: null }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      apiClient().get({ query: {}, headers: authHeaders() }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only org admins can view member usage",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns 400 for invalid timezone values", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, { currentPeriodEnd: null }, context.signal),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { tz: "Not/A/Timezone" },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Invalid timezone: Not/A/Timezone",
+        code: "BAD_REQUEST",
+      },
     });
   });
 
@@ -92,11 +136,60 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 
     expect(response.body).toStrictEqual({ period: null, members: [] });
+  });
+
+  it("returns aggregated usage for a selected range using processedAt", async () => {
+    mockClerkUserLookup();
+    const fixture = await track(
+      store.set(seedUsageFixture$, { currentPeriodEnd: null }, context.signal),
+    );
+    const outsideUserId = `user_${randomUUID()}`;
+    const now = nowDate();
+
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        inputTokens: 100,
+        creditsCharged: 25,
+        processedAt: new Date(now.getTime() - 60 * 60 * 1000),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: outsideUserId,
+        inputTokens: 500,
+        creditsCharged: 99,
+        processedAt: new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000),
+      },
+      context.signal,
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.period).not.toBeNull();
+    expect(response.body.members).toHaveLength(1);
+    expect(response.body.members[0]).toMatchObject({
+      userId: fixture.userId,
+      inputTokens: 100,
+      creditsCharged: 25,
+    });
   });
 
   it("returns aggregated usage for a single user with processed records", async () => {
@@ -137,7 +230,7 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 
@@ -190,7 +283,7 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 
@@ -234,7 +327,7 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 
@@ -355,7 +448,7 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 
@@ -443,7 +536,7 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 
@@ -508,7 +601,7 @@ describe("GET /api/zero/usage/members", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      apiClient().get({ headers: authHeaders() }),
+      apiClient().get({ query: {}, headers: authHeaders() }),
       [200],
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -127,12 +127,12 @@ describe("GET /api/zero/usage/record", () => {
     });
   });
 
-  it("returns 403 when a non-admin requests team usage", async () => {
+  it("returns 403 when team usage records are requested", async () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),
     );
     await enableCreditUsageRecords(fixture);
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const response = await accept(
       apiClient().get({
@@ -144,7 +144,7 @@ describe("GET /api/zero/usage/record", () => {
 
     expect(response.body).toStrictEqual({
       error: {
-        message: "Only org admins can view team usage",
+        message: "Team usage records are aggregated by member",
         code: "FORBIDDEN",
       },
     });
@@ -715,7 +715,7 @@ describe("GET /api/zero/usage/record", () => {
     ).toStrictEqual(["DST previous day"]);
   });
 
-  it("returns team usage rows with member emails for admins", async () => {
+  it("does not return team usage rows with conversation details for admins", async () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),
     );
@@ -776,24 +776,13 @@ describe("GET /api/zero/usage/record", () => {
         query: { scope: "team", range: "7d", tz: "UTC" },
         headers: authHeaders(),
       }),
-      [200],
+      [403],
     );
 
-    expect(response.body.rows).toHaveLength(2);
-    expect(response.body.rows[0]).toMatchObject({
-      title: "Teammate chat",
-      credits: 40,
-      member: {
-        userId: teammateId,
-        email: `${teammateId}@example.com`,
-      },
-    });
-    expect(response.body.rows[1]).toMatchObject({
-      title: "Admin chat",
-      credits: 20,
-      member: {
-        userId: fixture.userId,
-        email: `${fixture.userId}@example.com`,
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Team usage records are aggregated by member",
+        code: "FORBIDDEN",
       },
     });
   });

--- a/turbo/apps/api/src/signals/routes/zero-usage-members.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-members.ts
@@ -1,15 +1,45 @@
 import { command } from "ccstate";
 import { zeroUsageMembersContract } from "@vm0/api-contracts/contracts/zero-usage";
 
+import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
 import type { RouteEntry } from "../route";
 import { zeroUsageMembers$ } from "../services/zero-usage.service";
+import { isValidTimeZone } from "../utils";
+
+function forbidden() {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: "Only org admins can view member usage",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
 
 const getUsageMembersInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await set(zeroUsageMembers$, { orgId: auth.orgId }, signal);
+    const query = get(queryOf(zeroUsageMembersContract.get));
+    const range = query.range ?? "billingPeriod";
+    const tz = query.tz ?? "UTC";
+
+    if (auth.orgRole !== "admin") {
+      return forbidden();
+    }
+    if (!isValidTimeZone(tz)) {
+      return badRequestMessage(`Invalid timezone: ${tz}`);
+    }
+
+    const body = await set(
+      zeroUsageMembers$,
+      { orgId: auth.orgId, range, tz },
+      signal,
+    );
     signal.throwIfAborted();
     return { status: 200 as const, body };
   },

--- a/turbo/apps/api/src/signals/routes/zero-usage-record.ts
+++ b/turbo/apps/api/src/signals/routes/zero-usage-record.ts
@@ -13,12 +13,12 @@ import { zeroUsageRecord$ } from "../services/zero-usage-record.service";
 import type { RouteEntry } from "../route";
 import { isValidTimeZone } from "../utils";
 
-function forbidden() {
+function teamUsageRecordsUnavailable() {
   return {
     status: 403 as const,
     body: {
       error: {
-        message: "Only org admins can view team usage",
+        message: "Team usage records are aggregated by member",
         code: "FORBIDDEN",
       },
     },
@@ -57,6 +57,10 @@ const getUsageRecordInner$ = command(
       return badRequestMessage(`Invalid timezone: ${query.tz}`);
     }
 
+    if (query.scope === "team") {
+      return teamUsageRecordsUnavailable();
+    }
+
     const overrides = await get(
       userFeatureSwitchOverrides(auth.orgId, auth.userId),
     );
@@ -71,10 +75,6 @@ const getUsageRecordInner$ = command(
     );
     if (usesScopedUsageRecordQuery(rawQuery) && !creditUsageRecordsEnabled) {
       return creditUsageRecordsDisabled();
-    }
-
-    if (query.scope === "team" && auth.orgRole !== "admin") {
-      return forbidden();
     }
 
     const body = await set(

--- a/turbo/apps/api/src/signals/services/usage-period.ts
+++ b/turbo/apps/api/src/signals/services/usage-period.ts
@@ -1,0 +1,124 @@
+import type { UsageRecordRange } from "@vm0/api-contracts/contracts/zero-usage-record";
+
+import { nowDate } from "../external/time";
+
+export type UsageRangeArg = UsageRecordRange | "all";
+
+export interface UsagePeriod {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+const DAY_MS = 86_400_000;
+
+interface TimeParts {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+  readonly hour: number;
+  readonly minute: number;
+  readonly second: number;
+}
+
+function partsInTz(date: Date, tz: string): TimeParts {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const value = (type: Intl.DateTimeFormatPartTypes): number => {
+    return Number(
+      parts.find((part) => {
+        return part.type === type;
+      })?.value ?? 0,
+    );
+  };
+
+  return {
+    year: value("year"),
+    month: value("month"),
+    day: value("day"),
+    hour: value("hour"),
+    minute: value("minute"),
+    second: value("second"),
+  };
+}
+
+function startOfCalendarDateInTz(isoDate: string, tz: string): Date {
+  const [yearPart, monthPart, dayPart] = isoDate.split("-");
+  const year = Number(yearPart);
+  const month = Number(monthPart);
+  const day = Number(dayPart);
+  const target = Date.UTC(year, month - 1, day, 0, 0, 0);
+  let guess = target;
+
+  for (let i = 0; i < 4; i++) {
+    const parts = partsInTz(new Date(guess), tz);
+    const actual = Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+    );
+    const delta = actual - target;
+    if (delta === 0) {
+      return new Date(guess);
+    }
+    guess -= delta;
+  }
+
+  return new Date(guess);
+}
+
+function calendarDateInTz(date: Date, tz: string): string {
+  const parts = partsInTz(date, tz);
+  return [
+    parts.year.toString().padStart(4, "0"),
+    parts.month.toString().padStart(2, "0"),
+    parts.day.toString().padStart(2, "0"),
+  ].join("-");
+}
+
+function addCalendarDays(isoDate: string, days: number): string {
+  const [yearPart, monthPart, dayPart] = isoDate.split("-");
+  const date = new Date(
+    Date.UTC(Number(yearPart), Number(monthPart) - 1, Number(dayPart) + days),
+  );
+  return [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+  ].join("-");
+}
+
+export function fixedRangeToPeriod(
+  range: Exclude<UsageRecordRange, "billingPeriod">,
+  tz: string,
+): UsagePeriod {
+  const now = nowDate();
+  const todayDate = calendarDateInTz(now, tz);
+  const todayStart = startOfCalendarDateInTz(todayDate, tz);
+
+  switch (range) {
+    case "today": {
+      return { start: todayStart, end: now };
+    }
+    case "yesterday": {
+      const start = startOfCalendarDateInTz(addCalendarDays(todayDate, -1), tz);
+      return { start, end: todayStart };
+    }
+    case "24h": {
+      return { start: new Date(now.getTime() - DAY_MS), end: now };
+    }
+    case "7d": {
+      return { start: new Date(now.getTime() - 7 * DAY_MS), end: now };
+    }
+  }
+}

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -2,7 +2,6 @@ import { command } from "ccstate";
 import { sql } from "drizzle-orm";
 import type {
   UsageRecordKind,
-  UsageRecordRange,
   UsageRecordRow,
   UsageRecordResponse,
   UsageRecordScope,
@@ -10,10 +9,14 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-usage-record";
 
 import { clerk$ } from "../external/clerk";
-import { nowDate } from "../external/time";
 import { writeDb$, type Db } from "../external/db";
 import { getOrgBillingPeriod$ } from "./zero-org-billing-period.service";
 import { resolveEmails } from "./zero-usage.service";
+import {
+  fixedRangeToPeriod,
+  type UsagePeriod,
+  type UsageRangeArg,
+} from "./usage-period";
 
 const MODEL_USAGE_KIND = "model";
 const MODEL_TOKEN_CATEGORIES = [
@@ -24,7 +27,6 @@ const MODEL_TOKEN_CATEGORIES = [
 ] as const;
 const THREADED_SOURCES = ["chat", "schedule"] as const;
 const USAGE_RECORD_KINDS = ["model", "image", "video", "connector"] as const;
-const DAY_MS = 86_400_000;
 const PASSTHROUGH_TRIGGER_SOURCES = [
   "schedule",
   "slack",
@@ -36,22 +38,15 @@ const PASSTHROUGH_TRIGGER_SOURCES = [
   "agent",
 ] as const;
 
-type UsageRecordRangeArg = UsageRecordRange | "all";
-
 interface UsageRecordArgs {
   readonly userId: string;
   readonly orgId: string;
   readonly scope: UsageRecordScope;
-  readonly range: UsageRecordRangeArg;
+  readonly range: UsageRangeArg;
   readonly tz: string;
   readonly page: number;
   readonly pageSize: number;
   readonly source?: UsageRecordSource;
-}
-
-interface UsageRecordPeriod {
-  readonly start: Date;
-  readonly end: Date;
 }
 
 interface UsageRecordSqlRow extends Record<string, unknown> {
@@ -106,125 +101,13 @@ function usageKindExpr(kind: string): string {
     END`;
 }
 
-interface TimeParts {
-  readonly year: number;
-  readonly month: number;
-  readonly day: number;
-  readonly hour: number;
-  readonly minute: number;
-  readonly second: number;
-}
-
-function partsInTz(date: Date, tz: string): TimeParts {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hourCycle: "h23",
-  }).formatToParts(date);
-  const value = (type: Intl.DateTimeFormatPartTypes): number => {
-    return Number(
-      parts.find((part) => {
-        return part.type === type;
-      })?.value ?? 0,
-    );
-  };
-
-  return {
-    year: value("year"),
-    month: value("month"),
-    day: value("day"),
-    hour: value("hour"),
-    minute: value("minute"),
-    second: value("second"),
-  };
-}
-
-function startOfCalendarDateInTz(isoDate: string, tz: string): Date {
-  const [yearPart, monthPart, dayPart] = isoDate.split("-");
-  const year = Number(yearPart);
-  const month = Number(monthPart);
-  const day = Number(dayPart);
-  const target = Date.UTC(year, month - 1, day, 0, 0, 0);
-  let guess = target;
-
-  for (let i = 0; i < 4; i++) {
-    const parts = partsInTz(new Date(guess), tz);
-    const actual = Date.UTC(
-      parts.year,
-      parts.month - 1,
-      parts.day,
-      parts.hour,
-      parts.minute,
-      parts.second,
-    );
-    const delta = actual - target;
-    if (delta === 0) {
-      return new Date(guess);
-    }
-    guess -= delta;
-  }
-
-  return new Date(guess);
-}
-
-function calendarDateInTz(date: Date, tz: string): string {
-  const parts = partsInTz(date, tz);
-  return [
-    parts.year.toString().padStart(4, "0"),
-    parts.month.toString().padStart(2, "0"),
-    parts.day.toString().padStart(2, "0"),
-  ].join("-");
-}
-
-function addCalendarDays(isoDate: string, days: number): string {
-  const [yearPart, monthPart, dayPart] = isoDate.split("-");
-  const date = new Date(
-    Date.UTC(Number(yearPart), Number(monthPart) - 1, Number(dayPart) + days),
-  );
-  return [
-    date.getUTCFullYear().toString().padStart(4, "0"),
-    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
-    date.getUTCDate().toString().padStart(2, "0"),
-  ].join("-");
-}
-
-function fixedRangeToPeriod(
-  range: Exclude<UsageRecordRange, "billingPeriod">,
-  tz: string,
-): UsageRecordPeriod {
-  const now = nowDate();
-  const todayDate = calendarDateInTz(now, tz);
-  const todayStart = startOfCalendarDateInTz(todayDate, tz);
-
-  switch (range) {
-    case "today": {
-      return { start: todayStart, end: now };
-    }
-    case "yesterday": {
-      const start = startOfCalendarDateInTz(addCalendarDays(todayDate, -1), tz);
-      return { start, end: todayStart };
-    }
-    case "24h": {
-      return { start: new Date(now.getTime() - DAY_MS), end: now };
-    }
-    case "7d": {
-      return { start: new Date(now.getTime() - 7 * DAY_MS), end: now };
-    }
-  }
-}
-
 // Per-source usage for one user in one org. `record` is the shared CTE so the
 // row query and the count query stay in sync. Threaded sources collapse to one
 // row per source/thread; everything else is one row per run.
 function recordWith(
   userIdLit: string,
   orgIdLit: string,
-  period: UsageRecordPeriod | null,
+  period: UsagePeriod | null,
 ): string {
   const threadedSourceList = THREADED_SOURCES.map(pgLit).join(", ");
   const userPredicate = userIdLit ? `AND ue.user_id = ${userIdLit}` : "";
@@ -374,7 +257,7 @@ async function queryUsageRecordBreakdown(
   db: Db,
   userIdLit: string,
   orgIdLit: string,
-  period: UsageRecordPeriod | null,
+  period: UsagePeriod | null,
   rowKeys: readonly string[],
 ): Promise<Map<string, UsageRecordRow["breakdown"]>> {
   if (rowKeys.length === 0) {

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -4,6 +4,7 @@ import type {
   MemberUsage,
   UsageMembersResponse,
 } from "@vm0/api-contracts/contracts/zero-usage";
+import type { UsageRecordRange } from "@vm0/api-contracts/contracts/zero-usage-record";
 import type { UsageRunsResponse } from "@vm0/api-contracts/contracts/zero-usage-daily";
 import {
   agentComposes,
@@ -29,9 +30,12 @@ import {
   mergedRunModel,
   mergedRunOutputTokens,
 } from "./zero-usage-reporting-ledger";
+import { fixedRangeToPeriod } from "./usage-period";
 
 interface UsageMembersArgs {
   readonly orgId: string;
+  readonly range: UsageRecordRange;
+  readonly tz: string;
 }
 
 export const zeroUsageMembers$ = command(
@@ -40,22 +44,33 @@ export const zeroUsageMembers$ = command(
     args: UsageMembersArgs,
     signal: AbortSignal,
   ): Promise<UsageMembersResponse> => {
-    const billingPeriod = await set(getOrgBillingPeriod$, args.orgId, signal);
+    const billingPeriod =
+      args.range === "billingPeriod"
+        ? await set(getOrgBillingPeriod$, args.orgId, signal)
+        : null;
     signal.throwIfAborted();
 
-    if (!billingPeriod) {
+    if (args.range === "billingPeriod" && !billingPeriod) {
       return { period: null, members: [] };
     }
 
+    const period =
+      args.range === "billingPeriod"
+        ? billingPeriod
+        : fixedRangeToPeriod(args.range, args.tz);
+    if (!period) {
+      throw new Error("member usage period was not resolved");
+    }
+
     const db = set(writeDb$);
-    const rows = await getMemberUsageTotals(db, args.orgId, billingPeriod);
+    const rows = await getMemberUsageTotals(db, args.orgId, period);
     signal.throwIfAborted();
 
     if (rows.length === 0) {
       return {
         period: {
-          start: billingPeriod.start.toISOString(),
-          end: billingPeriod.end.toISOString(),
+          start: period.start.toISOString(),
+          end: period.end.toISOString(),
         },
         members: [],
       };
@@ -84,8 +99,8 @@ export const zeroUsageMembers$ = command(
 
     return {
       period: {
-        start: billingPeriod.start.toISOString(),
-        end: billingPeriod.end.toISOString(),
+        start: period.start.toISOString(),
+        end: period.end.toISOString(),
       },
       members,
     };

--- a/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
@@ -8,6 +8,14 @@ import { accept } from "../../lib/accept.ts";
 export const usageMembersAsync$ = computed(async (get) => {
   const createClient = get(zeroClient$);
   const client = createClient(zeroUsageMembersContract);
-  const result = await accept(client.get(), [200]);
+  const result = await accept(
+    client.get({
+      query: {
+        range: "billingPeriod",
+        tz: new Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+      },
+    }),
+    [200],
+  );
   return result.body;
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -4,6 +4,7 @@ import {
   type UsageRecordRange,
   type UsageRecordScope,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { zeroUsageMembersContract } from "@vm0/api-contracts/contracts/zero-usage";
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
 
@@ -24,7 +25,6 @@ export const setCreditBalanceTab$ = command(
 const PAGE_STEP = 20;
 
 const myUsagePageSize$ = state(PAGE_STEP);
-const teamUsagePageSize$ = state(PAGE_STEP);
 const myUsageRangeState$ = state<UsageRecordRange>("today");
 const teamUsageRangeState$ = state<UsageRecordRange>("billingPeriod");
 
@@ -44,16 +44,11 @@ export const setMyUsageRange$ = command(({ set }, range: UsageRecordRange) => {
 export const setTeamUsageRange$ = command(
   ({ set }, range: UsageRecordRange) => {
     set(teamUsageRangeState$, range);
-    set(teamUsagePageSize$, PAGE_STEP);
   },
 );
 
 export const loadMoreUsageRecord$ = command(
-  ({ get, set }, scope: UsageRecordScope) => {
-    if (scope === "team") {
-      set(teamUsagePageSize$, get(teamUsagePageSize$) + PAGE_STEP);
-      return;
-    }
+  ({ get, set }, _scope: UsageRecordScope) => {
     set(myUsagePageSize$, get(myUsagePageSize$) + PAGE_STEP);
   },
 );
@@ -83,17 +78,13 @@ export const myUsageRecordAsync$ = computed(async (get) => {
   return result.body;
 });
 
-export const teamUsageRecordAsync$ = computed(async (get) => {
-  const pageSize = get(teamUsagePageSize$);
+export const teamMemberUsageAsync$ = computed(async (get) => {
   const range = get(teamUsageRangeState$);
   const createClient = get(zeroClient$);
-  const client = createClient(zeroUsageRecordContract);
+  const client = createClient(zeroUsageMembersContract);
   const result = await accept(
     client.get({
       query: {
-        page: 1,
-        pageSize,
-        scope: "team",
         range,
         tz: currentTimeZone(),
       },

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -458,7 +458,7 @@ function OverviewSection({
               </p>
             </div>
           ) : (
-            <MembersTable members={members} memberMap={memberMap} />
+            <MemberUsageTable members={members} memberMap={memberMap} />
           )}
         </section>
       )}
@@ -466,7 +466,7 @@ function OverviewSection({
   );
 }
 
-function MembersTable({
+export function MemberUsageTable({
   members,
   memberMap,
 }: {

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import {
   IconBrandGithub,
   IconBrandSlack,
@@ -12,6 +12,7 @@ import {
   IconRobot,
   IconTerminal2,
 } from "@tabler/icons-react";
+import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type {
   UsageRecordKind,
   UsageRecordRange,
@@ -20,6 +21,7 @@ import type {
   UsageRecordScope,
   UsageRecordSource,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
+import type { UsageMembersResponse } from "@vm0/api-contracts/contracts/zero-usage";
 import {
   Button,
   DropdownMenu,
@@ -36,13 +38,15 @@ import {
 import {
   loadMoreUsageRecord$,
   myUsageRecordAsync$,
-  teamUsageRecordAsync$,
+  teamMemberUsageAsync$,
 } from "../../../../signals/zero-page/settings/personal-usage-record.ts";
+import { orgMembers$ } from "../../../../signals/external/org-members.ts";
 import { setSettingsDialogOpen$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { nowDate } from "../../../../lib/time.ts";
 import { Link } from "../../../router/link.tsx";
+import { MemberUsageTable } from "../org-manage/org-usage-tab.tsx";
 
 const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
 
@@ -103,6 +107,11 @@ type UsageRecordLoadable =
   | { readonly state: "loading" }
   | { readonly state: "hasError" }
   | { readonly state: "hasData"; readonly data: UsageRecordResponse };
+
+type UsageMembersLoadable =
+  | { readonly state: "loading" }
+  | { readonly state: "hasError" }
+  | { readonly state: "hasData"; readonly data: UsageMembersResponse };
 
 function formatCredits(n: number): string {
   if (n >= 1_000_000) {
@@ -392,12 +401,53 @@ function UsageRecordContent({
   );
 }
 
+function TeamMemberUsageContent({
+  loadable,
+  range,
+}: {
+  loadable: UsageMembersLoadable;
+  range: UsageRecordRange;
+}) {
+  const membersLoadable = useLoadable(orgMembers$);
+  const orgMembersList =
+    membersLoadable.state === "hasData" ? membersLoadable.data : [];
+  const memberMap = new Map<string, OrgMember>(
+    orgMembersList.map((member) => {
+      return [member.userId, member];
+    }),
+  );
+
+  return (
+    <section className="flex flex-col gap-4">
+      {loadable.state === "loading" && <UsageRecordSkeleton />}
+      {loadable.state === "hasError" && (
+        <p className="text-sm text-muted-foreground" role="alert">
+          Couldn&apos;t load team usage. Please try again later.
+        </p>
+      )}
+      {loadable.state === "hasData" &&
+        (!loadable.data.period ? (
+          <p className="text-sm text-muted-foreground">
+            No active billing period. Team usage is available on paid plans.
+          </p>
+        ) : loadable.data.members.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage(range)}</p>
+        ) : (
+          <MemberUsageTable
+            members={loadable.data.members}
+            memberMap={memberMap}
+          />
+        ))}
+    </section>
+  );
+}
+
 export function PersonalUsageRecord({ range }: { range: UsageRecordRange }) {
   const loadable = useLastLoadable(myUsageRecordAsync$);
   return <UsageRecordContent loadable={loadable} range={range} scope="mine" />;
 }
 
 export function TeamUsageRecord({ range }: { range: UsageRecordRange }) {
-  const loadable = useLastLoadable(teamUsageRecordAsync$);
-  return <UsageRecordContent loadable={loadable} range={range} scope="team" />;
+  const loadable = useLastLoadable(teamMemberUsageAsync$);
+  return <TeamMemberUsageContent loadable={loadable} range={range} />;
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -114,7 +114,7 @@ export const zeroUsageRecordContract = c.router({
       500: apiErrorSchema,
     },
     summary:
-      "Get personal or team usage records across sources, ordered by recent activity",
+      "Get personal usage records across sources, ordered by recent activity",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-usage.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { usageRecordRangeSchema } from "./zero-usage-record";
 
 const c = initContract();
 
@@ -32,12 +33,18 @@ export const zeroUsageMembersContract = c.router({
     method: "GET",
     path: "/api/zero/usage/members",
     headers: authHeadersSchema,
+    query: z.object({
+      range: usageRecordRangeSchema.default("billingPeriod"),
+      tz: z.string().default("UTC"),
+    }),
     responses: {
       200: usageMembersResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Get per-member usage for current billing period",
+    summary: "Get per-member usage for a selected period",
   },
 });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -355,7 +355,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.CreditUsageRecords]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Show ranged personal and team credit usage records in settings, and enable scoped/ranged /api/zero/usage/record queries.",
+      "Show ranged personal credit usage records and team member usage aggregates in settings, and enable scoped/ranged /api/zero/usage/record queries.",
     enabled: true,
   },
   [FeatureSwitchKey.ZeroAutomations]: {


### PR DESCRIPTION
## Summary
- Make Credit balance team usage use per-member aggregates instead of usage record rows
- Reject team-scoped usage records server-side so admins cannot access thread/run/conversation details
- Add range/timezone support and an admin guard to member usage totals

## Validation
- pnpm --dir apps/platform exec vitest run src/views/zero-page/__tests__/org-usage-tab.test.tsx
- pnpm --dir apps/platform exec tsc --noEmit
- pnpm --dir packages/api-contracts exec tsc --noEmit
- pnpm --dir packages/core exec tsc --noEmit
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir apps/api exec tsc --noEmit --skipLibCheck --pretty false
- oxlint on changed API/platform files
- git diff --check

## Note
- API route tests were attempted locally but require a local Postgres service; the environment returned ECONNREFUSED on localhost:5432.