### PR TITLE
feat(api): drop the transition aliases for the automation paths

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -190,22 +190,6 @@ export interface RouteEntry {
   readonly handler: SignalRouteHandler<unknown>;
 }
 
-/**
- * The automation resource API lived under /api/v2/* before #17307 moved it to
- * the clean /api/automations* paths. Clients built before the move (deployed
- * platform bundles, older CLI releases) still call the /v2 paths, so every
- * resource route is also mounted under its historical alias. Drop this once
- * those clients have aged out.
- */
-function withLegacyV2Alias(
-  entries: readonly RouteEntry[],
-): readonly RouteEntry[] {
-  return entries.flatMap((entry) => {
-    const aliasPath = entry.route.path.replace(/^\/api\//, "/api/v2/");
-    return [entry, { ...entry, route: { ...entry.route, path: aliasPath } }];
-  });
-}
-
 export const ROUTES: readonly RouteEntry[] = [
   {
     route: healthContract.check,
@@ -217,8 +201,7 @@ export const ROUTES: readonly RouteEntry[] = [
   // wins over the `/api/automations/:ref/...` params for that path shape.
   ...webhooksAutomationRoutes,
   // The unified Automation resource: one automation, N triggers of any kind.
-  // Mounted on /api/automations* plus the historical /api/v2/* alias paths.
-  ...withLegacyV2Alias(automationsV2Routes),
+  ...automationsV2Routes,
   ...cliAuthRoutes,
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations-v2.test.ts
@@ -223,34 +223,6 @@ describe("Automations v2 API", () => {
     });
   });
 
-  it("serves the historical /api/v2 alias paths during the transition", async () => {
-    // #17307 moved the resource API to /api/automations*; clients built
-    // before the move still call /api/v2/* and must keep working until they
-    // age out.
-    const fixture = await seedFixture();
-    await createAutomation({
-      name: "alias-check",
-      agentId: fixture.composeId,
-      trigger: { kind: "cron", cronExpression: "0 9 * * *" },
-    });
-
-    const v2AliasContract = {
-      list: {
-        ...automationsV2MainContract.list,
-        path: "/api/v2/automations",
-      },
-    } as const;
-    const aliasClient = setupApp({ context })(v2AliasContract);
-    const listed = await accept(
-      aliasClient.list({ headers: SESSION_HEADERS }),
-      [200],
-    );
-    const names = listed.body.automations.map((a) => {
-      return a.name;
-    });
-    expect(names).toContain("alias-check");
-  });
-
   it("creates an automation with a first cron trigger via sugar", async () => {
     const fixture = await seedFixture();
     await enableWebhookTriggers(fixture);

--- a/turbo/apps/api/src/signals/routes/cron-execute-automations.ts
+++ b/turbo/apps/api/src/signals/routes/cron-execute-automations.ts
@@ -32,13 +32,4 @@ export const cronExecuteAutomationsRoutes: readonly RouteEntry[] = [
     route: cronExecuteAutomationsContract.execute,
     handler: executeAutomationsRoute$,
   },
-  // The Vercel cron config flips to /api/cron/execute-automations with this
-  // release; the old path stays mounted for the deploy overlap, then goes.
-  {
-    route: {
-      ...cronExecuteAutomationsContract.execute,
-      path: "/api/cron/execute-schedules",
-    },
-    handler: executeAutomationsRoute$,
-  },
 ];

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -474,12 +474,12 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/cron")).toBe(false);
   });
 
-  it("matches the cron execute schedules rewrite path exactly", () => {
-    expect(matchesApiBackendRewritePath("/api/cron/execute-schedules")).toBe(
+  it("matches the cron execute automations rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/cron/execute-automations")).toBe(
       true,
     );
     expect(
-      matchesApiBackendRewritePath("/api/cron/execute-schedules/extra"),
+      matchesApiBackendRewritePath("/api/cron/execute-automations/extra"),
     ).toBe(false);
     expect(matchesApiBackendRewritePath("/api/cron")).toBe(false);
   });

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -458,10 +458,10 @@ const CRON_DRAIN_EMAIL_OUTBOX_NEXT_NEGATIVE_PATHS = [
   "/api/cron/drain-email-outbox/extra",
   "/api/cron",
 ] as const;
-const CRON_EXECUTE_SCHEDULES_REWRITE_SOURCE = "/api/cron/execute-schedules";
-const CRON_EXECUTE_SCHEDULES_PATH = "/api/cron/execute-schedules";
-const CRON_EXECUTE_SCHEDULES_NEXT_NEGATIVE_PATHS = [
-  "/api/cron/execute-schedules/extra",
+const CRON_EXECUTE_AUTOMATIONS_REWRITE_SOURCE = "/api/cron/execute-automations";
+const CRON_EXECUTE_AUTOMATIONS_PATH = "/api/cron/execute-automations";
+const CRON_EXECUTE_AUTOMATIONS_NEXT_NEGATIVE_PATHS = [
+  "/api/cron/execute-automations/extra",
   "/api/cron",
 ] as const;
 const CRON_PROCESS_USAGE_EVENTS_REWRITE_SOURCE =
@@ -2085,8 +2085,8 @@ describe("API backend rewrites", () => {
           destination: "https://api.example.test/api/cron/drain-email-outbox",
         },
         {
-          source: CRON_EXECUTE_SCHEDULES_REWRITE_SOURCE,
-          destination: "https://api.example.test/api/cron/execute-schedules",
+          source: CRON_EXECUTE_AUTOMATIONS_REWRITE_SOURCE,
+          destination: "https://api.example.test/api/cron/execute-automations",
         },
         {
           source: CRON_PROCESS_USAGE_EVENTS_REWRITE_SOURCE,
@@ -3643,25 +3643,25 @@ describe("API backend rewrites", () => {
     }
   });
 
-  it("should match only the exact cron execute schedules rewrite", async () => {
+  it("should match only the exact cron execute automations rewrite", async () => {
     vi.stubEnv("VM0_API_BACKEND_URL", "https://api.example.test");
 
     const rewrites = await getBeforeFileRewrites();
     const rewrite = rewrites.find((entry) => {
-      return entry.source === CRON_EXECUTE_SCHEDULES_REWRITE_SOURCE;
+      return entry.source === CRON_EXECUTE_AUTOMATIONS_REWRITE_SOURCE;
     });
     expect(rewrite).toStrictEqual({
-      source: CRON_EXECUTE_SCHEDULES_REWRITE_SOURCE,
-      destination: "https://api.example.test/api/cron/execute-schedules",
+      source: CRON_EXECUTE_AUTOMATIONS_REWRITE_SOURCE,
+      destination: "https://api.example.test/api/cron/execute-automations",
     });
 
-    const matcher = getPathMatch(CRON_EXECUTE_SCHEDULES_REWRITE_SOURCE, {
+    const matcher = getPathMatch(CRON_EXECUTE_AUTOMATIONS_REWRITE_SOURCE, {
       removeUnnamedParams: true,
       strict: true,
     });
 
-    expect(matcher(CRON_EXECUTE_SCHEDULES_PATH)).toStrictEqual({});
-    for (const pathname of CRON_EXECUTE_SCHEDULES_NEXT_NEGATIVE_PATHS) {
+    expect(matcher(CRON_EXECUTE_AUTOMATIONS_PATH)).toStrictEqual({});
+    for (const pathname of CRON_EXECUTE_AUTOMATIONS_NEXT_NEGATIVE_PATHS) {
       expect(matcher(pathname)).toBe(false);
     }
   });

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -59,8 +59,7 @@ const ZERO_LOGS_BY_ID_PATH_RE = new RegExp(
 const TEST_TELEGRAM_MOCK_REWRITE_SOURCE =
   "/api/test/telegram-mock/:botToken/:method";
 const TEST_TELEGRAM_MOCK_PATH_RE = /^\/api\/test\/telegram-mock\/[^/]+\/[^/]+$/;
-// The automation resource API on its clean paths (#17307); the /api/v2/*
-// entries below stay as transition aliases for clients built before the move.
+// The automation resource API on its clean paths (#17307).
 const AUTOMATIONS_BY_REF_REWRITE_SOURCE = "/api/automations/:ref";
 const AUTOMATIONS_BY_REF_PATH_RE = /^\/api\/automations\/[^/]+$/;
 const AUTOMATIONS_ENABLE_REWRITE_SOURCE = "/api/automations/:ref/enable";
@@ -86,36 +85,6 @@ const AUTOMATION_TRIGGERS_DISABLE_PATH_RE = new RegExp(
 const AUTOMATION_TRIGGERS_ROTATE_SECRET_REWRITE_SOURCE = `/api/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/rotate-secret`;
 const AUTOMATION_TRIGGERS_ROTATE_SECRET_PATH_RE = new RegExp(
   `^/api/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/rotate-secret$`,
-);
-const AUTOMATIONS_V2_BY_REF_REWRITE_SOURCE = "/api/v2/automations/:ref";
-const AUTOMATIONS_V2_BY_REF_PATH_RE = /^\/api\/v2\/automations\/[^/]+$/;
-const AUTOMATIONS_V2_ENABLE_REWRITE_SOURCE = "/api/v2/automations/:ref/enable";
-const AUTOMATIONS_V2_ENABLE_PATH_RE = /^\/api\/v2\/automations\/[^/]+\/enable$/;
-const AUTOMATIONS_V2_DISABLE_REWRITE_SOURCE =
-  "/api/v2/automations/:ref/disable";
-const AUTOMATIONS_V2_DISABLE_PATH_RE =
-  /^\/api\/v2\/automations\/[^/]+\/disable$/;
-const AUTOMATIONS_V2_RUN_REWRITE_SOURCE = "/api/v2/automations/:ref/run";
-const AUTOMATIONS_V2_RUN_PATH_RE = /^\/api\/v2\/automations\/[^/]+\/run$/;
-const AUTOMATIONS_V2_TRIGGERS_REWRITE_SOURCE =
-  "/api/v2/automations/:ref/triggers";
-const AUTOMATIONS_V2_TRIGGERS_PATH_RE =
-  /^\/api\/v2\/automations\/[^/]+\/triggers$/;
-const AUTOMATION_TRIGGERS_V2_BY_ID_REWRITE_SOURCE = `/api/v2/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})`;
-const AUTOMATION_TRIGGERS_V2_BY_ID_PATH_RE = new RegExp(
-  `^/api/v2/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}$`,
-);
-const AUTOMATION_TRIGGERS_V2_ENABLE_REWRITE_SOURCE = `/api/v2/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/enable`;
-const AUTOMATION_TRIGGERS_V2_ENABLE_PATH_RE = new RegExp(
-  `^/api/v2/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/enable$`,
-);
-const AUTOMATION_TRIGGERS_V2_DISABLE_REWRITE_SOURCE = `/api/v2/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/disable`;
-const AUTOMATION_TRIGGERS_V2_DISABLE_PATH_RE = new RegExp(
-  `^/api/v2/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/disable$`,
-);
-const AUTOMATION_TRIGGERS_V2_ROTATE_SECRET_REWRITE_SOURCE = `/api/v2/automation-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/rotate-secret`;
-const AUTOMATION_TRIGGERS_V2_ROTATE_SECRET_PATH_RE = new RegExp(
-  `^/api/v2/automation-triggers/${UUID_PATH_SEGMENT_PATTERN}/rotate-secret$`,
 );
 const AUTOMATIONS_WEBHOOK_INBOUND_REWRITE_SOURCE =
   "/api/automations/webhooks/:token";
@@ -553,7 +522,6 @@ export const API_BACKEND_REWRITES = [
   ],
   ["/api/cron/drain-email-outbox", "/api/cron/drain-email-outbox"],
   ["/api/cron/execute-automations", "/api/cron/execute-automations"],
-  ["/api/cron/execute-schedules", "/api/cron/execute-schedules"],
   ["/api/cron/process-usage-events", "/api/cron/process-usage-events"],
   [
     "/api/cron/reconcile-billing-entitlements",
@@ -1255,52 +1223,6 @@ export const API_BACKEND_REWRITES = [
     AUTOMATION_TRIGGERS_BY_ID_REWRITE_SOURCE,
     "/api/automation-triggers/:id",
     AUTOMATION_TRIGGERS_BY_ID_PATH_RE,
-  ],
-  ["/api/v2/automations", "/api/v2/automations"],
-  [
-    AUTOMATIONS_V2_ENABLE_REWRITE_SOURCE,
-    "/api/v2/automations/:ref/enable",
-    AUTOMATIONS_V2_ENABLE_PATH_RE,
-  ],
-  [
-    AUTOMATIONS_V2_DISABLE_REWRITE_SOURCE,
-    "/api/v2/automations/:ref/disable",
-    AUTOMATIONS_V2_DISABLE_PATH_RE,
-  ],
-  [
-    AUTOMATIONS_V2_RUN_REWRITE_SOURCE,
-    "/api/v2/automations/:ref/run",
-    AUTOMATIONS_V2_RUN_PATH_RE,
-  ],
-  [
-    AUTOMATIONS_V2_TRIGGERS_REWRITE_SOURCE,
-    "/api/v2/automations/:ref/triggers",
-    AUTOMATIONS_V2_TRIGGERS_PATH_RE,
-  ],
-  [
-    AUTOMATIONS_V2_BY_REF_REWRITE_SOURCE,
-    "/api/v2/automations/:ref",
-    AUTOMATIONS_V2_BY_REF_PATH_RE,
-  ],
-  [
-    AUTOMATION_TRIGGERS_V2_BY_ID_REWRITE_SOURCE,
-    "/api/v2/automation-triggers/:id",
-    AUTOMATION_TRIGGERS_V2_BY_ID_PATH_RE,
-  ],
-  [
-    AUTOMATION_TRIGGERS_V2_ENABLE_REWRITE_SOURCE,
-    "/api/v2/automation-triggers/:id/enable",
-    AUTOMATION_TRIGGERS_V2_ENABLE_PATH_RE,
-  ],
-  [
-    AUTOMATION_TRIGGERS_V2_DISABLE_REWRITE_SOURCE,
-    "/api/v2/automation-triggers/:id/disable",
-    AUTOMATION_TRIGGERS_V2_DISABLE_PATH_RE,
-  ],
-  [
-    AUTOMATION_TRIGGERS_V2_ROTATE_SECRET_REWRITE_SOURCE,
-    "/api/v2/automation-triggers/:id/rotate-secret",
-    AUTOMATION_TRIGGERS_V2_ROTATE_SECRET_PATH_RE,
   ],
   ["/api/zero/memory", "/api/zero/memory"],
   ["/api/zero/memory/activity", "/api/zero/memory/activity"],


### PR DESCRIPTION
## Summary

Follow-up 1 from the #17307 acceptance report — removes both transition bridges from the path move:

- **`/api/v2/*` dual-mount gone** (`withLegacyV2Alias` deleted from the route registry, v2 rewrite entries deleted from the web origin). Exposure check: the v2 paths were only ever reachable by staff — the resource API sat behind the `zeroAutomations` switch (staff-only) until #17340, and the very release that opened it to everyone also moved the CLI/platform to `/api/automations*`. Any pre-move staff CLI install gets a 404 and updates.
- **`/api/cron/execute-schedules` alias gone** (route entry + rewrite). The Vercel cron config has been invoking `/api/cron/execute-automations` since #17363's release; the alias never had a caller after that deploy.
- The `/api/v2` alias regression test is deleted with the alias; web rewrite-proxy and security-headers suites now pin the `execute-automations` path.

## Test plan

- [x] API: automations-v2 + cron poller + vercel-crons suites green (33 tests)
- [x] Web: rewrite-proxy + security-headers suites green (562 tests)
- [x] `check-types` (13/13), `lint`, `knip`, `format` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)