### PR TITLE
feat: merge inline feedback into the chat composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6,6 +6,7 @@ import type {
   DragEvent,
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
+  RefCallback,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -60,6 +61,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   cn,
+  matchShortcut,
   processShortcut,
 } from "@vm0/ui";
 import {
@@ -183,6 +185,7 @@ import {
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { readChatMessageFromClipboard } from "../../signals/zero-page/clipboard.ts";
+import type { FeedbackItem } from "../../signals/zero-page/chat-feedback.ts";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 
@@ -292,6 +295,23 @@ interface ZeroChatComposerProps {
   queuedItems?: QueuedComposerItem[];
   /** Cancels a queued message (routed to the recall flow by the caller). */
   onRemoveQueuedItem?: (id: string) => void;
+  /**
+   * Inline feedback drafted from selected assistant text. When at least one
+   * quoted fragment is present the composer swaps its textarea for the stacked
+   * quote + note rows and its Send button dispatches the feedback turn — so the
+   * feedback lives inside the composer instead of a separate panel above it.
+   */
+  feedback?: ComposerFeedback;
+}
+
+export interface ComposerFeedback {
+  items: readonly FeedbackItem[];
+  /** Fragments carrying a non-empty note — what Send will dispatch. */
+  sendCount: number;
+  onChangeNote: (id: number, note: string) => void;
+  onRemove: (id: number) => void;
+  onSubmit: () => void;
+  onDismiss: () => void;
 }
 
 export interface QueuedComposerItem {
@@ -471,6 +491,104 @@ function QueuedMessagesStrip({
           );
         })}
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline feedback rows — the docked feedback stack, rendered inside the
+// composer card in place of the textarea. Each selected passage is a quote line
+// above a borderless, composer-styled note input; fragments append to the
+// bottom so reading order matches selection order, and they share the
+// composer's toolbar and Send button.
+// ---------------------------------------------------------------------------
+
+function focusFeedbackNoteRef(element: HTMLTextAreaElement | null): void {
+  element?.focus();
+}
+
+function ComposerFeedbackRow({
+  item,
+  autoFocus,
+  onChangeNote,
+  onRemove,
+  onKeyDown,
+}: {
+  item: FeedbackItem;
+  autoFocus: boolean;
+  onChangeNote: (note: string) => void;
+  onRemove: () => void;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
+}) {
+  return (
+    <div className="border-b border-dashed border-border/60 pb-2 pt-1 last:border-b-0">
+      <div className="flex items-center gap-2">
+        <span className="h-3.5 w-[3px] shrink-0 rounded-sm bg-primary" />
+        <span className="min-w-0 flex-1 truncate text-xs italic leading-snug text-muted-foreground">
+          {item.quote}
+        </span>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Remove feedback"
+          title="Remove feedback"
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <IconX size={15} stroke={2} />
+        </button>
+      </div>
+      <textarea
+        ref={autoFocus ? focusFeedbackNoteRef : undefined}
+        value={item.note}
+        onChange={(event) => {
+          return onChangeNote(event.target.value);
+        }}
+        onKeyDown={onKeyDown}
+        rows={1}
+        placeholder="What should change about this?"
+        className="mt-1 w-full resize-none border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
+      />
+    </div>
+  );
+}
+
+function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter sends, Shift+Enter inserts a newline — matching the main composer.
+    // Escape clears the drafted feedback.
+    if (matchShortcut("enter", event)) {
+      event.preventDefault();
+      feedback.onSubmit();
+    } else if (matchShortcut("escape", event)) {
+      event.preventDefault();
+      feedback.onDismiss();
+    }
+  };
+
+  // Newest fragment sits at the bottom (nearest Send) and takes focus.
+  const newestId = feedback.items[feedback.items.length - 1]?.id;
+
+  return (
+    <div className="flex flex-col px-3 pt-3">
+      {feedback.items.map((item) => {
+        return (
+          <ComposerFeedbackRow
+            key={item.id}
+            item={item}
+            autoFocus={item.id === newestId}
+            onChangeNote={(note) => {
+              return feedback.onChangeNote(item.id, note);
+            }}
+            onRemove={() => {
+              return feedback.onRemove(item.id);
+            }}
+            onKeyDown={handleKeyDown}
+          />
+        );
+      })}
+      <span className="px-1 pt-1.5 text-xs leading-snug text-muted-foreground">
+        Select more text and click Provide feedback to add another comment
+      </span>
     </div>
   );
 }
