### PR TITLE
fix(runner): use live registry for doctor reports

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -75,8 +75,20 @@ pub async fn run_benchmark(
 
     // 1. Load config, force concurrency=1
     let mut runner_config = config::load(&args.config).await?;
+    let registry_config_path = tokio::fs::canonicalize(&args.config).await.map_err(|e| {
+        RunnerError::Config(format!(
+            "canonicalize config path {} for live runner registry: {e}",
+            args.config.display()
+        ))
+    })?;
     runner_config.sandbox.max_concurrent = 1;
     crate::private_fs::ensure_private_dir(&runner_config.base_dir).await?;
+    let base_dir_canonical = runner_config.base_dir.canonicalize().map_err(|e| {
+        RunnerError::Config(format!(
+            "canonicalize base_dir {} for live runner registry: {e}",
+            runner_config.base_dir.display()
+        ))
+    })?;
 
     let home = HomePaths::new()?;
 
@@ -118,6 +130,25 @@ pub async fn run_benchmark(
     let proxy_ms = t.elapsed().as_millis();
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
+    let live_runner_instance_handle = match crate::live_runner_instances::publish(
+        &home,
+        crate::live_runner_instances::LiveRunnerInstanceMetadata {
+            config_path: registry_config_path,
+            base_dir: base_dir_canonical,
+            runner_name: runner_config.name.clone(),
+            runner_group: runner_config.group.clone(),
+            subcommand: "benchmark".into(),
+        },
+    )
+    .await
+    {
+        Ok(handle) => handle,
+        Err(e) => {
+            stop_benchmark_proxy(&mut mitm, "live_runner_publish").await;
+            return Err(e);
+        }
+    };
+
     // 3. Factory init (with proxy port) via sandbox runtime
     let factory_config = runner_config.factory_config(profile_name, profile_config, &home);
 
@@ -133,18 +164,23 @@ pub async fn run_benchmark(
         Err(e) => {
             drop(resource_locks);
             stop_benchmark_proxy(&mut mitm, "runtime_create").await;
+            remove_benchmark_live_runner_instance(&live_runner_instance_handle, "runtime_create")
+                .await;
             return Err(e.into());
         }
     };
-    let mut factory =
-        match create_factory_or_shutdown_runtime(runtime.as_mut(), factory_config).await {
-            Ok(factory) => factory,
-            Err(e) => {
-                drop(resource_locks);
-                stop_benchmark_proxy(&mut mitm, "factory_create").await;
-                return Err(e.into());
-            }
-        };
+    let mut factory = match create_factory_or_shutdown_runtime(runtime.as_mut(), factory_config)
+        .await
+    {
+        Ok(factory) => factory,
+        Err(e) => {
+            drop(resource_locks);
+            stop_benchmark_proxy(&mut mitm, "factory_create").await;
+            remove_benchmark_live_runner_instance(&live_runner_instance_handle, "factory_create")
+                .await;
+            return Err(e.into());
+        }
+    };
     let factory_ms = t.elapsed().as_millis();
     info!(factory_ms, "factory ready");
 
@@ -169,6 +205,7 @@ pub async fn run_benchmark(
     if let Err(e) = mitm.stop().await {
         warn!(error = %e, "proxy stop failed");
     }
+    remove_benchmark_live_runner_instance(&live_runner_instance_handle, "complete").await;
 
     // 5. Log timing summary (always, even on error)
     let Timing {
@@ -225,6 +262,15 @@ pub async fn run_benchmark(
 async fn stop_benchmark_proxy(mitm: &mut proxy::MitmProxy, phase: &'static str) {
     if let Err(e) = mitm.stop().await {
         warn!(error = %e, phase, "proxy stop failed during benchmark cleanup");
+    }
+}
+
+async fn remove_benchmark_live_runner_instance(
+    handle: &crate::live_runner_instances::LiveRunnerInstanceHandle,
+    phase: &'static str,
+) {
+    if let Err(e) = handle.remove_if_current().await {
+        warn!(error = %e, phase, "failed to remove benchmark live runner instance record");
     }
 }
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -603,7 +603,7 @@ async fn build_runner_report(
         base_dir: Some(runner.base_dir.clone()),
         pid: runner.pid,
         config_path: runner.config_path.clone(),
-        subcommand: "start".into(),
+        subcommand: runner.subcommand.clone(),
         service_type,
         status,
         api_ok,
@@ -1914,6 +1914,7 @@ mod tests {
             base_dir,
             runner_name: "test-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         }
     }
@@ -2031,6 +2032,7 @@ mod tests {
                 base_dir: base_dir.clone(),
                 runner_name: "test-runner".into(),
                 runner_group: "vm0/test".into(),
+                subcommand: "start".into(),
             },
         )
         .await
@@ -2095,6 +2097,21 @@ mod tests {
         assert_eq!(report.subcommand, "start");
         assert!(report.status.is_some());
         assert_eq!(report.api_ok, None);
+    }
+
+    #[tokio::test]
+    async fn report_uses_registry_subcommand() {
+        let fixture = doctor_report_fixture("running", None, None);
+        let mut runner = live_runner_instance(
+            std::process::id(),
+            fixture.config_path.clone(),
+            fixture.base_dir.clone(),
+        );
+        runner.subcommand = "benchmark".into();
+
+        let report = build_runner_report(&runner, &[], &[], &[], &[]).await;
+
+        assert_eq!(report.subcommand, "benchmark");
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 
 use crate::config::RunnerConfig;
 use crate::error::RunnerResult;
+use crate::live_runner_instances::LiveRunnerInstance;
+use crate::paths::HomePaths;
 use crate::process;
 use clap::Args;
 use serde::Deserialize;
@@ -347,23 +349,14 @@ struct StoppedInfo {
 pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     // Phase 1: Discover running processes (single /proc scan)
     let discovered = process::discover_all().await;
+    let home = HomePaths::new()?;
 
     // Phase 2: Discover installed services
     let installed_services = find_installed_services().await;
 
     // Phase 3: Build runner reports
-    let mut reports = Vec::new();
-    for runner in &discovered.runners {
-        let report = build_runner_report(
-            runner,
-            &discovered.firecrackers,
-            &discovered.mitmdumps,
-            &discovered.dnsmasqs,
-            &installed_services,
-        )
-        .await;
-        reports.push(report);
-    }
+    let live_runners = crate::live_runner_instances::list(&home).await;
+    let reports = build_runner_reports(&live_runners, &discovered, &installed_services).await;
 
     // Phase 4: Find stopped services (installed but no matching running process)
     // Skip when filtering by name — other runners' stopped services are irrelevant
@@ -457,12 +450,32 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     }
 }
 
+async fn build_runner_reports(
+    live_runners: &[LiveRunnerInstance],
+    discovered: &process::DiscoveredProcesses,
+    installed: &[InstalledService],
+) -> Vec<RunnerReport> {
+    let mut reports = Vec::new();
+    for runner in live_runners {
+        let report = build_runner_report(
+            runner,
+            &discovered.firecrackers,
+            &discovered.mitmdumps,
+            &discovered.dnsmasqs,
+            installed,
+        )
+        .await;
+        reports.push(report);
+    }
+    reports
+}
+
 // ---------------------------------------------------------------------------
 // Report building
 // ---------------------------------------------------------------------------
 
 async fn build_runner_report(
-    runner: &process::RunnerProcessInfo,
+    runner: &LiveRunnerInstance,
     fc_procs: &[process::FirecrackerProcessInfo],
     mitm_procs: &[process::MitmproxyProcessInfo],
     dns_procs: &[process::DnsmasqProcessInfo],
@@ -472,17 +485,13 @@ async fn build_runner_report(
 
     // Load config (best-effort)
     let config = load_config_lenient(&runner.config_path).await;
-    let name = config.as_ref().map(|c| c.name.clone());
+    let name = Some(runner.runner_name.clone());
 
     // Detect service type
     let service_type = detect_service_type(runner.pid, installed).await;
 
     // Read status.json
-    let status = if let Some(cfg) = &config {
-        read_status(&cfg.base_dir).await
-    } else {
-        None
-    };
+    let status = read_status(&runner.base_dir).await;
 
     // API connectivity check (only when server is configured)
     let api_ok = match &config {
@@ -500,7 +509,7 @@ async fn build_runner_report(
     }
 
     // Base dir for job correlation
-    let base_dir = config.as_ref().map(|c| &c.base_dir);
+    let base_dir = &runner.base_dir;
 
     // Proxy check (match by port from status.json).
     //   running  + proxy missing  → NoMitmproxy warning
@@ -512,8 +521,10 @@ async fn build_runner_report(
         let pid = mitm_procs.iter().find(|m| m.port == port).map(|m| m.pid);
         match (st.mode.as_str(), pid) {
             ("running", None) => {
-                let bd = base_dir.map(|p| p.to_path_buf()).unwrap_or_default();
-                warnings.push(Warning::NoMitmproxy { port, base_dir: bd });
+                warnings.push(Warning::NoMitmproxy {
+                    port,
+                    base_dir: base_dir.clone(),
+                });
             }
             ("stopped", Some(mitm_pid)) => {
                 warnings.push(Warning::StaleMitmproxy {
@@ -534,8 +545,10 @@ async fn build_runner_report(
     {
         let pid = dns_procs.iter().find(|d| d.port == port).map(|d| d.pid);
         if st.mode == "running" && pid.is_none() {
-            let bd = base_dir.map(|p| p.to_path_buf()).unwrap_or_default();
-            warnings.push(Warning::NoDnsmasq { port, base_dir: bd });
+            warnings.push(Warning::NoDnsmasq {
+                port,
+                base_dir: base_dir.clone(),
+            });
         }
         pid
     } else {
@@ -543,8 +556,8 @@ async fn build_runner_report(
     };
 
     // Job correlation
-    let jobs = if let (Some(st), Some(bd)) = (&status, base_dir) {
-        let (job_reports, job_warnings) = correlate_jobs(st, bd, fc_procs);
+    let jobs = if let Some(st) = &status {
+        let (job_reports, job_warnings) = correlate_jobs(st, base_dir, fc_procs);
         warnings.extend(job_warnings);
         job_reports
     } else {
@@ -553,10 +566,10 @@ async fn build_runner_report(
 
     RunnerReport {
         name,
-        base_dir: config.as_ref().map(|c| c.base_dir.clone()),
+        base_dir: Some(runner.base_dir.clone()),
         pid: runner.pid,
         config_path: runner.config_path.clone(),
-        subcommand: runner.subcommand.clone(),
+        subcommand: "start".into(),
         service_type,
         status,
         api_ok,
@@ -1215,6 +1228,7 @@ fn format_uptime(started_at: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use httpmock::prelude::*;
 
     #[test]
     fn format_uptime_minutes() {
@@ -1762,6 +1776,7 @@ mod tests {
     struct DoctorReportFixture {
         _dir: tempfile::TempDir,
         config_path: PathBuf,
+        base_dir: PathBuf,
     }
 
     fn doctor_report_fixture(
@@ -1808,6 +1823,22 @@ mod tests {
         DoctorReportFixture {
             _dir: dir,
             config_path,
+            base_dir,
+        }
+    }
+
+    fn live_runner_instance(
+        pid: u32,
+        config_path: PathBuf,
+        base_dir: PathBuf,
+    ) -> LiveRunnerInstance {
+        LiveRunnerInstance {
+            pid,
+            config_path,
+            base_dir,
+            runner_name: "test-runner".into(),
+            runner_group: "vm0/test".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
         }
     }
 
@@ -1819,11 +1850,11 @@ mod tests {
         dns_procs: Vec<process::DnsmasqProcessInfo>,
     ) -> RunnerReport {
         let fixture = doctor_report_fixture(mode, proxy_port, dns_port);
-        let runner = process::RunnerProcessInfo {
-            pid: std::process::id(),
-            config_path: fixture.config_path.clone(),
-            subcommand: "start".into(),
-        };
+        let runner = live_runner_instance(
+            std::process::id(),
+            fixture.config_path.clone(),
+            fixture.base_dir.clone(),
+        );
         let report = build_runner_report(&runner, &[], &mitm_procs, &dns_procs, &[]).await;
         assert!(report.base_dir.is_some(), "test config should load");
         assert!(report.status.is_some(), "test status should load");
@@ -1842,6 +1873,15 @@ mod tests {
         process::DnsmasqProcessInfo { pid, port }
     }
 
+    fn empty_discovered() -> process::DiscoveredProcesses {
+        process::DiscoveredProcesses {
+            runners: vec![],
+            firecrackers: vec![],
+            mitmdumps: vec![],
+            dnsmasqs: vec![],
+        }
+    }
+
     fn has_proxy_warning(report: &RunnerReport) -> bool {
         report.warnings.iter().any(|w| {
             matches!(
@@ -1856,6 +1896,92 @@ mod tests {
             .warnings
             .iter()
             .any(|w| matches!(w, Warning::NoDnsmasq { .. }))
+    }
+
+    #[tokio::test]
+    async fn report_uses_registry_identity_when_config_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().join("runner");
+        std::fs::create_dir_all(&base_dir).unwrap();
+        std::fs::write(
+            base_dir.join("status.json"),
+            r#"{
+                "mode": "running",
+                "max_concurrent": 4,
+                "active_runs": [],
+                "started_at": "2026-01-01T00:00:00.000Z",
+                "updated_at": "2026-01-01T00:00:00.000Z"
+            }"#,
+        )
+        .unwrap();
+        let runner = live_runner_instance(
+            std::process::id(),
+            dir.path().join("missing-runner.yaml"),
+            base_dir.clone(),
+        );
+
+        let report = build_runner_report(&runner, &[], &[], &[], &[]).await;
+
+        assert_eq!(report.name.as_deref(), Some("test-runner"));
+        assert_eq!(report.base_dir.as_deref(), Some(base_dir.as_path()));
+        assert_eq!(report.config_path, dir.path().join("missing-runner.yaml"));
+        assert_eq!(report.pid, std::process::id());
+        assert_eq!(report.subcommand, "start");
+        assert!(report.status.is_some());
+        assert_eq!(report.api_ok, None);
+    }
+
+    #[tokio::test]
+    async fn build_runner_reports_ignores_discovered_runner_candidates() {
+        let server = MockServer::start_async().await;
+        let api = server
+            .mock_async(|when, then| {
+                when.method("HEAD").path("/api");
+                then.status(200);
+            })
+            .await;
+        let fixture = doctor_report_fixture("running", None, None);
+        let config = serde_json::json!({
+            "name": "spoofed-runner",
+            "group": "vm0/test",
+            "base_dir": fixture.base_dir.display().to_string(),
+            "ca_dir": fixture._dir.path().join("ca").display().to_string(),
+            "firecracker": {
+                "binary": fixture._dir.path().join("firecracker").display().to_string(),
+                "kernel": fixture._dir.path().join("vmlinux").display().to_string(),
+            },
+            "profiles": {
+                "vm0/default": {
+                    "rootfs_hash": "rootfs",
+                    "snapshot_hash": "snapshot",
+                    "vcpu": 1,
+                    "memory_mb": 512,
+                    "rootfs_disk_mb": 512,
+                    "workspace_disk_mb": 1024,
+                },
+            },
+            "server": {
+                "url": server.url("/api"),
+                "token": "spoofed-token",
+            },
+        });
+        std::fs::write(
+            &fixture.config_path,
+            serde_yaml_ng::to_string(&config).unwrap(),
+        )
+        .unwrap();
+        let discovered = process::DiscoveredProcesses {
+            runners: vec![process::RunnerProcessInfo {
+                pid: std::process::id(),
+                config_path: fixture.config_path,
+            }],
+            ..empty_discovered()
+        };
+
+        let reports = build_runner_reports(&[], &discovered, &[]).await;
+
+        assert!(reports.is_empty());
+        api.assert_calls_async(0).await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -158,7 +158,7 @@ impl Warning {
     /// Process-related checks use the pre-scanned `fresh` data (a single
     /// `/proc` scan shared across all warnings). Other checks do their own
     /// minimal I/O (status.json read, HTTP HEAD, flock).
-    async fn persists(&self, fresh: &process::DiscoveredProcesses) -> bool {
+    async fn persists(&self, fresh: &process::DiscoveredProcesses, runner_pids: &[u32]) -> bool {
         match self {
             Self::ApiUnreachable {
                 server_url,
@@ -245,8 +245,9 @@ impl Warning {
                 pid_exists(*pid)
             }
             Self::OrphanFirecracker { pid, .. } | Self::OrphanMitmdump { pid, .. } => {
-                // Resolved if process has exited.
-                pid_exists(*pid)
+                // Resolved if the process exited or a runner registry entry
+                // appeared after the initial scan and now owns the process.
+                pid_exists(*pid) && process::is_orphan(*pid, runner_pids).await
             }
             Self::OrphanNamespace { pool_idx, .. } => {
                 let lock_path = format!("/var/lock/vm0-netns-pool-{pool_idx}.lock");
@@ -424,9 +425,24 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
 
         recheck_per_runner_warnings(&home, &fresh, &mut reports).await;
 
+        let rechecks_orphan_process = global_warnings.iter().any(|warning| {
+            matches!(
+                warning,
+                Warning::OrphanFirecracker { .. } | Warning::OrphanMitmdump { .. }
+            )
+        });
+        let fresh_runner_pids: Vec<u32> = if rechecks_orphan_process {
+            crate::live_runner_instances::list(&home)
+                .await
+                .into_iter()
+                .map(|runner| runner.pid)
+                .collect()
+        } else {
+            Vec::new()
+        };
         let mut rechecked_global = Vec::new();
         for warning in global_warnings.drain(..) {
-            if warning.persists(&fresh).await {
+            if warning.persists(&fresh, &fresh_runner_pids).await {
                 rechecked_global.push(warning);
             }
         }
@@ -459,7 +475,7 @@ async fn recheck_per_runner_warnings(
 
         let mut rechecked = Vec::new();
         for warning in report.warnings.drain(..) {
-            if warning.persists(fresh).await {
+            if warning.persists(fresh, &[]).await {
                 rechecked.push(warning);
             }
         }
@@ -1508,7 +1524,7 @@ mod tests {
             base_dir: base_dir.clone(),
         };
         assert!(
-            !warning.persists(&empty_fresh()).await,
+            !warning.persists(&empty_fresh(), &[]).await,
             "warning about R1 must clear after R1 leaves active_runs even though S1 is reused"
         );
     }
@@ -1536,7 +1552,7 @@ mod tests {
             base_dir: base_dir.clone(),
         };
         // R1 is still active and there's no FC in fresh. Warning persists.
-        assert!(warning.persists(&empty_fresh()).await);
+        assert!(warning.persists(&empty_fresh(), &[]).await);
     }
 
     #[tokio::test]
@@ -1568,7 +1584,7 @@ mod tests {
             base_dir: base_dir.clone(),
         };
         assert!(
-            !warning.persists(&empty_fresh()).await,
+            !warning.persists(&empty_fresh(), &[]).await,
             "warning must clear once the sandbox is tracked as idle"
         );
     }
@@ -1596,7 +1612,7 @@ mod tests {
             sandbox_id: "S1".into(),
             base_dir: base_dir.clone(),
         };
-        assert!(!warning.persists(&empty_fresh()).await);
+        assert!(!warning.persists(&empty_fresh(), &[]).await);
     }
 
     #[tokio::test]
@@ -1620,7 +1636,7 @@ mod tests {
             sandbox_id: "S-ghost".into(),
             base_dir: base_dir.clone(),
         };
-        assert!(warning.persists(&empty_fresh()).await);
+        assert!(warning.persists(&empty_fresh(), &[]).await);
     }
 
     #[tokio::test]
@@ -1633,7 +1649,38 @@ mod tests {
             sandbox_id: "S-anything".into(),
             base_dir,
         };
-        assert!(!warning.persists(&empty_fresh()).await);
+        assert!(!warning.persists(&empty_fresh(), &[]).await);
+    }
+
+    #[tokio::test]
+    async fn orphan_mitmdump_clears_when_parent_runner_pid_appears() {
+        struct ChildGuard(std::process::Child);
+
+        impl Drop for ChildGuard {
+            fn drop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
+
+        let child = ChildGuard(
+            std::process::Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .unwrap(),
+        );
+        let warning = Warning::OrphanMitmdump {
+            pid: child.0.id(),
+            port: 32821,
+            ppid: Some(std::process::id()),
+        };
+
+        assert!(warning.persists(&empty_fresh(), &[]).await);
+        assert!(
+            !warning
+                .persists(&empty_fresh(), &[std::process::id()])
+                .await
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -281,6 +281,7 @@ fn pid_exists(pid: u32) -> bool {
 // ---------------------------------------------------------------------------
 
 struct RunnerReport {
+    live_runner: LiveRunnerInstance,
     name: Option<String>,
     base_dir: Option<PathBuf>,
     pid: u32,
@@ -421,15 +422,7 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
         // Single /proc scan shared across all warning rechecks.
         let fresh = process::discover_all().await;
 
-        for report in &mut reports {
-            let mut rechecked = Vec::new();
-            for warning in report.warnings.drain(..) {
-                if warning.persists(&fresh).await {
-                    rechecked.push(warning);
-                }
-            }
-            report.warnings = rechecked;
-        }
+        recheck_per_runner_warnings(&home, &fresh, &mut reports).await;
 
         let mut rechecked_global = Vec::new();
         for warning in global_warnings.drain(..) {
@@ -447,6 +440,30 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
         Ok(ExitCode::FAILURE)
     } else {
         Ok(ExitCode::SUCCESS)
+    }
+}
+
+async fn recheck_per_runner_warnings(
+    home: &HomePaths,
+    fresh: &process::DiscoveredProcesses,
+    reports: &mut [RunnerReport],
+) {
+    for report in reports {
+        if report.warnings.is_empty() {
+            continue;
+        }
+        if !crate::live_runner_instances::is_current(home, &report.live_runner).await {
+            report.warnings.clear();
+            continue;
+        }
+
+        let mut rechecked = Vec::new();
+        for warning in report.warnings.drain(..) {
+            if warning.persists(fresh).await {
+                rechecked.push(warning);
+            }
+        }
+        report.warnings = rechecked;
     }
 }
 
@@ -565,6 +582,7 @@ async fn build_runner_report(
     };
 
     RunnerReport {
+        live_runner: runner.clone(),
         name,
         base_dir: Some(runner.base_dir.clone()),
         pid: runner.pid,
@@ -1631,6 +1649,11 @@ mod tests {
             },
         ];
         let reports = vec![RunnerReport {
+            live_runner: live_runner_instance(
+                1,
+                PathBuf::from("/data/active.yaml"),
+                PathBuf::from("/data/active"),
+            ),
             name: None,
             base_dir: None,
             pid: 1,
@@ -1652,6 +1675,11 @@ mod tests {
 
     fn make_report(name: Option<&str>) -> RunnerReport {
         RunnerReport {
+            live_runner: live_runner_instance(
+                1,
+                PathBuf::from("/data/test.yaml"),
+                PathBuf::from("/data/test"),
+            ),
             name: name.map(String::from),
             base_dir: None,
             pid: 1,
@@ -1834,6 +1862,7 @@ mod tests {
     ) -> LiveRunnerInstance {
         LiveRunnerInstance {
             pid,
+            starttime: 0,
             config_path,
             base_dir,
             runner_name: "test-runner".into(),
@@ -1896,6 +1925,96 @@ mod tests {
             .warnings
             .iter()
             .any(|w| matches!(w, Warning::NoDnsmasq { .. }))
+    }
+
+    #[tokio::test]
+    async fn recheck_clears_runner_warnings_when_registry_entry_disappears() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let base_dir = dir.path().join("runner");
+        let runner = live_runner_instance(
+            std::process::id(),
+            dir.path().join("runner.yaml"),
+            base_dir.clone(),
+        );
+        let mut reports = vec![RunnerReport {
+            live_runner: runner.clone(),
+            name: Some(runner.runner_name.clone()),
+            base_dir: Some(base_dir.clone()),
+            pid: runner.pid,
+            config_path: runner.config_path.clone(),
+            subcommand: "start".into(),
+            service_type: ServiceType::Bare,
+            status: None,
+            api_ok: None,
+            proxy_pid: None,
+            dns_pid: None,
+            jobs: vec![],
+            warnings: vec![Warning::NoMitmproxy {
+                port: 32821,
+                base_dir,
+            }],
+        }];
+
+        recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports).await;
+
+        assert!(reports[0].warnings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn recheck_keeps_runner_warnings_while_registry_entry_is_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let base_dir = dir.path().join("runner");
+        std::fs::create_dir_all(&base_dir).unwrap();
+        std::fs::write(
+            base_dir.join("status.json"),
+            r#"{
+                "mode": "running",
+                "active_runs": [],
+                "started_at": "2026-01-01T00:00:00.000Z",
+                "proxy_port": 32821
+            }"#,
+        )
+        .unwrap();
+        let _handle = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: dir.path().join("runner.yaml"),
+                base_dir: base_dir.clone(),
+                runner_name: "test-runner".into(),
+                runner_group: "vm0/test".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let runner = crate::live_runner_instances::list(&home)
+            .await
+            .into_iter()
+            .next()
+            .unwrap();
+        let mut reports = vec![RunnerReport {
+            live_runner: runner.clone(),
+            name: Some(runner.runner_name.clone()),
+            base_dir: Some(base_dir.clone()),
+            pid: runner.pid,
+            config_path: runner.config_path.clone(),
+            subcommand: "start".into(),
+            service_type: ServiceType::Bare,
+            status: None,
+            api_ok: None,
+            proxy_pid: None,
+            dns_pid: None,
+            jobs: vec![],
+            warnings: vec![Warning::NoMitmproxy {
+                port: 32821,
+                base_dir,
+            }],
+        }];
+
+        recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports).await;
+
+        assert_eq!(reports[0].warnings.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -195,6 +195,12 @@ pub async fn run_start(
         .map_err(|e| RunnerError::Internal(format!("register signal handlers: {e}")))?;
 
     let mut runner_config = config::load(&args.config).await?;
+    let registry_config_path = tokio::fs::canonicalize(&args.config).await.map_err(|e| {
+        RunnerError::Config(format!(
+            "canonicalize config path {} for live runner registry: {e}",
+            args.config.display()
+        ))
+    })?;
 
     // CLI / env overrides — take server out so we can mutate independently
     let mut server = runner_config.server.take().unwrap_or(config::ServerConfig {
@@ -509,7 +515,7 @@ pub async fn run_start(
     });
 
     let live_runner_instance_metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
-        config_path: args.config.clone(),
+        config_path: registry_config_path,
         base_dir: base_dir_canonical.clone(),
         runner_name: name.clone(),
         runner_group: group_name.clone(),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -164,17 +164,36 @@ pub struct StartArgs {
     local: bool,
 }
 
+struct LiveRunnerPublishResources<'a> {
+    provider: &'a dyn JobProvider,
+    runtime: &'a mut dyn SandboxRuntime,
+    mitm: &'a mut proxy::MitmProxy,
+    kmsg_handle: kmsg_log::KmsgHandle,
+    dns_handle: dns::DnsProxy,
+    memory_prefetch: &'a mut prefetch::MemoryPrefetchTasks,
+}
+
 async fn publish_live_runner_instance_or_shutdown_startup_resources(
     home: &HomePaths,
     metadata: crate::live_runner_instances::LiveRunnerInstanceMetadata,
-    provider: &dyn JobProvider,
-    runtime: &mut dyn SandboxRuntime,
-) -> RunnerResult<crate::live_runner_instances::LiveRunnerInstanceHandle> {
+    resources: LiveRunnerPublishResources<'_>,
+) -> RunnerResult<(
+    crate::live_runner_instances::LiveRunnerInstanceHandle,
+    kmsg_log::KmsgHandle,
+    dns::DnsProxy,
+)> {
     match crate::live_runner_instances::publish(home, metadata).await {
-        Ok(handle) => Ok(handle),
+        Ok(handle) => Ok((handle, resources.kmsg_handle, resources.dns_handle)),
         Err(e) => {
-            provider.shutdown().await;
-            runtime.shutdown().await;
+            resources.memory_prefetch.cancel();
+            resources.provider.shutdown().await;
+            resources.runtime.shutdown().await;
+            if let Err(stop_error) = resources.mitm.stop().await {
+                warn!(error = %stop_error, "failed to stop proxy after live runner instance publish failed");
+            }
+            resources.kmsg_handle.stop().await;
+            resources.dns_handle.stop().await;
+            resources.memory_prefetch.drain().await;
             Err(e)
         }
     }
@@ -316,7 +335,7 @@ pub async fn run_start(
     })?;
 
     // Start background prefetch of snapshot memory for all profiles.
-    let memory_prefetch =
+    let mut memory_prefetch =
         prefetch::MemoryPrefetchTasks::spawn(runner_config.profiles.values().map(|profile| {
             crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash)
                 .snapshot(&profile.snapshot_hash)
@@ -521,13 +540,20 @@ pub async fn run_start(
         runner_group: group_name.clone(),
     };
 
-    let live_runner_instance_handle = publish_live_runner_instance_or_shutdown_startup_resources(
-        &home,
-        live_runner_instance_metadata,
-        provider.as_ref(),
-        runtime.as_mut(),
-    )
-    .await?;
+    let (live_runner_instance_handle, kmsg_handle, dns_handle) =
+        publish_live_runner_instance_or_shutdown_startup_resources(
+            &home,
+            live_runner_instance_metadata,
+            LiveRunnerPublishResources {
+                provider: provider.as_ref(),
+                runtime: runtime.as_mut(),
+                mitm: &mut mitm,
+                kmsg_handle,
+                dns_handle,
+                memory_prefetch: &mut memory_prefetch,
+            },
+        )
+        .await?;
 
     let config = RunConfig {
         runner: RunnerInfo {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -188,8 +188,8 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
             resources.memory_prefetch.cancel();
             resources.provider.shutdown().await;
             resources.runtime.shutdown().await;
-            if let Err(stop_error) = resources.mitm.stop().await {
-                warn!(error = %stop_error, "failed to stop proxy after live runner instance publish failed");
+            if let Err(kill_error) = resources.mitm.kill_now().await {
+                warn!(error = %kill_error, "failed to kill proxy after live runner instance publish failed");
             }
             resources.kmsg_handle.stop().await;
             resources.dns_handle.stop().await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -538,6 +538,7 @@ pub async fn run_start(
         base_dir: base_dir_canonical.clone(),
         runner_name: name.clone(),
         runner_group: group_name.clone(),
+        subcommand: "start".into(),
     };
 
     let (live_runner_instance_handle, kmsg_handle, dns_handle) =

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -105,6 +105,8 @@ fn write_usage_pending_state(
 
 #[tokio::test]
 async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
+    use tokio::io::AsyncBufReadExt;
+
     let dir = tempfile::tempdir().unwrap();
     let home = crate::paths::HomePaths::with_root(dir.path().join("vm0-runner"));
     std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
@@ -119,6 +121,33 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
         shutdowns: Arc::clone(&runtime_shutdowns),
     };
     let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
+    let mut ignore_term_child = tokio::process::Command::new("python3")
+        .arg("-c")
+        .arg(
+            r#"
+import os
+import signal
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+os.write(1, b"ready\n")
+while True:
+    signal.pause()
+"#,
+        )
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+    let stdout = ignore_term_child.stdout.take().unwrap();
+    let mut ready_lines = tokio::io::BufReader::new(stdout).lines();
+    let ready = tokio::time::timeout(Duration::from_secs(2), ready_lines.next_line())
+        .await
+        .expect("ignore-term child did not become ready")
+        .unwrap();
+    assert_eq!(ready.as_deref(), Some("ready"));
+    mitm.set_child_for_test(ignore_term_child);
     let prefetch_cancel = CancellationToken::new();
     let task_cancel = prefetch_cancel.clone();
     let (cancelled_tx, cancelled_rx) = tokio::sync::oneshot::channel();
@@ -135,19 +164,23 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
         runner_group: "vm0/test".into(),
     };
 
-    let error = match publish_live_runner_instance_or_shutdown_startup_resources(
-        &home,
-        metadata,
-        LiveRunnerPublishResources {
-            provider: &provider,
-            runtime: &mut runtime,
-            mitm: &mut mitm,
-            kmsg_handle: crate::kmsg_log::KmsgHandle::noop(),
-            dns_handle: crate::dns::DnsProxy::noop(),
-            memory_prefetch: &mut memory_prefetch,
-        },
+    let error = match tokio::time::timeout(
+        Duration::from_secs(2),
+        publish_live_runner_instance_or_shutdown_startup_resources(
+            &home,
+            metadata,
+            LiveRunnerPublishResources {
+                provider: &provider,
+                runtime: &mut runtime,
+                mitm: &mut mitm,
+                kmsg_handle: crate::kmsg_log::KmsgHandle::noop(),
+                dns_handle: crate::dns::DnsProxy::noop(),
+                memory_prefetch: &mut memory_prefetch,
+            },
+        ),
     )
     .await
+    .expect("publish failure cleanup should not wait for graceful proxy stop")
     {
         Ok(_) => panic!("live runner instance publish should fail"),
         Err(error) => error,

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -140,6 +140,7 @@ while True:
         .kill_on_drop(true)
         .spawn()
         .unwrap();
+    let proxy_child_pid = ignore_term_child.id().expect("proxy child should have pid");
     let stdout = ignore_term_child.stdout.take().unwrap();
     let mut ready_lines = tokio::io::BufReader::new(stdout).lines();
     let ready = tokio::time::timeout(Duration::from_secs(2), ready_lines.next_line())
@@ -197,6 +198,10 @@ while True:
         .expect("prefetch task should observe cleanup cancellation")
         .expect("prefetch task should report cancellation");
     assert_eq!(memory_prefetch.task_count(), 0);
+    assert!(
+        !std::path::Path::new(&format!("/proc/{proxy_child_pid}")).exists(),
+        "proxy child should be killed and reaped during cleanup"
+    );
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -118,6 +118,16 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
     let mut runtime = ShutdownRecordingRuntime {
         shutdowns: Arc::clone(&runtime_shutdowns),
     };
+    let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
+    let prefetch_cancel = CancellationToken::new();
+    let task_cancel = prefetch_cancel.clone();
+    let (cancelled_tx, cancelled_rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        task_cancel.cancelled().await;
+        let _ = cancelled_tx.send(());
+    });
+    let mut memory_prefetch =
+        crate::prefetch::MemoryPrefetchTasks::from_test_handle(prefetch_cancel, handle);
     let metadata = crate::live_runner_instances::LiveRunnerInstanceMetadata {
         config_path: dir.path().join("runner.yaml"),
         base_dir: dir.path().join("base"),
@@ -125,14 +135,23 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
         runner_group: "vm0/test".into(),
     };
 
-    let error = publish_live_runner_instance_or_shutdown_startup_resources(
+    let error = match publish_live_runner_instance_or_shutdown_startup_resources(
         &home,
         metadata,
-        &provider,
-        &mut runtime,
+        LiveRunnerPublishResources {
+            provider: &provider,
+            runtime: &mut runtime,
+            mitm: &mut mitm,
+            kmsg_handle: crate::kmsg_log::KmsgHandle::noop(),
+            dns_handle: crate::dns::DnsProxy::noop(),
+            memory_prefetch: &mut memory_prefetch,
+        },
     )
     .await
-    .unwrap_err();
+    {
+        Ok(_) => panic!("live runner instance publish should fail"),
+        Err(error) => error,
+    };
 
     assert!(
         error.to_string().contains("ensure live runner instances"),
@@ -140,6 +159,11 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
     );
     assert_eq!(provider_shutdowns.load(Ordering::SeqCst), 1);
     assert_eq!(runtime_shutdowns.load(Ordering::SeqCst), 1);
+    tokio::time::timeout(Duration::from_secs(5), cancelled_rx)
+        .await
+        .expect("prefetch task should observe cleanup cancellation")
+        .expect("prefetch task should report cancellation");
+    assert_eq!(memory_prefetch.task_count(), 0);
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -163,6 +163,7 @@ while True:
         base_dir: dir.path().join("base"),
         runner_name: "test-runner".into(),
         runner_group: "vm0/test".into(),
+        subcommand: "start".into(),
     };
 
     let error = match tokio::time::timeout(

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -120,10 +120,10 @@ pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
                 break;
             }
         };
-        if stable_record_identity_from_file_name(&entry.file_name()).is_none() {
+        let Some(identity) = stable_record_identity_from_file_name(&entry.file_name()) else {
             continue;
-        }
-        let Some(record) = read_valid_record(&entry.path()).await else {
+        };
+        let Some(record) = read_valid_record_for_identity(&entry.path(), identity).await else {
             continue;
         };
         instances.push(LiveRunnerInstance {
@@ -219,10 +219,13 @@ async fn remove_stale_records(home: &HomePaths) {
         };
         let file_name = entry.file_name();
         let path = entry.path();
-        if stable_record_identity_from_file_name(&file_name).is_some()
-            && read_valid_record(&path).await.is_none()
-        {
-            remove_stale_file(&path, "stale live runner instance record").await;
+        if let Some(identity) = stable_record_identity_from_file_name(&file_name) {
+            if read_valid_record_for_identity(&path, identity)
+                .await
+                .is_none()
+            {
+                remove_stale_file(&path, "stale live runner instance record").await;
+            }
             continue;
         }
         let Some(identity) = atomic_tmp_record_identity_from_file_name(&file_name) else {
@@ -231,6 +234,26 @@ async fn remove_stale_records(home: &HomePaths) {
         if !file_process_identity_is_live(identity).await {
             remove_stale_file(&path, "stale live runner instance tmp file").await;
         }
+    }
+}
+
+async fn read_valid_record_for_identity(
+    path: &Path,
+    identity: FileProcessIdentity,
+) -> Option<LiveRunnerInstanceRecord> {
+    let record = read_valid_record(path).await?;
+    if record.pid == identity.pid && record.starttime == identity.starttime {
+        Some(record)
+    } else {
+        tracing::debug!(
+            path = %path.display(),
+            record_pid = record.pid,
+            record_starttime = record.starttime,
+            file_pid = identity.pid,
+            file_starttime = identity.starttime,
+            "ignoring live runner instance record whose contents do not match file name"
+        );
+        None
     }
 }
 
@@ -517,6 +540,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_ignores_records_with_mismatched_file_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let record = read_valid_record(&handle.path).await.unwrap();
+        tokio::fs::remove_file(&handle.path).await.unwrap();
+        write_record(
+            &home.live_runner_instance_record_path(record.pid, record.starttime + 1),
+            &record,
+        )
+        .await;
+
+        let instances = list(&home).await;
+
+        assert!(instances.is_empty());
+    }
+
+    #[tokio::test]
     async fn read_valid_record_ignores_stale_pid() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
@@ -649,6 +690,22 @@ mod tests {
 
         assert!(!stale_path.exists());
         assert!(!stale_tmp_path.exists());
+    }
+
+    #[tokio::test]
+    async fn publish_removes_records_with_mismatched_file_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let record = read_valid_record(&handle.path).await.unwrap();
+        tokio::fs::remove_file(&handle.path).await.unwrap();
+        let mismatched_path =
+            home.live_runner_instance_record_path(record.pid, record.starttime + 1);
+        write_record(&mismatched_path, &record).await;
+
+        let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        assert!(!mismatched_path.exists());
     }
 
     #[cfg(unix)]

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -17,6 +17,7 @@ pub(crate) struct LiveRunnerInstanceMetadata {
     pub base_dir: PathBuf,
     pub runner_name: String,
     pub runner_group: String,
+    pub subcommand: String,
 }
 
 #[derive(Debug)]
@@ -33,6 +34,7 @@ pub(crate) struct LiveRunnerInstance {
     pub base_dir: PathBuf,
     pub runner_name: String,
     pub runner_group: String,
+    pub subcommand: String,
     pub started_at: String,
 }
 
@@ -60,6 +62,8 @@ struct LiveRunnerInstanceRecord {
     base_dir: PathBuf,
     runner_name: String,
     runner_group: String,
+    #[serde(default = "default_subcommand")]
+    subcommand: String,
     started_at: String,
 }
 
@@ -78,6 +82,7 @@ pub(crate) async fn publish(
         base_dir: metadata.base_dir,
         runner_name: metadata.runner_name,
         runner_group: metadata.runner_group,
+        subcommand: metadata.subcommand,
         started_at: chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
     };
     let content = serde_json::to_vec_pretty(&record)
@@ -136,6 +141,7 @@ pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
             base_dir: record.base_dir,
             runner_name: record.runner_name,
             runner_group: record.runner_group,
+            subcommand: record.subcommand,
             started_at: record.started_at,
         });
     }
@@ -162,6 +168,7 @@ pub(crate) async fn is_current(home: &HomePaths, instance: &LiveRunnerInstance) 
         && record.base_dir == instance.base_dir
         && record.runner_name == instance.runner_name
         && record.runner_group == instance.runner_group
+        && record.subcommand == instance.subcommand
         && record.started_at == instance.started_at
 }
 
@@ -216,6 +223,10 @@ async fn read_valid_record(path: &Path) -> Option<LiveRunnerInstanceRecord> {
     } else {
         None
     }
+}
+
+fn default_subcommand() -> String {
+    "start".into()
 }
 
 async fn remove_stale_records(home: &HomePaths) {
@@ -426,6 +437,7 @@ mod tests {
             base_dir: root.join("base"),
             runner_name: "test-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
         }
     }
 
@@ -510,7 +522,29 @@ mod tests {
         assert_eq!(instance.base_dir, dir.path().join("base"));
         assert_eq!(instance.runner_name, "test-runner");
         assert_eq!(instance.runner_group, "vm0/test");
+        assert_eq!(instance.subcommand, "start");
         assert!(!instance.started_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_defaults_legacy_records_to_start_subcommand() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let content = tokio::fs::read_to_string(&handle.path).await.unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&content).unwrap();
+        value.as_object_mut().unwrap().remove("subcommand").unwrap();
+        crate::state_file::write_private_atomic(
+            &handle.path,
+            &serde_json::to_vec_pretty(&value).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let instances = list(&home).await;
+
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].subcommand, "start");
     }
 
     #[tokio::test]
@@ -532,6 +566,7 @@ mod tests {
             base_dir: dir.path().join("stale-base"),
             runner_name: "stale-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
         write_record(
@@ -611,6 +646,7 @@ mod tests {
             base_dir: dir.path().join("base"),
             runner_name: "test-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
         let path = home.live_runner_instance_record_path(record.pid, record.starttime);
@@ -711,6 +747,7 @@ mod tests {
             base_dir: dir.path().join("stale-base"),
             runner_name: "stale-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
         let stale_path =
@@ -746,6 +783,7 @@ mod tests {
             base_dir: dir.path().join("stale-base"),
             runner_name: "stale-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
         let stale_path =
@@ -816,6 +854,7 @@ mod tests {
             base_dir: dir.path().join("other-base"),
             runner_name: "other-runner".into(),
             runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
         };
         let live_path =

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -26,6 +26,16 @@ pub(crate) struct LiveRunnerInstanceHandle {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LiveRunnerInstance {
+    pub pid: u32,
+    pub config_path: PathBuf,
+    pub base_dir: PathBuf,
+    pub runner_name: String,
+    pub runner_group: String,
+    pub started_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ProcessIdentity {
     boot_id: String,
     pid: u32,
@@ -87,6 +97,52 @@ pub(crate) async fn publish(
     crate::state_file::write_private_atomic(&path, &content).await?;
 
     Ok(LiveRunnerInstanceHandle { path, identity })
+}
+
+pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
+    let dir = home.live_runner_instances_dir();
+    let mut entries = match tokio::fs::read_dir(&dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(e) => {
+            tracing::debug!(path = %dir.display(), error = %e, "cannot scan live runner instances");
+            return Vec::new();
+        }
+    };
+
+    let mut instances = Vec::new();
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                tracing::debug!(path = %dir.display(), error = %e, "cannot read live runner instance entry");
+                break;
+            }
+        };
+        if stable_record_identity_from_file_name(&entry.file_name()).is_none() {
+            continue;
+        }
+        let Some(record) = read_valid_record(&entry.path()).await else {
+            continue;
+        };
+        instances.push(LiveRunnerInstance {
+            pid: record.pid,
+            config_path: record.config_path,
+            base_dir: record.base_dir,
+            runner_name: record.runner_name,
+            runner_group: record.runner_group,
+            started_at: record.started_at,
+        });
+    }
+
+    instances.sort_by(|left, right| {
+        left.runner_name
+            .cmp(&right.runner_name)
+            .then_with(|| left.pid.cmp(&right.pid))
+            .then_with(|| left.config_path.cmp(&right.config_path))
+    });
+    instances
 }
 
 impl LiveRunnerInstanceHandle {
@@ -383,6 +439,81 @@ mod tests {
         assert_eq!(record.boot_id, handle.identity.boot_id);
         assert_eq!(record.pid, handle.identity.pid);
         assert_eq!(record.starttime, handle.identity.starttime);
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_registry_dir_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+
+        let instances = list(&home).await;
+
+        assert!(instances.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_returns_valid_live_instance_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+
+        let instances = list(&home).await;
+
+        assert_eq!(instances.len(), 1);
+        let instance = &instances[0];
+        assert_eq!(instance.pid, handle.identity.pid);
+        assert_eq!(instance.config_path, dir.path().join("runner.yaml"));
+        assert_eq!(instance.base_dir, dir.path().join("base"));
+        assert_eq!(instance.runner_name, "test-runner");
+        assert_eq!(instance.runner_group, "vm0/test");
+        assert!(!instance.started_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_ignores_invalid_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runner_instances_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner instances",
+        )
+        .unwrap();
+        let stale_record = LiveRunnerInstanceRecord {
+            boot_id: current_boot_id().await.unwrap(),
+            pid: u32::MAX,
+            starttime: 1,
+            euid: current_euid(),
+            config_path: dir.path().join("stale-runner.yaml"),
+            base_dir: dir.path().join("stale-base"),
+            runner_name: "stale-runner".into(),
+            runner_group: "vm0/test".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
+        };
+        write_record(
+            &home.live_runner_instance_record_path(stale_record.pid, stale_record.starttime),
+            &stale_record,
+        )
+        .await;
+        crate::state_file::write_private_atomic(&home.live_runner_instance_record_path(1, 1), b"{")
+            .await
+            .unwrap();
+        crate::state_file::write_private_atomic(
+            &home.live_runner_instance_record_path(2, 2),
+            &vec![b'a'; (LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES + 1) as usize],
+        )
+        .await
+        .unwrap();
+        crate::state_file::write_private_atomic(
+            &home.live_runner_instances_dir().join("not-a-record.json"),
+            b"{}",
+        )
+        .await
+        .unwrap();
+
+        let instances = list(&home).await;
+
+        assert!(instances.is_empty());
     }
 
     #[tokio::test]

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -28,6 +28,7 @@ pub(crate) struct LiveRunnerInstanceHandle {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct LiveRunnerInstance {
     pub pid: u32,
+    pub starttime: u64,
     pub config_path: PathBuf,
     pub base_dir: PathBuf,
     pub runner_name: String,
@@ -128,6 +129,7 @@ pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
         };
         instances.push(LiveRunnerInstance {
             pid: record.pid,
+            starttime: record.starttime,
             config_path: record.config_path,
             base_dir: record.base_dir,
             runner_name: record.runner_name,
@@ -143,6 +145,22 @@ pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
             .then_with(|| left.config_path.cmp(&right.config_path))
     });
     instances
+}
+
+pub(crate) async fn is_current(home: &HomePaths, instance: &LiveRunnerInstance) -> bool {
+    let identity = FileProcessIdentity {
+        pid: instance.pid,
+        starttime: instance.starttime,
+    };
+    let path = home.live_runner_instance_record_path(identity.pid, identity.starttime);
+    let Some(record) = read_valid_record_for_identity(&path, identity).await else {
+        return false;
+    };
+    record.config_path == instance.config_path
+        && record.base_dir == instance.base_dir
+        && record.runner_name == instance.runner_name
+        && record.runner_group == instance.runner_group
+        && record.started_at == instance.started_at
 }
 
 impl LiveRunnerInstanceHandle {
@@ -485,6 +503,7 @@ mod tests {
         assert_eq!(instances.len(), 1);
         let instance = &instances[0];
         assert_eq!(instance.pid, handle.identity.pid);
+        assert_eq!(instance.starttime, handle.identity.starttime);
         assert_eq!(instance.config_path, dir.path().join("runner.yaml"));
         assert_eq!(instance.base_dir, dir.path().join("base"));
         assert_eq!(instance.runner_name, "test-runner");
@@ -555,6 +574,20 @@ mod tests {
         let instances = list(&home).await;
 
         assert!(instances.is_empty());
+    }
+
+    #[tokio::test]
+    async fn is_current_tracks_the_exact_registry_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        let instance = list(&home).await.into_iter().next().unwrap();
+
+        assert!(is_current(&home, &instance).await);
+
+        tokio::fs::remove_file(&handle.path).await.unwrap();
+
+        assert!(!is_current(&home, &instance).await);
     }
 
     #[tokio::test]

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -101,6 +101,8 @@ pub(crate) async fn publish(
 }
 
 pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
+    remove_stale_records(home).await;
+
     let dir = home.live_runner_instances_dir();
     let mut entries = match tokio::fs::read_dir(&dir).await {
         Ok(entries) => entries,
@@ -721,6 +723,42 @@ mod tests {
 
         let _handle = publish(&home, test_metadata(dir.path())).await.unwrap();
 
+        assert!(!stale_path.exists());
+        assert!(!stale_tmp_path.exists());
+    }
+
+    #[tokio::test]
+    async fn list_removes_stale_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        crate::host_file::ensure_dir(
+            &home.live_runner_instances_dir(),
+            crate::host_file::DirMode::Private,
+            "live runner instances",
+        )
+        .unwrap();
+        let stale_record = LiveRunnerInstanceRecord {
+            boot_id: current_boot_id().await.unwrap(),
+            pid: u32::MAX,
+            starttime: 1,
+            euid: current_euid(),
+            config_path: dir.path().join("stale-runner.yaml"),
+            base_dir: dir.path().join("stale-base"),
+            runner_name: "stale-runner".into(),
+            runner_group: "vm0/test".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
+        };
+        let stale_path =
+            home.live_runner_instance_record_path(stale_record.pid, stale_record.starttime);
+        write_record(&stale_path, &stale_record).await;
+        let stale_tmp_path = home
+            .live_runner_instances_dir()
+            .join(".4294967295-1.json.test.tmp");
+        tokio::fs::write(&stale_tmp_path, b"partial").await.unwrap();
+
+        let instances = list(&home).await;
+
+        assert!(instances.is_empty());
         assert!(!stale_path.exists());
         assert!(!stale_tmp_path.exists());
     }

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -145,11 +145,10 @@ pub async fn discover_all() -> DiscoveredProcesses {
     let mut dnsmasqs = Vec::new();
 
     for (pid, argv) in &procs {
-        if let Some((config_path, subcommand)) = parse_runner_cmdline(argv) {
+        if let Some((config_path, _)) = parse_runner_cmdline(argv) {
             runners.push(RunnerProcessInfo {
                 pid: *pid,
                 config_path,
-                subcommand,
             });
         }
         if is_firecracker_cmdline(argv) {

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -8,17 +8,16 @@ use super::types::{
 
 /// Parse a runner argv for `start`/`benchmark` subcommand and `--config` path.
 ///
-/// Returns `(config_path, subcommand)` or `None` if the argv doesn't match.
-fn parse_runner_cmdline(argv: &[String]) -> Option<(PathBuf, String)> {
-    let subcmd = argv
-        .iter()
-        .find(|t| *t == "start" || *t == "benchmark")?
-        .clone();
+/// Returns the config path or `None` if the argv doesn't match.
+fn parse_runner_cmdline(argv: &[String]) -> Option<PathBuf> {
+    if !argv.iter().any(|t| t == "start" || t == "benchmark") {
+        return None;
+    }
 
     let config_pos = argv.iter().position(|t| t == "--config" || t == "-c")?;
     let config_path = argv.get(config_pos + 1)?;
 
-    Some((PathBuf::from(config_path), subcmd))
+    Some(PathBuf::from(config_path))
 }
 
 /// Check if an argv belongs to a firecracker process.
@@ -145,7 +144,7 @@ pub async fn discover_all() -> DiscoveredProcesses {
     let mut dnsmasqs = Vec::new();
 
     for (pid, argv) in &procs {
-        if let Some((config_path, _)) = parse_runner_cmdline(argv) {
+        if let Some(config_path) = parse_runner_cmdline(argv) {
             runners.push(RunnerProcessInfo {
                 pid: *pid,
                 config_path,
@@ -246,9 +245,8 @@ mod tests {
             "--config",
             "/data/runner-01/config.yaml",
         ]);
-        let (config, subcmd) = parse_runner_cmdline(&a).unwrap();
+        let config = parse_runner_cmdline(&a).unwrap();
         assert_eq!(config, Path::new("/data/runner-01/config.yaml"));
-        assert_eq!(subcmd, "start");
     }
 
     #[test]
@@ -259,17 +257,15 @@ mod tests {
             "--config",
             "/etc/runner/bench.yaml",
         ]);
-        let (config, subcmd) = parse_runner_cmdline(&a).unwrap();
+        let config = parse_runner_cmdline(&a).unwrap();
         assert_eq!(config, Path::new("/etc/runner/bench.yaml"));
-        assert_eq!(subcmd, "benchmark");
     }
 
     #[test]
     fn parse_runner_short_config_flag() {
         let a = argv(&["runner", "start", "-c", "/data/runner.yaml"]);
-        let (config, subcmd) = parse_runner_cmdline(&a).unwrap();
+        let config = parse_runner_cmdline(&a).unwrap();
         assert_eq!(config, Path::new("/data/runner.yaml"));
-        assert_eq!(subcmd, "start");
     }
 
     #[test]
@@ -277,9 +273,8 @@ mod tests {
         // Regression for #10479: a path argument containing spaces must stay
         // as a single argv element, not be split into multiple tokens.
         let a = argv(&["runner", "start", "--config", "/data/my config/config.yaml"]);
-        let (config, subcmd) = parse_runner_cmdline(&a).unwrap();
+        let config = parse_runner_cmdline(&a).unwrap();
         assert_eq!(config, Path::new("/data/my config/config.yaml"));
-        assert_eq!(subcmd, "start");
     }
 
     #[test]

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -31,7 +31,6 @@ pub struct FirecrackerProcessIdentity {
 pub struct RunnerProcessInfo {
     pub pid: u32,
     pub config_path: PathBuf,
-    pub subcommand: String,
 }
 
 /// Info extracted from a firecracker process cmdline.

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -574,6 +574,19 @@ impl MitmProxy {
         self.child = None;
         Ok(())
     }
+
+    /// Immediately kill and reap mitmdump without the graceful SIGTERM window.
+    pub async fn kill_now(&mut self) -> RunnerResult<()> {
+        self.stopping.store(true, Ordering::Release);
+        let Some(ref mut child) = self.child else {
+            return Ok(());
+        };
+        child.kill().await.map_err(|e| {
+            RunnerError::Internal(format!("kill mitmdump process after startup failure: {e}"))
+        })?;
+        self.child = None;
+        Ok(())
+    }
 }
 
 fn now_millis() -> u64 {

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -589,9 +589,23 @@ impl MitmProxy {
             self.child = None;
             return Ok(());
         }
-        child.kill().await.map_err(|e| {
-            RunnerError::Internal(format!("kill mitmdump process after startup failure: {e}"))
-        })?;
+        if let Err(kill_error) = child.start_kill() {
+            if child
+                .try_wait()
+                .map_err(|e| RunnerError::Internal(format!("recheck mitmdump process: {e}")))?
+                .is_some()
+            {
+                self.child = None;
+                return Ok(());
+            }
+            return Err(RunnerError::Internal(format!(
+                "kill mitmdump process after startup failure: {kill_error}"
+            )));
+        }
+        child
+            .wait()
+            .await
+            .map_err(|e| RunnerError::Internal(format!("wait for killed mitmdump process: {e}")))?;
         self.child = None;
         Ok(())
     }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -581,6 +581,14 @@ impl MitmProxy {
         let Some(ref mut child) = self.child else {
             return Ok(());
         };
+        if child
+            .try_wait()
+            .map_err(|e| RunnerError::Internal(format!("check mitmdump process: {e}")))?
+            .is_some()
+        {
+            self.child = None;
+            return Ok(());
+        }
         child.kill().await.map_err(|e| {
             RunnerError::Internal(format!("kill mitmdump process after startup failure: {e}"))
         })?;
@@ -2526,6 +2534,23 @@ PY
         proxy.child = Some(child);
 
         assert!(proxy.usage_flush_target().is_none());
+        assert!(proxy.child.is_none());
+    }
+
+    #[tokio::test]
+    async fn kill_now_reaps_exited_child() {
+        let (mut proxy, _crash_rx) = MitmProxy::noop();
+        let mut child = tokio::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        child.wait().await.unwrap();
+        proxy.child = Some(child);
+
+        proxy.kill_now().await.unwrap();
+
         assert!(proxy.child.is_none());
     }
 


### PR DESCRIPTION
## Summary
- Build runner doctor reports from validated live runner registry records instead of discovered runner argv/config candidates.
- Preserve registry-backed runner identity and base directory even when the config file is missing.
- Store canonical config paths in live runner registry metadata and keep process discovery focused on process-based consumers.
- Validate registry record file identity against record contents and remove mismatched records during cleanup.
- Recheck registry liveness before preserving per-runner warnings, so warnings from a runner that exited during the recheck window do not fail doctor.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- git diff --check
- cargo test --manifest-path crates/Cargo.toml -p runner live_runner_instances
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::doctor
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start
- cargo test --manifest-path crates/Cargo.toml -p runner process
- cargo test --manifest-path crates/Cargo.toml -p runner run_resolution
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets

Fixes #17264