### PR TITLE
test(runner): move axiom layer tests into source tree

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -62,6 +62,8 @@ const _: () = assert!(
 const DEBUG_FIELD_MAX_BYTES: usize = 4 * 1024;
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
+const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
+const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 /// Target used for this layer's own diagnostics. Dispatcher diagnostics
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
@@ -102,13 +104,21 @@ impl AxiomGuard {
 /// caller should install a `None` layer in that case (no-op). Production
 /// entry point; always targets `DEFAULT_AXIOM_URL`.
 pub(crate) fn init() -> Option<(AxiomLayer, AxiomGuard)> {
-    let token = std::env::var("AXIOM_TOKEN_TELEMETRY")
-        .ok()
-        .filter(|s| !s.is_empty())?;
-    let suffix = std::env::var("AXIOM_DATASET_SUFFIX")
-        .ok()
-        .filter(|s| !s.is_empty())?;
-    init_with_base_url(DEFAULT_AXIOM_URL, &token, &suffix)
+    init_from_env_values(
+        DEFAULT_AXIOM_URL,
+        std::env::var(AXIOM_TOKEN_ENV).ok(),
+        std::env::var(AXIOM_SUFFIX_ENV).ok(),
+    )
+}
+
+fn init_from_env_values(
+    base_url: &str,
+    token: Option<String>,
+    suffix: Option<String>,
+) -> Option<(AxiomLayer, AxiomGuard)> {
+    let token = token.filter(|s| !s.is_empty())?;
+    let suffix = suffix.filter(|s| !s.is_empty())?;
+    init_with_base_url(base_url, &token, &suffix)
 }
 
 /// Core init with an explicit base URL. Exists so module tests can point

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -111,11 +111,11 @@ pub(crate) fn init() -> Option<(AxiomLayer, AxiomGuard)> {
     init_with_base_url(DEFAULT_AXIOM_URL, &token, &suffix)
 }
 
-/// Core init with an explicit base URL. Exists so integration tests can point
+/// Core init with an explicit base URL. Exists so module tests can point
 /// at an `httpmock` server without leaking an `AXIOM_URL` override into the
 /// runner's production env surface — production code should always call
 /// [`init`], which hard-codes [`DEFAULT_AXIOM_URL`].
-pub(crate) fn init_with_base_url(
+fn init_with_base_url(
     base_url: &str,
     token: &str,
     suffix: &str,
@@ -356,3 +356,7 @@ fn serialize_event(event: &Event<'_>) -> Value {
     out.insert("service".into(), Value::String(SERVICE_NAME.into()));
     Value::Object(out)
 }
+
+#[cfg(test)]
+#[path = "axiom_layer_tests.rs"]
+mod tests;

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -7,6 +7,7 @@
 //!
 //! Env vars are process-global, so tests serialize on `ENV_LOCK`.
 
+use std::ffi::{OsStr, OsString};
 use std::sync::{Arc, Mutex};
 
 use super::{INTERNAL_TARGET, init, init_with_base_url, with_ingest_filter};
@@ -17,6 +18,8 @@ use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
+const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 
 #[derive(Clone, Debug)]
 struct RecordedEvent {
@@ -77,16 +80,48 @@ where
     }
 }
 
-fn clear_axiom_env() {
-    // SAFETY: setenv is not thread-safe, but we hold ENV_LOCK for the
-    // duration of every test that touches these vars.
-    unsafe {
-        std::env::remove_var("AXIOM_TOKEN_TELEMETRY");
-        std::env::remove_var("AXIOM_DATASET_SUFFIX");
+struct AxiomEnvRestore {
+    token: Option<OsString>,
+    suffix: Option<OsString>,
+}
+
+impl AxiomEnvRestore {
+    fn capture() -> Self {
+        Self {
+            token: std::env::var_os(AXIOM_TOKEN_ENV),
+            suffix: std::env::var_os(AXIOM_SUFFIX_ENV),
+        }
     }
 }
 
-/// Acquire `ENV_LOCK`, run `f` with env state captured, then drop the lock.
+impl Drop for AxiomEnvRestore {
+    fn drop(&mut self) {
+        restore_env(AXIOM_TOKEN_ENV, self.token.as_deref());
+        restore_env(AXIOM_SUFFIX_ENV, self.suffix.as_deref());
+    }
+}
+
+fn restore_env(key: &str, value: Option<&OsStr>) {
+    // SAFETY: setenv is not thread-safe, but the restore guard is dropped
+    // before ENV_LOCK, so every Axiom env mutation stays serialized.
+    unsafe {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+}
+
+fn clear_axiom_env() {
+    // SAFETY: setenv is not thread-safe, but we hold ENV_LOCK for every Axiom
+    // env mutation and restore the original values before releasing the lock.
+    unsafe {
+        std::env::remove_var(AXIOM_TOKEN_ENV);
+        std::env::remove_var(AXIOM_SUFFIX_ENV);
+    }
+}
+
+/// Acquire `ENV_LOCK`, run `f` with env state captured, restore, then unlock.
 /// `f` does the env setup and returns anything cheap (e.g. a layer + guard).
 /// The lock never spans an `.await` — `init` owns its env reads
 /// synchronously, and the returned dispatcher holds owned strings.
@@ -95,6 +130,7 @@ fn with_env<T>(f: impl FnOnce() -> T) -> T {
     // only means a previous test panicked while holding it, which doesn't
     // corrupt the `()` payload.
     let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _restore = AxiomEnvRestore::capture();
     clear_axiom_env();
     f()
 }
@@ -260,8 +296,8 @@ async fn init_returns_none_when_env_missing() {
 async fn init_returns_none_when_token_empty() {
     let result = with_env(|| {
         unsafe {
-            std::env::set_var("AXIOM_TOKEN_TELEMETRY", "");
-            std::env::set_var("AXIOM_DATASET_SUFFIX", "dev");
+            std::env::set_var(AXIOM_TOKEN_ENV, "");
+            std::env::set_var(AXIOM_SUFFIX_ENV, "dev");
         }
         init()
     });

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -5,21 +5,15 @@
 //! that events flow through the layer → channel → dispatcher → POST
 //! endpoint with the TS-compatible payload shape.
 //!
-//! Env vars are process-global, so tests serialize on `ENV_LOCK`.
 
-use std::ffi::{OsStr, OsString};
 use std::sync::{Arc, Mutex};
 
-use super::{INTERNAL_TARGET, init, init_with_base_url, with_ingest_filter};
+use super::{INTERNAL_TARGET, init_from_env_values, init_with_base_url, with_ingest_filter};
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
-
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
-const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 
 #[derive(Clone, Debug)]
 struct RecordedEvent {
@@ -78,61 +72,6 @@ where
                 message: visitor.message,
             });
     }
-}
-
-struct AxiomEnvRestore {
-    token: Option<OsString>,
-    suffix: Option<OsString>,
-}
-
-impl AxiomEnvRestore {
-    fn capture() -> Self {
-        Self {
-            token: std::env::var_os(AXIOM_TOKEN_ENV),
-            suffix: std::env::var_os(AXIOM_SUFFIX_ENV),
-        }
-    }
-}
-
-impl Drop for AxiomEnvRestore {
-    fn drop(&mut self) {
-        restore_env(AXIOM_TOKEN_ENV, self.token.as_deref());
-        restore_env(AXIOM_SUFFIX_ENV, self.suffix.as_deref());
-    }
-}
-
-fn restore_env(key: &str, value: Option<&OsStr>) {
-    // SAFETY: setenv is not thread-safe, but the restore guard is dropped
-    // before ENV_LOCK, so every Axiom env mutation stays serialized.
-    unsafe {
-        match value {
-            Some(value) => std::env::set_var(key, value),
-            None => std::env::remove_var(key),
-        }
-    }
-}
-
-fn clear_axiom_env() {
-    // SAFETY: setenv is not thread-safe, but we hold ENV_LOCK for every Axiom
-    // env mutation and restore the original values before releasing the lock.
-    unsafe {
-        std::env::remove_var(AXIOM_TOKEN_ENV);
-        std::env::remove_var(AXIOM_SUFFIX_ENV);
-    }
-}
-
-/// Acquire `ENV_LOCK`, run `f` with env state captured, restore, then unlock.
-/// `f` does the env setup and returns anything cheap (e.g. a layer + guard).
-/// The lock never spans an `.await` — `init` owns its env reads
-/// synchronously, and the returned dispatcher holds owned strings.
-fn with_env<T>(f: impl FnOnce() -> T) -> T {
-    // `unwrap_or_else` handles poison by reusing the inner guard — poisoning
-    // only means a previous test panicked while holding it, which doesn't
-    // corrupt the `()` payload.
-    let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-    let _restore = AxiomEnvRestore::capture();
-    clear_axiom_env();
-    f()
 }
 
 #[tokio::test]
@@ -286,21 +225,19 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
     internal_mock.assert_calls_async(0).await;
 }
 
-#[tokio::test]
-async fn init_returns_none_when_env_missing() {
-    let result = with_env(init);
+#[test]
+fn init_returns_none_when_env_missing() {
+    let result = init_from_env_values("https://example.invalid", None, None);
     assert!(result.is_none());
 }
 
-#[tokio::test]
-async fn init_returns_none_when_token_empty() {
-    let result = with_env(|| {
-        unsafe {
-            std::env::set_var(AXIOM_TOKEN_ENV, "");
-            std::env::set_var(AXIOM_SUFFIX_ENV, "dev");
-        }
-        init()
-    });
+#[test]
+fn init_returns_none_when_token_empty() {
+    let result = init_from_env_values(
+        "https://example.invalid",
+        Some(String::new()),
+        Some("dev".to_string()),
+    );
     assert!(result.is_none());
 }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the Axiom tracing layer.
+//! Tests for the Axiom tracing layer.
 //!
 //! The layer + its dispatcher run for real; only the network boundary is
 //! mocked (`httpmock` stands in for `https://api.axiom.co`). Tests verify
@@ -7,11 +7,9 @@
 //!
 //! Env vars are process-global, so tests serialize on `ENV_LOCK`.
 
-#[path = "../src/axiom_layer.rs"]
-mod axiom_layer;
-
 use std::sync::{Arc, Mutex};
 
+use super::{INTERNAL_TARGET, init, init_with_base_url, with_ingest_filter};
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use tracing::field::{Field, Visit};
@@ -19,7 +17,6 @@ use tracing::{Event, Subscriber};
 use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
 #[derive(Clone, Debug)]
 struct RecordedEvent {
@@ -91,7 +88,7 @@ fn clear_axiom_env() {
 
 /// Acquire `ENV_LOCK`, run `f` with env state captured, then drop the lock.
 /// `f` does the env setup and returns anything cheap (e.g. a layer + guard).
-/// The lock never spans an `.await` — `axiom_layer::init` owns its env reads
+/// The lock never spans an `.await` — `init` owns its env reads
 /// synchronously, and the returned dispatcher holds owned strings.
 fn with_env<T>(f: impl FnOnce() -> T) -> T {
     // `unwrap_or_else` handles poison by reusing the inner guard — poisoning
@@ -140,12 +137,12 @@ async fn warn_and_error_events_are_ingested_with_ts_shape() {
         })
         .await;
 
-    // Use the test-only `init_with_base_url` to redirect at the mock server.
+    // Use the internal `init_with_base_url` to redirect at the mock server.
     // `init()` always targets api.axiom.co and can't be pointed elsewhere.
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "test-token", "test")
+    let (layer, guard) = init_with_base_url(&server.base_url(), "test-token", "test")
         .expect("init_with_base_url must succeed");
 
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::warn!(foo = "bar", "a warning");
@@ -200,12 +197,12 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
     let recording = RecordingLayer::default();
     let subscriber = tracing_subscriber::registry()
         .with(recording.clone())
-        .with(axiom_layer::with_ingest_filter(layer));
+        .with(with_ingest_filter(layer));
 
     {
         let _sub = tracing::subscriber::set_default(subscriber);
@@ -255,7 +252,7 @@ async fn axiom_filter_does_not_suppress_sibling_local_layers() {
 
 #[tokio::test]
 async fn init_returns_none_when_env_missing() {
-    let result = with_env(axiom_layer::init);
+    let result = with_env(init);
     assert!(result.is_none());
 }
 
@@ -266,7 +263,7 @@ async fn init_returns_none_when_token_empty() {
             std::env::set_var("AXIOM_TOKEN_TELEMETRY", "");
             std::env::set_var("AXIOM_DATASET_SUFFIX", "dev");
         }
-        axiom_layer::init()
+        init()
     });
     assert!(result.is_none());
 }
@@ -308,9 +305,9 @@ async fn error_field_serializes_with_message_and_source_chain() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         let err = ChainErr {
@@ -357,9 +354,9 @@ async fn u128_fields_serialize_as_numbers_when_in_u64_range() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::error!(
@@ -403,9 +400,9 @@ async fn none_option_fields_are_omitted_from_axiom_payload() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::error!(
@@ -444,9 +441,9 @@ async fn burst_past_channel_cap_drops_without_blocking_or_feeding_back() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
 
     // 3000 > CHANNEL_CAP (1024) + 1000 so we both overflow the channel and
     // cross the drop counter's multiple-of-1000 branch at least twice
@@ -510,12 +507,12 @@ async fn non_success_ingest_response_does_not_hang_shutdown_or_panic() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
     let recording = RecordingLayer::default();
     let subscriber = tracing_subscriber::registry()
         .with(recording.clone())
-        .with(axiom_layer::with_ingest_filter(layer));
+        .with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         tracing::error!("trigger ingest failure");
@@ -563,9 +560,9 @@ async fn debug_field_over_limit_is_truncated_with_marker() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // 5000 A's → sentinel → 3000 A's. Debug form: `"` + 5000 + sentinel
@@ -596,9 +593,9 @@ async fn debug_field_truncation_walks_to_utf8_char_boundary() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // 2500 × 2-byte `ñ` = 5000 bytes; Debug adds surrounding quotes →
@@ -639,9 +636,9 @@ async fn debug_field_at_exact_limit_passes_through_unmodified() {
         })
         .await;
 
-    let (layer, guard) = axiom_layer::init_with_base_url(&server.base_url(), "t", "test")
-        .expect("init must succeed");
-    let subscriber = tracing_subscriber::registry().with(axiom_layer::with_ingest_filter(layer));
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
     {
         let _sub = tracing::subscriber::set_default(subscriber);
         // Debug form of a &str is `"<contents>"` — surrounding quotes cost


### PR DESCRIPTION
## Summary
- Move the Axiom layer tests from `crates/runner/tests` into `crates/runner/src/axiom_layer_tests.rs`
- Attach the tests through `axiom_layer.rs` so they compile in the runner module tree
- Remove the source-file path include and narrow `init_with_base_url` to module-private visibility
- Split env-value parsing into a private helper so migrated unit tests cover missing/empty env behavior without mutating process env

Closes #17297

## Tests
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner axiom_layer::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit hook: cargo fmt, cargo doc, cargo clippy
