### PR TITLE
feat(api): replace schedule capabilities with automation capabilities

### DIFF
--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -28,7 +28,7 @@ const CONDITIONAL_CAPABILITIES = [
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
 const AGENT_EXCLUDED_CAPABILITIES = [
-  "schedule:delete",
+  "automation:delete",
   "agent-run:write",
   "agent:delete",
 ] as const satisfies readonly ZeroCapability[];
@@ -46,14 +46,54 @@ const sandboxTokenPayloadSchema = jwtBaseSchema.extend({
   orgId: z.string().min(1),
 });
 
-const zeroCapabilitySchema = z.custom<ZeroCapability>((value) => {
+// "automation:*" replaced "schedule:*" (#17307). In-flight zero tokens (2h
+// lifetime) may still carry the legacy names; they are accepted here and
+// normalized to their automation equivalents right after parse — a permanent
+// compatibility mapping in the authorization layer.
+type LegacyZeroCapability =
+  | "schedule:read"
+  | "schedule:write"
+  | "schedule:delete";
+
+const LEGACY_CAPABILITY_ALIASES: Readonly<
+  Record<LegacyZeroCapability, ZeroCapability>
+> = {
+  "schedule:read": "automation:read",
+  "schedule:write": "automation:write",
+  "schedule:delete": "automation:delete",
+};
+
+function isLegacyCapability(
+  value: ZeroCapability | LegacyZeroCapability,
+): value is LegacyZeroCapability {
   return (
-    typeof value === "string" &&
-    ZERO_CAPABILITIES.some((capability) => {
-      return capability === value;
-    })
+    value === "schedule:read" ||
+    value === "schedule:write" ||
+    value === "schedule:delete"
   );
-});
+}
+
+const zeroCapabilitySchema = z.custom<ZeroCapability | LegacyZeroCapability>(
+  (value) => {
+    return (
+      typeof value === "string" &&
+      (value in LEGACY_CAPABILITY_ALIASES ||
+        ZERO_CAPABILITIES.some((capability) => {
+          return capability === value;
+        }))
+    );
+  },
+);
+
+function normalizeCapabilities(
+  capabilities: readonly (ZeroCapability | LegacyZeroCapability)[],
+): readonly ZeroCapability[] {
+  return capabilities.map((capability) => {
+    return isLegacyCapability(capability)
+      ? LEGACY_CAPABILITY_ALIASES[capability]
+      : capability;
+  });
+}
 
 const zeroTokenPayloadSchema = jwtBaseSchema.extend({
   scope: z.literal("zero"),
@@ -190,7 +230,7 @@ export function verifyZeroToken(token: string): ZeroAuth | null {
     userId: parsed.data.userId,
     runId: parsed.data.runId,
     orgId: parsed.data.orgId,
-    capabilities: parsed.data.capabilities,
+    capabilities: normalizeCapabilities(parsed.data.capabilities),
     ...(parsed.data.computerUseHostId
       ? { computerUseHostId: parsed.data.computerUseHostId }
       : {}),

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -66,11 +66,7 @@ const LEGACY_CAPABILITY_ALIASES: Readonly<
 function isLegacyCapability(
   value: ZeroCapability | LegacyZeroCapability,
 ): value is LegacyZeroCapability {
-  return (
-    value === "schedule:read" ||
-    value === "schedule:write" ||
-    value === "schedule:delete"
-  );
+  return value in LEGACY_CAPABILITY_ALIASES;
 }
 
 const zeroCapabilitySchema = z.custom<ZeroCapability | LegacyZeroCapability>(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-schedules-delete.test.ts
@@ -24,6 +24,8 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
+// Carries only the LEGACY read capability: proves the schedule:* alias still
+// authenticates (normalized to automation:read) while delete stays forbidden.
 function zeroTokenWithoutScheduleDelete(args: {
   readonly userId: string;
   readonly orgId: string;
@@ -205,7 +207,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
 
     expect(response.body).toStrictEqual({
       error: {
-        message: "Missing required capability: schedule:delete",
+        message: "Missing required capability: automation:delete",
         code: "FORBIDDEN",
       },
     });

--- a/turbo/apps/api/src/signals/routes/automations-v2.ts
+++ b/turbo/apps/api/src/signals/routes/automations-v2.ts
@@ -547,7 +547,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       createInner$,
     ),
@@ -558,7 +558,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       listInner$,
     ),
@@ -569,7 +569,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       showInner$,
     ),
@@ -580,7 +580,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       updateInner$,
     ),
@@ -591,7 +591,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:delete",
+        requiredCapability: "automation:delete",
       },
       deleteInner$,
     ),
@@ -602,7 +602,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       enableInner$,
     ),
@@ -613,7 +613,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       disableInner$,
     ),
@@ -634,7 +634,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       addTriggerInner$,
     ),
@@ -645,7 +645,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       listTriggersInner$,
     ),
@@ -656,7 +656,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       showTriggerInner$,
     ),
@@ -667,7 +667,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:delete",
+        requiredCapability: "automation:delete",
       },
       removeTriggerInner$,
     ),
@@ -678,7 +678,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       enableTriggerInner$,
     ),
@@ -689,7 +689,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       disableTriggerInner$,
     ),
@@ -700,7 +700,7 @@ export const automationsV2Routes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       rotateSecretInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/automations.ts
+++ b/turbo/apps/api/src/signals/routes/automations.ts
@@ -323,7 +323,7 @@ export const automationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       createInner$,
     ),
