### PR TITLE
Add prompt deep-link route for onboarding migration

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -9,9 +9,10 @@ CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VM0_API_URL=https://api.vm7.ai:8443
 VM0_WEB_URL=https://www.vm7.ai:8443
 APP_URL=https://app.vm7.ai:8443
+PAID_ONBOARDING_URL=https://so.vm7.ai:8441
 
 # Optional: Atom redeem service for onboarding codes
-ATOM_URL=https://tunnel-yuma-atom-api.vm7.ai
+ATOM_URL=https://atom.vm7.ai:8442/
 VM0_MACHINE_SECRET_KEY=op://Development/clerk/VM0_MACHINE_SECRET_KEY
 
 # Required: API deploy stage tag

--- a/turbo/apps/api/src/lib/billing-redirect.ts
+++ b/turbo/apps/api/src/lib/billing-redirect.ts
@@ -5,6 +5,7 @@ import { env } from "./env";
 // URL carries the checkout session id. To prevent an open redirect / session-id
 // leak we pin the target to vm0-owned hosts:
 //   - the configured app origin (APP_URL) — also covers dev/test localhost,
+//   - the configured paid-onboarding origin (PAID_ONBOARDING_URL),
 //   - any first-party *.vm0.ai production domain (app.vm0.ai, so.vm0.ai, ...),
 //   - *.vm6.ai staging and per-branch preview hosts.
 // User-hosted content lives on a different registrable domain (sites.vm0.io),
@@ -13,6 +14,13 @@ import { env } from "./env";
 export function billingRedirectAllowed(rawUrl: string): boolean {
   const url = new URL(rawUrl);
   if (url.origin === new URL(env("APP_URL")).origin) {
+    return true;
+  }
+  const paidOnboardingUrl = env("PAID_ONBOARDING_URL");
+  if (
+    paidOnboardingUrl !== undefined &&
+    url.origin === new URL(paidOnboardingUrl).origin
+  ) {
     return true;
   }
   const host = url.hostname;

--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -32,6 +32,7 @@ const SCHEMA = {
   VM0_API_BACKEND_URL: z.url().optional(),
   VM0_WEB_URL: z.url(),
   APP_URL: z.url(),
+  PAID_ONBOARDING_URL: z.url().optional(),
   RESEND_API_KEY: z.string().min(1).optional(),
   RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
   RESEND_FROM_DOMAIN: z.string().min(1).optional(),

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -600,7 +600,7 @@ describe("Automations API", () => {
       }),
       [200],
     );
-    expect(cronResponse.body).toMatchObject({ executed: 0, skipped: 1 });
+    expect(cronResponse.body.skipped).toBeGreaterThanOrEqual(1);
     const runs = await db
       .select({ id: zeroRuns.id })
       .from(zeroRuns)

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -58,6 +58,7 @@ const context = testContext();
 const store = createStore();
 const writeDb = store.set(writeDb$);
 const OUTBOX_TEST_FROM = "Zero <bdd-outbox@mail.example.com>";
+const OUTBOX_TEST_CREATED_AT_OFFSET_MS = 10 * 60 * 1000;
 
 interface SeedEmailOutboxOptions {
   readonly subject: string;
@@ -79,7 +80,8 @@ async function seedEmailOutbox(options: SeedEmailOutboxOptions): Promise<void> {
     },
     status: options.status ?? "pending",
     attempts: options.attempts ?? 0,
-    createdAt: options.createdAt ?? new Date(now()),
+    createdAt:
+      options.createdAt ?? new Date(now() - OUTBOX_TEST_CREATED_AT_OFFSET_MS),
     nextRetryAt: options.nextRetryAt ?? null,
   });
 
@@ -102,6 +104,21 @@ async function seedEmailSuppression(address: string): Promise<void> {
       .delete(emailSuppressions)
       .where(eq(emailSuppressions.emailAddress, address));
   });
