### PR TITLE
feat(platform): finish the automation noun in dialogs and toasts

### DIFF
--- a/e2e/playwright/tests/create-schedule.spec.ts
+++ b/e2e/playwright/tests/create-schedule.spec.ts
@@ -20,14 +20,13 @@ test("create a new schedule and verify it appears in the list", async ({
   ).toHaveAttribute("aria-hidden", "true", { timeout: 60_000 });
 
   // Click "Add automation" in the page header (the list empty-state may show
-  // a second button). The dialog title still says "Add schedule" until the
-  // string sweep lands.
+  // a second button).
   await page
     .getByRole("banner")
     .getByRole("button", { name: "Add automation" })
     .click();
   await expect(
-    page.getByRole("heading", { name: "Add schedule" }),
+    page.getByRole("heading", { name: "Add automation" }),
   ).toBeVisible({ timeout: 30_000 });
 
   // Fill prompt and submit

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
@@ -238,7 +238,9 @@ export const saveAgentSchedule$ = command(
     await deploySchedule(get(zeroClient$), body, params.editName !== undefined);
     signal.throwIfAborted();
 
-    toast.success(params.editName ? "Schedule updated" : "Schedule created");
+    toast.success(
+      params.editName ? "Automation updated" : "Automation created",
+    );
     set(reloadAgentSchedule$);
   },
 );
@@ -280,7 +282,7 @@ export const deleteAgentSchedule$ = command(
     });
     signal.throwIfAborted();
 
-    toast.success("Schedule deleted");
+    toast.success("Automation deleted");
     set(reloadAgentSchedule$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -290,7 +290,9 @@ export const saveOrgSchedule$ = command(
     }
     signal.throwIfAborted();
 
-    toast.success(params.editName ? "Schedule updated" : "Schedule created");
+    toast.success(
+      params.editName ? "Automation updated" : "Automation created",
+    );
     await set(fetchAllOrgSchedules$, signal);
 
     return scheduleId;
@@ -326,7 +328,7 @@ export const deleteOrgSchedule$ = command(
     });
     signal.throwIfAborted();
 
-    toast.success("Schedule deleted");
+    toast.success("Automation deleted");
     await set(fetchAllOrgSchedules$, signal);
   },
 );

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -526,7 +526,7 @@ describe("team page navigation", () => {
 
     click(
       screen.getAllByLabelText(
-        "Open schedule Summarize open research requests",
+        "Open automation Summarize open research requests",
       )[0],
     );
 

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -455,7 +455,7 @@ describe("team page navigation", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Research Agent's scheduled tasks"),
+        screen.getByText("Research Agent's automations"),
       ).toBeInTheDocument();
     });
     expect(screen.getAllByText("Research digest")[0]).toBeInTheDocument();
