### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -1010,7 +1010,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
@@ -2031,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -3097,9 +3097,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"


### PR DESCRIPTION
## Summary

- Updated Rust dependency lockfile entries in the `crates` workspace:
  - `block-buffer 0.12.0 -> 0.12.1`
  - `memchr 2.8.1 -> 2.8.2`
  - `smallvec 1.15.1 -> 1.15.2`
- No `Cargo.toml` manifest changes.

## Dependencies Not Updated

- `generic-array 0.14.7 -> 0.14.9`: blocked by a transitive exact requirement from `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"`.
- `aws-smithy-eventstream 0.60.20 -> 0.60.21` and `aws-smithy-types 1.4.9 -> 1.5.0`: `cargo update` selected this pair, but compiling the workspace failed in `aws-runtime v1.7.4` with Rust `E0282` (`type annotations needed`) in `auth/sigv4.rs`. The pair was left at the currently compiling versions.

## Manual Version Bumps

- None. No `Cargo.toml` version specifiers were changed.

## Test Status

- Passed: `cargo test --workspace`
- Final command run from `crates`:

```bash
CARGO_TERM_COLOR=never CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 CARGO_HOME=/home/user/workspace/vm0-cargo-home CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target TMPDIR=/tmp/vt RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=gold" cargo test --workspace
```

Note: the default linker was killed by local memory limits (`ld terminated with signal 9`) during validation, so the final passing run used `clang -fuse-ld=gold`.
