### PR TITLE
feat: enable google analytics connector

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -168,7 +168,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.GoogleAnalyticsConnector]: {
     maintainer: "linghan@vm0.ai",
     description: "Enable the Google Analytics connector",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.GoogleSearchConsoleConnector]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable the Google Analytics connector feature switch by default

## Testing
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts -t getAvailableConnectorAuthMethodIds
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm test
- pnpm knip