### PR TITLE
refactor: remove connector default auth methods

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -22,7 +22,6 @@ import {
   type ConnectorConfig,
   type ConnectorDeviceAuthGrantConfig,
   type ConnectorExternalCodeGrantConfig,
-  type ConnectorInvalidDefaultAuthMethodType,
   type ConnectorManualGrantFieldConfig,
   type ConnectorType,
   type AuthCodeGrantConnectorType,
@@ -315,7 +314,6 @@ const connectorAuthMethodFixture = {
     authMethods: {
       "api-token": manualAuthMethodConfig,
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;
 
@@ -328,7 +326,6 @@ const multiAuthMethodFixture = {
       oauth: manualAuthMethodConfig,
       "api-token": manualAuthMethodConfig,
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;
 
@@ -472,42 +469,12 @@ describe("connector auth method config", () => {
     expectTypeOf<"app-credential">().not.toMatchTypeOf<
       keyof ConnectorConfig["authMethods"]
     >();
-    expectTypeOf<"app-credential">().not.toMatchTypeOf<
-      ConnectorConfig["defaultAuthMethod"]
-    >();
     expectTypeOf<
       ConnectorConfigAuthMethodIds<FixtureConfig>
     >().toEqualTypeOf<"api-token">();
     expectTypeOf<
       ConnectorConfigAuthMethodIds<MultiFixtureConfig>
     >().toEqualTypeOf<"oauth" | "api-token">();
-    expectTypeOf<
-      FixtureConfig["defaultAuthMethod"]
-    >().toEqualTypeOf<"api-token">();
-    expectTypeOf<
-      MultiFixtureConfig["defaultAuthMethod"]
-    >().toEqualTypeOf<"api-token">();
-    expectTypeOf<
-      ConnectorInvalidDefaultAuthMethodType<typeof connectorAuthMethodFixture>
-    >().toEqualTypeOf<never>();
-    expectTypeOf<
-      ConnectorInvalidDefaultAuthMethodType<typeof multiAuthMethodFixture>
-    >().toEqualTypeOf<never>();
-
-    const missingDefaultMethodFixture = {
-      "missing-default-method-fixture": {
-        label: "Missing Default Method Fixture",
-        category: "data-automation-infrastructure",
-        helpText: "Fixture used for connector auth method type coverage.",
-        authMethods: {
-          "api-token": manualAuthMethodConfig,
-        },
-        defaultAuthMethod: "oauth",
-      },
-    } as const satisfies Record<string, ConnectorConfig>;
-    expectTypeOf<
-      ConnectorInvalidDefaultAuthMethodType<typeof missingDefaultMethodFixture>
-    >().toEqualTypeOf<"missing-default-method-fixture">();
   });
 
   it("returns a single auth method config when present", () => {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -666,7 +666,6 @@ type ConnectorConfigBase = {
   readonly label: string;
   readonly helpText: string;
   readonly category: ConnectorDisplayCategory;
-  readonly defaultAuthMethod?: ConnectorAuthMethodId;
   /**
    * Output categories this connector skill can generate. This is product
    * metadata for discovery and routing, not a permission/capability grant.
@@ -1479,22 +1478,6 @@ type TokenRevokeConnectorTypeWithNonConfidentialClient = {
 }[TokenRevokeConnectorType];
 export type TokenRevokeConnectorAuthMethodsUseConfidentialClients =
   AssertNever<TokenRevokeConnectorTypeWithNonConfidentialClient>;
-
-export type ConnectorInvalidDefaultAuthMethodType<
-  Configs extends Record<string, ConnectorConfig>,
-> = {
-  [Type in keyof Configs & string]: Configs[Type] extends {
-    readonly defaultAuthMethod: infer DefaultMethod;
-  }
-    ? DefaultMethod extends Extract<keyof Configs[Type]["authMethods"], string>
-      ? never
-      : Type
-    : never;
-}[keyof Configs & string];
-
-export type ConnectorDefaultAuthMethodsMatchConfig = AssertNever<
-  ConnectorInvalidDefaultAuthMethodType<typeof CONNECTOR_TYPES_DEF>
->;
 
 export const CONNECTOR_TYPES = CONNECTOR_TYPES_DEF;
 export const CONNECTOR_TYPE_KEYS = Object.freeze(

--- a/turbo/packages/connectors/src/connectors/adzuna.ts
+++ b/turbo/packages/connectors/src/connectors/adzuna.ts
@@ -42,6 +42,5 @@ export const adzuna = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/agentmail.ts
+++ b/turbo/packages/connectors/src/connectors/agentmail.ts
@@ -34,6 +34,5 @@ export const agentmail = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/agora.ts
+++ b/turbo/packages/connectors/src/connectors/agora.ts
@@ -61,6 +61,5 @@ export const agora = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/ahrefs.ts
+++ b/turbo/packages/connectors/src/connectors/ahrefs.ts
@@ -73,6 +73,5 @@ export const ahrefs = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/airtable.ts
+++ b/turbo/packages/connectors/src/connectors/airtable.ts
@@ -53,6 +53,5 @@ export const airtable = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/alchemy.ts
+++ b/turbo/packages/connectors/src/connectors/alchemy.ts
@@ -33,6 +33,5 @@ export const alchemy = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/altium-365.ts
+++ b/turbo/packages/connectors/src/connectors/altium-365.ts
@@ -42,6 +42,5 @@ export const altium365 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/amadeus.ts
+++ b/turbo/packages/connectors/src/connectors/amadeus.ts
@@ -38,6 +38,5 @@ export const amadeus = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/amplitude.ts
+++ b/turbo/packages/connectors/src/connectors/amplitude.ts
@@ -41,6 +41,5 @@ export const amplitude = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/anthropic-managed-agents.ts
+++ b/turbo/packages/connectors/src/connectors/anthropic-managed-agents.ts
@@ -35,6 +35,5 @@ export const anthropicManagedAgents = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/apify.ts
+++ b/turbo/packages/connectors/src/connectors/apify.ts
@@ -34,6 +34,5 @@ export const apify = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/apollo.ts
+++ b/turbo/packages/connectors/src/connectors/apollo.ts
@@ -34,6 +34,5 @@ export const apollo = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/asana.ts
+++ b/turbo/packages/connectors/src/connectors/asana.ts
@@ -45,6 +45,5 @@ export const asana = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/ashby.ts
+++ b/turbo/packages/connectors/src/connectors/ashby.ts
@@ -34,6 +34,5 @@ export const ashby = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/atlascloud.ts
+++ b/turbo/packages/connectors/src/connectors/atlascloud.ts
@@ -36,6 +36,5 @@ export const atlascloud = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/atlassian.ts
+++ b/turbo/packages/connectors/src/connectors/atlassian.ts
@@ -48,6 +48,5 @@ export const atlassian = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/attio.ts
+++ b/turbo/packages/connectors/src/connectors/attio.ts
@@ -34,6 +34,5 @@ export const attio = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/aviationstack.ts
+++ b/turbo/packages/connectors/src/connectors/aviationstack.ts
@@ -33,6 +33,5 @@ export const aviationstack = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/aws.ts
+++ b/turbo/packages/connectors/src/connectors/aws.ts
@@ -72,6 +72,5 @@ export const aws = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "cli",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/axiom.ts
+++ b/turbo/packages/connectors/src/connectors/axiom.ts
@@ -34,6 +34,5 @@ export const axiom = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/base44.ts
+++ b/turbo/packages/connectors/src/connectors/base44.ts
@@ -44,6 +44,5 @@ export const base44 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bentoml.ts
+++ b/turbo/packages/connectors/src/connectors/bentoml.ts
@@ -45,6 +45,5 @@ export const bentoml = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bfl.ts
+++ b/turbo/packages/connectors/src/connectors/bfl.ts
@@ -36,6 +36,5 @@ export const bfl = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bitrefill.ts
+++ b/turbo/packages/connectors/src/connectors/bitrefill.ts
@@ -37,6 +37,5 @@ export const bitrefill = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bitrix.ts
+++ b/turbo/packages/connectors/src/connectors/bitrix.ts
@@ -34,6 +34,5 @@ export const bitrix = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bland.ts
+++ b/turbo/packages/connectors/src/connectors/bland.ts
@@ -36,6 +36,5 @@ export const bland = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/brave-search.ts
+++ b/turbo/packages/connectors/src/connectors/brave-search.ts
@@ -34,6 +34,5 @@ export const braveSearch = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/brevo.ts
+++ b/turbo/packages/connectors/src/connectors/brevo.ts
@@ -34,6 +34,5 @@ export const brevo = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/brex.ts
+++ b/turbo/packages/connectors/src/connectors/brex.ts
@@ -35,6 +35,5 @@ export const brex = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bright-data.ts
+++ b/turbo/packages/connectors/src/connectors/bright-data.ts
@@ -33,6 +33,5 @@ export const brightData = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/browser-use.ts
+++ b/turbo/packages/connectors/src/connectors/browser-use.ts
@@ -34,6 +34,5 @@ export const browserUse = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/browserbase.ts
+++ b/turbo/packages/connectors/src/connectors/browserbase.ts
@@ -39,6 +39,5 @@ export const browserbase = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/browserless.ts
+++ b/turbo/packages/connectors/src/connectors/browserless.ts
@@ -34,6 +34,5 @@ export const browserless = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/browserstack.ts
+++ b/turbo/packages/connectors/src/connectors/browserstack.ts
@@ -41,6 +41,5 @@ export const browserstack = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/bubblemaps.ts
+++ b/turbo/packages/connectors/src/connectors/bubblemaps.ts
@@ -34,6 +34,5 @@ export const bubblemaps = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/buffer.ts
+++ b/turbo/packages/connectors/src/connectors/buffer.ts
@@ -34,6 +34,5 @@ export const buffer = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/builtwith.ts
+++ b/turbo/packages/connectors/src/connectors/builtwith.ts
@@ -33,6 +33,5 @@ export const builtwith = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/cal-com.ts
+++ b/turbo/packages/connectors/src/connectors/cal-com.ts
@@ -34,6 +34,5 @@ export const calCom = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/calendly.ts
+++ b/turbo/packages/connectors/src/connectors/calendly.ts
@@ -34,6 +34,5 @@ export const calendly = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/canva.ts
+++ b/turbo/packages/connectors/src/connectors/canva.ts
@@ -60,6 +60,5 @@ export const canva = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/chatwoot.ts
+++ b/turbo/packages/connectors/src/connectors/chatwoot.ts
@@ -34,6 +34,5 @@ export const chatwoot = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/checkr.ts
+++ b/turbo/packages/connectors/src/connectors/checkr.ts
@@ -41,6 +41,5 @@ export const checkr = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/clado.ts
+++ b/turbo/packages/connectors/src/connectors/clado.ts
@@ -33,6 +33,5 @@ export const clado = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/clearbit.ts
+++ b/turbo/packages/connectors/src/connectors/clearbit.ts
@@ -34,6 +34,5 @@ export const clearbit = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/clerk.ts
+++ b/turbo/packages/connectors/src/connectors/clerk.ts
@@ -34,6 +34,5 @@ export const clerk = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/clickup.ts
+++ b/turbo/packages/connectors/src/connectors/clickup.ts
@@ -34,6 +34,5 @@ export const clickup = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/close.ts
+++ b/turbo/packages/connectors/src/connectors/close.ts
@@ -47,6 +47,5 @@ export const close = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/cloudflare.ts
+++ b/turbo/packages/connectors/src/connectors/cloudflare.ts
@@ -434,6 +434,5 @@ export const cloudflare = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/cloudinary.ts
+++ b/turbo/packages/connectors/src/connectors/cloudinary.ts
@@ -45,6 +45,5 @@ export const cloudinary = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/coda.ts
+++ b/turbo/packages/connectors/src/connectors/coda.ts
@@ -34,6 +34,5 @@ export const coda = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/coingecko.ts
+++ b/turbo/packages/connectors/src/connectors/coingecko.ts
@@ -34,6 +34,5 @@ export const coingecko = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/coresignal.ts
+++ b/turbo/packages/connectors/src/connectors/coresignal.ts
@@ -34,6 +34,5 @@ export const coresignal = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/cronlytic.ts
+++ b/turbo/packages/connectors/src/connectors/cronlytic.ts
@@ -39,6 +39,5 @@ export const cronlytic = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/crustdata.ts
+++ b/turbo/packages/connectors/src/connectors/crustdata.ts
@@ -33,6 +33,5 @@ export const crustdata = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/cursor.ts
+++ b/turbo/packages/connectors/src/connectors/cursor.ts
@@ -35,6 +35,5 @@ export const cursor = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/customer-io.ts
+++ b/turbo/packages/connectors/src/connectors/customer-io.ts
@@ -33,6 +33,5 @@ export const customerIo = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/daytona.ts
+++ b/turbo/packages/connectors/src/connectors/daytona.ts
@@ -35,6 +35,5 @@ export const daytona = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/db9.ts
+++ b/turbo/packages/connectors/src/connectors/db9.ts
@@ -34,6 +34,5 @@ export const db9 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/deel.ts
+++ b/turbo/packages/connectors/src/connectors/deel.ts
@@ -81,6 +81,5 @@ export const deel = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/deepseek.ts
+++ b/turbo/packages/connectors/src/connectors/deepseek.ts
@@ -35,6 +35,5 @@ export const deepseek = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/defillama.ts
+++ b/turbo/packages/connectors/src/connectors/defillama.ts
@@ -34,6 +34,5 @@ export const defillama = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/devto.ts
+++ b/turbo/packages/connectors/src/connectors/devto.ts
@@ -34,6 +34,5 @@ export const devto = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/diffbot.ts
+++ b/turbo/packages/connectors/src/connectors/diffbot.ts
@@ -33,6 +33,5 @@ export const diffbot = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/dify.ts
+++ b/turbo/packages/connectors/src/connectors/dify.ts
@@ -35,6 +35,5 @@ export const dify = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/discord-webhook.ts
+++ b/turbo/packages/connectors/src/connectors/discord-webhook.ts
@@ -33,6 +33,5 @@ export const discordWebhook = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/discord.ts
+++ b/turbo/packages/connectors/src/connectors/discord.ts
@@ -34,6 +34,5 @@ export const discord = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/docusign.ts
+++ b/turbo/packages/connectors/src/connectors/docusign.ts
@@ -47,6 +47,5 @@ export const docusign = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/doppler.ts
+++ b/turbo/packages/connectors/src/connectors/doppler.ts
@@ -34,6 +34,5 @@ export const doppler = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/doubao.ts
+++ b/turbo/packages/connectors/src/connectors/doubao.ts
@@ -36,6 +36,5 @@ export const doubao = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/drive9.ts
+++ b/turbo/packages/connectors/src/connectors/drive9.ts
@@ -34,6 +34,5 @@ export const drive9 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/dropbox-sign.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox-sign.ts
@@ -35,6 +35,5 @@ export const dropboxSign = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/dropbox.ts
+++ b/turbo/packages/connectors/src/connectors/dropbox.ts
@@ -76,6 +76,5 @@ export const dropbox = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/duffel.ts
+++ b/turbo/packages/connectors/src/connectors/duffel.ts
@@ -34,6 +34,5 @@ export const duffel = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/e2b.ts
+++ b/turbo/packages/connectors/src/connectors/e2b.ts
@@ -34,6 +34,5 @@ export const e2b = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/elevenlabs.ts
+++ b/turbo/packages/connectors/src/connectors/elevenlabs.ts
@@ -35,6 +35,5 @@ export const elevenlabs = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/etherscan.ts
+++ b/turbo/packages/connectors/src/connectors/etherscan.ts
@@ -33,6 +33,5 @@ export const etherscan = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/etsy.ts
+++ b/turbo/packages/connectors/src/connectors/etsy.ts
@@ -37,6 +37,5 @@ export const etsy = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/exa.ts
+++ b/turbo/packages/connectors/src/connectors/exa.ts
@@ -34,6 +34,5 @@ export const exa = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/explorium.ts
+++ b/turbo/packages/connectors/src/connectors/explorium.ts
@@ -34,6 +34,5 @@ export const explorium = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/faire.ts
+++ b/turbo/packages/connectors/src/connectors/faire.ts
@@ -42,6 +42,5 @@ export const faire = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/fal.ts
+++ b/turbo/packages/connectors/src/connectors/fal.ts
@@ -35,6 +35,5 @@ export const fal = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/figma.ts
+++ b/turbo/packages/connectors/src/connectors/figma.ts
@@ -82,6 +82,5 @@ export const figma = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/firecrawl.ts
+++ b/turbo/packages/connectors/src/connectors/firecrawl.ts
@@ -34,6 +34,5 @@ export const firecrawl = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/fireflies.ts
+++ b/turbo/packages/connectors/src/connectors/fireflies.ts
@@ -33,6 +33,5 @@ export const fireflies = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/flightaware.ts
+++ b/turbo/packages/connectors/src/connectors/flightaware.ts
@@ -33,6 +33,5 @@ export const flightaware = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/freshdesk.ts
+++ b/turbo/packages/connectors/src/connectors/freshdesk.ts
@@ -41,6 +41,5 @@ export const freshdesk = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/gamma.ts
+++ b/turbo/packages/connectors/src/connectors/gamma.ts
@@ -35,6 +35,5 @@ export const gamma = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/garmin-connect.ts
+++ b/turbo/packages/connectors/src/connectors/garmin-connect.ts
@@ -50,6 +50,5 @@ export const garminConnect = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/gemini.ts
+++ b/turbo/packages/connectors/src/connectors/gemini.ts
@@ -36,6 +36,5 @@ export const gemini = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/github.ts
+++ b/turbo/packages/connectors/src/connectors/github.ts
@@ -43,6 +43,5 @@ export const github = {
         },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/gitlab.ts
+++ b/turbo/packages/connectors/src/connectors/gitlab.ts
@@ -44,6 +44,5 @@ export const gitlab = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/gmail.ts
+++ b/turbo/packages/connectors/src/connectors/gmail.ts
@@ -45,6 +45,5 @@ export const gmail = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/gong.ts
+++ b/turbo/packages/connectors/src/connectors/gong.ts
@@ -46,6 +46,5 @@ export const gong = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-ads.ts
+++ b/turbo/packages/connectors/src/connectors/google-ads.ts
@@ -52,6 +52,5 @@ export const googleAds = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-analytics.ts
+++ b/turbo/packages/connectors/src/connectors/google-analytics.ts
@@ -63,6 +63,5 @@ export const googleAnalytics = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/google-calendar.ts
@@ -52,6 +52,5 @@ export const googleCalendar = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-cloud.ts
+++ b/turbo/packages/connectors/src/connectors/google-cloud.ts
@@ -63,6 +63,5 @@ export const googleCloud = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-docs.ts
+++ b/turbo/packages/connectors/src/connectors/google-docs.ts
@@ -47,6 +47,5 @@ export const googleDocs = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-drive.ts
+++ b/turbo/packages/connectors/src/connectors/google-drive.ts
@@ -47,6 +47,5 @@ export const googleDrive = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-maps.ts
+++ b/turbo/packages/connectors/src/connectors/google-maps.ts
@@ -36,6 +36,5 @@ export const googleMaps = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-meet.ts
+++ b/turbo/packages/connectors/src/connectors/google-meet.ts
@@ -53,6 +53,5 @@ export const googleMeet = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-search-console.ts
+++ b/turbo/packages/connectors/src/connectors/google-search-console.ts
@@ -63,6 +63,5 @@ export const googleSearchConsole = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/google-sheets.ts
+++ b/turbo/packages/connectors/src/connectors/google-sheets.ts
@@ -50,6 +50,5 @@ export const googleSheets = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/granola.ts
+++ b/turbo/packages/connectors/src/connectors/granola.ts
@@ -34,6 +34,5 @@ export const granola = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/greenhouse.ts
+++ b/turbo/packages/connectors/src/connectors/greenhouse.ts
@@ -34,6 +34,5 @@ export const greenhouse = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/groq.ts
+++ b/turbo/packages/connectors/src/connectors/groq.ts
@@ -36,6 +36,5 @@ export const groq = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/gumroad.ts
+++ b/turbo/packages/connectors/src/connectors/gumroad.ts
@@ -78,6 +78,5 @@ export const gumroad = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/helicone.ts
+++ b/turbo/packages/connectors/src/connectors/helicone.ts
@@ -33,6 +33,5 @@ export const helicone = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/heygen.ts
+++ b/turbo/packages/connectors/src/connectors/heygen.ts
@@ -35,6 +35,5 @@ export const heygen = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/hitem3d.ts
+++ b/turbo/packages/connectors/src/connectors/hitem3d.ts
@@ -42,6 +42,5 @@ export const hitem3d = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/honcho.ts
+++ b/turbo/packages/connectors/src/connectors/honcho.ts
@@ -34,6 +34,5 @@ export const honcho = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/htmlcsstoimage.ts
+++ b/turbo/packages/connectors/src/connectors/htmlcsstoimage.ts
@@ -40,6 +40,5 @@ export const htmlcsstoimage = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/hubspot.ts
+++ b/turbo/packages/connectors/src/connectors/hubspot.ts
@@ -58,6 +58,5 @@ export const hubspot = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/hugging-face.ts
+++ b/turbo/packages/connectors/src/connectors/hugging-face.ts
@@ -35,6 +35,5 @@ export const huggingFace = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/hume.ts
+++ b/turbo/packages/connectors/src/connectors/hume.ts
@@ -34,6 +34,5 @@ export const hume = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/hunter.ts
+++ b/turbo/packages/connectors/src/connectors/hunter.ts
@@ -33,6 +33,5 @@ export const hunter = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/imgur.ts
+++ b/turbo/packages/connectors/src/connectors/imgur.ts
@@ -33,6 +33,5 @@ export const imgur = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/infisical.ts
+++ b/turbo/packages/connectors/src/connectors/infisical.ts
@@ -34,6 +34,5 @@ export const infisical = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/instagram.ts
+++ b/turbo/packages/connectors/src/connectors/instagram.ts
@@ -40,6 +40,5 @@ export const instagram = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/instantly.ts
+++ b/turbo/packages/connectors/src/connectors/instantly.ts
@@ -34,6 +34,5 @@ export const instantly = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/intercom.ts
+++ b/turbo/packages/connectors/src/connectors/intercom.ts
@@ -33,6 +33,5 @@ export const intercom = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/intervals-icu.ts
+++ b/turbo/packages/connectors/src/connectors/intervals-icu.ts
@@ -36,6 +36,5 @@ export const intervalsIcu = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/ironclad.ts
+++ b/turbo/packages/connectors/src/connectors/ironclad.ts
@@ -41,6 +41,5 @@ export const ironclad = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/jam.ts
+++ b/turbo/packages/connectors/src/connectors/jam.ts
@@ -34,6 +34,5 @@ export const jam = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/jira.ts
+++ b/turbo/packages/connectors/src/connectors/jira.ts
@@ -48,6 +48,5 @@ export const jira = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/jotform.ts
+++ b/turbo/packages/connectors/src/connectors/jotform.ts
@@ -33,6 +33,5 @@ export const jotform = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/klaviyo.ts
+++ b/turbo/packages/connectors/src/connectors/klaviyo.ts
@@ -34,6 +34,5 @@ export const klaviyo = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/kommo.ts
+++ b/turbo/packages/connectors/src/connectors/kommo.ts
@@ -40,6 +40,5 @@ export const kommo = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/langfuse.ts
+++ b/turbo/packages/connectors/src/connectors/langfuse.ts
@@ -41,6 +41,5 @@ export const langfuse = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/langsmith.ts
+++ b/turbo/packages/connectors/src/connectors/langsmith.ts
@@ -34,6 +34,5 @@ export const langsmith = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/lark.ts
+++ b/turbo/packages/connectors/src/connectors/lark.ts
@@ -47,6 +47,5 @@ export const lark = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/line.ts
+++ b/turbo/packages/connectors/src/connectors/line.ts
@@ -33,6 +33,5 @@ export const line = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/linear.ts
+++ b/turbo/packages/connectors/src/connectors/linear.ts
@@ -56,6 +56,5 @@ export const linear = {
         },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/loops.ts
+++ b/turbo/packages/connectors/src/connectors/loops.ts
@@ -34,6 +34,5 @@ export const loops = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/luma-ai.ts
+++ b/turbo/packages/connectors/src/connectors/luma-ai.ts
@@ -35,6 +35,5 @@ export const lumaAi = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/luma.ts
+++ b/turbo/packages/connectors/src/connectors/luma.ts
@@ -35,6 +35,5 @@ export const luma = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mailchimp.ts
+++ b/turbo/packages/connectors/src/connectors/mailchimp.ts
@@ -64,6 +64,5 @@ export const mailchimp = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mailsac.ts
+++ b/turbo/packages/connectors/src/connectors/mailsac.ts
@@ -34,6 +34,5 @@ export const mailsac = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/make.ts
+++ b/turbo/packages/connectors/src/connectors/make.ts
@@ -33,6 +33,5 @@ export const make = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/manus.ts
+++ b/turbo/packages/connectors/src/connectors/manus.ts
@@ -34,6 +34,5 @@ export const manus = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mapbox.ts
+++ b/turbo/packages/connectors/src/connectors/mapbox.ts
@@ -34,6 +34,5 @@ export const mapbox = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/massive.ts
+++ b/turbo/packages/connectors/src/connectors/massive.ts
@@ -35,6 +35,5 @@ export const massive = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mathpix.ts
+++ b/turbo/packages/connectors/src/connectors/mathpix.ts
@@ -39,6 +39,5 @@ export const mathpix = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mem0.ts
+++ b/turbo/packages/connectors/src/connectors/mem0.ts
@@ -34,6 +34,5 @@ export const mem0 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mercury.ts
+++ b/turbo/packages/connectors/src/connectors/mercury.ts
@@ -73,6 +73,5 @@ export const mercury = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/meshy.ts
+++ b/turbo/packages/connectors/src/connectors/meshy.ts
@@ -35,6 +35,5 @@ export const meshy = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -56,6 +56,5 @@ export const metaAds = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/metabase.ts
+++ b/turbo/packages/connectors/src/connectors/metabase.ts
@@ -40,6 +40,5 @@ export const metabase = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/minimax.ts
+++ b/turbo/packages/connectors/src/connectors/minimax.ts
@@ -35,6 +35,5 @@ export const minimax = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/minio.ts
+++ b/turbo/packages/connectors/src/connectors/minio.ts
@@ -47,6 +47,5 @@ export const minio = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/miro.ts
+++ b/turbo/packages/connectors/src/connectors/miro.ts
@@ -34,6 +34,5 @@ export const miro = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/mixpanel.ts
+++ b/turbo/packages/connectors/src/connectors/mixpanel.ts
@@ -52,6 +52,5 @@ export const mixpanel = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/modal.ts
+++ b/turbo/packages/connectors/src/connectors/modal.ts
@@ -51,6 +51,5 @@ export const modal = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/monday.ts
+++ b/turbo/packages/connectors/src/connectors/monday.ts
@@ -60,6 +60,5 @@ export const monday = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/moss.ts
+++ b/turbo/packages/connectors/src/connectors/moss.ts
@@ -41,6 +41,5 @@ export const moss = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/msg9.ts
+++ b/turbo/packages/connectors/src/connectors/msg9.ts
@@ -34,6 +34,5 @@ export const msg9 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/n8n.ts
+++ b/turbo/packages/connectors/src/connectors/n8n.ts
@@ -41,6 +41,5 @@ export const n8n = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/neon.ts
+++ b/turbo/packages/connectors/src/connectors/neon.ts
@@ -80,6 +80,5 @@ export const neon = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/netdata.ts
+++ b/turbo/packages/connectors/src/connectors/netdata.ts
@@ -35,6 +35,5 @@ export const netdata = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/notion.ts
+++ b/turbo/packages/connectors/src/connectors/notion.ts
@@ -45,6 +45,5 @@ export const notion = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/novita.ts
+++ b/turbo/packages/connectors/src/connectors/novita.ts
@@ -35,6 +35,5 @@ export const novita = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/nyne.ts
+++ b/turbo/packages/connectors/src/connectors/nyne.ts
@@ -38,6 +38,5 @@ export const nyne = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/onyx.ts
+++ b/turbo/packages/connectors/src/connectors/onyx.ts
@@ -34,6 +34,5 @@ export const onyx = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/openai.ts
+++ b/turbo/packages/connectors/src/connectors/openai.ts
@@ -36,6 +36,5 @@ export const openai = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/openrouter.ts
+++ b/turbo/packages/connectors/src/connectors/openrouter.ts
@@ -35,6 +35,5 @@ export const openrouter = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/openweather.ts
+++ b/turbo/packages/connectors/src/connectors/openweather.ts
@@ -33,6 +33,5 @@ export const openweather = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/outlook-calendar.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-calendar.ts
@@ -50,6 +50,5 @@ export const outlookCalendar = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/outlook-mail.ts
+++ b/turbo/packages/connectors/src/connectors/outlook-mail.ts
@@ -51,6 +51,5 @@ export const outlookMail = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pandadoc.ts
+++ b/turbo/packages/connectors/src/connectors/pandadoc.ts
@@ -34,6 +34,5 @@ export const pandadoc = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/parallel.ts
+++ b/turbo/packages/connectors/src/connectors/parallel.ts
@@ -34,6 +34,5 @@ export const parallel = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pdf4me.ts
+++ b/turbo/packages/connectors/src/connectors/pdf4me.ts
@@ -35,6 +35,5 @@ export const pdf4me = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pdfco.ts
+++ b/turbo/packages/connectors/src/connectors/pdfco.ts
@@ -33,6 +33,5 @@ export const pdfco = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pdforge.ts
+++ b/turbo/packages/connectors/src/connectors/pdforge.ts
@@ -35,6 +35,5 @@ export const pdforge = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/people-data-labs.ts
+++ b/turbo/packages/connectors/src/connectors/people-data-labs.ts
@@ -34,6 +34,5 @@ export const peopleDataLabs = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/perplexity.ts
+++ b/turbo/packages/connectors/src/connectors/perplexity.ts
@@ -35,6 +35,5 @@ export const perplexity = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pika.ts
+++ b/turbo/packages/connectors/src/connectors/pika.ts
@@ -34,6 +34,5 @@ export const pika = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pinecone.ts
+++ b/turbo/packages/connectors/src/connectors/pinecone.ts
@@ -34,6 +34,5 @@ export const pinecone = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pipedream.ts
+++ b/turbo/packages/connectors/src/connectors/pipedream.ts
@@ -34,6 +34,5 @@ export const pipedream = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pipedrive.ts
+++ b/turbo/packages/connectors/src/connectors/pipedrive.ts
@@ -34,6 +34,5 @@ export const pipedrive = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/plain.ts
+++ b/turbo/packages/connectors/src/connectors/plain.ts
@@ -34,6 +34,5 @@ export const plain = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/plausible.ts
+++ b/turbo/packages/connectors/src/connectors/plausible.ts
@@ -34,6 +34,5 @@ export const plausible = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/podchaser.ts
+++ b/turbo/packages/connectors/src/connectors/podchaser.ts
@@ -34,6 +34,5 @@ export const podchaser = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/porkbun.ts
+++ b/turbo/packages/connectors/src/connectors/porkbun.ts
@@ -40,6 +40,5 @@ export const porkbun = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/posthog.ts
+++ b/turbo/packages/connectors/src/connectors/posthog.ts
@@ -98,6 +98,5 @@ export const posthog = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/printful.ts
+++ b/turbo/packages/connectors/src/connectors/printful.ts
@@ -37,6 +37,5 @@ export const printful = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/prisma-postgres.ts
+++ b/turbo/packages/connectors/src/connectors/prisma-postgres.ts
@@ -34,6 +34,5 @@ export const prismaPostgres = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/productlane.ts
+++ b/turbo/packages/connectors/src/connectors/productlane.ts
@@ -32,6 +32,5 @@ export const productlane = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/pushinator.ts
+++ b/turbo/packages/connectors/src/connectors/pushinator.ts
@@ -32,6 +32,5 @@ export const pushinator = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/qdrant.ts
+++ b/turbo/packages/connectors/src/connectors/qdrant.ts
@@ -41,6 +41,5 @@ export const qdrant = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/qiita.ts
+++ b/turbo/packages/connectors/src/connectors/qiita.ts
@@ -34,6 +34,5 @@ export const qiita = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/railway-project.ts
+++ b/turbo/packages/connectors/src/connectors/railway-project.ts
@@ -34,6 +34,5 @@ export const railwayProject = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/railway.ts
+++ b/turbo/packages/connectors/src/connectors/railway.ts
@@ -34,6 +34,5 @@ export const railway = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/reap.ts
+++ b/turbo/packages/connectors/src/connectors/reap.ts
@@ -49,6 +49,5 @@ export const reap = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/recraft.ts
+++ b/turbo/packages/connectors/src/connectors/recraft.ts
@@ -34,6 +34,5 @@ export const recraft = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/reddit.ts
+++ b/turbo/packages/connectors/src/connectors/reddit.ts
@@ -47,6 +47,5 @@ export const reddit = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/reducto.ts
+++ b/turbo/packages/connectors/src/connectors/reducto.ts
@@ -33,6 +33,5 @@ export const reducto = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/rentcast.ts
+++ b/turbo/packages/connectors/src/connectors/rentcast.ts
@@ -34,6 +34,5 @@ export const rentcast = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/replicate.ts
+++ b/turbo/packages/connectors/src/connectors/replicate.ts
@@ -35,6 +35,5 @@ export const replicate = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/reportei.ts
+++ b/turbo/packages/connectors/src/connectors/reportei.ts
@@ -34,6 +34,5 @@ export const reportei = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/resend.ts
+++ b/turbo/packages/connectors/src/connectors/resend.ts
@@ -34,6 +34,5 @@ export const resend = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/revenuecat.ts
+++ b/turbo/packages/connectors/src/connectors/revenuecat.ts
@@ -34,6 +34,5 @@ export const revenuecat = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/runway.ts
+++ b/turbo/packages/connectors/src/connectors/runway.ts
@@ -35,6 +35,5 @@ export const runway = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/salesforce.ts
+++ b/turbo/packages/connectors/src/connectors/salesforce.ts
@@ -39,6 +39,5 @@ export const salesforce = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/scrapeninja.ts
+++ b/turbo/packages/connectors/src/connectors/scrapeninja.ts
@@ -31,6 +31,5 @@ export const scrapeninja = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/segment.ts
+++ b/turbo/packages/connectors/src/connectors/segment.ts
@@ -35,6 +35,5 @@ export const segment = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/semrush.ts
+++ b/turbo/packages/connectors/src/connectors/semrush.ts
@@ -41,6 +41,5 @@ export const semrush = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/sendgrid.ts
+++ b/turbo/packages/connectors/src/connectors/sendgrid.ts
@@ -35,6 +35,5 @@ export const sendgrid = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/sentry.ts
+++ b/turbo/packages/connectors/src/connectors/sentry.ts
@@ -52,6 +52,5 @@ export const sentry = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/serpapi.ts
+++ b/turbo/packages/connectors/src/connectors/serpapi.ts
@@ -34,6 +34,5 @@ export const serpapi = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/servicenow.ts
+++ b/turbo/packages/connectors/src/connectors/servicenow.ts
@@ -48,6 +48,5 @@ export const servicenow = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/shopify.ts
+++ b/turbo/packages/connectors/src/connectors/shopify.ts
@@ -42,6 +42,5 @@ export const shopify = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/shortio.ts
+++ b/turbo/packages/connectors/src/connectors/shortio.ts
@@ -34,6 +34,5 @@ export const shortio = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/similarweb.ts
+++ b/turbo/packages/connectors/src/connectors/similarweb.ts
@@ -34,6 +34,5 @@ export const similarweb = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/slack-webhook.ts
+++ b/turbo/packages/connectors/src/connectors/slack-webhook.ts
@@ -33,6 +33,5 @@ export const slackWebhook = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/slack.ts
+++ b/turbo/packages/connectors/src/connectors/slack.ts
@@ -75,6 +75,5 @@ export const slack = {
         },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/slock.ts
+++ b/turbo/packages/connectors/src/connectors/slock.ts
@@ -48,6 +48,5 @@ export const slock = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/snowflake.ts
+++ b/turbo/packages/connectors/src/connectors/snowflake.ts
@@ -42,6 +42,5 @@ export const snowflake = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/sociavault.ts
+++ b/turbo/packages/connectors/src/connectors/sociavault.ts
@@ -33,6 +33,5 @@ export const sociavault = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/sponge.ts
+++ b/turbo/packages/connectors/src/connectors/sponge.ts
@@ -35,6 +35,5 @@ export const sponge = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/spotify.ts
+++ b/turbo/packages/connectors/src/connectors/spotify.ts
@@ -67,6 +67,5 @@ export const spotify = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/sproutgigs.ts
+++ b/turbo/packages/connectors/src/connectors/sproutgigs.ts
@@ -49,6 +49,5 @@ export const sproutgigs = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/square.ts
+++ b/turbo/packages/connectors/src/connectors/square.ts
@@ -34,6 +34,5 @@ export const square = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/stability-ai.ts
+++ b/turbo/packages/connectors/src/connectors/stability-ai.ts
@@ -35,6 +35,5 @@ export const stabilityAi = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/strapi.ts
+++ b/turbo/packages/connectors/src/connectors/strapi.ts
@@ -40,6 +40,5 @@ export const strapi = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/strava.ts
+++ b/turbo/packages/connectors/src/connectors/strava.ts
@@ -50,6 +50,5 @@ export const strava = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/streak.ts
+++ b/turbo/packages/connectors/src/connectors/streak.ts
@@ -34,6 +34,5 @@ export const streak = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -113,6 +113,5 @@ export const stripe = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/supabase.ts
+++ b/turbo/packages/connectors/src/connectors/supabase.ts
@@ -86,6 +86,5 @@ export const supabase = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/supadata.ts
+++ b/turbo/packages/connectors/src/connectors/supadata.ts
@@ -34,6 +34,5 @@ export const supadata = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/supermemory.ts
+++ b/turbo/packages/connectors/src/connectors/supermemory.ts
@@ -34,6 +34,5 @@ export const supermemory = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/tavily.ts
+++ b/turbo/packages/connectors/src/connectors/tavily.ts
@@ -34,6 +34,5 @@ export const tavily = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/test-oauth-device.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth-device.ts
@@ -79,6 +79,5 @@ export const testOauthDevice = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/test-oauth.ts
+++ b/turbo/packages/connectors/src/connectors/test-oauth.ts
@@ -159,6 +159,5 @@ export const testOauth = {
         revoke: TEST_OAUTH_REVOKE,
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/testrail.ts
+++ b/turbo/packages/connectors/src/connectors/testrail.ts
@@ -48,6 +48,5 @@ export const testrail = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/ticketmaster.ts
+++ b/turbo/packages/connectors/src/connectors/ticketmaster.ts
@@ -34,6 +34,5 @@ export const ticketmaster = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/tiktok-ads.ts
+++ b/turbo/packages/connectors/src/connectors/tiktok-ads.ts
@@ -49,6 +49,5 @@ export const tiktokAds = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/tldv.ts
+++ b/turbo/packages/connectors/src/connectors/tldv.ts
@@ -34,6 +34,5 @@ export const tldv = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/todoist.ts
+++ b/turbo/packages/connectors/src/connectors/todoist.ts
@@ -36,6 +36,5 @@ export const todoist = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/together.ts
+++ b/turbo/packages/connectors/src/connectors/together.ts
@@ -36,6 +36,5 @@ export const together = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/tripo.ts
+++ b/turbo/packages/connectors/src/connectors/tripo.ts
@@ -35,6 +35,5 @@ export const tripo = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/twenty.ts
+++ b/turbo/packages/connectors/src/connectors/twenty.ts
@@ -34,6 +34,5 @@ export const twenty = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/twilio.ts
+++ b/turbo/packages/connectors/src/connectors/twilio.ts
@@ -41,6 +41,5 @@ export const twilio = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/typeform.ts
+++ b/turbo/packages/connectors/src/connectors/typeform.ts
@@ -34,6 +34,5 @@ export const typeform = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/v0.ts
+++ b/turbo/packages/connectors/src/connectors/v0.ts
@@ -35,6 +35,5 @@ export const v0 = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/vercel.ts
+++ b/turbo/packages/connectors/src/connectors/vercel.ts
@@ -36,6 +36,5 @@ export const vercel = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/wandb.ts
+++ b/turbo/packages/connectors/src/connectors/wandb.ts
@@ -33,6 +33,5 @@ export const wandb = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/webflow.ts
+++ b/turbo/packages/connectors/src/connectors/webflow.ts
@@ -80,6 +80,5 @@ export const webflow = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/weread.ts
+++ b/turbo/packages/connectors/src/connectors/weread.ts
@@ -44,6 +44,5 @@ export const weread = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/whale-alert.ts
+++ b/turbo/packages/connectors/src/connectors/whale-alert.ts
@@ -34,6 +34,5 @@ export const whaleAlert = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/wix.ts
+++ b/turbo/packages/connectors/src/connectors/wix.ts
@@ -34,6 +34,5 @@ export const wix = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/workos.ts
+++ b/turbo/packages/connectors/src/connectors/workos.ts
@@ -34,6 +34,5 @@ export const workos = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/wrike.ts
+++ b/turbo/packages/connectors/src/connectors/wrike.ts
@@ -33,6 +33,5 @@ export const wrike = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/x.ts
+++ b/turbo/packages/connectors/src/connectors/x.ts
@@ -68,6 +68,5 @@ export const x = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/xero.ts
+++ b/turbo/packages/connectors/src/connectors/xero.ts
@@ -68,6 +68,5 @@ export const xero = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/youtube.ts
+++ b/turbo/packages/connectors/src/connectors/youtube.ts
@@ -34,6 +34,5 @@ export const youtube = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/zapier.ts
+++ b/turbo/packages/connectors/src/connectors/zapier.ts
@@ -34,6 +34,5 @@ export const zapier = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/zapsign.ts
+++ b/turbo/packages/connectors/src/connectors/zapsign.ts
@@ -34,6 +34,5 @@ export const zapsign = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/zendesk.ts
+++ b/turbo/packages/connectors/src/connectors/zendesk.ts
@@ -48,6 +48,5 @@ export const zendesk = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/zep.ts
+++ b/turbo/packages/connectors/src/connectors/zep.ts
@@ -34,6 +34,5 @@ export const zep = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/zeptomail.ts
+++ b/turbo/packages/connectors/src/connectors/zeptomail.ts
@@ -34,6 +34,5 @@ export const zeptomail = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "api-token",
   },
 } as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/zoom.ts
+++ b/turbo/packages/connectors/src/connectors/zoom.ts
@@ -62,6 +62,5 @@ export const zoom = {
         revoke: { kind: "none" },
       },
     },
-    defaultAuthMethod: "oauth",
   },
 } as const satisfies Record<string, ConnectorConfig>;


### PR DESCRIPTION
## Summary

- Remove unused `defaultAuthMethod` metadata from connector configs.
- Remove the connector-only type constraint and tests that existed only for that field.
- Keep model provider `defaultAuthMethod` unchanged because the model provider CLI still uses it for recommended auth-method display.

## Testing

- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm prettier --check packages/connectors/src/connectors.ts packages/connectors/src/__tests__/connectors.test.ts packages/connectors/src/connectors/*.ts`
- `pnpm check-types`
