### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -719,6 +719,7 @@ jobs:
             "$pg_bin/initdb" -D /tmp/pgdata -A trust
             "$pg_bin/pg_ctl" -D /tmp/pgdata -l /tmp/pgdata/log -o "-c listen_addresses=localhost" start
             pg_isready -h localhost
+            [ "$(psql -h localhost -d postgres -Atc "select 1")" = "1" ]
             "$pg_bin/pg_ctl" -D /tmp/pgdata stop
           ' \
             || { sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/pgdata/log 2>&1 || true; fail "PostgreSQL start"; }

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -707,7 +707,20 @@ jobs:
           done
           # Verify PostgreSQL can actually start (not just psql --version).
           # Test with TCP on localhost — users will connect via localhost:5432.
-          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "mkdir -p /tmp/pgdata && /usr/lib/postgresql/16/bin/initdb -D /tmp/pgdata -A trust && /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/pgdata -l /tmp/pgdata/log -o \"-c listen_addresses='localhost'\" start && pg_isready -h localhost && /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/pgdata stop" \
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c '
+            set -e
+            pg_bin=$(find /usr/lib/postgresql -mindepth 2 -maxdepth 2 -type f -name initdb -printf "%h\n" | sort -V | tail -n 1)
+            if [ -z "$pg_bin" ]; then
+              echo "initdb not found under /usr/lib/postgresql" >&2
+              exit 1
+            fi
+            rm -rf /tmp/pgdata
+            mkdir -p /tmp/pgdata
+            "$pg_bin/initdb" -D /tmp/pgdata -A trust
+            "$pg_bin/pg_ctl" -D /tmp/pgdata -l /tmp/pgdata/log -o "-c listen_addresses=localhost" start
+            pg_isready -h localhost
+            "$pg_bin/pg_ctl" -D /tmp/pgdata stop
+          ' \
             || { sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/pgdata/log 2>&1 || true; fail "PostgreSQL start"; }
           echo "  PostgreSQL start/stop: ok"
           echo "PASS: runtime availability"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -717,10 +717,19 @@ jobs:
             rm -rf /tmp/pgdata
             mkdir -p /tmp/pgdata
             "$pg_bin/initdb" -D /tmp/pgdata -A trust
-            "$pg_bin/pg_ctl" -D /tmp/pgdata -l /tmp/pgdata/log -o "-c listen_addresses=localhost" start
+            pg_started=0
+            stop_pg() {
+              if [ "$pg_started" = "1" ]; then
+                "$pg_bin/pg_ctl" -D /tmp/pgdata -m fast stop >/dev/null 2>&1 || true
+              fi
+            }
+            trap stop_pg EXIT
+            pg_started=1
+            "$pg_bin/pg_ctl" -D /tmp/pgdata -l /tmp/pgdata/log -o "-c listen_addresses=localhost" -w -t 30 start
             pg_isready -h localhost
             [ "$(psql -h localhost -d postgres -Atc "select 1")" = "1" ]
             "$pg_bin/pg_ctl" -D /tmp/pgdata stop
+            pg_started=0
           ' \
             || { sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/pgdata/log 2>&1 || true; fail "PostgreSQL start"; }
           echo "  PostgreSQL start/stop: ok"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -709,9 +709,14 @@ jobs:
           # Test with TCP on localhost — users will connect via localhost:5432.
           sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c '
             set -e
-            pg_bin=$(find /usr/lib/postgresql -mindepth 2 -maxdepth 2 -type f -name initdb -printf "%h\n" | sort -V | tail -n 1)
+            pg_bin=$(
+              for initdb in /usr/lib/postgresql/*/bin/initdb; do
+                [ -x "$initdb" ] && printf "%s\n" "${initdb%/initdb}"
+              done | sort -V | tail -n 1
+            )
             if [ -z "$pg_bin" ]; then
-              echo "initdb not found under /usr/lib/postgresql" >&2
+              echo "initdb not found under /usr/lib/postgresql/*/bin" >&2
+              ls -la /usr/lib/postgresql /usr/lib/postgresql/* /usr/lib/postgresql/*/bin 2>&1 || true
               exit 1
             fi
             rm -rf /tmp/pgdata

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -351,7 +351,7 @@ install_packages() {
     php php-cli php-common php-curl php-mbstring php-xml php-zip \
     default-jdk maven gradle \
     gcc g++ clang make cmake \
-    postgresql-18 \
+    postgresql-18 postgresql-contrib-18 \
     redis-server \
     gh
 

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -330,9 +330,15 @@ install_packages() {
   chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     > /etc/apt/sources.list.d/github-cli.list
+
+  # PostgreSQL Global Development Group repository (PostgreSQL 18)
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
+  echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
+    > /etc/apt/sources.list.d/pgdg.list
   '
 
-  # Step 3: Install all Ubuntu packages in single pass.
+  # Step 3: Install all APT packages in single pass.
   sudo chroot "$ROOTFS_DIR" bash -c 'set -e
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
@@ -345,7 +351,7 @@ install_packages() {
     php php-cli php-common php-curl php-mbstring php-xml php-zip \
     default-jdk maven gradle \
     gcc g++ clang make cmake \
-    postgresql-16 postgresql-contrib \
+    postgresql-18 \
     redis-server \
     gh
 
@@ -354,7 +360,9 @@ install_packages() {
        /etc/apt/preferences.d/nodesource \
        /usr/share/keyrings/nodesource.gpg \
        /etc/apt/sources.list.d/github-cli.list \
-       /usr/share/keyrings/githubcli-archive-keyring.gpg
+       /usr/share/keyrings/githubcli-archive-keyring.gpg \
+       /etc/apt/sources.list.d/pgdg.list \
+       /usr/share/keyrings/postgresql.gpg
   rm -rf /var/lib/apt/lists/* /var/cache/apt/*
   '
 

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -231,6 +231,9 @@ if [[ -f "${MOUNT_DIR}/usr/bin/psql" ]]; then
 else
   errors+=("psql not found at /usr/bin/psql")
 fi
+check_bin "/usr/lib/postgresql/*/bin/postgres" "PostgreSQL server"
+check_bin "/usr/lib/postgresql/*/bin/initdb"   "PostgreSQL initdb"
+check_bin "/usr/lib/postgresql/*/bin/pg_ctl"   "PostgreSQL pg_ctl"
 
 if [[ -f "${MOUNT_DIR}/usr/bin/redis-server" ]]; then
   echo "  redis-server: found"


### PR DESCRIPTION
## Summary
- Updated the rootfs PostgreSQL install from Ubuntu Noble `postgresql-16` to PGDG `postgresql-18`.
- Added the official PGDG Noble APT repository for the install step and remove its source/key before the template is finalized.

## Version updates
- PostgreSQL: `16` (`postgresql-16`, Ubuntu Noble latest `16.14`) -> `18` (`postgresql-18`, PGDG Noble `18.4`)

## Verification
- `bash -n crates/runner/scripts/build-template.sh`
- Checked the other direct pinned versions and found them current: Go `1.26.4`, Claude Code `2.1.174`, Codex CLI `0.139.0`, Google Workspace CLI `0.22.5`, xurl `1.0.3`, agent-browser `0.27.2`, pnpm `11.6.0`, and Node LTS stream `24`.
