### PR TITLE
fix: add safe-area-inset-top padding to fullscreen artifact sidebar on mobile

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -184,7 +184,7 @@ function ArtifactSidebarContent({
       <div
         className={cn(
           fullscreen
-            ? "fixed inset-0 z-[100] flex flex-col bg-background"
+            ? "fixed inset-0 z-[100] flex flex-col bg-background pt-[env(safe-area-inset-top)]"
             : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
           "animate-in fade-in duration-[180ms] ease",
         )}
@@ -232,7 +232,7 @@ function ArtifactSidebarContent({
     <div
       className={cn(
         fullscreen
-          ? "fixed inset-0 z-[100] flex flex-col bg-background"
+          ? "fixed inset-0 z-[100] flex flex-col bg-background pt-[env(safe-area-inset-top)]"
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background",
         "animate-in fade-in duration-[180ms] ease",
       )}


### PR DESCRIPTION
## Summary

- Adds `pt-[env(safe-area-inset-top)]` padding to the fullscreen container in `zero-artifact-sidebar.tsx` when the artifact sidebar enters fullscreen mode
- Prevents the toolbar from being overlapped/hidden behind the device status bar on iOS/Android devices running the app as a PWA or in browsers with `viewport-fit=cover`
- The `viewport-fit=cover` meta tag is already set in `turbo/apps/platform/index.html` (line 330), so the safe-area CSS env variable is available

## Test plan

- [ ] Open artifact sidebar on a mobile device (or simulator) with iOS notch/dynamic island
- [ ] Tap the fullscreen toggle button
- [ ] Verify the toolbar is fully visible and not obscured by the device status bar
- [ ] Verify the layout looks correct in both light and dark mode
- [ ] Verify non-fullscreen mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)