@@ -465,7 +465,7 @@ describe("team page navigation", () => {
     click(menuItemByText("Edit"));
 
     const editDialog = await screen.findByRole("dialog");
-    expect(within(editDialog).getByText("Edit schedule")).toBeInTheDocument();
+    expect(within(editDialog).getByText("Edit automation")).toBeInTheDocument();
     await fill(
       within(editDialog).getByDisplayValue("Research digest"),
       "Research digest summary",
@@ -473,17 +473,17 @@ describe("team page navigation", () => {
     click(buttonByText("Save"));
 
     await waitFor(() => {
-      expect(screen.getByText("Schedule updated")).toBeInTheDocument();
+      expect(screen.getByText("Automation updated")).toBeInTheDocument();
       expect(
         screen.getAllByText("Research digest summary")[0],
       ).toBeInTheDocument();
     });
 
-    click(buttonByText("Add schedule"));
+    click(buttonByText("Add automation"));
 
     const createScheduleDialog = await screen.findByRole("dialog");
     expect(
-      within(createScheduleDialog).getByText("Add schedule"),
+      within(createScheduleDialog).getByText("Add automation"),
     ).toBeInTheDocument();
     await fill(
       within(createScheduleDialog).getByLabelText("Prompt"),
@@ -492,7 +492,7 @@ describe("team page navigation", () => {
     click(buttonByText("Create"));
 
     await waitFor(() => {
-      expect(screen.getByText("Schedule created")).toBeInTheDocument();
+      expect(screen.getByText("Automation created")).toBeInTheDocument();
       expect(
         screen.getAllByText("Collect weekly research links")[0],
       ).toBeInTheDocument();
@@ -512,7 +512,7 @@ describe("team page navigation", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Research Agent's scheduled tasks"),
+        screen.getByText("Research Agent's automations"),
       ).toBeInTheDocument();
     });
     expect(screen.getAllByText("Research digest")[0]).toBeInTheDocument();
@@ -521,7 +521,7 @@ describe("team page navigation", () => {
     click(menuItemByText("Run now"));
 
     await waitFor(() => {
-      expect(buttonByText("Add schedule")).toBeInTheDocument();
+      expect(buttonByText("Add automation")).toBeInTheDocument();
     });
 
     click(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1867,16 +1867,16 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Scheduled launch review")).toBeInTheDocument();
-      expect(screen.getByLabelText("Schedules")).toBeInTheDocument();
+      expect(screen.getByLabelText("Automations")).toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Schedules"));
+    click(screen.getByLabelText("Automations"));
 
     await waitFor(() => {
       expect(screen.getByText("Launch review")).toBeInTheDocument();
       expect(screen.getByText(/Next run/u)).toBeInTheDocument();
       expect(screen.getByText("Paused launch audit")).toBeInTheDocument();
-      expect(screen.getByText("Schedule inactive")).toBeInTheDocument();
+      expect(screen.getByText("Automation inactive")).toBeInTheDocument();
       expect(screen.getByText("Manual launch reminder")).toBeInTheDocument();
       expect(screen.getByText("No upcoming run")).toBeInTheDocument();
     });
@@ -1887,7 +1887,7 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({ context, path: `/chats/${SCHEDULE_THREAD_ID}` });
 
-    click(await screen.findByLabelText("Schedules"));
+    click(await screen.findByLabelText("Automations"));
 
     await waitFor(() => {
       expect(screen.getByText("Launch review")).toBeInTheDocument();
@@ -1936,7 +1936,7 @@ describe("chat lifecycle", () => {
       expect(screen.getByText("Scheduled message")).toBeInTheDocument();
       expect(screen.getByText("Launch review")).toBeInTheDocument();
       expect(
-        screen.getByLabelText("Open schedule Launch review"),
+        screen.getByLabelText("Open automation Launch review"),
       ).toHaveAttribute("href", `/automations/${scheduleId}`);
       expect(screen.queryByText("Review launch risks")).not.toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -429,7 +429,7 @@ describe("zero jobs page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Research Agent's scheduled tasks"),
+        screen.getByText("Research Agent's automations"),
       ).toBeInTheDocument();
       expect(
         screen.getAllByText("Every week on Monday at 9:17 AM")[0],
@@ -443,7 +443,7 @@ describe("zero jobs page", () => {
     );
     click(menuItemByText("Edit"));
     const editScheduleDialog = await screen.findByRole("dialog", {
-      name: "Edit schedule",
+      name: "Edit automation",
     });
 
     expect(
@@ -582,7 +582,7 @@ describe("zero jobs page", () => {
       expect(screen.getAllByText("Release checklist").length).toBeGreaterThan(
         0,
       );
-      expect(screen.getByText("Add schedule")).toBeInTheDocument();
+      expect(screen.getByText("Add automation")).toBeInTheDocument();
     });
     expect(
       screen.getAllByText("Every weekday at 2:30 PM")[0],
@@ -608,9 +608,9 @@ describe("zero jobs page", () => {
       expect(screen.getByText("Instruction")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Add schedule"));
+    click(screen.getByText("Add automation"));
     const createScheduleDialog = await screen.findByRole("dialog", {
-      name: "Add schedule",
+      name: "Add automation",
     });
     await fill(screen.getByLabelText("Prompt"), "Prepare launch summary");
     click(buttonByText("Create", createScheduleDialog));
@@ -626,7 +626,7 @@ describe("zero jobs page", () => {
     );
     click(menuItemByText("Edit"));
     const editScheduleDialog = await screen.findByRole("dialog", {
-      name: "Edit schedule",
+      name: "Edit automation",
     });
     expect(
       within(editScheduleDialog).getByText("Day of week"),
@@ -667,7 +667,7 @@ describe("zero jobs page", () => {
     click(menuItemByText("Delete"));
     const deleteScheduleDialog = await screen.findByRole("dialog");
     expect(
-      within(deleteScheduleDialog).getByText("Delete schedule?"),
+      within(deleteScheduleDialog).getByText("Delete automation?"),
     ).toBeInTheDocument();
     expect(
       within(deleteScheduleDialog).getByText("monthly-risk-audit"),
@@ -675,7 +675,7 @@ describe("zero jobs page", () => {
     click(buttonByText("Cancel", deleteScheduleDialog));
 
     await waitFor(() => {
-      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete automation?")).not.toBeInTheDocument();
     });
 
     click(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
@@ -160,7 +160,7 @@ describe("zero schedule detail page", () => {
       expect(
         screen.getByText("This schedule doesn't exist or was removed."),
       ).toBeInTheDocument();
-      expect(screen.getByText("Back to scheduled tasks")).toBeInTheDocument();
+      expect(screen.getByText("Back to automations")).toBeInTheDocument();
     });
   });
 
@@ -227,7 +227,7 @@ describe("zero schedule detail page", () => {
     click(buttonByText("Save"));
 
     await waitFor(() => {
-      expect(screen.getByText("Schedule updated")).toBeInTheDocument();
+      expect(screen.getByText("Automation updated")).toBeInTheDocument();
       expect(
         screen.getByText("Send a concise launch brief"),
       ).toBeInTheDocument();
@@ -295,7 +295,7 @@ describe("zero schedule detail page", () => {
     click(buttonByText("Save"));
 
     await waitFor(() => {
-      expect(screen.getByText("Schedule updated")).toBeInTheDocument();
+      expect(screen.getByText("Automation updated")).toBeInTheDocument();
     });
     expect(screen.getByDisplayValue(/Team morning brief/u)).toBeInTheDocument();
   });
@@ -443,20 +443,20 @@ describe("zero schedule detail page", () => {
     });
     expect(screen.getByLabelText("Enable this schedule")).toBeInTheDocument();
 
-    click(buttonByText("Delete schedule"));
+    click(buttonByText("Delete automation"));
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
-    expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    expect(screen.getByText("Delete automation?")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
 
     await waitFor(() => {
-      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete automation?")).not.toBeInTheDocument();
     });
 
-    click(buttonByText("Delete schedule"));
+    click(buttonByText("Delete automation"));
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -465,7 +465,7 @@ describe("zero schedule detail page", () => {
     click(buttonByText("Cancel"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete automation?")).not.toBeInTheDocument();
     });
   });
 
@@ -487,7 +487,7 @@ describe("zero schedule detail page", () => {
       expect(screen.getByText("View activity")).toBeInTheDocument();
     });
 
-    click(buttonByText("Delete schedule"));
+    click(buttonByText("Delete automation"));
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -496,7 +496,7 @@ describe("zero schedule detail page", () => {
     click(buttonByText("Delete"));
 
     await waitFor(() => {
-      expect(screen.getByText("Schedule deleted")).toBeInTheDocument();
+      expect(screen.getByText("Automation deleted")).toBeInTheDocument();
       // Deletion returns to the schedules surface, which renders the
       // Automations product noun now that the switch is globally on (#17307).
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
@@ -156,9 +156,9 @@ describe("zero schedule detail page", () => {
     detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
 
     await waitFor(() => {
-      expect(screen.getByText("Schedule not found")).toBeInTheDocument();
+      expect(screen.getByText("Automation not found")).toBeInTheDocument();
       expect(
-        screen.getByText("This schedule doesn't exist or was removed."),
+        screen.getByText("This automation doesn't exist or was removed."),
       ).toBeInTheDocument();
       expect(screen.getByText("Back to automations")).toBeInTheDocument();
     });
@@ -181,7 +181,7 @@ describe("zero schedule detail page", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "This instruction runs each time this schedule executes.",
+          "This instruction runs each time this automation executes.",
         ),
       ).toBeInTheDocument();
       expect(
@@ -436,12 +436,12 @@ describe("zero schedule detail page", () => {
     });
     expect(screen.getByText("Active")).toBeInTheDocument();
 
-    click(screen.getByLabelText("Disable this schedule"));
+    click(screen.getByLabelText("Disable this automation"));
 
     await waitFor(() => {
       expect(screen.getByText("Paused")).toBeInTheDocument();
     });
-    expect(screen.getByLabelText("Enable this schedule")).toBeInTheDocument();
+    expect(screen.getByLabelText("Enable this automation")).toBeInTheDocument();
 
     click(buttonByText("Delete automation"));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -228,7 +228,9 @@ describe("zero schedule page", () => {
     click(buttonByText("Add automation"));
 
     const createDialog = await screen.findByRole("dialog");
-    expect(within(createDialog).getByText("Add schedule")).toBeInTheDocument();
+    expect(
+      within(createDialog).getByText("Add automation"),
+    ).toBeInTheDocument();
     expect(within(createDialog).getByText("Agent")).toBeInTheDocument();
     expect(within(createDialog).getByText("Prompt")).toBeInTheDocument();
     await fill(
@@ -578,7 +580,7 @@ describe("zero schedule page", () => {
 
     const deleteDialog = await screen.findByRole("dialog");
     expect(
-      within(deleteDialog).getByText("Delete schedule?"),
+      within(deleteDialog).getByText("Delete automation?"),
     ).toBeInTheDocument();
     expect(
       within(deleteDialog).getByText("weekday-morning-brief"),
@@ -587,7 +589,7 @@ describe("zero schedule page", () => {
     click(buttonByText("Cancel", deleteDialog));
 
     await waitFor(() => {
-      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete automation?")).not.toBeInTheDocument();
     });
 
     click(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -342,7 +342,7 @@ describe("zero schedule page", () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByLabelText(
-        "Open schedule Send morning brief to the team channel",
+        "Open automation Send morning brief to the team channel",
       )[0],
     ).toBeInTheDocument();
   });
@@ -450,7 +450,9 @@ describe("zero schedule page", () => {
     ).toBeInTheDocument();
 
     click(
-      screen.getAllByLabelText("Open schedule Review overnight escalations")[0],
+      screen.getAllByLabelText(
+        "Open automation Review overnight escalations",
+      )[0],
     );
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -516,9 +516,11 @@ describe("zero sidebar", () => {
     click(menuItemByText("Delete chat"));
 
     const dialog = await screen.findByRole("dialog", {
-      name: "Delete chat and schedules?",
+      name: "Delete chat and automations?",
     });
-    expect(within(dialog).getByText(/2 linked schedules/u)).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/2 linked automations/u),
+    ).toBeInTheDocument();
     expect(within(dialog).getByText("Launch cadence")).toBeInTheDocument();
     expect(within(dialog).getByText("Release risk review")).toBeInTheDocument();
 
@@ -527,7 +529,7 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", {
-          name: "Delete chat and schedules?",
+          name: "Delete chat and automations?",
         }),
       ).not.toBeInTheDocument();
       expect(
@@ -539,9 +541,9 @@ describe("zero sidebar", () => {
     click(menuItemByText("Delete chat"));
 
     const confirmDialog = await screen.findByRole("dialog", {
-      name: "Delete chat and schedules?",
+      name: "Delete chat and automations?",
     });
-    click(buttonByText("Delete chat and schedules", confirmDialog));
+    click(buttonByText("Delete chat and automations", confirmDialog));
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -231,7 +231,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
       ? {
           title: "Credit usage",
           description:
-            "Your credit usage across chats, schedules, and channels.",
+            "Your credit usage across chats, automations, and channels.",
         }
       : SECTION_META[resolvedSection];
 

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -588,7 +588,7 @@ function ScheduleFormDialogInner({
     onSave(current);
   };
 
-  const title = mode === "edit" ? "Edit schedule" : "Add schedule";
+  const title = mode === "edit" ? "Edit automation" : "Add automation";
   const saveLabel = getSaveLabel(mode, saving);
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -617,7 +617,7 @@ function ScheduleFormDialogInner({
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
             {mode === "edit"
-              ? "Update the schedule settings and save your changes."
+              ? "Update the automation settings and save your changes."
               : "Configure when and how often this agent should run."}
           </DialogDescription>
         </DialogHeader>

--- a/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
@@ -376,7 +376,7 @@ export function ScheduleListView<T extends ScheduleEntry>({
             onClick={onNew}
           >
             <IconPlus size={14} stroke={2} />
-            Add schedule
+            Add automation
           </Button>
         )}
       </div>

--- a/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
@@ -77,7 +77,7 @@ function ScheduleListRow<T extends ScheduleEntry>({
           <Link
             pathname="/automations/:scheduleId"
             options={{ pathParams: { scheduleId: entry.id } }}
-            aria-label={`Open schedule ${entry.prompt}`}
+            aria-label={`Open automation ${entry.prompt}`}
             onClick={(e) => {
               e.stopPropagation();
             }}
@@ -264,10 +264,10 @@ function ScheduleListCard<T extends ScheduleEntry>({
         <Link
           pathname="/automations/:scheduleId"
           options={{ pathParams: { scheduleId: entry.id } }}
-          aria-label={`Open schedule ${entry.prompt}`}
+          aria-label={`Open automation ${entry.prompt}`}
           className="absolute inset-0 z-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring rounded-sm"
         >
-          <span className="sr-only">Open schedule {entry.prompt}</span>
+          <span className="sr-only">Open automation {entry.prompt}</span>
         </Link>
       )}
       {/* Left: text content — pointer-events disabled so clicks pass through to the Link overlay */}
@@ -357,7 +357,7 @@ export function ScheduleListView<T extends ScheduleEntry>({
       <div className="flex flex-col items-center justify-center py-12 gap-3">
         <img
           src={emptyScheduleImg}
-          alt="No schedules"
+          alt="No automations"
           className="h-24 w-24 object-contain opacity-80"
         />
         <div className="text-center">

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -179,7 +179,7 @@ function MobileScheduleButtonLeaf() {
   return (
     <ScheduleMenuButton
       threadId={thread.threadId}
-      ariaLabel="Open mobile schedules"
+      ariaLabel="Open mobile automations"
     />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -653,12 +653,12 @@ function DeleteChatThreadDialog() {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
-            {hasSchedules ? "Delete chat and schedules?" : "Delete chat?"}
+            {hasSchedules ? "Delete chat and automations?" : "Delete chat?"}
           </DialogTitle>
           <DialogDescription>
             {hasSchedules
               ? `This will permanently delete this chat and its ${scheduleCount} linked ${
-                  scheduleCount === 1 ? "schedule" : "schedules"
+                  scheduleCount === 1 ? "automation" : "automations"
                 }. Any task currently running in this chat will be stopped immediately. This action cannot be undone.`
               : "This will permanently delete this chat. Any task currently running in this chat will be stopped immediately. This action cannot be undone."}
           </DialogDescription>
@@ -666,7 +666,7 @@ function DeleteChatThreadDialog() {
         {hasSchedules && pendingDeleteSchedules.length > 0 && (
           <div className="flex flex-col gap-1.5">
             <p className="text-sm font-medium">
-              These schedules will be deleted
+              These automations will be deleted
             </p>
             <ul className="flex list-disc flex-col gap-1 pl-5">
               {pendingDeleteSchedules.map((schedule) => {
@@ -692,7 +692,7 @@ function DeleteChatThreadDialog() {
             Cancel
           </Button>
           <Button variant="destructive" onClick={confirmDelete}>
-            {hasSchedules ? "Delete chat and schedules" : "Delete"}
+            {hasSchedules ? "Delete chat and automations" : "Delete"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -938,7 +938,7 @@ function GithubPrTrackingButton({
 // run time, or a note that the schedule is inactive when it has been disabled.
 function scheduleMenuSubline(schedule: HeaderScheduleEntry): string {
   if (!schedule.enabled) {
-    return "Schedule inactive";
+    return "Automation inactive";
   }
   if (!schedule.nextRunAt) {
     return "No upcoming run";
@@ -954,7 +954,7 @@ function scheduleMenuSubline(schedule: HeaderScheduleEntry): string {
 // schedule.
 export function ScheduleMenuButton({
   threadId,
-  ariaLabel = "Schedules",
+  ariaLabel = "Automations",
 }: {
   threadId: string;
   ariaLabel?: string;
@@ -5043,7 +5043,7 @@ function ScheduleUserMessage({
               pathname="/automations/:scheduleId"
               options={{ pathParams: { scheduleId } }}
               className={cn(cardClassName, "cursor-pointer hover:opacity-80")}
-              aria-label={`Open schedule ${scheduleLabel}`}
+              aria-label={`Open automation ${scheduleLabel}`}
             >
               {body}
             </Link>

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -424,7 +424,7 @@ const PRO_TRIAL_BENEFITS: readonly string[] = [
   "Slack-native agent in threads and @mentions",
   "Telegram and iMessage agents",
   "200+ integrations with real tool execution",
-  "Scheduled tasks that run on their own",
+  "Automations that run on their own",
   "Artifacts including slide decks, HTML pages, video and audio",
   "Voice input",
   "Unlimited workspace members",

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -395,7 +395,7 @@ export function ZeroScheduleCard({
               onClick={openAddSchedule}
             >
               <IconPlus size={14} stroke={2} />
-              Add schedule
+              Add automation
             </Button>
             <Tabs
               value={scheduleViewMode}
@@ -493,7 +493,7 @@ export function ZeroScheduleCard({
         >
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Delete schedule?</DialogTitle>
+              <DialogTitle>Delete automation?</DialogTitle>
               <DialogDescription>
                 This will permanently delete the schedule{" "}
                 <span className="font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -495,7 +495,7 @@ export function ZeroScheduleCard({
             <DialogHeader>
               <DialogTitle>Delete automation?</DialogTitle>
               <DialogDescription>
-                This will permanently delete the schedule{" "}
+                This will permanently delete the automation{" "}
                 <span className="font-medium text-foreground">
                   {pendingDelete?.name}
                 </span>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -196,7 +196,7 @@ function ScheduleNotFound() {
           pathname="/automations"
           className="zero-btn-morandi mt-2 inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium no-underline text-inherit hover:bg-accent"
         >
-          Back to scheduled tasks
+          Back to automations
         </Link>
       </div>
     </div>
@@ -456,7 +456,7 @@ function ScheduleSettingsForm({
                   }}
                 >
                   <IconTrash size={14} stroke={1.5} />
-                  Delete schedule
+                  Delete automation
                 </Button>
               </div>
             </div>
@@ -484,7 +484,7 @@ function ScheduleSettingsForm({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete schedule?</DialogTitle>
+            <DialogTitle>Delete automation?</DialogTitle>
             <DialogDescription>
               This will permanently delete the schedule{" "}
               <span className="font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -134,7 +134,7 @@ function ScheduleBreadcrumbLink({ chatThreadId }: { chatThreadId?: string }) {
       className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
     >
       <IconCalendar size={14} stroke={1.5} className="shrink-0" />
-      Scheduled
+      Automations
     </Link>
   );
 }
@@ -181,16 +181,16 @@ function ScheduleNotFound() {
         <ScheduleBreadcrumbLink />
         <span className="text-muted-foreground/40 select-none">/</span>
         <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium">
-          Schedule
+          Automation
         </span>
       </nav>
       <div className="flex-1 flex flex-col items-center justify-center gap-3 px-4 pb-20">
         <ZeroNoPermissionIllustration className="h-32 w-auto max-w-[220px] object-contain opacity-90" />
         <h2 className="text-lg font-semibold text-foreground">
-          Schedule not found
+          Automation not found
         </h2>
         <p className="text-sm text-muted-foreground text-center max-w-sm">
-          This schedule doesn&apos;t exist or was removed.
+          This automation doesn&apos;t exist or was removed.
         </p>
         <Link
           pathname="/automations"
@@ -339,7 +339,7 @@ function ScheduleSettingsForm({
         <CardContent className="p-4 sm:p-5">
           <InlineSettingsRow
             label="Agent"
-            description="The agent is fixed once a schedule is created. Delete and recreate the schedule to run it on a different agent."
+            description="The agent is fixed once an automation is created. Delete and recreate the automation to run it on a different agent."
           >
             <div className={SCHEDULE_DETAIL_CONTROL_WIDTH}>
               <Select value={form.agentId} disabled>
@@ -361,7 +361,7 @@ function ScheduleSettingsForm({
 
           <InlineSettingsRow
             label="Description"
-            description="A short summary shown in the schedule list. Leave blank to auto-generate."
+            description="A short summary shown in the automation list. Leave blank to auto-generate."
           >
             <div className={SCHEDULE_DETAIL_CONTROL_WIDTH}>
               <Input
@@ -418,7 +418,7 @@ function ScheduleSettingsForm({
 
           <InlineSettingsRow
             label="Status"
-            description="Paused schedules do not run until re-enabled."
+            description="Paused automations do not run until re-enabled."
             alignControls="center"
           >
             <LoadingSwitch
@@ -427,7 +427,7 @@ function ScheduleSettingsForm({
               onCheckedChange={(checked) => {
                 detach(onToggle(checked), Reason.DomCallback);
               }}
-              ariaLabel={`${entry.enabled !== false ? "Disable" : "Enable"} this schedule`}
+              ariaLabel={`${entry.enabled !== false ? "Disable" : "Enable"} this automation`}
             />
           </InlineSettingsRow>
         </CardContent>
@@ -442,7 +442,7 @@ function ScheduleSettingsForm({
                   Danger zone
                 </h3>
                 <p className="text-xs text-muted-foreground mt-1 leading-snug">
-                  Deleting removes this schedule permanently.
+                  Deleting removes this automation permanently.
                 </p>
               </div>
               <div className="flex shrink-0 self-end sm:self-auto sm:pt-0.5">
@@ -486,7 +486,7 @@ function ScheduleSettingsForm({
           <DialogHeader>
             <DialogTitle>Delete automation?</DialogTitle>
             <DialogDescription>
-              This will permanently delete the schedule{" "}
+              This will permanently delete the automation{" "}
               <span className="font-medium text-foreground">
                 {entry.description ?? entry.prompt}
               </span>
@@ -548,7 +548,7 @@ function ScheduleInstructionEditorBlock({
         initialContent={draft ?? entry.prompt}
         onChange={setDraft}
         disabled={saving}
-        footerHint="This instruction runs each time this schedule executes."
+        footerHint="This instruction runs each time this automation executes."
       />
       {isDirty && (
         <ZeroUnsavedBar
@@ -646,7 +646,7 @@ function ScheduleRunHistoryTab() {
             isLoading={isLoading}
             rowsPerPage={rowsPerPage}
             emptyTitle="No runs yet"
-            emptyDescription="When this schedule runs, its history will show up here."
+            emptyDescription="When this automation runs, its history will show up here."
             filteredEmptyTitle="Nothing matches that filter"
             filteredEmptyDescription="Try a different status filter."
             hasActiveFilter={statusFilter !== "all"}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -484,7 +484,7 @@ function DeleteScheduleDialogContainer() {
         <DialogHeader>
           <DialogTitle>Delete automation?</DialogTitle>
           <DialogDescription>
-            This will permanently delete the schedule{" "}
+            This will permanently delete the automation{" "}
             <span className="font-medium text-foreground">
               {pendingDelete?.name}
             </span>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -482,7 +482,7 @@ function DeleteScheduleDialogContainer() {
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete schedule?</DialogTitle>
+          <DialogTitle>Delete automation?</DialogTitle>
           <DialogDescription>
             This will permanently delete the schedule{" "}
             <span className="font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -109,7 +109,7 @@ export function ZeroScheduleTab({
   return (
     <div className="mx-auto max-w-[900px]">
       <ZeroScheduleCard
-        title={`${displayName}'s scheduled tasks`}
+        title={`${displayName}'s automations`}
         subtitle={`Tasks you've scheduled with ${displayName} to run automatically.`}
         initialSchedule={entries}
         onSave={handleSave}

--- a/turbo/apps/platform/src/views/zero-page/zero-usage-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-usage-page.tsx
@@ -12,7 +12,7 @@ export function ZeroUsagePage() {
                 Usage
               </h1>
               <p className="text-sm text-muted-foreground mt-1">
-                Your credit consumption across chats, schedules, and channels.
+                Your credit consumption across chats, automations, and channels.
               </p>
             </div>
             <UsageInsightSelectors />


### PR DESCRIPTION
## Summary

PR-7 of #17307 — the last user-visible schedule strings follow the surface rename:

- Create/edit dialog titles: "Add schedule"/"Edit schedule" → "Add automation"/"Edit automation"; empty-state and card "Add schedule" buttons follow.
- Delete confirmations: "Delete schedule?" → "Delete automation?" (page, card, detail page) and the detail page's "Delete schedule" button — including the dialog *descriptions* ("This will permanently delete the automation …", "Update the automation settings …").
- Chat-deletion dialog: "Delete chat and schedules?" → "Delete chat and automations?" (title, linked-count description, list header, confirm button).
- Toasts: "Schedule created/updated/deleted" → "Automation created/updated/deleted" (both the org schedule flow and the agent-tab flow).
- Agent tab title ("…'s scheduled tasks" → "…'s automations"), onboarding copy, and the detail page back link ("Back to scheduled tasks" → "Back to automations").
- Detail page copy: breadcrumb ("Scheduled" → "Automations", "Schedule" → "Automation"), not-found view ("Automation not found"), settings row descriptions, danger-zone copy, instructions footer hint, and runs empty state.
- Accessibility copy: "Open schedule …" links (list, card, chat message), the chat header "Schedules" menu button, "Disable/Enable this schedule" switch, mobile menu label, and the "No schedules" empty-state alt.
- Usage copy: "across chats, schedules, and channels" → "automations" (settings dialog and usage page header).
- The create-automation playwright spec now asserts the renamed dialog heading (it already enters via the legacy `/schedules` URL, pinning the redirect from #17363).

With this, the user-facing surfaces say Automations: page titles, sidebar, breadcrumb, URLs, dialogs, toasts, a11y labels, CLI. Remaining `schedule` mentions in the platform are:

- internal identifiers/file names and the historical data columns;
- timing labels kept on purpose: the "Schedule at" column header, the agent detail "Scheduled" tab, and "Scheduled run" message labels;
- the usage-insights bucket copy ("Schedules" tables in usage/network insights and the personal usage record "Schedule" bucket label) — tied to the `trigger_source` display-key decision tracked in #17307.

## Test plan

- [x] Schedule page / detail / jobs / team-navigation / onboarding / sidebar / chat-lifecycle suites updated and green (platform: 656 tests)
- [x] `check-types`, `lint`, `format`, `knip` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
