### PR TITLE
feat: collapse completed chat work history

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/completed-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/completed-work-folding.ts
@@ -1,0 +1,21 @@
+import { command, computed, state } from "ccstate";
+
+const internalCompletedWorkExpandedThreadIds$ = state<Set<string>>(new Set());
+
+export const completedWorkExpandedThreadIds$ = computed((get): Set<string> => {
+  return get(internalCompletedWorkExpandedThreadIds$);
+});
+
+export const toggleCompletedWorkExpanded$ = command(
+  ({ set }, threadId: string) => {
+    set(internalCompletedWorkExpandedThreadIds$, (prev) => {
+      const next = new Set(prev);
+      if (next.has(threadId)) {
+        next.delete(threadId);
+      } else {
+        next.add(threadId);
+      }
+      return next;
+    });
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1296,6 +1296,136 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("keeps completed chat work visible when folding is disabled", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-disabled",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Audit the launch checklist",
+          runId: "run-work-folding-disabled",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "The launch checklist is ready.",
+          runId: "run-work-folding-disabled",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:55Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-disabled",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Audit the launch checklist"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("The launch checklist is ready."),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Expand work history")).toBeNull();
+    });
+  });
+
+  it("keeps chat work visible while the run is active", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-running",
+      activeRunIds: ["run-work-folding-running"],
+      chatMessages: [
+        {
+          role: "user",
+          content: "Draft the launch checklist",
+          runId: "run-work-folding-running",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "Checking the remaining launch steps.",
+          runId: "run-work-folding-running",
+          createdAt: "2026-06-09T10:00:20Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-running",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Draft the launch checklist"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Checking the remaining launch steps."),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Expand work history")).toBeNull();
+    });
+  });
+
+  it("folds completed chat work and toggles the hidden history", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-completed",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Summarize the launch status",
+          runId: "run-work-folding-completed",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "Launch status is summarized.",
+          runId: "run-work-folding-completed",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:55Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-completed",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+
+    const expandButton = await screen.findByLabelText("Expand work history");
+    expect(expandButton).toHaveTextContent("Worked for 55s");
+    expect(screen.queryByText("Summarize the launch status")).toBeNull();
+    expect(
+      screen.getByText("Launch status is summarized."),
+    ).toBeInTheDocument();
+
+    click(expandButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Summarize the launch status"),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Collapse work history")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    click(screen.getByLabelText("Collapse work history"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Summarize the launch status")).toBeNull();
+      expect(screen.getByLabelText("Expand work history")).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+    });
+  });
+
   it("renders a server-corrected assistant message without the stale answer", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-corrected-answer",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -109,6 +109,10 @@ import {
   completeChatConnectorActionConnect$,
   type ConnectorActionBlock,
 } from "../../signals/chat-page/connector-action-block.ts";
+import {
+  completedWorkExpandedThreadIds$,
+  toggleCompletedWorkExpanded$,
+} from "../../signals/chat-page/completed-work-folding.ts";
 import type { PermissionActionBlock } from "../../signals/chat-page/permission-action-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
