### PR TITLE
fix: retain saturated usage webhook batches

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -144,7 +144,6 @@ class _PendingFlush:
 @dataclass(frozen=True)
 class _BatchAdmissionResult:
     admitted_batch_count: int
-    admitted_source_event_count: int
     retained_batches: list[_FlushBatch]
 
 
@@ -244,8 +243,27 @@ class _UsageBufferState:
     def has_pending_flushes(self) -> bool:
         return bool(self._pending_flushes)
 
-    def pop_pending_flush(self) -> _PendingFlush:
-        return self._pending_flushes.pop(0)
+    def pending_flush_priority(self) -> int | None:
+        if not self._pending_flushes:
+            return None
+        return min(
+            _pending_flush_priority(pending_flush) for pending_flush in self._pending_flushes
+        )
+
+    def pop_highest_priority_pending_flush(self) -> _PendingFlush:
+        selected_index = 0
+        selected_priority = _pending_flush_priority(self._pending_flushes[0])
+        for index, pending_flush in enumerate(self._pending_flushes[1:], start=1):
+            priority = _pending_flush_priority(pending_flush)
+            if priority < selected_priority:
+                selected_index = index
+                selected_priority = priority
+        return self._pending_flushes.pop(selected_index)
+
+    def live_priority(self) -> int | None:
+        if not self._buckets:
+            return None
+        return min(_destination_priority(destination) for destination in self._buckets)
 
     def snapshot_live_flush(self) -> _PendingFlush | None:
         if not self._buckets:
@@ -625,7 +643,15 @@ class UsageEventBuffer:
             timer = self._pop_timer_locked()
             if timer is not None:
                 timer.cancel()
-            return self._state.pop_pending_flush(), False
+            pending_priority = self._state.pending_flush_priority()
+            live_priority = self._state.live_priority() if snapshot_live else None
+            if (
+                pending_priority is not None
+                and live_priority is not None
+                and live_priority < pending_priority
+            ):
+                return self._state.snapshot_live_flush(), True
+            return self._state.pop_highest_priority_pending_flush(), False
         if not snapshot_live:
             return None, False
         timer = self._pop_timer_locked()
@@ -642,7 +668,6 @@ def _enqueue_batches(
     batches: list[_FlushBatch],
     enqueue_webhook: _EnqueueWebhook,
 ) -> _BatchAdmissionResult:
