### PR TITLE
fix(web): keep nav dropdown open on trigger click and modifier clicks

### DIFF
--- a/turbo/apps/web/app/components/NavMenu.tsx
+++ b/turbo/apps/web/app/components/NavMenu.tsx
@@ -61,6 +61,13 @@ export function NavMenu({
         onPointerEnter={onOpen}
         onFocus={onOpen}
         onBlur={onScheduleClose}
+        onClick={(event) => {
+          // The menu is hover/focus driven; a click must never toggle it shut.
+          // preventDefault stops Radix's onOpenToggle from closing an already
+          // open menu, then we keep it open explicitly (covers touch taps too).
+          event.preventDefault();
+          onOpen();
+        }}
       >
         {label}
         <IconChevronDown
@@ -102,6 +109,21 @@ interface NavMenuRowProps {
 }
 
 function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    // Modifier or non-primary clicks open the link in a new tab/window; keep
+    // the menu open so several items can be opened in a row without re-hovering.
+    if (
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.button !== 0
+    ) {
+      return;
+    }
+    onSelect();
+  };
+
   const body = (
     <>
       <Image
@@ -134,7 +156,7 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
         target="_blank"
         rel="noopener noreferrer"
         className="nav-popover-item"
-        onClick={onSelect}
+        onClick={handleClick}
       >
         {body}
       </a>
@@ -142,7 +164,7 @@ function NavMenuRow({ item, onSelect }: NavMenuRowProps) {
   }
 
   return (
-    <Link href={item.href} className="nav-popover-item" onClick={onSelect}>
+    <Link href={item.href} className="nav-popover-item" onClick={handleClick}>
       {body}
     </Link>
   );

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -289,6 +289,21 @@ describe("Navbar dropdown interactions", () => {
     expect(resources).not.toHaveClass("nav-trigger-active");
   });
 
+  it("keeps the open menu when a dropdown item is opened with a modifier click", () => {
+    renderNavbarClient();
+
+    const resources = getDesktopNavTrigger("resources");
+    fireEvent.pointerEnter(resources);
+    expect(resources).toHaveClass("nav-trigger-active");
+
+    const firstItem =
+      document.querySelector<HTMLAnchorElement>(".nav-popover-item");
+    expect(firstItem).not.toBeNull();
+    fireEvent.click(firstItem!, { metaKey: true });
+
+    expect(resources).toHaveClass("nav-trigger-active");
+  });
+
   it("does not reopen from trigger focus restoration after a dropdown item click", () => {
     vi.useFakeTimers();
     try {

--- a/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx
@@ -289,6 +289,20 @@ describe("Navbar dropdown interactions", () => {
     expect(resources).not.toHaveClass("nav-trigger-active");
   });
 
+  it("keeps the menu open when the already-open trigger is clicked", () => {
+    renderNavbarClient();
+
+    const resources = getDesktopNavTrigger("resources");
+    fireEvent.pointerEnter(resources);
+    expect(resources).toHaveClass("nav-trigger-active");
+
+    // Clicking the trigger (e.g. a touch tap, or cmd-clicking to open the
+    // trigger label itself) must not toggle the hover-opened menu shut.
+    fireEvent.click(resources);
+
+    expect(resources).toHaveClass("nav-trigger-active");
+  });
+
   it("keeps the open menu when a dropdown item is opened with a modifier click", () => {
     renderNavbarClient();
 


### PR DESCRIPTION
## Summary

Ethan reported the marketing nav dropdowns (Explore / Resources / Trust & Tech) feel unhandy:

1. **Click dismisses the menu** — especially cmd-click to open in a new tab; you then have to hover again.
2. **Hover and click both respond** — after hover opens it, a click closes it again.

Both menus are hover/focus driven (the shared hotzone controller from #13081), but two click paths in `NavMenu.tsx` were fighting that model:

- The Radix `Popover.Trigger` toggles on click, so clicking an already-open trigger closes it.
- `NavMenuRow`'s `onClick` always called `onSelect()` (which closes the menu) for **every** click — including cmd/ctrl/shift/middle clicks that open the link in a new tab. So you couldn't open several items in a row without re-hovering.

## Changes

`turbo/apps/web/app/components/NavMenu.tsx`
- **Trigger:** add an `onClick` that `preventDefault()`s Radix's toggle and keeps the menu open (also covers touch taps). Clicking no longer dismisses a hovered-open menu.
- **Item rows:** only close the menu on a plain primary click (actual same-tab navigation). Modifier / non-primary clicks now leave the menu open so you can open multiple items in new tabs.

`turbo/apps/web/app/components/__tests__/navbar-blog.test.tsx`
- Add a test asserting a modifier (cmd) click on a dropdown item keeps the menu open.

## Test plan

- [ ] Hover Resources / Trust & Tech, then click the trigger — menu stays open.
- [ ] cmd-click multiple items — each opens in a new tab, menu stays open.
- [ ] Plain click an item — navigates and closes the menu.
- [ ] Move pointer away — still closes after ~250ms (hotzone behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)