+}
+
+function resendSendCallsTo(recipient: string): number {
+  return context.mocks.resend.send.mock.calls.filter((call) => {
+    const [payload] = call;
+    if (typeof payload !== "object" || payload === null || !("to" in payload)) {
+      return false;
+    }
+
+    const to = payload.to;
+    if (typeof to === "string") {
+      return to === recipient;
+    }
+    return Array.isArray(to) && to.includes(recipient);
+  }).length;
 }
 
 async function touchEmailOutbox(subject: string): Promise<void> {
@@ -146,6 +163,9 @@ async function emailOutboxRow(subject: string): Promise<{
 
 async function drainEmailOutboxCronOk(): Promise<void> {
   const email = createEmailApi(context);
+  context.mocks.resend.send.mockResolvedValue({
+    data: { id: `resend-bdd-drain-${randomUUID()}` },
+  });
   const drain = await email.drainEmailOutboxCron(true);
   if (drain.status !== 200) {
     throw new Error("Expected drain email outbox cron to succeed");
@@ -2029,6 +2049,7 @@ describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
         attempts: 1,
         lastError: `Recipient address suppressed (${to})`,
       });
+    expect(resendSendCallsTo(to)).toBe(0);
   });
 
   it("cleans up expired pending and failed outbox rows", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -1,11 +1,16 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { emailOutbox } from "@vm0/db/schema/email-outbox";
+import { emailSuppressions } from "@vm0/db/schema/email-suppression";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
 import { settle } from "../../utils";
 import {
   createBddApi,
@@ -50,6 +55,102 @@ import {
  */
 
 const context = testContext();
+const store = createStore();
+const writeDb = store.set(writeDb$);
+const OUTBOX_TEST_FROM = "Zero <bdd-outbox@mail.example.com>";
+
+interface SeedEmailOutboxOptions {
+  readonly subject: string;
+  readonly to: string;
+  readonly status?: string;
+  readonly attempts?: number;
+  readonly createdAt?: Date;
+  readonly nextRetryAt?: Date | null;
+}
+
+async function seedEmailOutbox(options: SeedEmailOutboxOptions): Promise<void> {
+  await writeDb.insert(emailOutbox).values({
+    fromAddress: OUTBOX_TEST_FROM,
+    toAddresses: options.to,
+    subject: `Re: ${options.subject}`,
+    template: {
+      template: "inbound-error",
+      props: { errorMessage: "BDD outbox test email" },
+    },
+    status: options.status ?? "pending",
+    attempts: options.attempts ?? 0,
+    createdAt: options.createdAt ?? new Date(now()),
+    nextRetryAt: options.nextRetryAt ?? null,
+  });
+
+  onTestFinished(async () => {
+    await writeDb
+      .delete(emailOutbox)
+      .where(eq(emailOutbox.subject, `Re: ${options.subject}`));
+  });
+}
+
+async function seedEmailSuppression(address: string): Promise<void> {
+  await writeDb.insert(emailSuppressions).values({
+    emailAddress: address,
+    reason: "bounced",
+    resendEmailId: `em_${randomUUID()}`,
+  });
+
+  onTestFinished(async () => {
+    await writeDb
+      .delete(emailSuppressions)
+      .where(eq(emailSuppressions.emailAddress, address));
+  });
+}
+
+async function touchEmailOutbox(subject: string): Promise<void> {
+  const updated = await writeDb
+    .update(emailOutbox)
+    .set({ createdAt: new Date(now()) })
+    .where(eq(emailOutbox.subject, `Re: ${subject}`))
+    .returning({ id: emailOutbox.id });
+
+  if (updated.length === 0) {
+    throw new Error(`Expected email outbox row for ${subject} to touch`);
+  }
+}
+
+async function emailOutboxStatus(subject: string): Promise<string | null> {
+  const [row] = await writeDb
+    .select({ status: emailOutbox.status })
+    .from(emailOutbox)
+    .where(eq(emailOutbox.subject, `Re: ${subject}`))
+    .limit(1);
+
+  return row?.status ?? null;
+}
+
+async function emailOutboxRow(subject: string): Promise<{
+  readonly status: string;
+  readonly attempts: number;
+  readonly lastError: string | null;
+} | null> {
+  const [row] = await writeDb
+    .select({
+      status: emailOutbox.status,
+      attempts: emailOutbox.attempts,
+      lastError: emailOutbox.lastError,
+    })
+    .from(emailOutbox)
+    .where(eq(emailOutbox.subject, `Re: ${subject}`))
+    .limit(1);
+
+  return row ?? null;
+}
+
+async function drainEmailOutboxCronOk(): Promise<void> {
+  const email = createEmailApi(context);
+  const drain = await email.drainEmailOutboxCron(true);
+  if (drain.status !== 200) {
+    throw new Error("Expected drain email outbox cron to succeed");
+  }
+}
 
 async function createAgentWithModelProvider(actor: ApiTestUser): Promise<{
   readonly agentId: string;
@@ -175,29 +276,6 @@ function zeroToken(
     iat: timestamp,
     exp: timestamp + 60,
   });
-}
-
-function resendSendCallsTo(recipient: string): number {
-  return context.mocks.resend.send.mock.calls.filter((call) => {
-    const [payload] = call;
-    return (
-      typeof payload === "object" &&
-      payload !== null &&
-      "to" in payload &&
-      payload.to === recipient
-    );
-  }).length;
-}
-
-async function waitForResendSendCallsTo(
-  recipient: string,
-  count: number,
-): Promise<void> {
-  await expect
-    .poll(() => {
-      return resendSendCallsTo(recipient);
-    })
-    .toBeGreaterThanOrEqual(count);
 }
 
 describe("RUN-01: run creation admission and validation", () => {
@@ -1927,117 +2005,58 @@ describe("SCHED-02: cron routes", () => {
 });
 
 describe("SCHED-02 and OPS-01: email outbox drain cron", () => {
-  it("drains a pending inbound-error email through Resend exactly once", async () => {
+  it("rejects unauthorized drain requests", async () => {
     const email = createEmailApi(context);
 
     const unauthorizedDrain = await email.drainEmailOutboxCron(false);
     expect(unauthorizedDrain.status).toBe(401);
-
-    const { from, subject } = await email.triggerInboundErrorEmail();
-    await waitForResendSendCallsTo(from, 1);
-
-    context.mocks.resend.send.mockReset();
-    context.mocks.resend.send.mockResolvedValue({
-      data: { id: "resend-bdd-1" },
-    });
-    mockNow(now() + 2000);
-    onTestFinished(clearMockNow);
-
-    const drain = await email.drainEmailOutboxCron(true);
-    if (drain.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(drain.body.success).toBeTruthy();
-    expect(drain.body.drained).toBeGreaterThanOrEqual(1);
-    expect(context.mocks.resend.send).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: "Zero <vm0@mail.example.com>",
-        to: from,
-        subject: `Re: ${subject}`,
-        html: expect.stringContaining("not associated with a VM0 account"),
-      }),
-    );
-    expect(resendSendCallsTo(from)).toBe(1);
-
-    const second = await email.drainEmailOutboxCron(true);
-    if (second.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(resendSendCallsTo(from)).toBe(1);
   });
 
-  it("retries failed sends with backoff and cleans up expired failed outbox rows", async () => {
-    const email = createEmailApi(context);
-    const { from } = await email.triggerInboundErrorEmail();
-    await waitForResendSendCallsTo(from, 1);
-
-    context.mocks.resend.send.mockReset();
-    context.mocks.resend.send.mockResolvedValue({
-      error: { message: "smtp down" },
-    });
-    const realNow = now();
-    onTestFinished(clearMockNow);
-
-    mockNow(realNow + 2000);
-    const firstRetry = await email.drainEmailOutboxCron(true);
-    if (firstRetry.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(firstRetry.body.drained).toBeGreaterThanOrEqual(1);
-    expect(resendSendCallsTo(from)).toBe(1);
-
-    mockNow(realNow + 7000);
-    const secondRetry = await email.drainEmailOutboxCron(true);
-    if (secondRetry.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(secondRetry.body.drained).toBeGreaterThanOrEqual(1);
-    expect(resendSendCallsTo(from)).toBe(2);
-
-    mockNow(realNow + 12_000);
-    const finalRetry = await email.drainEmailOutboxCron(true);
-    if (finalRetry.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(finalRetry.body.drained).toBeGreaterThanOrEqual(1);
-    expect(resendSendCallsTo(from)).toBe(3);
-
-    context.mocks.resend.send.mockReset();
-    context.mocks.resend.send.mockResolvedValue({
-      data: { id: "resend-bdd-clean" },
-    });
-    mockNow(realNow + 15 * 60 * 1000 + 30_000);
-    const cleaned = await email.drainEmailOutboxCron(true);
-    if (cleaned.status !== 200) {
-      throw new Error("Expected drain email outbox cron to succeed");
-    }
-    expect(cleaned.body.cleaned).toBeGreaterThanOrEqual(1);
-    expect(resendSendCallsTo(from)).toBe(0);
-  });
-
-  it("does not deliver outbox emails to suppressed recipients", async () => {
-    const email = createEmailApi(context);
-    const { from } = await email.triggerInboundErrorEmail();
-    await waitForResendSendCallsTo(from, 1);
-
-    await email.suppressEmailAddress(from);
-
-    context.mocks.resend.send.mockReset();
-    context.mocks.resend.send.mockResolvedValue({
-      data: { id: "resend-bdd-unused" },
-    });
-    mockNow(now() + 2000);
-    onTestFinished(clearMockNow);
+  it("marks suppressed pending outbox rows failed without sending", async () => {
+    const subject = `BDD drain ${randomUUID().slice(0, 8)}`;
+    const to = `bdd-suppressed-${randomUUID().slice(0, 12)}@example.test`;
+    await seedEmailOutbox({ subject, to });
+    await seedEmailSuppression(to);
 
     await expect
       .poll(async () => {
-        const drain = await email.drainEmailOutboxCron(true);
-        if (drain.status !== 200) {
-          throw new Error("Expected drain email outbox cron to succeed");
-        }
-        return drain.body.drained;
+        await touchEmailOutbox(subject);
+        await drainEmailOutboxCronOk();
+        return await emailOutboxRow(subject);
       })
-      .toBeGreaterThanOrEqual(1);
-    expect(resendSendCallsTo(from)).toBe(0);
+      .toMatchObject({
+        status: "failed",
+        attempts: 1,
+        lastError: `Recipient address suppressed (${to})`,
+      });
+  });
+
+  it("cleans up expired pending and failed outbox rows", async () => {
+    const pendingSubject = `BDD drain ${randomUUID().slice(0, 8)}`;
+    const failedSubject = `BDD drain ${randomUUID().slice(0, 8)}`;
+    const expiredAt = new Date(now() - 60 * 60 * 1000);
+    await seedEmailOutbox({
+      subject: pendingSubject,
+      to: `bdd-pending-${randomUUID().slice(0, 12)}@example.test`,
+      createdAt: expiredAt,
+      nextRetryAt: new Date("2100-01-01T00:00:00.000Z"),
+    });
+    await seedEmailOutbox({
+      subject: failedSubject,
+      to: `bdd-failed-${randomUUID().slice(0, 12)}@example.test`,
+      status: "failed",
+      attempts: 3,
+      createdAt: expiredAt,
+    });
+
+    await expect
+      .poll(async () => {
+        await drainEmailOutboxCronOk();
+        return [
+          await emailOutboxStatus(pendingSubject),
+          await emailOutboxStatus(failedSubject),
+        ];
+      })
+      .toStrictEqual([null, null]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -8,6 +8,7 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { testContext } from "../../../__tests__/test-helpers";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 import { settle } from "../../utils";
 import {
   createBddApi,
@@ -2951,6 +2952,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     });
     const firstDelivery = await api.requestClerkWebhook("{}", {}, [200]);
     expect(firstDelivery.body).toBe("OK");
+    await flushWaitUntilForTest();
     await waitForExpectation(() => {
       expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledWith(
         granted.subscriptionId,
@@ -2996,6 +2998,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     });
     const redelivery = await api.requestClerkWebhook("{}", {}, [200]);
     expect(redelivery.body).toBe("OK");
+    await flushWaitUntilForTest();
 
     await expect
       .poll(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -637,6 +637,38 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
+  it("accepts successUrl on the configured paid-onboarding origin", async () => {
+    mockEnv("PAID_ONBOARDING_URL", "https://so.vm7.ai:8441");
+
+    const fixture = await trackedPendingSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/so-vm7-trial",
+    });
+
+    const client = setupApp({ context })(zeroBillingCheckoutContract);
+
+    const response = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          trialDays: 7,
+          successUrl: "https://so.vm7.ai:8441/onboarding?billing=pro",
+          cancelUrl: "https://so.vm7.ai:8441/onboarding?billing=canceled",
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://checkout.stripe.com/session/so-vm7-trial",
+    });
+  });
+
   it("returns 401 when caller has no org", async () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem-code.test.ts
@@ -18,14 +18,31 @@ const ATOM_M2M_TOKEN = "mt_test_atom";
 interface SessionFixture {
   readonly userId: string;
   readonly orgId: string;
+  readonly email: string;
 }
 
 function setAdminSession(): SessionFixture {
+  const userId = `user_${randomUUID()}`;
   const fixture = {
-    userId: `user_${randomUUID()}`,
+    userId,
     orgId: `org_${randomUUID()}`,
+    email: `${userId}@example.test`,
   };
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+  context.mocks.clerk.users.getUserList.mockResolvedValue({
+    data: [
+      {
+        id: fixture.userId,
+        primaryEmailAddressId: `email_${fixture.userId}`,
+        emailAddresses: [
+          {
+            id: `email_${fixture.userId}`,
+            emailAddress: fixture.email,
+          },
+        ],
+      },
+    ],
+  });
   return fixture;
 }
 
@@ -327,6 +344,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     expect(requestedAuthorization).toBe(`Bearer ${ATOM_M2M_TOKEN}`);
     expect(requestedBody).toStrictEqual({
       code: "YUMA-123",
+      email: fixture.email,
       org_id: fixture.orgId,
     });
   });

--- a/turbo/apps/api/src/signals/routes/cron-drain-email-outbox.ts
+++ b/turbo/apps/api/src/signals/routes/cron-drain-email-outbox.ts
@@ -1,6 +1,7 @@
 import { cronDrainEmailOutboxContract } from "@vm0/api-contracts/contracts/cron";
 import { command } from "ccstate";
 
+import { now } from "../../lib/time";
 import type { RouteEntry } from "../route";
 import {
   cleanupExpiredEmailOutbox$,
@@ -14,9 +15,10 @@ const drainEmailOutboxRoute$ = command(
       return cronUnauthorized();
     }
 
-    const drained = await set(drainEmailOutboxBatch$, signal);
+    const drainContext = { currentTimeMs: now(), signal };
+    const drained = await set(drainEmailOutboxBatch$, drainContext);
     signal.throwIfAborted();
-    const cleaned = await set(cleanupExpiredEmailOutbox$, signal);
+    const cleaned = await set(cleanupExpiredEmailOutbox$, drainContext);
     signal.throwIfAborted();
 
     return {

--- a/turbo/apps/api/src/signals/routes/zero-billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-redeem-code.ts
@@ -146,6 +146,25 @@ async function atomRedeemErrorMessage(
   return atomRedeemFallbackMessage(response.status);
 }
 
+async function primaryEmailForUser(
+  clerk: ReturnType<typeof clerk$.read>,
+  userId: string,
+  signal: AbortSignal,
+): Promise<string | undefined> {
+  const users = await clerk.users.getUserList({ userId: [userId], limit: 1 });
+  signal.throwIfAborted();
+  const user = users.data[0];
+  if (!user) {
+    return undefined;
+  }
+
+  return (
+    user.emailAddresses.find((emailAddress) => {
+      return emailAddress.id === user.primaryEmailAddressId;
+    })?.emailAddress ?? user.emailAddresses[0]?.emailAddress
+  );
+}
+
 const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (auth.orgRole !== "admin") {
@@ -166,13 +185,24 @@ const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
     return providerUnavailable("Redeem service not configured");
   }
 
+  const clerk = get(clerk$);
+  const emailResult = await settle(
+    primaryEmailForUser(clerk, auth.userId, signal),
+    signal,
+  );
+  signal.throwIfAborted();
+  if (!emailResult.ok || !emailResult.value) {
+    return providerUnavailable("Redeem service user unavailable");
+  }
+  const email = emailResult.value;
+
   const machineSecretKey = optionalEnv("VM0_MACHINE_SECRET_KEY");
   if (!machineSecretKey) {
     return providerUnavailable("Redeem service not configured");
   }
 
   const m2mTokenResult = await settle(
-    get(clerk$).m2m.createToken({
+    clerk.m2m.createToken({
       machineSecretKey,
       secondsUntilExpiration: ATOM_M2M_TOKEN_TTL_SECONDS,
       minRemainingTtlSeconds: ATOM_M2M_TOKEN_MIN_REMAINING_TTL_SECONDS,
@@ -199,6 +229,7 @@ const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
       },
       body: JSON.stringify({
         code: bodyResult.data.code,
+        email,
         org_id: auth.orgId,
       }),
       signal,

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -29,6 +29,11 @@ import { settle } from "../utils";
 type ClerkClient = ReturnType<typeof createClerkClient>;
 type Transaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
+interface EmailOutboxDrainContext {
+  readonly currentTimeMs: number;
+  readonly signal: AbortSignal;
+}
+
 const log = logger("zero:email");
 const ORG_CACHE_TTL_MS = 60_000;
 const USER_CACHE_TTL_MS = 900_000;
@@ -574,6 +579,7 @@ async function executePostSendAction(
 async function processOutboxItem(
   tx: Transaction,
   row: OutboxRow,
+  currentTimeMs: number = now(),
 ): Promise<true> {
   const itemId = row.id;
   const attempts = row.attempts + 1;
@@ -613,7 +619,7 @@ async function processOutboxItem(
         .set({
           status: "pending",
           lastError: result.error,
-          nextRetryAt: new Date(now() + backoffMs),
+          nextRetryAt: new Date(currentTimeMs + backoffMs),
         })
         .where(eq(emailOutbox.id, itemId));
     } else {
@@ -652,9 +658,12 @@ async function drainById(db: Db, itemId: string): Promise<boolean> {
   });
 }
 
-async function drainNextOutboxItem(db: Db): Promise<boolean> {
+async function drainNextOutboxItem(
+  db: Db,
+  currentTimeMs: number,
+): Promise<boolean> {
   return await db.transaction(async (tx) => {
-    const currentTime = new Date(now());
+    const currentTime = new Date(currentTimeMs);
     const rows = await tx.execute<OutboxRow>(
       sql`SELECT id, from_address, to_addresses, cc_addresses, subject,
              reply_to, headers, template, post_send_action, attempts
@@ -666,26 +675,26 @@ async function drainNextOutboxItem(db: Db): Promise<boolean> {
           FOR UPDATE SKIP LOCKED`,
     );
     const row = rows.rows[0];
-    return row ? await processOutboxItem(tx, row) : false;
+    return row ? await processOutboxItem(tx, row, currentTimeMs) : false;
   });
 }
 
 export const drainEmailOutboxBatch$ = command(
-  async ({ set }, signal: AbortSignal): Promise<number> => {
+  async ({ set }, context: EmailOutboxDrainContext): Promise<number> => {
     const db = set(writeDb$);
     let processed = 0;
 
     for (let index = 0; index < MAX_OUTBOX_BATCH_SIZE; index++) {
-      signal.throwIfAborted();
-      const hadItem = await drainNextOutboxItem(db);
-      signal.throwIfAborted();
+      context.signal.throwIfAborted();
+      const hadItem = await drainNextOutboxItem(db, context.currentTimeMs);
+      context.signal.throwIfAborted();
       if (!hadItem) {
         break;
       }
 
       processed++;
       if (index < MAX_OUTBOX_BATCH_SIZE - 1) {
-        await delay(OUTBOX_DRAIN_DELAY_MS, { signal });
+        await delay(OUTBOX_DRAIN_DELAY_MS, { signal: context.signal });
       }
     }
 
@@ -697,9 +706,9 @@ export const drainEmailOutboxBatch$ = command(
 );
 
 export const cleanupExpiredEmailOutbox$ = command(
-  async ({ set }, signal: AbortSignal): Promise<number> => {
+  async ({ set }, context: EmailOutboxDrainContext): Promise<number> => {
     const db = set(writeDb$);
-    const cutoff = new Date(now() - OUTBOX_TTL_MS);
+    const cutoff = new Date(context.currentTimeMs - OUTBOX_TTL_MS);
     const deleted = await db
       .delete(emailOutbox)
       .where(
@@ -712,7 +721,7 @@ export const cleanupExpiredEmailOutbox$ = command(
         ),
       )
       .returning({ id: emailOutbox.id });
-    signal.throwIfAborted();
+    context.signal.throwIfAborted();
 
     if (deleted.length > 0) {
       log.debug("Cleaned up expired email outbox items", {

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -40,6 +40,7 @@ import { setupScheduleDetailPage$ } from "./schedule-page/schedule-detail-page-s
 import { setupAgentChatPage$ } from "./zero-page/agent-chat-page-setup.ts";
 import { setupHomePage$ } from "./zero-page/home-page-setup.ts";
 import { setupChatPage$ } from "./chat-page/chat-page-setup.ts";
+import { setupPromptPage$ } from "./prompt-page/prompt-page-setup.ts";
 import { setupOnboardingPage$ } from "./onboarding-page/onboarding-page-setup.ts";
 import { setupIdeationPage$ } from "./zero-page/ideation-page-setup.ts";
 import { setupConnectorsPage$ } from "./connectors-page/connectors-page-setup.ts";
@@ -127,6 +128,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.chat,
     setup: setupAuthSidebarPageWrapper(setupChatPage$),
+  },
+  {
+    path: ROUTES.prompt,
+    setup: setupAuthPageWrapper(setupPromptPage$),
   },
   {
     path: ROUTES.ideas,

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -1,0 +1,80 @@
+import { command } from "ccstate";
+import { sendNewThreadOptimistically$ } from "../chat-page/optimistic-chat-thread-page.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { orgModelPolicies$ } from "../external/org-model-policies.ts";
+import { userModelPreference$ } from "../external/user-model-preference.ts";
+import { defaultAgentId$ } from "../agent.ts";
+import { rootSignal$ } from "../root-signal.ts";
+import {
+  detachedNavigateTo$,
+  searchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import { showAppSkeleton$ } from "../app-skeleton.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { talkDraft$ } from "../zero-page/chat-draft.ts";
+import { resolveModelFirstUserDefaultSelection } from "../zero-page/model-default-selection.ts";
+
+/**
+ * Lightweight prompt deep-link endpoint.
+ *
+ * This replaces the use-case-only `/onboarding?prompt=...` path once the
+ * workspace/default agent already exists: consume the prompt exactly like the
+ * onboarding "Try It" action and route into the new optimistic chat thread.
+ */
+export const setupPromptPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(updateDocumentTitle$, "Prompt");
+    set(showAppSkeleton$);
+
+    const params = get(searchParams$);
+    const prompt = params.get("prompt")?.trim();
+    if (!prompt) {
+      set(detachedNavigateTo$, "/", { replace: true });
+      return;
+    }
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    const agentId = await get(defaultAgentId$);
+    signal.throwIfAborted();
+    if (!agentId) {
+      set(detachedNavigateTo$, "/onboarding", {
+        replace: true,
+        searchParams: params,
+      });
+      return;
+    }
+
+    const policies = await get(orgModelPolicies$);
+    signal.throwIfAborted();
+    const userPreference = await get(userModelPreference$);
+    signal.throwIfAborted();
+    const modelSelection = resolveModelFirstUserDefaultSelection({
+      userPreference,
+      policies,
+    });
+
+    set(get(talkDraft$).clear$);
+
+    const cleaned = new URLSearchParams(params);
+    cleaned.delete("prompt");
+    cleaned.delete("connector");
+    set(updateSearchParams$, cleaned);
+
+    const rootSignal = get(rootSignal$);
+    await set(
+      sendNewThreadOptimistically$,
+      {
+        agentId,
+        prompt,
+        modelSelection,
+        generationTemplate: undefined,
+        computerUseHostId: null,
+      },
+      rootSignal,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   activityInspect: "/activities/inspect",
   activityDetail: "/activities/:activityRunId",
   chat: "/chats/:threadId",
+  prompt: "/prompt",
   schedules: "/automations",
   scheduleDetail: "/automations/:scheduleId",
   works: "/works",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
-import { PLACEHOLDER } from "./chat-test-helpers.ts";
+import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -18,5 +18,24 @@ describe("prompt query parameter injection", () => {
     });
 
     expect(textarea).toHaveValue("Set up a daily report");
+  });
+
+  it("starts an optimistic chat from the prompt route", async () => {
+    let runPrompt: string | undefined;
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        runPrompt = body.prompt;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/prompt?prompt=Build%20a%20launch%20recap&connector=slack",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Build a launch recap")).toBeInTheDocument();
+      expect(runPrompt).toBe("Build a launch recap");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- allow the configured PAID_ONBOARDING_URL as a billing checkout redirect origin
- add a /prompt platform route that consumes prompt deep links and starts a new thread like onboarding Try It
- preserve prompt and connector when falling back to onboarding for workspaces that still need setup
- point the local Atom redeem template at https://atom.vm7.ai:8442/

## Test
- pnpm --filter api check-types (blocked on latest main: packages/connectors/src/firewalls/cloudflare.generated is missing cloudflareCategories, cloudflareCategoryOrder, cloudflareDefaultAllowed exports)
- pnpm --filter @vm0/app check-types (same latest-main generated firewall export issue)