### PR TITLE
feat: remove the zero automations feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -111,7 +111,7 @@ async function seedFixture(): Promise<SchedulesFixture> {
   return fixture;
 }
 
-async function enableAutomations(
+async function enableWebhookTriggers(
   fixture: SchedulesFixture,
   options?: { readonly webhookTriggers?: boolean },
 ): Promise<void> {
@@ -120,19 +120,9 @@ async function enableAutomations(
     orgId: fixture.orgId,
     userId: fixture.userId,
     switches: {
-      [FeatureSwitchKey.ZeroAutomations]: true,
       [FeatureSwitchKey.AutomationWebhookTriggers]:
         options?.webhookTriggers ?? true,
     },
-  });
-}
-
-async function disableAutomations(fixture: SchedulesFixture): Promise<void> {
-  const db = store.set(writeDb$);
-  await db.insert(userFeatureSwitches).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    switches: { [FeatureSwitchKey.ZeroAutomations]: false },
   });
 }
 
@@ -185,7 +175,7 @@ async function findTriggerRows(automationId: string) {
 describe("Automations v2 API", () => {
   it("creates a triggerless automation with a server-created chat thread", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "daily-digest",
@@ -235,7 +225,7 @@ describe("Automations v2 API", () => {
 
   it("creates an automation with a first cron trigger via sugar", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "cron-sugar",
@@ -272,7 +262,7 @@ describe("Automations v2 API", () => {
 
   it("creates an automation with a webhook trigger and returns the secret once", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "on-deploy",
@@ -312,7 +302,7 @@ describe("Automations v2 API", () => {
     // Webhook triggers are a feature-gated NEW capability (#17307): with the
     // switch off the surface stays feature-equivalent to legacy schedules.
     const fixture = await seedFixture();
-    await enableAutomations(fixture, { webhookTriggers: false });
+    await enableWebhookTriggers(fixture, { webhookTriggers: false });
 
     const viaSugar = await accept(
       mainApi().create({
@@ -367,7 +357,7 @@ describe("Automations v2 API", () => {
 
   it("rejects an invalid cron expression, a past atTime, and a bad timezone", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const badCron = await accept(
       mainApi().create({
@@ -417,7 +407,7 @@ describe("Automations v2 API", () => {
 
   it("rejects a duplicate name on the same agent", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     await createAutomation({ name: "dup", agentId: fixture.composeId });
     const conflictResponse = await accept(
@@ -436,7 +426,7 @@ describe("Automations v2 API", () => {
 
   it("rejects an ambiguous name ref and still resolves by id", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const extraComposeId = await trackExtraComposes(
       Promise.resolve(randomUUID()),
@@ -476,7 +466,7 @@ describe("Automations v2 API", () => {
 
   it("shows and lists automations with all their triggers", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "multi-trigger",
@@ -528,7 +518,7 @@ describe("Automations v2 API", () => {
 
   it("updates identity fields and rejects a rename onto a taken name", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     await createAutomation({
       name: "alpha",
@@ -572,7 +562,7 @@ describe("Automations v2 API", () => {
 
   it("disable suspends the poller and enable recomputes time-trigger next runs", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
     mockEnv("CRON_SECRET", CRON_SECRET);
 
     const created = await createAutomation({
@@ -663,7 +653,7 @@ describe("Automations v2 API", () => {
 
   it("enables and disables a single trigger", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "per-trigger",
@@ -754,7 +744,7 @@ describe("Automations v2 API", () => {
 
   it("manually fires an automation: chat callback only, automation-only provenance", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "fire-now",
@@ -852,7 +842,7 @@ describe("Automations v2 API", () => {
 
   it("manually fires a triggerless automation without a conflict check", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "triggerless-run",
@@ -883,7 +873,7 @@ describe("Automations v2 API", () => {
 
   it("rotates a webhook trigger's secret and rejects non-webhook rotation", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "rotate-me",
@@ -940,7 +930,7 @@ describe("Automations v2 API", () => {
 
   it("deletes an automation and cascades its triggers; removes single triggers", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = await createAutomation({
       name: "remove-me",
@@ -982,47 +972,6 @@ describe("Automations v2 API", () => {
     expect(automationRows).toHaveLength(0);
     await expect(findTriggerRows(created.automation.id)).resolves.toHaveLength(
       0,
-    );
-  });
-
-  it("returns 404 on every endpoint when the feature switch is off", async () => {
-    const fixture = await seedFixture();
-    // The switch is globally on (#17307); an explicit false override keeps the
-    // gating path covered until the switch is deleted.
-    await disableAutomations(fixture);
-
-    const create = await accept(
-      mainApi().create({
-        headers: SESSION_HEADERS,
-        body: {
-          name: "blocked",
-          agentId: fixture.composeId,
-          instruction: "Should not exist.",
-        },
-      }),
-      [404],
-    );
-    expect(create.body.error.code).toBe("NOT_FOUND");
-
-    await accept(mainApi().list({ headers: SESSION_HEADERS }), [404]);
-    await accept(
-      refApi().show({ params: { ref: "blocked" }, headers: SESSION_HEADERS }),
-      [404],
-    );
-    await accept(
-      refApi().run({
-        params: { ref: "blocked" },
-        headers: SESSION_HEADERS,
-        body: {},
-      }),
-      [404],
-    );
-    await accept(
-      triggerApi().show({
-        params: { id: randomUUID() },
-        headers: SESSION_HEADERS,
-      }),
-      [404],
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -8,10 +8,8 @@ import { scheduleListResponseSchema } from "@vm0/api-contracts/contracts/zero-sc
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatMessages } from "@vm0/db/schema/chat-message";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -93,24 +91,6 @@ async function seedFixture(
   );
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return fixture;
-}
-
-async function enableAutomations(fixture: SchedulesFixture): Promise<void> {
-  const db = store.set(writeDb$);
-  await db.insert(userFeatureSwitches).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    switches: { [FeatureSwitchKey.ZeroAutomations]: true },
-  });
-}
-
-async function disableAutomations(fixture: SchedulesFixture): Promise<void> {
-  const db = store.set(writeDb$);
-  await db.insert(userFeatureSwitches).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    switches: { [FeatureSwitchKey.ZeroAutomations]: false },
-  });
 }
 
 function expectErrorCode(response: TestApiResponse): string {
@@ -206,7 +186,6 @@ const TRIGGER_CASES: readonly TriggerCase[] = [
 describe("Automations API parity with the legacy schedule surface", () => {
   it("create + list produce equivalent automation/schedule rows", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
 
     const oldResponse = await requestJson(
       "/api/zero/schedules",
@@ -322,7 +301,6 @@ describe("Automations API parity with the legacy schedule surface", () => {
           },
         ],
       });
-      await enableAutomations(fixture);
 
       const oldScheduleId = fixture.scheduleIds[0];
       const newScheduleId = fixture.scheduleIds[1];
@@ -362,93 +340,6 @@ describe("Automations API parity with the legacy schedule surface", () => {
   );
 });
 
-describe("Automations API feature-switch gating", () => {
-  it("returns 404 on every automation endpoint when the switch is off", async () => {
-    const fixture = await seedFixture({
-      schedules: [
-        {
-          name: "gated",
-          prompt: "Run me",
-          cronExpression: "0 9 * * *",
-          enabled: true,
-        },
-      ],
-    });
-    const scheduleId = fixture.scheduleIds[0];
-    if (!scheduleId) {
-      throw new Error("Expected seeded schedule");
-    }
-    // The switch is globally on (#17307); an explicit false override keeps the
-    // gating path covered until the switch is deleted.
-    await disableAutomations(fixture);
-
-    const create = await requestJson(
-      "/api/automations",
-      jsonInit("POST", {
-        name: "blocked",
-        agentId: fixture.composeId,
-        cronExpression: "0 9 * * *",
-        prompt: "Should not be created",
-      }),
-    );
-    expect(create.status).toBe(404);
-    expect(expectErrorCode(create)).toBe("NOT_FOUND");
-
-    const list = await requestJson("/api/automations", {
-      method: "GET",
-      headers: SESSION_HEADERS,
-    });
-    expect(list.status).toBe(404);
-
-    const update = await requestJson(
-      "/api/automations/gated",
-      jsonInit("PUT", {
-        agentId: fixture.composeId,
-        cronExpression: "0 10 * * *",
-        prompt: "Should not update",
-      }),
-    );
-    expect(update.status).toBe(404);
-
-    const enable = await requestJson(
-      "/api/automations/gated/enable",
-      jsonInit("POST", { agentId: fixture.composeId }),
-    );
-    expect(enable.status).toBe(404);
-
-    const disable = await requestJson(
-      "/api/automations/gated/disable",
-      jsonInit("POST", { agentId: fixture.composeId }),
-    );
-    expect(disable.status).toBe(404);
-
-    const run = await requestJson(
-      "/api/automations/run",
-      jsonInit("POST", { automationId: scheduleId }),
-    );
-    expect(run.status).toBe(404);
-
-    const del = await requestJson(
-      `/api/automations/gated?agentId=${fixture.composeId}`,
-      { method: "DELETE", headers: SESSION_HEADERS },
-    );
-    expect(del.status).toBe(404);
-
-    // The legacy surface is unaffected while the switch is off.
-    const legacyList = await requestJson("/api/zero/schedules", {
-      method: "GET",
-      headers: SESSION_HEADERS,
-    });
-    expect(legacyList.status).toBe(200);
-    const parsed = scheduleListResponseSchema.parse(legacyList.body);
-    expect(
-      parsed.schedules.some((schedule) => {
-        return schedule.name === "gated";
-      }),
-    ).toBeTruthy();
-  });
-});
-
 describe("Automations API behaviors", () => {
   it("updates an existing automation by name via PUT", async () => {
     const fixture = await seedFixture({
@@ -461,7 +352,6 @@ describe("Automations API behaviors", () => {
         },
       ],
     });
-    await enableAutomations(fixture);
 
     const response = await requestJson(
       "/api/automations/editable",
@@ -505,7 +395,6 @@ describe("Automations API behaviors", () => {
         },
       ],
     });
-    await enableAutomations(fixture);
 
     const enabled = await requestJson(
       "/api/automations/toggle/enable",
@@ -533,7 +422,6 @@ describe("Automations API behaviors", () => {
         },
       ],
     });
-    await enableAutomations(fixture);
 
     const delStatus = await requestStatus(
       `/api/automations/removable?agentId=${fixture.composeId}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhook-automations.test.ts
@@ -107,7 +107,7 @@ async function seedFixture(): Promise<SchedulesFixture> {
   return fixture;
 }
 
-async function enableAutomations(
+async function enableWebhookTriggers(
   fixture: SchedulesFixture,
   options?: { readonly webhookTriggers?: boolean },
 ): Promise<void> {
@@ -116,19 +116,9 @@ async function enableAutomations(
     orgId: fixture.orgId,
     userId: fixture.userId,
     switches: {
-      [FeatureSwitchKey.ZeroAutomations]: true,
       [FeatureSwitchKey.AutomationWebhookTriggers]:
         options?.webhookTriggers ?? true,
     },
-  });
-}
-
-async function disableAutomations(fixture: SchedulesFixture): Promise<void> {
-  const db = store.set(writeDb$);
-  await db.insert(userFeatureSwitches).values({
-    orgId: fixture.orgId,
-    userId: fixture.userId,
-    switches: { [FeatureSwitchKey.ZeroAutomations]: false },
   });
 }
 
@@ -139,7 +129,7 @@ function expectErrorCode(response: TestApiResponse): string {
 describe("Webhook automations management API", () => {
   it("creates a webhook automation, returns the url + secret once, and persists rows", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const response = await requestJson(
       "/api/automations/webhooks",
@@ -222,7 +212,7 @@ describe("Webhook automations management API", () => {
 
   it("links an existing owned chat thread when chatThreadId is supplied", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const db = store.set(writeDb$);
     const [thread] = await db
@@ -250,7 +240,7 @@ describe("Webhook automations management API", () => {
 
   it("rejects a chat thread that is not owned by the caller", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const db = store.set(writeDb$);
     const [thread] = await db
@@ -279,7 +269,7 @@ describe("Webhook automations management API", () => {
 
   it("returns 404 when the target agent is not visible", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const response = await requestJson(
       "/api/automations/webhooks",
@@ -295,7 +285,7 @@ describe("Webhook automations management API", () => {
 
   it("lists webhook automations without the secret", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = webhookAutomationCreateResponseSchema.parse(
       (
@@ -327,7 +317,7 @@ describe("Webhook automations management API", () => {
 
   it("deletes a webhook automation and cascades the trigger", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = webhookAutomationCreateResponseSchema.parse(
       (
@@ -363,7 +353,7 @@ describe("Webhook automations management API", () => {
 
   it("returns 404 deleting an automation owned by another scope", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const delStatus = await requestStatus(
       "/api/automations/webhooks/00000000-0000-0000-0000-000000000000",
@@ -374,7 +364,7 @@ describe("Webhook automations management API", () => {
 
   it("accepts the minted token at the inbound webhook route end-to-end", async () => {
     const fixture = await seedFixture();
-    await enableAutomations(fixture);
+    await enableWebhookTriggers(fixture);
 
     const created = webhookAutomationCreateResponseSchema.parse(
       (
@@ -436,41 +426,11 @@ describe("Webhook automations management API", () => {
 });
 
 describe("Webhook automations management feature gating", () => {
-  it("returns 404 on every endpoint when the switch is off", async () => {
-    const fixture = await seedFixture();
-    // The switch is globally on (#17307); an explicit false override keeps the
-    // gating path covered until the switch is deleted.
-    await disableAutomations(fixture);
-
-    const create = await requestJson(
-      "/api/automations/webhooks",
-      jsonInit("POST", {
-        name: "blocked",
-        instruction: "Should not be created.",
-        agentId: fixture.composeId,
-      }),
-    );
-    expect(create.status).toBe(404);
-    expect(expectErrorCode(create)).toBe("NOT_FOUND");
-
-    const list = await requestJson("/api/automations/webhooks", {
-      method: "GET",
-      headers: SESSION_HEADERS,
-    });
-    expect(list.status).toBe(404);
-
-    const del = await requestStatus(
-      "/api/automations/webhooks/00000000-0000-0000-0000-000000000000",
-      { method: "DELETE", headers: SESSION_HEADERS },
-    );
-    expect(del).toBe(404);
-  });
-
   it("returns 404 creating when only the webhook trigger switch is off", async () => {
     // Creating a webhook automation mints a webhook trigger, so it is gated
-    // by AutomationWebhookTriggers even with ZeroAutomations on (#17307).
+    // by AutomationWebhookTriggers (#17307).
     const fixture = await seedFixture();
-    await enableAutomations(fixture, { webhookTriggers: false });
+    await enableWebhookTriggers(fixture, { webhookTriggers: false });
 
     const create = await requestJson(
       "/api/automations/webhooks",

--- a/turbo/apps/api/src/signals/routes/automations-v2.ts
+++ b/turbo/apps/api/src/signals/routes/automations-v2.ts
@@ -32,7 +32,6 @@ import { webhookUrlForToken } from "../services/webhook-automations.service";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
-import { automationsEnabled$ } from "./automations";
 import type { RouteEntry } from "../route";
 
 const NOT_FOUND_MESSAGE = "Resource not found";
@@ -129,10 +128,6 @@ const WEBHOOK_TRIGGERS_DISABLED_MESSAGE =
   "Webhook triggers are not enabled for this workspace";
 
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const bodyResult = await get(bodyResultOf(automationsV2MainContract.create));
   signal.throwIfAborted();
@@ -172,10 +167,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const listInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const views = await set(
     listAutomationsV2$,
@@ -190,10 +181,6 @@ const listInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const showInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsV2ByRefContract.show));
 
@@ -217,10 +204,6 @@ const showInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsV2ByRefContract.update));
   const bodyResult = await get(bodyResultOf(automationsV2ByRefContract.update));
@@ -254,10 +237,6 @@ const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsV2ByRefContract.delete));
 
@@ -279,10 +258,6 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 function makeSetEnabledInner(enabled: boolean) {
   return command(async ({ get, set }, signal: AbortSignal) => {
-    if (!(await get(automationsEnabled$))) {
-      return notFound(NOT_FOUND_MESSAGE);
-    }
-    signal.throwIfAborted();
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationsV2ByRefContract.enable));
 
@@ -310,10 +285,6 @@ const enableInner$ = makeSetEnabledInner(true);
 const disableInner$ = makeSetEnabledInner(false);
 
 const runInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsV2ByRefContract.run));
 
@@ -345,10 +316,6 @@ const runInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const addTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsV2ByRefContract.addTrigger));
   const bodyResult = await get(
@@ -400,10 +367,6 @@ const addTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 const listTriggersInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!(await get(automationsEnabled$))) {
-      return notFound(NOT_FOUND_MESSAGE);
-    }
-    signal.throwIfAborted();
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationsV2ByRefContract.listTriggers));
 
@@ -431,10 +394,6 @@ const listTriggersInner$ = command(
 );
 
 const showTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound(NOT_FOUND_MESSAGE);
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationTriggersV2Contract.show));
 
@@ -453,10 +412,6 @@ const showTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 const removeTriggerInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!(await get(automationsEnabled$))) {
-      return notFound(NOT_FOUND_MESSAGE);
-    }
-    signal.throwIfAborted();
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationTriggersV2Contract.remove));
 
@@ -476,10 +431,6 @@ const removeTriggerInner$ = command(
 
 function makeSetTriggerEnabledInner(enabled: boolean) {
   return command(async ({ get, set }, signal: AbortSignal) => {
-    if (!(await get(automationsEnabled$))) {
-      return notFound(NOT_FOUND_MESSAGE);
-    }
-    signal.throwIfAborted();
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationTriggersV2Contract.enable));
 
@@ -505,9 +456,6 @@ const disableTriggerInner$ = makeSetTriggerEnabledInner(false);
 
 const rotateSecretInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    if (!(await get(automationsEnabled$))) {
-      return notFound(NOT_FOUND_MESSAGE);
-    }
     if (!(await get(webhookTriggersEnabled$))) {
       return badRequestMessage(WEBHOOK_TRIGGERS_DISABLED_MESSAGE);
     }

--- a/turbo/apps/api/src/signals/routes/automations.ts
+++ b/turbo/apps/api/src/signals/routes/automations.ts
@@ -52,27 +52,7 @@ function toAutomationMutation(response: {
   };
 }
 
-// The Automations API is gated behind the zeroAutomations switch. When off, the
-// surface is not reachable: handlers report not-found so the new paths are
-// indistinguishable from unmounted routes. Shared by every automation surface
-// (this one, the webhook-automation management routes, and the v2 resource).
-export const automationsEnabled$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  return isFeatureEnabled(FeatureSwitchKey.ZeroAutomations, {
-    orgId: auth.orgId,
-    userId: auth.userId,
-    overrides,
-  });
-});
-
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const bodyResult = await get(bodyResultOf(automationsMainContract.create));
   signal.throwIfAborted();
@@ -115,10 +95,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsByNameContract.update));
   const bodyResult = await get(bodyResultOf(automationsByNameContract.update));
@@ -163,10 +139,6 @@ const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const listInner$ = command(async ({ get }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const result = await get(
     zeroScheduleList({ orgId: auth.orgId, userId: auth.userId }),
@@ -176,10 +148,6 @@ const listInner$ = command(async ({ get }, signal: AbortSignal) => {
 });
 
 const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsByNameContract.delete));
   const query = get(queryOf(automationsByNameContract.delete));
@@ -203,10 +171,6 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const disableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsEnableContract.disable));
   const bodyResult = await get(bodyResultOf(automationsEnableContract.disable));
@@ -237,10 +201,6 @@ const disableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const enableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(automationsEnableContract.enable));
   const bodyResult = await get(bodyResultOf(automationsEnableContract.enable));
@@ -282,10 +242,6 @@ const enableInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const runNowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const bodyResult = await get(bodyResultOf(automationRunContract.run));
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/automations.ts
+++ b/turbo/apps/api/src/signals/routes/automations.ts
@@ -1,4 +1,4 @@
-import { command, computed } from "ccstate";
+import { command } from "ccstate";
 import {
   automationRunContract,
   automationsByNameContract,
@@ -12,14 +12,11 @@ import type {
   ScheduleListResponse,
   ScheduleResponse,
 } from "@vm0/api-contracts/contracts/zero-schedules";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   deleteSchedule$,
   deploySchedule$,

--- a/turbo/apps/api/src/signals/routes/webhook-automations.ts
+++ b/turbo/apps/api/src/signals/routes/webhook-automations.ts
@@ -15,7 +15,6 @@ import {
   listWebhookAutomations$,
   type WebhookAutomationView,
 } from "../services/webhook-automations.service";
-import { automationsEnabled$ } from "./automations";
 import { webhookTriggersEnabled$ } from "./automations-v2";
 import type { RouteEntry } from "../route";
 
@@ -24,9 +23,6 @@ function toResponse(view: WebhookAutomationView): WebhookAutomationResponse {
 }
 
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
   // Creating a webhook automation mints a webhook trigger — gated like the
   // resource API's webhook trigger creation (#17307).
   if (!(await get(webhookTriggersEnabled$))) {
@@ -69,10 +65,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const listInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const automations = await set(
     listWebhookAutomations$,
@@ -87,10 +79,6 @@ const listInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  if (!(await get(automationsEnabled$))) {
-    return notFound("Resource not found");
-  }
-  signal.throwIfAborted();
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(webhookAutomationsByIdContract.delete));
 

--- a/turbo/packages/api-contracts/src/contracts/automations-v2.ts
+++ b/turbo/packages/api-contracts/src/contracts/automations-v2.ts
@@ -9,7 +9,7 @@ const c = initContract();
  * identity + intent (agent, instruction, one linked chat thread, enabled),
  * carrying N triggers (cron / once / loop / webhook) that only decide WHEN it
  * fires. Replaces the split schedule/webhook surfaces, which remain as
- * deprecated aliases. Gated behind the `zeroAutomations` feature switch.
+ * deprecated aliases.
  *
  * `:ref` resolves an automation by id (UUID) or by name; a name shared across
  * agents within the org/user scope is ambiguous and rejected with 400 — use

--- a/turbo/packages/api-contracts/src/contracts/automations.ts
+++ b/turbo/packages/api-contracts/src/contracts/automations.ts
@@ -9,8 +9,7 @@ const c = initContract();
  * automation service that also backs the legacy `/api/zero/schedules` routes.
  * The field set is the post-cleanup schedule set (no secrets / vars /
  * volumeVersions); the two surfaces drive the same service and therefore the
- * same agent run + chat-thread rendering. Gated behind the `zeroAutomations`
- * feature switch — when off, these endpoints are not mounted (404).
+ * same agent run + chat-thread rendering.
  */
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/webhook-automations.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhook-automations.ts
@@ -7,9 +7,7 @@ const c = initContract();
 /**
  * Webhook-automation management API. Creates/lists/deletes the events-first
  * webhook automations that live on the new `automations` + `automation_triggers`
- * tables. Gated behind the `zeroAutomations`
- * feature switch — when off, these endpoints are not mounted (404), matching the
- * time-automation surface.
+ * tables.
  *
  * A webhook automation pairs a user `instruction` with an agent and a linked
  * chat thread. Creation mints an unguessable URL token plus an HMAC signing

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -63,6 +63,5 @@ export enum FeatureSwitchKey {
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",
   CreditUsageRecords = "creditUsageRecords",
-  ZeroAutomations = "zeroAutomations",
   AutomationWebhookTriggers = "automationWebhookTriggers",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -358,12 +358,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show ranged personal credit usage records and team member usage aggregates in settings, and enable scoped/ranged /api/zero/usage/record queries.",
     enabled: true,
   },
-  [FeatureSwitchKey.ZeroAutomations]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Expose the Automations API surface (/api/automations) over the shared automation service. Fully on since #17307 (the schedule surface is being retired); the switch is removed once the dual-mode consumers are gone.",
-    enabled: true,
-  },
   [FeatureSwitchKey.AutomationWebhookTriggers]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

PR-3c of #17307, the last step of retiring the `zeroAutomations` switch: #17340 turned it fully on, #17352 stopped the platform from reading it, and this PR deletes it.

- `FeatureSwitchKey.ZeroAutomations` and its config block are gone.
- The `automationsEnabled$` gate and its not-found short-circuits are removed from all three automation surfaces (flat alias routes, v2 resource routes, webhook management routes) — they are now unconditionally mounted, which is behaviorally identical to the switch being globally on.
- Webhook trigger creation/rotation and the inbound dispatch stay gated behind `automationWebhookTriggers` (unchanged).
- Test suites drop the switch seeding and the switch-off gating tests; the webhook-trigger gating tests remain.

## Test plan

- [x] automations, automations-v2, webhook-automations, webhooks-automation suites green (41 tests)
- [x] `check-types`, `lint`, `format`, `knip` clean
- [x] `rg zeroAutomations` returns nothing

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)