### PR TITLE
feat: make cloudflare connector generally available

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -385,13 +385,6 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     orgIds.push(orgId);
     mocks.clerk.session(userId, orgId);
 
-    const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.CloudflareConnector]: true },
-    });
-
     const response = await requestOauthStart("cloudflare", {
       headers: { authorization: "Bearer clerk-session" },
       origin: WEB_ORIGIN,
@@ -415,6 +408,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     const state = authorizationUrl.searchParams.get("state");
     expect(state).toMatch(/^[0-9a-f]{64}$/);
 
+    const db = store.set(writeDb$);
     const [storedState] = await db
       .select()
       .from(connectorOauthStates)
@@ -440,13 +434,6 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     mockEnv("VM0_API_URL", "https://tunnel-liangyou-vm2-www.vm7.ai");
     mockEnv("VM0_WEB_URL", "https://www.vm7.ai:8443");
 
-    const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.CloudflareConnector]: true },
-    });
-
     const response = await requestOauthStart("cloudflare", {
       headers: { authorization: "Bearer clerk-session" },
       origin: "https://www.vm7.ai:8443",
@@ -463,6 +450,7 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expectCloudflareAuthorizationScopes(authorizationUrl);
 
     const state = authorizationUrl.searchParams.get("state");
+    const db = store.set(writeDb$);
     const [storedState] = await db
       .select()
       .from(connectorOauthStates)

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2514,15 +2514,11 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth"]);
   });
 
-  it("exposes Cloudflare OAuth only when its switch is enabled", () => {
+  it("exposes Cloudflare auth methods by default", () => {
     expect(getAvailableConnectorAuthMethodIds("cloudflare", {})).toStrictEqual([
+      "oauth",
       "api-token",
     ]);
-    expect(
-      getAvailableConnectorAuthMethodIds("cloudflare", {
-        [FeatureSwitchKey.CloudflareConnector]: true,
-      }),
-    ).toStrictEqual(["oauth", "api-token"]);
   });
 
   it("exposes Google Maps API-token auth only when its switch is enabled", () => {
@@ -4145,7 +4141,6 @@ describe("connector OAuth lifecycle grant helpers", () => {
       ]),
     );
     expect(getConnectorAuthMethod("cloudflare", "oauth")).toMatchObject({
-      featureFlag: FeatureSwitchKey.CloudflareConnector,
       client: {
         clientRegistration: "static",
         clientType: "confidential",

--- a/turbo/packages/connectors/src/connectors/cloudflare.ts
+++ b/turbo/packages/connectors/src/connectors/cloudflare.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 const CLOUDFLARE_OAUTH_SCOPES = [
   "agent-memory.write",
@@ -365,7 +364,6 @@ export const cloudflare = {
       "Connect your Cloudflare account to manage DNS, zones, workers, and other Cloudflare services",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.CloudflareConnector,
         label: "OAuth",
         helpText: "Sign in with Cloudflare to grant access.",
         client: {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -8,7 +8,6 @@ export enum FeatureSwitchKey {
   AhrefsConnector = "ahrefsConnector",
   BentomlConnector = "bentomlConnector",
   CanvaConnector = "canvaConnector",
-  CloudflareConnector = "cloudflareConnector",
   DeelConnector = "deelConnector",
   DocuSignConnector = "docusignConnector",
   DropboxConnector = "dropboxConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -54,11 +54,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Canva design connector",
     enabled: false,
   },
-  [FeatureSwitchKey.CloudflareConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Cloudflare OAuth connector",
-    enabled: false,
-  },
   [FeatureSwitchKey.DeelConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Deel HR connector",


### PR DESCRIPTION
## Summary
- remove the Cloudflare connector feature switch from the feature switch registry
- expose Cloudflare OAuth alongside API token auth by default
- update OAuth start and connector availability tests to no longer seed the Cloudflare switch

## Verification
- cd turbo && pnpm format
- cd turbo && pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
- cd turbo && pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/zero-feature-switches.test.ts
- cd turbo && pnpm -F @vm0/app exec vitest run src/views/lab-page/__tests__/lab-page.test.tsx
- cd turbo && pnpm -F @vm0/connectors check-types
- cd turbo && pnpm -F @vm0/core check-types
- cd turbo && pnpm -F api check-types
- pre-commit: prettier, knip, turbo check-types
