### PR TITLE
feat: restructure /illustration into a product landing funnel

### DIFF
--- a/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
@@ -180,7 +180,7 @@ function ComparisonSection() {
     <section className="illu-section illu-compare">
       <div className="container">
         <div className="illu-section-head">
-          <p className="illu-eyebrow">Why it's different</p>
+          <p className="illu-eyebrow">Why it&apos;s different</p>
           <h2 className="illu-section-title">
             How this compares to a raw image generator
           </h2>
@@ -222,7 +222,7 @@ function AudienceSection() {
     <section className="illu-section illu-audience">
       <div className="container">
         <div className="illu-section-head">
-          <p className="illu-eyebrow">Who it's for</p>
+          <p className="illu-eyebrow">Who it&apos;s for</p>
           <h2 className="illu-section-title">
             For anyone who needs a consistent look
           </h2>

--- a/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
@@ -8,6 +8,13 @@ import {
   ILLUSTRATION_STYLES,
   type IllustrationStyle,
 } from "@vm0/core";
+import {
+  ILLUSTRATION_AUDIENCES,
+  ILLUSTRATION_COMPARISON,
+  ILLUSTRATION_FAQ,
+  ILLUSTRATION_FEATURES,
+  SIGNUP_HREF,
+} from "./content";
 
 interface LightboxState {
   style: IllustrationStyle;
@@ -46,41 +53,20 @@ export function IllustrationGalleryClient() {
 
   return (
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
-      <section className="hero-section illu-hero">
-        <div className="container">
-          <h1 className="hero-title">Illustration</h1>
-          <p className="hero-description">
-            An open gallery of every illustration style in the vm0-skills
-            register. Click any plate to see every AI variation the style can
-            produce.
-          </p>
-          <dl className="illu-meta-grid">
-            <div>
-              <dt>Pieces</dt>
-              <dd>{ILLUSTRATION_STYLES.length} styles</dd>
-            </div>
-            <div>
-              <dt>Source register</dt>
-              <dd>
-                <a
-                  href="https://github.com/vm0-ai/vm0-skills/pulls?q=is%3Apr+illustration-template"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  vm0-skills #201 – #236
-                </a>
-              </dd>
-            </div>
-            <div>
-              <dt>Rendered with</dt>
-              <dd>gpt-image-2 · seedream 5 · nano-banana-2</dd>
-            </div>
-          </dl>
-        </div>
-      </section>
+      <HeroSection />
+      <FeaturesSection />
+      <ComparisonSection />
 
-      <section style={{ paddingBottom: "120px" }}>
+      <section id="gallery" className="illu-gallery-section">
         <div className="illu-wrap">
+          <div className="illu-section-head">
+            <p className="illu-eyebrow">The register</p>
+            <h2 className="illu-section-title">See what you can make</h2>
+            <p className="illu-section-sub">
+              Every style in the register, with all of its variations. Click any
+              plate to open it.
+            </p>
+          </div>
           <div className="illu-masonry">
             {ILLUSTRATION_STYLES.map((style) => {
               return (
@@ -95,6 +81,10 @@ export function IllustrationGalleryClient() {
         </div>
       </section>
 
+      <AudienceSection />
+      <FaqSection />
+      <FinalCtaSection />
+
       <Footer />
 
       {lightbox && (
@@ -107,6 +97,189 @@ export function IllustrationGalleryClient() {
         />
       )}
     </div>
+  );
+}
+
+function HeroSection() {
+  return (
+    <section className="hero-section illu-hero">
+      <div className="container">
+        <p className="illu-eyebrow">Illustration · powered by Zero</p>
+        <h1 className="hero-title illu-hero-title">
+          On-brand illustration in a house style that <em>stays consistent</em>
+        </h1>
+        <p className="hero-description illu-hero-desc">
+          Hand Zero a brief and a style. It researches the subject, generates
+          editorial illustration in one of {ILLUSTRATION_STYLES.length}+ locked
+          styles from the vm0-skills register, and keeps every piece in a series
+          on the same palette, line, and cast — not one-off prompt roulette.
+        </p>
+        <div className="illu-hero-actions">
+          <a className="illu-btn illu-btn-primary" href={SIGNUP_HREF}>
+            Try a style in Zero
+          </a>
+          <a className="illu-btn illu-btn-secondary" href="#gallery">
+            Browse the gallery
+          </a>
+        </div>
+        <dl className="illu-meta-grid">
+          <div>
+            <dt>Styles</dt>
+            <dd>{ILLUSTRATION_STYLES.length} in the register</dd>
+          </div>
+          <div>
+            <dt>Source register</dt>
+            <dd>
+              <a
+                href="https://github.com/vm0-ai/vm0-skills/pulls?q=is%3Apr+illustration-template"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                vm0-skills #201 – #236
+              </a>
+            </dd>
+          </div>
+          <div>
+            <dt>Rendered with</dt>
+            <dd>gpt-image-2 · seedream 5 · nano-banana-2</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+function FeaturesSection() {
+  return (
+    <section className="illu-section illu-features">
+      <div className="container">
+        <div className="illu-section-head">
+          <p className="illu-eyebrow">What you get</p>
+          <h2 className="illu-section-title">
+            A style system, not a slot machine
+          </h2>
+        </div>
+        <div className="illu-feature-grid">
+          {ILLUSTRATION_FEATURES.map((feature) => {
+            return (
+              <article key={feature.title} className="illu-feature-card">
+                <h3>{feature.title}</h3>
+                <p>{feature.body}</p>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ComparisonSection() {
+  return (
+    <section className="illu-section illu-compare">
+      <div className="container">
+        <div className="illu-section-head">
+          <p className="illu-eyebrow">Why it's different</p>
+          <h2 className="illu-section-title">
+            How this compares to a raw image generator
+          </h2>
+        </div>
+        <div className="illu-compare-table" role="table">
+          <div className="illu-compare-row illu-compare-head" role="row">
+            <span role="columnheader" />
+            <span role="columnheader">Generic AI image tool</span>
+            <span role="columnheader" className="illu-compare-zero-col">
+              Zero illustration styles
+            </span>
+          </div>
+          {ILLUSTRATION_COMPARISON.map((row) => {
+            return (
+              <div key={row.aspect} className="illu-compare-row" role="row">
+                <span className="illu-compare-aspect" role="rowheader">
+                  {row.aspect}
+                </span>
+                <span className="illu-compare-generic" role="cell">
+                  {row.generic}
+                </span>
+                <span
+                  className="illu-compare-cell illu-compare-zero-col"
+                  role="cell"
+                >
+                  {row.zero}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AudienceSection() {
+  return (
+    <section className="illu-section illu-audience">
+      <div className="container">
+        <div className="illu-section-head">
+          <p className="illu-eyebrow">Who it's for</p>
+          <h2 className="illu-section-title">
+            For anyone who needs a consistent look
+          </h2>
+        </div>
+        <div className="illu-audience-grid">
+          {ILLUSTRATION_AUDIENCES.map((audience) => {
+            return (
+              <article key={audience.title} className="illu-audience-card">
+                <h3>{audience.title}</h3>
+                <p>{audience.body}</p>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FaqSection() {
+  return (
+    <section className="illu-section illu-faq">
+      <div className="container">
+        <div className="illu-section-head">
+          <p className="illu-eyebrow">Good to know</p>
+          <h2 className="illu-section-title">Frequently asked questions</h2>
+        </div>
+        <div className="illu-faq-list">
+          {ILLUSTRATION_FAQ.map((item) => {
+            return (
+              <details key={item.q} className="illu-faq-item">
+                <summary>{item.q}</summary>
+                <p>{item.a}</p>
+              </details>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FinalCtaSection() {
+  return (
+    <section className="illu-section illu-final-cta">
+      <div className="container">
+        <h2 className="illu-final-cta-title">
+          Turn a brief into on-brand illustration
+        </h2>
+        <p className="illu-final-cta-sub">
+          Pick a style, hand Zero the idea, and get illustration that matches
+          the rest of your brand.
+        </p>
+        <a className="illu-btn illu-btn-primary" href={SIGNUP_HREF}>
+          Start in Zero
+        </a>
+      </div>
+    </section>
   );
 }
 

--- a/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import Link from "next/link";
 import { Footer } from "../../components/Footer";
 import {
   ILLUSTRATION_ASSET_BASE,
@@ -115,9 +116,9 @@ function HeroSection() {
           on the same palette, line, and cast — not one-off prompt roulette.
         </p>
         <div className="illu-hero-actions">
-          <a className="illu-btn illu-btn-primary" href={SIGNUP_HREF}>
+          <Link className="illu-btn illu-btn-primary" href={SIGNUP_HREF}>
             Try a style in Zero
-          </a>
+          </Link>
           <a className="illu-btn illu-btn-secondary" href="#gallery">
             Browse the gallery
           </a>
@@ -275,9 +276,9 @@ function FinalCtaSection() {
           Pick a style, hand Zero the idea, and get illustration that matches
           the rest of your brand.
         </p>
-        <a className="illu-btn illu-btn-primary" href={SIGNUP_HREF}>
+        <Link className="illu-btn illu-btn-primary" href={SIGNUP_HREF}>
           Start in Zero
-        </a>
+        </Link>
       </div>
     </section>
   );

--- a/turbo/apps/web/app/[locale]/illustration/content.ts
+++ b/turbo/apps/web/app/[locale]/illustration/content.ts
@@ -5,7 +5,7 @@
 
 export const SIGNUP_HREF = "/sign-up";
 
-export interface IllustrationFeature {
+interface IllustrationFeature {
   readonly title: string;
   readonly body: string;
 }
@@ -29,7 +29,7 @@ export const ILLUSTRATION_FEATURES: readonly IllustrationFeature[] = [
   },
 ];
 
-export interface ComparisonRow {
+interface ComparisonRow {
   readonly aspect: string;
   readonly generic: string;
   readonly zero: string;
@@ -63,7 +63,7 @@ export const ILLUSTRATION_COMPARISON: readonly ComparisonRow[] = [
   },
 ];
 
-export interface AudienceCard {
+interface AudienceCard {
   readonly title: string;
   readonly body: string;
 }
@@ -83,7 +83,7 @@ export const ILLUSTRATION_AUDIENCES: readonly AudienceCard[] = [
   },
 ];
 
-export interface FaqItem {
+interface FaqItem {
   readonly q: string;
   readonly a: string;
 }

--- a/turbo/apps/web/app/[locale]/illustration/content.ts
+++ b/turbo/apps/web/app/[locale]/illustration/content.ts
@@ -1,0 +1,116 @@
+// Marketing copy for the /illustration funnel page. Kept as plain data so the
+// gallery client stays focused on rendering. The arc mirrors a product landing
+// page: value prop → capabilities → comparison → results gallery → audiences →
+// FAQ → final CTA.
+
+export const SIGNUP_HREF = "/sign-up";
+
+export interface IllustrationFeature {
+  readonly title: string;
+  readonly body: string;
+}
+
+export const ILLUSTRATION_FEATURES: readonly IllustrationFeature[] = [
+  {
+    title: "30+ locked house styles",
+    body: "Pick from a register of editorial styles — Loose Contour, Riso Relic, Folk Storybook, Jade Blockprint and more. Each is a fixed recipe, not a vibe you re-describe every time.",
+  },
+  {
+    title: "Consistent across a series",
+    body: "Palette, line weight, and cast are dials Zero holds steady. Generate a ten-piece blog set or a campaign and every frame belongs to the same family.",
+  },
+  {
+    title: "Brief-aware, not prompt roulette",
+    body: "Zero reads your topic, picks the metaphor and scene, and composes the piece. You describe the idea; it handles the art direction.",
+  },
+  {
+    title: "Invoke as a skill, regenerate on demand",
+    body: "Each style is a Zero skill. Call it, tweak the brief, and re-run for a fresh variation — no re-prompting from scratch.",
+  },
+];
+
+export interface ComparisonRow {
+  readonly aspect: string;
+  readonly generic: string;
+  readonly zero: string;
+}
+
+export const ILLUSTRATION_COMPARISON: readonly ComparisonRow[] = [
+  {
+    aspect: "Style consistency",
+    generic: "Drifts with every prompt",
+    zero: "Locked recipe, repeatable",
+  },
+  {
+    aspect: "Across a series",
+    generic: "Each image is its own world",
+    zero: "Shared palette, line & cast",
+  },
+  {
+    aspect: "Art direction",
+    generic: "You write the whole prompt",
+    zero: "Zero researches & composes from a brief",
+  },
+  {
+    aspect: "Revisions",
+    generic: "Re-prompt and hope",
+    zero: "Re-run the skill, same style",
+  },
+  {
+    aspect: "What you keep",
+    generic: "A one-off file",
+    zero: "A reusable, named style skill",
+  },
+];
+
+export interface AudienceCard {
+  readonly title: string;
+  readonly body: string;
+}
+
+export const ILLUSTRATION_AUDIENCES: readonly AudienceCard[] = [
+  {
+    title: "Founders & solo builders",
+    body: "Give your blog and brand a consistent visual voice without hiring an illustrator for every post.",
+  },
+  {
+    title: "Marketing & content teams",
+    body: "Spin up campaign and social visuals that all look like one brand — fast enough to keep up with the calendar.",
+  },
+  {
+    title: "Designers",
+    body: "Get on-brand drafts and explorations in seconds, then take them the last mile yourself.",
+  },
+];
+
+export interface FaqItem {
+  readonly q: string;
+  readonly a: string;
+}
+
+export const ILLUSTRATION_FAQ: readonly FaqItem[] = [
+  {
+    q: "How is this different from a normal AI image generator?",
+    a: "A normal generator gives you a different look every prompt. Here you pick a fixed style from the register and Zero reproduces it consistently — across one image or a whole series — driven by a brief instead of a long prompt.",
+  },
+  {
+    q: "Can I use the illustrations commercially?",
+    a: "Yes. Illustrations you generate are yours to use in products, marketing, and content.",
+  },
+  {
+    q: "How does the consistency actually work?",
+    a: "Each style is a locked recipe in the vm0-skills register — palette, line, grain, and cast are fixed reference points. Zero varies the scene and subject per brief while holding the look steady.",
+  },
+  {
+    q: "Can I add my own style?",
+    a: "Yes. Styles are open skills in the vm0-skills repo. A new house style can be trained from your references and registered alongside these.",
+  },
+  {
+    q: "What formats do I get?",
+    a: "Standard raster output sized for editorial and social use; several styles support transparent PNGs for stickers and overlays.",
+  },
+  {
+    q: "How do I generate one?",
+    a: "Sign in to Zero, invoke the style you want as a skill, and describe the piece. Zero researches, composes, and returns the illustration — re-run anytime for variations.",
+  },
+];

--- a/turbo/apps/web/app/[locale]/illustration/page.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/page.tsx
@@ -4,6 +4,7 @@ import type { Locale } from "../../../i18n";
 import { buildLocaleAlternates } from "../../lib/seo/alternates";
 import { ILLUSTRATION_ASSET_BASE, ILLUSTRATION_STYLES } from "@vm0/core";
 import { IllustrationGalleryClient } from "./IllustrationGalleryClient";
+import { ILLUSTRATION_FAQ } from "./content";
 
 const BASE_URL = "https://www.vm0.ai";
 
@@ -25,9 +26,9 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { locale } = await params;
   const url = `${BASE_URL}/${locale}/illustration`;
-  const title = "Illustration — VM0";
+  const title = "AI Illustration in a Consistent House Style — VM0";
   const description =
-    "An open gallery of every illustration style in the vm0-skills register. Each plate shows one piece in that style with every AI variation behind it.";
+    "Generate on-brand editorial illustration with Zero. Pick from 30+ locked styles in the vm0-skills register and keep every piece in a series on the same palette, line, and cast — not one-off prompt roulette.";
 
   return {
     title,
@@ -77,6 +78,21 @@ export default async function IllustrationPage({ params }: PageProps) {
     }),
   };
 
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: ILLUSTRATION_FAQ.map((item) => {
+      return {
+        "@type": "Question",
+        name: item.q,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.a,
+        },
+      };
+    }),
+  };
+
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -103,6 +119,9 @@ export default async function IllustrationPage({ params }: PageProps) {
       </script>
       <script type="application/ld+json" suppressHydrationWarning>
         {JSON.stringify(breadcrumbJsonLd)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(faqJsonLd)}
       </script>
       <IllustrationGalleryClient />
     </div>

--- a/turbo/apps/web/app/illustration.css
+++ b/turbo/apps/web/app/illustration.css
@@ -72,6 +72,329 @@
   }
 }
 
+/* ===== Funnel sections (hero → features → compare → gallery → who → faq → cta) ===== */
+
+.illu-eyebrow {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #ed4e01;
+  margin: 0 0 14px;
+}
+
+.illu-hero-title em,
+.illu-section-title em {
+  font-family: var(--font-fraunces), Georgia, serif;
+  font-style: italic;
+  font-weight: 400;
+}
+
+.illu-hero-desc {
+  max-width: 640px;
+}
+
+.illu-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.illu-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: 10px;
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    border-color 0.2s,
+    transform 0.2s;
+}
+.illu-btn-primary {
+  background: #ed4e01;
+  color: #fff;
+  border: 0.7px solid #ed4e01;
+}
+.illu-btn-primary:hover {
+  background: #ff6a1f;
+  border-color: #ff6a1f;
+  transform: translateY(-1px);
+}
+.illu-btn-secondary {
+  background: hsl(var(--gray-0));
+  color: hsl(var(--foreground));
+  border: 0.7px solid hsl(var(--gray-300));
+}
+.illu-btn-secondary:hover {
+  background: hsl(var(--gray-50));
+}
+
+.illu-section {
+  padding: 88px 0;
+}
+.illu-section + .illu-section {
+  padding-top: 0;
+}
+@media (max-width: 720px) {
+  .illu-section {
+    padding: 56px 0;
+  }
+}
+
+.illu-section-head {
+  max-width: 680px;
+  margin: 0 0 40px;
+}
+.illu-section-title {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: clamp(26px, 3.4vw, 36px);
+  font-weight: 500;
+  letter-spacing: -0.5px;
+  line-height: 1.18;
+  color: hsl(var(--foreground));
+  margin: 0;
+}
+.illu-section-sub {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: hsl(var(--muted-foreground));
+  margin: 14px 0 0;
+}
+
+/* Feature grid */
+.illu-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+}
+@media (max-width: 720px) {
+  .illu-feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.illu-feature-card {
+  background: #fff;
+  border: 0.7px solid hsl(var(--gray-200));
+  border-radius: 14px;
+  padding: 28px;
+  transition:
+    border-color 0.25s,
+    box-shadow 0.3s;
+}
+.illu-feature-card:hover {
+  border-color: hsl(var(--gray-300));
+  box-shadow: 0 18px 40px -28px rgba(20, 24, 30, 0.18);
+}
+.illu-feature-card h3 {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  color: hsl(var(--foreground));
+  margin: 0 0 10px;
+}
+.illu-feature-card p {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: hsl(var(--muted-foreground));
+  margin: 0;
+}
+
+/* Comparison table */
+.illu-compare-table {
+  border: 0.7px solid hsl(var(--gray-200));
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+.illu-compare-row {
+  display: grid;
+  grid-template-columns: 1.1fr 1.3fr 1.3fr;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 24px;
+  border-top: 0.7px solid hsl(var(--gray-200));
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 15px;
+}
+.illu-compare-row:first-child {
+  border-top: 0;
+}
+.illu-compare-head {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--gray-50));
+}
+.illu-compare-aspect {
+  font-weight: 500;
+  color: hsl(var(--foreground));
+}
+.illu-compare-generic {
+  color: hsl(var(--muted-foreground));
+}
+.illu-compare-cell {
+  color: hsl(var(--foreground));
+  font-weight: 500;
+}
+.illu-compare-zero-col {
+  position: relative;
+  color: #ed4e01;
+}
+.illu-compare-head .illu-compare-zero-col {
+  color: #ed4e01;
+}
+@media (max-width: 720px) {
+  .illu-compare-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+    padding: 16px 18px;
+  }
+  .illu-compare-head {
+    display: none;
+  }
+  .illu-compare-aspect {
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
+    margin-bottom: 4px;
+  }
+  .illu-compare-generic::before {
+    content: "Generic: ";
+    color: hsl(var(--muted-foreground));
+  }
+  .illu-compare-zero-col::before {
+    content: "Zero: ";
+    color: hsl(var(--muted-foreground));
+  }
+}
+
+/* Audience cards */
+.illu-audience-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+@media (max-width: 880px) {
+  .illu-audience-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.illu-audience-card {
+  border: 0.7px solid hsl(var(--gray-200));
+  border-radius: 14px;
+  padding: 28px;
+  background: #fff;
+}
+.illu-audience-card h3 {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 17px;
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  margin: 0 0 10px;
+}
+.illu-audience-card p {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  color: hsl(var(--muted-foreground));
+  margin: 0;
+}
+
+/* FAQ */
+.illu-faq-list {
+  max-width: 820px;
+  border-top: 0.7px solid hsl(var(--gray-200));
+}
+.illu-faq-item {
+  border-bottom: 0.7px solid hsl(var(--gray-200));
+}
+.illu-faq-item summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 22px 36px 22px 0;
+  position: relative;
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 17px;
+  font-weight: 500;
+  color: hsl(var(--foreground));
+}
+.illu-faq-item summary::-webkit-details-marker {
+  display: none;
+}
+.illu-faq-item summary::after {
+  content: "+";
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 22px;
+  font-weight: 400;
+  color: #ed4e01;
+  transition: transform 0.2s;
+}
+.illu-faq-item[open] summary::after {
+  content: "−";
+}
+.illu-faq-item p {
+  margin: 0;
+  padding: 0 36px 24px 0;
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+  color: hsl(var(--muted-foreground));
+}
+
+/* Gallery section spacing inside the funnel */
+.illu-gallery-section {
+  padding: 88px 0 120px;
+}
+@media (max-width: 720px) {
+  .illu-gallery-section {
+    padding: 56px 0 80px;
+  }
+}
+
+/* Final CTA */
+.illu-final-cta {
+  text-align: center;
+}
+.illu-final-cta .container {
+  max-width: 720px;
+}
+.illu-final-cta-title {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: clamp(26px, 3.6vw, 38px);
+  font-weight: 500;
+  letter-spacing: -0.5px;
+  line-height: 1.15;
+  color: hsl(var(--foreground));
+  margin: 0;
+}
+.illu-final-cta-sub {
+  font-family: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  color: hsl(var(--muted-foreground));
+  margin: 16px auto 28px;
+  max-width: 540px;
+}
+
 /* Masonry of plates */
 .illu-masonry {
   column-count: 3;


### PR DESCRIPTION
## What

Reframes `vm0.ai/[locale]/illustration` from a bare gallery grid into a **conversion-funnel landing page**, porting the *content structure / strategy* of a product tool landing page (e.g. manus.im/tools/ai-design) onto our illustration offering — **not** the visual style.

### New section arc (top → bottom)
1. **Hero** — value prop (`On-brand illustration in a house style that stays consistent`) + primary CTA `Try a style in Zero` + `Browse the gallery`. Keeps the compact meta line (style count, source register, render models).
2. **Feature grid** — 4 capability cards (locked styles · series consistency · brief-aware · invoke-as-skill).
3. **Comparison table** — "How this compares to a raw image generator" (generic AI image tool vs. Zero styles).
4. **Results gallery** — the existing masonry + lightbox, demoted to the social-proof slot (`#gallery`, "See what you can make"). Unchanged behavior.
5. **Who it's for** — 3 audience cards (founders · marketing/content · designers).
6. **FAQ** — 6 objection-handling Q/A via native `<details>`.
7. **Final CTA** — `Start in Zero`.

### Also
- Marketing copy extracted to `content.ts` (data, no logic).
- New funnel CSS added to `illustration.css`, reusing existing tokens (`#ed4e01` accent, Fraunces italic, Noto Sans, gray vars, `.container`).
- `page.tsx`: updated title/description to the product positioning; added **FAQPage** JSON-LD.

## Notes
- The style gallery, lightbox, and asset data (`ILLUSTRATION_STYLES` from `@vm0/core`) are untouched — every existing plate still renders.
- Prettier (3.8.1) and oxlint pass locally on the changed files. Relying on the PR pipeline for full build/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)