### PR TITLE
[codex] strengthen video template preset guidance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
+  VIDEO_STYLE_PRESETS,
 } from "@vm0/core";
 import { buildGenerationTemplatePrompt } from "../generation-template-prompt";
 
@@ -39,5 +40,39 @@ describe("buildGenerationTemplatePrompt", () => {
         `Image style ID: ${item.illustrationStyleId}`,
       ),
     });
+  });
+
+  it("builds video template preset guidance", () => {
+    const item = VIDEO_STYLE_PRESETS[0]!;
+
+    const result = buildGenerationTemplatePrompt({
+      type: "video",
+      selection: {
+        stylePresetId: item.id,
+      },
+    });
+
+    expect(result).toStrictEqual({
+      status: "resolved",
+      prompt: expect.stringContaining("# Video Template Preset"),
+    });
+    if (result.status !== "resolved") {
+      return;
+    }
+    expect(result.prompt).toContain(`Preset ID: ${item.id}`);
+    expect(result.prompt).toContain(`Preset name: ${item.nameEn}`);
+    expect(result.prompt).toContain(
+      "The selected stylePresetId resolves to the seven video template dimensions below.",
+    );
+    expect(result.prompt).toContain("- Visual Tone:");
+    expect(result.prompt).toContain("- Camera Style:");
+    expect(result.prompt).toContain("- Editing Pace:");
+    expect(result.prompt).toContain("- Narrative Mode:");
+    expect(result.prompt).toContain("- Production Type:");
+    expect(result.prompt).toContain("- Emotional Tone:");
+    expect(result.prompt).toContain("- Style Reference:");
+    expect(result.prompt).toContain(
+      "Apply all seven preset dimensions below as hard generation constraints",
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -47,6 +47,7 @@ import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -672,7 +673,12 @@ describe("POST /api/zero/chat/messages", () => {
       .limit(1);
 
     expect(run?.prompt).toBe("make a product video");
-    expect(run?.appendSystemPrompt).toContain(`## Video Style: ${item.nameEn}`);
+    expect(run?.appendSystemPrompt).toContain("# Video Template Preset");
+    expect(run?.appendSystemPrompt).toContain(`Preset ID: ${item.id}`);
+    expect(run?.appendSystemPrompt).toContain(`Preset name: ${item.nameEn}`);
+    expect(run?.appendSystemPrompt).toContain(
+      "The selected stylePresetId resolves to the seven video template dimensions below.",
+    );
     expect(run?.appendSystemPrompt).toContain(
       `- Visual Tone: ${item.dimensions.visualTone}`,
     );
@@ -680,7 +686,22 @@ describe("POST /api/zero/chat/messages", () => {
       `- Camera Style: ${item.dimensions.cameraStyle}`,
     );
     expect(run?.appendSystemPrompt).toContain(
+      `- Editing Pace: ${item.dimensions.editingPace}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      `- Narrative Mode: ${item.dimensions.narrativeMode}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      `- Production Type: ${item.dimensions.productionType}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      `- Emotional Tone: ${item.dimensions.emotionalTone}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
       `- Style Reference: ${item.dimensions.styleReference}`,
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      "Apply all seven preset dimensions below as hard generation constraints",
     );
     expect(run?.appendSystemPrompt).toContain(
       "safe for all audiences, positive and uplifting, no violence, no explicit content",
@@ -865,11 +886,14 @@ describe("POST /api/zero/chat/messages", () => {
       .where(eq(agentRuns.id, response.body.runId!))
       .limit(1);
 
-    expect(run?.appendSystemPrompt).toContain(
-      `## Video Style: ${preset.nameEn}`,
-    );
+    expect(run?.appendSystemPrompt).toContain("# Video Template Preset");
+    expect(run?.appendSystemPrompt).toContain(`Preset ID: ${preset.id}`);
+    expect(run?.appendSystemPrompt).toContain(`Preset name: ${preset.nameEn}`);
     expect(run?.appendSystemPrompt).toContain("- Visual Tone:");
     expect(run?.appendSystemPrompt).toContain("- Style Reference:");
+    expect(run?.appendSystemPrompt).toContain(
+      `In the final video prompt, reflect every dimension listed above and the style ${preset.nameEn}.`,
+    );
     expect(run?.appendSystemPrompt).toContain(
       "safe for all audiences, positive and uplifting, no violence, no explicit content",
     );

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -120,9 +120,13 @@ function buildVideoGenerationTemplatePrompt(
   return {
     status: "resolved",
     prompt: [
-      `## Video Style: ${preset.nameEn}`,
+      "# Video Template Preset",
+      `- The selected stylePresetId resolves to the seven video template dimensions below.`,
+      `- Preset ID: ${preset.id}`,
+      `- Preset name: ${preset.nameEn}`,
       "",
-      "Apply these style constraints to the user's scene:",
+      "- Apply all seven preset dimensions below as hard generation constraints.",
+      "- Keep the user's prompt as the source of the requested content.",
       `- Visual Tone: ${describeSlug(preset.dimensions.visualTone)}`,
       `- Camera Style: ${describeSlug(preset.dimensions.cameraStyle)}`,
       `- Editing Pace: ${describeSlug(preset.dimensions.editingPace)}`,
@@ -131,8 +135,8 @@ function buildVideoGenerationTemplatePrompt(
       `- Emotional Tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
       `- Style Reference: ${describeSlug(preset.dimensions.styleReference)}`,
       "",
-      "Generate a single video prompt (2–3 sentences) that applies the above style to the user's scene.",
-      "End with: safe for all audiences, positive and uplifting, no violence, no explicit content",
+      `- In the final video prompt, reflect every dimension listed above and the style ${preset.nameEn}.`,
+      "- End the final video prompt with: safe for all audiences, positive and uplifting, no violence, no explicit content",
     ].join("\n"),
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1254,6 +1254,33 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("opens video templates by default when only the video picker is enabled", async () => {
+    const videoStyle = VIDEO_STYLE_PRESETS[0]!;
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.VideoTemplatePicker]: true },
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(tabByText("Video")).toBeInTheDocument();
+      expect(screen.getByText("VM0 video styles")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText(`Select video style ${videoStyle.nameEn}`),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("PPT")).not.toBeInTheDocument();
+      expect(screen.queryByText("Illustration")).not.toBeInTheDocument();
+    });
+  });
+
   it("queues a selected template during an active run and clears the picker state", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_ITEMS[0]!;


### PR DESCRIPTION
## Summary
- Update video generation template guidance to present the selected stylePresetId as a video template preset.
- List all seven resolved preset dimensions as hard generation constraints.
- Add prompt-builder coverage and update chat-message assertions for the stronger guidance.

## Validation
- pnpm -F api exec vitest src/signals/routes/__tests__/generation-template-prompt.test.ts
- pnpm -F api check-types

## Notes
- Full zero-chat-messages route tests still require a local vm0_test database; focused no-DB prompt coverage passed.