### PR TITLE
fix(desktop): auto-start computer use from menu bar launch

### DIFF
--- a/turbo/apps/desktop/src/desktop-launch-computer-use.test.ts
+++ b/turbo/apps/desktop/src/desktop-launch-computer-use.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopAuthCallback } from "./desktop-auth";
+import { startDesktopLaunchComputerUse } from "./desktop-launch-computer-use";
+
+const pendingCallback: DesktopAuthCallback = {
+  code: "a".repeat(32),
+  handoffId: "11111111-1111-1111-1111-111111111111",
+};
+
+async function flushLaunchHandlers(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await Promise.resolve();
+}
+
+function launchOptions(
+  overrides: {
+    readonly pendingCallback?: DesktopAuthCallback | null;
+    readonly consumeAuthCallback?: (
+      callback: DesktopAuthCallback,
+    ) => Promise<void>;
+    readonly autoStartComputerUse?: () => Promise<void>;
+    readonly logAuthError?: (error: unknown) => void;
+    readonly logAutoStartError?: (error: unknown) => void;
+  } = {},
+) {
+  return {
+    pendingCallback: null,
+    consumeAuthCallback: vi.fn(async () => {}),
+    autoStartComputerUse: vi.fn(async () => {}),
+    logAuthError: vi.fn(),
+    logAutoStartError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("startDesktopLaunchComputerUse", () => {
+  it("auto-starts Computer Use when launch has no pending auth callback", async () => {
+    const options = launchOptions();
+
+    startDesktopLaunchComputerUse(options);
+    await flushLaunchHandlers();
+
+    expect(options.autoStartComputerUse).toHaveBeenCalledOnce();
+    expect(options.consumeAuthCallback).not.toHaveBeenCalled();
+    expect(options.logAutoStartError).not.toHaveBeenCalled();
+  });
+
+  it("consumes the pending auth callback instead of auto-starting", async () => {
+    const options = launchOptions({ pendingCallback });
+
+    startDesktopLaunchComputerUse(options);
+    await flushLaunchHandlers();
+
+    expect(options.consumeAuthCallback).toHaveBeenCalledWith(pendingCallback);
+    expect(options.autoStartComputerUse).not.toHaveBeenCalled();
+    expect(options.logAuthError).not.toHaveBeenCalled();
+  });
+
+  it("logs auth callback failures from the background launch task", async () => {
+    const error = new Error("consume failed");
+    const options = launchOptions({
+      pendingCallback,
+      consumeAuthCallback: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    startDesktopLaunchComputerUse(options);
+    await flushLaunchHandlers();
+
+    expect(options.logAuthError).toHaveBeenCalledWith(error);
+    expect(options.logAutoStartError).not.toHaveBeenCalled();
+  });
+
+  it("logs auto-start failures from the background launch task", async () => {
+    const error = new Error("auto-start failed");
+    const options = launchOptions({
+      autoStartComputerUse: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    startDesktopLaunchComputerUse(options);
+    await flushLaunchHandlers();
+
+    expect(options.logAutoStartError).toHaveBeenCalledWith(error);
+    expect(options.logAuthError).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-launch-computer-use.ts
+++ b/turbo/apps/desktop/src/desktop-launch-computer-use.ts
@@ -1,0 +1,24 @@
+import type { DesktopAuthCallback } from "./desktop-auth";
+
+interface DesktopLaunchComputerUseOptions {
+  readonly pendingCallback: DesktopAuthCallback | null;
+  readonly consumeAuthCallback: (
+    callback: DesktopAuthCallback,
+  ) => Promise<void>;
+  readonly autoStartComputerUse: () => Promise<void>;
+  readonly logAuthError: (error: unknown) => void;
+  readonly logAutoStartError: (error: unknown) => void;
+}
+
+export function startDesktopLaunchComputerUse(
+  options: DesktopLaunchComputerUseOptions,
+): void {
+  if (options.pendingCallback) {
+    void options
+      .consumeAuthCallback(options.pendingCallback)
+      .catch(options.logAuthError);
+    return;
+  }
+
+  void options.autoStartComputerUse().catch(options.logAutoStartError);
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -47,6 +47,7 @@ import { resolveDesktopConfig } from "./config";
 import { installDesktopAutoUpdates } from "./desktop-auto-updates";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
 import { DesktopKeepAwakeController } from "./desktop-keep-awake";
+import { startDesktopLaunchComputerUse } from "./desktop-launch-computer-use";
 import {
   DesktopQuitConfirmationController,
   buildDesktopQuitConfirmationOptions,
@@ -599,6 +600,10 @@ function logDesktopAuthError(error: unknown): void {
   console.error("Desktop auth flow failed", error);
 }
 
+function logComputerUseAutoStartError(error: unknown): void {
+  console.error("Desktop Computer Use auto-start failed", error);
+}
+
 async function loadAuthUrl(window: BrowserWindow, url: string): Promise<void> {
   try {
     await window.loadURL(url);
@@ -1008,12 +1013,16 @@ if (!hasSingleInstanceLock) {
     installTray();
     queueDesktopAuthCallbackArgv(process.argv);
 
-    const pendingCallback = desktopAuthSession.takePendingCallback();
-    if (pendingCallback) {
-      void desktopAuthSession
-        .consumeCode(pendingCallback.code, pendingCallback.handoffId)
-        .catch(logDesktopAuthError);
-    }
+    startDesktopLaunchComputerUse({
+      pendingCallback: desktopAuthSession.takePendingCallback(),
+      consumeAuthCallback: (callback) =>
+        desktopAuthSession.consumeCode(callback.code, callback.handoffId),
+      autoStartComputerUse: async () => {
+        await startComputerUseRuntime();
+      },
+      logAuthError: logDesktopAuthError,
+      logAutoStartError: logComputerUseAutoStartError,
+    });
 
     app.on("activate", () => {
       void createMainWindow();


### PR DESCRIPTION
Summary
- Auto-start the Desktop Computer Use runtime from the main process during menu-bar-only launch.
- Keep pending desktop auth callbacks ahead of launch auto-start so sign-in completion still owns startup.
- Add launch orchestration tests for auto-start, auth callback precedence, and background error logging.

Validation
- pnpm exec prettier --check apps/desktop/src/main.ts apps/desktop/src/desktop-launch-computer-use.ts apps/desktop/src/desktop-launch-computer-use.test.ts
- pnpm -F @vm0/desktop exec vitest run src/desktop-launch-computer-use.test.ts src/renderer/computer-use-state.test.ts src/computer-use-startup-gate.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test
- pnpm knip --workspace @vm0/desktop