### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,12 +111,12 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.173"
+CLAUDE_CODE_VERSION="2.1.174"
 CODEX_CLI_VERSION="0.139.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.2"
-PNPM_VERSION="11.5.3"
+PNPM_VERSION="11.6.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Updates pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`.

Updated versions:
- Claude Code CLI: `2.1.173` -> `2.1.174`
- pnpm: `11.5.3` -> `11.6.0`

Checked and left unchanged:
- Go: `1.26.4` is the latest stable Go release.
- NodeSource: `node_24.x` remains the current LTS channel.
- OpenAI Codex CLI: `0.139.0` is the latest stable npm release.
- Google Workspace CLI: `0.22.5` is the latest npm release.
- xurl: `1.0.3` is the latest npm release.
- agent-browser: `0.27.2` is the latest npm release.
- Ubuntu release is unchanged as requested.

## Validation

- `bash -n crates/runner/scripts/build-template.sh`