### PR TITLE
docs: document firecracker sandbox lifecycle

### DIFF
--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -10,8 +10,8 @@
 //!
 //! - [`FirecrackerRuntime`], which manages shared host resources and creates
 //!   sandbox factories for configured rootfs, kernel, and profile settings.
-//! - [`FirecrackerSandbox`], the running microVM implementation of the
-//!   `sandbox::Sandbox` trait.
+//! - [`FirecrackerSandbox`], the Firecracker-backed implementation of
+//!   `sandbox::Sandbox` for a sandbox lifecycle.
 //! - [`FirecrackerControl`], which exposes control-plane operations for a
 //!   running sandbox.
 //! - [`FirecrackerSnapshotProvider`], which creates snapshots compatible with

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -634,6 +634,18 @@ enum ProcessMonitorExit {
     Reaped(io::Result<std::process::ExitStatus>),
 }
 
+/// Firecracker-backed implementation of [`sandbox::Sandbox`].
+///
+/// A `FirecrackerSandbox` owns the host-side resources for one Firecracker
+/// sandbox lifecycle, including the VM process once started. Callers normally
+/// obtain instances through [`crate::FirecrackerRuntime`] and
+/// [`sandbox::SandboxFactory::create`] rather than constructing this type
+/// directly.
+///
+/// Use the [`sandbox::Sandbox`] trait methods for sandbox operations and release
+/// instances through [`sandbox::SandboxFactory::destroy`]. `Drop` only provides
+/// best-effort emergency leak cleanup if explicit destruction is missed; it is
+/// not a substitute for successful factory destruction.
 pub struct FirecrackerSandbox {
     pub(crate) config: SandboxConfig,
     factory_config: FirecrackerConfig,


### PR DESCRIPTION
## Summary

- Add public rustdoc for `FirecrackerSandbox`
- Document the runtime/factory creation path, trait-based operations, explicit factory destruction, and Drop fallback semantics
- Align the crate overview wording so it describes a sandbox lifecycle instead of implying the VM is always running

Closes #17301

## Validation

- `cargo fmt --all -- --check`
- `cargo doc --workspace --all-features --no-deps`
- lefthook pre-commit: `cargo fmt`, `cargo clippy`, `cargo doc`