### PR TITLE
feat: support multiple online computer use hosts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts
@@ -269,45 +269,54 @@ describe("desktop computer-use runtime", () => {
     expect(fixture.orgId).toBeTruthy();
   });
 
-  it("rejects a second active Desktop app computer-use host", async () => {
+  it("starts and lists multiple active Desktop app computer-use hosts", async () => {
     await createOrgFixture();
     const client = setupApp({ context })(zeroComputerUseHostsContract);
-    const body = {
+    const firstBody = {
       hostName: "Zero Desktop",
       appVersion: "0.1.0",
       osVersion: "macOS 15",
       supportedCapabilities: [...supportedCapabilities],
       permissions: { accessibility: true, screenRecording: true },
     };
+    const secondBody = { ...firstBody, hostName: "Studio Mac" };
 
-    const started = await accept(
+    const first = await accept(
       client.start({
-        body,
+        body: firstBody,
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
-
-    const rejected = await accept(
+    const second = await accept(
       client.start({
-        body,
+        body: secondBody,
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [409],
-    );
-
-    expect(rejected.body.error.message).toBe(
-      "A Desktop Computer Use host is already active",
+      [200],
     );
     const listed = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
       [200],
     );
-    expect(listed.body.hosts).toHaveLength(1);
-    expect(listed.body.hosts[0]?.id).toBe(started.body.hostId);
+    expect(listed.body.hosts).toHaveLength(2);
+    expect(listed.body.hosts).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: first.body.hostId,
+          hostName: "Zero Desktop",
+          status: "online",
+        }),
+        expect.objectContaining({
+          id: second.body.hostId,
+          hostName: "Studio Mac",
+          status: "online",
+        }),
+      ]),
+    );
   });
 
-  it("rejects a stale host heartbeat when another Desktop host is active", async () => {
+  it("accepts a stale host heartbeat when another Desktop host is active", async () => {
     const fixture = await createOrgFixture();
     const staleHostToken = "stale-host-token";
     const staleHostId = await seedComputerUseHost({
@@ -335,10 +344,10 @@ describe("desktop computer-use runtime", () => {
       [200],
     );
 
-    const rejected = await accept(
+    const heartbeat = await accept(
       heartbeatClient.heartbeat({
         body: {
-          hostName: "Zero Desktop",
+          hostName: "Recovered Desktop",
           appVersion: "0.1.0",
           osVersion: "macOS 15",
           supportedCapabilities: [...supportedCapabilities],
@@ -346,19 +355,20 @@ describe("desktop computer-use runtime", () => {
         },
         headers: { authorization: `Bearer ${staleHostToken}` },
       }),
-      [409],
+      [200],
     );
 
-    expect(rejected.body.error.message).toBe(
-      "A Desktop Computer Use host is already active",
-    );
+    expect(heartbeat.body).toStrictEqual({ ok: true, hostId: staleHostId });
     const writeDb = store.set(writeDb$);
     const [staleHost] = await writeDb
       .select()
       .from(computerUseHosts)
       .where(eq(computerUseHosts.id, staleHostId));
-    expect(staleHost).toMatchObject({ status: "offline" });
-    expect(staleHost?.revokedAt).toBeInstanceOf(Date);
+    expect(staleHost).toMatchObject({
+      displayName: "Recovered Desktop",
+      status: "online",
+      revokedAt: null,
+    });
   });
 
   it("stops a Desktop host so another host can start immediately", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -132,9 +132,6 @@ const hostStartInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
   signal.throwIfAborted();
 
-  if (result.status === "active_host_exists") {
-    return conflict("A Desktop Computer Use host is already active");
-  }
   return {
     status: 200 as const,
     body: { hostId: result.hostId, hostToken: result.hostToken },
@@ -163,9 +160,6 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   if (result.status === "invalid_token") {
     return invalidComputerUseToken;
-  }
-  if (result.status === "active_host_exists") {
-    return conflict("A Desktop Computer Use host is already active");
   }
   return {
     status: 200 as const,

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -1,17 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 
 import { command, computed, type Computed } from "ccstate";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  inArray,
-  isNull,
-  or,
-  sql,
-  type SQL,
-} from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, or, type SQL } from "drizzle-orm";
 import {
   isExpiredScreenshotPointer,
   isStoredScreenshotPointer,
@@ -106,18 +96,15 @@ type ResolveComputerUseCommandTargetsResult =
   | { readonly status: "host_offline" }
   | { readonly status: "host_unsupported" };
 
-type StartComputerUseHostResult =
-  | {
-      readonly status: "started";
-      readonly hostId: string;
-      readonly hostToken: string;
-    }
-  | { readonly status: "active_host_exists"; readonly hostId: string };
+type StartComputerUseHostResult = {
+  readonly status: "started";
+  readonly hostId: string;
+  readonly hostToken: string;
+};
 
 type HeartbeatComputerUseHostResult =
   | { readonly status: "ok"; readonly hostId: string }
-  | { readonly status: "invalid_token" }
-  | { readonly status: "active_host_exists"; readonly hostId: string };
+  | { readonly status: "invalid_token" };
 
 type StopComputerUseHostResult =
   | { readonly status: "stopped"; readonly hostId: string }
@@ -674,31 +661,6 @@ async function hostFromToken(
   return host ?? null;
 }
 
-async function hostIdentityFromToken(
-  tx: ComputerUseTx,
-  hostToken: string,
-  signal: AbortSignal,
-): Promise<{
-  readonly orgId: string;
-  readonly userId: string;
-} | null> {
-  const [host] = await tx
-    .select({
-      orgId: computerUseHosts.orgId,
-      userId: computerUseHosts.userId,
-    })
-    .from(computerUseHosts)
-    .where(
-      and(
-        eq(computerUseHosts.tokenHash, hashSecret(hostToken)),
-        isNull(computerUseHosts.revokedAt),
-      ),
-    )
-    .limit(1);
-  signal.throwIfAborted();
-  return host ?? null;
-}
-
 export const startComputerUseHost$ = command(
   async (
     { set },
@@ -720,33 +682,6 @@ export const startComputerUseHost$ = command(
     const hostToken = generateOpaqueToken("vm0_computer_use_host");
     const now = nowDate();
     const result = await db.transaction(async (tx) => {
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext('computer_use_host:' || ${params.orgId} || ':' || ${params.userId}))`,
-      );
-
-      const existingHosts = await tx
-        .select()
-        .from(computerUseHosts)
-        .where(
-          and(
-            eq(computerUseHosts.orgId, params.orgId),
-            eq(computerUseHosts.userId, params.userId),
-            isNull(computerUseHosts.revokedAt),
-          ),
-        )
-        .for("update");
-      signal.throwIfAborted();
-
-      const activeHost = existingHosts.find((host) => {
-        return hostIsOnline(host, now);
-      });
-      if (activeHost) {
-        return {
-          status: "active_host_exists" as const,
-          hostId: activeHost.id,
-        };
-      }
-
       const [host] = await tx
         .insert(computerUseHosts)
         .values({
@@ -798,50 +733,9 @@ export const heartbeatComputerUseHost$ = command(
     const db = set(writeDb$);
     const now = nowDate();
     const result = await db.transaction(async (tx) => {
-      const hostIdentity = await hostIdentityFromToken(
-        tx,
-        params.hostToken,
-        signal,
-      );
-      if (!hostIdentity) {
-        return { status: "invalid_token" as const };
-      }
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext('computer_use_host:' || ${hostIdentity.orgId} || ':' || ${hostIdentity.userId}))`,
-      );
-      signal.throwIfAborted();
-
       const lockedHost = await hostFromToken(tx, params.hostToken, signal);
       if (!lockedHost) {
         return { status: "invalid_token" as const };
-      }
-
-      const existingHosts = await tx
-        .select()
-        .from(computerUseHosts)
-        .where(
-          and(
-            eq(computerUseHosts.orgId, lockedHost.orgId),
-            eq(computerUseHosts.userId, lockedHost.userId),
-            isNull(computerUseHosts.revokedAt),
-          ),
-        )
-        .for("update");
-      signal.throwIfAborted();
-
-      const activeHost = existingHosts.find((candidate) => {
-        return candidate.id !== lockedHost.id && hostIsOnline(candidate, now);
-      });
-      if (activeHost) {
-        await tx
-          .update(computerUseHosts)
-          .set({ status: "offline", revokedAt: now, updatedAt: now })
-          .where(eq(computerUseHosts.id, lockedHost.id));
-        signal.throwIfAborted();
-        return {
-          status: "active_host_exists" as const,
-          hostId: activeHost.id,
-        };
       }
 
       await tx

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2502,6 +2502,17 @@ describe("chat lifecycle", () => {
             createdAt: "2026-06-10T11:00:00Z",
           },
           {
+            id: "host-online-2",
+            displayName: "Office Mac",
+            appVersion: "1.0.0",
+            osVersion: "macOS 15.0",
+            supportedCapabilities: ["app.open"],
+            permissions: { accessibility: true, screenRecording: true },
+            status: "online",
+            lastSeenAt: "2026-06-10T12:01:00Z",
+            createdAt: "2026-06-10T11:01:00Z",
+          },
+          {
             id: "host-offline",
             displayName: "Offline Desktop",
             appVersion: "1.0.0",
@@ -2526,9 +2537,70 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Studio Mac")).toBeInTheDocument();
+      expect(screen.getByText("Office Mac")).toBeInTheDocument();
       expect(screen.queryByText("Offline Desktop")).not.toBeInTheDocument();
       expect(screen.getByText("Connect my computer")).toBeInTheDocument();
-      expect(screen.getByLabelText("Enable Studio Mac")).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Studio Mac" })).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+      expect(screen.getByRole("radio", { name: "Office Mac" })).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+    });
+  });
+
+  it("does not auto-select the only online Computer Use host", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "computer-use-manual-selection";
+    let sentComputerUseHostId: string | null | undefined;
+    mockChatLifecycle(context, {
+      threadId,
+      onRunCreate: (body) => {
+        sentComputerUseHostId = body.computerUseHostId;
+      },
+    });
+    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+      return respond(200, {
+        hosts: [
+          {
+            id: "host-online",
+            displayName: "Studio Mac",
+            appVersion: "1.0.0",
+            osVersion: "macOS 15.0",
+            supportedCapabilities: ["app.open"],
+            permissions: { accessibility: true, screenRecording: true },
+            status: "online",
+            lastSeenAt: "2026-06-10T12:00:00Z",
+            createdAt: "2026-06-10T11:00:00Z",
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
+    });
+
+    await user.click(await screen.findByLabelText("Computer Use"));
+    expect(screen.getByRole("radio", { name: "Studio Mac" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+
+    const textarea = (await screen.findByPlaceholderText(
+      PLACEHOLDER,
+    )) as HTMLTextAreaElement;
+    await sendMessageInUI(user, textarea, "Open the app on my computer");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Open the app on my computer"),
+      ).toBeInTheDocument();
+      expect(sentComputerUseHostId).toBeNull();
     });
   });
 
@@ -2567,7 +2639,7 @@ describe("chat lifecycle", () => {
     });
 
     await user.click(await screen.findByLabelText("Computer Use"));
-    await user.click(await screen.findByLabelText("Enable Studio Mac"));
+    await user.click(await screen.findByRole("radio", { name: "Studio Mac" }));
 
     const textarea = (await screen.findByPlaceholderText(
       PLACEHOLDER,
@@ -2617,18 +2689,14 @@ describe("chat lifecycle", () => {
 
     await user.click(await screen.findByLabelText("Computer Use"));
 
-    const disableSwitch = await screen.findByLabelText("Disable Studio Mac");
-    expect(disableSwitch).toBeInTheDocument();
-    await user.click(disableSwitch);
+    const selectedComputer = await screen.findByRole("radio", {
+      name: "Studio Mac",
+    });
+    expect(selectedComputer).toHaveAttribute("aria-checked", "true");
+    await user.click(selectedComputer);
 
     await waitFor(() => {
-      expect(
-        screen.queryByLabelText("Disable Studio Mac"),
-      ).not.toBeInTheDocument();
-    });
-    await user.click(await screen.findByLabelText("Computer Use"));
-    await waitFor(() => {
-      expect(screen.getByLabelText("Enable Studio Mac")).toBeInTheDocument();
+      expect(selectedComputer).toHaveAttribute("aria-checked", "false");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -18,6 +18,7 @@ import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import {
   IconAlertTriangle,
   IconArrowUp,
+  IconCheck,
   IconChevronLeft,
   IconChevronRight,
   IconDeviceDesktop,
@@ -2200,13 +2201,26 @@ function ComputerUsePopoverButton({
               })}
             </div>
           ) : computerUse.hosts.length > 0 ? (
-            <div className="flex max-h-72 flex-col overflow-y-auto">
+            <div
+              className="flex max-h-72 flex-col overflow-y-auto"
+              role="radiogroup"
+              aria-label="Computer Use host"
+            >
               {computerUse.hosts.map((host) => {
                 const checked = computerUse.selectedHostId === host.id;
                 return (
-                  <div
+                  <button
                     key={host.id}
-                    className="flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors"
+                    type="button"
+                    role="radio"
+                    aria-checked={checked}
+                    onClick={() => {
+                      computerUse.onChange(checked ? null : host.id);
+                    }}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
+                      checked ? "bg-primary/5" : "hover:bg-muted/50",
+                    )}
                   >
                     <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
                       <IconDeviceDesktop size={16} stroke={1.5} />
@@ -2214,16 +2228,18 @@ function ComputerUsePopoverButton({
                     <span className="text-sm flex-1 truncate text-foreground">
                       {host.hostName}
                     </span>
-                    <LoadingSwitch
-                      checked={checked}
-                      onCheckedChange={(nextChecked) => {
-                        computerUse.onChange(nextChecked ? host.id : null);
-                      }}
-                      loading={false}
-                      ariaLabel={`${checked ? "Disable" : "Enable"} ${host.hostName}`}
-                      size="sm"
-                    />
-                  </div>
+                    <span
+                      className={cn(
+                        "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors",
+                        checked
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-border text-transparent",
+                      )}
+                      aria-hidden="true"
+                    >
+                      {checked && <IconCheck size={11} stroke={3} />}
+                    </span>
+                  </button>
                 );
               })}
             </div>


### PR DESCRIPTION
Closes #17317

## Summary
- Remove the API start/heartbeat active-host mutual exclusion so multiple Desktop Computer Use hosts can stay online for the same user/org.
- Preserve explicit `targetHostId` command routing and existing ambiguous-host safeguards.
- Replace the Computer Use host Switch UI with a single-select radio-style list while keeping manual authorization required for both single-host and multi-host states.

## Verification
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-computer-use.test.ts`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app lint`
- `git diff --check`