### PR TITLE
refactor: centralize connector auth method filtering

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -16,7 +16,7 @@ import {
 import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
-  getConfiguredConnectorAuthMethodIds,
+  getAvailableConnectorAuthMethodIds,
   getConnectorTags,
   hasRequiredConnectorAuthMethodScopes,
   hasConnectorDeviceAuthGrant,
@@ -103,36 +103,6 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 
 type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
-
-function getAvailableConnectorConnectAuthMethods(
-  type: ConnectorType,
-  featureStates: Record<string, boolean> | null | undefined,
-  options: {
-    readonly includeManagedForTypes: readonly ConnectorType[];
-  },
-): ConnectorAuthMethodId[] {
-  return getConfiguredConnectorAuthMethodIds(type).filter((authMethod) => {
-    const method = getConnectorAuthMethod(type, authMethod);
-    switch (method?.grant.kind) {
-      case "managed": {
-        if (!options.includeManagedForTypes.includes(type)) {
-          return false;
-        }
-        break;
-      }
-      case "auth-code":
-      case "external-code":
-      case "device-auth":
-      case "manual": {
-        break;
-      }
-      case undefined: {
-        return false;
-      }
-    }
-    return !method.featureFlag || !!featureStates?.[method.featureFlag];
-  });
-}
 
 export function getConnectorConnectLaunchMode({
   type,
@@ -258,12 +228,9 @@ function buildConnectorTypeStatus(params: {
   readonly features: Record<string, boolean> | null | undefined;
 }): ConnectorTypeWithStatus {
   const config = CONNECTOR_TYPES[params.type];
-  const availableAuthMethods = getAvailableConnectorConnectAuthMethods(
+  const availableAuthMethods = getAvailableConnectorAuthMethodIds(
     params.type,
     params.features,
-    {
-      includeManagedForTypes: [],
-    },
   );
   const hasManualGrant = availableAuthMethods.some((authMethod) => {
     return (
@@ -365,11 +332,7 @@ export const allConnectorTypes$ = computed(async (get) => {
   );
 
   const items = CONNECTOR_TYPE_KEYS.filter((type) => {
-    return (
-      getAvailableConnectorConnectAuthMethods(type, features, {
-        includeManagedForTypes: [],
-      }).length > 0
-    );
+    return getAvailableConnectorAuthMethodIds(type, features).length > 0;
   }).map((type) => {
     return buildConnectorTypeStatus({
       type,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -306,25 +306,25 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.CloudflareConnector]: false },
+      featureSwitches: { [FeatureSwitchKey.StripeConnector]: false },
     });
 
     const searchInput = await screen.findByPlaceholderText("Find connectors");
-    await fill(searchInput, "cloudflare");
-    click(await screen.findByLabelText("Connect Cloudflare"));
+    await fill(searchInput, "stripe");
+    click(await screen.findByLabelText("Connect Stripe"));
 
     const connectDialog = await screen.findByRole("dialog", {
-      name: "Cloudflare",
+      name: "Stripe",
     });
-    expect(within(connectDialog).getByText("API Token")).toBeInTheDocument();
-    expect(within(connectDialog).queryByText("OAuth")).not.toBeInTheDocument();
-    const buttonLabels = queryAllByRoleFast("button", connectDialog).map(
-      (button) => {
-        return button.textContent?.replace(/\s+/g, " ").trim();
-      },
-    );
-    expect(buttonLabels).not.toContain("Connect");
-    expect(buttonLabels).toContain("Save");
+    expect(
+      within(connectDialog).getByText("Sign in with Stripe"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectDialog).getAllByText("API Key").length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(connectDialog).queryByText("OAuth (Recommended)"),
+    ).not.toBeInTheDocument();
   });
 
   it("completes a device-auth connector grant", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -282,6 +282,51 @@ describe("connectors page", () => {
     });
   });
 
+  it("hides a fully feature-gated connector when its switch is disabled", async () => {
+    mockConnectors([]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.AwsConnector]: false },
+    });
+
+    const searchInput = await screen.findByPlaceholderText("Find connectors");
+    await fill(searchInput, "aws");
+
+    await waitFor(() => {
+      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
+  });
+
+  it("shows a partially gated connector with only ungated auth methods", async () => {
+    mockConnectors([]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.CloudflareConnector]: false },
+    });
+
+    const searchInput = await screen.findByPlaceholderText("Find connectors");
+    await fill(searchInput, "cloudflare");
+    click(await screen.findByLabelText("Connect Cloudflare"));
+
+    const connectDialog = await screen.findByRole("dialog", {
+      name: "Cloudflare",
+    });
+    expect(within(connectDialog).getByText("API Token")).toBeInTheDocument();
+    expect(within(connectDialog).queryByText("OAuth")).not.toBeInTheDocument();
+    const buttonLabels = queryAllByRoleFast("button", connectDialog).map(
+      (button) => {
+        return button.textContent?.replace(/\s+/g, " ").trim();
+      },
+    );
+    expect(buttonLabels).not.toContain("Connect");
+    expect(buttonLabels).toContain("Save");
+  });
+
   it("completes a device-auth connector grant", async () => {
     mockConnectors([]);
 

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -89,7 +89,7 @@ export function getConfiguredConnectorAuthMethodIds(
  * Connector utility vocabulary:
  *
  * - Available auth methods are user-selectable connection flows after
- *   feature-switch filtering.
+ *   feature-switch and surface policy filtering.
  * - Runtime available connector types are connector types the current server
  *   environment can offer as connection candidates.
  * - User connected connector types come from persisted connector rows.


### PR DESCRIPTION
## Summary
- replace the app connectors page duplicate auth-method availability filter with the shared connectors helper
- keep managed/API policy behavior unchanged for the connect UI by using the shared helper default policy
- add page-level regression coverage for fully gated and partially gated connector auth methods

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/connectors check-types
- pnpm format
- git diff --check

Closes #17382