### PR TITLE
fix: fold completed chat work per run

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-messages.test.ts
@@ -47,7 +47,6 @@ import { drainOrgQueue$ } from "../../services/zero-run-queue.service";
 import { writeDb$ } from "../../external/db";
 import { nowDate } from "../../external/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { clearAllDetached } from "../../utils";
 import {
   createFixtureTracker,
   createZeroRouteMocks,

--- a/turbo/apps/platform/src/signals/chat-page/completed-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/completed-work-folding.ts
@@ -1,21 +1,19 @@
 import { command, computed, state } from "ccstate";
 
-const internalCompletedWorkExpandedThreadIds$ = state<Set<string>>(new Set());
+const internalCompletedWorkExpandedKeys$ = state<Set<string>>(new Set());
 
-export const completedWorkExpandedThreadIds$ = computed((get): Set<string> => {
-  return get(internalCompletedWorkExpandedThreadIds$);
+export const completedWorkExpandedKeys$ = computed((get): Set<string> => {
+  return get(internalCompletedWorkExpandedKeys$);
 });
 
-export const toggleCompletedWorkExpanded$ = command(
-  ({ set }, threadId: string) => {
-    set(internalCompletedWorkExpandedThreadIds$, (prev) => {
-      const next = new Set(prev);
-      if (next.has(threadId)) {
-        next.delete(threadId);
-      } else {
-        next.add(threadId);
-      }
-      return next;
-    });
-  },
-);
+export const toggleCompletedWorkExpanded$ = command(({ set }, key: string) => {
+  set(internalCompletedWorkExpandedKeys$, (prev) => {
+    const next = new Set(prev);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    return next;
+  });
+});

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   usageInsightLast7DaysAgentFixture,
@@ -84,6 +85,8 @@ describe("/usage page", () => {
   });
 
   it("shows linked usage details and updates totals by date range and group", async () => {
+    mockNow();
+
     context.mocks.api(zeroUsageInsightContract.get, ({ query, respond }) => {
       if (query.range === "7d" && query.groupBy === "agent") {
         return respond(200, usageInsightLast7DaysAgentFixture);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1425,6 +1425,59 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("folds completed chat work without hiding the answer before the lifecycle marker", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-completion-marker",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Summarize the production launch status",
+          runId: "run-work-folding-completion-marker",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "The production launch status is ready.",
+          runId: "run-work-folding-completion-marker",
+          createdAt: "2026-06-09T10:00:55Z",
+        },
+        {
+          role: "assistant",
+          content: null,
+          runId: "run-work-folding-completion-marker",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:56Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-completion-marker",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+
+    const expandButton = await screen.findByLabelText("Expand work history");
+    expect(expandButton).toHaveTextContent("Worked for 56s");
+    expect(
+      screen.queryByText("Summarize the production launch status"),
+    ).toBeNull();
+    expect(
+      screen.getByText("The production launch status is ready."),
+    ).toBeInTheDocument();
+
+    click(expandButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Summarize the production launch status"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("The production launch status is ready."),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("folds each completed run independently", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-work-folding-each-run",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1396,6 +1396,7 @@ describe("chat lifecycle", () => {
 
     const expandButton = await screen.findByLabelText("Expand work history");
     expect(expandButton).toHaveTextContent("Worked for 55s");
+    expect(expandButton.closest('[data-role="assistant"]')).not.toBeNull();
     expect(screen.queryByText("Summarize the launch status")).toBeNull();
     expect(
       screen.getByText("Launch status is summarized."),
@@ -1421,6 +1422,110 @@ describe("chat lifecycle", () => {
         "aria-expanded",
         "false",
       );
+    });
+  });
+
+  it("folds each completed run independently", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-each-run",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Summarize the first launch",
+          runId: "run-work-folding-first",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "The first launch summary is ready.",
+          runId: "run-work-folding-first",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:20Z",
+        },
+        {
+          role: "user",
+          content: "Summarize the second launch",
+          runId: "run-work-folding-second",
+          createdAt: "2026-06-09T10:05:00Z",
+        },
+        {
+          role: "assistant",
+          content: "Checking the second launch notes.",
+          runId: "run-work-folding-second",
+          createdAt: "2026-06-09T10:05:25Z",
+        },
+        {
+          role: "assistant",
+          content: "The second launch summary is ready.",
+          runId: "run-work-folding-second",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:05:55Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-each-run",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+
+    const expandButtons = await screen.findAllByLabelText(
+      "Expand work history",
+    );
+    expect(expandButtons).toHaveLength(2);
+    expect(expandButtons[0]).toHaveTextContent("Worked for 20s");
+    expect(expandButtons[1]).toHaveTextContent("Worked for 55s");
+    expect(screen.queryByText("Summarize the first launch")).toBeNull();
+    expect(
+      screen.getByText("The first launch summary is ready."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Summarize the second launch")).toBeNull();
+    expect(screen.queryByText("Checking the second launch notes.")).toBeNull();
+    expect(
+      screen.getByText("The second launch summary is ready."),
+    ).toBeInTheDocument();
+
+    click(expandButtons[1]!);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Summarize the first launch")).toBeNull();
+      expect(
+        screen.getByText("Summarize the second launch"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Checking the second launch notes."),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Collapse work history")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+  });
+
+  it("does not fold a completed run with a single message", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-single-message",
+      chatMessages: [
+        {
+          role: "assistant",
+          content: "Standalone run result.",
+          runId: "run-work-folding-single",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-single-message",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Standalone run result.")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Expand work history")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2491,6 +2491,13 @@ function groupMessagesForCompletedWorkDisplay(
   return groups;
 }
 
+function isRenderableAssistantMessage(message: EnrichedChatMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    (Boolean(message.content) || Boolean(message.error))
+  );
+}
+
 function buildCompletedWorkFolding(
   groups: readonly GroupedChatMessageGroup[],
   allFinished: boolean,
@@ -2519,9 +2526,29 @@ function buildCompletedWorkFolding(
     }
 
     const runMessages = messages.slice(index, endIndex);
-    const finalMessage = runMessages[runMessages.length - 1]!;
-    if (runMessages.length > 1 && finalMessage.role === "assistant") {
-      const hiddenMessages = runMessages.slice(0, -1);
+    let finalMessageIndex = -1;
+    for (let offset = runMessages.length - 1; offset >= 0; offset--) {
+      if (isRenderableAssistantMessage(runMessages[offset]!)) {
+        finalMessageIndex = offset;
+        break;
+      }
+    }
+    const finalMessage =
+      finalMessageIndex >= 0 ? runMessages[finalMessageIndex]! : undefined;
+    const hiddenMessages =
+      finalMessageIndex > 0 ? runMessages.slice(0, finalMessageIndex) : [];
+    const trailingMessages =
+      finalMessageIndex >= 0 ? runMessages.slice(finalMessageIndex + 1) : [];
+    const trailingMessagesAreMarkers = trailingMessages.every((message) => {
+      return (
+        message.role === "assistant" && !isRenderableAssistantMessage(message)
+      );
+    });
+    if (
+      finalMessage !== undefined &&
+      hiddenMessages.length > 0 &&
+      trailingMessagesAreMarkers
+    ) {
       visibleMessages.push(finalMessage);
       folds.push({
         key: `${runId}:${finalMessage.id}`,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -111,7 +111,7 @@ import {
   type ConnectorActionBlock,
 } from "../../signals/chat-page/connector-action-block.ts";
 import {
-  completedWorkExpandedThreadIds$,
+  completedWorkExpandedKeys$,
   toggleCompletedWorkExpanded$,
 } from "../../signals/chat-page/completed-work-folding.ts";
 import type { PermissionActionBlock } from "../../signals/chat-page/permission-action-block.ts";
@@ -2301,17 +2301,12 @@ function ChatThreadMessagesMain({
   const allFinishedLoadable = useLastLoadable(thread.allFinished$);
   const allFinished =
     allFinishedLoadable.state === "hasData" ? allFinishedLoadable.data : false;
-  const completedWorkExpandedThreadIds = useGet(
-    completedWorkExpandedThreadIds$,
-  );
-  const workExpanded = completedWorkExpandedThreadIds.has(thread.threadId);
+  const completedWorkFolding = completedWorkFoldingEnabled
+    ? buildCompletedWorkFolding(activeGroups, allFinished)
+    : null;
+  const completedWorkExpandedKeys = useGet(completedWorkExpandedKeys$);
   const toggleCompletedWorkExpanded = useSet(toggleCompletedWorkExpanded$);
-  const shouldFoldCompletedWork =
-    completedWorkFoldingEnabled && allFinished && activeGroups.length > 1;
-  const hiddenGroups = shouldFoldCompletedWork ? activeGroups.slice(0, -1) : [];
-  const visibleGroups = shouldFoldCompletedWork
-    ? activeGroups.slice(-1)
-    : activeGroups;
+  const visibleGroups = completedWorkFolding?.visibleGroups ?? activeGroups;
 
   return (
     <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
@@ -2354,38 +2349,213 @@ function ChatThreadMessagesMain({
             </p>
           </div>
         )}
-        {shouldFoldCompletedWork && (
-          <CompletedWorkFoldRow
-            groups={activeGroups}
-            expanded={workExpanded}
-            onToggle={() => {
-              toggleCompletedWorkExpanded(thread.threadId);
-            }}
-          />
-        )}
-        {workExpanded &&
-          hiddenGroups.map((group) => {
-            return (
-              <PagedGroupRow
-                key={group.beginMessageId}
-                group={group}
-                thread={thread}
-              />
-            );
-          })}
-        {visibleGroups.map((group) => {
-          return (
-            <PagedGroupRow
-              key={group.beginMessageId}
-              group={group}
-              thread={thread}
-            />
-          );
-        })}
+        <ChatThreadMessageGroups
+          thread={thread}
+          groups={visibleGroups}
+          completedWorkFolding={completedWorkFolding}
+          completedWorkExpandedKeys={completedWorkExpandedKeys}
+          onToggleCompletedWork={toggleCompletedWorkExpanded}
+        />
         <ThinkingIndicator thread={thread} groups={activeGroups} />
       </div>
     </main>
   );
+}
+
+function ChatThreadMessageGroups({
+  thread,
+  groups,
+  completedWorkFolding,
+  completedWorkExpandedKeys,
+  onToggleCompletedWork,
+}: {
+  thread: ChatThreadSignals;
+  groups: readonly GroupedChatMessageGroup[];
+  completedWorkFolding: CompletedWorkFolding | null;
+  completedWorkExpandedKeys: ReadonlySet<string>;
+  onToggleCompletedWork: (key: string) => void;
+}) {
+  return (
+    <>
+      {groups.map((group) => {
+        const completedWorkFold =
+          completedWorkFolding !== null
+            ? (group.messages
+                .map((message) => {
+                  return completedWorkFolding.foldsByFinalMessageId.get(
+                    message.id,
+                  );
+                })
+                .find((fold) => {
+                  return fold !== undefined;
+                }) ?? null)
+            : null;
+        const completedWorkExpanded =
+          completedWorkFold !== null &&
+          completedWorkExpandedKeys.has(completedWorkFold.key);
+        return (
+          <div key={group.beginMessageId} className="contents">
+            {completedWorkFold !== null &&
+              completedWorkExpanded &&
+              completedWorkFold.hiddenGroups.map((hiddenGroup) => {
+                return (
+                  <PagedGroupRow
+                    key={hiddenGroup.beginMessageId}
+                    group={hiddenGroup}
+                    thread={thread}
+                  />
+                );
+              })}
+            <PagedGroupRow
+              group={group}
+              thread={thread}
+              completedWorkFold={
+                completedWorkFold !== null
+                  ? {
+                      groups: completedWorkFold.labelGroups,
+                      expanded: completedWorkExpanded,
+                      onToggle: () => {
+                        onToggleCompletedWork(completedWorkFold.key);
+                      },
+                    }
+                  : undefined
+              }
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function groupMessagesByRole(
+  messages: readonly EnrichedChatMessage[],
+): GroupedChatMessageGroup[] {
+  const groups: GroupedChatMessageGroup[] = [];
+  for (const message of messages) {
+    const last = groups[groups.length - 1];
+    if (last && last.role === message.role) {
+      last.messages.push(message);
+      continue;
+    }
+    groups.push({
+      beginMessageId: message.id,
+      role: message.role,
+      messages: [message],
+    });
+  }
+  return groups;
+}
+
+interface CompletedWorkFold {
+  key: string;
+  finalMessageId: string;
+  hiddenGroups: GroupedChatMessageGroup[];
+  labelGroups: GroupedChatMessageGroup[];
+}
+
+interface CompletedWorkFolding {
+  visibleGroups: GroupedChatMessageGroup[];
+  foldsByFinalMessageId: Map<string, CompletedWorkFold>;
+}
+
+function groupMessagesForCompletedWorkDisplay(
+  messages: readonly EnrichedChatMessage[],
+  foldFinalMessageIds: ReadonlySet<string>,
+): GroupedChatMessageGroup[] {
+  const groups: GroupedChatMessageGroup[] = [];
+  for (const message of messages) {
+    const forceStandalone = foldFinalMessageIds.has(message.id);
+    const last = groups[groups.length - 1];
+    const lastHasFoldFinal =
+      last?.messages.some((candidate) => {
+        return foldFinalMessageIds.has(candidate.id);
+      }) ?? false;
+
+    if (
+      !forceStandalone &&
+      last &&
+      last.role === message.role &&
+      !lastHasFoldFinal
+    ) {
+      last.messages.push(message);
+      continue;
+    }
+
+    groups.push({
+      beginMessageId: message.id,
+      role: message.role,
+      messages: [message],
+    });
+  }
+  return groups;
+}
+
+function buildCompletedWorkFolding(
+  groups: readonly GroupedChatMessageGroup[],
+  allFinished: boolean,
+): CompletedWorkFolding | null {
+  if (!allFinished) {
+    return null;
+  }
+
+  const messages = groups.flatMap((group) => {
+    return group.messages;
+  });
+  const visibleMessages: EnrichedChatMessage[] = [];
+  const folds: CompletedWorkFold[] = [];
+
+  for (let index = 0; index < messages.length; ) {
+    const runId = messages[index]!.runId;
+    if (runId === undefined) {
+      visibleMessages.push(messages[index]!);
+      index++;
+      continue;
+    }
+
+    let endIndex = index + 1;
+    while (endIndex < messages.length && messages[endIndex]!.runId === runId) {
+      endIndex++;
+    }
+
+    const runMessages = messages.slice(index, endIndex);
+    const finalMessage = runMessages[runMessages.length - 1]!;
+    if (runMessages.length > 1 && finalMessage.role === "assistant") {
+      const hiddenMessages = runMessages.slice(0, -1);
+      visibleMessages.push(finalMessage);
+      folds.push({
+        key: `${runId}:${finalMessage.id}`,
+        finalMessageId: finalMessage.id,
+        hiddenGroups: groupMessagesByRole(hiddenMessages),
+        labelGroups: groupMessagesByRole(runMessages),
+      });
+    } else {
+      visibleMessages.push(...runMessages);
+    }
+
+    index = endIndex;
+  }
+
+  if (folds.length === 0) {
+    return null;
+  }
+
+  const foldFinalMessageIds = new Set(
+    folds.map((fold) => {
+      return fold.finalMessageId;
+    }),
+  );
+  return {
+    visibleGroups: groupMessagesForCompletedWorkDisplay(
+      visibleMessages,
+      foldFinalMessageIds,
+    ),
+    foldsByFinalMessageId: new Map(
+      folds.map((fold) => {
+        return [fold.finalMessageId, fold];
+      }),
+    ),
+  };
 }
 
 function parseMessageTime(value: string): number | null {
@@ -2435,11 +2605,7 @@ function CompletedWorkFoldRow({
 }) {
   const label = completedWorkLabel(groups);
   return (
-    <div
-      data-chat-completed-work-fold
-      className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]"
-    >
-      <div className="hidden @[900px]:block" />
+    <div data-chat-completed-work-fold>
       <button
         type="button"
         aria-expanded={expanded}
@@ -4575,14 +4741,26 @@ function AssistantBubbleAvatar({ thread }: { thread: ChatThreadSignals }) {
 function PagedGroupRow({
   group,
   thread,
+  completedWorkFold,
 }: {
   group: GroupedChatMessageGroup;
   thread: ChatThreadSignals;
+  completedWorkFold?: {
+    groups: readonly GroupedChatMessageGroup[];
+    expanded: boolean;
+    onToggle: () => void;
+  };
 }) {
   if (group.role === "user") {
     return <PagedUserGroup group={group} thread={thread} />;
   }
-  return <PagedAssistantGroup group={group} thread={thread} />;
+  return (
+    <PagedAssistantGroup
+      group={group}
+      thread={thread}
+      completedWorkFold={completedWorkFold}
+    />
+  );
 }
 
 function PagedUserGroup({
@@ -5154,9 +5332,15 @@ function PagedUserMessage({
 function PagedAssistantGroup({
   group,
   thread,
+  completedWorkFold,
 }: {
   group: GroupedChatMessageGroup;
   thread: ChatThreadSignals;
+  completedWorkFold?: {
+    groups: readonly GroupedChatMessageGroup[];
+    expanded: boolean;
+    onToggle: () => void;
+  };
 }) {
   const groupElementId = `chat-message-group-${group.beginMessageId}`;
   const fullContent = group.messages
@@ -5175,6 +5359,13 @@ function PagedAssistantGroup({
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
         <div className="relative flex flex-col gap-3">
+          {completedWorkFold && (
+            <CompletedWorkFoldRow
+              groups={completedWorkFold.groups}
+              expanded={completedWorkFold.expanded}
+              onToggle={completedWorkFold.onToggle}
+            />
+          )}
           {group.messages.map((msg) => {
             return <PagedAssistantMessageItem key={msg.id} message={msg} />;
           })}


### PR DESCRIPTION
## Summary
- create an independent completed-work fold for each completed run segment in the thread
- fold only inside a run and keep that run final assistant message visible
- skip folding for single-message runs
- keep each fold row inside its final assistant group so it appears below the avatar
- track fold expansion per run/final-message key instead of per thread

## Tests
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx apps/platform/src/signals/chat-page/completed-work-folding.ts
- pnpm --filter ./apps/platform exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- git diff --check

Note: local typecheck needed a refresh of the ignored Cloudflare generated file via pnpm -F @vm0/firewalls-generator generate:cloudflare; it is not part of the PR diff.