### PR TITLE
fix: show full permission names in drawer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1104,7 +1104,7 @@ function PermissionRow({
         className={`flex items-center gap-2.5 px-3 py-2.5 rounded-md hover:bg-muted/50 transition-colors ${indent ? "pl-8" : ""}`}
       >
         <div className="min-w-0 flex-1">
-          <code className="text-xs font-medium text-foreground truncate block">
+          <code className="block whitespace-normal break-words text-xs font-medium text-foreground [overflow-wrap:anywhere]">
             {permission.name}
           </code>
           {permission.description && (


### PR DESCRIPTION
## Summary
- allow permission names in the permissions drawer to wrap instead of truncating
- preserve long token-style names such as `cloud-email-security.read` without overflowing the drawer

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm prettier --check apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx`
- `TZ=UTC pnpm -F @vm0/app test`