### PR TITLE
feat: enable zero automations for all users

### DIFF
--- a/e2e/playwright/tests/create-schedule.spec.ts
+++ b/e2e/playwright/tests/create-schedule.spec.ts
@@ -8,19 +8,21 @@ test("create a new schedule and verify it appears in the list", async ({
 }) => {
   const schedulePrompt = `E2E schedule ${Date.now()}`;
 
-  // Navigate to schedule page
+  // Navigate to schedule page — the `zeroAutomations` switch is globally on
+  // (#17307), so the surface renders the Automations product noun.
   await page.goto(`${appUrl}/schedules`);
-  await expect(
-    page.getByRole("heading", { name: "Scheduled tasks" }),
-  ).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole("heading", { name: "Automations" })).toBeVisible(
+    { timeout: 20_000 },
+  );
   await expect(
     page.getByTestId("app-skeleton"),
   ).toHaveAttribute("aria-hidden", "true", { timeout: 60_000 });
 
-  // Click "Add schedule" in the page header (the list empty-state may show a second button)
+  // Click "Add automation" in the page header (the list empty-state may show
+  // a second "Add schedule" button)
   await page
     .getByRole("banner")
-    .getByRole("button", { name: "Add schedule" })
+    .getByRole("button", { name: "Add automation" })
     .click();
   await expect(
     page.getByRole("heading", { name: "Add schedule" }),

--- a/e2e/playwright/tests/schedule.spec.ts
+++ b/e2e/playwright/tests/schedule.spec.ts
@@ -5,9 +5,11 @@ const appUrl = deriveAppUrl(process.env.VM0_API_URL!);
 
 test("navigate to schedule page and verify heading", async ({ page }) => {
   await page.goto(`${appUrl}/schedules`);
-  await expect(
-    page.getByRole("heading", { name: "Scheduled tasks" }),
-  ).toBeVisible({
-    timeout: 20_000,
-  });
+  // The `zeroAutomations` switch is globally on (#17307), so the schedules
+  // surface renders the Automations product noun.
+  await expect(page.getByRole("heading", { name: "Automations" })).toBeVisible(
+    {
+      timeout: 20_000,
+    },
+  );
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -124,6 +124,15 @@ async function enableAutomations(
   });
 }
 
+async function disableAutomations(fixture: SchedulesFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ZeroAutomations]: false },
+  });
+}
+
 interface CreateArgs {
   readonly name: string;
   readonly agentId: string;
@@ -972,6 +981,9 @@ describe("Automations v2 API", () => {
 
   it("returns 404 on every endpoint when the feature switch is off", async () => {
     const fixture = await seedFixture();
+    // The switch is globally on (#17307); an explicit false override keeps the
+    // gating path covered until the switch is deleted.
+    await disableAutomations(fixture);
 
     const create = await accept(
       mainApi().create({

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -104,6 +104,15 @@ async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
   });
 }
 
+async function disableAutomations(fixture: SchedulesFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ZeroAutomations]: false },
+  });
+}
+
 function expectErrorCode(response: TestApiResponse): string {
   return apiErrorSchema.parse(response.body).error.code;
 }
@@ -369,6 +378,9 @@ describe("Automations API feature-switch gating", () => {
     if (!scheduleId) {
       throw new Error("Expected seeded schedule");
     }
+    // The switch is globally on (#17307); an explicit false override keeps the
+    // gating path covered until the switch is deleted.
+    await disableAutomations(fixture);
 
     const create = await requestJson(
       "/api/automations",

--- a/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
@@ -123,6 +123,15 @@ async function enableAutomations(
   });
 }
 
+async function disableAutomations(fixture: SchedulesFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(userFeatureSwitches).values({
+    orgId: fixture.orgId,
+    userId: fixture.userId,
+    switches: { [FeatureSwitchKey.ZeroAutomations]: false },
+  });
+}
+
 function expectErrorCode(response: TestApiResponse): string {
   return apiErrorSchema.parse(response.body).error.code;
 }
@@ -429,6 +438,9 @@ describe("Webhook automations management API", () => {
 describe("Webhook automations management feature gating", () => {
   it("returns 404 on every endpoint when the switch is off", async () => {
     const fixture = await seedFixture();
+    // The switch is globally on (#17307); an explicit false override keeps the
+    // gating path covered until the switch is deleted.
+    await disableAutomations(fixture);
 
     const create = await requestJson(
       "/api/automations/webhooks",

--- a/turbo/apps/platform/src/mocks/handlers/api-automations.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-automations.ts
@@ -7,6 +7,7 @@ import {
 import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
 import { nowDate } from "../../lib/time.ts";
 import { mockApi } from "../msw-contract.ts";
+import { createStoredSchedule } from "./api-schedules.ts";
 import { getMockSchedules, setMockSchedules } from "./schedules-store.ts";
 
 // Mirrors the production Automations route: a thin product projection over the
@@ -17,7 +18,6 @@ import { getMockSchedules, setMockSchedules } from "./schedules-store.ts";
 function upsert(
   body: {
     readonly agentId: string;
-    readonly name: string;
     readonly cronExpression?: string;
     readonly atTime?: string;
     readonly intervalSeconds?: number;
@@ -31,31 +31,9 @@ function upsert(
   name: string,
 ): { automation: ScheduleResponse; created: boolean; status: 200 | 201 } {
   const now = nowDate().toISOString();
-  const automation: ScheduleResponse = {
-    id: crypto.randomUUID(),
-    agentId: body.agentId,
-    displayName: null,
-    userId: "test-user-123",
-    name,
-    triggerType: body.cronExpression ? "cron" : body.atTime ? "once" : "loop",
-    cronExpression: body.cronExpression ?? null,
-    atTime: body.atTime ?? null,
-    intervalSeconds: body.intervalSeconds ?? null,
-    timezone: body.timezone,
-    prompt: body.prompt,
-    description: body.description ?? null,
-    appendSystemPrompt: body.appendSystemPrompt ?? null,
-    enabled: body.enabled ?? true,
-    nextRunAt: null,
-    lastRunAt: null,
-    retryStartedAt: null,
-    consecutiveFailures: 0,
-    chatThreadId: body.chatThreadId ?? crypto.randomUUID(),
-    createdAt: now,
-    updatedAt: now,
-  };
   const automations = getMockSchedules();
   const existing = automations.find((s) => s.name === name);
+  const automation = createStoredSchedule({ ...body, name }, existing, now);
   if (existing) {
     setMockSchedules(
       automations.map((s) => (s.name === name ? automation : s)),
@@ -80,10 +58,7 @@ export const apiAutomationsHandlers = [
 
   // PUT /api/automations/:name
   mockApi(automationsByNameContract.update, ({ params, body, respond }) => {
-    const { automation, created, status } = upsert(
-      { ...body, name: params.name },
-      params.name,
-    );
+    const { automation, created, status } = upsert(body, params.name);
     return respond(status, { automation, created });
   }),
 

--- a/turbo/apps/platform/src/mocks/handlers/api-schedules.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-schedules.ts
@@ -69,7 +69,10 @@ function getMockScheduleTriggerType(
   return "loop";
 }
 
-function createStoredSchedule(
+// Shared with the automations mock handlers: an automation row IS a schedule
+// row, so upserts on either surface must preserve the stored identity fields
+// (id, chatThreadId, createdAt) the same way the production service does.
+export function createStoredSchedule(
   body: MockScheduleDeployBody,
   existing: ScheduleResponse | undefined,
   now: string,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -13,10 +13,8 @@ import {
   zeroAgentsByIdContract,
   zeroAgentsMainContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
-import {
-  type ScheduleResponse,
-  zeroSchedulesMainContract,
-} from "@vm0/api-contracts/contracts/zero-schedules";
+import { automationsByNameContract } from "@vm0/api-contracts/contracts/automations";
+import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
 import {
   type TeamComposeItem,
   zeroTeamContract,
@@ -199,7 +197,9 @@ describe("zero jobs page", () => {
     expect(findSectionCreateButton("Public")).toBeInTheDocument();
     expect(findSectionCreateButton("Private")).toBeInTheDocument();
 
-    click(screen.getByText("Scheduled"));
+    // The `zeroAutomations` switch is globally on (#17307), so the sidebar nav
+    // item is labeled with the Automations product noun by default.
+    click(screen.getByText("Automations"));
 
     await waitFor(() => {
       expect(screen.getAllByText("Morning brief")[0]).toBeInTheDocument();
@@ -373,31 +373,36 @@ describe("zero jobs page", () => {
     ];
     let capturedDeployBody: unknown = null;
     context.mocks.data.schedules(schedules);
-    context.mocks.api(zeroSchedulesMainContract.deploy, ({ body, respond }) => {
-      capturedDeployBody = body;
-      const currentSchedule = schedules[0];
-      if (!currentSchedule) {
-        throw new Error("schedule fixture not found");
-      }
-      const updated = createMockScheduleResponse({
-        ...currentSchedule,
-        name: body.name,
-        agentId: body.agentId,
-        triggerType: "cron",
-        cronExpression: body.cronExpression ?? null,
-        atTime: null,
-        intervalSeconds: null,
-        timezone: body.timezone ?? "UTC",
-        prompt: body.prompt,
-        description: body.description ?? null,
-        appendSystemPrompt: body.appendSystemPrompt ?? null,
-        enabled: body.enabled ?? true,
-        updatedAt: "2026-03-10T00:05:00Z",
-      });
-      schedules = [updated];
-      context.mocks.data.schedules(schedules);
-      return respond(200, { schedule: updated, created: false });
-    });
+    // The `zeroAutomations` switch is globally on (#17307), so schedule edits
+    // deploy through the Automations update endpoint (name in the path).
+    context.mocks.api(
+      automationsByNameContract.update,
+      ({ params, body, respond }) => {
+        capturedDeployBody = { ...body, name: params.name };
+        const currentSchedule = schedules[0];
+        if (!currentSchedule) {
+          throw new Error("schedule fixture not found");
+        }
+        const updated = createMockScheduleResponse({
+          ...currentSchedule,
+          name: params.name,
+          agentId: body.agentId,
+          triggerType: "cron",
+          cronExpression: body.cronExpression ?? null,
+          atTime: null,
+          intervalSeconds: null,
+          timezone: body.timezone ?? "UTC",
+          prompt: body.prompt,
+          description: body.description ?? null,
+          appendSystemPrompt: body.appendSystemPrompt ?? null,
+          enabled: body.enabled ?? true,
+          updatedAt: "2026-03-10T00:05:00Z",
+        });
+        schedules = [updated];
+        context.mocks.data.schedules(schedules);
+        return respond(200, { automation: updated, created: false });
+      },
+    );
 
     detachedSetupPage({ context, path: `/agents/${agentId}?tab=schedule` });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
@@ -497,7 +497,11 @@ describe("zero schedule detail page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Schedule deleted")).toBeInTheDocument();
-      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+      // Deletion returns to the schedules surface, which renders the
+      // Automations product noun now that the switch is globally on (#17307).
+      expect(
+        screen.getByRole("heading", { name: "Automations" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { zeroSchedulesMainContract } from "@vm0/api-contracts/contracts/zero-schedules";
+import { automationsMainContract } from "@vm0/api-contracts/contracts/automations";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -158,31 +158,11 @@ function mockScheduleListEdgeStory(): void {
   ]);
 }
 
+// The `zeroAutomations` switch is globally on (#17307), so the default surface
+// is Automations mode; the legacy Schedules surface stays covered by the
+// pinned switch-off test below until the dual-mode consumers are deleted.
 async function openSchedulePage(): Promise<void> {
   detachedSetupPage({ context, path: "/schedules" });
-
-  await waitFor(() => {
-    expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
-    expect(screen.getByText("Week view")).toBeInTheDocument();
-  });
-}
-
-async function openScheduleList(): Promise<void> {
-  await openSchedulePage();
-  click(tabByText("List"));
-
-  await waitFor(() => {
-    expect(screen.getByText("Instruction")).toBeInTheDocument();
-    expect(screen.getByText("Schedule at")).toBeInTheDocument();
-  });
-}
-
-async function openAutomationsList(): Promise<void> {
-  detachedSetupPage({
-    context,
-    path: "/schedules",
-    featureSwitches: { [FeatureSwitchKey.ZeroAutomations]: true },
-  });
 
   await waitFor(() => {
     expect(
@@ -190,6 +170,10 @@ async function openAutomationsList(): Promise<void> {
     ).toBeInTheDocument();
     expect(screen.getByText("Week view")).toBeInTheDocument();
   });
+}
+
+async function openScheduleList(): Promise<void> {
+  await openSchedulePage();
   click(tabByText("List"));
 
   await waitFor(() => {
@@ -222,7 +206,7 @@ describe("zero schedule page", () => {
 
     await openSchedulePage();
 
-    click(buttonByText("Add schedule"));
+    click(buttonByText("Add automation"));
 
     const createDialog = await screen.findByRole("dialog");
     expect(within(createDialog).getByText("Add schedule")).toBeInTheDocument();
@@ -301,7 +285,7 @@ describe("zero schedule page", () => {
 
     await openSchedulePage();
 
-    click(buttonByText("Add schedule"));
+    click(buttonByText("Add automation"));
 
     const createDialog = await screen.findByRole("dialog");
     await fill(
@@ -379,10 +363,10 @@ describe("zero schedule page", () => {
 
     const schedulesReady = context.mocks.deferred<void>();
 
-    context.mocks.api(zeroSchedulesMainContract.list, async ({ respond }) => {
+    context.mocks.api(automationsMainContract.list, async ({ respond }) => {
       await schedulesReady.promise;
       return respond(200, {
-        schedules: [
+        automations: [
           createMockScheduleResponse({
             id: "f0000001-0000-4000-a000-000000000306",
             agentId: researchAgentId,
@@ -401,7 +385,9 @@ describe("zero schedule page", () => {
     detachedSetupPage({ context, path: "/schedules" });
 
     await waitFor(() => {
-      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Automations" }),
+      ).toBeInTheDocument();
     });
     click(tabByText("List"));
 
@@ -477,11 +463,8 @@ describe("zero schedule page", () => {
     mockNow();
     mockSchedulePageStory();
 
-    await openAutomationsList();
+    await openScheduleList();
 
-    expect(
-      screen.getByRole("heading", { name: "Automations" }),
-    ).toBeInTheDocument();
     expect(screen.getAllByText("Morning brief")[0]).toBeInTheDocument();
 
     click(screen.getAllByLabelText("Disable Every weekday at 2:30 PM")[0]);
@@ -585,6 +568,76 @@ describe("zero schedule page", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("heading", { name: "Office AC" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // The switch is globally on (#17307); an explicit false override keeps the
+  // legacy Schedules surface covered until the dual-mode consumers are
+  // deleted, mirroring the pinned gating tests in the API suites.
+  it("manages schedules through the legacy surface when the switch is off", async () => {
+    mockNow();
+    mockSchedulePageStory();
+
+    detachedSetupPage({
+      context,
+      path: "/schedules",
+      featureSwitches: { [FeatureSwitchKey.ZeroAutomations]: false },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled tasks")).toBeInTheDocument();
+      expect(screen.getByText("Week view")).toBeInTheDocument();
+    });
+    click(tabByText("List"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Instruction")).toBeInTheDocument();
+      expect(screen.getAllByText("Morning brief")[0]).toBeInTheDocument();
+    });
+
+    click(screen.getAllByLabelText("Disable Every weekday at 2:30 PM")[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByLabelText("Enable Every weekday at 2:30 PM")[0],
+      ).toBeInTheDocument();
+    });
+
+    click(screen.getAllByLabelText("More actions for Every 45 minutes")[0]);
+    click(menuItemByText("Run now"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Run started/u)).toBeInTheDocument();
+      expect(screen.getByText("View activity")).toBeInTheDocument();
+    });
+
+    click(
+      screen.getAllByLabelText("More actions for Every weekday at 2:30 PM")[0],
+    );
+    click(menuItemByText("Delete"));
+
+    const deleteDialog = await screen.findByRole("dialog");
+    click(buttonByText("Delete", deleteDialog));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Morning brief")).not.toBeInTheDocument();
+    });
+
+    click(buttonByText("Add schedule"));
+
+    const createDialog = await screen.findByRole("dialog");
+    await fill(
+      within(createDialog).getByLabelText("Prompt"),
+      "Review legacy schedule coverage",
+    );
+    click(buttonByText("Create", createDialog));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", {
+          name: "Review legacy schedule coverage",
+        }),
       ).toBeInTheDocument();
     });
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -361,9 +361,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ZeroAutomations]: {
     maintainer: "lancy@vm0.ai",
     description:
-      "Expose the Automations API surface (/api/automations) over the shared automation service. When disabled, the new endpoints 404 and only the legacy /api/zero/schedules surface is reachable.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+      "Expose the Automations API surface (/api/automations) over the shared automation service. Fully on since #17307 (the schedule surface is being retired); the switch is removed once the dual-mode consumers are gone.",
+    enabled: true,
   },
   [FeatureSwitchKey.AutomationWebhookTriggers]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary

PR-3a of #17307. One-line flip: `zeroAutomations` goes from staff-only (`enabledOrgIdHashes`) to `enabled: true` for everyone.

Effect: all users now see the Automations surface — the `/api/automations` flat alias and `/api/v2/automations` resource API respond, and the platform dual-mode labels the page/sidebar "Automations" instead of "Schedules". This rides the existing, staff-tested dual-mode code path; no behavior change beyond the audience.

The switch (and the platform dual-mode that reads it) is deleted in a follow-up once the platform calls the resource API directly.

## Test plan

- [x] `feature-switch` unit suite green (21 tests)
- [x] `check-types` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)