### PR TITLE
chore: set paid onboarding url default

### DIFF
--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -34,7 +34,7 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 
 # Optional: Paid-onboarding origin
-PAID_ONBOARDING_URL=
+PAID_ONBOARDING_URL=https://so.vm7.ai:8441
 
 # Optional: Vercel preview proxy bypass
 VERCEL_AUTOMATION_BYPASS_SECRET=


### PR DESCRIPTION
## Summary
- Set the paid onboarding URL default in the web env template.

## Verification
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-third-party.test.ts --run
- pnpm vitest
- pnpm knip