### PR TITLE
feat: add connector auth method visibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 
-import type { ConnectorAuthMethodId } from "@vm0/connectors/connectors";
+import {
+  CONNECTOR_TYPES,
+  type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodId,
+} from "@vm0/connectors/connectors";
 import { getConnectorAuthMethodAuthCodeGrantConfig } from "@vm0/connectors/connector-utils";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectors } from "@vm0/db/schema/connector";
@@ -111,6 +115,7 @@ async function requestOauthStart(
 describe("POST /api/zero/connectors/:type/oauth/start", () => {
   const orgIds: string[] = [];
   const stateIds: string[] = [];
+  const restoreConnectorRegistry: (() => void)[] = [];
 
   beforeEach(() => {
     mockEnv("VM0_API_URL", API_ORIGIN);
@@ -119,6 +124,9 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
   });
 
   afterEach(async () => {
+    while (restoreConnectorRegistry.length > 0) {
+      restoreConnectorRegistry.pop()?.();
+    }
     const db = store.set(writeDb$);
     while (stateIds.length > 0) {
       const stateId = stateIds.pop();
@@ -159,6 +167,49 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     const orgId = `org_${randomUUID()}`;
     orgIds.push(orgId);
     mocks.clerk.session(userId, orgId);
+
+    const response = await requestOauthStart("google-cloud", {
+      headers: { authorization: "Bearer clerk-session" },
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "google-cloud connector is not available",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("rejects OAuth start when the auth method is statically hidden", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    orgIds.push(orgId);
+    mocks.clerk.session(userId, orgId);
+    const db = store.set(writeDb$);
+    await db.insert(userFeatureSwitches).values({
+      orgId,
+      userId,
+      switches: { [FeatureSwitchKey.GoogleCloudConnector]: true },
+    });
+
+    const authMethods = CONNECTOR_TYPES["google-cloud"].authMethods;
+    const originalOauth = authMethods.oauth;
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "oauth", {
+        value: originalOauth,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "oauth", {
+      value: {
+        ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
 
     const response = await requestOauthStart("google-cloud", {
       headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -4,6 +4,7 @@ import { zeroConnectorsSearchContract } from "@vm0/api-contracts/contracts/zero-
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodConfig,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
@@ -49,8 +50,12 @@ describe("GET /api/zero/connectors/search", () => {
     readonly userId: string;
   }[] = [];
   const seededOrgs: OrgMembershipFixture[] = [];
+  const restoreConnectorRegistry: (() => void)[] = [];
 
   afterEach(async () => {
+    while (restoreConnectorRegistry.length > 0) {
+      restoreConnectorRegistry.pop()?.();
+    }
     const writeDb = store.set(writeDb$);
     while (seededFeatureSwitches.length > 0) {
       const fixture = seededFeatureSwitches.pop();
@@ -232,6 +237,94 @@ describe("GET /api/zero/connectors/search", () => {
     });
     expect(connector).toBeDefined();
     expect(connector?.authMethods).toStrictEqual(["oauth", "api"]);
+  });
+
+  it("applies static auth method visibility to connector search", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededFeatureSwitches.push({ orgId, userId });
+    await enableFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.StripeConnector]: true,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const authMethods = CONNECTOR_TYPES.stripe.authMethods;
+    const originalOauth = authMethods.oauth;
+    const originalCli = authMethods.cli;
+    const originalApiToken = authMethods["api-token"];
+
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "oauth", {
+        value: originalOauth,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "oauth", {
+      value: {
+        ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+
+    const client = setupApp({ context })(zeroConnectorsSearchContract);
+    const partial = await accept(
+      client.search({
+        query: { keyword: "stripe" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const visibleStripe = partial.body.connectors.find((connector) => {
+      return connector.id === "stripe";
+    });
+    expect(visibleStripe?.authMethods).toStrictEqual(["cli", "api-token"]);
+
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "cli", {
+        value: originalCli,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "cli", {
+      value: {
+        ...originalCli,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "api-token", {
+        value: originalApiToken,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "api-token", {
+      value: {
+        ...originalApiToken,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+
+    const fullyHidden = await accept(
+      client.search({
+        query: { keyword: "stripe" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      fullyHidden.body.connectors.find((connector) => {
+        return connector.id === "stripe";
+      }),
+    ).toBeUndefined();
   });
 
   it("matches connector tags while preserving feature-switch visibility", async () => {

--- a/turbo/apps/api/src/signals/services/connector-availability.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-availability.service.ts
@@ -17,11 +17,12 @@ const USER_CONNECTOR_AUTH_METHOD_OPTIONS = {
 } as const satisfies AvailableConnectorAuthMethodsOptions;
 
 /**
- * Feature-aware user availability for new connector actions.
+ * User availability for new connector actions.
  *
- * This is intentionally separate from runtime availability: disabling a
- * feature switch should block new connect/authorize/write entry points, while
- * existing runtime connector use remains a separate product policy.
+ * This is intentionally separate from runtime availability: disabling a feature
+ * switch or static auth-method visibility should block new
+ * connect/authorize/write entry points, while existing runtime connector use
+ * remains a separate product policy.
  */
 interface UserConnectorAvailability {
   readonly isAuthMethodAvailable: (

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -85,7 +85,7 @@ export interface ConnectorTypeWithStatus {
   tags: readonly string[];
   connected: boolean;
   connector: ConnectorResponse | null;
-  /** Auth methods available for this connector (considering feature flags). */
+  /** Auth methods available for this connector after availability filtering. */
   availableAuthMethods: ConnectorAuthMethodId[];
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -5,13 +5,15 @@ import {
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import type {
-  ConnectorAuthMethodId,
-  ConnectorType,
+import {
+  CONNECTOR_TYPES,
+  type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodId,
+  type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -180,6 +182,14 @@ function mockCustomConnectorStory(): void {
 }
 
 describe("connectors page", () => {
+  const restoreConnectorRegistry: (() => void)[] = [];
+
+  afterEach(() => {
+    while (restoreConnectorRegistry.length > 0) {
+      restoreConnectorRegistry.pop()?.();
+    }
+  });
+
   it("lets users browse connectors by grouped categories", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
@@ -325,6 +335,119 @@ describe("connectors page", () => {
     expect(
       within(connectDialog).queryByText("OAuth (Recommended)"),
     ).not.toBeInTheDocument();
+  });
+
+  it("hides statically hidden auth methods from the connect dialog", async () => {
+    mockConnectors([]);
+    const authMethods = CONNECTOR_TYPES.stripe.authMethods;
+    const originalOauth = authMethods.oauth;
+
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "oauth", {
+        value: originalOauth,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "oauth", {
+      value: {
+        ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.StripeConnector]: true },
+    });
+
+    const searchInput = await screen.findByPlaceholderText("Find connectors");
+    await fill(searchInput, "stripe");
+    click(await screen.findByLabelText("Connect Stripe"));
+
+    const connectDialog = await screen.findByRole("dialog", {
+      name: "Stripe",
+    });
+    expect(
+      within(connectDialog).getByText("Sign in with Stripe"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectDialog).getAllByText("API Key").length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(connectDialog).queryByText("OAuth (Recommended)"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides a connector when all auth methods are statically hidden", async () => {
+    mockConnectors([]);
+    const authMethods = CONNECTOR_TYPES.stripe.authMethods;
+    const originalOauth = authMethods.oauth;
+    const originalCli = authMethods.cli;
+    const originalApiToken = authMethods["api-token"];
+
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "oauth", {
+        value: originalOauth,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "oauth", {
+      value: {
+        ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "cli", {
+        value: originalCli,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "cli", {
+      value: {
+        ...originalCli,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    restoreConnectorRegistry.push(() => {
+      Object.defineProperty(authMethods, "api-token", {
+        value: originalApiToken,
+        configurable: true,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(authMethods, "api-token", {
+      value: {
+        ...originalApiToken,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.StripeConnector]: true },
+    });
+
+    const searchInput = await screen.findByPlaceholderText("Find connectors");
+    await fill(searchInput, "stripe");
+
+    await waitFor(() => {
+      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Connect Stripe")).not.toBeInTheDocument();
   });
 
   it("completes a device-auth connector grant", async () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2430,6 +2430,74 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 
+  it("treats statically hidden auth methods as unavailable", () => {
+    const authMethods = CONNECTOR_TYPES.stripe.authMethods;
+    const originalOauth = authMethods.oauth;
+    const originalCli = authMethods.cli;
+    const originalApiToken = authMethods["api-token"];
+
+    Object.defineProperty(authMethods, "oauth", {
+      value: {
+        ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+
+    try {
+      expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
+        "oauth",
+        "cli",
+        "api-token",
+      ]);
+      expect(
+        getAvailableConnectorAuthMethodIds("stripe", {
+          [FeatureSwitchKey.StripeConnector]: true,
+        }),
+      ).toStrictEqual(["cli", "api-token"]);
+
+      Object.defineProperty(authMethods, "cli", {
+        value: {
+          ...originalCli,
+          visible: false,
+        } satisfies ConnectorAuthMethodConfig,
+        configurable: true,
+        enumerable: true,
+      });
+      Object.defineProperty(authMethods, "api-token", {
+        value: {
+          ...originalApiToken,
+          visible: false,
+        } satisfies ConnectorAuthMethodConfig,
+        configurable: true,
+        enumerable: true,
+      });
+
+      expect(
+        getAvailableConnectorAuthMethodIds("stripe", {
+          [FeatureSwitchKey.StripeConnector]: true,
+        }),
+      ).toStrictEqual([]);
+    } finally {
+      Object.defineProperty(authMethods, "oauth", {
+        value: originalOauth,
+        configurable: true,
+        enumerable: true,
+      });
+      Object.defineProperty(authMethods, "cli", {
+        value: originalCli,
+        configurable: true,
+        enumerable: true,
+      });
+      Object.defineProperty(authMethods, "api-token", {
+        value: originalApiToken,
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  });
+
   it("exposes AWS CLI auth only when the AWS switch is enabled", () => {
     expect(getAvailableConnectorAuthMethodIds("aws", {})).toStrictEqual([]);
     expect(

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -73,7 +73,7 @@ function connectorAuthMethodPriority(
 export function getConfiguredConnectorAuthMethodIds(
   type: ConnectorType,
 ): ConnectorAuthMethodId[] {
-  // Configured methods are raw registry entries; callers apply feature flags.
+  // Configured methods are raw registry entries; callers apply availability filters.
   return Object.keys(CONNECTOR_TYPES[type].authMethods)
     .map((authMethod) => {
       return connectorAuthMethodIdSchema.parse(authMethod);
@@ -1103,6 +1103,9 @@ export function isConnectorAuthMethodAvailable(
   if (!method) {
     return false;
   }
+  if (method.visible === false) {
+    return false;
+  }
   return !method.featureFlag || !!featureStates?.[method.featureFlag];
 }
 
@@ -1123,7 +1126,8 @@ function shouldIncludeApiAuthMethod(
 /**
  * Return user-selectable connector connection flows for a surface.
  *
- * This does not describe persisted connected state.
+ * This includes static visibility, feature-switch, and surface policy filtering.
+ * It does not describe persisted connected state.
  */
 export function getAvailableConnectorAuthMethodIds(
   type: ConnectorType,

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -491,6 +491,8 @@ export type ConnectorRevokeConfig =
 interface ConnectorAuthMethodConfigBase {
   label: string;
   helpText?: string;
+  /** When false, this auth method is unavailable for new connector actions. */
+  visible?: boolean;
   /** When set, this auth method is only available while the feature is enabled. */
   featureFlag?: FeatureSwitchKey;
   /** When false, feature-gated UI surfaces should not add an experimental label. */


### PR DESCRIPTION
## Summary

- add `visible?: boolean` to connector auth method config
- treat `visible: false` as unavailable in the shared connector availability helper
- update connector API/UI availability comments and add coverage for UI, search, and direct OAuth start behavior

## Tests

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit hook: prettier, knip, `turbo run check-types --concurrency=1`

Closes #17400