### PR TITLE
feat(api): move the automation resource api to /api/automations

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -190,15 +190,35 @@ export interface RouteEntry {
   readonly handler: SignalRouteHandler<unknown>;
 }
 
+/**
+ * The automation resource API lived under /api/v2/* before #17307 moved it to
+ * the clean /api/automations* paths. Clients built before the move (deployed
+ * platform bundles, older CLI releases) still call the /v2 paths, so every
+ * resource route is also mounted under its historical alias. Drop this once
+ * those clients have aged out.
+ */
+function withLegacyV2Alias(
+  entries: readonly RouteEntry[],
+): readonly RouteEntry[] {
+  return entries.flatMap((entry) => {
+    const aliasPath = entry.route.path.replace(/^\/api\//, "/api/v2/");
+    return [entry, { ...entry, route: { ...entry.route, path: aliasPath } }];
+  });
+}
+
 export const ROUTES: readonly RouteEntry[] = [
   {
     route: healthContract.check,
     handler: apiHealth$,
   },
   ...authMeRoutes,
-  // The unified Automations v2 resource (#16847 slice 2): one automation,
-  // N triggers of any kind.
-  ...automationsV2Routes,
+  // Inbound webhook dispatch (POST /api/automations/webhooks/:token) is
+  // registered before the resource routes so the static "webhooks" segment
+  // wins over the `/api/automations/:ref/...` params for that path shape.
+  ...webhooksAutomationRoutes,
+  // The unified Automation resource: one automation, N triggers of any kind.
+  // Mounted on /api/automations* plus the historical /api/v2/* alias paths.
+  ...withLegacyV2Alias(automationsV2Routes),
   ...cliAuthRoutes,
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,
@@ -220,7 +240,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...logsSearchRoutes,
   ...usageRoutes,
   ...userExportRoutes,
-  ...webhooksAutomationRoutes,
   ...webhooksClerkRoutes,
   ...webhooksBuiltInGenerationRoutes,
   ...webhooksGithubRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -223,6 +223,34 @@ describe("Automations v2 API", () => {
     });
   });
 
