### PR TITLE
fix: show active state on download button when dropdown is open

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -446,7 +446,9 @@ export function ArtifactDownloadMenu({
           aria-label={ariaLabel}
           aria-haspopup="menu"
           aria-expanded={open}
-          className={iconButtonClassName(className)}
+          className={iconButtonClassName(
+            cn("data-[state=open]:bg-muted/60 data-[state=open]:text-foreground", className),
+          )}
         >
           <IconDownload size={iconSize} stroke={1.5} />
         </button>

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -447,7 +447,10 @@ export function ArtifactDownloadMenu({
           aria-haspopup="menu"
           aria-expanded={open}
           className={iconButtonClassName(
-            cn("data-[state=open]:bg-muted/60 data-[state=open]:text-foreground", className),
+            cn(
+              "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground",
+              className,
+            ),
           )}
         >
           <IconDownload size={iconSize} stroke={1.5} />


### PR DESCRIPTION
## Summary

- When the download dropdown is open, the trigger button now shows an active/highlighted state (`bg-muted/60` + `text-foreground`), matching the hover appearance
- Uses Radix UI's `data-state="open"` attribute (injected by `PopoverTrigger asChild`) with Tailwind `data-[state=open]:` variants — no extra JS needed

## Root Cause

The `PopoverTrigger` button used `iconButtonClassName` which only had `hover:` styles. When the popover was open the button appeared in its default resting state, giving no visual feedback that the dropdown was active.

## Test plan

- [ ] Open the download dropdown on an artifact — the download icon button should appear highlighted (same background as hover)
- [ ] Close the dropdown — the button should return to its default state

🤖 Generated with [Claude Code](https://claude.com/claude-code)