### PR TITLE
chore: remove run context legacy map fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1880,8 +1880,27 @@ describe("RUN-04: agent run telemetry families", () => {
     expect(contextRead.body.firewalls).toHaveLength(1);
     expect(contextRead.body.volumes).toHaveLength(1);
 
-    // Sparse snapshots drop non-string and null values entirely.
-    dispatchAxiomQueries({ [runId]: { runContext: [{ runId }] } });
+    // Legacy dynamic map fields are ignored now that run context snapshots
+    // are entries-only.
+    dispatchAxiomQueries({
+      [runId]: {
+        runContext: [
+          {
+            runId,
+            environment: { LEGACY_IGNORED: "legacy-map" },
+            networkPolicies: {
+              legacyIgnored: {
+                allow: ["legacy"],
+                deny: [],
+                ask: [],
+                unknownPolicy: "allow",
+              },
+            },
+            featureFlags: { legacyIgnored: true },
+          },
+        ],
+      },
+    });
     const sparseContext = await api.requestRunContext(actor, runId, [200]);
     if (sparseContext.status !== 200) {
       throw new Error("Expected the sparse run context read to succeed");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1901,11 +1901,11 @@ describe("RUN-04: agent run telemetry families", () => {
         ],
       },
     });
-    const sparseContext = await api.requestRunContext(actor, runId, [200]);
-    if (sparseContext.status !== 200) {
-      throw new Error("Expected the sparse run context read to succeed");
+    const legacyOnlyContext = await api.requestRunContext(actor, runId, [200]);
+    if (legacyOnlyContext.status !== 200) {
+      throw new Error("Expected the legacy-only run context read to succeed");
     }
-    expect(sparseContext.body).toMatchObject({
+    expect(legacyOnlyContext.body).toMatchObject({
       runId,
       sessionId: null,
       environment: {},

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -93,23 +93,6 @@ function stringRecordValue(value: unknown): Record<string, string> | undefined {
   return Object.fromEntries(entries);
 }
 
-function booleanRecordValue(
-  value: unknown,
-): Record<string, boolean> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const entries = Object.entries(value).filter(
-    (entry): entry is [string, boolean] => {
-      return typeof entry[1] === "boolean";
-    },
-  );
-  if (entries.length === 0) {
-    return undefined;
-  }
-  return Object.fromEntries(entries);
-}
-
 function networkPolicyValue(value: unknown): NetworkPolicyValue | undefined {
   return value === "allow" || value === "deny" || value === "ask"
     ? value
@@ -130,24 +113,6 @@ function networkPolicyFromUnknown(value: unknown): NetworkPolicy | undefined {
     ask: stringArrayValue(value.ask) ?? [],
     unknownPolicy,
   };
-}
-
-function networkPoliciesFromUnknown(
-  value: unknown,
-): RunContextResponse["networkPolicies"] {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const policies: NetworkPolicies = {};
-  for (const [name, rawPolicy] of Object.entries(value)) {
-    const policy = networkPolicyFromUnknown(rawPolicy);
-    if (policy) {
-      policies[name] = policy;
-    }
-  }
-
-  return Object.keys(policies).length > 0 ? policies : null;
 }
 
 function environmentFromEntries(value: unknown): Record<string, string> {
@@ -374,17 +339,6 @@ export function featureFlagsRecordToEntries(
 export function normalizeRunContextSnapshot(
   snapshot: Record<string, unknown>,
 ): NormalizedRunContextSnapshot {
-  // Temporary legacy map fallback for #17222; remove after June 18, 2026.
-  const environment = Array.isArray(snapshot.environmentEntries)
-    ? environmentFromEntries(snapshot.environmentEntries)
-    : (stringRecordValue(snapshot.environment) ?? {});
-  const networkPolicies = Array.isArray(snapshot.networkPolicyEntries)
-    ? networkPoliciesFromEntries(snapshot.networkPolicyEntries)
-    : networkPoliciesFromUnknown(snapshot.networkPolicies);
-  const featureFlags = Array.isArray(snapshot.featureFlagEntries)
-    ? featureFlagsFromEntries(snapshot.featureFlagEntries)
-    : (booleanRecordValue(snapshot.featureFlags) ?? null);
-
   return {
     runId: stringValue(snapshot.runId),
     userId: stringValue(snapshot.userId),
@@ -396,11 +350,11 @@ export function normalizeRunContextSnapshot(
         : undefined,
     sessionId: stringValue(snapshot.sessionId) ?? null,
     secretNames: stringArrayFromUnknown(snapshot.secretNames),
-    environment,
+    environment: environmentFromEntries(snapshot.environmentEntries),
     firewalls: firewallsFromUnknown(snapshot.firewalls),
-    networkPolicies,
+    networkPolicies: networkPoliciesFromEntries(snapshot.networkPolicyEntries),
     volumes: volumesFromUnknown(snapshot.volumes),
     artifact: artifactFromUnknown(snapshot.artifact),
-    featureFlags,
+    featureFlags: featureFlagsFromEntries(snapshot.featureFlagEntries),
   };
 }


### PR DESCRIPTION
## Summary

- Remove legacy `environment`, `networkPolicies`, and `featureFlags` map fallback from run context snapshot normalization.
- Keep the external run context response shape by returning empty/null dynamic fields when entries are absent.
- Update BDD coverage to assert old dynamic map fields are ignored instead of parsed.

Closes #17222

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts src/signals/routes/__tests__/zero-report-error.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `git diff --check`
- pre-commit: prettier, knip, workspace check-types
