### PR TITLE
fix: show computer use offline status

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -99,7 +99,7 @@ describe("ComputerUseHostRuntime", () => {
 
     await vi.advanceTimersByTimeAsync(60_000);
 
-    expect(runtime.getState().status).toBe("idle");
+    expect(runtime.getState().status).toBe("offline");
     expect(sessionFetch).not.toHaveBeenCalled();
     expect(hostFetch).not.toHaveBeenCalled();
   });
@@ -692,7 +692,7 @@ describe("ComputerUseHostRuntime", () => {
     expect(stopCall[1]?.method).toBe("POST");
     expect(headers.get("authorization")).toBe("Bearer token-1");
     expect(runtime.getState()).toMatchObject({
-      status: "idle",
+      status: "offline",
       hostId: null,
       lastError: null,
     });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -212,7 +212,7 @@ export class ComputerUseHostRuntime {
   private hostToken: string | null = null;
   private nextErrorLogId = 0;
   private state: ComputerUseHostRuntimeState = {
-    status: "idle",
+    status: "offline",
     hostId: null,
     lastHeartbeatAt: null,
     lastCommandAt: null,
@@ -261,7 +261,7 @@ export class ComputerUseHostRuntime {
     this.clearRecoveryTimer();
     const hostToken = this.hostToken;
     this.setState({
-      status: "idle",
+      status: "offline",
       hostId: null,
       lastError: null,
       recovery: null,

--- a/turbo/apps/desktop/src/computer-use-startup-gate.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.ts
@@ -1,6 +1,6 @@
 import type { DesktopAuthState } from "./desktop-bridge";
 import {
-  IDLE_COMPUTER_USE_HOST_STATE,
+  OFFLINE_COMPUTER_USE_HOST_STATE,
   hasRequiredComputerUsePermissions,
   type ComputerUseHostRuntimeState,
   type ComputerUsePermissionState,
@@ -42,7 +42,7 @@ export function resolveComputerUseStartupGate(args: {
     return {
       status: "blocked",
       host: {
-        ...IDLE_COMPUTER_USE_HOST_STATE,
+        ...OFFLINE_COMPUTER_USE_HOST_STATE,
         status: "unauthenticated",
         lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
       },
@@ -53,7 +53,7 @@ export function resolveComputerUseStartupGate(args: {
     return {
       status: "blocked",
       host: {
-        ...IDLE_COMPUTER_USE_HOST_STATE,
+        ...OFFLINE_COMPUTER_USE_HOST_STATE,
         status: "needs_organization",
         lastError: COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
       },

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -6,7 +6,7 @@ export interface ComputerUsePermissionState {
 }
 
 export type ComputerUseHostRuntimeStatus =
-  | "idle"
+  | "offline"
   | "connecting"
   | "online"
   | "recovering"
@@ -104,9 +104,9 @@ export function hasRequiredComputerUsePermissions(
   return permissions.accessibility && permissions.screenRecording;
 }
 
-export const IDLE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =
+export const OFFLINE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =
   Object.freeze({
-    status: "idle",
+    status: "offline",
     hostId: null,
     lastHeartbeatAt: null,
     lastCommandAt: null,

--- a/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
@@ -37,7 +37,7 @@ function hostState(
   overrides: Partial<ComputerUseHostRuntimeState>,
 ): ComputerUseHostRuntimeState {
   return {
-    status: "idle",
+    status: "offline",
     hostId: null,
     lastHeartbeatAt: null,
     lastCommandAt: null,

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DesktopConfig } from "./config";
-import { IDLE_COMPUTER_USE_HOST_STATE } from "./computer-use-types";
+import { OFFLINE_COMPUTER_USE_HOST_STATE } from "./computer-use-types";
 import type { ComputerUseHostRuntimeState } from "./computer-use-types";
 import { installDesktopAutoUpdates } from "./desktop-auto-updates";
 
@@ -120,9 +120,9 @@ describe("desktop auto-updates", () => {
     });
   });
 
-  it("silently restarts after a downloaded update when Computer Use is idle", async () => {
+  it("silently restarts after a downloaded update when Computer Use is offline", async () => {
     const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => IDLE_COMPUTER_USE_HOST_STATE);
+      installAndCaptureUpdateOptions(() => OFFLINE_COMPUTER_USE_HOST_STATE);
 
     updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
 
@@ -136,7 +136,7 @@ describe("desktop auto-updates", () => {
   it("prompts instead of silently restarting during recent command activity", async () => {
     const { updateOptions, prepareForQuitAndInstall } =
       installAndCaptureUpdateOptions(() => ({
-        ...IDLE_COMPUTER_USE_HOST_STATE,
+        ...OFFLINE_COMPUTER_USE_HOST_STATE,
         lastCommandAt: new Date().toISOString(),
       }));
 

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./desktop-tray-menu";
 
 const baseHostState: ComputerUseHostRuntimeState = {
-  status: "idle",
+  status: "offline",
   hostId: null,
   lastHeartbeatAt: null,
   lastCommandAt: null,
@@ -189,18 +189,18 @@ describe("desktop tray menu", () => {
     expect(setKeepAwakeEnabled).toHaveBeenCalledWith(false);
   });
 
-  it("enables starting Computer Use when ready and signed in", () => {
+  it("enables starting Computer Use when offline and signed in", () => {
     const startComputerUse = vi.fn();
     const menu = buildDesktopTrayMenuItems(
       {
-        computerUse: computerUseState({ status: "idle" }),
+        computerUse: computerUseState({ status: "offline" }),
         auth: signedInAuth,
         authError: null,
       },
       trayActions({ startComputerUse }),
     );
 
-    const computerUseMenu = submenu(findItem(menu, "Computer Use: Ready"));
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Offline"));
     const startItem = findItem(computerUseMenu, "Start Computer Use");
 
     expect(startItem.enabled).toBe(true);
@@ -253,7 +253,7 @@ describe("desktop tray menu", () => {
     const openSignIn = vi.fn();
     const menu = buildDesktopTrayMenuItems(
       {
-        computerUse: computerUseState({ status: "idle" }),
+        computerUse: computerUseState({ status: "offline" }),
         auth: {
           status: "signed_out",
           user: null,
@@ -276,7 +276,7 @@ describe("desktop tray menu", () => {
   it("shows signing in and disables start while auth is signing in", () => {
     const menu = buildDesktopTrayMenuItems(
       {
-        computerUse: computerUseState({ status: "idle" }),
+        computerUse: computerUseState({ status: "offline" }),
         auth: signingInAuth,
         authError: null,
       },
@@ -293,10 +293,10 @@ describe("desktop tray menu", () => {
     expect(findItem(computerUseMenu, "Signing in...").enabled).toBe(false);
   });
 
-  it("keeps stale signed-in auth from showing ready while auth is loading", () => {
+  it("keeps stale signed-in auth from showing offline while auth is loading", () => {
     const menu = buildDesktopTrayMenuItems(
       {
-        computerUse: computerUseState({ status: "idle" }),
+        computerUse: computerUseState({ status: "offline" }),
         auth: signedInAuth,
         authLoading: true,
         authError: null,
@@ -322,7 +322,7 @@ describe("desktop tray menu", () => {
     const menu = buildDesktopTrayMenuItems(
       {
         computerUse: computerUseState(
-          { status: "idle" },
+          { status: "offline" },
           { accessibility: false, screenRecording: false },
         ),
         auth: signedInAuth,
@@ -355,7 +355,7 @@ describe("desktop tray menu", () => {
     const openScreenRecordingSettings = vi.fn();
     const menu = buildDesktopTrayMenuItems(
       {
-        computerUse: computerUseState({ status: "idle" }),
+        computerUse: computerUseState({ status: "offline" }),
         auth: signedInAuth,
         authError: null,
       },
@@ -365,8 +365,8 @@ describe("desktop tray menu", () => {
       }),
     );
 
-    const computerUseMenu = submenu(findItem(menu, "Computer Use: Ready"));
-    expect(findItem(computerUseMenu, "Status: Ready").enabled).toBe(false);
+    const computerUseMenu = submenu(findItem(menu, "Computer Use: Offline"));
+    expect(findItem(computerUseMenu, "Status: Offline").enabled).toBe(false);
     expect(findItem(computerUseMenu, "Accessibility: Ready").enabled).toBe(
       false,
     );

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -7,7 +7,7 @@ import {
 } from "./computer-use-types";
 
 const HOST_STATUS_LABELS = {
-  idle: "Ready",
+  offline: "Offline",
   connecting: "Starting...",
   online: "Online",
   recovering: "Recovering",
@@ -73,7 +73,7 @@ function computerUseStatusLabel(state: DesktopTrayMenuState): string {
   if (!hasRequiredComputerUsePermissions(state.computerUse.permissions)) {
     return "Needs permissions";
   }
-  if (state.computerUse.host.status !== "idle") {
+  if (state.computerUse.host.status !== "offline") {
     return HOST_STATUS_LABELS[state.computerUse.host.status];
   }
   if (isAuthLoading(state)) {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -26,7 +26,7 @@ import {
 } from "./computer-use-host";
 import {
   COMPUTER_USE_FEATURE_SWITCH_KEY,
-  IDLE_COMPUTER_USE_HOST_STATE,
+  OFFLINE_COMPUTER_USE_HOST_STATE,
   hasRequiredComputerUsePermissions,
   type ComputerUseHostRuntimeState,
   type DesktopComputerUseState,
@@ -283,7 +283,7 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
     host:
       computerUseRuntime?.getState() ??
       computerUseBlockedHostState ??
-      IDLE_COMPUTER_USE_HOST_STATE,
+      OFFLINE_COMPUTER_USE_HOST_STATE,
     keepAwake: keepAwakeController?.getState() ?? {
       enabled: false,
       active: false,

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -60,7 +60,7 @@ interface ScreenshotPreview {
 }
 
 const STATUS_LABELS = {
-  idle: "Idle",
+  offline: "Offline",
   connecting: "Connecting",
   online: "Online",
   recovering: "Recovering",

--- a/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.test.ts
@@ -19,7 +19,7 @@ function computerUseState(
       active: false,
     },
     host: {
-      status: "idle",
+      status: "offline",
       hostId: null,
       lastHeartbeatAt: null,
       lastCommandAt: null,

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -49,7 +49,7 @@ export function shouldAutoStartComputerUse(
     stateValue.supported &&
     hasReadyDesktopAuth(authState) &&
     hasRequiredComputerUsePermissions(stateValue.permissions) &&
-    (stateValue.host.status === "idle" ||
+    (stateValue.host.status === "offline" ||
       stateValue.host.status === "unauthenticated")
   );
 }

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -696,7 +696,7 @@ button {
   background: #ecfdf3;
 }
 
-.status-idle {
+.status-offline {
   color: #3d4a5c;
   background: #eef2f6;
 }


### PR DESCRIPTION
## Summary
- rename the local Computer Use runtime idle state to offline
- show Offline consistently in the desktop tray and main runtime panel
- keep the command-poll idle response unchanged because it means no command is available

## Tests
- pnpm --dir turbo/apps/desktop exec vitest run src/desktop-tray-menu.test.ts src/renderer/computer-use-state.test.ts src/computer-use-host.test.ts src/desktop-auto-update-policy.test.ts src/desktop-auto-updates.test.ts
- pnpm --dir turbo/apps/desktop check-types
- pnpm --dir turbo/apps/desktop lint
- pnpm --dir turbo exec prettier --write <changed desktop files>
- git diff --check