### PR TITLE
fix: log runner context validation issues

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners.test.ts
@@ -647,6 +647,7 @@ describe("POST /api/runners/*", () => {
       contextOverrides: { apiStartTime: 1 },
     });
 
+    context.mocks.axiomLogging.warn.mockClear();
     const response = await claimRunnerJob({
       runId: queued.runId,
       authorization: OFFICIAL_RUNNER_TOKEN,
@@ -682,6 +683,22 @@ describe("POST /api/runners/*", () => {
     });
     expect(run?.completedAt).toBeInstanceOf(Date);
     expect(run?.startedAt).toBeNull();
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Runner job missing valid execution context",
+      expect.objectContaining({
+        context: "Runners",
+        runId: queued.runId,
+        validationIssueCount: 1,
+        validationIssues: [
+          expect.objectContaining({
+            path: "apiStartTime",
+            code: "too_small",
+            message: expect.any(String),
+          }),
+        ],
+        validationIssuesOmitted: 0,
+      }),
+    );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `run:changed:${queued.runId}`,
       { status: "failed" },

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -40,6 +40,49 @@ const L = logger("Runners");
 const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
 const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
+const MAX_VALIDATION_ISSUES_TO_LOG = 10;
+
+interface ValidationIssueLike {
+  readonly path: readonly PropertyKey[];
+  readonly code: string;
+  readonly message: string;
+}
+
+function validationIssuePath(path: readonly PropertyKey[]): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+  return path
+    .map((segment) => {
+      return String(segment);
+    })
+    .join(".");
+}
+
+function warnInvalidStoredExecutionContext(
+  runId: string,
+  issues: readonly ValidationIssueLike[],
+): void {
+  const validationIssueCount = issues.length;
+  const validationIssues = issues
+    .slice(0, MAX_VALIDATION_ISSUES_TO_LOG)
+    .map((issue) => {
+      return {
+        path: validationIssuePath(issue.path),
+        code: issue.code,
+        message: issue.message,
+      };
+    });
+  L.warn(INVALID_EXECUTION_CONTEXT_ERROR, {
+    runId,
+    validationIssueCount,
+    validationIssues,
+    validationIssuesOmitted: Math.max(
+      0,
+      validationIssueCount - MAX_VALIDATION_ISSUES_TO_LOG,
+    ),
+  });
+}
 
 const unauthorizedNotAuthenticated = Object.freeze({
   status: 401 as const,
@@ -715,7 +758,7 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     jobWithRun.job.executionContext,
   );
   if (!storedContextResult.success) {
-    L.warn(INVALID_EXECUTION_CONTEXT_ERROR, { runId });
+    warnInvalidStoredExecutionContext(runId, storedContextResult.error.issues);
     const poisonResult = await failPoisonQueuedJob(
       db,
       runId,


### PR DESCRIPTION
## Summary
- log sanitized stored execution context validation issues when runner claim rejects a queued job
- include issue count, omitted count, and per-issue path/code/message without logging the execution context payload
- cover the warning payload in the runner claim route test

## Tests
- pnpm exec prettier --check apps/api/src/signals/routes/runners.ts apps/api/src/signals/routes/__tests__/runners.test.ts
- pnpm -F ./apps/api lint
- pnpm -F ./apps/api exec vitest src/signals/routes/__tests__/runners.test.ts --run
- pnpm -F ./apps/api check-types
- pre-commit hook: prettier, knip, turbo check-types