@@ -3116,6 +3234,82 @@ function resolveKeyboardSendAction({
   return sending ? "queue" : "send";
 }
 
+function resolveActiveFeedback(
+  feedback: ComposerFeedback | undefined,
+): ComposerFeedback | null {
+  if (feedback && feedback.items.length > 0) {
+    return feedback;
+  }
+  return null;
+}
+
+function composerTextareaRef(
+  autoFocus: boolean | undefined,
+  setInputRef: ((el: HTMLElement | null) => void) | undefined,
+): RefCallback<HTMLTextAreaElement> {
+  return (el) => {
+    if (el && autoFocus && !isIOSDevice()) {
+      el.focus();
+    }
+    setInputRef?.(el);
+  };
+}
+
+// Stop while an empty composer is mid-run; otherwise Send. In feedback mode the
+// same button dispatches the feedback turn and stays disabled until a note is
+// written.
+function ComposerSendButton({
+  showStopButton,
+  onCancel,
+  activeFeedback,
+  sendAction,
+  onSend,
+}: {
+  showStopButton: boolean;
+  onCancel: (() => void) | undefined;
+  activeFeedback: ComposerFeedback | null;
+  sendAction: KeyboardSendAction;
+  onSend: () => void;
+}) {
+  if (showStopButton && !activeFeedback) {
+    return (
+      <Button
+        size="sm"
+        variant="destructive"
+        className="rounded-lg h-9 w-9 p-0 shrink-0"
+        onClick={onCancel}
+        aria-label="Stop"
+      >
+        <IconPlayerStop size={16} />
+      </Button>
+    );
+  }
+  if (activeFeedback) {
+    return (
+      <Button
+        size="sm"
+        className="rounded-lg h-9 w-9 p-0 shrink-0"
+        onClick={activeFeedback.onSubmit}
+        disabled={activeFeedback.sendCount === 0}
+        aria-label="Send feedback"
+      >
+        <IconArrowUp size={18} stroke={2} />
+      </Button>
+    );
+  }
+  return (
+    <Button
+      size="sm"
+      className="rounded-lg h-9 w-9 p-0 shrink-0"
+      onClick={onSend}
+      disabled={sendAction === "none"}
+      aria-label="Send"
+    >
+      <IconArrowUp size={18} stroke={2} />
+    </Button>
+  );
+}
+
 function ModelConfigurationWarning({
   blocker,
 }: {
@@ -3227,6 +3421,7 @@ export function ZeroChatComposer({
   submitBlocker,
   queuedItems,
   onRemoveQueuedItem,
+  feedback,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
   const setShowAddDialog = useSet(setShowAddDialog$);
@@ -3270,6 +3465,11 @@ export function ZeroChatComposer({
         attachmentUploadSummary.data.attachmentCount,
   });
   const canSubmit = canSend && !submitBlocker;
+
+  // When feedback fragments are present the composer is in "feedback mode": the
+  // textarea is replaced by the stacked quote + note rows and Send dispatches
+  // the feedback turn instead of the draft.
+  const activeFeedback = resolveActiveFeedback(feedback);
 
   // File upload handlers (paste / drag-drop)
   const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -3601,43 +3801,44 @@ export function ZeroChatComposer({
         >
           <CardContent className="p-0">
             <div className="flex flex-col">
-              <SelectedTemplateChipSlot
-                picker={templatePicker}
-                onDraftChange={onDraftChange}
-              />
-              {visibleAttachments.length > 0 && (
-                <AttachmentChips
-                  attachments={visibleAttachments}
-                  onRemove={(attachment) => {
-                    removeAttachment(attachment);
-                    onDraftChange?.();
-                  }}
-                />
+              {activeFeedback ? (
+                <ComposerFeedbackRows feedback={activeFeedback} />
+              ) : (
+                <>
+                  <SelectedTemplateChipSlot
+                    picker={templatePicker}
+                    onDraftChange={onDraftChange}
+                  />
+                  {visibleAttachments.length > 0 && (
+                    <AttachmentChips
+                      attachments={visibleAttachments}
+                      onRemove={(attachment) => {
+                        removeAttachment(attachment);
+                        onDraftChange?.();
+                      }}
+                    />
+                  )}
+                  <textarea
+                    ref={composerTextareaRef(autoFocus, setInputRef)}
+                    className={cn(
+                      "w-full resize-none bg-transparent px-4 pt-4 pb-0 text-[0.9375rem] text-foreground placeholder:text-muted-foreground/40 border-0 focus:outline-none focus:ring-0 min-h-[96px]",
+                    )}
+                    rows={3}
+                    placeholder={
+                      sending
+                        ? "Type your next message\u2026"
+                        : "Ask me to automate workflows, manage tasks..."
+                    }
+                    value={input}
+                    onChange={(e) => {
+                      return onInputChange(e.target.value);
+                    }}
+                    enterKeyHint="enter"
+                    onKeyDown={handleKeyDown}
+                    onPaste={handlePaste}
+                  />
+                </>
               )}
-              <textarea
-                ref={(el) => {
-                  if (el && autoFocus && !isIOSDevice()) {
-                    el.focus();
-                  }
-                  setInputRef?.(el);
-                }}
-                className={cn(
-                  "w-full resize-none bg-transparent px-4 pt-4 pb-0 text-[0.9375rem] text-foreground placeholder:text-muted-foreground/40 border-0 focus:outline-none focus:ring-0 min-h-[96px]",
-                )}
-                rows={3}
-                placeholder={
-                  sending
-                    ? "Type your next message\u2026"
-                    : "Ask me to automate workflows, manage tasks..."
-                }
-                value={input}
-                onChange={(e) => {
-                  return onInputChange(e.target.value);
-                }}
-                enterKeyHint="enter"
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-              />
               <div className="flex items-center justify-between gap-2 px-4 pb-3 pt-1">
                 <div className="flex items-center gap-1 text-muted-foreground sm:gap-1.5">
                   <TooltipProvider delayDuration={300}>
@@ -3693,27 +3894,13 @@ export function ZeroChatComposer({
                           onDraftChange?.();
                         }}
                       />
-                      {showStopButton ? (
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          className="rounded-lg h-9 w-9 p-0 shrink-0"
-                          onClick={onCancel}
-                          aria-label="Stop"
-                        >
-                          <IconPlayerStop size={16} />
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          className="rounded-lg h-9 w-9 p-0 shrink-0"
-                          onClick={handleButtonSend}
-                          disabled={sendAction === "none"}
-                          aria-label="Send"
-                        >
-                          <IconArrowUp size={18} stroke={2} />
-                        </Button>
-                      )}
+                      <ComposerSendButton
+                        showStopButton={showStopButton}
+                        onCancel={onCancel}
+                        activeFeedback={activeFeedback}
+                        sendAction={sendAction}
+                        onSend={handleButtonSend}
+                      />
                     </>
                   )}
                 </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -1,40 +1,17 @@
-import type {
-  CSSProperties,
-  KeyboardEvent as ReactKeyboardEvent,
-  RefCallback,
-} from "react";
-import {
-  IconArrowUp,
-  IconCheck,
-  IconCopy,
-  IconMessageCircle,
-  IconX,
-} from "@tabler/icons-react";
+import type { CSSProperties, RefCallback } from "react";
+import { IconCheck, IconCopy, IconMessageCircle } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
-import {
-  Button,
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  matchShortcut,
-} from "@vm0/ui";
+import { Popover, PopoverAnchor, PopoverContent } from "@vm0/ui";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   captureFeedbackSelection$,
   copyFeedbackSelection$,
-  dismissFeedback$,
   dismissFeedbackOnScroll$,
   dismissFeedbackSelection$,
   feedbackCopiedValue$,
-  feedbackItemsValue$,
   feedbackSelectionValue$,
-  feedbackSendCountValue$,
-  removeFeedbackItem$,
-  setFeedbackItemNote$,
   startFeedback$,
-  submitFeedback$,
-  type FeedbackItem,
   type FeedbackSelection,
 } from "../../signals/zero-page/chat-feedback.ts";
 
@@ -66,10 +43,6 @@ function selectionListenersRef(
       });
     };
   };
-}
-
-function focusOnMountRef(element: HTMLTextAreaElement | null): void {
-  element?.focus();
 }
 
 function anchorStyle(selection: FeedbackSelection): CSSProperties {
@@ -129,56 +102,10 @@ function FeedbackToolbar({
   );
 }
 
-// One quoted fragment and its note. Every fragment renders identically — a
-// quote line above a borderless, composer-styled note input — so the tray reads
-// as a single stack of comments rather than a mix of cards and a bare field.
-function FeedbackRow({
-  item,
-  autoFocus,
-  onChangeNote,
-  onRemove,
-  onKeyDown,
-}: {
-  item: FeedbackItem;
-  autoFocus: boolean;
-  onChangeNote: (note: string) => void;
-  onRemove: () => void;
-  onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
-}) {
-  return (
-    <div className="border-b border-dashed border-border/60 pb-2 pt-1 last:border-b-0">
-      <div className="flex items-center gap-2">
-        <span className="h-3.5 w-[3px] shrink-0 rounded-sm bg-primary" />
-        <span className="min-w-0 flex-1 truncate text-xs italic leading-snug text-muted-foreground">
-          {item.quote}
-        </span>
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label="Remove feedback"
-          title="Remove feedback"
-          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <IconX size={15} stroke={2} />
-        </button>
-      </div>
-      <textarea
-        ref={autoFocus ? focusOnMountRef : undefined}
-        value={item.note}
-        onChange={(event) => {
-          return onChangeNote(event.target.value);
-        }}
-        onKeyDown={onKeyDown}
-        rows={1}
-        placeholder="What should change about this?"
-        className="mt-1 w-full resize-none border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
-      />
-    </div>
-  );
-}
-
 // Mounts the selection listeners and the floating Copy / Provide feedback
-// toolbar anchored to the highlighted passage.
+// toolbar anchored to the highlighted passage. Picking "Provide feedback"
+// drops the quoted passage straight into the composer (see ComposerFeedbackRows
+// in zero-chat-composer.tsx) — there is no separate feedback panel.
 export function ChatFeedbackSelection() {
   const selection = useGet(feedbackSelectionValue$);
   const copied = useGet(feedbackCopiedValue$);
@@ -214,92 +141,5 @@ export function ChatFeedbackSelection() {
         </Popover>
       ) : null}
     </>
-  );
-}
-
-// The docked feedback tray: a consistent stack of quoted fragments — newest on
-// top, each with its own note — and a single Send that dispatches them as one
-// turn. Sits flush above the composer and survives thread scrolling.
-export function ChatFeedbackTray({
-  onSubmit,
-}: {
-  onSubmit: (prompt: string) => void;
-}) {
-  const items = useGet(feedbackItemsValue$);
-  const sendCount = useGet(feedbackSendCountValue$);
-  const setNote = useSet(setFeedbackItemNote$);
-  const removeItem = useSet(removeFeedbackItem$);
-  const submit = useSet(submitFeedback$);
-  const dismiss = useSet(dismissFeedback$);
-
-  if (items.length === 0) {
-    return null;
-  }
-
-  const handleSubmit = () => {
-    const prompt = submit();
-    if (prompt === null) {
-      return;
-    }
-    onSubmit(prompt);
-    dismiss();
-  };
-
-  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-    // Enter sends, Shift+Enter inserts a newline — matching the main composer.
-    // Escape closes the tray.
-    if (matchShortcut("enter", event)) {
-      event.preventDefault();
-      handleSubmit();
-    } else if (matchShortcut("escape", event)) {
-      event.preventDefault();
-      dismiss();
-    }
-  };
-
-  // Oldest fragment sits on top; the stack runs down to the newest, which
-  // takes the composer position nearest the Send button and holds focus.
-  const newestId = items[items.length - 1]?.id;
-  const ordered = items;
-
-  return (
-    <div className="shrink-0 px-4 pb-0 pt-2 sm:px-6">
-      <div className="mx-auto max-w-[900px]">
-        <div className="rounded-t-xl border border-b-0 border-border bg-popover px-3 pb-1 pt-1.5 shadow-[0_-2px_12px_rgba(15,23,42,0.05)]">
-          <div className="flex flex-col">
-            {ordered.map((item) => {
-              return (
-                <FeedbackRow
-                  key={item.id}
-                  item={item}
-                  autoFocus={item.id === newestId}
-                  onChangeNote={(note) => {
-                    return setNote({ id: item.id, note });
-                  }}
-                  onRemove={() => {
-                    return removeItem(item.id);
-                  }}
-                  onKeyDown={handleKeyDown}
-                />
-              );
-            })}
-          </div>
-          <div className="flex items-center justify-between gap-3 pt-1.5">
-            <span className="text-xs leading-snug text-muted-foreground">
-              Select more text and click Provide feedback to add another comment
-            </span>
-            <Button
-              size="sm"
-              onClick={handleSubmit}
-              disabled={sendCount === 0}
-              aria-label="Send feedback"
-              className="h-9 w-9 shrink-0 rounded-lg p-0"
-            >
-              <IconArrowUp size={18} stroke={2} />
-            </Button>
-          </div>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -190,11 +190,17 @@ import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-a
 import {
   ZeroChatComposer,
   type QueuedComposerItem,
+  type ComposerFeedback,
 } from "./zero-chat-composer.tsx";
+import { ChatFeedbackSelection } from "./zero-chat-feedback-selection.tsx";
 import {
-  ChatFeedbackSelection,
-  ChatFeedbackTray,
-} from "./zero-chat-feedback-selection.tsx";
+  feedbackItemsValue$,
+  feedbackSendCountValue$,
+  setFeedbackItemNote$,
+  removeFeedbackItem$,
+  submitFeedback$,
+  dismissFeedback$,
+} from "../../signals/zero-page/chat-feedback.ts";
 import {
   setThreadGenerationTemplate$,
   threadGenerationTemplate$,
@@ -2563,17 +2569,9 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const skeletonVisible = useGet(thread.skeletonVisible$);
   const loadingHistory = loadHistoryLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
-  const [, sendMessage] = useLoadableSet(thread.sendMessage$);
-  const rootSignal = useGet(rootSignal$);
   const features = useLastResolved(featureSwitch$);
   const inlineFeedbackEnabled =
     features?.[FeatureSwitchKey.ChatInlineFeedback] ?? false;
-  const onSubmitFeedback = (prompt: string) => {
-    detach(
-      sendMessage(prompt, null, { includeDraftAttachments: false }, rootSignal),
-      Reason.DomCallback,
-    );
-  };
   const onLoadHistory = onDomEventFn(() => {
     return loadHistory(pageSignal);
   });
@@ -2621,9 +2619,6 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
             />
           </div>
 
-          {inlineFeedbackEnabled && (
-            <ChatFeedbackTray onSubmit={onSubmitFeedback} />
-          )}
           <ChatThreadComposer thread={thread} />
         </div>
 
@@ -3123,6 +3118,57 @@ function useChatThreadComputerUse(thread: ChatThreadSignals) {
   };
 }
 
+// Bridges the global inline-feedback signals to the composer's `feedback` prop.
+// Returns undefined when the feature is off, so the composer keeps its textarea.
+function useChatThreadComposerFeedback(
+  thread: ChatThreadSignals,
+): ComposerFeedback | undefined {
+  const features = useLastResolved(featureSwitch$);
+  const inlineFeedbackEnabled =
+    features?.[FeatureSwitchKey.ChatInlineFeedback] ?? false;
+  const items = useGet(feedbackItemsValue$);
+  const sendCount = useGet(feedbackSendCountValue$);
+  const setNote = useSet(setFeedbackItemNote$);
+  const removeItem = useSet(removeFeedbackItem$);
+  const compose = useSet(submitFeedback$);
+  const dismiss = useSet(dismissFeedback$);
+  const [, sendMessage] = useLoadableSet(thread.sendMessage$);
+  const rootSignal = useGet(rootSignal$);
+
+  if (!inlineFeedbackEnabled) {
+    return undefined;
+  }
+  return {
+    items,
+    sendCount,
+    onChangeNote: (id, note) => {
+      setNote({ id, note });
+    },
+    onRemove: (id) => {
+      removeItem(id);
+    },
+    onSubmit: () => {
+      const prompt = compose();
+      if (prompt === null) {
+        return;
+      }
+      detach(
+        sendMessage(
+          prompt,
+          null,
+          { includeDraftAttachments: false },
+          rootSignal,
+        ),
+        Reason.DomCallback,
+      );
+      dismiss();
+    },
+    onDismiss: () => {
+      dismiss();
+    },
+  };
+}
+
 function ChatThreadComposer({
   thread,
   autoFocus: autoFocusProp = true,
@@ -3192,6 +3238,8 @@ function ChatThreadComposer({
     detach(scheduleDraftSync(pageSignal), Reason.DomCallback);
   };
 
+  const feedback = useChatThreadComposerFeedback(thread);
+
   return (
     <footer
       data-chat-composer
@@ -3234,6 +3282,7 @@ function ChatThreadComposer({
             submitBlocker={submitBlockerProps}
             queuedItems={queuedItems}
             onRemoveQueuedItem={onRemoveQueuedItem}
+            feedback={feedback}
           />
           <PersonalClaudeCodeDeviceAuthDialog />
           <PersonalCodexDeviceAuthDialog />


### PR DESCRIPTION
## What

Folds the selected-text feedback UI into the chat composer so it's **one surface, one send action** instead of a separate docked tray stacked above the composer.

Before, picking *Provide feedback* on selected assistant text opened a separate card (quoted fragments + per-fragment note inputs) with **its own Send button**, sitting on top of the normal composer ("Ask me to automate workflows…"). Two panels, two send buttons — redundant.

Now, when feedback is drafted the composer enters "feedback mode": it swaps its textarea for the stacked `quote + note` rows and its **single Send button** dispatches the feedback turn. The toolbar (attach · connectors · template · model · mic) is shared. In the common one-snippet case it's just the composer.

Matches the agreed [prototype](https://feedback-consistent-order-715f6d07-f455641e.sites.vm0.io/).

## Behavior (locked with Ming)

- **Append to bottom** — new fragments stack below, so reading order matches selection order (first selection on top, latest nearest Send).
- **No empty sends** — Send stays disabled until at least one note has text; bare quotes can't be sent.
- Each row keeps its own quote line, note input, and × to remove. Enter sends, Shift+Enter newlines, Esc clears.

## Changes

- Remove `ChatFeedbackTray` / `FeedbackRow`; `zero-chat-feedback-selection.tsx` now only owns the floating Copy / Provide feedback toolbar.
- Render the rows inside the composer card via `ComposerFeedbackRows`.
- Add a `feedback` prop to `ZeroChatComposer`; wire the global feedback signals through `ChatThreadComposer` (`useChatThreadComposerFeedback`).
- Extract `ComposerSendButton` + small ref/feedback helpers to stay under the cyclomatic-complexity cap.

## Testing

- Existing inline-feedback lifecycle tests (single send, multi-comment stack, edit-and-send, append order, empty-removal) pass unchanged — labels/placeholders preserved.
- Full `chat-lifecycle` (56), attachment-chips, and onboarding-continue-web suites green.
- Local type-check, oxlint, eslint, prettier, knip clean.
- Did not run the live app locally (per repo PR convention) — visual walkthrough on the per-PR preview can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)