### PR TITLE
perf: store compact run context firewalls

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
@@ -40,13 +40,9 @@ function makeEntriesSnapshot(runId: string): Record<string, unknown> {
     ],
     firewalls: [
       {
-        name: "test-fw",
-        apis: [
-          {
-            base: "https://api.example.com",
-            permissions: [{ name: "read", rules: ["GET /users/*"] }],
-          },
-        ],
+        kind: "builtin",
+        name: "hosted-fw",
+        baseUrlVars: { HOST: "api.example.com" },
       },
     ],
     volumes: [
@@ -295,8 +291,13 @@ describe("GET /api/zero/runs/:id/context", () => {
       NODE_ENV: "production",
       API_KEY: "***",
     });
-    expect(response.body.firewalls).toHaveLength(1);
-    expect(response.body.firewalls[0]?.name).toBe("test-fw");
+    expect(response.body.firewalls).toStrictEqual([
+      {
+        kind: "builtin",
+        name: "hosted-fw",
+        baseUrlVars: { HOST: "api.example.com" },
+      },
+    ]);
     expect(response.body.volumes).toHaveLength(1);
     expect(response.body.artifact).toBeDefined();
     expect(response.body.networkPolicies).toStrictEqual({
@@ -336,6 +337,7 @@ describe("GET /api/zero/runs/:id/context", () => {
       {
         ...makeEntriesSnapshot(runId),
         firewalls: [
+          { kind: "builtin", name: null },
           {
             name: "valid-fw",
             apis: [
@@ -626,6 +628,17 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(response.body.featureFlags).toStrictEqual({
       lab: true,
     });
+    expect(response.body.firewalls).toStrictEqual([
+      {
+        name: "test-fw",
+        apis: [
+          {
+            base: "https://api.example.com",
+            permissions: [{ name: "read", rules: ["GET /users/*"] }],
+          },
+        ],
+      },
+    ]);
   });
 
   it("returns 403 for a sandbox token without agent-run:read capability", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-run-context.test.ts
@@ -356,6 +356,18 @@ describe("GET /api/zero/runs/:id/context", () => {
             ],
           },
           { name: "bad-fw", apis: null },
+          {
+            kind: "inline",
+            firewall: {
+              name: "leaky-fw",
+              apis: [
+                {
+                  base: "https://leaky.example.com",
+                  auth: { headers: { Authorization: "Bearer secret" } },
+                },
+              ],
+            },
+          },
         ],
         volumes: [
           {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -111,6 +111,63 @@ function getInlineFirewallEntry(
   }
   return entry;
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function runContextSnapshot(
+  runId: string,
+): Record<string, unknown> | undefined {
+  for (const [dataset, events] of context.mocks.axiom.ingest.mock.calls) {
+    if (dataset !== "run-context") {
+      continue;
+    }
+    const snapshots = events as readonly Record<string, unknown>[];
+    const snapshot = snapshots.find((event) => {
+      return event.runId === runId;
+    });
+    if (snapshot) {
+      return snapshot;
+    }
+  }
+  return undefined;
+}
+
+function runContextSnapshotFirewalls(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  const snapshot = runContextSnapshot(runId);
+  if (!snapshot) {
+    throw new Error(`Missing run-context snapshot for run: ${runId}`);
+  }
+  if (!Array.isArray(snapshot.firewalls)) {
+    throw new Error(`Missing run-context firewalls for run: ${runId}`);
+  }
+  return snapshot.firewalls.map((firewall) => {
+    if (!isRecord(firewall)) {
+      throw new Error(`Invalid run-context firewall for run: ${runId}`);
+    }
+    return firewall;
+  });
+}
+
+function hasObjectKey(value: unknown, key: string): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => {
+      return hasObjectKey(item, key);
+    });
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    Object.hasOwn(value, key) ||
+    Object.values(value).some((item) => {
+      return hasObjectKey(item, key);
+    })
+  );
+}
 const SLACK_READ_PERMISSION = "channels:read";
 const SLACK_WRITE_PERMISSION = "chat:write";
 
@@ -1935,6 +1992,12 @@ describe("POST /api/zero/runs", () => {
     expect(
       getBuiltinFirewallEntry(executionContext.firewalls, "cloudflare"),
     ).toMatchObject({ kind: "builtin", name: "cloudflare" });
+
+    const snapshotFirewalls = runContextSnapshotFirewalls(response.body.runId);
+    expect(snapshotFirewalls).toStrictEqual([
+      { kind: "builtin", name: "cloudflare" },
+    ]);
+    expect(snapshotFirewalls[0]).not.toHaveProperty("apis");
   });
 
   it("maps static connector env aliases", async () => {
@@ -2711,6 +2774,19 @@ describe("POST /api/zero/runs", () => {
     expect(
       executionContext.networkPolicies["internal-api"]?.unknownPolicy,
     ).toBe("allow");
+
+    const snapshotFirewalls = runContextSnapshotFirewalls(response.body.runId);
+    expect(snapshotFirewalls).toMatchObject([
+      {
+        name: "internal-api",
+        apis: [
+          {
+            base: "https://{hostWildcard1}.internal.example.com/api/",
+          },
+        ],
+      },
+    ]);
+    expect(hasObjectKey(snapshotFirewalls, "auth")).toBeFalsy();
   });
 
   it("keeps connector-owned vars out of custom connector firewall base URLs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-runs-create.test.ts
@@ -2896,6 +2896,13 @@ describe("POST /api/zero/runs", () => {
     expect(zendeskFirewall.baseUrlVars).toStrictEqual({
       ZENDESK_SUBDOMAIN: "connector-subdomain",
     });
+
+    const snapshotFirewalls = runContextSnapshotFirewalls(response.body.runId);
+    expect(snapshotFirewalls).toContainEqual({
+      kind: "builtin",
+      name: "zendesk",
+      baseUrlVars: { ZENDESK_SUBDOMAIN: "connector-subdomain" },
+    });
   });
 
   it("rejects omitted modelProvider when the org default provider is VM0", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -20,7 +20,6 @@ import {
   getVm0Vendor,
   hasAuthMethods,
   isSupportedRunModel,
-  MODEL_PROVIDER_FIREWALL_CONFIGS,
   MODEL_PROVIDER_TYPES,
   normalizeRunModelId,
   type ModelProviderEnvBindings,
@@ -3111,58 +3110,45 @@ function sanitizeEnvironment(
   return sanitized;
 }
 
-function builtinFirewallByName(
-  name: string,
-): ExpandedFirewallConfig | undefined {
-  if (isFirewallConnectorType(name)) {
-    return getConnectorFirewall(name);
-  }
-  return Object.values(MODEL_PROVIDER_FIREWALL_CONFIGS).find((firewall) => {
-    return firewall.name === name;
-  });
+function sanitizedFirewallSnapshot(
+  firewall: Firewall,
+): Extract<RunContextResponse["firewalls"][number], { apis: unknown }> {
+  return {
+    name: firewall.name,
+    apis: firewall.apis.map((api) => {
+      return {
+        base: api.base,
+        permissions: api.permissions?.map((permission) => {
+          return {
+            name: permission.name,
+            description: permission.description,
+            rules: permission.rules,
+          };
+        }),
+      };
+    }),
+  };
 }
 
-function fullFirewallsForEntry(
+function firewallSnapshotEntry(
   entry: ExecutionFirewallEntry,
-): readonly Firewall[] {
+): RunContextResponse["firewalls"][number] {
   if (entry.kind === "inline") {
-    return [entry.firewall];
+    return sanitizedFirewallSnapshot(entry.firewall);
   }
-  const firewall = builtinFirewallByName(entry.name);
-  if (!firewall) {
-    return [];
-  }
-  return resolveFirewallBaseUrlVars(
-    [runtimeFirewall(firewall)],
-    entry.baseUrlVars,
-  );
+  return entry.baseUrlVars
+    ? { kind: "builtin", name: entry.name, baseUrlVars: entry.baseUrlVars }
+    : { kind: "builtin", name: entry.name };
 }
 
-function sanitizeFirewalls(
+function firewallSnapshots(
   firewalls: ExecutionFirewalls | null | undefined,
 ): RunContextResponse["firewalls"] {
   if (!firewalls) {
     return [];
   }
-  const fullFirewalls = firewalls.flatMap((entry) => {
-    return [...fullFirewallsForEntry(entry)];
-  });
-  return fullFirewalls.map((firewall) => {
-    return {
-      name: firewall.name,
-      apis: firewall.apis.map((api) => {
-        return {
-          base: api.base,
-          permissions: api.permissions?.map((permission) => {
-            return {
-              name: permission.name,
-              description: permission.description,
-              rules: permission.rules,
-            };
-          }),
-        };
-      }),
-    };
+  return firewalls.map((entry) => {
+    return firewallSnapshotEntry(entry);
   });
 }
 
@@ -3187,7 +3173,7 @@ function ingestRunContextSnapshot(args: {
     sessionId: storedContext.resumeSession?.sessionId ?? null,
     secretNames: [...args.builtContext.secretNames],
     environmentEntries: environmentRecordToEntries(sanitizedEnvironment),
-    firewalls: sanitizeFirewalls(storedContext.firewalls),
+    firewalls: firewallSnapshots(storedContext.firewalls),
     networkPolicyEntries: networkPoliciesRecordToEntries(
       storedContext.networkPolicies,
     ),

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -5,7 +5,15 @@ type UnknownRecord = Record<string, unknown>;
 type NetworkPolicy = NetworkPolicies[string];
 type NetworkPolicyValue = "allow" | "deny" | "ask";
 type RunContextFirewall = RunContextResponse["firewalls"][number];
-type RunContextFirewallApi = RunContextFirewall["apis"][number];
+type RunContextBuiltinFirewall = Extract<
+  RunContextFirewall,
+  { kind: "builtin" }
+>;
+type RunContextSanitizedFirewall = Extract<
+  RunContextFirewall,
+  { apis: unknown }
+>;
+type RunContextFirewallApi = RunContextSanitizedFirewall["apis"][number];
 type RunContextFirewallPermission = NonNullable<
   RunContextFirewallApi["permissions"]
 >[number];
@@ -219,28 +227,60 @@ function firewallApiFromUnknown(
   };
 }
 
+function builtinFirewallFromUnknown(
+  value: UnknownRecord,
+): RunContextBuiltinFirewall | undefined {
+  if (value.kind !== "builtin") {
+    return undefined;
+  }
+  const name = stringValue(value.name);
+  if (!name) {
+    return undefined;
+  }
+  const baseUrlVars = stringRecordValue(value.baseUrlVars);
+  return baseUrlVars
+    ? { kind: "builtin", name, baseUrlVars }
+    : { kind: "builtin", name };
+}
+
+function sanitizedFirewallFromUnknown(
+  value: UnknownRecord,
+): RunContextSanitizedFirewall | undefined {
+  const name = stringValue(value.name);
+  if (!name || !Array.isArray(value.apis)) {
+    return undefined;
+  }
+  return {
+    name,
+    apis: value.apis.flatMap((api) => {
+      const normalized = firewallApiFromUnknown(api);
+      return normalized ? [normalized] : [];
+    }),
+  };
+}
+
 function firewallsFromUnknown(value: unknown): RunContextResponse["firewalls"] {
   if (!Array.isArray(value)) {
     return [];
   }
-  return value.flatMap((item) => {
+  const firewalls: RunContextResponse["firewalls"] = [];
+  for (const item of value) {
     if (!isRecord(item)) {
-      return [];
+      continue;
     }
-    const name = stringValue(item.name);
-    if (!name || !Array.isArray(item.apis)) {
-      return [];
+    if (item.kind === "builtin") {
+      const normalized = builtinFirewallFromUnknown(item);
+      if (normalized) {
+        firewalls.push(normalized);
+      }
+      continue;
     }
-    return [
-      {
-        name,
-        apis: item.apis.flatMap((api) => {
-          const normalized = firewallApiFromUnknown(api);
-          return normalized ? [normalized] : [];
-        }),
-      },
-    ];
-  });
+    const normalized = sanitizedFirewallFromUnknown(item);
+    if (normalized) {
+      firewalls.push(normalized);
+    }
+  }
+  return firewalls;
 }
 
 function volumeFromUnknown(value: unknown): RunContextVolume | undefined {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -783,6 +783,46 @@ describe("zero doctor check-connector command", () => {
       );
     });
 
+    it("should resolve compact built-in run context firewalls", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [{ kind: "builtin", name: "github" }],
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/repos/owner/repo",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("matches the GitHub connector");
+      expect(output).toContain("Matched base URL: https://api.github.com");
+      expect(output).toContain("Relative path:    /repos/owner/repo");
+      expect(output).toContain(
+        "The GitHub connector is configured for this run with the following base URLs:",
+      );
+      expect(output).toContain("  - https://api.github.com");
+    });
+
     it("should strip query and match permissions only on the resolved API base", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -823,6 +823,63 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain("  - https://api.github.com");
     });
 
+    it("should resolve compact built-in run context firewalls with base URL vars", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      vi.stubEnv("ZENDESK_API_TOKEN", "zk-placeholder");
+      server.use(
+        stubAvailableConnectors(["zendesk"]),
+        http.get("https://app.vm0.ai/api/zero/connectors/zendesk", () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            type: "zendesk",
+            authMethod: "api-token",
+          });
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["zendesk"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                kind: "builtin",
+                name: "zendesk",
+                baseUrlVars: { ZENDESK_SUBDOMAIN: "acme" },
+              },
+            ],
+            networkPolicies: {
+              zendesk: {
+                allow: [],
+                deny: [],
+                ask: [],
+                unknownPolicy: "allow" as const,
+              },
+            },
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://acme.zendesk.com/api/v2/tickets.json",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("matches the Zendesk connector");
+      expect(output).toContain("Matched base URL: https://acme.zendesk.com");
+      expect(output).toContain("Relative path:    /api/v2/tickets.json");
+      expect(output).toContain("  - https://acme.zendesk.com");
+    });
+
     it("should strip query and match permissions only on the resolved API base", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -128,11 +128,10 @@ function runContextFirewallPermissionConfig(
       return null;
     }
     const config = getConnectorFirewall(firewall.name);
-    const [resolved] = resolveFirewallBaseUrlVars(
+    return resolveFirewallBaseUrlVars(
       [{ name: config.name, apis: config.apis }],
       firewall.baseUrlVars,
-    );
-    return resolved ?? { name: config.name, apis: [] };
+    )[0]!;
   }
   return {
     name: firewall.name,

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -15,6 +15,7 @@ import {
 } from "@vm0/connectors/firewall-rule-matcher";
 import {
   extractSecretNamesFromApis,
+  resolveFirewallBaseUrlVars,
   type FirewallConfig,
   type NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
@@ -118,7 +119,21 @@ function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
 
 function runContextFirewallPermissionConfig(
   firewall: RunContextResponse["firewalls"][number],
-): FirewallConfig {
+): FirewallConfig | null {
+  if (!("apis" in firewall)) {
+    if (!isConnectorType(firewall.name)) {
+      return null;
+    }
+    if (!isFirewallConnectorType(firewall.name)) {
+      return null;
+    }
+    const config = getConnectorFirewall(firewall.name);
+    const [resolved] = resolveFirewallBaseUrlVars(
+      [{ name: config.name, apis: config.apis }],
+      firewall.baseUrlVars,
+    );
+    return resolved ?? { name: config.name, apis: [] };
+  }
   return {
     name: firewall.name,
     apis: firewall.apis.map((api) => {
@@ -144,14 +159,16 @@ function resolveConnectorFromRunContext(
   for (const firewall of runContext.firewalls) {
     if (!isConnectorType(firewall.name)) continue;
     if (!isFirewallConnectorType(firewall.name)) continue;
-    for (const api of firewall.apis) {
+    const permissionConfig = runContextFirewallPermissionConfig(firewall);
+    if (!permissionConfig) continue;
+    for (const api of permissionConfig.apis) {
       const match = matchFirewallBaseUrl(url, api.base);
       if (match === null) continue;
       if (!bestMatch || match.score > bestMatch.match.score) {
         bestMatch = {
           connectorType: firewall.name,
           match,
-          permissionConfig: runContextFirewallPermissionConfig(firewall),
+          permissionConfig,
         };
       }
     }
@@ -338,11 +355,21 @@ function printConnectorDomains(
     );
     return;
   }
+  const permissionConfig = runContextFirewallPermissionConfig(matchingEntry);
+  if (!permissionConfig) {
+    console.log(
+      `No configuration found for the ${ctx.label} connector in this run.`,
+    );
+    console.log(
+      "This means no base URLs are registered for credential replacement for this connector.",
+    );
+    return;
+  }
 
   console.log(
     `The ${ctx.label} connector is configured for this run with the following base URLs:`,
   );
-  for (const api of matchingEntry.apis) {
+  for (const api of permissionConfig.apis) {
     console.log(`  - ${api.base}`);
   }
   console.log("");

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
-import { networkPoliciesSchema } from "@vm0/connectors/firewall-types";
+import {
+  executionFirewallBuiltinEntrySchema,
+  networkPoliciesSchema,
+} from "@vm0/connectors/firewall-types";
 import {
   createRunResponseSchema,
   getRunResponseSchema,
@@ -175,7 +178,7 @@ const runContextArtifactSchema = z.object({
   vasVersionId: z.string(),
 });
 
-const runContextFirewallSchema = z.object({
+const runContextSanitizedFirewallSchema = z.object({
   name: z.string(),
   apis: z.array(
     z.object({
@@ -192,6 +195,11 @@ const runContextFirewallSchema = z.object({
     }),
   ),
 });
+
+const runContextFirewallSchema = z.union([
+  executionFirewallBuiltinEntrySchema,
+  runContextSanitizedFirewallSchema,
+]);
 
 const runContextResponseSchema = z.object({
   prompt: z.string(),


### PR DESCRIPTION
## Summary

- Store built-in run-context firewall snapshots as compact `{ kind: "builtin", name, baseUrlVars? }` entries instead of expanding permissions/rules.
- Keep inline/custom firewall snapshots in the sanitized debug shape so `auth` is not persisted.
- Allow the run-context API and CLI doctor to consume both compact built-in entries and legacy expanded snapshots.

Closes #17341

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-run-context.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-runs-create.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/check-connector.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/cli lint`

Pre-commit also ran `pnpm check-types` for the full workspace.