@@ -2191,6 +2195,23 @@ function ChatThreadMessagesMain({
     groups.length === 0 &&
     !messagesLoading &&
     !skeletonVisible;
+  const features = useLastResolved(featureSwitch$);
+  const completedWorkFoldingEnabled =
+    features?.[FeatureSwitchKey.ChatCompletedWorkFolding] ?? false;
+  const allFinishedLoadable = useLastLoadable(thread.allFinished$);
+  const allFinished =
+    allFinishedLoadable.state === "hasData" ? allFinishedLoadable.data : false;
+  const completedWorkExpandedThreadIds = useGet(
+    completedWorkExpandedThreadIds$,
+  );
+  const workExpanded = completedWorkExpandedThreadIds.has(thread.threadId);
+  const toggleCompletedWorkExpanded = useSet(toggleCompletedWorkExpanded$);
+  const shouldFoldCompletedWork =
+    completedWorkFoldingEnabled && allFinished && activeGroups.length > 1;
+  const hiddenGroups = shouldFoldCompletedWork ? activeGroups.slice(0, -1) : [];
+  const visibleGroups = shouldFoldCompletedWork
+    ? activeGroups.slice(-1)
+    : activeGroups;
 
   return (
     <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
@@ -2233,7 +2254,26 @@ function ChatThreadMessagesMain({
             </p>
           </div>
         )}
-        {activeGroups.map((group) => {
+        {shouldFoldCompletedWork && (
+          <CompletedWorkFoldRow
+            groups={activeGroups}
+            expanded={workExpanded}
+            onToggle={() => {
+              toggleCompletedWorkExpanded(thread.threadId);
+            }}
+          />
+        )}
+        {workExpanded &&
+          hiddenGroups.map((group) => {
+            return (
+              <PagedGroupRow
+                key={group.beginMessageId}
+                group={group}
+                thread={thread}
+              />
+            );
+          })}
+        {visibleGroups.map((group) => {
           return (
             <PagedGroupRow
               key={group.beginMessageId}
@@ -2245,6 +2285,80 @@ function ChatThreadMessagesMain({
         <ThinkingIndicator thread={thread} groups={activeGroups} />
       </div>
     </main>
+  );
+}
+
+function parseMessageTime(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function formatCompactDuration(totalSeconds: number): string {
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const totalMinutes = Math.round(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+  const totalHours = Math.round(totalMinutes / 60);
+  return `${totalHours}h`;
+}
+
+function completedWorkLabel(
+  groups: readonly GroupedChatMessageGroup[],
+): string {
+  const timestamps = groups.flatMap((group) => {
+    return group.messages.flatMap((message) => {
+      const timestamp = parseMessageTime(message.createdAt);
+      return timestamp === null ? [] : [timestamp];
+    });
+  });
+  if (timestamps.length < 2) {
+    return "Worked";
+  }
+  const elapsedSeconds = Math.max(
+    1,
+    Math.round((Math.max(...timestamps) - Math.min(...timestamps)) / 1000),
+  );
+  return `Worked for ${formatCompactDuration(elapsedSeconds)}`;
+}
+
+function CompletedWorkFoldRow({
+  groups,
+  expanded,
+  onToggle,
+}: {
+  groups: readonly GroupedChatMessageGroup[];
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const label = completedWorkLabel(groups);
+  return (
+    <div
+      data-chat-completed-work-fold
+      className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]"
+    >
+      <div className="hidden @[900px]:block" />
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={expanded ? "Collapse work history" : "Expand work history"}
+        onClick={onToggle}
+        className="group flex h-9 w-full items-center gap-2 rounded-lg px-1 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+      >
+        <span className="min-w-0 shrink-0">{label}</span>
+        <IconChevronRight
+          size={17}
+          stroke={1.7}
+          className={cn(
+            "shrink-0 transition-transform duration-150",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="h-px min-w-8 flex-1 bg-border/50 transition-colors group-hover:bg-border" />
+      </button>
+    </div>
   );
 }
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   VideoTemplatePicker = "videoTemplatePicker",
   MemoryViewer = "memoryViewer",
   MemoryDevRefresh = "memoryDevRefresh",
+  ChatCompletedWorkFolding = "chatCompletedWorkFolding",
   ChatRecommendedFollowups = "chatRecommendedFollowups",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -326,6 +326,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatCompletedWorkFolding]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Collapse earlier Zero chat work history after a run finishes, leaving the final message visible.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatRecommendedFollowups]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add `ChatCompletedWorkFolding` feature switch
- collapse completed chat work history behind a Codex-style `Worked for ...` row while keeping the final message group visible
- add local per-thread expand/collapse state and focused chat lifecycle coverage

Closes #17321

## Tests

- `pnpm exec prettier --write apps/platform/src/signals/chat-page/completed-work-folding.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm --filter ./apps/platform exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
