### PR TITLE
fix(web): inline feedback styling, thread scoping, and persistent highlight

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  captureFeedbackSelection$,
+  startFeedback$,
+  dismissFeedback$,
+  feedbackItemsValue$,
+  feedbackThreadIdValue$,
+} from "../zero-page/chat-feedback.ts";
+import { testContext } from "./test-helpers.ts";
+
+// Render a minimal assistant bubble inside a thread container, matching the DOM
+// the inline-feedback selection logic reads (the thread id and bubble class).
+function mountThreadBubble(threadId: string, text: string): HTMLElement {
+  const section = document.createElement("section");
+  section.setAttribute("data-chat-thread-container-id", threadId);
+  const bubble = document.createElement("div");
+  bubble.className = "zero-chat-bubble-assistant";
+  bubble.textContent = text;
+  section.appendChild(bubble);
+  document.body.appendChild(section);
+  return bubble;
+}
+
+function selectContents(element: HTMLElement): void {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+describe("inline feedback thread scoping", () => {
+  const ctx = testContext();
+
+  it("binds a feedback draft to the thread it was selected in", () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    expect(ctx.store.get(feedbackThreadIdValue$)).toBe("thread-a");
+    expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(1);
+  });
+
+  it("starts a fresh stack when feedback moves to another thread", () => {
+    const bubbleA = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubbleA);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    // Picking a passage in a different thread must not append to thread A's
+    // draft — the comment only follows its own chat thread.
+    const bubbleB = mountThreadBubble("thread-b", "Reply from thread B");
+    selectContents(bubbleB);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    const items = ctx.store.get(feedbackItemsValue$);
+    expect(ctx.store.get(feedbackThreadIdValue$)).toBe("thread-b");
+    expect(items).toHaveLength(1);
+    expect(items[0]?.quote).toBe("Reply from thread B");
+  });
+
+  it("clears the owning thread when feedback is dismissed", () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+    expect(ctx.store.get(feedbackThreadIdValue$)).toBe("thread-a");
+
+    ctx.store.set(dismissFeedback$);
+
+    expect(ctx.store.get(feedbackThreadIdValue$)).toBeNull();
+    expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(0);
+  });
+});

--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   captureFeedbackSelection$,
   startFeedback$,
+  removeFeedbackItem$,
   dismissFeedback$,
   feedbackItemsValue$,
   feedbackThreadIdValue$,
@@ -74,5 +75,54 @@ describe("inline feedback thread scoping", () => {
 
     expect(ctx.store.get(feedbackThreadIdValue$)).toBeNull();
     expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(0);
+  });
+});
+
+// happy-dom has no CSS Custom Highlight API, so stub the pieces the highlight
+// manager touches and inspect the registry it writes to.
+class FakeHighlight {
+  readonly ranges: readonly Range[];
+  constructor(...ranges: Range[]) {
+    this.ranges = ranges;
+  }
+}
+
+interface HighlightGlobals {
+  Highlight?: unknown;
+  CSS?: { highlights?: Map<string, FakeHighlight> };
+}
+
+describe("inline feedback source highlight", () => {
+  const ctx = testContext();
+  const globals = globalThis as unknown as HighlightGlobals;
+  const originalHighlight = globals.Highlight;
+  const originalCss = globals.CSS;
+
+  afterEach(() => {
+    globals.Highlight = originalHighlight;
+    globals.CSS = originalCss;
+  });
+
+  it("highlights the drafted passage and clears it on remove", () => {
+    // Reset the module-level highlight ranges left by earlier tests.
+    ctx.store.set(dismissFeedback$);
+    const highlights = new Map<string, FakeHighlight>();
+    globals.Highlight = FakeHighlight;
+    globals.CSS = { highlights };
+
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    const registered = highlights.get("zero-feedback");
+    expect(registered).toBeDefined();
+    expect(registered?.ranges).toHaveLength(1);
+
+    const id = ctx.store.get(feedbackItemsValue$)[0]?.id;
+    expect(id).toBeDefined();
+    ctx.store.set(removeFeedbackItem$, id as number);
+
+    expect(highlights.has("zero-feedback")).toBe(false);
   });
 });

