### PR TITLE
fix: retain usage flushes after webhook failures

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -34,7 +34,7 @@ from logging_utils import log_proxy_entry
 
 from .counters import set_buffered_usage_events
 from .idempotency import USAGE_EVENT_NAMESPACE_AGGREGATE, derive_usage_idempotency_key
-from .webhook import _enqueue_webhook
+from .webhook import WebhookDeliveryOutcome, _enqueue_webhook
 
 DEFAULT_FLUSH_INTERVAL_SECONDS = 30.0
 DEFAULT_FLUSH_JITTER_RATIO = 0.2
@@ -69,7 +69,8 @@ class _TimerHandle(Protocol):
 
 
 _TimerFactory = Callable[[float, Callable[[], None]], _TimerHandle]
-_EnqueueWebhook = Callable[[str, str, dict, str, str], bool]
+_DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
+_EnqueueWebhook = Callable[[str, str, dict, str, str, _DeliveryOutcomeCallback], bool]
 
 
 class _FlushOwnerLock(Protocol):
@@ -139,6 +140,23 @@ class _PendingFlush:
     flush_sequence: int
     batches: list[_FlushBatch]
     summaries: list[_FlushSummary]
+    retry_after_flush_generation: int = 0
+
+
+@dataclass
+class _DeliveringFlush:
+    pending_flush: _PendingFlush
+    trigger: UsageFlushTrigger
+    flush_generation: int
+    remaining_batch_count: int
+    retryable_failure: bool = False
+
+
+@dataclass(frozen=True)
+class _DeliveryCompletion:
+    pending_flush: _PendingFlush
+    trigger: UsageFlushTrigger
+    retryable: bool
 
 
 @dataclass(frozen=True)
@@ -158,15 +176,17 @@ class _UsageBufferState:
         # turn response/error duplicates into distinct server-side rows.
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
         self._source_event_count = 0
-        self._enqueuing_source_event_count = 0
+        self._active_enqueue_count = 0
         self._pending_flushes: list[_PendingFlush] = []
+        self._delivering_flushes: dict[int, _DeliveringFlush] = {}
 
     def clear(self) -> None:
         self._buckets = {}
         self._seen_source_keys.clear()
         self._source_event_count = 0
-        self._enqueuing_source_event_count = 0
+        self._active_enqueue_count = 0
         self._pending_flushes = []
