### PR TITLE
test: cover invalid utf8 write file paths

### DIFF
--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -260,6 +260,15 @@ mod tests {
     }
 
     #[test]
+    fn decode_write_file_rejects_invalid_utf8_path() {
+        let payload = [0, 1, 0xC3, 0, 0, 0, 0, 0];
+
+        let err = decode_write_file(&payload).unwrap_err();
+
+        assert_invalid_payload(err, "invalid UTF-8 in path");
+    }
+
+    #[test]
     fn decode_write_file_result_rejects_trailing_bytes() {
         let mut payload = encode_write_file_result(false, "permission denied");
         payload.push(0);


### PR DESCRIPTION
## Summary
- add decoder coverage for invalid UTF-8 write-file paths
- assert the existing protocol error contract for malformed path bytes

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto decode_write_file_rejects_invalid_utf8_path
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets -- -D warnings

Closes #17295