### PR TITLE
feat(api): add work intake reconciliation guidance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -552,6 +552,9 @@ describe("POST /api/zero/chat/messages", () => {
       chatThreadId: response.body.threadId,
     });
     expect(run?.appendSystemPrompt).not.toContain("# Generation Template");
+    expect(run?.appendSystemPrompt).not.toContain(
+      "# Active Workflow: Work Intake Reconciliation",
+    );
 
     const message = await firstUserMessage(response.body.threadId);
     expect(message).toMatchObject({
@@ -592,6 +595,54 @@ describe("POST /api/zero/chat/messages", () => {
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `chatThreadRunCreated:${response.body.threadId}`,
       null,
+    );
+  });
+
+  it("adds work intake reconciliation guidance when the feature is enabled", async () => {
+    const fixture = await track(seedFixture());
+    await store
+      .set(writeDb$)
+      .insert(userFeatureSwitches)
+      .values({
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        switches: {
+          [FeatureSwitchKey.ChatWorkIntakeReconciliation]: true,
+        },
+        updatedAt: nowDate(),
+      });
+
+    const response = await send({
+      agentId: fixture.agentId,
+      prompt: [
+        "Please process these meeting notes and identify customer requirements.",
+        "",
+        "Acme said SAML SSO blocks the enterprise upgrade.",
+        "Sarah mentioned Linear ENG-482 already exists but is still P3.",
+        "David said a Slack thread from Globex may contain the same request.",
+        "Mark mentioned a GitHub issue about org-level auth policy.",
+      ].join("\n"),
+    });
+    await flushWaitUntilForTest();
+
+    const [run] = await store
+      .set(writeDb$)
+      .select({
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
+      })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, response.body.runId!))
+      .limit(1);
+
+    expect(run?.appendSystemPrompt).toContain(
+      "# Active Workflow: Work Intake Reconciliation",
+    );
+    expect(run?.appendSystemPrompt).toContain("Do not only summarize it.");
+    expect(run?.appendSystemPrompt).toContain(
+      "Separate next steps into: can do now, needs connector or permission, and needs user approval.",
+    );
+    expect(run?.appendSystemPrompt).toContain(
+      "Recommend a connector only when it unlocks a concrete next step for this task.",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -436,6 +436,14 @@ function chatCallbackUrl(): string {
   ).toString();
 }
 
+function buildChatRunCallback(threadId: string, agentId: string) {
+  return {
+    url: chatCallbackUrl(),
+    secret: generateCallbackSecret(),
+    payload: { threadId, agentId },
+  };
+}
+
 function buildWebChatPrompt(): string {
   return [
     "# Current Integration\nYou are currently running inside: Web",
@@ -461,17 +469,158 @@ function buildAppendSystemPrompt(
   incompleteContext: string,
   priorContext: string,
   generationTemplatePrompt: string,
+  workflowPrompt: string,
 ): string {
   return [
     buildWebChatPrompt(),
     priorContext,
     incompleteContext,
     generationTemplatePrompt,
+    workflowPrompt,
   ]
     .filter((part) => {
       return part.length > 0;
     })
     .join("\n\n");
+}
+
+function normalizedIncludesAny(
+  normalizedText: string,
+  terms: readonly string[],
+): boolean {
+  return terms.some((term) => {
+    return normalizedText.includes(term);
+  });
+}
+
+function attachmentsSuggestWorkIntakeInput(
+  attachFiles: readonly AttachFile[] | undefined,
+): boolean {
+  if (!attachFiles || attachFiles.length === 0) {
+    return false;
+  }
+
+  return attachFiles.some((file) => {
+    const normalizedFilename = file.filename.toLowerCase();
+    const normalizedType = file.contentType.toLowerCase();
+    return (
+      normalizedFilename.endsWith(".vtt") ||
+      normalizedFilename.endsWith(".srt") ||
+      normalizedFilename.includes("transcript") ||
+      normalizedFilename.includes("meeting") ||
+      normalizedFilename.includes("notes") ||
+      normalizedFilename.includes("feedback") ||
+      normalizedFilename.includes("requirements") ||
+      normalizedFilename.includes("backlog") ||
+      normalizedType === "text/vtt" ||
+      normalizedType === "text/plain" ||
+      normalizedType === "text/markdown"
+    );
+  });
+}
+
+function shouldActivateWorkIntakeReconciliationWorkflow(
+  prompt: string,
+  attachFiles: readonly AttachFile[] | undefined,
+): boolean {
+  const normalizedPrompt = prompt.toLowerCase();
+  const intakeTerms = [
+    "meeting notes",
+    "meeting minutes",
+    "meeting transcript",
+    "call notes",
+    "sales call",
+    "customer call",
+    "transcript",
+    "customer feedback",
+    "customer request",
+    "feature request",
+    "product feedback",
+    "requirements",
+    "action items",
+    "follow-up",
+    "follow up",
+    "slack thread",
+    "backlog",
+    "roadmap",
+    "prd",
+    "incident review",
+    "sprint planning",
+  ] as const;
+  const workTerms = [
+    "linear",
+    "jira",
+    "github",
+    "slack",
+    "prd",
+    "ticket",
+    "issue",
+    "action item",
+    "customer request",
+    "requirement",
+    "blocker",
+    "owner",
+    "deadline",
+    "decision",
+    "risk",
+    "customer",
+    "crm",
+    "salesforce",
+    "hubspot",
+  ] as const;
+  const reconciliationTerms = [
+    "reconcile",
+    "triage",
+    "dedupe",
+    "duplicate",
+    "existing ticket",
+    "group",
+    "merge",
+    "organize",
+    "turn into work",
+    "turn into tickets",
+    "create tickets",
+  ] as const;
+
+  const hasIntakeInput =
+    normalizedIncludesAny(normalizedPrompt, intakeTerms) ||
+    attachmentsSuggestWorkIntakeInput(attachFiles);
+  const hasWorkSignal = normalizedIncludesAny(normalizedPrompt, workTerms);
+  const asksForReconciliation = normalizedIncludesAny(
+    normalizedPrompt,
+    reconciliationTerms,
+  );
+
+  return hasIntakeInput && (hasWorkSignal || asksForReconciliation);
+}
+
+function buildWorkIntakeReconciliationWorkflowPrompt(
+  prompt: string,
+  attachFiles: readonly AttachFile[] | undefined,
+): string {
+  if (!shouldActivateWorkIntakeReconciliationWorkflow(prompt, attachFiles)) {
+    return "";
+  }
+
+  return [
+    "# Active Workflow: Work Intake Reconciliation",
+    "The user's message appears to contain scattered work intake: meeting notes, transcripts, customer feedback, Slack discussion, backlog context, PRD notes, or requirements. Do not only summarize it.",
+    "Treat the task as reconciliation: identify what needs to become tracked work, what may already exist, and what needs more context before execution.",
+    "",
+    "Default response shape:",
+    "- Start with a concise summary only if it helps orient the user.",
+    "- Extract requirements, decisions, risks, open questions, owners, and deadlines.",
+    "- For each important requirement or action, list evidence from the provided material.",
+    "- Identify existing-work hints such as ticket IDs, issue names, Slack threads, PRDs, CRM records, repos, or customer names.",
+    "- Call out conflicts, duplicates, missing owners, unclear deadlines, and commitments that should not be overpromised.",
+    "- Separate next steps into: can do now, needs connector or permission, and needs user approval.",
+    "",
+    "Connector guidance:",
+    "- Recommend a connector only when it unlocks a concrete next step for this task.",
+    "- Explain the exact added capability, such as checking a Linear ticket, finding a Slack evidence thread, searching a GitHub issue, updating a PRD, or recording CRM context.",
+    "- Do not recommend optional connectors that only provide vague extra context.",
+    "- Do not execute external writes such as creating tickets, sending messages, changing CRM fields, or editing docs unless the user clearly requested that action or approved the proposed action.",
+  ].join("\n");
 }
 
 function buildFullPrompt(
@@ -1299,6 +1448,56 @@ async function computerUseFeatureEnabled(params: {
     userId: params.userId,
     overrides: context.overrides,
   });
+}
+
+async function workIntakeReconciliationFeatureEnabled(params: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<boolean> {
+  const context = await loadUserFeatureSwitchContext(
+    params.db,
+    params.orgId,
+    params.userId,
+  );
+  return isFeatureEnabled(FeatureSwitchKey.ChatWorkIntakeReconciliation, {
+    orgId: params.orgId,
+    userId: params.userId,
+    overrides: context.overrides,
+  });
+}
+
+async function buildNormalChatAppendSystemPrompt(
+  params: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly prompt: string;
+    readonly attachFiles: readonly AttachFile[] | undefined;
+    readonly incompleteContext: string;
+    readonly priorContext: string;
+    readonly generationTemplatePrompt: string;
+  },
+  signal: AbortSignal,
+): Promise<string> {
+  const workflowPrompt = (await workIntakeReconciliationFeatureEnabled({
+    db: params.db,
+    orgId: params.orgId,
+    userId: params.userId,
+  }))
+    ? buildWorkIntakeReconciliationWorkflowPrompt(
+        params.prompt,
+        params.attachFiles,
+      )
+    : "";
+  signal.throwIfAborted();
+
+  return buildAppendSystemPrompt(
+    params.incompleteContext,
+    params.priorContext,
+    params.generationTemplatePrompt,
+    workflowPrompt,
+  );
 }
 
 async function updateThreadComputerUseHost(params: {
@@ -2456,6 +2655,20 @@ const createNormalChatRun$ = command(
       });
     }
 
+    const appendSystemPrompt = await buildNormalChatAppendSystemPrompt(
+      {
+        db: prepared.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        prompt: args.body.prompt,
+        attachFiles: args.body.attachFiles,
+        incompleteContext: prepared.thread.incompleteContext,
+        priorContext: prepared.priorContext,
+        generationTemplatePrompt: prepared.generationTemplatePrompt,
+      },
+      signal,
+    );
+
     const runResult = await set(
       createZeroRun$,
       {
@@ -2468,14 +2681,7 @@ const createNormalChatRun$ = command(
           modelPin.modelProviderCredentialScope ?? undefined,
         selectedModelOverride: modelPin.selectedModel ?? undefined,
         callbacks: [
-          {
-            url: chatCallbackUrl(),
-            secret: generateCallbackSecret(),
-            payload: {
-              threadId: prepared.thread.threadId,
-              agentId: args.body.agentId,
-            },
-          },
+          buildChatRunCallback(prepared.thread.threadId, args.body.agentId),
         ],
         body: {
           prompt: fullPrompt,
@@ -2490,11 +2696,7 @@ const createNormalChatRun$ = command(
           debugNoMockCodex: args.body.debugNoMockCodex,
         },
         triggerSource: "web",
-        appendSystemPrompt: buildAppendSystemPrompt(
-          prepared.thread.incompleteContext,
-          prepared.priorContext,
-          prepared.generationTemplatePrompt,
-        ),
+        appendSystemPrompt,
       },
       signal,
     );

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -60,6 +60,7 @@ export enum FeatureSwitchKey {
   MemoryDevRefresh = "memoryDevRefresh",
   ChatCompletedWorkFolding = "chatCompletedWorkFolding",
   ChatRecommendedFollowups = "chatRecommendedFollowups",
+  ChatWorkIntakeReconciliation = "chatWorkIntakeReconciliation",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",
   CreditUsageRecords = "creditUsageRecords",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -339,6 +339,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Generate and show recommended follow-up prompts after completed chat runs.",
     enabled: true,
   },
+  [FeatureSwitchKey.ChatWorkIntakeReconciliation]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Inject work-intake reconciliation guidance for meetings, transcripts, customer feedback, and scattered requirements in chat.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PresentationHtmlPptxDownload]: {
     maintainer: "bingjie@vm0.ai",
     description: "Show a PPTX download action for presentation HTML artifacts.",


### PR DESCRIPTION
## Background / Motivation
We started from exploring meeting transcription and meeting-notes workflows, but the core product insight is broader: the valuable moment is not the transcript itself. It is helping users reconcile scattered work intake into executable follow-up.

In real teams, requirements and decisions often land across meeting notes, Slack threads, Linear/Jira tickets, GitHub issues, PRDs, customer feedback, and CRM context. A generic meeting-summary response stops too early: it tells the user what happened, but still leaves them to connect evidence, dedupe existing work, find the right system of record, and decide what can actually be done next.

This PR is a first gated step toward that behavior. The platform detects when a chat prompt looks like work intake/reconciliation, while the agent remains responsible for deciding whether any specific connector is useful for the concrete task. This avoids both extremes: users do not need to discover a hidden template, and vm0 does not blindly promote connectors when they do not unlock a next step.

## Summary
- add a gated chatWorkIntakeReconciliation feature switch
- detect scattered work-intake inputs such as meeting notes, transcripts, customer feedback, Slack/PRD/backlog context, and requirements
- inject workflow guidance that asks the agent to reconcile requirements, evidence, existing-work hints, risks, and connector-dependent next steps
- cover the enabled workflow prompt injection in the zero chat messages route test

## Product behavior
The platform detects when a prompt looks like work intake/reconciliation, but the agent decides whether a specific connector is useful. Connector recommendations are constrained to concrete next steps instead of blanket promotion.

## Verification
- pnpm exec prettier --write apps/api/src/signals/routes/zero-chat-messages.ts apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts
- pnpm -F api lint
- git diff --check

## Known local verification gaps
- pnpm -F api exec vitest src/signals/routes/__tests__/zero-chat-messages.test.ts fails locally because database "vm0_test" does not exist
- pnpm -F api check-types fails on existing cloudflare.generated missing exports from packages/connectors/src/firewalls/index.ts
- git commit reported lefthook was not available in PATH, so local hooks did not run
