### PR TITLE
fix: send follow-ups without revoking messages

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -47,7 +47,6 @@ import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
   createZeroRouteMocks,

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -1,12 +1,13 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { zeroUsageInsightContract } from "@vm0/core";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   click,
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   usageInsightLast7DaysAgentFixture,
@@ -27,6 +28,10 @@ function tabByText(text: string): HTMLElement {
 }
 
 describe("/usage page", () => {
+  beforeEach(() => {
+    mockNow();
+  });
+
   it("shows a usage load error", async () => {
     context.mocks.api(zeroUsageInsightContract.get, ({ respond }) => {
       return respond(500, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2517,6 +2517,10 @@ describe("chat lifecycle", () => {
   it("sends a recommended follow-up from the latest assistant reply", async () => {
     const assistantReply = "I can turn this into a launch package.";
     const followupPrompt = "Create a presentation outline";
+    const sentMessages: {
+      prompt?: string;
+      revokesMessageId?: string;
+    }[] = [];
 
     mockChatLifecycle(context, {
       threadId: FOLLOWUP_THREAD_ID,
@@ -2575,6 +2579,9 @@ describe("chat lifecycle", () => {
           createdAt: "2026-06-09T10:01:01Z",
         },
       ],
+      onRunCreate: (body) => {
+        sentMessages.push(body);
+      },
     });
 
     detachedSetupPage({
@@ -2600,6 +2607,85 @@ describe("chat lifecycle", () => {
       expect(queryButtonByText(followupPrompt)).not.toBeInTheDocument();
       expect(screen.getByText(followupPrompt)).toBeInTheDocument();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]).toMatchObject({ prompt: followupPrompt });
+    expect(sentMessages[0]?.revokesMessageId).toBeUndefined();
+  });
+
+  it("hides recommended follow-ups after a newer assistant reply", async () => {
+    const firstAssistantReply = "I can turn this into a launch package.";
+    const newerAssistantReply = "Here is the newer launch package.";
+    const followupPrompt = "Create a presentation outline";
+
+    mockChatLifecycle(context, {
+      threadId: FOLLOWUP_THREAD_ID,
+      threadTitle: "Launch package",
+      chatMessages: [
+        {
+          id: "msg-followup-old-user",
+          role: "user",
+          content: "Package this launch plan",
+          runId: "run-followup-old",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-followup-old-assistant",
+          role: "assistant",
+          content: firstAssistantReply,
+          runId: "run-followup-old",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+        {
+          id: "msg-followup-old-completed",
+          role: "assistant",
+          content: null,
+          runId: "run-followup-old",
+          runLifecycleEvent: "completed",
+          recommendedFollowups: [
+            {
+              prompt: followupPrompt,
+              kind: "generate",
+              generationType: "presentation",
+            },
+          ],
+          createdAt: "2026-06-09T10:01:01Z",
+        },
+        {
+          id: "msg-followup-new-user",
+          role: "user",
+          content: followupPrompt,
+          runId: "run-followup-new",
+          createdAt: "2026-06-09T10:02:00Z",
+        },
+        {
+          id: "msg-followup-new-assistant",
+          role: "assistant",
+          content: newerAssistantReply,
+          runId: "run-followup-new",
+          createdAt: "2026-06-09T10:03:00Z",
+        },
+        {
+          id: "msg-followup-new-completed",
+          role: "assistant",
+          content: null,
+          runId: "run-followup-new",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:03:01Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FOLLOWUP_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatRecommendedFollowups]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(firstAssistantReply)).toBeInTheDocument();
+      expect(screen.getByText(newerAssistantReply)).toBeInTheDocument();
+      expect(queryButtonByText(followupPrompt)).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -353,6 +353,7 @@ export function mockChatLifecycle(
       prompt?: string;
       clientMessageId?: string;
       computerUseHostId?: string | null;
+      revokesMessageId?: string;
     }) => void;
   },
 ): MockLifecycleControl {
@@ -492,6 +493,7 @@ export function mockChatLifecycle(
     prompt?: string;
     clientMessageId?: string;
     computerUseHostId?: string | null;
+    revokesMessageId?: string;
   }) => {
     if (options?.sendGate) {
       await options.sendGate;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2674,22 +2674,35 @@ interface RecommendedFollowupSource {
 function latestRecommendedFollowups(
   groups: readonly GroupedChatMessageGroup[],
 ): RecommendedFollowupSource | null {
-  const lastGroup = groups[groups.length - 1];
-  if (lastGroup?.role !== "assistant") {
-    return null;
+  for (let groupIndex = groups.length - 1; groupIndex >= 0; groupIndex -= 1) {
+    const group = groups[groupIndex];
+    if (!group || group.role !== "assistant") {
+      continue;
+    }
+
+    for (
+      let messageIndex = group.messages.length - 1;
+      messageIndex >= 0;
+      messageIndex -= 1
+    ) {
+      const message = group.messages[messageIndex];
+      if (!message || message.role !== "assistant") {
+        continue;
+      }
+
+      const content = message.content?.trim();
+      if (content) {
+        return null;
+      }
+
+      const followups = message.recommendedFollowups ?? [];
+      if (followups.length > 0) {
+        return { messageId: message.id, followups };
+      }
+    }
   }
-  const lastMessage = lastGroup.messages[lastGroup.messages.length - 1];
-  if (!lastMessage || lastMessage.role !== "assistant") {
-    return null;
-  }
-  if (lastMessage.runLifecycleEvent !== "completed") {
-    return null;
-  }
-  const followups = lastMessage.recommendedFollowups ?? [];
-  if (followups.length === 0) {
-    return null;
-  }
-  return { messageId: lastMessage.id, followups };
+
+  return null;
 }
 
 function RecommendedFollowupIcon({
@@ -2777,7 +2790,6 @@ function RecommendedFollowupList({
         followup.prompt,
         modelSelection,
         {
-          revokesMessageId: source.messageId,
           includeDraftAttachments: false,
         },
         rootSignal,


### PR DESCRIPTION
## Summary
- Send recommended follow-up prompts as normal chat messages without revoking the recommendation marker
- Show recommended follow-ups only when no later assistant text message is displayed
- Add lifecycle tests for no-revoke sends and hiding stale follow-ups

## Tests
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint