### PR TITLE
feat: retire the schedule trigger source value

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -689,7 +689,7 @@ export const seedScheduleBatch$ = command(
         }
         await db.insert(zeroRuns).values({
           id: run.id,
-          triggerSource: "schedule",
+          triggerSource: "automation",
           automationId: scheduleRow.id,
         });
         const credits = args.creditsForIndex(index);

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-trigger.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-trigger.test.ts
@@ -132,7 +132,7 @@ async function seedRunAndCallback(
       orgId: fixture.orgId,
       userId: fixture.userId,
       composeId: fixture.composeId,
-      triggerSource: "schedule",
+      triggerSource: "automation",
       prompt: "Triggered task",
     },
     context.signal,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2139,24 +2139,6 @@ function captureScheduleRunCallbacks(): void {
   );
 }
 
-async function expectSingleLogSourceMatch(args: {
-  readonly actor: ApiTestUser;
-  readonly triggerSource: "schedule" | "automation";
-  readonly runId: string;
-}): Promise<void> {
-  const response = await reads.requestListLogs(
-    args.actor,
-    { triggerSource: args.triggerSource },
-    [200],
-  );
-  mustOk(response, `${args.triggerSource}-source log list`);
-  expect(
-    response.body.data.map((entry) => {
-      return entry.id;
-    }),
-  ).toStrictEqual([args.runId]);
-}
-
 describe("RUN-04/OPS-01: zero run logs", () => {
   it("lists run logs with filters, paging, zero tokens, and detail residue", async () => {
     const actor = await entitledActor();
@@ -2368,16 +2350,17 @@ describe("RUN-04/OPS-01: zero run logs", () => {
         .sort(),
     ).toStrictEqual([webRun.runId, secondAgentRun.runId].sort());
 
-    await expectSingleLogSourceMatch({
+    const automationSourceList = await reads.requestListLogs(
       actor,
-      triggerSource: "schedule",
-      runId: scheduleRun.body.runId,
-    });
-    await expectSingleLogSourceMatch({
-      actor,
-      triggerSource: "automation",
-      runId: scheduleRun.body.runId,
-    });
+      { triggerSource: "automation" },
+      [200],
+    );
+    mustOk(automationSourceList, "automation-source log list");
+    expect(
+      automationSourceList.body.data.map((entry) => {
+        return entry.id;
+      }),
+    ).toStrictEqual([scheduleRun.body.runId]);
 
     const noSourceMatch = await reads.requestListLogs(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-banking.test.ts
@@ -496,40 +496,39 @@ describe("POST /api/zero/banking/*", () => {
     expect(authRequestCount).toBe(0);
   });
 
-  it.each(["schedule", "automation"] as const)(
-    "denies %s-triggered runs unless the banking grant allows them",
-    async (triggerSource) => {
-      const fixture = await track(seedBankingFixture({ triggerSource }));
-      let authRequestCount = 0;
-      server.use(
-        http.post(FINICITY_AUTH_URL, () => {
-          authRequestCount += 1;
-          return HttpResponse.json({ token: "test-app-token" });
-        }),
-      );
+  it("denies automation-triggered runs unless the banking grant allows them", async () => {
+    const fixture = await track(
+      seedBankingFixture({ triggerSource: "automation" }),
+    );
+    let authRequestCount = 0;
+    server.use(
+      http.post(FINICITY_AUTH_URL, () => {
+        authRequestCount += 1;
+        return HttpResponse.json({ token: "test-app-token" });
+      }),
+    );
 
-      const client = setupApp({ context })(zeroBankingContract);
-      const response = await accept(
-        client.accounts({
-          headers: { authorization: `Bearer ${zeroToken(fixture)}` },
-          body: {},
-        }),
-        [403],
-      );
+    const client = setupApp({ context })(zeroBankingContract);
+    const response = await accept(
+      client.accounts({
+        headers: { authorization: `Bearer ${zeroToken(fixture)}` },
+        body: {},
+      }),
+      [403],
+    );
 
-      expect(response.body.error.message).toBe(
-        "Banking is not enabled for scheduled runs",
-      );
-      expect(authRequestCount).toBe(0);
-      await expect(bankingAuditEvents(fixture)).resolves.toMatchObject([
-        {
-          action: "accounts.read",
-          status: "denied",
-          failureCode: "SCHEDULE_NOT_ALLOWED",
-        },
-      ]);
-    },
-  );
+    expect(response.body.error.message).toBe(
+      "Banking is not enabled for scheduled runs",
+    );
+    expect(authRequestCount).toBe(0);
+    await expect(bankingAuditEvents(fixture)).resolves.toMatchObject([
+      {
+        action: "accounts.read",
+        status: "denied",
+        failureCode: "SCHEDULE_NOT_ALLOWED",
+      },
+    ]);
+  });
 
   it("denies revoked banking connections before provider access", async () => {
     const fixture = await track(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-message.test.ts
@@ -421,7 +421,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
         userId,
         composeId,
         scheduleId,
-        triggerSource: "schedule",
+        triggerSource: "automation",
       },
       context.signal,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -259,7 +259,7 @@ describe("GET /api/zero/usage/insight", () => {
     expect(totalByBucket["chat"]).toBeGreaterThanOrEqual(50);
     expect(totalByBucket["slack"]).toBeGreaterThanOrEqual(50);
     expect(totalByBucket["email"]).toBeGreaterThanOrEqual(50);
-    expect(totalByBucket["schedule"]).toBeGreaterThanOrEqual(50);
+    expect(totalByBucket["automation"]).toBeGreaterThanOrEqual(50);
     expect(totalByBucket["others"]).toBeGreaterThanOrEqual(250);
   });
 
@@ -888,7 +888,7 @@ describe("GET /api/zero/usage/insight", () => {
           orgId: fixture.orgId,
           userId: fixture.userId,
           composeId: agentId,
-          triggerSource: "schedule",
+          triggerSource: "automation",
           scheduleId,
           status: "completed",
         },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -287,7 +287,7 @@ describe("GET /api/zero/usage/record", () => {
     expect(response.body.rows[2]?.credits).toBe(80);
   });
 
-  it("labels schedule threads and filters by source", async () => {
+  it("labels automation threads and filters by source", async () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),
     );
@@ -322,7 +322,7 @@ describe("GET /api/zero/usage/record", () => {
         orgId: fixture.orgId,
         userId: fixture.userId,
         title: "Daily brief",
-        triggerSource: "schedule",
+        triggerSource: "automation",
         createdAt: createdAt(10),
       },
       context.signal,
@@ -344,7 +344,7 @@ describe("GET /api/zero/usage/record", () => {
 
     const response = await accept(
       apiClient().get({
-        query: { source: "schedule" },
+        query: { source: "automation" },
         headers: authHeaders(),
       }),
       [200],
@@ -352,13 +352,13 @@ describe("GET /api/zero/usage/record", () => {
 
     expect(response.body.rows).toHaveLength(1);
     expect(response.body.pagination.total).toBe(1);
-    expect(response.body.rows[0]?.source).toBe("schedule");
+    expect(response.body.rows[0]?.source).toBe("automation");
     expect(response.body.rows[0]?.threadId).toBe(schedule.threadId);
     expect(response.body.rows[0]?.title).toBe("Daily brief");
     expect(response.body.rows[0]?.credits).toBe(120);
   });
 
-  it("keeps chat and schedule usage separate within the same thread", async () => {
+  it("keeps chat and automation usage separate within the same thread", async () => {
     const fixture = await track(
       store.set(seedUsageFixture$, {}, context.signal),
     );
@@ -420,7 +420,7 @@ describe("GET /api/zero/usage/record", () => {
     expect(allResponse.body.rows).toHaveLength(2);
     expect(allResponse.body.pagination.total).toBe(2);
     expect(allResponse.body.rows[0]).toMatchObject({
-      source: "schedule",
+      source: "automation",
       threadId: chat.threadId,
       runId: null,
       title: "Shared thread",

--- a/turbo/apps/api/src/signals/services/automations-v2.service.ts
+++ b/turbo/apps/api/src/signals/services/automations-v2.service.ts
@@ -1228,9 +1228,6 @@ export const runAutomationNowV2$ = command(
             : {}),
         },
         apiStartTime: args.apiStartTime,
-        // Manual fires record automation provenance; trigger_source follows
-        // (#17307). Historical rows may still carry "schedule" until the
-        // backfill migration lands.
         triggerSource: "automation",
         chatThreadId: runInput.chatThreadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -301,9 +301,6 @@ const runTriggerNow$ = command(
             : {}),
         },
         apiStartTime: args.apiStartTime,
-        // Time fires record automation provenance; trigger_source follows
-        // (#17307). Historical rows may still carry "schedule" until the
-        // backfill migration lands.
         triggerSource: "automation",
         chatThreadId: runInput.chatThreadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,

--- a/turbo/apps/api/src/signals/services/zero-banking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-banking.service.ts
@@ -532,10 +532,7 @@ async function authorizeBankingAccess(
     });
   }
 
-  if (
-    (run.triggerSource === "schedule" || run.triggerSource === "automation") &&
-    !grant.allowScheduledRuns
-  ) {
+  if (run.triggerSource === "automation" && !grant.allowScheduledRuns) {
     return await denyBankingAccess(db, auth, action, providerAccountId, {
       agentId: run.agentId,
       connectionId: grant.connectionId,

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -66,15 +66,6 @@ function normalizeTriggerSource(
   return parsed.success ? parsed.data : null;
 }
 
-// "automation" supersedes "schedule" (#17307); until the backfill migration
-// unifies historical rows, a filter on either value matches both.
-function triggerSourceCondition(source: TriggerSource): SQL {
-  if (source === "schedule" || source === "automation") {
-    return inArray(zeroRuns.triggerSource, ["schedule", "automation"]);
-  }
-  return eq(zeroRuns.triggerSource, source);
-}
-
 function buildCursorCondition(cursor: string): SQL | null {
   const separatorIndex = cursor.lastIndexOf("|");
   if (separatorIndex <= 0) {
@@ -161,7 +152,7 @@ export function zeroLogsList(
       conditions.push(eq(agentRuns.status, params.status));
     }
     if (params.triggerSource) {
-      conditions.push(triggerSourceCondition(params.triggerSource));
+      conditions.push(eq(zeroRuns.triggerSource, params.triggerSource));
     }
     if (params.scheduleId) {
       // Schedule ids are automation ids (D2 on #16847); historical runs were
@@ -269,7 +260,7 @@ async function getLogsTotalCount(
     conditions.push(eq(agentRuns.status, params.status));
   }
   if (params.triggerSource) {
-    conditions.push(triggerSourceCondition(params.triggerSource));
+    conditions.push(eq(zeroRuns.triggerSource, params.triggerSource));
   }
   if (params.scheduleId) {
     conditions.push(eq(zeroRuns.automationId, params.scheduleId));
@@ -351,7 +342,6 @@ async function getAvailableFilters(
     .filter((s): s is TriggerSource => {
       return [
         "automation",
-        "schedule",
         "web",
         "slack",
         "email",

--- a/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-insight.service.ts
@@ -369,7 +369,7 @@ function queryUsageInsightSourceBuckets(db: Db, p: UsageInsightSqlParams) {
           WHEN zr.trigger_source = 'web' THEN 'chat'
           WHEN zr.trigger_source = 'slack' THEN 'slack'
           WHEN zr.trigger_source = 'email' THEN 'email'
-          WHEN zr.trigger_source IN ('schedule', 'automation') THEN 'schedule'
+          WHEN zr.trigger_source = 'automation' THEN 'automation'
           ELSE 'others'
         END AS bucket,
         COALESCE(SUM(${USAGE_ROW_ALIAS}.credits_charged), 0)::bigint AS credits,
@@ -517,7 +517,7 @@ async function queryUsageInsightTopSchedules(
         FROM usage_rows ${USAGE_ROW_ALIAS}
         INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
         LEFT JOIN automations a ON a.id = zr.automation_id
-        WHERE zr.trigger_source IN ('schedule', 'automation')
+        WHERE zr.trigger_source = 'automation'
           AND zr.automation_id IS NOT NULL
         GROUP BY zr.automation_id, a.name, a.description
       )
@@ -563,7 +563,7 @@ async function queryUsageInsightTopSchedules(
             ROW_NUMBER() OVER (ORDER BY SUM(${USAGE_ROW_ALIAS}.credits_charged) DESC NULLS LAST) AS rn
           FROM usage_rows ${USAGE_ROW_ALIAS}
           INNER JOIN zero_runs zr ON zr.id = ${USAGE_ROW_ALIAS}.run_id
-          WHERE zr.trigger_source IN ('schedule', 'automation') AND zr.automation_id IS NOT NULL
+          WHERE zr.trigger_source = 'automation' AND zr.automation_id IS NOT NULL
           GROUP BY zr.automation_id
         )
         SELECT COUNT(*)::bigint AS cnt FROM agg WHERE rn > 100

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -25,10 +25,10 @@ const MODEL_TOKEN_CATEGORIES = [
   "tokens.cache_read",
   "tokens.cache_creation",
 ] as const;
-const THREADED_SOURCES = ["chat", "schedule"] as const;
+const THREADED_SOURCES = ["chat", "automation"] as const;
 const USAGE_RECORD_KINDS = ["model", "image", "video", "connector"] as const;
 const PASSTHROUGH_TRIGGER_SOURCES = [
-  "schedule",
+  "automation",
   "slack",
   "telegram",
   "email",
@@ -87,7 +87,6 @@ function sourceExpr(triggerSource: string): string {
   return `
     CASE
       WHEN ${triggerSource} = 'web' THEN 'chat'
-      WHEN ${triggerSource} = 'automation' THEN 'schedule'
       WHEN ${triggerSource} IN (${passthroughList}) THEN ${triggerSource}
       ELSE 'other'
     END`;

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -10,7 +10,6 @@ export type { LogStatus, TriggerSource };
 /** Human-readable labels for each trigger source, shared across activity views. */
 export const TRIGGER_SOURCE_LABELS: Readonly<Record<TriggerSource, string>> = {
   automation: "Automation",
-  schedule: "Schedule",
   web: "Web",
   slack: "Slack",
   email: "Email",

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
@@ -532,7 +532,7 @@ describe("network insights page", () => {
     });
 
     expect(screen.queryByText("Hidden Schedule")).not.toBeInTheDocument();
-    await user.click(screen.getByText("+1 more schedule"));
+    await user.click(screen.getByText("+1 more automation"));
     expect(screen.getByText("Hidden Schedule")).toBeInTheDocument();
 
     expect(screen.queryByText("Hidden chat")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1041,7 +1041,7 @@ function DaySchedulesCard({
         className="text-xs font-semibold uppercase tracking-widest mb-3"
         style={{ color: accent }}
       >
-        Schedules
+        Automations
       </p>
       <div className="flex items-center mb-3">
         <span className="text-3xl font-black tabular-nums font-serif">
@@ -1049,7 +1049,7 @@ function DaySchedulesCard({
         </span>
       </div>
       <p className="text-sm opacity-60">
-        {schedules.length === 1 ? "schedule" : "schedules"} used{" "}
+        {schedules.length === 1 ? "automation" : "automations"} used{" "}
         {formatCardValue(totalCredits)}{" "}
         {totalCredits === 1 ? "credit" : "credits"}
       </p>
@@ -1109,7 +1109,7 @@ function DaySchedulesCard({
               >
                 {showAll
                   ? "Show less"
-                  : `+${overflow} more ${overflow === 1 ? "schedule" : "schedules"}`}
+                  : `+${overflow} more ${overflow === 1 ? "automation" : "automations"}`}
               </button>
             </li>
           )}

--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -77,7 +77,7 @@ describe("/usage page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("No schedules used in this period"),
+        screen.getByText("No automations used in this period"),
       ).toBeInTheDocument();
       expect(screen.getByText("No chats in this period")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-schedules-table.tsx
@@ -43,7 +43,7 @@ export function UsageInsightSchedulesTable({
           Schedules
         </p>
         <p className="text-sm text-muted-foreground">
-          No schedules used in this period
+          No automations used in this period
         </p>
       </section>
     );
@@ -72,7 +72,7 @@ export function UsageInsightSchedulesTable({
         {totalCount}
       </p>
       <p className="text-sm opacity-60 mt-2">
-        {totalCount === 1 ? "schedule" : "schedules"} used{" "}
+        {totalCount === 1 ? "automation" : "automations"} used{" "}
         {formatValue(totalCredits)} {totalCredits === 1 ? "credit" : "credits"}
       </p>
       <TooltipProvider delayDuration={300}>
@@ -138,7 +138,7 @@ export function UsageInsightSchedulesTable({
             >
               <span className="text-sm text-muted-foreground truncate col-span-2">
                 +{scheduleOtherCount} more{" "}
-                {scheduleOtherCount === 1 ? "schedule" : "schedules"}
+                {scheduleOtherCount === 1 ? "automation" : "automations"}
               </span>
               <span className="text-xs tabular-nums text-muted-foreground text-right">
                 {formatValue(scheduleOtherCredits)}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -38,7 +38,7 @@ function usageRows(): UsageRecordRow[] {
     ...Array.from({ length: 18 }, (_, index) => {
       const day = String(index + 1).padStart(2, "0");
       return {
-        source: "schedule",
+        source: "automation",
         threadId: `thread-scheduled-${index}`,
         runId: null,
         title: `Scheduled digest ${index + 1}`,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
@@ -88,7 +88,7 @@ function mockScheduleDetailStory(): void {
       agentId,
       displayName: "Zero",
       framework: "claude-code",
-      triggerSource: "schedule",
+      triggerSource: "automation",
       triggerAgentName: null,
       scheduleId,
       status: "completed",
@@ -103,7 +103,7 @@ function mockScheduleDetailStory(): void {
       agentId,
       displayName: "Zero",
       framework: "claude-code",
-      triggerSource: "schedule",
+      triggerSource: "automation",
       triggerAgentName: null,
       scheduleId,
       status: "failed",
@@ -141,7 +141,7 @@ function mockScheduleDetailStory(): void {
       pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
       filters: {
         statuses: ["completed", "failed"],
-        sources: ["schedule"],
+        sources: ["automation"],
         agents: [agentId],
       },
     });
@@ -367,7 +367,7 @@ describe("zero schedule detail page", () => {
             agentId,
             displayName: "Zero",
             framework: "claude-code",
-            triggerSource: "schedule",
+            triggerSource: "automation",
             triggerAgentName: null,
             scheduleId,
             status: cursor === "page-2" ? "failed" : "completed",
@@ -384,7 +384,7 @@ describe("zero schedule detail page", () => {
         },
         filters: {
           statuses: ["completed", "failed"],
-          sources: ["schedule"],
+          sources: ["automation"],
           agents: [agentId],
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -52,7 +52,7 @@ const CARD_BORDER = "0.7px solid hsl(var(--gray-400))";
 
 const SOURCE_META = {
   chat: { label: "Chat", Icon: IconMessageCircle },
-  schedule: { label: "Schedule", Icon: IconClock },
+  automation: { label: "Automation", Icon: IconClock },
   slack: { label: "Slack", Icon: IconBrandSlack },
   telegram: { label: "Telegram", Icon: IconBrandTelegram },
   email: { label: "Email", Icon: IconMail },

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -238,9 +238,7 @@ export function ActivityHeaderCard({
             <>
               <div className="flex items-center gap-1.5 px-3">
                 <span className="text-muted-foreground shrink-0">Source</span>
-                {(triggerSource === "schedule" ||
-                  triggerSource === "automation") &&
-                detail.scheduleId ? (
+                {triggerSource === "automation" && detail.scheduleId ? (
                   <Link
                     pathname="/automations/:scheduleId"
                     options={{

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -40,10 +40,7 @@ const logStatusSchema = z.enum([
  * Trigger source enum — how the run was initiated
  */
 export const triggerSourceSchema = z.enum([
-  // "automation" supersedes "schedule" (#17307); both appear on historical
-  // rows until the backfill migration lands.
   "automation",
-  "schedule",
   "web",
   "slack",
   "email",

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -9,7 +9,7 @@ const c = initContract();
 // grouped as `other`.
 export const usageRecordSourceSchema = z.enum([
   "chat",
-  "schedule",
+  "automation",
   "slack",
   "telegram",
   "email",
@@ -59,13 +59,13 @@ const usageRecordMemberSchema = z.object({
   email: z.string(),
 });
 
-// One usage row. Threaded sources (chat, schedule) aggregate every run in the
+// One usage row. Threaded sources (chat, automation) aggregate every run in the
 // thread into a single row that links to the thread; unthreaded sources are one
 // row per run that links to the run's activity detail. Ordered by most recent
 // activity so the list reads as a chronological record.
 const usageRecordRowSchema = z.object({
   source: usageRecordSourceSchema,
-  // Set for threaded sources (web chat, schedule) — links to the chat thread.
+  // Set for threaded sources (web chat, automation) — links to the chat thread.
   threadId: z.string().nullable(),
   // Set for unthreaded sources (slack, telegram, …) — links to the run.
   runId: z.string().nullable(),

--- a/turbo/packages/core/src/usage-source-bucket.ts
+++ b/turbo/packages/core/src/usage-source-bucket.ts
@@ -4,7 +4,7 @@ import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
  * Source bucket for per-user usage insight grouping.
  * Maps TriggerSource values to one of 5 display buckets.
  */
-export type SourceBucket = "chat" | "slack" | "email" | "schedule" | "others";
+export type SourceBucket = "chat" | "slack" | "email" | "automation" | "others";
 
 /**
  * Map a TriggerSource (or null for deleted runs) to a display bucket.
@@ -21,9 +21,8 @@ export function triggerSourceToBucket(
       return "slack";
     case "email":
       return "email";
-    case "schedule":
     case "automation":
-      return "schedule";
+      return "automation";
     default:
       // telegram, github, cli, agent, phone, agentphone, null
       return "others";
@@ -37,6 +36,6 @@ export const SOURCE_BUCKET_COLORS: Record<SourceBucket, string> = {
   chat: "hsl(var(--primary))",
   slack: "#4ade80",
   email: "#f59e0b",
-  schedule: "#8b5cf6",
+  automation: "#8b5cf6",
   others: "hsl(var(--muted-foreground))",
 };


### PR DESCRIPTION
## Summary

Follow-up 2 from the #17307 acceptance report. The backfill (#17365) is live — production has **zero** `trigger_source='schedule'` rows and writers emit only `'automation'` — so every dual-value compatibility shim collapses:

- **Contract**: `triggerSourceSchema` drops `"schedule"`; `usageRecordSourceSchema` swaps `"schedule"` for `"automation"`.
- **Readers**: the logs trigger-source filter returns to a plain equality (helper deleted); the usage-insight SQL buckets key on `'automation'`; the usage-record `sourceExpr` passes `'automation'` through (threaded-aggregation behavior unchanged); the banking gate and the platform activity detail page check only `"automation"`.
- **Core**: `SourceBucket` renames its `schedule` member to `automation` (same chart color); `triggerSourceToBucket` follows. The insight chart renders keys dynamically, so legends now read "Automation" with no platform chart changes.
- **UI copy**: usage/network-insight cards, counters, table heading, and empty state say automations; `TRIGGER_SOURCE_LABELS` and the usage-record `SOURCE_META` swap entries.
- **Tests**: all seeds/assertions move to `"automation"`; the dual-value filter and `it.each` gate tests collapse to single-value.

Remaining `"schedule"` string literals (verified by sweep): the agent-detail **tab URL value** (renamed in the upcoming internal-naming PR) — nothing trigger-source related.

## Test plan

- [x] API suites green: banking, logs-list/get-by-id, usage-insight, usage-record, internal-callbacks-trigger, slack-message, automations-v2 (144 tests)
- [x] Platform suites green: schedule page/detail, personal-usage, usage-page, network-insights
- [x] `check-types` (13/13), `lint`, `knip`, `format` clean

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)