### PR TITLE
fix: keep expanded work in assistant group

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -946,6 +946,16 @@ describe("CHAT-02: failed chat callbacks", () => {
       threadId = run.threadId;
       runIds.push(run.runId);
       const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+      await expect
+        .poll(() => {
+          return context.mocks.ably.publish.mock.calls.some((call) => {
+            return (
+              call[0] === `chatThreadRunCreated:${run.threadId}` &&
+              call[1] === null
+            );
+          });
+        })
+        .toBe(true);
       context.mocks.ably.publish.mockClear();
       await failChatRun(run.runId, sandboxHeaders, round.error);
       expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -558,6 +558,26 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
       prompt: "progress probe",
     });
     const firstHeaders = await claimChatRun(runnerGroup, first.runId);
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some((call) => {
+          return (
+            call[0] === `chatThreadMessageCreated:${first.threadId}` &&
+            call[1] === null
+          );
+        });
+      })
+      .toBe(true);
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some((call) => {
+          return (
+            call[0] === `chatThreadRunCreated:${first.threadId}` &&
+            call[1] === null
+          );
+        });
+      })
+      .toBe(true);
     context.mocks.axiom.query.mockClear();
     context.mocks.ably.publish.mockClear();
     await webhooks.requestAgentHeartbeat(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1402,7 +1402,13 @@ describe("chat lifecycle", () => {
 
     const expandButton = await screen.findByLabelText("Expand work history");
     expect(expandButton).toHaveTextContent("Worked for 55s");
-    expect(expandButton.closest('[data-role="assistant"]')).not.toBeNull();
+    const foldedAssistantGroup = expandButton.closest(
+      '[data-role="assistant"]',
+    ) as HTMLElement | null;
+    expect(foldedAssistantGroup).not.toBeNull();
+    expect(
+      within(foldedAssistantGroup!).getAllByLabelText("View agent profile"),
+    ).toHaveLength(1);
     expect(screen.getByText("Summarize the launch status")).toBeInTheDocument();
     expect(screen.queryByText("Checking launch status.")).toBeNull();
     expect(
@@ -1412,7 +1418,12 @@ describe("chat lifecycle", () => {
     click(expandButton);
 
     await waitFor(() => {
-      expect(screen.getByText("Checking launch status.")).toBeInTheDocument();
+      expect(
+        within(foldedAssistantGroup!).getByText("Checking launch status."),
+      ).toBeInTheDocument();
+      expect(
+        within(foldedAssistantGroup!).getAllByLabelText("View agent profile"),
+      ).toHaveLength(1);
       expect(screen.getByLabelText("Collapse work history")).toHaveAttribute(
         "aria-expanded",
         "true",
@@ -1550,6 +1561,10 @@ describe("chat lifecycle", () => {
     expect(expandButtons).toHaveLength(2);
     expect(expandButtons[0]).toHaveTextContent("Worked for 20s");
     expect(expandButtons[1]).toHaveTextContent("Worked for 55s");
+    const secondAssistantGroup = expandButtons[1]!.closest(
+      '[data-role="assistant"]',
+    ) as HTMLElement | null;
+    expect(secondAssistantGroup).not.toBeNull();
     expect(screen.getByText("Summarize the first launch")).toBeInTheDocument();
     expect(screen.queryByText("Checking the first launch notes.")).toBeNull();
     expect(
@@ -1572,8 +1587,13 @@ describe("chat lifecycle", () => {
         screen.getByText("Summarize the second launch"),
       ).toBeInTheDocument();
       expect(
-        screen.getByText("Checking the second launch notes."),
+        within(secondAssistantGroup!).getByText(
+          "Checking the second launch notes.",
+        ),
       ).toBeInTheDocument();
+      expect(
+        within(secondAssistantGroup!).getAllByLabelText("View agent profile"),
+      ).toHaveLength(1);
       expect(screen.getByLabelText("Collapse work history")).toHaveAttribute(
         "aria-expanded",
         "true",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2401,17 +2401,6 @@ function ChatThreadMessageGroups({
           completedWorkExpandedKeys.has(completedWorkFold.key);
         return (
           <div key={group.beginMessageId} className="contents">
-            {completedWorkFold !== null &&
-              completedWorkExpanded &&
-              completedWorkFold.hiddenGroups.map((hiddenGroup) => {
-                return (
-                  <PagedGroupRow
-                    key={hiddenGroup.beginMessageId}
-                    group={hiddenGroup}
-                    thread={thread}
-                  />
-                );
-              })}
             <PagedGroupRow
               group={group}
               thread={thread}
@@ -2419,6 +2408,7 @@ function ChatThreadMessageGroups({
                 completedWorkFold !== null
                   ? {
                       groups: completedWorkFold.labelGroups,
+                      hiddenGroups: completedWorkFold.hiddenGroups,
                       expanded: completedWorkExpanded,
                       onToggle: () => {
                         onToggleCompletedWork(completedWorkFold.key);
@@ -4843,6 +4833,7 @@ function PagedGroupRow({
   thread: ChatThreadSignals;
   completedWorkFold?: {
     groups: readonly GroupedChatMessageGroup[];
+    hiddenGroups: readonly GroupedChatMessageGroup[];
     expanded: boolean;
     onToggle: () => void;
   };
@@ -5434,6 +5425,7 @@ function PagedAssistantGroup({
   thread: ChatThreadSignals;
   completedWorkFold?: {
     groups: readonly GroupedChatMessageGroup[];
+    hiddenGroups: readonly GroupedChatMessageGroup[];
     expanded: boolean;
     onToggle: () => void;
   };
@@ -5455,6 +5447,19 @@ function PagedAssistantGroup({
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
         <div className="relative flex flex-col gap-3">
+          {completedWorkFold?.expanded
+            ? completedWorkFold.hiddenGroups.map((hiddenGroup) => {
+                return (
+                  <div key={hiddenGroup.beginMessageId} className="contents">
+                    {hiddenGroup.messages.map((msg) => {
+                      return (
+                        <PagedAssistantMessageItem key={msg.id} message={msg} />
+                      );
+                    })}
+                  </div>
+                );
+              })
+            : null}
           {completedWorkFold && (
             <CompletedWorkFoldRow
               groups={completedWorkFold.groups}


### PR DESCRIPTION
## Summary\n- render expanded completed-work history inside the final assistant group instead of as sibling message rows\n- keep the fold header, hidden work, and final answer under a single assistant avatar\n- add regression assertions that expanded work stays within the same assistant group and does not add another agent avatar\n\n## Verification\n- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx\n- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx\n- pnpm -F @vm0/app lint\n- pnpm -F @vm0/app check-types