+  it("serves the historical /api/v2 alias paths during the transition", async () => {
+    // #17307 moved the resource API to /api/automations*; clients built
+    // before the move still call /api/v2/* and must keep working until they
+    // age out.
+    const fixture = await seedFixture();
+    await createAutomation({
+      name: "alias-check",
+      agentId: fixture.composeId,
+      trigger: { kind: "cron", cronExpression: "0 9 * * *" },
+    });
+
+    const v2AliasContract = {
+      list: {
+        ...automationsV2MainContract.list,
+        path: "/api/v2/automations",
+      },
+    } as const;
+    const aliasClient = setupApp({ context })(v2AliasContract);
+    const listed = await accept(
+      aliasClient.list({ headers: SESSION_HEADERS }),
+      [200],
+    );
+    const names = listed.body.automations.map((a) => {
+      return a.name;
+    });
+    expect(names).toContain("alias-check");
+  });
+
   it("creates an automation with a first cron trigger via sugar", async () => {
     const fixture = await seedFixture();
     await enableWebhookTriggers(fixture);

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/create.test.ts
@@ -110,7 +110,7 @@ describe("zero automation create command", () => {
     server.use(
       composeByNameHandler(),
       http.post(
-        "http://localhost:3000/api/v2/automations",
+        "http://localhost:3000/api/automations",
         async ({ request }) => {
           capturedBody = (await request.json()) as Record<string, unknown>;
           return HttpResponse.json(
@@ -150,7 +150,7 @@ describe("zero automation create command", () => {
     server.use(
       composeByNameHandler(),
       http.post(
-        "http://localhost:3000/api/v2/automations",
+        "http://localhost:3000/api/automations",
         async ({ request }) => {
           capturedBody = (await request.json()) as Record<string, unknown>;
           return HttpResponse.json(
@@ -193,7 +193,7 @@ describe("zero automation create command", () => {
     server.use(
       composeByNameHandler(),
       http.post(
-        "http://localhost:3000/api/v2/automations",
+        "http://localhost:3000/api/automations",
         async ({ request }) => {
           capturedBody = (await request.json()) as Record<string, unknown>;
           return HttpResponse.json(
@@ -226,7 +226,7 @@ describe("zero automation create command", () => {
   it("should print the webhook URL and one-time secret with --webhook", async () => {
     server.use(
       composeByNameHandler(),
-      http.post("http://localhost:3000/api/v2/automations", () => {
+      http.post("http://localhost:3000/api/automations", () => {
         return HttpResponse.json(
           {
             automation: baseAutomation([webhookTrigger]),
@@ -305,7 +305,7 @@ describe("zero automation create command", () => {
   it("should surface API validation errors", async () => {
     server.use(
       composeByNameHandler(),
-      http.post("http://localhost:3000/api/v2/automations", () => {
+      http.post("http://localhost:3000/api/automations", () => {
         return HttpResponse.json(
           {
             error: {

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/delete.test.ts
@@ -39,7 +39,7 @@ describe("zero automation delete command", () => {
 
     server.use(
       http.delete(
-        "http://localhost:3000/api/v2/automations/:ref",
+        "http://localhost:3000/api/automations/:ref",
         ({ params }) => {
           deletedRef = params.ref as string;
           return new HttpResponse(null, { status: 204 });
@@ -67,7 +67,7 @@ describe("zero automation delete command", () => {
 
   it("should surface not-found errors", async () => {
     server.use(
-      http.delete("http://localhost:3000/api/v2/automations/:ref", () => {
+      http.delete("http://localhost:3000/api/automations/:ref", () => {
         return HttpResponse.json(
           { error: { message: "Automation not found", code: "NOT_FOUND" } },
           { status: 404 },

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/disable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/disable.test.ts
@@ -55,7 +55,7 @@ describe("zero automation disable command", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/v2/automations/:ref/disable",
+        "http://localhost:3000/api/automations/:ref/disable",
         ({ params }) => {
           disabledRef = params.ref as string;
           return HttpResponse.json(mockAutomation);
@@ -72,7 +72,7 @@ describe("zero automation disable command", () => {
 
   it("should surface API errors", async () => {
     server.use(
-      http.post("http://localhost:3000/api/v2/automations/:ref/disable", () => {
+      http.post("http://localhost:3000/api/automations/:ref/disable", () => {
         return HttpResponse.json(
           { error: { message: "Automation not found", code: "NOT_FOUND" } },
           { status: 404 },

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/enable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/enable.test.ts
@@ -55,7 +55,7 @@ describe("zero automation enable command", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/v2/automations/:ref/enable",
+        "http://localhost:3000/api/automations/:ref/enable",
         ({ params }) => {
           enabledRef = params.ref as string;
           return HttpResponse.json(mockAutomation);
@@ -72,7 +72,7 @@ describe("zero automation enable command", () => {
 
   it("should surface API errors", async () => {
     server.use(
-      http.post("http://localhost:3000/api/v2/automations/:ref/enable", () => {
+      http.post("http://localhost:3000/api/automations/:ref/enable", () => {
         return HttpResponse.json(
           { error: { message: "Automation not found", code: "NOT_FOUND" } },
           { status: 404 },

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/list.test.ts
@@ -78,7 +78,7 @@ describe("zero automation list command", () => {
 
   it("should display automations with their trigger kinds", async () => {
     server.use(
-      http.get("http://localhost:3000/api/v2/automations", () => {
+      http.get("http://localhost:3000/api/automations", () => {
         return HttpResponse.json({ automations: [mockAutomation] });
       }),
     );
@@ -95,7 +95,7 @@ describe("zero automation list command", () => {
 
   it("should display empty state message when no automations", async () => {
     server.use(
-      http.get("http://localhost:3000/api/v2/automations", () => {
+      http.get("http://localhost:3000/api/automations", () => {
         return HttpResponse.json({ automations: [] });
       }),
     );
@@ -109,7 +109,7 @@ describe("zero automation list command", () => {
 
   it("should handle authentication error", async () => {
     server.use(
-      http.get("http://localhost:3000/api/v2/automations", () => {
+      http.get("http://localhost:3000/api/automations", () => {
         return HttpResponse.json(
           { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
           { status: 401 },

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/run.test.ts
@@ -39,7 +39,7 @@ describe("zero automation run command", () => {
 
     server.use(
       http.post(
-        "http://localhost:3000/api/v2/automations/:ref/run",
+        "http://localhost:3000/api/automations/:ref/run",
         ({ params }) => {
           firedRef = params.ref as string;
           return HttpResponse.json({ runId: "run-123" }, { status: 201 });
@@ -57,7 +57,7 @@ describe("zero automation run command", () => {
 
   it("should surface API errors (e.g. insufficient credits)", async () => {
     server.use(
-      http.post("http://localhost:3000/api/v2/automations/:ref/run", () => {
+      http.post("http://localhost:3000/api/automations/:ref/run", () => {
         return HttpResponse.json(
           {
             error: {

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/show.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/show.test.ts
@@ -78,13 +78,10 @@ describe("zero automation show command", () => {
 
   it("should display automation fields and the triggers table", async () => {
     server.use(
-      http.get(
-        "http://localhost:3000/api/v2/automations/:ref",
-        ({ params }) => {
-          expect(params.ref).toBe("alerts");
-          return HttpResponse.json(mockAutomation);
-        },
-      ),
+      http.get("http://localhost:3000/api/automations/:ref", ({ params }) => {
+        expect(params.ref).toBe("alerts");
+        return HttpResponse.json(mockAutomation);
+      }),
     );
 
     await showCommand.parseAsync(["node", "cli", "alerts"]);
@@ -107,7 +104,7 @@ describe("zero automation show command", () => {
 
   it("should hint at adding a trigger when the automation has none", async () => {
     server.use(
-      http.get("http://localhost:3000/api/v2/automations/:ref", () => {
+      http.get("http://localhost:3000/api/automations/:ref", () => {
         return HttpResponse.json({ ...mockAutomation, triggers: [] });
       }),
     );
@@ -121,7 +118,7 @@ describe("zero automation show command", () => {
 
   it("should surface the ambiguous-name API error", async () => {
     server.use(
-      http.get("http://localhost:3000/api/v2/automations/:ref", () => {
+      http.get("http://localhost:3000/api/automations/:ref", () => {
         return HttpResponse.json(
           {
             error: {

--- a/turbo/apps/cli/src/commands/zero/automation/__tests__/update.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/__tests__/update.test.ts
@@ -56,7 +56,7 @@ describe("zero automation update command", () => {
 
     server.use(
       http.patch(
-        "http://localhost:3000/api/v2/automations/:ref",
+        "http://localhost:3000/api/automations/:ref",
         async ({ request, params }) => {
           capturedRef = params.ref as string;
           capturedBody = (await request.json()) as Record<string, unknown>;
@@ -101,7 +101,7 @@ describe("zero automation update command", () => {
 
   it("should surface API errors", async () => {
     server.use(
-      http.patch("http://localhost:3000/api/v2/automations/:ref", () => {
+      http.patch("http://localhost:3000/api/automations/:ref", () => {
         return HttpResponse.json(
           {
             error: {

--- a/turbo/apps/cli/src/commands/zero/automation/trigger/__tests__/trigger.test.ts
+++ b/turbo/apps/cli/src/commands/zero/automation/trigger/__tests__/trigger.test.ts
@@ -86,7 +86,7 @@ describe("zero automation trigger commands", () => {
     const captured: { ref?: string; body?: Record<string, unknown> } = {};
     server.use(
       http.post(
-        "http://localhost:3000/api/v2/automations/:ref/triggers",
+        "http://localhost:3000/api/automations/:ref/triggers",
         async ({ request, params }) => {
           captured.ref = params.ref as string;
           captured.body = (await request.json()) as Record<string, unknown>;
@@ -247,7 +247,7 @@ describe("zero automation trigger commands", () => {
     it("should display the triggers table", async () => {
       server.use(
         http.get(
-          "http://localhost:3000/api/v2/automations/:ref/triggers",
+          "http://localhost:3000/api/automations/:ref/triggers",
           ({ params }) => {
             expect(params.ref).toBe("alerts");
             return HttpResponse.json({
@@ -269,12 +269,9 @@ describe("zero automation trigger commands", () => {
 
     it("should display empty state with an add hint", async () => {
       server.use(
-        http.get(
-          "http://localhost:3000/api/v2/automations/:ref/triggers",
-          () => {
-            return HttpResponse.json({ triggers: [] });
-          },
-        ),
+        http.get("http://localhost:3000/api/automations/:ref/triggers", () => {
+          return HttpResponse.json({ triggers: [] });
+        }),
       );
 
       await triggerCommand.parseAsync(["node", "cli", "list", "alerts"]);
@@ -289,7 +286,7 @@ describe("zero automation trigger commands", () => {
     it("should display trigger details", async () => {
       server.use(
         http.get(
-          "http://localhost:3000/api/v2/automation-triggers/:id",
+          "http://localhost:3000/api/automation-triggers/:id",
           ({ params }) => {
             expect(params.id).toBe(TRIGGER_ID);
             return HttpResponse.json(loopTrigger);
@@ -313,7 +310,7 @@ describe("zero automation trigger commands", () => {
 
       server.use(
         http.delete(
-          "http://localhost:3000/api/v2/automation-triggers/:id",
+          "http://localhost:3000/api/automation-triggers/:id",
           ({ params }) => {
             removedId = params.id as string;
             return new HttpResponse(null, { status: 204 });
@@ -333,7 +330,7 @@ describe("zero automation trigger commands", () => {
     it("should enable a single trigger", async () => {
       server.use(
         http.post(
-          "http://localhost:3000/api/v2/automation-triggers/:id/enable",
+          "http://localhost:3000/api/automation-triggers/:id/enable",
           () => {
             return HttpResponse.json(cronTrigger);
           },
@@ -349,7 +346,7 @@ describe("zero automation trigger commands", () => {
     it("should disable a single trigger", async () => {
       server.use(
         http.post(
-          "http://localhost:3000/api/v2/automation-triggers/:id/disable",
+          "http://localhost:3000/api/automation-triggers/:id/disable",
           () => {
             return HttpResponse.json({ ...cronTrigger, enabled: false });
           },
@@ -367,7 +364,7 @@ describe("zero automation trigger commands", () => {
     it("should rotate a webhook trigger secret and print it once", async () => {
       server.use(
         http.post(
-          "http://localhost:3000/api/v2/automation-triggers/:id/rotate-secret",
+          "http://localhost:3000/api/automation-triggers/:id/rotate-secret",
           () => {
             return HttpResponse.json({
               trigger: webhookTrigger,
@@ -393,7 +390,7 @@ describe("zero automation trigger commands", () => {
     it("should surface the non-webhook trigger error", async () => {
       server.use(
         http.post(
-          "http://localhost:3000/api/v2/automation-triggers/:id/rotate-secret",
+          "http://localhost:3000/api/automation-triggers/:id/rotate-secret",
           () => {
             return HttpResponse.json(
               {

--- a/turbo/apps/platform/src/mocks/handlers/api-automations-v2.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-automations-v2.ts
@@ -137,14 +137,14 @@ function replaceRow(updated: ScheduleResponse): void {
 }
 
 export const apiAutomationsV2Handlers = [
-  // GET /api/v2/automations
+  // GET /api/automations
   mockApi(automationsV2MainContract.list, ({ respond }) =>
     respond(200, {
       automations: getMockSchedules().map(toMockAutomationResponse),
     }),
   ),
 
-  // POST /api/v2/automations
+  // POST /api/automations
   mockApi(automationsV2MainContract.create, ({ body, respond }) => {
     if (!body.trigger) {
       throw new Error("Schedule mocks expect the first-trigger sugar");
@@ -173,7 +173,7 @@ export const apiAutomationsV2Handlers = [
     return respond(201, { automation: toMockAutomationResponse(row) });
   }),
 
-  // PATCH /api/v2/automations/:ref
+  // PATCH /api/automations/:ref
   mockApi(automationsV2ByRefContract.update, ({ params, body, respond }) => {
     const row = findByRef(params.ref);
     if (!row) {
@@ -192,7 +192,7 @@ export const apiAutomationsV2Handlers = [
     return respond(200, toMockAutomationResponse(updated));
   }),
 
-  // DELETE /api/v2/automations/:ref
+  // DELETE /api/automations/:ref
   mockApi(automationsV2ByRefContract.delete, ({ params, respond }) => {
     const row = findByRef(params.ref);
     if (!row) {
@@ -204,7 +204,7 @@ export const apiAutomationsV2Handlers = [
     return respond(204);
   }),
 
-  // POST /api/v2/automations/:ref/enable
+  // POST /api/automations/:ref/enable
   mockApi(automationsV2ByRefContract.enable, ({ params, respond }) => {
     const row = findByRef(params.ref);
     if (!row) {
@@ -217,7 +217,7 @@ export const apiAutomationsV2Handlers = [
     return respond(200, toMockAutomationResponse(updated));
   }),
 
-  // POST /api/v2/automations/:ref/disable
+  // POST /api/automations/:ref/disable
   mockApi(automationsV2ByRefContract.disable, ({ params, respond }) => {
     const row = findByRef(params.ref);
     if (!row) {
@@ -230,12 +230,12 @@ export const apiAutomationsV2Handlers = [
     return respond(200, toMockAutomationResponse(updated));
   }),
 
-  // POST /api/v2/automations/:ref/run
+  // POST /api/automations/:ref/run
   mockApi(automationsV2ByRefContract.run, ({ respond }) =>
     respond(201, { runId: crypto.randomUUID() }),
   ),
 
-  // POST /api/v2/automations/:ref/triggers
+  // POST /api/automations/:ref/triggers
   mockApi(
     automationsV2ByRefContract.addTrigger,
     ({ params, body, respond }) => {
@@ -260,7 +260,7 @@ export const apiAutomationsV2Handlers = [
     },
   ),
 
-  // DELETE /api/v2/automation-triggers/:id
+  // DELETE /api/automation-triggers/:id
   mockApi(automationTriggersV2Contract.remove, ({ params, respond }) => {
     const automationId = automationIdForTrigger(params.id);
     if (!automationId) {
@@ -277,7 +277,7 @@ export const apiAutomationsV2Handlers = [
     return respond(204);
   }),
 
-  // POST /api/v2/automation-triggers/:id/enable
+  // POST /api/automation-triggers/:id/enable
   mockApi(automationTriggersV2Contract.enable, ({ params, respond }) => {
     const automationId = automationIdForTrigger(params.id);
     const row = automationId

--- a/turbo/apps/platform/src/mocks/handlers/schedules-store.ts
+++ b/turbo/apps/platform/src/mocks/handlers/schedules-store.ts
@@ -1,7 +1,7 @@
 import type { ScheduleResponse } from "@vm0/api-contracts/contracts/zero-schedules";
 
 // Shared in-memory store backing the v2 automations mock handlers
-// (`/api/v2/automations`).
+// (`/api/automations`).
 let mockSchedules: ScheduleResponse[] = [];
 
 export function getMockSchedules(): ScheduleResponse[] {

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -59,6 +59,34 @@ const ZERO_LOGS_BY_ID_PATH_RE = new RegExp(
 const TEST_TELEGRAM_MOCK_REWRITE_SOURCE =
   "/api/test/telegram-mock/:botToken/:method";
 const TEST_TELEGRAM_MOCK_PATH_RE = /^\/api\/test\/telegram-mock\/[^/]+\/[^/]+$/;
+// The automation resource API on its clean paths (#17307); the /api/v2/*
+// entries below stay as transition aliases for clients built before the move.
+const AUTOMATIONS_BY_REF_REWRITE_SOURCE = "/api/automations/:ref";
+const AUTOMATIONS_BY_REF_PATH_RE = /^\/api\/automations\/[^/]+$/;
+const AUTOMATIONS_ENABLE_REWRITE_SOURCE = "/api/automations/:ref/enable";
+const AUTOMATIONS_ENABLE_PATH_RE = /^\/api\/automations\/[^/]+\/enable$/;
+const AUTOMATIONS_DISABLE_REWRITE_SOURCE = "/api/automations/:ref/disable";
+const AUTOMATIONS_DISABLE_PATH_RE = /^\/api\/automations\/[^/]+\/disable$/;
+const AUTOMATIONS_RUN_REWRITE_SOURCE = "/api/automations/:ref/run";
+const AUTOMATIONS_RUN_PATH_RE = /^\/api\/automations\/[^/]+\/run$/;
+const AUTOMATIONS_TRIGGERS_REWRITE_SOURCE = "/api/automations/:ref/triggers";
+const AUTOMATIONS_TRIGGERS_PATH_RE = /^\/api\/automations\/[^/]+\/triggers$/;
+const AUTOMATION_TRIGGERS_BY_ID_REWRITE_SOURCE = `/api/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})`;
+const AUTOMATION_TRIGGERS_BY_ID_PATH_RE = new RegExp(
+  `^/api/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}$`,
+);
+const AUTOMATION_TRIGGERS_ENABLE_REWRITE_SOURCE = `/api/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/enable`;
+const AUTOMATION_TRIGGERS_ENABLE_PATH_RE = new RegExp(
+  `^/api/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/enable$`,
+);
+const AUTOMATION_TRIGGERS_DISABLE_REWRITE_SOURCE = `/api/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/disable`;
+const AUTOMATION_TRIGGERS_DISABLE_PATH_RE = new RegExp(
+  `^/api/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/disable$`,
+);
+const AUTOMATION_TRIGGERS_ROTATE_SECRET_REWRITE_SOURCE = `/api/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/rotate-secret`;
+const AUTOMATION_TRIGGERS_ROTATE_SECRET_PATH_RE = new RegExp(
+  `^/api/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/rotate-secret$`,
+);
 const AUTOMATIONS_V2_BY_REF_REWRITE_SOURCE = "/api/v2/automations/:ref";
 const AUTOMATIONS_V2_BY_REF_PATH_RE = /^\/api\/v2\/automations\/[^/]+$/;
 const AUTOMATIONS_V2_ENABLE_REWRITE_SOURCE = "/api/v2/automations/:ref/enable";
@@ -1180,6 +1208,52 @@ export const API_BACKEND_REWRITES = [
     AUTOMATIONS_WEBHOOK_INBOUND_REWRITE_SOURCE,
     "/api/automations/webhooks/:token",
     AUTOMATIONS_WEBHOOK_INBOUND_PATH_RE,
+  ],
+  ["/api/automations", "/api/automations"],
+  [
+    AUTOMATIONS_ENABLE_REWRITE_SOURCE,
+    "/api/automations/:ref/enable",
+    AUTOMATIONS_ENABLE_PATH_RE,
+  ],
+  [
+    AUTOMATIONS_DISABLE_REWRITE_SOURCE,
+    "/api/automations/:ref/disable",
+    AUTOMATIONS_DISABLE_PATH_RE,
+  ],
+  [
+    AUTOMATIONS_RUN_REWRITE_SOURCE,
+    "/api/automations/:ref/run",
+    AUTOMATIONS_RUN_PATH_RE,
+  ],
+  [
+    AUTOMATIONS_TRIGGERS_REWRITE_SOURCE,
+    "/api/automations/:ref/triggers",
+    AUTOMATIONS_TRIGGERS_PATH_RE,
+  ],
+  [
+    AUTOMATIONS_BY_REF_REWRITE_SOURCE,
+    "/api/automations/:ref",
+    AUTOMATIONS_BY_REF_PATH_RE,
+  ],
+  [
+    AUTOMATION_TRIGGERS_ENABLE_REWRITE_SOURCE,
+    "/api/automation-triggers/:id/enable",
+    AUTOMATION_TRIGGERS_ENABLE_PATH_RE,
+  ],
+  [
+    AUTOMATION_TRIGGERS_DISABLE_REWRITE_SOURCE,
+    "/api/automation-triggers/:id/disable",
+    AUTOMATION_TRIGGERS_DISABLE_PATH_RE,
+  ],
+  [
+    AUTOMATION_TRIGGERS_ROTATE_SECRET_REWRITE_SOURCE,
+    "/api/automation-triggers/:id/rotate-secret",
+    AUTOMATION_TRIGGERS_ROTATE_SECRET_PATH_RE,
+  ],
+  [
+    AUTOMATION_TRIGGERS_BY_ID_REWRITE_SOURCE,
+    "/api/automation-triggers/:id",
+    AUTOMATION_TRIGGERS_BY_ID_PATH_RE,
   ],
   ["/api/v2/automations", "/api/v2/automations"],
   [

--- a/turbo/packages/api-contracts/src/contracts/automations-v2.ts
+++ b/turbo/packages/api-contracts/src/contracts/automations-v2.ts
@@ -5,11 +5,12 @@ import { apiErrorSchema } from "./errors";
 const c = initContract();
 
 /**
- * The unified Automation resource API (#16847 slice 2): one automation =
- * identity + intent (agent, instruction, one linked chat thread, enabled),
- * carrying N triggers (cron / once / loop / webhook) that only decide WHEN it
- * fires. Replaces the split schedule/webhook surfaces, which remain as
- * deprecated aliases.
+ * The unified Automation resource API: one automation = identity + intent
+ * (agent, instruction, one linked chat thread, enabled), carrying N triggers
+ * (cron / once / loop / webhook) that only decide WHEN it fires. It replaced
+ * the split schedule/webhook surfaces (deleted in #17307) and now lives on
+ * the clean /api/automations* paths; the server keeps the historical
+ * /api/v2/* paths mounted as aliases for clients built before the move.
  *
  * `:ref` resolves an automation by id (UUID) or by name; a name shared across
  * agents within the org/user scope is ambiguous and rejected with 400 — use
@@ -157,7 +158,7 @@ const triggerIdParamsSchema = z.object({
 export const automationsV2MainContract = c.router({
   create: {
     method: "POST",
-    path: "/api/v2/automations",
+    path: "/api/automations",
     headers: authHeadersSchema,
     body: createAutomationRequestSchema,
     responses: {
@@ -171,7 +172,7 @@ export const automationsV2MainContract = c.router({
   },
   list: {
     method: "GET",
-    path: "/api/v2/automations",
+    path: "/api/automations",
     headers: authHeadersSchema,
     responses: {
       200: automationListResponseSchemaV2,
@@ -186,7 +187,7 @@ export const automationsV2MainContract = c.router({
 export const automationsV2ByRefContract = c.router({
   show: {
     method: "GET",
-    path: "/api/v2/automations/:ref",
+    path: "/api/automations/:ref",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     responses: {
@@ -200,7 +201,7 @@ export const automationsV2ByRefContract = c.router({
   },
   update: {
     method: "PATCH",
-    path: "/api/v2/automations/:ref",
+    path: "/api/automations/:ref",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     body: updateAutomationRequestSchema,
@@ -215,7 +216,7 @@ export const automationsV2ByRefContract = c.router({
   },
   delete: {
     method: "DELETE",
-    path: "/api/v2/automations/:ref",
+    path: "/api/automations/:ref",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     responses: {
@@ -229,7 +230,7 @@ export const automationsV2ByRefContract = c.router({
   },
   enable: {
     method: "POST",
-    path: "/api/v2/automations/:ref/enable",
+    path: "/api/automations/:ref/enable",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     body: z.object({}).optional(),
@@ -244,7 +245,7 @@ export const automationsV2ByRefContract = c.router({
   },
   disable: {
     method: "POST",
-    path: "/api/v2/automations/:ref/disable",
+    path: "/api/automations/:ref/disable",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     body: z.object({}).optional(),
@@ -259,7 +260,7 @@ export const automationsV2ByRefContract = c.router({
   },
   run: {
     method: "POST",
-    path: "/api/v2/automations/:ref/run",
+    path: "/api/automations/:ref/run",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     body: z.object({}).optional(),
@@ -278,7 +279,7 @@ export const automationsV2ByRefContract = c.router({
   },
   addTrigger: {
     method: "POST",
-    path: "/api/v2/automations/:ref/triggers",
+    path: "/api/automations/:ref/triggers",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     body: createTriggerRequestSchema,
@@ -293,7 +294,7 @@ export const automationsV2ByRefContract = c.router({
   },
   listTriggers: {
     method: "GET",
-    path: "/api/v2/automations/:ref/triggers",
+    path: "/api/automations/:ref/triggers",
     headers: authHeadersSchema,
     pathParams: refParamsSchema,
     responses: {
@@ -312,7 +313,7 @@ export const automationsV2ByRefContract = c.router({
 export const automationTriggersV2Contract = c.router({
   show: {
     method: "GET",
-    path: "/api/v2/automation-triggers/:id",
+    path: "/api/automation-triggers/:id",
     headers: authHeadersSchema,
     pathParams: triggerIdParamsSchema,
     responses: {
@@ -325,7 +326,7 @@ export const automationTriggersV2Contract = c.router({
   },
   remove: {
     method: "DELETE",
-    path: "/api/v2/automation-triggers/:id",
+    path: "/api/automation-triggers/:id",
     headers: authHeadersSchema,
     pathParams: triggerIdParamsSchema,
     responses: {
@@ -338,7 +339,7 @@ export const automationTriggersV2Contract = c.router({
   },
   enable: {
     method: "POST",
-    path: "/api/v2/automation-triggers/:id/enable",
+    path: "/api/automation-triggers/:id/enable",
     headers: authHeadersSchema,
     pathParams: triggerIdParamsSchema,
     body: z.object({}).optional(),
@@ -353,7 +354,7 @@ export const automationTriggersV2Contract = c.router({
   },
   disable: {
     method: "POST",
-    path: "/api/v2/automation-triggers/:id/disable",
+    path: "/api/automation-triggers/:id/disable",
     headers: authHeadersSchema,
     pathParams: triggerIdParamsSchema,
     body: z.object({}).optional(),
@@ -367,7 +368,7 @@ export const automationTriggersV2Contract = c.router({
   },
   rotateSecret: {
     method: "POST",
-    path: "/api/v2/automation-triggers/:id/rotate-secret",
+    path: "/api/automation-triggers/:id/rotate-secret",
     headers: authHeadersSchema,
     pathParams: triggerIdParamsSchema,
     body: z.object({}).optional(),


### PR DESCRIPTION
## Summary

PR-4d of #17307 — the resource API takes the clean paths it always wanted.

- **Contract paths move**: `/api/v2/automations*` → `/api/automations*`, `/api/v2/automation-triggers/*` → `/api/automation-triggers/*`. The `/v2` prefix only ever existed because the flat alias squatted on the clean path, and that alias was deleted in #17358.
- **`/api/v2/*` stays mounted as a server-side alias**: `withLegacyV2Alias` in the route registry mounts every resource route twice, so platform bundles and CLI releases built before the move keep working until they age out. A regression test pins the alias.
- **Route ordering**: the inbound webhook dispatch (`POST /api/automations/webhooks/:token`) registers ahead of the resource routes so its static `webhooks` segment wins over the `:ref` params.
- **Web-origin rewrites** gain entries for the clean paths (by-ref, enable/disable/run/triggers, trigger sub-resource) and keep the `/v2` entries for the transition.
- Platform and CLI need no code changes — they consume the contract objects, which now carry the new paths. CLI test MSW fixtures and platform mock-handler comments are updated.

After this, `/api/automations` is the single resource API surface — no v1/v2 split, per the epic goal.

## Test plan

- [x] New regression test: the `/api/v2/automations` alias serves the list during the transition
- [x] API suites green (automations-v2, inbound webhooks, agents-create, cron poller — 48 tests)
- [x] CLI automation command suites green against the new paths (40 tests)
- [x] Platform schedule-page suites green (23 tests); web rewrite-proxy + security-headers suites green (562 tests)
- [x] `check-types` (13/13), `lint`, `knip`, `format` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)