### PR TITLE
fix(runner): include decode path in api errors

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_yaml_ng",
  "sha2",
  "tar",
@@ -2978,6 +2979,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -76,6 +76,7 @@ rmpv = "1"
 sentry = { version = "0.48", default-features = false }
 serde = "1"
 serde_json = "1"
+serde_path_to_error = "0.1"
 serde_yaml_ng = "0.10"
 sha2 = "0.11"
 tar = "0.4"

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -21,6 +21,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 nix = { workspace = true, features = ["user", "signal", "fs", "process"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_path_to_error = { workspace = true }
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "net", "io-util"] }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -641,7 +641,7 @@ fn is_static_json_field(field: &str) -> bool {
     )
 }
 
-fn format_json_decode_error(path: String, error: &serde_json::Error) -> String {
+fn format_json_decode_error(mut path: String, error: &serde_json::Error) -> String {
     let category = match error.classify() {
         serde_json::error::Category::Io => "io",
         serde_json::error::Category::Syntax => "syntax",
@@ -650,11 +650,24 @@ fn format_json_decode_error(path: String, error: &serde_json::Error) -> String {
     };
     let location = format!("line {} column {}", error.line(), error.column());
     let detail = sanitized_json_error_detail(error);
+    if detail == "unknown variant" && is_firewall_entry_decode_path(&path) {
+        path.push_str(".kind");
+    }
     if path == "." {
         format!("failed at <root>: {detail}; {category} error at {location}")
     } else {
         format!("failed at {path}: {detail}; {category} error at {location}")
     }
+}
+
+fn is_firewall_entry_decode_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("firewalls[") else {
+        return false;
+    };
+    let Some((index, suffix)) = rest.split_once(']') else {
+        return false;
+    };
+    !index.is_empty() && index.chars().all(|c| c.is_ascii_digit()) && suffix.is_empty()
 }
 
 fn sanitized_json_error_detail(error: &serde_json::Error) -> String {
@@ -1185,7 +1198,7 @@ mod tests {
             panic!("expected RunnerError::Api");
         };
         assert!(
-            message.contains("claim decode: failed at firewalls[0]"),
+            message.contains("claim decode: failed at firewalls[0].kind"),
             "decode error should include JSON path, got: {message}"
         );
         assert!(
@@ -1234,7 +1247,7 @@ mod tests {
             panic!("expected RunnerError::Api");
         };
         assert!(
-            message.contains("claim decode: failed at firewalls[0]"),
+            message.contains("claim decode: failed at firewalls[0].kind"),
             "decode error should include JSON path, got: {message}"
         );
         assert!(

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -520,46 +520,32 @@ fn sanitized_json_error_detail(error: &serde_json::Error) -> String {
     let detail = message
         .strip_suffix(&location_suffix)
         .unwrap_or(message.as_str());
-    if detail.contains("missing field `")
-        || detail.contains("duplicate field `")
-        || detail.contains("unknown field `")
-    {
+    if detail.starts_with("missing field `") || detail.starts_with("duplicate field `") {
         return detail.to_string();
     }
 
-    redact_json_error_values(detail)
-}
-
-fn redact_json_error_values(detail: &str) -> String {
-    let mut redacted = String::with_capacity(detail.len());
-    let mut chars = detail.chars();
-    while let Some(ch) = chars.next() {
-        match ch {
-            '`' => {
-                redacted.push_str("`<redacted>`");
-                for inner in chars.by_ref() {
-                    if inner == '`' {
-                        break;
-                    }
-                }
-            }
-            '"' => {
-                redacted.push_str("\"<redacted>\"");
-                let mut escaped = false;
-                for inner in chars.by_ref() {
-                    if escaped {
-                        escaped = false;
-                    } else if inner == '\\' {
-                        escaped = true;
-                    } else if inner == '"' {
-                        break;
-                    }
-                }
-            }
-            _ => redacted.push(ch),
-        }
+    if detail.starts_with("unknown field `") {
+        return "unknown field".to_string();
     }
-    redacted
+    if detail.starts_with("trailing characters") {
+        return "trailing characters".to_string();
+    }
+    if detail.starts_with("invalid type:") {
+        return "invalid type".to_string();
+    }
+    if detail.starts_with("invalid value:") {
+        return "invalid value".to_string();
+    }
+    if detail.starts_with("unknown variant `") {
+        return "unknown variant".to_string();
+    }
+    if detail.starts_with("expected value") {
+        return "expected value".to_string();
+    }
+    if detail.starts_with("EOF while parsing") {
+        return "unexpected end of input".to_string();
+    }
+    "invalid JSON".to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -1036,6 +1022,55 @@ mod tests {
                     "cliAgentType": "claude_code",
                     "firewalls": [{
                         "kind": "secret-kind-value",
+                        "name": "github"
+                    }],
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let api = api_client_for_server(&server);
+
+        let err = api
+            .claim(&JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .unwrap_err();
+
+        let RunnerError::Api(message) = err else {
+            panic!("expected RunnerError::Api");
+        };
+        assert!(
+            message.contains("claim decode: failed at firewalls[0]"),
+            "decode error should include JSON path, got: {message}"
+        );
+        assert!(
+            !message.contains("claim-sandbox-token"),
+            "decode error must not include response body values, got: {message}"
+        );
+        assert!(
+            !message.contains("secret-kind-value"),
+            "decode error must not include invalid field values, got: {message}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_client_claim_decode_error_redacts_values_that_look_like_field_errors() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let path = format!("/api/runners/jobs/{run_id}/claim");
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id,
+                    "prompt": "hello",
+                    "sandboxToken": "claim-sandbox-token",
+                    "cliAgentType": "claude_code",
+                    "firewalls": [{
+                        "kind": "missing field `secret-kind-value`",
                         "name": "github"
                     }],
                     "billableFirewalls": []

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -471,9 +471,11 @@ async fn check_api_status(resp: Response, label: &str) -> RunnerResult<Response>
 }
 
 async fn decode_api_json<T: DeserializeOwned>(resp: Response, label: &str) -> RunnerResult<T> {
-    resp.json()
+    let body = resp
+        .bytes()
         .await
-        .map_err(|e| RunnerError::Api(format!("{label} decode: {e}")))
+        .map_err(|e| RunnerError::Api(format!("{label} decode read body: {e}")))?;
+    decode_api_json_bytes(&body).map_err(|e| RunnerError::Api(format!("{label} decode: {e}")))
 }
 
 async fn read_api_error(resp: Response) -> (StatusCode, String) {
@@ -484,6 +486,25 @@ async fn read_api_error(resp: Response) -> (StatusCode, String) {
 
 fn api_status_error(label: &str, status: StatusCode, body: &str) -> RunnerError {
     RunnerError::Api(format!("{label} {status}: {body}"))
+}
+
+fn decode_api_json_bytes<T: DeserializeOwned>(body: &[u8]) -> Result<T, String> {
+    let mut deserializer = serde_json::Deserializer::from_slice(body);
+    serde_path_to_error::deserialize(&mut deserializer).map_err(|e| {
+        let path = e.path().to_string();
+        let category = match e.inner().classify() {
+            serde_json::error::Category::Io => "io",
+            serde_json::error::Category::Syntax => "syntax",
+            serde_json::error::Category::Data => "data",
+            serde_json::error::Category::Eof => "eof",
+        };
+        let location = format!("line {} column {}", e.inner().line(), e.inner().column());
+        if path == "." {
+            format!("failed at <root>: {category} error at {location}")
+        } else {
+            format!("failed at {path}: {category} error at {location}")
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -943,6 +964,55 @@ mod tests {
             assert!(matches!(err, RunnerError::AlreadyClaimed));
             mock.assert_async().await;
         }
+    }
+
+    #[tokio::test]
+    async fn api_client_claim_decode_error_includes_json_path_without_body_values() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let path = format!("/api/runners/jobs/{run_id}/claim");
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id,
+                    "prompt": "hello",
+                    "sandboxToken": "claim-sandbox-token",
+                    "cliAgentType": "claude_code",
+                    "firewalls": [{
+                        "kind": "builtin",
+                        "name": 42
+                    }],
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let api = api_client_for_server(&server);
+
+        let err = api
+            .claim(&JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .unwrap_err();
+
+        let RunnerError::Api(message) = err else {
+            panic!("expected RunnerError::Api");
+        };
+        assert!(
+            message.contains("claim decode: failed at firewalls[0]"),
+            "decode error should include JSON path, got: {message}"
+        );
+        assert!(
+            !message.contains("claim-sandbox-token"),
+            "decode error must not include response body values, got: {message}"
+        );
+        assert!(
+            !message.contains("42"),
+            "decode error must not include invalid field values, got: {message}"
+        );
+        mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -499,12 +499,61 @@ fn decode_api_json_bytes<T: DeserializeOwned>(body: &[u8]) -> Result<T, String> 
             serde_json::error::Category::Eof => "eof",
         };
         let location = format!("line {} column {}", e.inner().line(), e.inner().column());
+        let detail = sanitized_json_error_detail(e.inner());
         if path == "." {
-            format!("failed at <root>: {category} error at {location}")
+            format!("failed at <root>: {detail}; {category} error at {location}")
         } else {
-            format!("failed at {path}: {category} error at {location}")
+            format!("failed at {path}: {detail}; {category} error at {location}")
         }
     })
+}
+
+fn sanitized_json_error_detail(error: &serde_json::Error) -> String {
+    let message = error.to_string();
+    let location_suffix = format!(" at line {} column {}", error.line(), error.column());
+    let detail = message
+        .strip_suffix(&location_suffix)
+        .unwrap_or(message.as_str());
+    if detail.contains("missing field `")
+        || detail.contains("duplicate field `")
+        || detail.contains("unknown field `")
+    {
+        return detail.to_string();
+    }
+
+    redact_json_error_values(detail)
+}
+
+fn redact_json_error_values(detail: &str) -> String {
+    let mut redacted = String::with_capacity(detail.len());
+    let mut chars = detail.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '`' => {
+                redacted.push_str("`<redacted>`");
+                for inner in chars.by_ref() {
+                    if inner == '`' {
+                        break;
+                    }
+                }
+            }
+            '"' => {
+                redacted.push_str("\"<redacted>\"");
+                let mut escaped = false;
+                for inner in chars.by_ref() {
+                    if escaped {
+                        escaped = false;
+                    } else if inner == '\\' {
+                        escaped = true;
+                    } else if inner == '"' {
+                        break;
+                    }
+                }
+            }
+            _ => redacted.push(ch),
+        }
+    }
+    redacted
 }
 
 // ---------------------------------------------------------------------------
@@ -1011,6 +1060,59 @@ mod tests {
         assert!(
             !message.contains("42"),
             "decode error must not include invalid field values, got: {message}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_client_claim_decode_error_includes_missing_field_name() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let path = format!("/api/runners/jobs/{run_id}/claim");
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id,
+                    "prompt": "hello",
+                    "sandboxToken": "claim-sandbox-token",
+                    "cliAgentType": "claude_code",
+                    "firewalls": [{
+                        "name": "github",
+                        "apis": []
+                    }],
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let api = api_client_for_server(&server);
+
+        let err = api
+            .claim(&JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .unwrap_err();
+
+        let RunnerError::Api(message) = err else {
+            panic!("expected RunnerError::Api");
+        };
+        assert!(
+            message.contains("claim decode: failed at firewalls[0]"),
+            "decode error should include JSON path, got: {message}"
+        );
+        assert!(
+            message.contains("missing field `kind`"),
+            "decode error should include the missing field name, got: {message}"
+        );
+        assert!(
+            !message.contains("claim-sandbox-token"),
+            "decode error must not include response body values, got: {message}"
+        );
+        assert!(
+            !message.contains("github"),
+            "decode error must not include response body values, got: {message}"
         );
         mock.assert_async().await;
     }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -491,11 +491,154 @@ fn api_status_error(label: &str, status: StatusCode, body: &str) -> RunnerError 
 fn decode_api_json_bytes<T: DeserializeOwned>(body: &[u8]) -> Result<T, String> {
     let mut deserializer = serde_json::Deserializer::from_slice(body);
     let value = serde_path_to_error::deserialize(&mut deserializer)
-        .map_err(|e| format_json_decode_error(e.path().to_string(), e.inner()))?;
+        .map_err(|e| format_json_decode_error(format_json_decode_path(e.path()), e.inner()))?;
     deserializer
         .end()
         .map_err(|e| format_json_decode_error(".".to_string(), &e))?;
     Ok(value)
+}
+
+fn format_json_decode_path(path: &serde_path_to_error::Path) -> String {
+    let mut formatted = String::new();
+    let mut redact_next_map_key = false;
+
+    for segment in path {
+        match segment {
+            serde_path_to_error::Segment::Seq { index } => {
+                formatted.push('[');
+                formatted.push_str(&index.to_string());
+                formatted.push(']');
+            }
+            serde_path_to_error::Segment::Map { key } => {
+                push_json_path_map_segment(&mut formatted, key, redact_next_map_key);
+                redact_next_map_key = !redact_next_map_key && is_dynamic_json_map_field(key);
+            }
+            serde_path_to_error::Segment::Enum { .. } => {
+                push_json_path_segment(&mut formatted, "<variant>");
+                redact_next_map_key = false;
+            }
+            serde_path_to_error::Segment::Unknown => {
+                push_json_path_segment(&mut formatted, "?");
+                redact_next_map_key = false;
+            }
+        }
+    }
+
+    if formatted.is_empty() {
+        ".".to_string()
+    } else {
+        formatted
+    }
+}
+
+fn push_json_path_map_segment(formatted: &mut String, key: &str, redact: bool) {
+    let segment = if redact {
+        "<map-key>"
+    } else if is_static_json_field(key) {
+        key
+    } else {
+        "<field>"
+    };
+    push_json_path_segment(formatted, segment);
+}
+
+fn push_json_path_segment(formatted: &mut String, segment: &str) {
+    if !formatted.is_empty() {
+        formatted.push('.');
+    }
+    formatted.push_str(segment);
+}
+
+fn is_dynamic_json_map_field(field: &str) -> bool {
+    matches!(
+        field,
+        "vars"
+            | "environment"
+            | "secretConnectorMap"
+            | "secretConnectorMetadataMap"
+            | "baseUrlVars"
+            | "headers"
+            | "query"
+            | "networkPolicies"
+            | "featureFlags"
+    )
+}
+
+// serde_path_to_error reports both struct fields and runtime map keys as Map
+// segments, so only known response schema fields are safe to print verbatim.
+fn is_static_json_field(field: &str) -> bool {
+    matches!(
+        field,
+        "allow"
+            | "apiStartTime"
+            | "apis"
+            | "archiveUrl"
+            | "artifacts"
+            | "ask"
+            | "auth"
+            | "base"
+            | "baseUrlVars"
+            | "billableFirewalls"
+            | "cached"
+            | "capability"
+            | "captureNetworkBodies"
+            | "checkpointId"
+            | "cliAgentType"
+            | "clientId"
+            | "debugNoMockClaude"
+            | "debugNoMockCodex"
+            | "deny"
+            | "description"
+            | "disallowedTools"
+            | "encryptedSecrets"
+            | "environment"
+            | "experimentalProfile"
+            | "expires"
+            | "featureFlags"
+            | "firewall"
+            | "firewalls"
+            | "headers"
+            | "issued"
+            | "job"
+            | "keyName"
+            | "kind"
+            | "mac"
+            | "manifestUrl"
+            | "metadataKey"
+            | "missingRootPolicy"
+            | "modelUsageProvider"
+            | "mountPath"
+            | "name"
+            | "networkPolicies"
+            | "nonce"
+            | "permissions"
+            | "prompt"
+            | "query"
+            | "resumeSession"
+            | "rules"
+            | "runId"
+            | "sandboxToken"
+            | "secretConnectorMap"
+            | "secretConnectorMetadataMap"
+            | "secretValues"
+            | "sessionHistory"
+            | "sessionId"
+            | "settings"
+            | "sourceType"
+            | "sourceUserId"
+            | "storageManifest"
+            | "storages"
+            | "timestamp"
+            | "token"
+            | "tools"
+            | "ttl"
+            | "unknownPolicy"
+            | "userTimezone"
+            | "vars"
+            | "vasStorageId"
+            | "vasStorageName"
+            | "vasVersionId"
+    )
 }
 
 fn format_json_decode_error(path: String, error: &serde_json::Error) -> String {
@@ -1153,6 +1296,54 @@ mod tests {
         );
         assert!(
             !message.contains("github"),
+            "decode error must not include response body values, got: {message}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_client_claim_decode_error_redacts_dynamic_map_keys() {
+        let server = MockServer::start_async().await;
+        let run_id = RunId::nil();
+        let path = format!("/api/runners/jobs/{run_id}/claim");
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(path.as_str());
+                then.status(200).json_body(serde_json::json!({
+                    "runId": run_id,
+                    "prompt": "hello",
+                    "sandboxToken": "claim-sandbox-token",
+                    "cliAgentType": "claude_code",
+                    "environment": {
+                        "OPENAI_API_KEY": 123
+                    },
+                    "billableFirewalls": []
+                }));
+            })
+            .await;
+        let api = api_client_for_server(&server);
+
+        let err = api
+            .claim(&JobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+            ))
+            .await
+            .unwrap_err();
+
+        let RunnerError::Api(message) = err else {
+            panic!("expected RunnerError::Api");
+        };
+        assert!(
+            message.contains("claim decode: failed at environment.<map-key>"),
+            "decode error should include a redacted dynamic map path, got: {message}"
+        );
+        assert!(
+            !message.contains("OPENAI_API_KEY"),
+            "decode error must not include dynamic map keys, got: {message}"
+        );
+        assert!(
+            !message.contains("claim-sandbox-token"),
             "decode error must not include response body values, got: {message}"
         );
         mock.assert_async().await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -490,22 +490,28 @@ fn api_status_error(label: &str, status: StatusCode, body: &str) -> RunnerError 
 
 fn decode_api_json_bytes<T: DeserializeOwned>(body: &[u8]) -> Result<T, String> {
     let mut deserializer = serde_json::Deserializer::from_slice(body);
-    serde_path_to_error::deserialize(&mut deserializer).map_err(|e| {
-        let path = e.path().to_string();
-        let category = match e.inner().classify() {
-            serde_json::error::Category::Io => "io",
-            serde_json::error::Category::Syntax => "syntax",
-            serde_json::error::Category::Data => "data",
-            serde_json::error::Category::Eof => "eof",
-        };
-        let location = format!("line {} column {}", e.inner().line(), e.inner().column());
-        let detail = sanitized_json_error_detail(e.inner());
-        if path == "." {
-            format!("failed at <root>: {detail}; {category} error at {location}")
-        } else {
-            format!("failed at {path}: {detail}; {category} error at {location}")
-        }
-    })
+    let value = serde_path_to_error::deserialize(&mut deserializer)
+        .map_err(|e| format_json_decode_error(e.path().to_string(), e.inner()))?;
+    deserializer
+        .end()
+        .map_err(|e| format_json_decode_error(".".to_string(), &e))?;
+    Ok(value)
+}
+
+fn format_json_decode_error(path: String, error: &serde_json::Error) -> String {
+    let category = match error.classify() {
+        serde_json::error::Category::Io => "io",
+        serde_json::error::Category::Syntax => "syntax",
+        serde_json::error::Category::Data => "data",
+        serde_json::error::Category::Eof => "eof",
+    };
+    let location = format!("line {} column {}", error.line(), error.column());
+    let detail = sanitized_json_error_detail(error);
+    if path == "." {
+        format!("failed at <root>: {detail}; {category} error at {location}")
+    } else {
+        format!("failed at {path}: {detail}; {category} error at {location}")
+    }
 }
 
 fn sanitized_json_error_detail(error: &serde_json::Error) -> String {
@@ -1029,8 +1035,8 @@ mod tests {
                     "sandboxToken": "claim-sandbox-token",
                     "cliAgentType": "claude_code",
                     "firewalls": [{
-                        "kind": "builtin",
-                        "name": 42
+                        "kind": "secret-kind-value",
+                        "name": "github"
                     }],
                     "billableFirewalls": []
                 }));
@@ -1058,7 +1064,7 @@ mod tests {
             "decode error must not include response body values, got: {message}"
         );
         assert!(
-            !message.contains("42"),
+            !message.contains("secret-kind-value"),
             "decode error must not include invalid field values, got: {message}"
         );
         mock.assert_async().await;
@@ -1113,6 +1119,42 @@ mod tests {
         assert!(
             !message.contains("github"),
             "decode error must not include response body values, got: {message}"
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn api_client_poll_decode_rejects_trailing_response_body() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"job":null} trailing-response-value"#);
+            })
+            .await;
+        let api = api_client_for_server(&server);
+
+        let err = api
+            .poll(
+                "default",
+                &[crate::profile::DEFAULT_PROFILE.to_string()],
+                &[],
+            )
+            .await
+            .unwrap_err();
+
+        let RunnerError::Api(message) = err else {
+            panic!("expected RunnerError::Api");
+        };
+        assert!(
+            message.contains("poll decode: failed at <root>: trailing characters"),
+            "decode error should reject trailing response content, got: {message}"
+        );
+        assert!(
+            !message.contains("trailing-response-value"),
+            "decode error must not include trailing response values, got: {message}"
         );
         mock.assert_async().await;
     }


### PR DESCRIPTION
## Summary
- Decode runner API JSON responses through serde_path_to_error so failures include the JSON path that failed to deserialize.
- Preserve strict serde_json response parsing by checking for trailing response content after path-aware deserialization.
- Preserve field-level diagnostics like missing field names while redacting response values from decode errors.
- Redact dynamic map keys and enum variants from decode paths so logs identify schema fields without leaking response-body keys or values.
- Report invalid firewall entry tags as `firewalls[N].kind` so malformed firewall refs identify the concrete field.
- Add runner API regression tests covering claim decode failures, legacy firewall shape, value redaction, dynamic map key redaction, and trailing response content.

## Testing
- cargo fmt --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p runner api_client_claim_decode_error_includes_json_path_without_body_values
- cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests
- cargo test --manifest-path crates/Cargo.toml -p runner api_client_claim_decode_error_redacts_dynamic_map_keys -- --nocapture
- lefthook pre-commit: cargo-fmt, cargo-doc, cargo-clippy

Closes #17394
