### PR TITLE
feat(api): record automation as the trigger source for automation runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -698,7 +698,7 @@ describe("Automations v2 API", () => {
 
     const db = store.set(writeDb$);
     // Provenance: the automation alone — no trigger fired this run. B2 is
-    // deferred, so the trigger source stays "schedule".
+    // deferred, so the run records the automation trigger source.
     const [zeroRun] = await db
       .select({
         triggerSource: zeroRuns.triggerSource,
@@ -709,7 +709,7 @@ describe("Automations v2 API", () => {
       .from(zeroRuns)
       .where(eq(zeroRuns.id, runId));
     expect(zeroRun).toStrictEqual({
-      triggerSource: "schedule",
+      triggerSource: "automation",
       automationId: created.automation.id,
       triggerId: null,
       chatThreadId: created.automation.chatThreadId,

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -340,7 +340,7 @@ describe("Automations API parity with the legacy schedule surface", () => {
 
       // Same agent run + same chat-thread rendering for this trigger type.
       expect(newArtifacts).toStrictEqual(oldArtifacts);
-      expect(newArtifacts.triggerSource).toBe("schedule");
+      expect(newArtifacts.triggerSource).toBe("automation");
       expect(newArtifacts.callbackPaths).toContain(
         "/api/internal/callbacks/chat",
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-schedules.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-schedules.test.ts
@@ -252,7 +252,7 @@ describe("GET /api/cron/execute-schedules (trigger-table poller)", () => {
     const runs = await findMirrorRuns(scheduleId);
     expect(runs).toHaveLength(1);
     expect(runs[0]?.prompt).toBe("Daily task");
-    expect(runs[0]?.triggerSource).toBe("schedule");
+    expect(runs[0]?.triggerSource).toBe("automation");
     expect(runs[0]?.automationId).toBe(mirror?.automationId);
     expect(runs[0]?.triggerId).toBe(mirror?.trigger.id);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
@@ -496,39 +496,40 @@ describe("POST /api/zero/banking/*", () => {
     expect(authRequestCount).toBe(0);
   });
 
-  it("denies scheduled runs unless the banking grant allows them", async () => {
-    const fixture = await track(
-      seedBankingFixture({ triggerSource: "schedule" }),
-    );
-    let authRequestCount = 0;
-    server.use(
-      http.post(FINICITY_AUTH_URL, () => {
-        authRequestCount += 1;
-        return HttpResponse.json({ token: "test-app-token" });
-      }),
-    );
+  it.each(["schedule", "automation"] as const)(
+    "denies %s-triggered runs unless the banking grant allows them",
+    async (triggerSource) => {
+      const fixture = await track(seedBankingFixture({ triggerSource }));
+      let authRequestCount = 0;
+      server.use(
+        http.post(FINICITY_AUTH_URL, () => {
+          authRequestCount += 1;
+          return HttpResponse.json({ token: "test-app-token" });
+        }),
+      );
 
-    const client = setupApp({ context })(zeroBankingContract);
-    const response = await accept(
-      client.accounts({
-        headers: { authorization: `Bearer ${zeroToken(fixture)}` },
-        body: {},
-      }),
-      [403],
-    );
+      const client = setupApp({ context })(zeroBankingContract);
+      const response = await accept(
+        client.accounts({
+          headers: { authorization: `Bearer ${zeroToken(fixture)}` },
+          body: {},
+        }),
+        [403],
+      );
 
-    expect(response.body.error.message).toBe(
-      "Banking is not enabled for scheduled runs",
-    );
-    expect(authRequestCount).toBe(0);
-    await expect(bankingAuditEvents(fixture)).resolves.toMatchObject([
-      {
-        action: "accounts.read",
-        status: "denied",
-        failureCode: "SCHEDULE_NOT_ALLOWED",
-      },
-    ]);
-  });
+      expect(response.body.error.message).toBe(
+        "Banking is not enabled for scheduled runs",
+      );
+      expect(authRequestCount).toBe(0);
+      await expect(bankingAuditEvents(fixture)).resolves.toMatchObject([
+        {
+          action: "accounts.read",
+          status: "denied",
+          failureCode: "SCHEDULE_NOT_ALLOWED",
+        },
+      ]);
+    },
+  );
 
   it("denies revoked banking connections before provider access", async () => {
     const fixture = await track(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-logs-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-logs-list.test.ts
@@ -675,6 +675,40 @@ describe("GET /api/zero/logs", () => {
       expect(run?.scheduleId).toBe(scheduleId);
     });
 
+    it("matches both 'schedule' and 'automation' rows when filtering by either value", async () => {
+      const { fixture, composeId } = await setupComposeForSource();
+      for (const triggerSource of ["schedule", "automation"] as const) {
+        await store.set(
+          seedRun$,
+          {
+            orgId: fixture.orgId,
+            userId: fixture.userId,
+            composeId,
+            status: "completed",
+            triggerSource,
+          },
+          context.signal,
+        );
+      }
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+
+      for (const filter of ["schedule", "automation"] as const) {
+        const response = await accept(
+          logsClient().list({
+            query: { triggerSource: filter },
+            headers: authHeaders(),
+          }),
+          [200],
+        );
+        const sources = response.body.data
+          .map((r) => {
+            return r.triggerSource;
+          })
+          .sort();
+        expect(sources).toStrictEqual(["automation", "schedule"]);
+      }
+    });
+
     it("returns null scheduleId for non-schedule runs", async () => {
       const { fixture, composeId } = await setupComposeForSource();
       await store.set(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-run.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-run.test.ts
@@ -223,7 +223,7 @@ describe("POST /api/zero/schedules/run", () => {
       .from(zeroRuns)
       .where(eq(zeroRuns.id, body.runId));
     expect(zeroRun).toStrictEqual({
-      triggerSource: "schedule",
+      triggerSource: "automation",
       automationId: scheduleId,
       triggerId: trigger?.id,
     });
@@ -274,7 +274,7 @@ describe("POST /api/zero/schedules/run", () => {
       .from(zeroRuns)
       .where(eq(zeroRuns.id, body.runId));
     expect(zeroRun).toStrictEqual({
-      triggerSource: "schedule",
+      triggerSource: "automation",
       chatThreadId: threadId,
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-uploads-complete.test.ts
@@ -214,6 +214,29 @@ describe("POST /api/zero/uploads/complete", () => {
     });
   });
 
+  it("records the automation trigger source for an automation run upload", async () => {
+    const fixture = await seedRunFixture({ triggerSource: "automation" });
+    const fileId = randomUUID();
+    mocks.s3.listObjects([s3Object(fixture.userId, fileId, "report.pdf")]);
+
+    const token = zeroToken(fixture);
+    await accept(
+      apiClient().complete({
+        headers: authHeaders(token),
+        body: { id: fileId },
+      }),
+      [200],
+    );
+
+    const rows = await findUploadedFiles(fileId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId: fixture.runId,
+      source: "automation",
+      externalId: fileId,
+    });
+  });
+
   it("publishes the artifacts changed signal for a chat-thread run upload", async () => {
     const fixture = await seedRunFixture({ withChatThread: true });
     const fileId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -393,7 +393,7 @@ describe("GET /api/zero/usage/record", () => {
         orgId: fixture.orgId,
         userId: fixture.userId,
         threadId: chat.threadId,
-        triggerSource: "schedule",
+        triggerSource: "automation",
         createdAt: createdAt(5),
       },
       context.signal,

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -714,7 +714,7 @@ async function latestSessionForThread(
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
     // D7: only web-source runs join the thread's session-continuity chain, so a
-    // chat-mode scheduled run (triggerSource "schedule") never resumes a web
+    // chat-mode automation run (triggerSource "automation") never resumes a web
     // session and a later web turn never resumes a scheduled one. The 'web'
     // filter (before .limit) is mirrored in latestSessionForThreadFromDb
     // (internal-callbacks-chat.ts) and latestSessionIdForThread

--- a/turbo/apps/api/src/signals/services/automations-v2.service.ts
+++ b/turbo/apps/api/src/signals/services/automations-v2.service.ts
@@ -1201,9 +1201,9 @@ export const runAutomationNowV2$ = command(
             : {}),
         },
         apiStartTime: args.apiStartTime,
-        // B2 on #16847 (a dedicated "manual"/"automation" trigger source) is
-        // deferred: manual fires keep the schedule source the run-now surface
-        // has always used.
+        // Manual fires record automation provenance; trigger_source follows
+        // (#17307). Historical rows may still carry "schedule" until the
+        // backfill migration lands.
         triggerSource: "automation",
         chatThreadId: runInput.chatThreadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,

--- a/turbo/apps/api/src/signals/services/automations-v2.service.ts
+++ b/turbo/apps/api/src/signals/services/automations-v2.service.ts
@@ -1204,7 +1204,7 @@ export const runAutomationNowV2$ = command(
         // B2 on #16847 (a dedicated "manual"/"automation" trigger source) is
         // deferred: manual fires keep the schedule source the run-now surface
         // has always used.
-        triggerSource: "schedule",
+        triggerSource: "automation",
         chatThreadId: runInput.chatThreadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -301,7 +301,10 @@ const runTriggerNow$ = command(
             : {}),
         },
         apiStartTime: args.apiStartTime,
-        triggerSource: "schedule",
+        // Time fires record automation provenance; trigger_source follows
+        // (#17307). Historical rows may still carry "schedule" until the
+        // backfill migration lands.
+        triggerSource: "automation",
         chatThreadId: runInput.chatThreadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:

--- a/turbo/apps/api/src/signals/services/zero-banking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-banking.service.ts
@@ -532,7 +532,10 @@ async function authorizeBankingAccess(
     });
   }
 
-  if (run.triggerSource === "schedule" && !grant.allowScheduledRuns) {
+  if (
+    (run.triggerSource === "schedule" || run.triggerSource === "automation") &&
+    !grant.allowScheduledRuns
+  ) {
     return await denyBankingAccess(db, auth, action, providerAccountId, {
       agentId: run.agentId,
       connectionId: grant.connectionId,

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -66,6 +66,15 @@ function normalizeTriggerSource(
   return parsed.success ? parsed.data : null;
 }
 
+// "automation" supersedes "schedule" (#17307); until the backfill migration
+// unifies historical rows, a filter on either value matches both.
+function triggerSourceCondition(source: TriggerSource): SQL {
+  if (source === "schedule" || source === "automation") {
+    return inArray(zeroRuns.triggerSource, ["schedule", "automation"]);
+  }
+  return eq(zeroRuns.triggerSource, source);
+}
+
 function buildCursorCondition(cursor: string): SQL | null {
   const separatorIndex = cursor.lastIndexOf("|");
   if (separatorIndex <= 0) {
@@ -152,7 +161,7 @@ export function zeroLogsList(
       conditions.push(eq(agentRuns.status, params.status));
     }
     if (params.triggerSource) {
-      conditions.push(eq(zeroRuns.triggerSource, params.triggerSource));
+      conditions.push(triggerSourceCondition(params.triggerSource));
     }
     if (params.scheduleId) {
       // Schedule ids are automation ids (D2 on #16847); historical runs were
@@ -260,7 +269,7 @@ async function getLogsTotalCount(
     conditions.push(eq(agentRuns.status, params.status));
   }
   if (params.triggerSource) {
-    conditions.push(eq(zeroRuns.triggerSource, params.triggerSource));
+    conditions.push(triggerSourceCondition(params.triggerSource));
   }
   if (params.scheduleId) {
     conditions.push(eq(zeroRuns.automationId, params.scheduleId));
@@ -341,6 +350,7 @@ async function getAvailableFilters(
     })
     .filter((s): s is TriggerSource => {
       return [
+        "automation",
         "schedule",
         "web",
         "slack",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -230,7 +230,7 @@ function buildAgentToolsPrompt(triggerSource: TriggerSource): string {
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- Discover available commands: `zero --help`.",
     "- Search agent run logs, web chat messages, or external services via connectors: `zero search --help`.",
-    "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
+    "- Automate recurring tasks: `zero automation --help`. Do NOT use /loop, cron tools (CronCreate, CronList, CronDelete), or ScheduleWakeup — they are not available.",
     "- Browser access: the runtime environment includes `agent-browser` for browser automation and inspection.",
     ...buildIntegrationToolsPrompt(triggerSource),
     "- Maps, geocoding, directions, and places: use `zero maps --help`.",

--- a/turbo/apps/api/src/signals/services/zero-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-schedules.service.ts
@@ -1170,7 +1170,7 @@ export const runScheduleNow$ = command(
             : {}),
         },
         apiStartTime: args.apiStartTime,
-        triggerSource: "schedule",
+        triggerSource: "automation",
         chatThreadId: runInput.chatThreadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -369,7 +369,7 @@ function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
           WHEN zr.trigger_source = 'web' THEN 'chat'
           WHEN zr.trigger_source = 'slack' THEN 'slack'
           WHEN zr.trigger_source = 'email' THEN 'email'
-          WHEN zr.trigger_source = 'schedule' THEN 'schedule'
+          WHEN zr.trigger_source IN ('schedule', 'automation') THEN 'schedule'
           ELSE 'others'
         END AS bucket,
         COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
@@ -517,7 +517,7 @@ async function queryUsageInsightTopSchedules(
         FROM usage_rows ${USAGE_ROW_ALIAS}
         INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
         LEFT JOIN automations a ON a.id = zr.automation_id
-        WHERE zr.trigger_source = 'schedule'
+        WHERE zr.trigger_source IN ('schedule', 'automation')
           AND zr.automation_id IS NOT NULL
         GROUP BY zr.automation_id, a.name, a.description
       )
@@ -563,7 +563,7 @@ async function queryUsageInsightTopSchedules(
             ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
           FROM usage_rows ${USAGE_ROW_ALIAS}
           INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
-          WHERE zr.trigger_source = 'schedule' AND zr.automation_id IS NOT NULL
+          WHERE zr.trigger_source IN ('schedule', 'automation') AND zr.automation_id IS NOT NULL
           GROUP BY zr.automation_id
         )
         SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -87,6 +87,7 @@ function sourceExpr(triggerSource: string): string {
   return `
     CASE
       WHEN ${triggerSource} = 'web' THEN 'chat'
+      WHEN ${triggerSource} = 'automation' THEN 'schedule'
       WHEN ${triggerSource} IN (${passthroughList}) THEN ${triggerSource}
       ELSE 'other'
     END`;

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -9,6 +9,7 @@ export type { LogStatus, TriggerSource };
 
 /** Human-readable labels for each trigger source, shared across activity views. */
 export const TRIGGER_SOURCE_LABELS: Readonly<Record<TriggerSource, string>> = {
+  automation: "Automation",
   schedule: "Schedule",
   web: "Web",
   slack: "Slack",

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -238,7 +238,9 @@ export function ActivityHeaderCard({
             <>
               <div className="flex items-center gap-1.5 px-3">
                 <span className="text-muted-foreground shrink-0">Source</span>
-                {triggerSource === "schedule" && detail.scheduleId ? (
+                {(triggerSource === "schedule" ||
+                  triggerSource === "automation") &&
+                detail.scheduleId ? (
                   <Link
                     pathname="/schedules/:scheduleId"
                     options={{

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -40,6 +40,9 @@ const logStatusSchema = z.enum([
  * Trigger source enum — how the run was initiated
  */
 export const triggerSourceSchema = z.enum([
+  // "automation" supersedes "schedule" (#17307); both appear on historical
+  // rows until the backfill migration lands.
+  "automation",
   "schedule",
   "web",
   "slack",

--- a/turbo/packages/core/src/usage-source-bucket.ts
+++ b/turbo/packages/core/src/usage-source-bucket.ts
@@ -22,6 +22,7 @@ export function triggerSourceToBucket(
     case "email":
       return "email";
     case "schedule":
+    case "automation":
       return "schedule";
     default:
       // telegram, github, cli, agent, phone, agentphone, null

--- a/turbo/packages/db/src/schema/run-uploaded-file.ts
+++ b/turbo/packages/db/src/schema/run-uploaded-file.ts
@@ -13,6 +13,7 @@ import { agentRuns } from "./agent-run";
 
 export const RUN_UPLOADED_FILE_SOURCES = [
   "schedule",
+  "automation",
   "web",
   "slack",
   "email",


### PR DESCRIPTION
## Summary

PR-2 of #17307 (retire the "schedule" concept; converge on a single Automations surface).

Runs started by an automation now record `trigger_source = "automation"` instead of `"schedule"`:

- **Writers** — the trigger poller, the legacy schedule run-now path, and the automation manual-fire path all stamp `"automation"`.
- **Contract** — `triggerSourceSchema` gains `"automation"`; `"schedule"` stays valid for historical rows.
- **Readers accept both values during the transition**:
  - usage insight SQL buckets (`IN ('schedule', 'automation')`) and the authoritative `triggerSourceToBucket` mapping in `@vm0/core`
  - usage record `sourceExpr` maps `'automation'` to the existing `'schedule'` display bucket
  - banking `allowScheduledRuns` gate denies both values
  - logs `triggerSource` filter matches both values whichever one is queried
  - platform activity detail page shows the schedule link for both values
- **Agent tools prompt** now teaches `zero automation --help` instead of `zero schedule --help`.

A follow-up standalone migration (PR-5 of the epic) will backfill historical `'schedule'` rows to `'automation'` after this reader/writer change is live in production, per the #17280 incident learning.

## Test plan

- [x] Writer assertions updated: cron poller run, automation manual fire, legacy run-now (sync + chat mode), automations parity suite now expect `"automation"`
- [x] New: logs list filter test proves `triggerSource=schedule` and `triggerSource=automation` both match rows with either stored value
- [x] New: banking gate test parametrized over both trigger source values
- [x] Usage record test seeds an `"automation"` row and asserts it lands in the `"schedule"` display bucket
- [x] 178 tests across 11 affected API suites + platform detail page suite green
- [x] `check-types`, `lint`, `format`, `knip` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)