-    admitted_source_event_count = 0
     for index, batch in enumerate(batches):
         admitted = enqueue_webhook(
             batch.url,
@@ -654,13 +679,10 @@ def _enqueue_batches(
         if admitted is False:
             return _BatchAdmissionResult(
                 admitted_batch_count=index,
-                admitted_source_event_count=admitted_source_event_count,
                 retained_batches=batches[index:],
             )
-        admitted_source_event_count += batch.source_event_count
     return _BatchAdmissionResult(
         admitted_batch_count=len(batches),
-        admitted_source_event_count=admitted_source_event_count,
         retained_batches=[],
     )
 
@@ -713,7 +735,21 @@ def _pending_flush_from_batches(flush_sequence: int, batches: list[_FlushBatch])
 
 
 def _destination_priority(destination: _DestinationKey) -> int:
-    if destination.log_type == "usage_event":
+    return _log_type_priority(destination.log_type)
+
+
+def _pending_flush_priority(pending_flush: _PendingFlush) -> int:
+    if not pending_flush.batches:
+        return 1
+    return min(_batch_priority(batch) for batch in pending_flush.batches)
+
+
+def _batch_priority(batch: _FlushBatch) -> int:
+    return _log_type_priority(batch.log_type)
+
+
+def _log_type_priority(log_type: str) -> int:
+    if log_type == "usage_event":
         return 0
     return 1
 

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -98,6 +98,18 @@ class _AggregateKey:
     category: str
 
 
+@dataclass
+class _AggregateBucket:
+    quantity: int = 0
+    source_event_count: int = 0
+
+
+@dataclass(frozen=True)
+class _FlushEvent:
+    payload: dict
+    source_event_count: int
+
+
 @dataclass(frozen=True)
 class _FlushBatch:
     url: str
@@ -105,6 +117,7 @@ class _FlushBatch:
     payload: dict
     proxy_log_path: str
     log_type: str
+    source_event_count: int
 
 
 @dataclass
@@ -114,6 +127,8 @@ class _FlushSummary:
     aggregate_event_count: int = 0
     webhook_batch_count: int = 0
     dropped_webhook_batch_count: int = 0
+    retained_webhook_batch_count: int = 0
+    retained_source_event_count: int = 0
     run_ids: set[str] = field(default_factory=set)
     destinations: set[tuple[str, str]] = field(default_factory=set)
 
@@ -126,17 +141,23 @@ class _PendingFlush:
     summaries: list[_FlushSummary]
 
 
+@dataclass(frozen=True)
+class _BatchAdmissionResult:
+    admitted_batch_count: int
+    admitted_source_event_count: int
+    retained_batches: list[_FlushBatch]
+
+
 class _UsageBufferState:
     """Mutable usage work state; callers must hold UsageEventBuffer._lock."""
 
     def __init__(self) -> None:
         self._buffer_id = str(uuid.uuid4())
         self._flush_sequence = 0
-        self._buckets: dict[_DestinationKey, dict[_AggregateKey, int]] = {}
+        self._buckets: dict[_DestinationKey, dict[_AggregateKey, _AggregateBucket]] = {}
         # Keep source keys across flushes so aggregate idempotency does not
         # turn response/error duplicates into distinct server-side rows.
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
-        self._destination_source_event_counts: dict[_DestinationKey, int] = {}
         self._source_event_count = 0
         self._enqueuing_source_event_count = 0
         self._pending_flushes: list[_PendingFlush] = []
@@ -144,7 +165,6 @@ class _UsageBufferState:
     def clear(self) -> None:
         self._buckets = {}
         self._seen_source_keys.clear()
-        self._destination_source_event_counts = {}
         self._source_event_count = 0
         self._enqueuing_source_event_count = 0
         self._pending_flushes = []
@@ -161,7 +181,7 @@ class _UsageBufferState:
         include_kind: bool,
         log_type: str,
     ) -> int:
-        buckets: dict[_AggregateKey, int] | None = None
+        buckets: dict[_AggregateKey, _AggregateBucket] | None = None
         destination = _DestinationKey(
             url,
             sandbox_token,
@@ -184,10 +204,9 @@ class _UsageBufferState:
                 provider=event["provider"],
                 category=event["category"],
             )
-            buckets[aggregate_key] = buckets.get(aggregate_key, 0) + event["quantity"]
-            self._destination_source_event_counts[destination] = (
-                self._destination_source_event_counts.get(destination, 0) + 1
-            )
+            bucket = buckets.setdefault(aggregate_key, _AggregateBucket())
+            bucket.quantity += event["quantity"]
+            bucket.source_event_count += 1
             self._source_event_count += 1
             accepted_count += 1
         self._evict_source_keys()
@@ -229,9 +248,6 @@ class _UsageBufferState:
         return self._pending_flushes.pop(0)
 
     def snapshot_live_flush(self) -> _PendingFlush | None:
-        source_event_count = self._source_event_count
-        destination_source_event_counts = self._destination_source_event_counts
-        self._destination_source_event_counts = {}
         if not self._buckets:
             self._source_event_count = 0
             return None
@@ -242,12 +258,7 @@ class _UsageBufferState:
         self._buckets = {}
         self._source_event_count = 0
         batches = self._build_flush_batches(buckets, flush_sequence)
-        return _PendingFlush(
-            source_event_count=source_event_count,
-            flush_sequence=flush_sequence,
-            batches=batches,
-            summaries=_build_flush_summaries(destination_source_event_counts, batches),
-        )
+        return _pending_flush_from_batches(flush_sequence, batches)
 
     def begin_enqueue(self, pending_flush: _PendingFlush) -> None:
         self._enqueuing_source_event_count += pending_flush.source_event_count
@@ -262,6 +273,15 @@ class _UsageBufferState:
         self._pending_flushes.insert(0, pending_flush)
         self.complete_enqueue(pending_flush)
 
+    def retain_unadmitted_batches(
+        self, pending_flush: _PendingFlush, retained_batches: list[_FlushBatch]
+    ) -> None:
+        self.complete_enqueue(pending_flush)
+        if retained_batches:
+            self._pending_flushes.insert(
+                0, _pending_flush_from_batches(pending_flush.flush_sequence, retained_batches)
+            )
+
     def buffered_source_event_count(self) -> int:
         return (
             self._source_event_count
@@ -271,13 +291,14 @@ class _UsageBufferState:
 
     def _build_flush_batches(
         self,
-        buckets: dict[_DestinationKey, dict[_AggregateKey, int]],
+        buckets: dict[_DestinationKey, dict[_AggregateKey, _AggregateBucket]],
         flush_sequence: int,
     ) -> list[_FlushBatch]:
         batches: list[_FlushBatch] = []
         for destination in sorted(
             buckets,
             key=lambda item: (
+                _destination_priority(item),
                 item.url,
                 item.sandbox_token,
                 item.proxy_log_path,
@@ -290,16 +311,20 @@ class _UsageBufferState:
             for run_id in sorted(events_by_run):
                 events = events_by_run[run_id]
                 for start in range(0, len(events), USAGE_EVENT_BATCH_SIZE):
+                    batch_events = events[start : start + USAGE_EVENT_BATCH_SIZE]
                     batches.append(
                         _FlushBatch(
                             url=destination.url,
                             sandbox_token=destination.sandbox_token,
                             payload={
                                 "runId": run_id,
-                                "events": events[start : start + USAGE_EVENT_BATCH_SIZE],
+                                "events": [event.payload for event in batch_events],
                             },
                             proxy_log_path=destination.proxy_log_path,
                             log_type=destination.log_type,
+                            source_event_count=sum(
+                                event.source_event_count for event in batch_events
+                            ),
                         )
                     )
         return batches
@@ -307,24 +332,28 @@ class _UsageBufferState:
     def _events_by_run(
         self,
         destination: _DestinationKey,
-        buckets: dict[_AggregateKey, int],
+        buckets: dict[_AggregateKey, _AggregateBucket],
         flush_sequence: int,
-    ) -> dict[str, list[dict]]:
-        events_by_run: dict[str, list[dict]] = {}
+    ) -> dict[str, list[_FlushEvent]]:
+        events_by_run: dict[str, list[_FlushEvent]] = {}
         for aggregate_key in sorted(
             buckets,
             key=lambda item: (item.run_id, item.kind, item.provider, item.category),
         ):
-            event = {
-                "idempotencyKey": self._aggregate_idempotency_key(
-                    destination, aggregate_key, flush_sequence
-                ),
-                destination.resource_field_name: aggregate_key.provider,
-                "category": aggregate_key.category,
-                "quantity": buckets[aggregate_key],
-            }
+            bucket = buckets[aggregate_key]
+            event = _FlushEvent(
+                payload={
+                    "idempotencyKey": self._aggregate_idempotency_key(
+                        destination, aggregate_key, flush_sequence
+                    ),
+                    destination.resource_field_name: aggregate_key.provider,
+                    "category": aggregate_key.category,
+                    "quantity": bucket.quantity,
+                },
+                source_event_count=bucket.source_event_count,
+            )
             if destination.include_kind:
-                event["kind"] = aggregate_key.kind
+                event.payload["kind"] = aggregate_key.kind
             events_by_run.setdefault(aggregate_key.run_id, []).append(event)
         return events_by_run
 
@@ -498,7 +527,7 @@ class UsageEventBuffer:
                 return flushed_batch_count
 
             try:
-                self._enqueue_pending_flush(pending_flush, trigger)
+                admission_result = self._enqueue_pending_flush(pending_flush, trigger)
             except Exception:
                 timer_to_start = None
                 with self._lock:
@@ -510,30 +539,35 @@ class UsageEventBuffer:
                     timer_to_start.start()
                 raise
 
-            flushed_batch_count += len(pending_flush.batches)
+            flushed_batch_count += admission_result.admitted_batch_count
+            timer_to_start = None
             with self._lock:
-                self._state.complete_enqueue(pending_flush)
+                self._state.retain_unadmitted_batches(
+                    pending_flush, admission_result.retained_batches
+                )
+                if admission_result.retained_batches and trigger != "shutdown":
+                    timer_to_start = self._schedule_timer_if_buffered_locked()
                 self._sync_buffered_counter_locked()
+            if timer_to_start is not None:
+                timer_to_start.start()
+            if admission_result.retained_batches:
+                return flushed_batch_count
 
     def _enqueue_pending_flush(
         self,
         pending_flush: _PendingFlush,
         trigger: UsageFlushTrigger,
-    ) -> None:
+    ) -> _BatchAdmissionResult:
         started_at = time.monotonic()
         try:
             _log_flush_summaries(
                 "started", trigger, pending_flush.flush_sequence, pending_flush.summaries
             )
-            _apply_dropped_batch_counts(
-                pending_flush.summaries,
-                _enqueue_batches(
-                    pending_flush.batches,
-                    self._enqueue_webhook
-                    if self._enqueue_webhook is not None
-                    else _enqueue_webhook,
-                ),
+            admission_result = _enqueue_batches(
+                pending_flush.batches,
+                self._enqueue_webhook if self._enqueue_webhook is not None else _enqueue_webhook,
             )
+            _apply_retained_batch_counts(pending_flush.summaries, admission_result.retained_batches)
             _log_flush_summaries(
                 "completed",
                 trigger,
@@ -541,6 +575,7 @@ class UsageEventBuffer:
                 pending_flush.summaries,
                 duration_ms=_elapsed_ms(started_at),
             )
+            return admission_result
         except Exception as exc:
             _log_flush_summaries(
                 "failed",
@@ -604,11 +639,11 @@ class UsageEventBuffer:
 
 
 def _enqueue_batches(
-    batches: Iterable[_FlushBatch],
+    batches: list[_FlushBatch],
     enqueue_webhook: _EnqueueWebhook,
-) -> dict[str, int]:
-    dropped_counts: dict[str, int] = {}
-    for batch in batches:
+) -> _BatchAdmissionResult:
+    admitted_source_event_count = 0
+    for index, batch in enumerate(batches):
         admitted = enqueue_webhook(
             batch.url,
             batch.sandbox_token,
@@ -617,38 +652,45 @@ def _enqueue_batches(
             batch.log_type,
         )
         if admitted is False:
-            dropped_counts[batch.proxy_log_path] = dropped_counts.get(batch.proxy_log_path, 0) + 1
-    return dropped_counts
+            return _BatchAdmissionResult(
+                admitted_batch_count=index,
+                admitted_source_event_count=admitted_source_event_count,
+                retained_batches=batches[index:],
+            )
+        admitted_source_event_count += batch.source_event_count
+    return _BatchAdmissionResult(
+        admitted_batch_count=len(batches),
+        admitted_source_event_count=admitted_source_event_count,
+        retained_batches=[],
+    )
 
 
-def _apply_dropped_batch_counts(
+def _apply_retained_batch_counts(
     summaries: Iterable[_FlushSummary],
-    dropped_counts: dict[str, int],
+    retained_batches: Iterable[_FlushBatch],
 ) -> None:
-    if not dropped_counts:
-        return
-    for summary in summaries:
-        summary.dropped_webhook_batch_count = dropped_counts.get(summary.proxy_log_path, 0)
-
-
-def _build_flush_summaries(
-    source_counts: dict[_DestinationKey, int],
-    batches: Iterable[_FlushBatch],
-) -> list[_FlushSummary]:
-    summaries: dict[str, _FlushSummary] = {}
-    for destination, source_event_count in source_counts.items():
-        summary = summaries.setdefault(
-            destination.proxy_log_path,
-            _FlushSummary(proxy_log_path=destination.proxy_log_path),
+    retained_batch_counts: dict[str, int] = {}
+    retained_source_counts: dict[str, int] = {}
+    for batch in retained_batches:
+        retained_batch_counts[batch.proxy_log_path] = (
+            retained_batch_counts.get(batch.proxy_log_path, 0) + 1
         )
-        summary.source_event_count += source_event_count
-        summary.destinations.add((destination.url, destination.proxy_log_path))
+        retained_source_counts[batch.proxy_log_path] = (
+            retained_source_counts.get(batch.proxy_log_path, 0) + batch.source_event_count
+        )
+    for summary in summaries:
+        summary.retained_webhook_batch_count = retained_batch_counts.get(summary.proxy_log_path, 0)
+        summary.retained_source_event_count = retained_source_counts.get(summary.proxy_log_path, 0)
 
+
+def _build_flush_summaries(batches: Iterable[_FlushBatch]) -> list[_FlushSummary]:
+    summaries: dict[str, _FlushSummary] = {}
     for batch in batches:
         summary = summaries.setdefault(
             batch.proxy_log_path,
             _FlushSummary(proxy_log_path=batch.proxy_log_path),
         )
+        summary.source_event_count += batch.source_event_count
         events = batch.payload.get("events")
         if isinstance(events, list):
             summary.aggregate_event_count += len(events)
@@ -656,8 +698,24 @@ def _build_flush_summaries(
         run_id = batch.payload.get("runId")
         if isinstance(run_id, str) and run_id:
             summary.run_ids.add(run_id)
+        summary.destinations.add((batch.url, batch.proxy_log_path))
 
     return [summaries[path] for path in sorted(summaries)]
+
+
+def _pending_flush_from_batches(flush_sequence: int, batches: list[_FlushBatch]) -> _PendingFlush:
+    return _PendingFlush(
+        source_event_count=sum(batch.source_event_count for batch in batches),
+        flush_sequence=flush_sequence,
+        batches=batches,
+        summaries=_build_flush_summaries(batches),
+    )
+
+
+def _destination_priority(destination: _DestinationKey) -> int:
+    if destination.log_type == "usage_event":
+        return 0
+    return 1
 
 
 def _log_flush_summaries(
@@ -681,6 +739,8 @@ def _log_flush_summaries(
             "aggregate_event_count": summary.aggregate_event_count,
             "webhook_batch_count": summary.webhook_batch_count,
             "dropped_webhook_batch_count": summary.dropped_webhook_batch_count,
+            "retained_webhook_batch_count": summary.retained_webhook_batch_count,
+            "retained_source_event_count": summary.retained_source_event_count,
             "run_count": len(summary.run_ids),
             "destination_count": len(summary.destinations),
         }
@@ -690,9 +750,9 @@ def _log_flush_summaries(
             extra["error_type"] = error_type
         level = "error" if phase == "failed" else "info"
         message = f"Usage event buffer flush {phase}"
-        if phase == "completed" and summary.dropped_webhook_batch_count:
+        if phase == "completed" and summary.retained_webhook_batch_count:
             level = "warn"
-            message = "Usage event buffer flush completed with dropped webhook batches"
+            message = "Usage event buffer flush retained webhook batches for retry"
         log_proxy_entry(
             summary.proxy_log_path,
             level,

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -527,13 +527,9 @@ class UsageEventBuffer:
                 )
                 if live_snapshot_attempted and trigger != "shutdown":
                     snapshot_live = False
-                if (
-                    trigger != "shutdown"
-                    and self._state.has_active_enqueue()
-                    and pending_flush is None
-                ):
-                    timer_to_start = self._schedule_timer_if_buffered_locked()
                 if pending_flush is None:
+                    if trigger != "shutdown":
+                        timer_to_start = self._schedule_timer_if_buffered_locked()
                     self._sync_buffered_counter_locked()
                 else:
                     self._state.begin_enqueue(pending_flush)

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -269,14 +269,14 @@ def _enqueue_webhook(
     falls back to synchronous delivery so the report is not silently lost.
 
     Returns whether the payload was admitted to delivery.  ``False`` means
-    delivery was saturated and the payload was explicitly dropped.
+    delivery was saturated and the caller still owns the payload.
     """
     admitted_count = _try_acquire_delivery_capacity()
     if admitted_count is None:
         _log_webhook_entry(
             proxy_log_path,
             "warn",
-            f"Webhook POST to {url} dropped because usage delivery is saturated",
+            f"Webhook POST to {url} not admitted because usage delivery is saturated",
             url,
             log_type,
             payload,

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -7,6 +7,7 @@ import pytest
 
 import usage
 from tests.pending_helpers import assert_pending
+from tests.usage_buffer_helpers import RecordingEnqueue, event
 
 
 class TestUsagePendingCounter:
@@ -185,6 +186,31 @@ class TestUsagePendingCounter:
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+
+    def test_saturated_usage_flush_keeps_buffered_pending_snapshot(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+        enqueue = RecordingEnqueue(return_value=False)
+        usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1")],
+            str(tmp_path / "proxy.jsonl"),
+        )
+
+        assert usage.flush_usage_events(trigger="runner") == 0
+
+        usage.write_pending_snapshot(flush_request_id="request-1")
+        assert_pending(pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1")
+
+        enqueue.return_value = True
+        enqueue.clear()
+        assert usage.flush_usage_events(trigger="runner") == 1
+        usage.write_pending_snapshot(flush_request_id="request-2")
+        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
 
     def test_set_pending_path_accepts_explicit_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -283,6 +283,55 @@ def test_billable_usage_is_admitted_before_model_usage_observation(tmp_path):
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_live_billable_usage_preempts_retained_model_usage_observation(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [event(source_key="observation-source")],
+        proxy_log_path,
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 0
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.log_type == "model_usage_observation"
+    assert usage.counters._buffered_usage_events == 1
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="usage-source")],
+        proxy_log_path,
+    )
+    attempted_log_types = []
+
+    def admit_usage_then_saturate_observation(url, sandbox_token, payload, path, log_type):
+        del url, sandbox_token, payload, path
+        attempted_log_types.append(log_type)
+        return log_type == "usage_event"
+
+    enqueue.side_effect = admit_usage_then_saturate_observation
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert attempted_log_types == ["usage_event", "model_usage_observation"]
+    assert usage.counters._buffered_usage_events == 1
+
+    enqueue.side_effect = None
+    enqueue.return_value = True
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.log_type == "model_usage_observation"
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):
     def fail_first_flush(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, payload, path, log_type

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -139,6 +139,150 @@ def test_threshold_flush_failure_preserves_retryable_payload_with_same_idempoten
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_saturated_flush_retains_retryable_payload_with_same_idempotency_key(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1", quantity=10)],
+        proxy_log_path,
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 0
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 1
+    retained_key = enqueue.last_call.payload["events"][0]["idempotencyKey"]
+
+    enqueue.return_value = True
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    retry_payload = enqueue.last_call.payload
+    assert retry_payload["runId"] == "run-1"
+    assert retry_payload["events"][0]["quantity"] == 10
+    assert retry_payload["events"][0]["idempotencyKey"] == retained_key
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_partial_saturated_flush_retries_only_unadmitted_batches(tmp_path):
+    attempted_payloads = []
+
+    def saturate_second_batch(url, sandbox_token, payload, path, log_type):
+        del url, sandbox_token, path, log_type
+        attempted_payloads.append(payload)
+        return len(attempted_payloads) != 2
+
+    enqueue = RecordingEnqueue(side_effect=saturate_second_batch)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        proxy_log_path,
+    )
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-2",
+        [event(source_key="source-2")],
+        proxy_log_path,
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert [payload["runId"] for payload in attempted_payloads] == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 1
+    retained_key = attempted_payloads[1]["events"][0]["idempotencyKey"]
+
+    enqueue.side_effect = None
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    retry_payload = enqueue.last_call.payload
+    assert retry_payload["runId"] == "run-2"
+    assert retry_payload["events"][0]["idempotencyKey"] == retained_key
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_retained_aggregate_batch_keeps_source_event_count(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [
+            event(source_key="source-1", quantity=10),
+            event(source_key="source-2", quantity=5),
+            event(source_key="source-3", quantity=7),
+        ],
+        proxy_log_path,
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 0
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 22
+    assert usage.counters._buffered_usage_events == 3
+
+    enqueue.return_value = True
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 22
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_billable_usage_is_admitted_before_model_usage_observation(tmp_path):
+    attempted_log_types = []
+
+    def admit_one_batch(url, sandbox_token, payload, path, log_type):
+        del url, sandbox_token, payload, path
+        attempted_log_types.append(log_type)
+        return len(attempted_log_types) == 1
+
+    enqueue = RecordingEnqueue(side_effect=admit_one_batch)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [event(source_key="observation-source")],
+        proxy_log_path,
+    )
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="usage-source")],
+        proxy_log_path,
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert attempted_log_types == ["usage_event", "model_usage_observation"]
+    assert usage.counters._buffered_usage_events == 1
+
+    enqueue.side_effect = None
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.log_type == "model_usage_observation"
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_pending_flush_retries_before_live_usage_snapshot(tmp_path):
     def fail_first_flush(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, payload, path, log_type

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -49,7 +49,7 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
     assert entries[1]["duration_ms"] >= 0
 
 
-def test_flush_logs_dropped_webhook_batches(tmp_path):
+def test_flush_logs_retained_webhook_batches(tmp_path):
     enqueue = RecordingEnqueue(return_value=False)
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
     proxy_log_path = tmp_path / "proxy.jsonl"
@@ -62,17 +62,18 @@ def test_flush_logs_dropped_webhook_batches(tmp_path):
         str(proxy_log_path),
     )
 
-    assert usage.flush_usage_events(trigger="test") == 1
+    assert usage.flush_usage_events(trigger="test") == 0
 
     enqueue.assert_called_once()
     entries = flush_log_entries(proxy_log_path)
     assert [entry["phase"] for entry in entries] == ["started", "completed"]
     assert entries[0]["dropped_webhook_batch_count"] == 0
+    assert entries[0]["retained_webhook_batch_count"] == 0
     assert entries[1]["level"] == "warn"
-    assert entries[1]["message"] == (
-        "Usage event buffer flush completed with dropped webhook batches"
-    )
-    assert entries[1]["dropped_webhook_batch_count"] == 1
+    assert entries[1]["message"] == "Usage event buffer flush retained webhook batches for retry"
+    assert entries[1]["dropped_webhook_batch_count"] == 0
+    assert entries[1]["retained_webhook_batch_count"] == 1
+    assert entries[1]["retained_source_event_count"] == 1
     assert entries[1]["webhook_batch_count"] == 1
     assert "secret-token" not in json.dumps(entries)
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -358,6 +358,65 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert len(timers) == 1
+
+    assert usage.flush_usage_events(trigger="shutdown") == 0
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 1
+    assert len(timers) == 1
+    assert timers[0].cancelled is True
+
+    enqueue.return_value = True
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["runId"] == "run-1"
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert len(timers) == 1
+    assert timers[0].started is True
+
+    timers[0].callback()
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 1
+    assert len(timers) == 2
+    assert timers[0].cancelled is True
+    assert timers[1].started is True
+
+    enqueue.return_value = True
+    enqueue.clear()
+    timers[1].callback()
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["runId"] == "run-1"
+    assert usage.counters._buffered_usage_events == 0
+    assert timers[1].cancelled is True
+
+
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
     enqueue = RecordingEnqueue()
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -417,6 +417,67 @@ def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
     assert timers[1].cancelled is True
 
 
+def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [event(source_key="observation-source")],
+        proxy_log_path,
+    )
+    assert len(timers) == 1
+
+    assert usage.flush_usage_events(trigger="test") == 0
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.log_type == "model_usage_observation"
+    assert len(timers) == 2
+    assert timers[0].cancelled is True
+    assert timers[1].started is True
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="usage-source-1")],
+        proxy_log_path,
+    )
+    attempted_log_types = []
+
+    def enqueue_and_buffer_later_usage(url, sandbox_token, payload, path, log_type):
+        attempted_log_types.append(log_type)
+        if log_type == "usage_event" and payload["runId"] == "run-1":
+            usage.buffer_usage_events(
+                url,
+                sandbox_token,
+                "run-2",
+                [event(source_key="usage-source-2")],
+                path,
+            )
+            assert len(timers) == 3
+        return True
+
+    enqueue.side_effect = enqueue_and_buffer_later_usage
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 2
+
+    assert attempted_log_types == ["usage_event", "model_usage_observation"]
+    assert usage.counters._buffered_usage_events == 1
+    assert len(timers) == 4
+    assert timers[2].cancelled is True
+    assert timers[3].started is True
+
+    enqueue.clear()
+    timers[3].callback()
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["runId"] == "run-2"
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
     enqueue = RecordingEnqueue()
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -386,7 +386,7 @@ class TestUsageWebhookDelivery:
         assert body["events"][0]["quantity"] == 42
         assert body["events"][0]["category"] == "tokens.input"
 
-    def test_drops_when_delivery_capacity_is_saturated(self, tmp_path):
+    def test_does_not_admit_when_delivery_capacity_is_saturated(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
         executor = _QueuedUsageExecutor()
 
@@ -400,7 +400,7 @@ class TestUsageWebhookDelivery:
                     "usage_event",
                 )
 
-            dropped = usage.webhook._enqueue_webhook(
+            admitted = usage.webhook._enqueue_webhook(
                 "https://api.vm0.ai/api/webhooks/agent/usage-event",
                 "tok",
                 {
@@ -412,23 +412,25 @@ class TestUsageWebhookDelivery:
                 "usage_event",
             )
 
-        assert dropped is False
+        assert admitted is False
         assert len(executor.submissions) == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
         assert usage.counters._pending_reports == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
 
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
-        dropped_entry = entries[-1]
-        assert dropped_entry["level"] == "warn"
-        assert "saturated" in dropped_entry["message"]
-        assert dropped_entry["webhook_delivery_capacity"] == (
+        saturated_entry = entries[-1]
+        assert saturated_entry["level"] == "warn"
+        assert "not admitted" in saturated_entry["message"]
+        assert "saturated" in saturated_entry["message"]
+        assert "dropped" not in saturated_entry["message"]
+        assert saturated_entry["webhook_delivery_capacity"] == (
             usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
         )
-        assert dropped_entry["webhook_delivery_pending"] == (
+        assert saturated_entry["webhook_delivery_pending"] == (
             usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
         )
-        _assert_body_free_webhook_entry(dropped_entry, run_id="run-drop", event_count=1)
-        assert "payload_bytes" not in dropped_entry
-        assert "secret-payload" not in json.dumps(dropped_entry)
+        _assert_body_free_webhook_entry(saturated_entry, run_id="run-drop", event_count=1)
+        assert "payload_bytes" not in saturated_entry
+        assert "secret-payload" not in json.dumps(saturated_entry)
 
     def test_delivery_capacity_released_after_success(
         self, tmp_path, sync_usage_executor, usage_webhook_server


### PR DESCRIPTION
## Summary
- retain usage flush batches when webhook delivery reports saturated admission instead of dropping them
- track per-batch source event counts so retained partial flushes keep buffered counters accurate
- prioritize billable `usage_event` batches ahead of `model_usage_observation` batches under shared delivery capacity
- update saturation logging to say batches were retained/not admitted, without logging payload bodies, tokens, or idempotency keys

## Reliability boundary
This remains an in-process admission fix. It prevents loss before webhook delivery accepts ownership, but it does not add a durable queue or change the existing behavior for payloads that are admitted and later exhaust HTTP retries or are lost on process exit.

Closes #17380

## Tests
- `/tmp/vm5-mitm-addon-test-venv/bin/python -m ruff format --check .`
- `/tmp/vm5-mitm-addon-test-venv/bin/python -m ruff check .`
- `/tmp/vm5-mitm-addon-test-venv/bin/python -m basedpyright --pythonpath /tmp/vm5-mitm-addon-test-venv/bin/python`
- `/tmp/vm5-mitm-addon-test-venv/bin/python -m pytest tests/test_webhook.py tests/test_usage_buffer_flush_failures.py tests/test_usage_buffer_logging.py tests/test_usage_buffer_timer_shutdown.py tests/test_counters.py`
- `/tmp/vm5-mitm-addon-test-venv/bin/python -m pytest`