### PR TITLE
fix(runner): resolve runs from live registry status

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -2156,7 +2156,6 @@ mod tests {
         let discovered = process::DiscoveredProcesses {
             runners: vec![process::RunnerProcessInfo {
                 pid: std::process::id(),
-                config_path: fixture.config_path,
             }],
             ..empty_discovered()
         };

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -8,7 +8,7 @@ use clap::Args;
 use sandbox::{SandboxControl, SandboxControlError};
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::process;
+use crate::paths::HomePaths;
 use crate::run_resolution;
 
 // ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@ fn shell_quote(arg: &str) -> String {
 /// Executes the requested command inside a running sandbox.
 ///
 /// `--sandbox` targets are used directly as sandbox identifiers. `--run`
-/// targets are resolved through the current runner process state before
+/// targets are resolved through trusted live runner status before
 /// dispatching to [`SandboxControl::exec_remote`].
 ///
 /// Guest stdout and stderr are forwarded to local stdout and stderr. The guest
@@ -99,8 +99,8 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
     let sandbox_id = if let Some(ref sid) = args.sandbox {
         sid.clone()
     } else if let Some(ref rid) = args.run {
-        let discovered = process::discover_all().await;
-        let mappings = run_resolution::collect_active_run_mappings(&discovered.runners).await;
+        let home = HomePaths::new()?;
+        let mappings = run_resolution::collect_active_run_mappings_from_home(&home).await;
         run_resolution::resolve_run_to_sandbox(rid, &mappings)?
     } else {
         // clap group guarantees one is set — this branch is unreachable.

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -23,6 +23,7 @@ use sandbox::{RemoteKillResult, SandboxControl, SandboxControlError};
 use tracing::info;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
 use crate::process::{
     self, DiscoveredProcesses, FirecrackerProcessIdentity, FirecrackerProcessInfo, ProcessStat,
 };
@@ -227,7 +228,13 @@ impl KillOutcome {
 async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKillTarget> {
     let discovered = process::discover_all().await;
     let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
-    let resolved = resolve_target(args, &discovered).await?;
+    let run_mappings = if args.run.is_some() {
+        let home = HomePaths::new()?;
+        Some(run_resolution::collect_active_run_mappings_from_home(&home).await)
+    } else {
+        None
+    };
+    let resolved = resolve_target(args, &discovered, run_mappings.as_ref())?;
     let mut target = KillTarget::from(resolved.process);
     target.run_id = resolved.run_id;
 
@@ -237,13 +244,16 @@ async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKi
     })
 }
 
-async fn resolve_target<'a>(
+fn resolve_target<'a>(
     args: &KillArgs,
     discovered: &'a DiscoveredProcesses,
+    run_mappings: Option<&run_resolution::ActiveRunMappings>,
 ) -> RunnerResult<ResolvedProcessTarget<'a>> {
     if let Some(ref run_id) = args.run {
-        let mappings = run_resolution::collect_active_run_mappings(&discovered.runners).await;
-        let resolved = resolve_by_run_id(run_id, &mappings, &discovered.firecrackers)?;
+        let mappings = run_mappings.ok_or_else(|| {
+            RunnerError::Config("run mappings are required when resolving --run".into())
+        })?;
+        let resolved = resolve_by_run_id(run_id, mappings, &discovered.firecrackers)?;
         return Ok(ResolvedProcessTarget {
             process: resolved.process,
             run_id: Some(resolved.run_id),
@@ -1034,6 +1044,27 @@ mod tests {
         assert!(msg.contains("multiple firecracker processes"), "{msg}");
         assert!(msg.contains("200"), "{msg}");
         assert!(msg.contains("201"), "{msg}");
+    }
+
+    #[test]
+    fn resolve_target_uses_supplied_mappings_not_discovered_runner_candidates() {
+        let args = KillArgs {
+            run: Some("run-live".into()),
+            sandbox: None,
+            force: true,
+        };
+        let discovered = DiscoveredProcesses {
+            runners: vec![process::RunnerProcessInfo { pid: 999 }],
+            firecrackers: vec![make_fc(200, "sandbox-live")],
+            mitmdumps: vec![],
+            dnsmasqs: vec![],
+        };
+        let supplied_mappings = mappings(vec![("run-live-123".into(), "sandbox-live".into())]);
+
+        let resolved = resolve_target(&args, &discovered, Some(&supplied_mappings)).unwrap();
+
+        assert_eq!(resolved.process.pid, 200);
+        assert_eq!(resolved.run_id.as_deref(), Some("run-live-123"));
     }
 
     // -- resolve_by_sandbox_id tests -----------------------------------------

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -13,8 +13,10 @@ pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_i
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{read_cmdline, read_cwd, read_process_stat};
+#[cfg(test)]
+pub(crate) use self::types::RunnerProcessInfo;
 pub(crate) use self::types::process_stat_is_live;
 pub use self::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo,
+    MitmproxyProcessInfo, ProcessStat,
 };

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -6,18 +6,16 @@ use super::types::{
     MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo, process_stat_is_live,
 };
 
-/// Parse a runner argv for `start`/`benchmark` subcommand and `--config` path.
-///
-/// Returns the config path or `None` if the argv doesn't match.
-fn parse_runner_cmdline(argv: &[String]) -> Option<PathBuf> {
+/// Check whether argv looks like a runner `start`/`benchmark` command.
+fn is_runner_cmdline(argv: &[String]) -> bool {
     if !argv.iter().any(|t| t == "start" || t == "benchmark") {
-        return None;
+        return false;
     }
 
-    let config_pos = argv.iter().position(|t| t == "--config" || t == "-c")?;
-    let config_path = argv.get(config_pos + 1)?;
-
-    Some(PathBuf::from(config_path))
+    let Some(config_pos) = argv.iter().position(|t| t == "--config" || t == "-c") else {
+        return false;
+    };
+    argv.get(config_pos + 1).is_some()
 }
 
 /// Check if an argv belongs to a firecracker process.
@@ -144,11 +142,8 @@ pub async fn discover_all() -> DiscoveredProcesses {
     let mut dnsmasqs = Vec::new();
 
     for (pid, argv) in &procs {
-        if let Some(config_path) = parse_runner_cmdline(argv) {
-            runners.push(RunnerProcessInfo {
-                pid: *pid,
-                config_path,
-            });
+        if is_runner_cmdline(argv) {
+            runners.push(RunnerProcessInfo { pid: *pid });
         }
         if is_firecracker_cmdline(argv) {
             firecrackers.push(*pid);
@@ -238,60 +233,58 @@ mod tests {
     }
 
     #[test]
-    fn parse_runner_start_cmdline() {
+    fn detect_runner_start_cmdline() {
         let a = argv(&[
             "/var/lib/vm0-runner/bin/runner",
             "start",
             "--config",
             "/data/runner-01/config.yaml",
         ]);
-        let config = parse_runner_cmdline(&a).unwrap();
-        assert_eq!(config, Path::new("/data/runner-01/config.yaml"));
+        assert!(is_runner_cmdline(&a));
     }
 
     #[test]
-    fn parse_runner_benchmark_cmdline() {
+    fn detect_runner_benchmark_cmdline() {
         let a = argv(&[
             "/usr/local/bin/runner",
             "benchmark",
             "--config",
             "/etc/runner/bench.yaml",
         ]);
-        let config = parse_runner_cmdline(&a).unwrap();
-        assert_eq!(config, Path::new("/etc/runner/bench.yaml"));
+        assert!(is_runner_cmdline(&a));
     }
 
     #[test]
-    fn parse_runner_short_config_flag() {
+    fn detect_runner_short_config_flag() {
         let a = argv(&["runner", "start", "-c", "/data/runner.yaml"]);
-        let config = parse_runner_cmdline(&a).unwrap();
-        assert_eq!(config, Path::new("/data/runner.yaml"));
+        assert!(is_runner_cmdline(&a));
     }
 
     #[test]
-    fn parse_runner_config_path_with_spaces() {
+    fn detect_runner_config_path_with_spaces() {
         // Regression for #10479: a path argument containing spaces must stay
         // as a single argv element, not be split into multiple tokens.
         let a = argv(&["runner", "start", "--config", "/data/my config/config.yaml"]);
-        let config = parse_runner_cmdline(&a).unwrap();
-        assert_eq!(config, Path::new("/data/my config/config.yaml"));
+        assert!(is_runner_cmdline(&a));
     }
 
     #[test]
-    fn parse_runner_no_config_returns_none() {
-        assert!(parse_runner_cmdline(&argv(&["runner", "start"])).is_none());
+    fn detect_runner_no_config_returns_false() {
+        assert!(!is_runner_cmdline(&argv(&["runner", "start"])));
     }
 
     #[test]
-    fn parse_runner_no_subcommand_returns_none() {
-        assert!(
-            parse_runner_cmdline(&argv(&["runner", "--config", "/data/config.yaml"])).is_none()
-        );
+    fn detect_runner_no_subcommand_returns_false() {
+        assert!(!is_runner_cmdline(&argv(&[
+            "runner",
+            "--config",
+            "/data/config.yaml",
+        ])));
     }
 
     #[test]
-    fn parse_runner_empty_cmdline() {
-        assert!(parse_runner_cmdline(&[]).is_none());
+    fn detect_runner_empty_cmdline() {
+        assert!(!is_runner_cmdline(&[]));
     }
 
     #[test]

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -30,7 +30,6 @@ pub struct FirecrackerProcessIdentity {
 /// Info extracted from a runner process cmdline.
 pub struct RunnerProcessInfo {
     pub pid: u32,
-    pub config_path: PathBuf,
 }
 
 /// Info extracted from a firecracker process cmdline.

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -76,7 +76,12 @@ pub(crate) async fn collect_active_run_mappings(
 ) -> ActiveRunMappings {
     let mut entries = Vec::new();
     let mut failed = 0usize;
+    let mut scanned = 0usize;
     for runner in runners {
+        if runner.subcommand != "start" {
+            continue;
+        }
+        scanned += 1;
         match read_active_runs(&runner.base_dir).await {
             Some(runs) => entries.extend(runs),
             None => failed += 1,
@@ -84,7 +89,7 @@ pub(crate) async fn collect_active_run_mappings(
     }
     ActiveRunMappings {
         entries,
-        runners_total: runners.len(),
+        runners_total: scanned,
         runners_failed: failed,
     }
 }
@@ -172,6 +177,13 @@ mod tests {
             runner_group: "vm0/test".into(),
             subcommand: "start".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
+        }
+    }
+
+    fn live_runner_with_subcommand(base_dir: &Path, subcommand: &str) -> LiveRunnerInstance {
+        LiveRunnerInstance {
+            subcommand: subcommand.into(),
+            ..live_runner(base_dir)
         }
     }
 
@@ -299,6 +311,25 @@ mod tests {
         assert!(mappings.entries.is_empty());
         assert_eq!(mappings.runners_total, 1);
         assert_eq!(mappings.runners_failed, 1);
+    }
+
+    #[tokio::test]
+    async fn collect_active_run_mappings_ignores_non_start_runners() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("benchmark-runner");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(
+            base.join("status.json"),
+            r#"{"active_runs":[{"run_id":"stale-run","sandbox_id":"stale-sandbox"}]}"#,
+        )
+        .unwrap();
+
+        let mappings =
+            collect_active_run_mappings(&[live_runner_with_subcommand(&base, "benchmark")]).await;
+
+        assert!(mappings.entries.is_empty());
+        assert_eq!(mappings.runners_total, 0);
+        assert_eq!(mappings.runners_failed, 0);
     }
 
     #[tokio::test]

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -1,43 +1,10 @@
-//! Resolve user-supplied run ids through live runner config and status state.
+//! Resolve user-supplied run ids through live runner registry and status state.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::process::RunnerProcessInfo;
-
-/// Load only the `base_dir` field from a runner config YAML (best-effort).
-///
-/// Read / parse failures log at `warn` level and return `None` so a single
-/// broken runner config doesn't stop resolution for the rest.
-async fn load_base_dir(config_path: &Path) -> Option<PathBuf> {
-    #[derive(serde::Deserialize)]
-    struct ConfigShape {
-        base_dir: PathBuf,
-    }
-    let content = match crate::config::read_diagnostic_config_to_string(config_path).await {
-        Ok(Some(c)) => c,
-        Ok(None) => {
-            tracing::warn!(path = %config_path.display(), "skipping runner: config is missing");
-            return None;
-        }
-        Err(e) => {
-            tracing::warn!(path = %config_path.display(), error = %e, "skipping runner: cannot read config");
-            return None;
-        }
-    };
-    let shape: ConfigShape = match serde_yaml_ng::from_str(&content) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(path = %config_path.display(), error = %e, "skipping runner: cannot parse config");
-            return None;
-        }
-    };
-    if shape.base_dir.is_absolute() {
-        Some(shape.base_dir)
-    } else {
-        config_path.parent().map(|p| p.join(&shape.base_dir))
-    }
-}
+use crate::live_runner_instances::LiveRunnerInstance;
+use crate::paths::HomePaths;
 
 /// Read `{base_dir}/status.json` and extract `(run_id, sandbox_id)` for
 /// every active run. Returns `None` if the file is missing or unparseable
@@ -89,9 +56,9 @@ async fn read_active_runs(base_dir: &Path) -> Option<Vec<(String, String)>> {
 /// Result of collecting `(run_id, sandbox_id)` pairs from runners.
 pub(crate) struct ActiveRunMappings {
     pub entries: Vec<(String, String)>,
-    /// How many runners were discovered on the host.
+    /// How many trusted live runner registry entries were scanned.
     pub runners_total: usize,
-    /// How many runners had unreadable configs or status files.
+    /// How many trusted live runner status files were unreadable.
     pub runners_failed: usize,
 }
 
@@ -105,16 +72,12 @@ pub(crate) struct ResolvedRunMapping {
 /// `status.json`. Used by `kill --run` and `exec --run` to translate a
 /// user-supplied run_id into the sandbox_id that identifies the FC.
 pub(crate) async fn collect_active_run_mappings(
-    runners: &[RunnerProcessInfo],
+    runners: &[LiveRunnerInstance],
 ) -> ActiveRunMappings {
     let mut entries = Vec::new();
     let mut failed = 0usize;
     for runner in runners {
-        let Some(base_dir) = load_base_dir(&runner.config_path).await else {
-            failed += 1;
-            continue;
-        };
-        match read_active_runs(&base_dir).await {
+        match read_active_runs(&runner.base_dir).await {
             Some(runs) => entries.extend(runs),
             None => failed += 1,
         }
@@ -124,6 +87,12 @@ pub(crate) async fn collect_active_run_mappings(
         runners_total: runners.len(),
         runners_failed: failed,
     }
+}
+
+/// Collect active run mappings from the validated live runner registry.
+pub(crate) async fn collect_active_run_mappings_from_home(home: &HomePaths) -> ActiveRunMappings {
+    let runners = crate::live_runner_instances::list(home).await;
+    collect_active_run_mappings(&runners).await
 }
 
 /// Given a `run_id` prefix, find the unique matching active run from collected
@@ -158,12 +127,12 @@ pub(crate) fn resolve_run_mapping(
             let mut msg = format!("no active run matches '{input}'");
             if mappings.runners_failed > 0 {
                 msg.push_str(&format!(
-                    " ({} of {} runner(s) had unreadable config/status — \
+                    " ({} of {} trusted live runner status file(s) were unreadable — \
                      check warnings above)",
                     mappings.runners_failed, mappings.runners_total,
                 ));
             } else if mappings.runners_total == 0 {
-                msg.push_str(" (no runner processes found on this host)");
+                msg.push_str(" (no trusted live runner status found on this host)");
             }
             Err(RunnerError::Config(msg))
         }
@@ -193,6 +162,19 @@ pub(crate) fn resolve_run_to_sandbox(
 mod tests {
     use super::*;
 
+    fn live_runner(base_dir: &Path) -> LiveRunnerInstance {
+        LiveRunnerInstance {
+            pid: 1,
+            starttime: 1,
+            config_path: base_dir.join("runner.yaml"),
+            base_dir: base_dir.to_path_buf(),
+            runner_name: "test-runner".into(),
+            runner_group: "vm0/test".into(),
+            subcommand: "start".into(),
+            started_at: "2026-01-01T00:00:00.000Z".into(),
+        }
+    }
+
     fn mappings(entries: Vec<(String, String)>) -> ActiveRunMappings {
         let total = if entries.is_empty() { 0 } else { 1 };
         ActiveRunMappings {
@@ -200,38 +182,6 @@ mod tests {
             runners_total: total,
             runners_failed: 0,
         }
-    }
-
-    #[tokio::test]
-    async fn load_base_dir_absolute() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = dir.path().join("runner.yaml");
-        std::fs::write(&config, "base_dir: /data/runner-01\nname: test\n").unwrap();
-        let bd = load_base_dir(&config).await.unwrap();
-        assert_eq!(bd, Path::new("/data/runner-01"));
-    }
-
-    #[tokio::test]
-    async fn load_base_dir_relative() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = dir.path().join("runner.yaml");
-        std::fs::write(&config, "base_dir: ./data\nname: test\n").unwrap();
-        let bd = load_base_dir(&config).await.unwrap();
-        assert_eq!(bd, dir.path().join("./data"));
-    }
-
-    #[tokio::test]
-    async fn load_base_dir_missing_file() {
-        let result = load_base_dir(Path::new("/no/such/config.yaml")).await;
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn load_base_dir_malformed_yaml() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = dir.path().join("runner.yaml");
-        std::fs::write(&config, "not: valid: yaml: [[[").unwrap();
-        assert!(load_base_dir(&config).await.is_none());
     }
 
     #[tokio::test]
@@ -298,6 +248,57 @@ mod tests {
 
         assert!(result.is_ok(), "FIFO read should not block");
         assert!(result.unwrap().is_none(), "FIFO status should be rejected");
+    }
+
+    #[tokio::test]
+    async fn collect_active_run_mappings_reads_registry_base_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_a = dir.path().join("runner-a");
+        let base_b = dir.path().join("runner-b");
+        std::fs::create_dir_all(&base_a).unwrap();
+        std::fs::create_dir_all(&base_b).unwrap();
+        std::fs::write(
+            base_a.join("status.json"),
+            r#"{"active_runs":[{"run_id":"run-a","sandbox_id":"sandbox-a"}]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            base_b.join("status.json"),
+            r#"{"active_runs":[{"run_id":"run-b","sandbox_id":"sandbox-b"}]}"#,
+        )
+        .unwrap();
+        let runners = vec![live_runner(&base_a), live_runner(&base_b)];
+
+        let mappings = collect_active_run_mappings(&runners).await;
+
+        assert_eq!(mappings.runners_total, 2);
+        assert_eq!(mappings.runners_failed, 0);
+        assert_eq!(
+            mappings.entries,
+            vec![
+                ("run-a".into(), "sandbox-a".into()),
+                ("run-b".into(), "sandbox-b".into()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn collect_active_run_mappings_counts_unreadable_status_without_config_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("runner");
+        std::fs::create_dir_all(&base).unwrap();
+        let config_path = base.join("runner.yaml");
+        std::fs::write(&config_path, "base_dir: /wrong\n").unwrap();
+        let runner = LiveRunnerInstance {
+            config_path,
+            ..live_runner(&base)
+        };
+
+        let mappings = collect_active_run_mappings(&[runner]).await;
+
+        assert!(mappings.entries.is_empty());
+        assert_eq!(mappings.runners_total, 1);
+        assert_eq!(mappings.runners_failed, 1);
     }
 
     #[test]
@@ -405,6 +406,7 @@ mod tests {
         let err = resolve_run_to_sandbox("abc", &m).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("2 of 3"), "{msg}");
+        assert!(msg.contains("trusted live runner status"), "{msg}");
         assert!(msg.contains("unreadable"), "{msg}");
     }
 
@@ -417,6 +419,6 @@ mod tests {
         };
         let err = resolve_run_to_sandbox("abc", &m).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("no runner processes"), "{msg}");
+        assert!(msg.contains("no trusted live runner status"), "{msg}");
     }
 }

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -301,6 +301,41 @@ mod tests {
         assert_eq!(mappings.runners_failed, 1);
     }
 
+    #[tokio::test]
+    async fn collect_active_run_mappings_from_home_reads_live_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let base = dir.path().join("runner-base");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(
+            base.join("status.json"),
+            r#"{"active_runs":[{"run_id":"run-live","sandbox_id":"sandbox-live"}]}"#,
+        )
+        .unwrap();
+        let handle = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: base.join("runner.yaml"),
+                base_dir: base,
+                runner_name: "test-runner".into(),
+                runner_group: "vm0/test".into(),
+                subcommand: "start".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let mappings = collect_active_run_mappings_from_home(&home).await;
+
+        assert_eq!(mappings.runners_total, 1);
+        assert_eq!(mappings.runners_failed, 0);
+        assert_eq!(
+            mappings.entries,
+            vec![("run-live".into(), "sandbox-live".into())]
+        );
+        assert!(handle.remove_if_current().await.unwrap());
+    }
+
     #[test]
     fn run_prefix_resolves_to_sandbox_id() {
         let status = mappings(vec![(


### PR DESCRIPTION
## Summary
- move `kill --run` and `exec --run` active run mapping to validated live runner registry entries
- read active runs directly from registry-backed `base_dir/status.json`, removing argv-derived config reads from run resolution
- keep `kill --sandbox` and orphan classification behavior unchanged while narrowing runner-like argv to a pid-only conservative signal

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner run_resolution
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::kill
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::exec
- cargo test --manifest-path crates/Cargo.toml -p runner process
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::doctor
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets

Fixes #17267