--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -14,7 +14,7 @@ import { testContext } from "./test-helpers.ts";
 // the inline-feedback selection logic reads (the thread id and bubble class).
 function mountThreadBubble(threadId: string, text: string): HTMLElement {
   const section = document.createElement("section");
-  section.setAttribute("data-chat-thread-container-id", threadId);
+  section.dataset.chatThreadContainerId = threadId;
   const bubble = document.createElement("div");
   bubble.className = "zero-chat-bubble-assistant";
   bubble.textContent = text;
@@ -123,6 +123,6 @@ describe("inline feedback source highlight", () => {
     expect(id).toBeDefined();
     ctx.store.set(removeFeedbackItem$, id as number);
 
-    expect(highlights.has("zero-feedback")).toBe(false);
+    expect(highlights.has("zero-feedback")).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -22,6 +22,9 @@ export interface FeedbackSelection {
   // The thread the selected passage belongs to. Feedback stays with this
   // thread, so switching chats never carries the draft across.
   readonly threadId: string | null;
+  // A snapshot of the selected range. Kept so the passage can stay highlighted
+  // once the comment is drafted and the native selection clears.
+  readonly range: Range | null;
 }
 
 // A quoted passage together with the note the user is writing about it. Every
@@ -81,6 +84,65 @@ function resolveSelectionThreadId(bubble: Element): string | null {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Source-passage highlight. While a feedback comment is being drafted, its
+// quoted passage stays highlighted inside the message via the CSS Custom
+// Highlight API, so the comment is visibly anchored to the text it is about.
+// Ranges are kept here, outside the reactive state, and the registry is a
+// no-op where the API is unavailable (e.g. the test/SSR environment).
+// ---------------------------------------------------------------------------
+
+const FEEDBACK_HIGHLIGHT_NAME = "zero-feedback";
+const feedbackHighlightRanges = new Map<number, Range>();
+
+function highlightRegistry(): HighlightRegistry | null {
+  if (
+    typeof CSS === "undefined" ||
+    typeof Highlight === "undefined" ||
+    !CSS.highlights
+  ) {
+    return null;
+  }
+  return CSS.highlights;
+}
+
+function syncFeedbackHighlight(): void {
+  const registry = highlightRegistry();
+  if (!registry) {
+    return;
+  }
+  if (feedbackHighlightRanges.size === 0) {
+    registry.delete(FEEDBACK_HIGHLIGHT_NAME);
+    return;
+  }
+  registry.set(
+    FEEDBACK_HIGHLIGHT_NAME,
+    new Highlight(...feedbackHighlightRanges.values()),
+  );
+}
+
+function addFeedbackHighlight(id: number, range: Range | null): void {
+  if (!range) {
+    return;
+  }
+  feedbackHighlightRanges.set(id, range);
+  syncFeedbackHighlight();
+}
+
+function removeFeedbackHighlight(id: number): void {
+  if (feedbackHighlightRanges.delete(id)) {
+    syncFeedbackHighlight();
+  }
+}
+
+function clearFeedbackHighlight(): void {
+  if (feedbackHighlightRanges.size === 0) {
+    return;
+  }
+  feedbackHighlightRanges.clear();
+  syncFeedbackHighlight();
+}
+
 // Read the live document selection when it sits inside an assistant message.
 function readAssistantSelection(): {
   text: string;
@@ -137,6 +199,7 @@ export const captureFeedbackSelection$ = command(({ get, set }) => {
   set(feedbackSelection$, {
     text: found.text,
     threadId: resolveSelectionThreadId(found.bubble),
+    range: found.range.cloneRange(),
     rect: {
       top: rect.top,
       left: rect.left,
@@ -158,14 +221,17 @@ export const startFeedback$ = command(({ get, set }) => {
   // different thread starts a fresh stack instead of mixing comments across
   // threads.
   const activeThreadId = get(feedbackThreadId$);
-  const existing =
-    activeThreadId !== null && activeThreadId !== selection.threadId
-      ? []
-      : get(feedbackItems$);
+  const crossesThreads =
+    activeThreadId !== null && activeThreadId !== selection.threadId;
+  if (crossesThreads) {
+    clearFeedbackHighlight();
+  }
+  const existing = crossesThreads ? [] : get(feedbackItems$);
   const id = get(feedbackNextId$);
   set(feedbackNextId$, id + 1);
   set(feedbackThreadId$, selection.threadId);
   set(feedbackItems$, [...existing, { id, quote: selection.text, note: "" }]);
+  addFeedbackHighlight(id, selection.range);
   set(feedbackSelection$, null);
 });
 
@@ -181,6 +247,7 @@ export const setFeedbackItemNote$ = command(
 );
 
 export const removeFeedbackItem$ = command(({ get, set }, id: number) => {
+  removeFeedbackHighlight(id);
   set(
     feedbackItems$,
     get(feedbackItems$).filter((item) => {
@@ -207,6 +274,7 @@ export const dismissFeedback$ = command(({ get, set }) => {
     window.clearTimeout(timerId);
     set(feedbackCopiedTimerId$, null);
   }
+  clearFeedbackHighlight();
   set(feedbackSelection$, null);
   set(feedbackItems$, []);
   set(feedbackThreadId$, null);

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -77,11 +77,11 @@ function resolveSelectionBubble(range: Range): Element | null {
 // The id of the thread that owns the selected passage, or null when it sits
 // outside any thread container.
 function resolveSelectionThreadId(bubble: Element): string | null {
-  return (
-    bubble
-      .closest(THREAD_CONTAINER_SELECTOR)
-      ?.getAttribute("data-chat-thread-container-id") ?? null
-  );
+  const container = bubble.closest(THREAD_CONTAINER_SELECTOR);
+  if (!(container instanceof HTMLElement)) {
+    return null;
+  }
+  return container.dataset.chatThreadContainerId ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -5,6 +5,10 @@ import { writeToClipboard } from "./clipboard.ts";
 // inside one of them is what we offer feedback on.
 const ASSISTANT_BUBBLE_SELECTOR = ".zero-chat-bubble-assistant";
 
+// Each chat thread renders inside a container tagged with its thread id. We
+// read it off the selection so a feedback draft stays bound to its own thread.
+const THREAD_CONTAINER_SELECTOR = "[data-chat-thread-container-id]";
+
 export interface FeedbackSelectionRect {
   readonly top: number;
   readonly left: number;
@@ -15,6 +19,9 @@ export interface FeedbackSelectionRect {
 export interface FeedbackSelection {
   readonly text: string;
   readonly rect: FeedbackSelectionRect;
+  // The thread the selected passage belongs to. Feedback stays with this
+  // thread, so switching chats never carries the draft across.
+  readonly threadId: string | null;
 }
 
 // A quoted passage together with the note the user is writing about it. Every
@@ -28,6 +35,7 @@ export interface FeedbackItem {
 
 const feedbackSelection$ = state<FeedbackSelection | null>(null);
 const feedbackItems$ = state<readonly FeedbackItem[]>([]);
+const feedbackThreadId$ = state<string | null>(null);
 const feedbackNextId$ = state<number>(1);
 const feedbackCopied$ = state<boolean>(false);
 const feedbackCopiedTimerId$ = state<number | null>(null);
@@ -38,6 +46,12 @@ export const feedbackSelectionValue$ = computed((get) => {
 
 export const feedbackItemsValue$ = computed((get) => {
   return get(feedbackItems$);
+});
+
+// Which thread the docked feedback belongs to. The composer compares this to
+// its own thread id so a draft only ever shows in the thread it came from.
+export const feedbackThreadIdValue$ = computed((get) => {
+  return get(feedbackThreadId$);
 });
 
 export const feedbackCopiedValue$ = computed((get) => {
@@ -57,8 +71,22 @@ function resolveSelectionBubble(range: Range): Element | null {
   return element?.closest(ASSISTANT_BUBBLE_SELECTOR) ?? null;
 }
 
+// The id of the thread that owns the selected passage, or null when it sits
+// outside any thread container.
+function resolveSelectionThreadId(bubble: Element): string | null {
+  return (
+    bubble
+      .closest(THREAD_CONTAINER_SELECTOR)
+      ?.getAttribute("data-chat-thread-container-id") ?? null
+  );
+}
+
 // Read the live document selection when it sits inside an assistant message.
-function readAssistantSelection(): { text: string; range: Range } | null {
+function readAssistantSelection(): {
+  text: string;
+  range: Range;
+  bubble: Element;
+} | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
     return null;
@@ -68,10 +96,11 @@ function readAssistantSelection(): { text: string; range: Range } | null {
     return null;
   }
   const range = selection.getRangeAt(0);
-  if (!resolveSelectionBubble(range)) {
+  const bubble = resolveSelectionBubble(range);
+  if (!bubble) {
     return null;
   }
-  return { text, range };
+  return { text, range, bubble };
 }
 
 // Compose every noted fragment into a single follow-up turn, each passage
@@ -107,6 +136,7 @@ export const captureFeedbackSelection$ = command(({ get, set }) => {
   const rect = found.range.getBoundingClientRect();
   set(feedbackSelection$, {
     text: found.text,
+    threadId: resolveSelectionThreadId(found.bubble),
     rect: {
       top: rect.top,
       left: rect.left,
@@ -124,12 +154,18 @@ export const startFeedback$ = command(({ get, set }) => {
   if (!selection) {
     return;
   }
+  // A feedback stack belongs to a single thread. Picking a passage from a
+  // different thread starts a fresh stack instead of mixing comments across
+  // threads.
+  const activeThreadId = get(feedbackThreadId$);
+  const existing =
+    activeThreadId !== null && activeThreadId !== selection.threadId
+      ? []
+      : get(feedbackItems$);
   const id = get(feedbackNextId$);
   set(feedbackNextId$, id + 1);
-  set(feedbackItems$, [
-    ...get(feedbackItems$),
-    { id, quote: selection.text, note: "" },
-  ]);
+  set(feedbackThreadId$, selection.threadId);
+  set(feedbackItems$, [...existing, { id, quote: selection.text, note: "" }]);
   set(feedbackSelection$, null);
 });
 
@@ -173,6 +209,7 @@ export const dismissFeedback$ = command(({ get, set }) => {
   }
   set(feedbackSelection$, null);
   set(feedbackItems$, []);
+  set(feedbackThreadId$, null);
   set(feedbackCopied$, false);
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -39,6 +39,9 @@ export interface FeedbackItem {
 const feedbackSelection$ = state<FeedbackSelection | null>(null);
 const feedbackItems$ = state<readonly FeedbackItem[]>([]);
 const feedbackThreadId$ = state<string | null>(null);
+// Source-passage ranges keyed by feedback item id, used to keep each commented
+// passage highlighted while its draft lives.
+const feedbackRanges$ = state<ReadonlyMap<number, Range>>(new Map());
 const feedbackNextId$ = state<number>(1);
 const feedbackCopied$ = state<boolean>(false);
 const feedbackCopiedTimerId$ = state<number | null>(null);
@@ -88,12 +91,11 @@ function resolveSelectionThreadId(bubble: Element): string | null {
 // Source-passage highlight. While a feedback comment is being drafted, its
 // quoted passage stays highlighted inside the message via the CSS Custom
 // Highlight API, so the comment is visibly anchored to the text it is about.
-// Ranges are kept here, outside the reactive state, and the registry is a
-// no-op where the API is unavailable (e.g. the test/SSR environment).
+// The painter is a pure function of the range map (kept in feedbackRanges$) and
+// is a no-op where the API is unavailable (e.g. the test/SSR environment).
 // ---------------------------------------------------------------------------
 
 const FEEDBACK_HIGHLIGHT_NAME = "zero-feedback";
-const feedbackHighlightRanges = new Map<number, Range>();
 
 function highlightRegistry(): HighlightRegistry | null {
   if (
@@ -106,41 +108,16 @@ function highlightRegistry(): HighlightRegistry | null {
   return CSS.highlights;
 }
 
-function syncFeedbackHighlight(): void {
+function applyFeedbackHighlight(ranges: ReadonlyMap<number, Range>): void {
   const registry = highlightRegistry();
   if (!registry) {
     return;
   }
-  if (feedbackHighlightRanges.size === 0) {
+  if (ranges.size === 0) {
     registry.delete(FEEDBACK_HIGHLIGHT_NAME);
     return;
   }
-  registry.set(
-    FEEDBACK_HIGHLIGHT_NAME,
-    new Highlight(...feedbackHighlightRanges.values()),
-  );
-}
-
-function addFeedbackHighlight(id: number, range: Range | null): void {
-  if (!range) {
-    return;
-  }
-  feedbackHighlightRanges.set(id, range);
-  syncFeedbackHighlight();
-}
-
-function removeFeedbackHighlight(id: number): void {
-  if (feedbackHighlightRanges.delete(id)) {
-    syncFeedbackHighlight();
-  }
-}
-
-function clearFeedbackHighlight(): void {
-  if (feedbackHighlightRanges.size === 0) {
-    return;
-  }
-  feedbackHighlightRanges.clear();
-  syncFeedbackHighlight();
+  registry.set(FEEDBACK_HIGHLIGHT_NAME, new Highlight(...ranges.values()));
 }
 
 // Read the live document selection when it sits inside an assistant message.
@@ -223,15 +200,21 @@ export const startFeedback$ = command(({ get, set }) => {
   const activeThreadId = get(feedbackThreadId$);
   const crossesThreads =
     activeThreadId !== null && activeThreadId !== selection.threadId;
-  if (crossesThreads) {
-    clearFeedbackHighlight();
-  }
   const existing = crossesThreads ? [] : get(feedbackItems$);
   const id = get(feedbackNextId$);
   set(feedbackNextId$, id + 1);
   set(feedbackThreadId$, selection.threadId);
   set(feedbackItems$, [...existing, { id, quote: selection.text, note: "" }]);
-  addFeedbackHighlight(id, selection.range);
+
+  // A fresh stack on a thread switch starts the highlights over too.
+  const ranges = new Map<number, Range>(
+    crossesThreads ? [] : get(feedbackRanges$),
+  );
+  if (selection.range) {
+    ranges.set(id, selection.range);
+  }
+  set(feedbackRanges$, ranges);
+  applyFeedbackHighlight(ranges);
   set(feedbackSelection$, null);
 });
 
@@ -247,7 +230,11 @@ export const setFeedbackItemNote$ = command(
 );
 
 export const removeFeedbackItem$ = command(({ get, set }, id: number) => {
-  removeFeedbackHighlight(id);
+  const ranges = new Map<number, Range>(get(feedbackRanges$));
+  if (ranges.delete(id)) {
+    set(feedbackRanges$, ranges);
+    applyFeedbackHighlight(ranges);
+  }
   set(
     feedbackItems$,
     get(feedbackItems$).filter((item) => {
@@ -274,7 +261,9 @@ export const dismissFeedback$ = command(({ get, set }) => {
     window.clearTimeout(timerId);
     set(feedbackCopiedTimerId$, null);
   }
-  clearFeedbackHighlight();
+  const emptyRanges = new Map<number, Range>();
+  set(feedbackRanges$, emptyRanges);
+  applyFeedbackHighlight(emptyRanges);
   set(feedbackSelection$, null);
   set(feedbackItems$, []);
   set(feedbackThreadId$, null);

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -563,6 +563,14 @@
   color: hsl(var(--foreground));
 }
 
+/* Inline feedback: keep the commented passage highlighted while its draft is
+   open, so the comment stays anchored to the text it is about. A lighter tint
+   than the live selection above. */
+::highlight(zero-feedback) {
+  background-color: hsl(var(--primary-100));
+  color: hsl(var(--foreground));
+}
+
 /* ==========================================================================
    Markdown Preview — full theme override for @uiw/react-markdown-preview.
    We set data-color-mode on the wrapper (via React prop) so the library's

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2621,9 +2621,7 @@ describe("chat lifecycle", () => {
     expect(comments[0]).toHaveValue("Assign each risk to an owner.");
     expect(comments[1]).toHaveValue("");
     expect(
-      screen.getByText(
-        "Select more text and click Provide feedback to add another comment",
-      ),
+      screen.getByText("Select more text to add another comment"),
     ).toBeInTheDocument();
 
     // Removing the empty draft row leaves the noted fragment intact.

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -523,8 +523,8 @@ function ComposerFeedbackRow({
   return (
     <div className="border-b border-dashed border-border/60 pb-2 pt-1 last:border-b-0">
       <div className="flex items-center gap-2">
-        <span className="h-3.5 w-[3px] shrink-0 rounded-sm bg-primary" />
-        <span className="min-w-0 flex-1 truncate text-xs italic leading-snug text-muted-foreground">
+        <span className="h-4 w-[3px] shrink-0 bg-muted-foreground/30" />
+        <span className="min-w-0 flex-1 truncate text-sm italic leading-snug text-muted-foreground">
           {item.quote}
         </span>
         <button
@@ -569,7 +569,7 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
   const newestId = feedback.items[feedback.items.length - 1]?.id;
 
   return (
-    <div className="flex flex-col px-3 pt-3">
+    <div className="flex flex-col px-3 pb-2 pt-3">
       {feedback.items.map((item) => {
         return (
           <ComposerFeedbackRow
@@ -586,8 +586,8 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
           />
         );
       })}
-      <span className="px-1 pt-1.5 text-xs leading-snug text-muted-foreground">
-        Select more text and click Provide feedback to add another comment
+      <span className="px-1 pt-2 text-sm leading-snug text-muted-foreground">
+        Select more text to add another comment
       </span>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -586,7 +586,7 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
           />
         );
       })}
-      <span className="px-1 pt-2 text-sm leading-snug text-muted-foreground">
+      <span className="px-1 pt-2 font-serif text-[13px] italic leading-snug text-muted-foreground/50">
         Select more text to add another comment
       </span>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -195,6 +195,7 @@ import {
 import { ChatFeedbackSelection } from "./zero-chat-feedback-selection.tsx";
 import {
   feedbackItemsValue$,
+  feedbackThreadIdValue$,
   feedbackSendCountValue$,
   setFeedbackItemNote$,
   removeFeedbackItem$,
@@ -3340,6 +3341,7 @@ function useChatThreadComposerFeedback(
   const inlineFeedbackEnabled =
     features?.[FeatureSwitchKey.ChatInlineFeedback] ?? false;
   const items = useGet(feedbackItemsValue$);
+  const feedbackThreadId = useGet(feedbackThreadIdValue$);
   const sendCount = useGet(feedbackSendCountValue$);
   const setNote = useSet(setFeedbackItemNote$);
   const removeItem = useSet(removeFeedbackItem$);
@@ -3348,7 +3350,9 @@ function useChatThreadComposerFeedback(
   const [, sendMessage] = useLoadableSet(thread.sendMessage$);
   const rootSignal = useGet(rootSignal$);
 
-  if (!inlineFeedbackEnabled) {
+  // Feedback is owned by the thread it was drafted in; other threads keep their
+  // own composer textarea so a draft never bleeds across chats.
+  if (!inlineFeedbackEnabled || feedbackThreadId !== thread.threadId) {
     return undefined;
   }
   return {


### PR DESCRIPTION
Follow-up to #17371 addressing design feedback on the inline feedback composer, plus two behavior fixes.

## Styling (from annotated screenshot)
- **Quote marker**: square gray bar instead of the rounded primary-color bar; quote text bumped to 14px for a neutral blockquote look.
- **"Add another comment" hint**: now 14px and simplified — `Select more text to add another comment`.
- **Spacing**: added padding between the hint text and the composer toolbar below.

## Feedback leaked across chat threads
The inline feedback stack lived in module-level signals with no thread binding, so a drafted comment carried over when switching chats.
- Each draft is tagged with the `threadId` of the selected passage (`data-chat-thread-container-id`).
- Selecting in a different thread starts a fresh stack; the composer only surfaces the stack for its owning thread.

## Commented passage lost its highlight
Clicking **Provide feedback** cleared the native selection, so the passage a comment was about became invisible.
- Snapshot the selected `Range` and re-apply it as a persistent highlight via the **CSS Custom Highlight API** (`::highlight(zero-feedback)`, no DOM mutation).
- Added per comment, removed when a comment is deleted, cleared on submit/dismiss or thread switch. No-op where the API is unavailable.

Tests: added `chat-feedback.test.ts` (thread scoping + highlight registration) and updated the assertion in `chat-lifecycle.test.tsx`.

Note: the highlight persists while drafting in the thread's view. It does not re-anchor after navigating away and back (the message DOM re-renders); re-finding passages on remount would be a larger follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)