### PR TITLE
fix: bound skipped json number tokens

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -123,6 +123,7 @@ class _NumberState:
     selected: bool
     raw: bytearray | None
     max_bytes: int
+    bytes_seen: int = 0
     phase: str = "start"
 
 
@@ -758,10 +759,12 @@ class JsonSelectiveExtractor:
             self._error = "invalid number"
             return
 
+        state.bytes_seen += 1
+        if state.bytes_seen > state.max_bytes:
+            self._error = "number limit exceeded"
+            return
         if state.raw is not None:
             state.raw.append(b)
-            if len(state.raw) > state.max_bytes:
-                self._error = "number limit exceeded"
 
     def _finish_number(self) -> None:
         state = self._number

--- a/crates/runner/mitm-addon/tests/test_json_selective.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective.py
@@ -613,7 +613,7 @@ def test_rejects_oversized_number_with_field_limit():
     assert result.error == "number limit exceeded"
 
 
-def test_skips_oversized_unselected_number_without_storing_value():
+def test_rejects_oversized_unselected_number():
     extractor = JsonSelectiveExtractor(
         scalar_fields={("usage", "input_tokens"): ScalarField("int")},
         max_number_bytes=3,
@@ -622,8 +622,59 @@ def test_skips_oversized_unselected_number_without_storing_value():
     extractor.feed(b'{"content":{"score":1234567890},"usage":{"input_tokens":7}}')
     result = _finish(extractor)
 
+    assert result.complete is False
+    assert result.error == "number limit exceeded"
+    assert result.values == {}
+
+
+def test_skips_unselected_number_at_limit_without_storing_value():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")},
+        max_number_bytes=3,
+    )
+
+    extractor.feed(b'{"content":{"score":123},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
     assert result.complete is True
     assert result.values == {("usage", "input_tokens"): 7}
+
+
+def test_rejects_oversized_unselected_root_number_at_eof():
+    extractor = JsonSelectiveExtractor(max_number_bytes=3)
+
+    extractor.feed(b"1234")
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "number limit exceeded"
+    assert result.values == {}
+
+
+def test_rejects_oversized_unselected_number_across_chunks():
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")},
+        max_number_bytes=3,
+    )
+
+    extractor.feed(b'{"content":{"score":12')
+    extractor.feed(b'34},"usage":{"input_tokens":7}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "number limit exceeded"
+    assert result.values == {}
+
+
+def test_rejects_invalid_unselected_number_before_limit_exceeded():
+    extractor = JsonSelectiveExtractor(max_number_bytes=3)
+
+    extractor.feed(b'{"content":{"score":12x}}')
+    result = _finish(extractor)
+
+    assert result.complete is False
+    assert result.error == "invalid number"
+    assert result.values == {}
 
 
 def test_rejects_invalid_unselected_number():


### PR DESCRIPTION
## Summary

- enforce max_number_bytes for skipped JSON number tokens without buffering them
- keep selected number capture using the stricter field/global byte limit
- add parser regressions for unselected object, root, and split-chunk number bounds

## Tests

- /tmp/vm5-mitm-addon-test-venv/bin/python -m pytest tests/test_json_selective.py
- /tmp/vm5-mitm-addon-test-venv/bin/python -m pytest tests/test_openai_responses_sse.py tests/test_anthropic_messages.py tests/test_model_provider_response_usage.py tests/test_x_connector_usage.py
- /tmp/vm5-mitm-addon-test-venv/bin/python -m ruff check src/usage/json_selective.py tests/test_json_selective.py
- /tmp/vm5-mitm-addon-test-venv/bin/python -m ruff format --check src/usage/json_selective.py tests/test_json_selective.py
- /tmp/vm5-mitm-addon-test-venv/bin/basedpyright -p . --pythonpath /tmp/vm5-mitm-addon-test-venv/bin/python

Closes #17375