### PR TITLE
feat(api): gate webhook triggers behind a feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -327,6 +327,17 @@ describe("Automations v2 API", () => {
     );
     expect(viaAdd.body.error.message).toContain("not enabled");
 
+    // Rotation is gated before trigger resolution, so any id is rejected.
+    const viaRotate = await accept(
+      triggerApi().rotateSecret({
+        params: { id: "00000000-0000-0000-0000-000000000000" },
+        headers: SESSION_HEADERS,
+        body: {},
+      }),
+      [400],
+    );
+    expect(viaRotate.body.error.message).toContain("not enabled");
+
     // Time triggers stay fully available.
     const cron = await accept(
       refApi().addTrigger({

--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -108,12 +108,19 @@ async function seedFixture(): Promise<SchedulesFixture> {
   return fixture;
 }
 
-async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
+async function enableAutomations(
+  fixture: SchedulesFixture,
+  options?: { readonly webhookTriggers?: boolean },
+): Promise<void> {
   const db = store.set(writeDb$);
   await db.insert(userFeatureSwitches).values({
     orgId: fixture.orgId,
     userId: fixture.userId,
-    switches: { [FeatureSwitchKey.ZeroAutomations]: true },
+    switches: {
+      [FeatureSwitchKey.ZeroAutomations]: true,
+      [FeatureSwitchKey.AutomationWebhookTriggers]:
+        options?.webhookTriggers ?? true,
+    },
   });
 }
 
@@ -284,6 +291,52 @@ describe("Automations v2 API", () => {
       [200],
     );
     expect(Object.keys(shown.body)).not.toContain("webhookSecret");
+  });
+
+  it("rejects webhook trigger creation and rotation while the switch is off", async () => {
+    // Webhook triggers are a feature-gated NEW capability (#17307): with the
+    // switch off the surface stays feature-equivalent to legacy schedules.
+    const fixture = await seedFixture();
+    await enableAutomations(fixture, { webhookTriggers: false });
+
+    const viaSugar = await accept(
+      mainApi().create({
+        body: {
+          name: "gated-webhook",
+          agentId: fixture.composeId,
+          instruction: "Handle the hook",
+          trigger: { kind: "webhook" },
+        },
+        headers: SESSION_HEADERS,
+      }),
+      [400],
+    );
+    expect(viaSugar.body.error.message).toContain("not enabled");
+
+    const created = await createAutomation({
+      name: "gated-add",
+      agentId: fixture.composeId,
+    });
+    const viaAdd = await accept(
+      refApi().addTrigger({
+        params: { ref: created.automation.id },
+        body: { kind: "webhook" },
+        headers: SESSION_HEADERS,
+      }),
+      [400],
+    );
+    expect(viaAdd.body.error.message).toContain("not enabled");
+
+    // Time triggers stay fully available.
+    const cron = await accept(
+      refApi().addTrigger({
+        params: { ref: created.automation.id },
+        body: { kind: "cron", cronExpression: "0 9 * * *" },
+        headers: SESSION_HEADERS,
+      }),
+      [201],
+    );
+    expect(cron.body.trigger.kind).toBe("cron");
   });
 
   it("rejects an invalid cron expression, a past atTime, and a bad timezone", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
@@ -107,14 +107,18 @@ async function seedFixture(): Promise<SchedulesFixture> {
   return fixture;
 }
 
-async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
+async function enableAutomations(
+  fixture: SchedulesFixture,
+  options?: { readonly webhookTriggers?: boolean },
+): Promise<void> {
   const db = store.set(writeDb$);
   await db.insert(userFeatureSwitches).values({
     orgId: fixture.orgId,
     userId: fixture.userId,
     switches: {
       [FeatureSwitchKey.ZeroAutomations]: true,
-      [FeatureSwitchKey.AutomationWebhookTriggers]: true,
+      [FeatureSwitchKey.AutomationWebhookTriggers]:
+        options?.webhookTriggers ?? true,
     },
   });
 }
@@ -448,6 +452,24 @@ describe("Webhook automations management feature gating", () => {
       { method: "DELETE", headers: SESSION_HEADERS },
     );
     expect(del).toBe(404);
+  });
+
+  it("returns 404 creating when only the webhook trigger switch is off", async () => {
+    // Creating a webhook automation mints a webhook trigger, so it is gated
+    // by AutomationWebhookTriggers even with ZeroAutomations on (#17307).
+    const fixture = await seedFixture();
+    await enableAutomations(fixture, { webhookTriggers: false });
+
+    const create = await requestJson(
+      "/api/automations/webhooks",
+      jsonInit("POST", {
+        name: "blocked",
+        instruction: "Should not be created.",
+        agentId: fixture.composeId,
+      }),
+    );
+    expect(create.status).toBe(404);
+    expect(expectErrorCode(create)).toBe("NOT_FOUND");
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
@@ -112,7 +112,10 @@ async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
   await db.insert(userFeatureSwitches).values({
     orgId: fixture.orgId,
     userId: fixture.userId,
-    switches: { [FeatureSwitchKey.ZeroAutomations]: true },
+    switches: {
+      [FeatureSwitchKey.ZeroAutomations]: true,
+      [FeatureSwitchKey.AutomationWebhookTriggers]: true,
+    },
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-automation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-automation.test.ts
@@ -2,6 +2,7 @@ import { createHmac, randomUUID } from "node:crypto";
 
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -9,6 +10,8 @@ import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { afterEach } from "vitest";
+
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-helpers";
@@ -73,6 +76,7 @@ function sign(body: string, secret: string = WEBHOOK_SECRET): string {
 async function seedAutomation(args?: {
   readonly enabled?: boolean;
   readonly triggerEnabled?: boolean;
+  readonly webhookTriggersEnabled?: boolean;
 }): Promise<AutomationFixture> {
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   context.mocks.s3.send.mockResolvedValue({});
@@ -92,6 +96,16 @@ async function seedAutomation(args?: {
   mocks.clerk.session(schedules.userId, schedules.orgId);
 
   const db = store.set(writeDb$);
+  // Inbound dispatch evaluates the webhook-trigger switch against the
+  // automation's owner (#17307).
+  await db.insert(userFeatureSwitches).values({
+    orgId: schedules.orgId,
+    userId: schedules.userId,
+    switches: {
+      [FeatureSwitchKey.AutomationWebhookTriggers]:
+        args?.webhookTriggersEnabled ?? true,
+    },
+  });
   const [thread] = await db
     .insert(chatThreads)
     .values({
@@ -279,6 +293,19 @@ describe("POST /api/automations/webhooks/:token", () => {
 
   it("returns 404 for a disabled automation", async () => {
     const fixture = await seedAutomation({ enabled: false });
+    const body = JSON.stringify({ event: "ping" });
+
+    const response = await postWebhook(fixture.token, body, {
+      [SIGNATURE_HEADER]: sign(body),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when webhook triggers are not enabled for the owner", async () => {
+    // Webhook triggers are a feature-gated NEW capability (#17307): with the
+    // switch off for the automation's owner, the inbound hook is unreachable.
+    const fixture = await seedAutomation({ webhookTriggersEnabled: false });
     const body = JSON.stringify({ event: "ping" });
 
     const response = await postWebhook(fixture.token, body, {

--- a/turbo/apps/api/src/signals/routes/automations-v2.ts
+++ b/turbo/apps/api/src/signals/routes/automations-v2.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, computed } from "ccstate";
 import {
   automationsV2ByRefContract,
   automationsV2MainContract,
@@ -29,6 +29,9 @@ import {
   type AutomationViewV2,
 } from "../services/automations-v2.service";
 import { webhookUrlForToken } from "../services/webhook-automations.service";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { automationsEnabled$ } from "./automations";
 import type { RouteEntry } from "../route";
 
@@ -106,6 +109,25 @@ function automationResponse(view: AutomationViewV2): AutomationResponseV2 {
   };
 }
 
+// Webhook triggers are a NEW capability gated separately from the automation
+// surface itself (#17307): while off, automations stay feature-equivalent to
+// legacy schedules (time triggers only). Creating webhook triggers, rotating
+// their secrets, and the inbound dispatch all respect this switch.
+export const webhookTriggersEnabled$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.AutomationWebhookTriggers, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
+
+const WEBHOOK_TRIGGERS_DISABLED_MESSAGE =
+  "Webhook triggers are not enabled for this workspace";
+
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!(await get(automationsEnabled$))) {
     return notFound(NOT_FOUND_MESSAGE);
@@ -117,6 +139,13 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
+  if (
+    bodyResult.data.trigger?.kind === "webhook" &&
+    !(await get(webhookTriggersEnabled$))
+  ) {
+    return badRequestMessage(WEBHOOK_TRIGGERS_DISABLED_MESSAGE);
+  }
+  signal.throwIfAborted();
 
   const result = await set(
     createAutomationV2$,
@@ -329,6 +358,13 @@ const addTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
+  if (
+    bodyResult.data.kind === "webhook" &&
+    !(await get(webhookTriggersEnabled$))
+  ) {
+    return badRequestMessage(WEBHOOK_TRIGGERS_DISABLED_MESSAGE);
+  }
+  signal.throwIfAborted();
 
   const result = await set(
     addTriggerV2$,
@@ -471,6 +507,9 @@ const rotateSecretInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (!(await get(automationsEnabled$))) {
       return notFound(NOT_FOUND_MESSAGE);
+    }
+    if (!(await get(webhookTriggersEnabled$))) {
+      return badRequestMessage(WEBHOOK_TRIGGERS_DISABLED_MESSAGE);
     }
     signal.throwIfAborted();
     const auth = get(organizationAuthContext$);

--- a/turbo/apps/api/src/signals/routes/webhook-automations.ts
+++ b/turbo/apps/api/src/signals/routes/webhook-automations.ts
@@ -16,6 +16,7 @@ import {
   type WebhookAutomationView,
 } from "../services/webhook-automations.service";
 import { automationsEnabled$ } from "./automations";
+import { webhookTriggersEnabled$ } from "./automations-v2";
 import type { RouteEntry } from "../route";
 
 function toResponse(view: WebhookAutomationView): WebhookAutomationResponse {
@@ -24,6 +25,11 @@ function toResponse(view: WebhookAutomationView): WebhookAutomationResponse {
 
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!(await get(automationsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  // Creating a webhook automation mints a webhook trigger — gated like the
+  // resource API's webhook trigger creation (#17307).
+  if (!(await get(webhookTriggersEnabled$))) {
     return notFound("Resource not found");
   }
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/webhooks-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-automation.service.ts
@@ -1,10 +1,13 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
-import { command } from "ccstate";
+import { command, computed } from "ccstate";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, count, eq, gte } from "drizzle-orm";
+
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
@@ -12,6 +15,7 @@ import { safeJsonParse, settle } from "../utils";
 import { decryptStoredSecretValue } from "./crypto.utils";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { postAutomationUserMessage } from "../routes/zero-chat-messages";
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import {
   DefaultInterpreter,
   webhookRowToAutomation,
@@ -95,6 +99,37 @@ async function isWebhookRateLimited(
   return (recent?.value ?? 0) >= RATE_LIMIT_MAX_RUNS;
 }
 
+// Signature verification is required: a trigger without a stored secret can
+// never authenticate a caller, so it is unreachable rather than open.
+async function verifyInboundSignature(args: {
+  readonly encryptedSecret: string | null;
+  readonly signature: string | null;
+  readonly rawBody: string;
+}): Promise<boolean> {
+  if (!args.encryptedSecret || !args.signature) {
+    return false;
+  }
+  const secret = await decryptStoredSecretValue(args.encryptedSecret);
+  return await verifySignature({
+    secret,
+    signature: args.signature,
+    body: args.rawBody,
+  });
+}
+
+// Webhook triggers are feature-gated (#17307). Inbound calls carry no
+// requester auth, so the switch is evaluated against the automation's owner.
+function webhookTriggersEnabledForOwner(orgId: string, userId: string) {
+  return computed(async (get) => {
+    const overrides = await get(userFeatureSwitchOverrides(orgId, userId));
+    return isFeatureEnabled(FeatureSwitchKey.AutomationWebhookTriggers, {
+      orgId,
+      userId,
+      overrides,
+    });
+  });
+}
+
 /**
  * Dispatch an inbound webhook: resolve the automation by trigger token, verify
  * the HMAC signature, enforce the per-automation rate limit, then interpret the
@@ -104,7 +139,7 @@ async function isWebhookRateLimited(
  */
 export const dispatchAutomationWebhook$ = command(
   async (
-    { set },
+    { get, set },
     args: {
       readonly token: string;
       readonly signature: string | null;
@@ -146,21 +181,21 @@ export const dispatchAutomationWebhook$ = command(
       return { kind: "not_found" };
     }
 
-    // Signature verification is required: a trigger without a stored secret can
-    // never authenticate a caller, so it is unreachable rather than open.
-    if (!row.encryptedSecret || !args.signature) {
-      return { kind: "unauthorized" };
+    const gateEnabled = await get(
+      webhookTriggersEnabledForOwner(row.orgId, row.userId),
+    );
+    signal.throwIfAborted();
+    if (!gateEnabled) {
+      return { kind: "not_found" };
     }
 
-    const secret = await decryptStoredSecretValue(row.encryptedSecret);
-    signal.throwIfAborted();
-    const verified = await verifySignature({
-      secret,
+    const authorized = await verifyInboundSignature({
+      encryptedSecret: row.encryptedSecret,
       signature: args.signature,
-      body: args.rawBody,
+      rawBody: args.rawBody,
     });
     signal.throwIfAborted();
-    if (!verified) {
+    if (!authorized) {
       return { kind: "unauthorized" };
     }
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -63,4 +63,5 @@ export enum FeatureSwitchKey {
   ChatInlineFeedback = "chatInlineFeedback",
   CreditUsageRecords = "creditUsageRecords",
   ZeroAutomations = "zeroAutomations",
+  AutomationWebhookTriggers = "automationWebhookTriggers",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -358,6 +358,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.AutomationWebhookTriggers]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Allow webhook triggers on automations: creating them (API + CLI sugar), the inbound dispatch endpoint, and secret rotation. Webhook triggers are a NEW capability on top of the schedule-parity automation surface; while off, automations are feature-equivalent to legacy schedules (time triggers only).",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

**#17307 decision 4** — webhook triggers are a NEW capability on top of the schedule-parity automation surface (legacy schedules never had them; the inbound endpoint has no external consumers yet — 0 webhook trigger rows in prod). This PR gates the whole capability behind a new `automationWebhookTriggers` feature switch (staff-only default, like `zeroAutomations`), so that **with the switch off, automations are feature-equivalent to legacy schedules** (time triggers only).

## Gated paths

| Path | Off behavior |
|---|---|
| `POST /api/v2/automations` with `trigger: {kind: webhook}` sugar | 400 "Webhook triggers are not enabled…" |
| `POST /api/v2/automations/:ref/triggers` kind=webhook | 400 |
| `POST /api/v2/automation-triggers/:id/rotate-secret` | 400 |
| legacy `POST /api/automations/webhooks` (create) | 404 |
| inbound `POST /api/automations/webhooks/:token` | 404 — evaluated against the **automation owner** (inbound calls carry no requester auth) |

Time triggers (cron/once/loop) are untouched at every path.

## Tests

New off-state cases: sugar create 400, trigger add 400 (with cron still 201 in the same automation), inbound 404 for a gated owner. Existing webhook suites updated to enable the switch in fixtures (34 tests across 3 suites green).

Part of #17307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)