### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.172"
+CLAUDE_CODE_VERSION="2.1.173"
 CODEX_CLI_VERSION="0.139.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Updated pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.172` -> `2.1.173`

## Checks

- Verified Go `1.26.4`, Codex CLI `0.139.0`, Google Workspace CLI `0.22.5`, xurl `1.0.3`, agent-browser `0.27.2`, and pnpm `11.5.3` are already current.
- Kept NodeSource on `node_24.x` because Node 24 is the current LTS line.
- Did not update Ubuntu, per request.
- Verified Claude Code `2.1.173` standalone binary manifest and Linux x64/arm64 artifacts are available.
- Ran `bash -n crates/runner/scripts/build-template.sh`.
- Ran `git diff --check`.