@@ -334,7 +334,7 @@ export const automationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       listInner$,
     ),
@@ -345,7 +345,7 @@ export const automationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       updateInner$,
     ),
@@ -356,7 +356,7 @@ export const automationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:delete",
+        requiredCapability: "automation:delete",
       },
       deleteInner$,
     ),
@@ -367,7 +367,7 @@ export const automationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       disableInner$,
     ),
@@ -378,7 +378,7 @@ export const automationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       enableInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/webhook-automations.ts
+++ b/turbo/apps/api/src/signals/routes/webhook-automations.ts
@@ -114,7 +114,7 @@ export const webhookAutomationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       createInner$,
     ),
@@ -125,7 +125,7 @@ export const webhookAutomationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       listInner$,
     ),
@@ -136,7 +136,7 @@ export const webhookAutomationsRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:delete",
+        requiredCapability: "automation:delete",
       },
       deleteInner$,
     ),

--- a/turbo/apps/api/src/signals/routes/zero-schedules.ts
+++ b/turbo/apps/api/src/signals/routes/zero-schedules.ts
@@ -198,7 +198,7 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       deployInner$,
     ),
@@ -209,7 +209,7 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:read",
+        requiredCapability: "automation:read",
       },
       listSchedulesInner$,
     ),
@@ -220,7 +220,7 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:delete",
+        requiredCapability: "automation:delete",
       },
       deleteInner$,
     ),
@@ -231,7 +231,7 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       disableInner$,
     ),
@@ -242,7 +242,7 @@ export const zeroSchedulesRoutes: readonly RouteEntry[] = [
       {
         requireOrganization: true,
         missingOrganizationStatus: 401,
-        requiredCapability: "schedule:write",
+        requiredCapability: "automation:write",
       },
       enableInner$,
     ),

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -662,6 +662,19 @@ describe("registerZeroCommands", () => {
     expect(hiddenCommandNames(prog)).toContain("agent");
   });
 
+  it("should keep schedule visible with a new-style automation:read token", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["automation:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(visibleCommandNames(prog)).toContain("schedule");
+    expect(hiddenCommandNames(prog)).toContain("agent");
+  });
+
   it("should show connector when connector:read capability is present", () => {
     const token = buildZeroToken({
       scope: "zero",

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -50,8 +50,11 @@ const COMMAND_CAPABILITY_MAP: Record<
   agent: "agent:read",
   skill: "agent:read",
   connector: "connector:read",
-  schedule: "schedule:read",
-  automation: "schedule:read",
+  // Tokens minted before #17307 carry "schedule:read"; newer ones carry
+  // "automation:read". Accept both so the commands stay visible regardless
+  // of which side (API or CLI) deploys first.
+  schedule: ["schedule:read", "automation:read"],
+  automation: ["schedule:read", "automation:read"],
   doctor: null,
   credit: "billing:write",
   model: null,

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -42,9 +42,9 @@ export const ZERO_CAPABILITIES = [
   "agent:delete",
   "agent-run:read",
   "agent-run:write",
-  "schedule:read",
-  "schedule:write",
-  "schedule:delete",
+  "automation:read",
+  "automation:write",
+  "automation:delete",
   "github:read",
   "github:write",
   "slack:write",
@@ -86,12 +86,15 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "agent:delete": { group: "Agent", label: "Delete agents" },
     "agent-run:read": { group: "Agent Runs", label: "View runs & telemetry" },
     "agent-run:write": { group: "Agent Runs", label: "Create & cancel runs" },
-    "schedule:read": { group: "Schedules", label: "View schedules" },
-    "schedule:write": {
-      group: "Schedules",
-      label: "Create & manage schedules",
+    "automation:read": { group: "Automations", label: "View automations" },
+    "automation:write": {
+      group: "Automations",
+      label: "Create & manage automations",
     },
-    "schedule:delete": { group: "Schedules", label: "Delete schedules" },
+    "automation:delete": {
+      group: "Automations",
+      label: "Delete automations",
+    },
     "github:read": {
       group: "Integrations",
       label: "Download GitHub files",


### PR DESCRIPTION
## Summary

PR-4a of #17307: the token capability vocabulary moves from `schedule:*` to `automation:*`.

- `ZERO_CAPABILITIES` and `ZERO_CAPABILITY_META` swap `schedule:read|write|delete` for `automation:read|write|delete` (UI group "Automations"); newly minted zero tokens carry only the new names.
- All automation-family routes (`/api/zero/schedules`, flat `/api/automations` alias, v2 resource API, webhook management) now require the `automation:*` capability.
- **Legacy compatibility is permanent**: the zero-token parser accepts `schedule:*` and normalizes each to its `automation:*` equivalent right after parse, so in-flight tokens (2-hour lifetime) and any stored capability lists keep working. The alias is typed (`LegacyZeroCapability`) — no casts.
- `AGENT_EXCLUDED_CAPABILITIES` swaps `schedule:delete` for `automation:delete`, preserving the agent-scoped exclusion.
- The zero-schedules-delete suite keeps minting a token with legacy `"schedule:read"`, which now doubles as the normalization regression test (authenticates as `automation:read`, still 403s on delete with the new error message).

## Test plan

- [x] 10 affected API suites green (205 tests) including contract meta exhaustiveness
- [x] Legacy-alias path covered: token with `schedule:read` authenticates, delete still forbidden
- [x] `check-types`, `lint`, `format`, `knip` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)