### PR TITLE
fix(vsock-guest): reject zero-sequence write_file requests

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -295,6 +295,9 @@ impl ConnectionDispatcher {
     }
 
     fn handle_write_file(&self, msg: &RawMessage) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, "write_file", &self.writer)? {
+            return Ok(());
+        }
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }

--- a/crates/vsock-guest/tests/connection/quiesce.rs
+++ b/crates/vsock-guest/tests/connection/quiesce.rs
@@ -96,6 +96,21 @@ fn quiesced_connection_rejects_write_file_without_creating_file() {
 }
 
 #[test]
+fn quiesced_connection_rejects_write_file_seq_zero_before_quiesce_state() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_quiesce_operations(&mut host_stream, 214);
+    let quiesced = read_message(&mut host_stream);
+    assert_eq!(quiesced.msg_type, MSG_OPERATIONS_QUIESCED);
+
+    send_control_payload(&mut host_stream, MSG_WRITE_FILE, 0, b"bad");
+    let error = read_error_response(&mut host_stream, 0);
+    assert_eq!(error, "write_file requires non-zero sequence");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn quiesced_connection_rejects_new_operation_without_decoding_payload() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -1,8 +1,10 @@
-use vsock_proto::MSG_WRITE_FILE;
+use std::path::Path;
+
+use vsock_proto::{self, MSG_WRITE_FILE};
 
 use super::support::{
     assert_ping_pong, finish_guest_connection, read_error_response, send_control_payload,
-    start_guest_connection,
+    start_guest_connection, unique_tmp_path,
 };
 
 #[test]
@@ -12,6 +14,21 @@ fn write_file_seq_zero_returns_error() {
     send_control_payload(&mut host_stream, MSG_WRITE_FILE, 0, b"bad");
     let error = read_error_response(&mut host_stream, 0);
     assert_eq!(error, "write_file requires non-zero sequence");
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn write_file_seq_zero_does_not_write_valid_payload() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let path = unique_tmp_path("write-file-seq-zero", ".txt");
+    let payload = vsock_proto::encode_write_file(path.as_str(), b"should-not-write", false, false)
+        .expect("encode write_file");
+
+    send_control_payload(&mut host_stream, MSG_WRITE_FILE, 0, &payload);
+    let error = read_error_response(&mut host_stream, 0);
+    assert_eq!(error, "write_file requires non-zero sequence");
+    assert!(!Path::new(path.as_str()).exists());
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -1,29 +1,24 @@
 use std::io::Write;
 
-use vsock_proto::{self, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT};
+use vsock_proto::{self, MSG_WRITE_FILE};
 
 use super::support::{
-    assert_ping_pong, finish_guest_connection, read_error_response, read_message,
-    send_control_payload, start_guest_connection, unique_tmp_path,
+    assert_ping_pong, finish_guest_connection, read_error_response, send_control_payload,
+    start_guest_connection,
 };
 
 #[test]
-fn write_file_seq_zero_is_not_rejected_as_invalid_sequence() {
+fn write_file_seq_zero_returns_error() {
     let (handle, mut host_stream) = start_guest_connection();
-    let path = unique_tmp_path("write-file-seq-zero", ".txt");
 
-    let payload = vsock_proto::encode_write_file(path.as_str(), b"ok", false, false).unwrap();
+    let payload =
+        vsock_proto::encode_write_file("/tmp/write-file-seq-zero.txt", b"ok", false, false)
+            .unwrap();
     let msg = vsock_proto::encode(MSG_WRITE_FILE, 0, &payload).unwrap();
     host_stream.write_all(&msg).unwrap();
 
-    let response = read_message(&mut host_stream);
-    assert_eq!(response.msg_type, MSG_WRITE_FILE_RESULT);
-    assert_eq!(response.seq, 0);
-    let (_success, error) = vsock_proto::decode_write_file_result(&response.payload).unwrap();
-    assert!(
-        !error.contains("non-zero sequence"),
-        "write_file seq=0 should reach the write_file handler, got: {error}"
-    );
+    let error = read_error_response(&mut host_stream, 0);
+    assert_eq!(error, "write_file requires non-zero sequence");
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -1,6 +1,4 @@
-use std::io::Write;
-
-use vsock_proto::{self, MSG_WRITE_FILE};
+use vsock_proto::MSG_WRITE_FILE;
 
 use super::support::{
     assert_ping_pong, finish_guest_connection, read_error_response, send_control_payload,
@@ -11,12 +9,7 @@ use super::support::{
 fn write_file_seq_zero_returns_error() {
     let (handle, mut host_stream) = start_guest_connection();
 
-    let payload =
-        vsock_proto::encode_write_file("/tmp/write-file-seq-zero.txt", b"ok", false, false)
-            .unwrap();
-    let msg = vsock_proto::encode(MSG_WRITE_FILE, 0, &payload).unwrap();
-    host_stream.write_all(&msg).unwrap();
-
+    send_control_payload(&mut host_stream, MSG_WRITE_FILE, 0, b"bad");
     let error = read_error_response(&mut host_stream, 0);
     assert_eq!(error, "write_file requires non-zero sequence");
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -41,9 +41,10 @@
 //! | 0x11 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
-//! Exec operation messages are request-scoped; host/guest dispatch layers must
-//! use a non-zero sequence number for exec
-//! start/started/output/result/cancel/control/control_result messages.
+//! Host-initiated operations that produce request-scoped replies must use
+//! non-zero sequence numbers. This covers `write_file`, `exec_start`,
+//! `exec_cancel`, and `exec_control`; guest exec lifecycle frames reuse the
+//! original non-zero request sequence.
 //! `exec_output.output_seq` is per exec operation and starts at 0,
 //! incrementing by 1 for each output frame across stdout and stderr.
 //! `exec_start.lifecycle` uses 0=one_shot and 1=supervised.

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -41,10 +41,9 @@
 //! | 0x11 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
-//! Host-initiated operations that produce request-scoped replies must use
-//! non-zero sequence numbers. This covers `write_file`, `exec_start`,
-//! `exec_cancel`, and `exec_control`; guest exec lifecycle frames reuse the
-//! original non-zero request sequence.
+//! Request-scoped operation messages must use non-zero sequence numbers. This
+//! covers `write_file`, `exec_start`, `exec_cancel`, and `exec_control`; guest
+//! exec lifecycle frames reuse the original non-zero request sequence.
 //! `exec_output.output_seq` is per exec operation and starts at 0,
 //! incrementing by 1 for each output frame across stdout and stderr.
 //! `exec_start.lifecycle` uses 0=one_shot and 1=supervised.


### PR DESCRIPTION
## Summary

- reject `MSG_WRITE_FILE` requests with sequence `0` before quiesce checks or payload decoding
- replace the weak seq-zero write-file test with an exact `MSG_ERROR` assertion
- keep malformed non-zero write-file payload coverage intact

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest write_file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy, commitlint

Closes #17294