+        self._delivering_flushes = {}
 
     def add_events(
         self,
@@ -238,27 +258,39 @@ class _UsageBufferState:
         return bool(self._pending_flushes or self._source_event_count)
 
     def has_active_enqueue(self) -> bool:
-        return bool(self._enqueuing_source_event_count)
+        return bool(self._active_enqueue_count)
 
-    def has_pending_flushes(self) -> bool:
-        return bool(self._pending_flushes)
-
-    def pending_flush_priority(self) -> int | None:
-        if not self._pending_flushes:
-            return None
-        return min(
-            _pending_flush_priority(pending_flush) for pending_flush in self._pending_flushes
+    def has_available_pending_flushes(self, flush_generation: int) -> bool:
+        return any(
+            pending_flush.retry_after_flush_generation != flush_generation
+            for pending_flush in self._pending_flushes
         )
 
-    def pop_highest_priority_pending_flush(self) -> _PendingFlush:
-        selected_index = 0
-        selected_priority = _pending_flush_priority(self._pending_flushes[0])
-        for index, pending_flush in enumerate(self._pending_flushes[1:], start=1):
+    def pending_flush_priority(self, flush_generation: int) -> int | None:
+        priorities = [
+            _pending_flush_priority(pending_flush)
+            for pending_flush in self._pending_flushes
+            if pending_flush.retry_after_flush_generation != flush_generation
+        ]
+        if not priorities:
+            return None
+        return min(priorities)
+
+    def pop_highest_priority_pending_flush(self, flush_generation: int) -> _PendingFlush:
+        selected_index: int | None = None
+        selected_priority: int | None = None
+        for index, pending_flush in enumerate(self._pending_flushes):
+            if pending_flush.retry_after_flush_generation == flush_generation:
+                continue
             priority = _pending_flush_priority(pending_flush)
-            if priority < selected_priority:
+            if selected_priority is None or priority < selected_priority:
                 selected_index = index
                 selected_priority = priority
-        return self._pending_flushes.pop(selected_index)
+        if selected_index is None:
+            raise RuntimeError("no pending flush is available for this flush generation")
+        pending_flush = self._pending_flushes.pop(selected_index)
+        pending_flush.retry_after_flush_generation = 0
+        return pending_flush
 
     def live_priority(self) -> int | None:
         if not self._buckets:
@@ -278,33 +310,102 @@ class _UsageBufferState:
         batches = self._build_flush_batches(buckets, flush_sequence)
         return _pending_flush_from_batches(flush_sequence, batches)
 
-    def begin_enqueue(self, pending_flush: _PendingFlush) -> None:
-        self._enqueuing_source_event_count += pending_flush.source_event_count
-
-    def complete_enqueue(self, pending_flush: _PendingFlush) -> None:
-        self._enqueuing_source_event_count = max(
-            0,
-            self._enqueuing_source_event_count - pending_flush.source_event_count,
+    def begin_delivery(
+        self,
+        pending_flush: _PendingFlush,
+        trigger: UsageFlushTrigger,
+        flush_generation: int,
+    ) -> None:
+        self._active_enqueue_count += 1
+        self._delivering_flushes[id(pending_flush)] = _DeliveringFlush(
+            pending_flush=pending_flush,
+            trigger=trigger,
+            flush_generation=flush_generation,
+            remaining_batch_count=len(pending_flush.batches),
         )
 
-    def fail_enqueue(self, pending_flush: _PendingFlush) -> None:
-        self._pending_flushes.insert(0, pending_flush)
-        self.complete_enqueue(pending_flush)
+    def complete_enqueue(self) -> None:
+        self._active_enqueue_count = max(0, self._active_enqueue_count - 1)
 
-    def retain_unadmitted_batches(
-        self, pending_flush: _PendingFlush, retained_batches: list[_FlushBatch]
+    def fail_enqueue(self, pending_flush: _PendingFlush) -> None:
+        if self._delivering_flushes.pop(id(pending_flush), None) is not None:
+            pending_flush.retry_after_flush_generation = 0
+            self._pending_flushes.insert(0, pending_flush)
+        self.complete_enqueue()
+
+    def record_delivery_outcome(
+        self,
+        pending_flush: _PendingFlush,
+        outcome: WebhookDeliveryOutcome,
+    ) -> _DeliveryCompletion | None:
+        delivering_flush = self._delivering_flushes.get(id(pending_flush))
+        if delivering_flush is None:
+            return None
+
+        if outcome == "retryable_failure":
+            delivering_flush.retryable_failure = True
+        delivering_flush.remaining_batch_count -= 1
+        if delivering_flush.remaining_batch_count > 0:
+            return None
+
+        del self._delivering_flushes[id(pending_flush)]
+        completed_flush = delivering_flush.pending_flush
+        if delivering_flush.retryable_failure:
+            completed_flush.retry_after_flush_generation = delivering_flush.flush_generation
+            self._pending_flushes.insert(0, completed_flush)
+        return _DeliveryCompletion(
+            pending_flush=completed_flush,
+            trigger=delivering_flush.trigger,
+            retryable=delivering_flush.retryable_failure,
+        )
+
+    def complete_admission(
+        self, pending_flush: _PendingFlush, admission_result: _BatchAdmissionResult
     ) -> None:
-        self.complete_enqueue(pending_flush)
-        if retained_batches:
-            self._pending_flushes.insert(
-                0, _pending_flush_from_batches(pending_flush.flush_sequence, retained_batches)
+        delivering_flush = self._delivering_flushes.get(id(pending_flush))
+        if delivering_flush is not None and admission_result.retained_batches:
+            retained_flush = _pending_flush_from_batches(
+                pending_flush.flush_sequence,
+                admission_result.retained_batches,
             )
+            retained_flush.retry_after_flush_generation = delivering_flush.flush_generation
+            self._pending_flushes.insert(
+                0,
+                retained_flush,
+            )
+
+            admitted_batches = pending_flush.batches[: admission_result.admitted_batch_count]
+            completed_outcome_count = (
+                len(pending_flush.batches) - delivering_flush.remaining_batch_count
+            )
+            remaining_admitted_count = (
+                admission_result.admitted_batch_count - completed_outcome_count
+            )
+            if admitted_batches and remaining_admitted_count > 0:
+                delivering_flush.pending_flush = _pending_flush_from_batches(
+                    pending_flush.flush_sequence,
+                    admitted_batches,
+                )
+                delivering_flush.remaining_batch_count = remaining_admitted_count
+            else:
+                del self._delivering_flushes[id(pending_flush)]
+                if admitted_batches and delivering_flush.retryable_failure:
+                    admitted_flush = _pending_flush_from_batches(
+                        pending_flush.flush_sequence,
+                        admitted_batches,
+                    )
+                    admitted_flush.retry_after_flush_generation = delivering_flush.flush_generation
+                    self._pending_flushes.insert(0, admitted_flush)
+        self.complete_enqueue()
 
     def buffered_source_event_count(self) -> int:
         return (
             self._source_event_count
             + sum(pending_flush.source_event_count for pending_flush in self._pending_flushes)
-            + self._enqueuing_source_event_count
+            + sum(
+                delivering_flush.pending_flush.source_event_count
+                for delivering_flush in self._delivering_flushes.values()
+            )
         )
 
     def _build_flush_batches(
@@ -424,6 +525,7 @@ class UsageEventBuffer:
         self._timer_enabled = timer_enabled
         self._timer_factory = timer_factory if timer_factory is not None else self._make_timer
         self._timer: _TimerHandle | None = None
+        self._flush_generation = 0
 
     def configure(self, *, flush_interval_seconds: float) -> None:
         """Update runtime buffer settings."""
@@ -513,6 +615,8 @@ class UsageEventBuffer:
     def _flush_usage_events_owned(self, *, trigger: UsageFlushTrigger) -> int:
         flushed_batch_count = 0
         snapshot_live = True
+        self._flush_generation += 1
+        flush_generation = self._flush_generation
         if trigger in ("shutdown", "timer"):
             with self._lock:
                 timer = self._pop_timer_locked()
@@ -523,7 +627,8 @@ class UsageEventBuffer:
             timer_to_start: _TimerHandle | None = None
             with self._lock:
                 pending_flush, live_snapshot_attempted = self._next_pending_flush_locked(
-                    snapshot_live=snapshot_live
+                    snapshot_live=snapshot_live,
+                    flush_generation=flush_generation,
                 )
                 if live_snapshot_attempted and trigger != "shutdown":
                     snapshot_live = False
@@ -532,7 +637,7 @@ class UsageEventBuffer:
                         timer_to_start = self._schedule_timer_if_buffered_locked()
                     self._sync_buffered_counter_locked()
                 else:
-                    self._state.begin_enqueue(pending_flush)
+                    self._state.begin_delivery(pending_flush, trigger, flush_generation)
                     self._sync_buffered_counter_locked()
 
             if timer_to_start is not None:
@@ -556,9 +661,7 @@ class UsageEventBuffer:
             flushed_batch_count += admission_result.admitted_batch_count
             timer_to_start = None
             with self._lock:
-                self._state.retain_unadmitted_batches(
-                    pending_flush, admission_result.retained_batches
-                )
+                self._state.complete_admission(pending_flush, admission_result)
                 if admission_result.retained_batches and trigger != "shutdown":
                     timer_to_start = self._schedule_timer_if_buffered_locked()
                 self._sync_buffered_counter_locked()
@@ -580,10 +683,11 @@ class UsageEventBuffer:
             admission_result = _enqueue_batches(
                 pending_flush.batches,
                 self._enqueue_webhook if self._enqueue_webhook is not None else _enqueue_webhook,
+                self._make_delivery_outcome_callback(pending_flush),
             )
             _apply_retained_batch_counts(pending_flush.summaries, admission_result.retained_batches)
             _log_flush_summaries(
-                "completed",
+                "enqueued",
                 trigger,
                 pending_flush.flush_sequence,
                 pending_flush.summaries,
@@ -600,6 +704,38 @@ class UsageEventBuffer:
                 error_type=type(exc).__name__,
             )
             raise
+
+    def _make_delivery_outcome_callback(
+        self,
+        pending_flush: _PendingFlush,
+    ) -> _DeliveryOutcomeCallback:
+        def callback(outcome: WebhookDeliveryOutcome) -> None:
+            self._record_delivery_outcome(pending_flush, outcome)
+
+        return callback
+
+    def _record_delivery_outcome(
+        self,
+        pending_flush: _PendingFlush,
+        outcome: WebhookDeliveryOutcome,
+    ) -> None:
+        timer_to_start: _TimerHandle | None = None
+        completion: _DeliveryCompletion | None = None
+        with self._lock:
+            completion = self._state.record_delivery_outcome(pending_flush, outcome)
+            if completion is not None and completion.retryable and completion.trigger != "shutdown":
+                timer_to_start = self._schedule_timer_if_buffered_locked()
+            self._sync_buffered_counter_locked()
+
+        if completion is not None and completion.retryable:
+            _log_flush_summaries(
+                "retained",
+                completion.trigger,
+                completion.pending_flush.flush_sequence,
+                completion.pending_flush.summaries,
+            )
+        if timer_to_start is not None:
+            timer_to_start.start()
 
     def _sync_buffered_counter_locked(self) -> None:
         set_buffered_usage_events(self._state.buffered_source_event_count())
@@ -631,15 +767,15 @@ class UsageEventBuffer:
         return max(0.001, self._flush_interval_seconds + _jitter_rng.uniform(-jitter, jitter))
 
     def _next_pending_flush_locked(
-        self, *, snapshot_live: bool
+        self, *, snapshot_live: bool, flush_generation: int
     ) -> tuple[_PendingFlush | None, bool]:
         if self._state.has_active_enqueue():
             return None, False
-        if self._state.has_pending_flushes():
+        if self._state.has_available_pending_flushes(flush_generation):
             timer = self._pop_timer_locked()
             if timer is not None:
                 timer.cancel()
-            pending_priority = self._state.pending_flush_priority()
+            pending_priority = self._state.pending_flush_priority(flush_generation)
             live_priority = self._state.live_priority() if snapshot_live else None
             if (
                 pending_priority is not None
@@ -647,7 +783,7 @@ class UsageEventBuffer:
                 and live_priority < pending_priority
             ):
                 return self._state.snapshot_live_flush(), True
-            return self._state.pop_highest_priority_pending_flush(), False
+            return self._state.pop_highest_priority_pending_flush(flush_generation), False
         if not snapshot_live:
             return None, False
         timer = self._pop_timer_locked()
@@ -663,6 +799,7 @@ class UsageEventBuffer:
 def _enqueue_batches(
     batches: list[_FlushBatch],
     enqueue_webhook: _EnqueueWebhook,
+    delivery_outcome_callback: _DeliveryOutcomeCallback,
 ) -> _BatchAdmissionResult:
     for index, batch in enumerate(batches):
         admitted = enqueue_webhook(
@@ -671,6 +808,7 @@ def _enqueue_batches(
             batch.payload,
             batch.proxy_log_path,
             batch.log_type,
+            delivery_outcome_callback,
         )
         if admitted is False:
             return _BatchAdmissionResult(
@@ -782,7 +920,10 @@ def _log_flush_summaries(
             extra["error_type"] = error_type
         level = "error" if phase == "failed" else "info"
         message = f"Usage event buffer flush {phase}"
-        if phase == "completed" and summary.retained_webhook_batch_count:
+        if phase == "retained":
+            level = "warn"
+            message = "Usage event buffer flush retained for retry"
+        elif phase == "enqueued" and summary.retained_webhook_batch_count:
             level = "warn"
             message = "Usage event buffer flush retained webhook batches for retry"
         log_proxy_entry(

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -900,6 +900,11 @@ def _log_flush_summaries(
     for summary in summaries:
         if not summary.proxy_log_path:
             continue
+        retained_webhook_batch_count = summary.retained_webhook_batch_count
+        retained_source_event_count = summary.retained_source_event_count
+        if phase == "retained":
+            retained_webhook_batch_count = summary.webhook_batch_count
+            retained_source_event_count = summary.source_event_count
         extra: dict[str, object] = {
             "type": "usage_event_buffer_flush",
             "phase": phase,
@@ -909,8 +914,8 @@ def _log_flush_summaries(
             "aggregate_event_count": summary.aggregate_event_count,
             "webhook_batch_count": summary.webhook_batch_count,
             "dropped_webhook_batch_count": summary.dropped_webhook_batch_count,
-            "retained_webhook_batch_count": summary.retained_webhook_batch_count,
-            "retained_source_event_count": summary.retained_source_event_count,
+            "retained_webhook_batch_count": retained_webhook_batch_count,
+            "retained_source_event_count": retained_source_event_count,
             "run_count": len(summary.run_ids),
             "destination_count": len(summary.destinations),
         }

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -12,12 +12,22 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from typing import Literal
 
 from auth import make_api_request
 from logging_utils import log_proxy_entry
 
 from .counters import decrement_pending_reports, increment_pending_reports
+
+WebhookDeliveryOutcome = Literal["success", "retryable_failure", "permanent_failure"]
+_DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
+_SUCCESS: WebhookDeliveryOutcome = "success"
+_RETRYABLE_FAILURE: WebhookDeliveryOutcome = "retryable_failure"
+_PERMANENT_FAILURE: WebhookDeliveryOutcome = "permanent_failure"
+_MIN_RETRYABLE_HTTP_STATUS_CODE = 500
+_RETRYABLE_HTTP_STATUS_CODES = {408, 429}
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -94,19 +104,27 @@ def _post_webhook_with_retry(
     proxy_log_path: str,
     log_type: str,
     max_retries: int = 1,
+    delivery_outcome_callback: _DeliveryOutcomeCallback | None = None,
 ) -> None:
     """POST with retry.
 
-    Swallows retryable network errors (``URLError``, ``OSError``,
-    ``TimeoutError``) after the final attempt.  Non-retryable errors
-    (``TypeError`` from a non-serializable payload, etc.) are logged
-    once via :func:`log_proxy_entry` and re-raised so callers see them
-    instead of silently losing the report.
+    Reports the final delivery outcome before decrementing pending reports.
+    Non-retryable programming errors (``TypeError`` from a non-serializable
+    payload, invalid request URLs, etc.) are logged and reported as permanent.
+    They are re-raised only when no outcome callback owns the failure.
     """
     try:
-        _do_post_webhook_attempts(
+        outcome = _do_post_webhook_attempts(
             url, sandbox_token, payload, proxy_log_path, log_type, max_retries
         )
+    except Exception:
+        if delivery_outcome_callback is not None:
+            delivery_outcome_callback(_PERMANENT_FAILURE)
+        else:
+            raise
+    else:
+        if delivery_outcome_callback is not None:
+            delivery_outcome_callback(outcome)
     finally:
         decrement_pending_reports()
 
@@ -118,7 +136,7 @@ def _do_post_webhook_attempts(
     proxy_log_path: str,
     log_type: str,
     max_retries: int,
-) -> None:
+) -> WebhookDeliveryOutcome:
     try:
         data = json.dumps(payload).encode()
     except Exception as exc:
@@ -148,7 +166,47 @@ def _do_post_webhook_attempts(
                 payload_bytes=payload_bytes,
                 attempt=attempt + 1,
             )
-            return
+            return _SUCCESS
+        except urllib.error.HTTPError as exc:
+            if not _is_retryable_http_error(exc):
+                _log_webhook_entry(
+                    proxy_log_path,
+                    "error",
+                    f"Webhook POST to {url} failed with permanent HTTP error: {exc}",
+                    url,
+                    log_type,
+                    payload,
+                    payload_bytes=payload_bytes,
+                    attempt=attempt + 1,
+                    error=str(exc),
+                )
+                return _PERMANENT_FAILURE
+            if attempt < max_retries:
+                _log_webhook_entry(
+                    proxy_log_path,
+                    "warn",
+                    f"Webhook POST to {url} attempt {attempt + 1} failed, retrying: {exc}",
+                    url,
+                    log_type,
+                    payload,
+                    payload_bytes=payload_bytes,
+                    attempt=attempt + 1,
+                    error=str(exc),
+                )
+                time.sleep(0.5)
+            else:
+                _log_webhook_entry(
+                    proxy_log_path,
+                    "error",
+                    f"Webhook POST to {url} failed after {attempt + 1} attempts: {exc}",
+                    url,
+                    log_type,
+                    payload,
+                    payload_bytes=payload_bytes,
+                    attempt=attempt + 1,
+                    error=str(exc),
+                )
+                return _RETRYABLE_FAILURE
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             if attempt < max_retries:
                 _log_webhook_entry(
@@ -167,7 +225,7 @@ def _do_post_webhook_attempts(
                 _log_webhook_entry(
                     proxy_log_path,
                     "error",
-                    f"Webhook POST to {url} failed after {attempt + 1} attempts, giving up: {exc}",
+                    f"Webhook POST to {url} failed after {attempt + 1} attempts: {exc}",
                     url,
                     log_type,
                     payload,
@@ -175,6 +233,7 @@ def _do_post_webhook_attempts(
                     attempt=attempt + 1,
                     error=str(exc),
                 )
+                return _RETRYABLE_FAILURE
         except Exception as exc:
             # Catch-all by design: non-retryable failures (TypeError on
             # non-serializable payload, AttributeError, ValueError, or any
@@ -194,6 +253,12 @@ def _do_post_webhook_attempts(
                 error=str(exc),
             )
             raise
+
+    return _RETRYABLE_FAILURE
+
+
+def _is_retryable_http_error(exc: urllib.error.HTTPError) -> bool:
+    return exc.code >= _MIN_RETRYABLE_HTTP_STATUS_CODE or exc.code in _RETRYABLE_HTTP_STATUS_CODES
 
 
 USAGE_WEBHOOK_WORKERS = 4
@@ -246,9 +311,17 @@ def _post_admitted_webhook_with_retry(
     payload: dict,
     proxy_log_path: str,
     log_type: str,
+    delivery_outcome_callback: _DeliveryOutcomeCallback | None,
 ) -> None:
     try:
-        _post_webhook_with_retry(url, sandbox_token, payload, proxy_log_path, log_type)
+        _post_webhook_with_retry(
+            url,
+            sandbox_token,
+            payload,
+            proxy_log_path,
+            log_type,
+            delivery_outcome_callback=delivery_outcome_callback,
+        )
     finally:
         _release_delivery_capacity()
 
@@ -259,6 +332,7 @@ def _enqueue_webhook(
     payload: dict,
     proxy_log_path: str,
     log_type: str,
+    delivery_outcome_callback: _DeliveryOutcomeCallback | None = None,
 ) -> bool:
     """Submit webhook POST to the thread pool.
 
@@ -269,14 +343,14 @@ def _enqueue_webhook(
     falls back to synchronous delivery so the report is not silently lost.
 
     Returns whether the payload was admitted to delivery.  ``False`` means
-    delivery was saturated and the caller still owns the payload.
+    delivery was saturated and the caller still owns retry handling.
     """
     admitted_count = _try_acquire_delivery_capacity()
     if admitted_count is None:
         _log_webhook_entry(
             proxy_log_path,
             "warn",
-            f"Webhook POST to {url} not admitted because usage delivery is saturated",
+            f"Webhook POST to {url} was not admitted because usage delivery is saturated",
             url,
             log_type,
             payload,
@@ -313,6 +387,7 @@ def _enqueue_webhook(
             payload,
             proxy_log_path,
             log_type,
+            delivery_outcome_callback,
         )
     except RuntimeError:
         # Executor shut down (done() already called during drain).
@@ -324,7 +399,14 @@ def _enqueue_webhook(
                 type=log_type,
                 url=url,
             )
-            _post_webhook_with_retry(url, sandbox_token, payload, proxy_log_path, log_type)
+            _post_webhook_with_retry(
+                url,
+                sandbox_token,
+                payload,
+                proxy_log_path,
+                log_type,
+                delivery_outcome_callback=delivery_outcome_callback,
+            )
         finally:
             _release_delivery_capacity()
     except Exception:

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -785,6 +785,70 @@ class TestRunnerUsageFlushSignal:
         log.warn.assert_called_once()
         assert flush_triggers == ["runner", "runner"]
 
+    def test_signal_retryable_delivery_failure_recovers_on_later_signal(
+        self,
+        tmp_path,
+        sync_usage_executor,
+        usage_webhook_server,
+    ):
+        del sync_usage_executor
+        reset_runner_usage_flush_state()
+        pending_path = tmp_path / "usage-pending"
+        request_path = tmp_path / "usage-flush-request"
+        proxy_log_path = str(tmp_path / "proxy.jsonl")
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        request_path.write_text(
+            json.dumps(
+                {
+                    "usageStateId": "runner-state",
+                    "flushRequestId": "request-1",
+                    "requestedAtMs": 1_770_000_000_000,
+                }
+            )
+        )
+        usage.buffer_usage_events(
+            usage_webhook_server.url("/usage"),
+            "token-a",
+            "run-1",
+            [event(source_key="source-1")],
+            proxy_log_path,
+        )
+
+        try:
+            usage_webhook_server.queue_response(500)
+            usage_webhook_server.queue_response(500)
+            with patch.object(usage.webhook.time, "sleep"):
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+
+            assert usage_webhook_server.request_count == 2
+            failed_key = usage_webhook_server.requests[0].json_body()["events"][0]["idempotencyKey"]
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=1,
+                reports=0,
+                flush_request_id="request-1",
+            )
+
+            usage_webhook_server.queue_response(204)
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            wait_for_usage_flush_worker_to_stop()
+
+            assert usage_webhook_server.request_count == 3
+            retry_key = usage_webhook_server.requests[2].json_body()["events"][0]["idempotencyKey"]
+            assert retry_key == failed_key
+            assert_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=0,
+                flush_request_id="request-1",
+            )
+        finally:
+            wait_for_usage_flush_worker_to_stop()
+            usage.set_pending_path("")
+
 
 class TestTlsClienthello:
     def test_unregistered_vm_ignored(self, registry_file, make_tls_data, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -335,7 +335,7 @@ class TestUsagePendingCounter:
     def test_report_decrements_after_completion(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
-        """Retry exhaustion still runs the decrement finally-block."""
+        """Retry exhaustion decrements reports but keeps the usage flush buffered."""
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
 
@@ -359,7 +359,7 @@ class TestUsagePendingCounter:
         assert usage.counters._pending_reports == 0
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+        assert_pending(pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1")
 
     def test_enqueue_increments_and_drains_reports(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -1,10 +1,13 @@
 """Tests for usage-buffer retry and overlapping flush behavior."""
 
+from unittest.mock import patch
+
 import pytest
 
 import usage
 import usage.buffer as usage_buffer
-from tests.usage_buffer_helpers import RecordingEnqueue, event
+from tests.pending_helpers import assert_pending
+from tests.usage_buffer_helpers import DeliveryOutcomeCallback, RecordingEnqueue, event
 
 
 def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp_path):
@@ -457,3 +460,156 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
 
     enqueue.assert_called_once()
     assert usage.counters._buffered_usage_events == 0
+
+
+def test_retryable_delivery_failure_retains_flush_and_retries_with_same_key(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    del sync_usage_executor
+    pending_path = tmp_path / "usage-pending"
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.set_pending_path(str(pending_path))
+
+    usage.buffer_usage_events(
+        usage_webhook_server.url("/usage"),
+        "token-a",
+        "run-1",
+        [event(source_key="source-1", quantity=10)],
+        str(proxy_log_path),
+    )
+    usage_webhook_server.queue_response(500)
+    usage_webhook_server.queue_response(500)
+
+    with patch.object(usage.webhook.time, "sleep"):
+        assert usage.flush_usage_events(trigger="test") == 1
+
+    assert usage_webhook_server.request_count == 2
+    failed_key = usage_webhook_server.requests[0].json_body()["events"][0]["idempotencyKey"]
+    assert usage.counters._pending_reports == 0
+    assert usage.counters._buffered_usage_events == 1
+    usage.write_pending_snapshot(flush_request_id="request-1")
+    assert_pending(pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1")
+
+    usage_webhook_server.queue_response(204)
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert usage_webhook_server.request_count == 3
+    retry_body = usage_webhook_server.requests[2].json_body()
+    assert retry_body["runId"] == "run-1"
+    assert retry_body["events"][0]["quantity"] == 10
+    assert retry_body["events"][0]["idempotencyKey"] == failed_key
+    assert usage.counters._buffered_usage_events == 0
+    usage.write_pending_snapshot(flush_request_id="request-2")
+    assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
+
+
+def test_partial_delivery_failure_retains_whole_flush_with_same_keys(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    del sync_usage_executor
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    for run_id, source_key in (("run-a", "source-a"), ("run-b", "source-b")):
+        usage.buffer_usage_events(
+            usage_webhook_server.url("/usage"),
+            "token-a",
+            run_id,
+            [event(source_key=source_key)],
+            str(proxy_log_path),
+        )
+
+    usage_webhook_server.queue_response(204)
+    usage_webhook_server.queue_response(500)
+    usage_webhook_server.queue_response(500)
+    with patch.object(usage.webhook.time, "sleep"):
+        assert usage.flush_usage_events(trigger="test") == 2
+
+    first_attempts = [
+        usage_webhook_server.requests[0].json_body(),
+        usage_webhook_server.requests[1].json_body(),
+    ]
+    assert [body["runId"] for body in first_attempts] == ["run-a", "run-b"]
+    assert usage.counters._buffered_usage_events == 2
+
+    usage_webhook_server.queue_response(204)
+    usage_webhook_server.queue_response(204)
+    assert usage.flush_usage_events(trigger="test") == 2
+
+    retry_bodies = [
+        usage_webhook_server.requests[3].json_body(),
+        usage_webhook_server.requests[4].json_body(),
+    ]
+    assert [body["runId"] for body in retry_bodies] == ["run-a", "run-b"]
+    assert [body["events"][0]["idempotencyKey"] for body in retry_bodies] == [
+        body["events"][0]["idempotencyKey"] for body in first_attempts
+    ]
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_delivery_in_progress_does_not_block_live_usage_snapshot(tmp_path):
+    callbacks: list[DeliveryOutcomeCallback] = []
+    payloads: list[dict] = []
+
+    def enqueue_without_completion(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, path, log_type
+        payloads.append(payload)
+        callbacks.append(delivery_outcome_callback)
+        return True
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_without_completion)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        str(proxy_log_path),
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert usage.counters._buffered_usage_events == 1
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-2",
+        [event(source_key="source-2")],
+        str(proxy_log_path),
+    )
+    assert usage.counters._buffered_usage_events == 2
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert [payload["runId"] for payload in payloads] == ["run-1", "run-2"]
+    callbacks[0]("success")
+    assert usage.counters._buffered_usage_events == 1
+    callbacks[1]("success")
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_permanent_sync_fallback_failure_does_not_requeue(tmp_path, fresh_usage_executor):
+    del fresh_usage_executor
+    usage.webhook.usage_executor.shutdown(wait=True)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.buffer_usage_events(
+        "not-a-url",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        str(proxy_log_path),
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert usage.counters._pending_reports == 0
+    assert usage.counters._buffered_usage_events == 0
+    assert "non-retryable" in proxy_log_path.read_text()

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -613,3 +613,31 @@ def test_permanent_sync_fallback_failure_does_not_requeue(tmp_path, fresh_usage_
     assert usage.counters._pending_reports == 0
     assert usage.counters._buffered_usage_events == 0
     assert "non-retryable" in proxy_log_path.read_text()
+
+
+def test_permanent_http_delivery_failure_completes_flush(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    del sync_usage_executor
+    pending_path = tmp_path / "usage-pending"
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.set_pending_path(str(pending_path))
+
+    usage.buffer_usage_events(
+        usage_webhook_server.url("/usage"),
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        str(proxy_log_path),
+    )
+    usage_webhook_server.queue_response(400)
+
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert usage_webhook_server.request_count == 1
+    assert usage.counters._pending_reports == 0
+    assert usage.counters._buffered_usage_events == 0
+    usage.write_pending_snapshot(flush_request_id="request-1")
+    assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -28,10 +28,10 @@ def test_flush_logs_aggregate_summary_without_token(tmp_path):
 
     enqueue.assert_called_once()
     entries = flush_log_entries(proxy_log_path)
-    assert [entry["phase"] for entry in entries] == ["started", "completed"]
+    assert [entry["phase"] for entry in entries] == ["started", "enqueued"]
     assert [entry["message"] for entry in entries] == [
         "Usage event buffer flush started",
-        "Usage event buffer flush completed",
+        "Usage event buffer flush enqueued",
     ]
     for entry in entries:
         assert entry["level"] == "info"
@@ -66,7 +66,7 @@ def test_flush_logs_retained_webhook_batches(tmp_path):
 
     enqueue.assert_called_once()
     entries = flush_log_entries(proxy_log_path)
-    assert [entry["phase"] for entry in entries] == ["started", "completed"]
+    assert [entry["phase"] for entry in entries] == ["started", "enqueued"]
     assert entries[0]["dropped_webhook_batch_count"] == 0
     assert entries[0]["retained_webhook_batch_count"] == 0
     assert entries[1]["level"] == "warn"
@@ -76,6 +76,7 @@ def test_flush_logs_retained_webhook_batches(tmp_path):
     assert entries[1]["retained_source_event_count"] == 1
     assert entries[1]["webhook_batch_count"] == 1
     assert "secret-token" not in json.dumps(entries)
+    assert usage.counters._buffered_usage_events == 1
 
 
 def test_flush_logs_failure_without_token(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -5,7 +5,12 @@ import json
 import pytest
 
 import usage
-from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
+from tests.usage_buffer_helpers import (
+    DeliveryOutcomeCallback,
+    RecordingEnqueue,
+    event,
+    flush_log_entries,
+)
 
 
 def test_flush_logs_aggregate_summary_without_token(tmp_path):
@@ -77,6 +82,51 @@ def test_flush_logs_retained_webhook_batches(tmp_path):
     assert entries[1]["webhook_batch_count"] == 1
     assert "secret-token" not in json.dumps(entries)
     assert usage.counters._buffered_usage_events == 1
+
+
+def test_flush_logs_delivery_retry_retained_counts(tmp_path):
+    callbacks: list[DeliveryOutcomeCallback] = []
+
+    def enqueue_webhook(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, payload, path, log_type
+        callbacks.append(delivery_outcome_callback)
+        return True
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "secret-token",
+        "run-1",
+        [
+            event(source_key="source-1", category="tokens.input", quantity=10),
+            event(source_key="source-2", category="tokens.output", quantity=5),
+        ],
+        str(proxy_log_path),
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    callbacks[0]("retryable_failure")
+
+    entries = flush_log_entries(proxy_log_path)
+    assert [entry["phase"] for entry in entries] == ["started", "enqueued", "retained"]
+    retained_entry = entries[2]
+    assert retained_entry["level"] == "warn"
+    assert retained_entry["message"] == "Usage event buffer flush retained for retry"
+    assert retained_entry["source_event_count"] == 2
+    assert retained_entry["webhook_batch_count"] == 1
+    assert retained_entry["retained_webhook_batch_count"] == 1
+    assert retained_entry["retained_source_event_count"] == 2
+    assert "secret-token" not in json.dumps(entries)
+    assert usage.counters._buffered_usage_events == 2
 
 
 def test_flush_logs_failure_without_token(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -531,6 +531,47 @@ def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
     assert usage.counters._buffered_usage_events == 1
 
 
+def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
+    callbacks: list[Callable[[usage.webhook.WebhookDeliveryOutcome], None]] = []
+    enqueued_keys: list[str] = []
+
+    def enqueue_webhook(url, sandbox_token, payload, path, log_type, delivery_callback):
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        enqueued_keys.append(payload["events"][0]["idempotencyKey"])
+        if len(enqueued_keys) == 1:
+            callbacks.append(delivery_callback)
+        else:
+            delivery_callback("success")
+        return True
+
+    timers = install_recording_usage_timer(enqueue_webhook=enqueue_webhook)
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1", quantity=10)],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    timers[0].callback()
+
+    assert len(callbacks) == 1
+    assert usage.counters._buffered_usage_events == 1
+    assert len(timers) == 1
+    callbacks[0]("retryable_failure")
+
+    assert usage.counters._buffered_usage_events == 1
+    assert len(timers) == 2
+    assert timers[1].started is True
+    assert timers[1].cancelled is False
+
+    timers[1].callback()
+
+    assert enqueued_keys == [enqueued_keys[0], enqueued_keys[0]]
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_threshold_flush_cancels_scheduled_timer_and_allows_reschedule(tmp_path):
     enqueue = RecordingEnqueue()
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -244,7 +244,7 @@ class TestUsageWebhookDelivery:
         payload = {"error": "payload-error", "attempt": 99, "runId": "run-1", "events": []}
         payload_bytes = len(json.dumps(payload).encode())
 
-        usage.webhook._do_post_webhook_attempts(
+        outcome = usage.webhook._do_post_webhook_attempts(
             usage_webhook_server.url("/x"),
             "tok",
             payload,
@@ -253,6 +253,7 @@ class TestUsageWebhookDelivery:
             max_retries=0,
         )
 
+        assert outcome == "retryable_failure"
         [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         assert entry["level"] == "error"
         assert entry["attempt"] == 1
@@ -263,6 +264,45 @@ class TestUsageWebhookDelivery:
             event_count=0,
             payload_bytes=payload_bytes,
         )
+
+    def test_http_429_is_retryable(self, tmp_path, usage_webhook_server):
+        proxy_log = tmp_path / "proxy.jsonl"
+        usage_webhook_server.queue_response(429)
+        usage_webhook_server.queue_response(429)
+
+        with patch.object(usage.webhook.time, "sleep") as mock_sleep:
+            outcome = usage.webhook._do_post_webhook_attempts(
+                usage_webhook_server.url("/x"),
+                "tok",
+                {"runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage",
+                max_retries=1,
+            )
+
+        assert outcome == "retryable_failure"
+        assert usage_webhook_server.request_count == 2
+        mock_sleep.assert_called_once_with(0.5)
+
+    def test_http_400_is_permanent(self, tmp_path, usage_webhook_server):
+        proxy_log = tmp_path / "proxy.jsonl"
+        usage_webhook_server.queue_response(400)
+
+        outcome = usage.webhook._do_post_webhook_attempts(
+            usage_webhook_server.url("/x"),
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage",
+            max_retries=1,
+        )
+
+        assert outcome == "permanent_failure"
+        assert usage_webhook_server.request_count == 1
+        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert entry["level"] == "error"
+        assert entry["attempt"] == 1
+        assert "permanent HTTP error" in entry["message"]
 
     def test_sync_executor_worker_error_preserves_other_pending_reports(
         self, tmp_path, sync_usage_executor

--- a/crates/runner/mitm-addon/tests/usage_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_buffer_helpers.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 import usage.buffer as usage_buffer
+from usage.webhook import WebhookDeliveryOutcome
 
 
 def event(
@@ -36,7 +38,8 @@ class RecordedEnqueueCall:
     log_type: str
 
 
-RecordingEnqueueSideEffect = Callable[[str, str, dict, str, str], bool | None]
+RecordingEnqueueSideEffect = Callable[..., bool | None]
+DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
 
 
 class RecordingEnqueue:
@@ -49,6 +52,9 @@ class RecordingEnqueue:
         self.return_value = return_value
         self.side_effect = side_effect
         self.calls: list[RecordedEnqueueCall] = []
+        self._side_effect_accepts_callback = (
+            side_effect is not None and len(inspect.signature(side_effect).parameters) >= 6
+        )
 
     @property
     def call_count(self) -> int:
@@ -69,6 +75,7 @@ class RecordingEnqueue:
         payload: dict,
         proxy_log_path: str,
         log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
     ) -> bool:
         self.calls.append(
             RecordedEnqueueCall(
@@ -80,9 +87,31 @@ class RecordingEnqueue:
             )
         )
         if self.side_effect is None:
+            if self.return_value:
+                delivery_outcome_callback("success")
             return self.return_value
-        result = self.side_effect(url, sandbox_token, payload, proxy_log_path, log_type)
-        return self.return_value if result is None else result
+        callback_called = False
+
+        def record_outcome(outcome: WebhookDeliveryOutcome) -> None:
+            nonlocal callback_called
+            callback_called = True
+            delivery_outcome_callback(outcome)
+
+        if self._side_effect_accepts_callback:
+            result = self.side_effect(
+                url,
+                sandbox_token,
+                payload,
+                proxy_log_path,
+                log_type,
+                record_outcome,
+            )
+        else:
+            result = self.side_effect(url, sandbox_token, payload, proxy_log_path, log_type)
+        admitted = self.return_value if result is None else result
+        if admitted and not callback_called:
+            delivery_outcome_callback("success")
+        return admitted
 
     def clear(self) -> None:
         self.calls.clear()

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -14,7 +14,8 @@ from typing import Any, Protocol
 
 import usage
 
-_EnqueueWebhook = Callable[[str, str, dict, str, str], bool]
+_DeliveryOutcomeCallback = Callable[[usage.webhook.WebhookDeliveryOutcome], None]
+_EnqueueWebhook = Callable[[str, str, dict, str, str, _DeliveryOutcomeCallback], bool]
 
 
 class _FlushOwnerLock(Protocol):


### PR DESCRIPTION
## Summary
- Track final webhook delivery outcomes for usage flushes instead of completing at executor admission.
- Requeue retained flushes after retryable delivery failures or saturated delivery admission, preserving aggregate idempotency keys.
- Classify retryable HTTP failures separately from permanent HTTP 4xx failures and keep runner pending snapshots non-zero while usage is retained.

Closes #17379

## Tests
- cd crates/runner/mitm-addon && VIRTUAL_ENV=/tmp/mitm-addon-venv PATH=/tmp/mitm-addon-venv/bin:$PATH basedpyright -p .
- cd crates/runner/mitm-addon && /tmp/mitm-addon-venv/bin/ruff check .
- cd crates/runner/mitm-addon && /tmp/mitm-addon-venv/bin/ruff format --check .
- cd crates/runner/mitm-addon && /tmp/mitm-addon-venv/bin/python -m pytest -q