### PR TITLE
fix: update chat feature switch defaults

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -387,7 +387,6 @@ describe("zero sidebar", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatThreadRename]: true },
       path: `/chats/${EXISTING_THREAD_ID}?sidebar=detached-thread`,
     });
 
@@ -442,7 +441,6 @@ describe("zero sidebar", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: { [FeatureSwitchKey.ChatThreadRename]: true },
       path: `/chats/${EXISTING_THREAD_ID}`,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -14,7 +14,6 @@ import {
   IconPinnedOff,
 } from "@tabler/icons-react";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
 import {
   Tooltip,
@@ -48,7 +47,6 @@ import {
   unpinChatThread$,
   renameChatThread$,
 } from "../../signals/chat-page/chat-message.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   SIDEBAR_PARAM,
   currentLeftThread$,
@@ -239,13 +237,11 @@ function ChatThreadMenu({
   threadId,
   isPinned,
   isHighlighted,
-  renameEnabled,
   hasOtherIndicator,
 }: {
   threadId: string;
   isPinned: boolean;
   isHighlighted: boolean;
-  renameEnabled: boolean;
   hasOtherIndicator: boolean;
 }) {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
@@ -317,12 +313,10 @@ function ChatThreadMenu({
               </>
             )}
           </DropdownMenuItem>
-          {renameEnabled && (
-            <DropdownMenuItem onSelect={openRenameDialog}>
-              <IconPencil size={16} stroke={2} className="mr-2" />
-              Rename chat
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuItem onSelect={openRenameDialog}>
+            <IconPencil size={16} stroke={2} className="mr-2" />
+            Rename chat
+          </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
               setPendingDeleteThreadId(threadId);
@@ -342,13 +336,11 @@ function ChatThreadSideDecorator({
   threadId,
   isPinned,
   isHighlighted,
-  renameEnabled,
   indicatorState,
 }: {
   threadId: string;
   isPinned: boolean;
   isHighlighted: boolean;
-  renameEnabled: boolean;
   indicatorState: IndicatorState | null;
 }) {
   if (indicatorState === "draft") {
@@ -367,7 +359,6 @@ function ChatThreadSideDecorator({
         threadId={threadId}
         isPinned={isPinned}
         isHighlighted={isHighlighted}
-        renameEnabled={renameEnabled}
         hasOtherIndicator={hasOtherIndicator}
       />
       {indicatorState !== null ? (
@@ -415,8 +406,6 @@ function useChatThreadItemState(session: ChatThreadListItem) {
   const loadRightThread = useSet(loadRightThread$);
   const unloadRightThread = useSet(unloadRightThread$);
   const pageSignal = useGet(pageSignal$);
-  const features = useLastResolved(featureSwitch$);
-  const renameEnabled = features?.[FeatureSwitchKey.ChatThreadRename] ?? false;
 
   const isPinned = session.pinnedAt !== null && session.pinnedAt !== undefined;
   const onChatPage = urlMainThreadId !== null;
@@ -445,7 +434,6 @@ function useChatThreadItemState(session: ChatThreadListItem) {
     onChatPage,
     pageSignal,
     paneIndicator,
-    renameEnabled,
     setSidebarExpanded,
     unloadRightThread,
     indicatorState,
@@ -510,7 +498,6 @@ function ChatThreadItem({ session }: { session: ChatThreadListItem }) {
         threadId={session.id}
         isPinned={state.isPinned}
         isHighlighted={state.isHighlighted}
-        renameEnabled={state.renameEnabled}
         indicatorState={state.indicatorState}
       />
     </div>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -45,7 +45,6 @@ export enum FeatureSwitchKey {
   AudioOutput = "audioOutput",
   SkillsViewer = "skillsViewer",
   TestOauthConnector = "testOauthConnector",
-  ChatThreadRename = "chatThreadRename",
   FreshdeskConnector = "freshdeskConnector",
   StabilityAiConnector = "stabilityAiConnector",
   ZoomConnector = "zoomConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -101,7 +101,9 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatThreadRename]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatCompletedWorkFolding]).toBe(
+      false,
+    );
     expect(staffOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
       true,
     );
@@ -111,7 +113,9 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatThreadRename]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.ChatCompletedWorkFolding]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
       true,
     );
@@ -124,6 +128,14 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.AhrefsConnector]).toBe(true);
     // Non-overridden disabled feature stays false
     expect(states[FeatureSwitchKey.DropboxConnector]).toBe(false);
+  });
+
+  it("should let individuals opt in to completed work folding", () => {
+    const states = getAllFeatureStates({
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      overrides: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+    expect(states[FeatureSwitchKey.ChatCompletedWorkFolding]).toBe(true);
   });
 
   it("should apply overrides to disable enabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -249,12 +249,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the test-oauth connector, a synthetic OAuth 2.0 provider used only for automated tests. Off in prod.",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatThreadRename]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Adds a Rename chat item to the sidebar thread kebab menu. When the user renames a thread, automated title generation is suppressed for that thread.",
-    enabled: true,
-  },
   [FeatureSwitchKey.FreshdeskConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Freshdesk helpdesk connector",
@@ -329,9 +323,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ChatCompletedWorkFolding]: {
     maintainer: "lancy@vm0.ai",
     description:
-      "Collapse earlier Zero chat work history after a run finishes, leaving the final message visible.",
+      "Collapse earlier Zero chat work history after a run finishes, leaving the final message visible. Users can opt in individually from Lab.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatRecommendedFollowups]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary
- remove the `chatThreadRename` feature switch and make sidebar rename always available
- stop enabling `chatCompletedWorkFolding` by staff org default; leave it disabled by registry default and available through personal overrides
- update feature-switch and sidebar tests for the new defaults

## Tests
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/sidebar-threads.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`