### PR TITLE
refactor(runner): remove argv-derived runner identity

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1490,7 +1490,6 @@ mod tests {
 
     fn empty_fresh() -> process::DiscoveredProcesses {
         process::DiscoveredProcesses {
-            runners: vec![],
             firecrackers: vec![],
             mitmdumps: vec![],
             dnsmasqs: vec![],
@@ -1952,7 +1951,6 @@ mod tests {
 
     fn empty_discovered() -> process::DiscoveredProcesses {
         process::DiscoveredProcesses {
-            runners: vec![],
             firecrackers: vec![],
             mitmdumps: vec![],
             dnsmasqs: vec![],
@@ -2115,7 +2113,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_runner_reports_ignores_discovered_runner_candidates() {
+    async fn build_runner_reports_requires_live_registry_entries() {
         let server = MockServer::start_async().await;
         let api = server
             .mock_async(|when, then| {
@@ -2153,12 +2151,7 @@ mod tests {
             serde_yaml_ng::to_string(&config).unwrap(),
         )
         .unwrap();
-        let discovered = process::DiscoveredProcesses {
-            runners: vec![process::RunnerProcessInfo {
-                pid: std::process::id(),
-            }],
-            ..empty_discovered()
-        };
+        let discovered = empty_discovered();
 
         let reports = build_runner_reports(&[], &discovered, &[]).await;
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -423,7 +423,7 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
         // Single /proc scan shared across all warning rechecks.
         let fresh = process::discover_all().await;
 
-        recheck_per_runner_warnings(&home, &fresh, &mut reports).await;
+        recheck_per_runner_warnings(&home, &fresh, &mut reports).await?;
 
         let rechecks_orphan_process = global_warnings.iter().any(|warning| {
             matches!(
@@ -463,12 +463,12 @@ async fn recheck_per_runner_warnings(
     home: &HomePaths,
     fresh: &process::DiscoveredProcesses,
     reports: &mut [RunnerReport],
-) {
+) -> RunnerResult<()> {
     for report in reports {
         if report.warnings.is_empty() {
             continue;
         }
-        if !crate::live_runner_instances::is_current(home, &report.live_runner).await {
+        if !crate::live_runner_instances::is_current(home, &report.live_runner).await? {
             report.warnings.clear();
             continue;
         }
@@ -481,6 +481,7 @@ async fn recheck_per_runner_warnings(
         }
         report.warnings = rechecked;
     }
+    Ok(())
 }
 
 async fn build_runner_reports(
@@ -2002,7 +2003,9 @@ mod tests {
             }],
         }];
 
-        recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports).await;
+        recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports)
+            .await
+            .unwrap();
 
         assert!(reports[0].warnings.is_empty());
     }
@@ -2060,9 +2063,71 @@ mod tests {
             }],
         }];
 
-        recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports).await;
+        recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports)
+            .await
+            .unwrap();
 
         assert_eq!(reports[0].warnings.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn recheck_fails_when_live_registry_entry_becomes_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let base_dir = dir.path().join("runner");
+        let _handle = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: dir.path().join("runner.yaml"),
+                base_dir: base_dir.clone(),
+                runner_name: "test-runner".into(),
+                runner_group: "vm0/test".into(),
+                subcommand: "start".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let runner = crate::live_runner_instances::try_list(&home)
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        crate::state_file::write_private_atomic(
+            &home.live_runner_instance_record_path(runner.pid, runner.starttime),
+            b"{",
+        )
+        .await
+        .unwrap();
+        let mut reports = vec![RunnerReport {
+            live_runner: runner.clone(),
+            name: Some(runner.runner_name.clone()),
+            base_dir: Some(base_dir.clone()),
+            pid: runner.pid,
+            config_path: runner.config_path.clone(),
+            subcommand: "start".into(),
+            service_type: ServiceType::Bare,
+            status: None,
+            api_ok: None,
+            proxy_pid: None,
+            dns_pid: None,
+            jobs: vec![],
+            warnings: vec![Warning::NoMitmproxy {
+                port: 32821,
+                base_dir,
+            }],
+        }];
+
+        let error =
+            match recheck_per_runner_warnings(&home, &empty_discovered(), &mut reports).await {
+                Ok(_) => panic!("expected invalid live registry entry to fail"),
+                Err(error) => error,
+            };
+
+        assert!(
+            error.to_string().contains("live process identity"),
+            "{error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -357,7 +357,7 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
     let installed_services = find_installed_services().await;
 
     // Phase 3: Build runner reports
-    let live_runners = crate::live_runner_instances::list(&home).await;
+    let live_runners = crate::live_runner_instances::try_list(&home).await?;
     let reports = build_runner_reports(&live_runners, &discovered, &installed_services).await;
 
     // Phase 4: Find stopped services (installed but no matching running process)
@@ -432,8 +432,8 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
             )
         });
         let fresh_runner_pids: Vec<u32> = if rechecks_orphan_process {
-            crate::live_runner_instances::list(&home)
-                .await
+            crate::live_runner_instances::try_list(&home)
+                .await?
                 .into_iter()
                 .map(|runner| runner.pid)
                 .collect()
@@ -2035,8 +2035,9 @@ mod tests {
         )
         .await
         .unwrap();
-        let runner = crate::live_runner_instances::list(&home)
+        let runner = crate::live_runner_instances::try_list(&home)
             .await
+            .unwrap()
             .into_iter()
             .next()
             .unwrap();

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -100,7 +100,7 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
         sid.clone()
     } else if let Some(ref rid) = args.run {
         let home = HomePaths::new()?;
-        let mappings = run_resolution::collect_active_run_mappings_from_home(&home).await;
+        let mappings = run_resolution::collect_active_run_mappings_from_home(&home).await?;
         run_resolution::resolve_run_to_sandbox(rid, &mappings)?
     } else {
         // clap group guarantees one is set — this branch is unreachable.

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -1062,7 +1062,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_runner_context_fails_when_registry_cannot_be_scanned() {
+    async fn live_runner_context_fails_when_registry_cannot_be_validated() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
@@ -1074,7 +1074,7 @@ mod tests {
         };
 
         assert!(
-            error.to_string().contains("scan live runner instances"),
+            error.to_string().contains("validate live runner instances"),
             "{error}"
         );
     }

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -201,6 +201,11 @@ struct ResolvedKillTarget {
     runner_pids: Vec<u32>,
 }
 
+struct LiveRunnerContext {
+    runner_pids: Vec<u32>,
+    run_mappings: Option<run_resolution::ActiveRunMappings>,
+}
+
 #[derive(Debug)]
 enum KillOutcome {
     OwnerAccepted(RemoteKillResult),
@@ -226,22 +231,31 @@ impl KillOutcome {
 }
 
 async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKillTarget> {
+    let home = HomePaths::new()?;
+    let live_runner_context = live_runner_context(&home, args.run.is_some()).await;
     let discovered = process::discover_all().await;
-    let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
-    let run_mappings = if args.run.is_some() {
-        let home = HomePaths::new()?;
-        Some(run_resolution::collect_active_run_mappings_from_home(&home).await)
-    } else {
-        None
-    };
-    let resolved = resolve_target(args, &discovered, run_mappings.as_ref())?;
+    let resolved = resolve_target(args, &discovered, live_runner_context.run_mappings.as_ref())?;
     let mut target = KillTarget::from(resolved.process);
     target.run_id = resolved.run_id;
 
     Ok(ResolvedKillTarget {
         target,
-        runner_pids,
+        runner_pids: live_runner_context.runner_pids,
     })
+}
+
+async fn live_runner_context(home: &HomePaths, include_run_mappings: bool) -> LiveRunnerContext {
+    let live_runners = crate::live_runner_instances::list(home).await;
+    let runner_pids = live_runners.iter().map(|runner| runner.pid).collect();
+    let run_mappings = if include_run_mappings {
+        Some(run_resolution::collect_active_run_mappings(&live_runners).await)
+    } else {
+        None
+    };
+    LiveRunnerContext {
+        runner_pids,
+        run_mappings,
+    }
 }
 
 fn resolve_target<'a>(
@@ -287,13 +301,15 @@ async fn rediscover_same_target(
 async fn rediscover_same_sandbox_process(
     expected: &KillTarget,
 ) -> Result<ResolvedKillTarget, RediscoverTargetError> {
+    let home =
+        HomePaths::new().map_err(|error| RediscoverTargetError::Resolve(error.to_string()))?;
+    let live_runner_context = live_runner_context(&home, false).await;
     let discovered = process::discover_all().await;
-    let runner_pids: Vec<u32> = discovered.runners.iter().map(|r| r.pid).collect();
     let target = resolve_same_sandbox_process(expected, &discovered)?;
 
     Ok(ResolvedKillTarget {
         target,
-        runner_pids,
+        runner_pids: live_runner_context.runner_pids,
     })
 }
 
@@ -1016,6 +1032,30 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn live_runner_context_uses_registry_pids_for_orphan_owners() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = crate::live_runner_instances::publish(
+            &home,
+            crate::live_runner_instances::LiveRunnerInstanceMetadata {
+                config_path: dir.path().join("benchmark.yaml"),
+                base_dir: dir.path().join("benchmark-base"),
+                runner_name: "bench-runner".into(),
+                runner_group: "vm0/test".into(),
+                subcommand: "benchmark".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let context = live_runner_context(&home, false).await;
+
+        assert_eq!(context.runner_pids, vec![std::process::id()]);
+        assert!(context.run_mappings.is_none());
+        assert!(handle.remove_if_current().await.unwrap());
+    }
+
     // -- resolve_by_run_id (run_id → FC lookup via status + FC list) ---------
 
     #[test]
@@ -1047,14 +1087,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_target_uses_supplied_mappings_not_discovered_runner_candidates() {
+    fn resolve_target_uses_supplied_registry_mappings() {
         let args = KillArgs {
             run: Some("run-live".into()),
             sandbox: None,
             force: true,
         };
         let discovered = DiscoveredProcesses {
-            runners: vec![process::RunnerProcessInfo { pid: 999 }],
             firecrackers: vec![make_fc(200, "sandbox-live")],
             mitmdumps: vec![],
             dnsmasqs: vec![],
@@ -1203,7 +1242,6 @@ mod tests {
         firecrackers: Vec<FirecrackerProcessInfo>,
     ) -> DiscoveredProcesses {
         DiscoveredProcesses {
-            runners: vec![],
             firecrackers,
             mitmdumps: vec![],
             dnsmasqs: vec![],

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -232,7 +232,7 @@ impl KillOutcome {
 
 async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKillTarget> {
     let home = HomePaths::new()?;
-    let live_runner_context = live_runner_context(&home, args.run.is_some()).await;
+    let live_runner_context = live_runner_context(&home, args.run.is_some()).await?;
     let discovered = process::discover_all().await;
     let resolved = resolve_target(args, &discovered, live_runner_context.run_mappings.as_ref())?;
     let mut target = KillTarget::from(resolved.process);
@@ -244,18 +244,21 @@ async fn discover_and_resolve_target(args: &KillArgs) -> RunnerResult<ResolvedKi
     })
 }
 
-async fn live_runner_context(home: &HomePaths, include_run_mappings: bool) -> LiveRunnerContext {
-    let live_runners = crate::live_runner_instances::list(home).await;
+async fn live_runner_context(
+    home: &HomePaths,
+    include_run_mappings: bool,
+) -> RunnerResult<LiveRunnerContext> {
+    let live_runners = crate::live_runner_instances::try_list(home).await?;
     let runner_pids = live_runners.iter().map(|runner| runner.pid).collect();
     let run_mappings = if include_run_mappings {
         Some(run_resolution::collect_active_run_mappings(&live_runners).await)
     } else {
         None
     };
-    LiveRunnerContext {
+    Ok(LiveRunnerContext {
         runner_pids,
         run_mappings,
-    }
+    })
 }
 
 fn resolve_target<'a>(
@@ -303,7 +306,9 @@ async fn rediscover_same_sandbox_process(
 ) -> Result<ResolvedKillTarget, RediscoverTargetError> {
     let home =
         HomePaths::new().map_err(|error| RediscoverTargetError::Resolve(error.to_string()))?;
-    let live_runner_context = live_runner_context(&home, false).await;
+    let live_runner_context = live_runner_context(&home, false)
+        .await
+        .map_err(|error| RediscoverTargetError::Resolve(error.to_string()))?;
     let discovered = process::discover_all().await;
     let target = resolve_same_sandbox_process(expected, &discovered)?;
 
@@ -1049,11 +1054,29 @@ mod tests {
         .await
         .unwrap();
 
-        let context = live_runner_context(&home, false).await;
+        let context = live_runner_context(&home, false).await.unwrap();
 
         assert_eq!(context.runner_pids, vec![std::process::id()]);
         assert!(context.run_mappings.is_none());
         assert!(handle.remove_if_current().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn live_runner_context_fails_when_registry_cannot_be_scanned() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
+        std::fs::write(home.live_runner_instances_dir(), b"not a directory").unwrap();
+
+        let error = match live_runner_context(&home, false).await {
+            Ok(_) => panic!("expected unreadable registry to fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("scan live runner instances"),
+            "{error}"
+        );
     }
 
     // -- resolve_by_run_id (run_id → FC lookup via status + FC list) ---------

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -76,7 +76,8 @@ enum RecordForIdentity {
 enum RecordRead {
     Valid(LiveRunnerInstanceRecord),
     Missing,
-    Invalid,
+    InvalidFile,
+    NotLive,
 }
 
 pub(crate) async fn publish(
@@ -208,15 +209,14 @@ pub(crate) async fn is_current(
 
 impl LiveRunnerInstanceHandle {
     pub(crate) async fn remove_if_current(&self) -> RunnerResult<bool> {
-        let Some(record) = read_valid_record(&self.path).await else {
-            return Ok(false);
-        };
-        if record.boot_id != self.identity.boot_id
-            || record.pid != self.identity.pid
-            || record.starttime != self.identity.starttime
-            || record.euid != self.identity.euid
-        {
-            return Ok(false);
+        match read_record(&self.path).await {
+            RecordRead::Valid(record)
+                if record.boot_id == self.identity.boot_id
+                    && record.pid == self.identity.pid
+                    && record.starttime == self.identity.starttime
+                    && record.euid == self.identity.euid => {}
+            RecordRead::InvalidFile => {}
+            RecordRead::Missing | RecordRead::NotLive | RecordRead::Valid(_) => return Ok(false),
         }
 
         match tokio::fs::remove_file(&self.path).await {
@@ -230,10 +230,11 @@ impl LiveRunnerInstanceHandle {
     }
 }
 
+#[cfg(test)]
 async fn read_valid_record(path: &Path) -> Option<LiveRunnerInstanceRecord> {
     match read_record(path).await {
         RecordRead::Valid(record) => Some(record),
-        RecordRead::Missing | RecordRead::Invalid => None,
+        RecordRead::Missing | RecordRead::InvalidFile | RecordRead::NotLive => None,
     }
 }
 
@@ -249,20 +250,20 @@ async fn read_record(path: &Path) -> RecordRead {
         Ok(None) => return RecordRead::Missing,
         Err(e) => {
             tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner instance record");
-            return RecordRead::Invalid;
+            return RecordRead::InvalidFile;
         }
     };
     let record: LiveRunnerInstanceRecord = match serde_json::from_str(&content) {
         Ok(record) => record,
         Err(e) => {
             tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner instance record");
-            return RecordRead::Invalid;
+            return RecordRead::InvalidFile;
         }
     };
     if record_is_live(&record).await {
         RecordRead::Valid(record)
     } else {
-        RecordRead::Invalid
+        RecordRead::NotLive
     }
 }
 
@@ -313,7 +314,9 @@ async fn read_record_for_identity(path: &Path, identity: FileProcessIdentity) ->
     let record = match read_record(path).await {
         RecordRead::Valid(record) => record,
         RecordRead::Missing => return RecordForIdentity::InvalidForStaleProcess,
-        RecordRead::Invalid => return invalid_record_for_identity(identity).await,
+        RecordRead::InvalidFile | RecordRead::NotLive => {
+            return invalid_record_for_identity(identity).await;
+        }
     };
     if record.pid == identity.pid && record.starttime == identity.starttime {
         RecordForIdentity::Valid(record)
@@ -968,5 +971,20 @@ mod tests {
 
         assert!(!removed);
         assert!(handle.path.exists());
+    }
+
+    #[tokio::test]
+    async fn remove_if_current_removes_invalid_current_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        crate::state_file::write_private_atomic(&handle.path, b"{")
+            .await
+            .unwrap();
+
+        let removed = handle.remove_if_current().await.unwrap();
+
+        assert!(removed);
+        assert!(!handle.path.exists());
     }
 }

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -106,15 +106,27 @@ pub(crate) async fn publish(
 }
 
 pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
+    match try_list(home).await {
+        Ok(instances) => instances,
+        Err(e) => {
+            tracing::debug!(error = %e, "cannot list live runner instances");
+            Vec::new()
+        }
+    }
+}
+
+pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerInstance>> {
     remove_stale_records(home).await;
 
     let dir = home.live_runner_instances_dir();
     let mut entries = match tokio::fs::read_dir(&dir).await {
         Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => {
-            tracing::debug!(path = %dir.display(), error = %e, "cannot scan live runner instances");
-            return Vec::new();
+            return Err(RunnerError::Internal(format!(
+                "scan live runner instances {}: {e}",
+                dir.display()
+            )));
         }
     };
 
@@ -124,8 +136,10 @@ pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
             Ok(Some(entry)) => entry,
             Ok(None) => break,
             Err(e) => {
-                tracing::debug!(path = %dir.display(), error = %e, "cannot read live runner instance entry");
-                break;
+                return Err(RunnerError::Internal(format!(
+                    "read live runner instance entry in {}: {e}",
+                    dir.display()
+                )));
             }
         };
         let Some(identity) = stable_record_identity_from_file_name(&entry.file_name()) else {
@@ -152,7 +166,7 @@ pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
             .then_with(|| left.pid.cmp(&right.pid))
             .then_with(|| left.config_path.cmp(&right.config_path))
     });
-    instances
+    Ok(instances)
 }
 
 pub(crate) async fn is_current(home: &HomePaths, instance: &LiveRunnerInstance) -> bool {

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -111,16 +111,6 @@ pub(crate) async fn publish(
     Ok(LiveRunnerInstanceHandle { path, identity })
 }
 
-pub(crate) async fn list(home: &HomePaths) -> Vec<LiveRunnerInstance> {
-    match try_list(home).await {
-        Ok(instances) => instances,
-        Err(e) => {
-            tracing::debug!(error = %e, "cannot list live runner instances");
-            Vec::new()
-        }
-    }
-}
-
 pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerInstance>> {
     remove_stale_records(home).await;
 
@@ -544,22 +534,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_returns_empty_when_registry_dir_is_missing() {
+    async fn try_list_returns_empty_when_registry_dir_is_missing() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
 
-        let instances = list(&home).await;
+        let instances = try_list(&home).await.unwrap();
 
         assert!(instances.is_empty());
     }
 
     #[tokio::test]
-    async fn list_returns_valid_live_instance_metadata() {
+    async fn try_list_returns_valid_live_instance_metadata() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
 
-        let instances = list(&home).await;
+        let instances = try_list(&home).await.unwrap();
 
         assert_eq!(instances.len(), 1);
         let instance = &instances[0];
@@ -574,7 +564,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_defaults_legacy_records_to_start_subcommand() {
+    async fn try_list_defaults_legacy_records_to_start_subcommand() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
@@ -588,14 +578,14 @@ mod tests {
         .await
         .unwrap();
 
-        let instances = list(&home).await;
+        let instances = try_list(&home).await.unwrap();
 
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].subcommand, "start");
     }
 
     #[tokio::test]
-    async fn list_ignores_invalid_records() {
+    async fn try_list_ignores_invalid_records_for_stale_file_identities() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
@@ -637,7 +627,7 @@ mod tests {
         .await
         .unwrap();
 
-        let instances = list(&home).await;
+        let instances = try_list(&home).await.unwrap();
 
         assert!(instances.is_empty());
     }
@@ -664,7 +654,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_ignores_records_with_mismatched_file_identity() {
+    async fn try_list_ignores_records_with_mismatched_stale_file_identity() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
@@ -676,7 +666,7 @@ mod tests {
         )
         .await;
 
-        let instances = list(&home).await;
+        let instances = try_list(&home).await.unwrap();
 
         assert!(instances.is_empty());
     }
@@ -686,7 +676,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
-        let instance = list(&home).await.into_iter().next().unwrap();
+        let instance = try_list(&home).await.unwrap().into_iter().next().unwrap();
 
         assert!(is_current(&home, &instance).await);
 
@@ -833,7 +823,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_removes_stale_records() {
+    async fn try_list_removes_stale_records() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("vm0-runner"));
         crate::host_file::ensure_dir(
@@ -862,7 +852,7 @@ mod tests {
             .join(".4294967295-1.json.test.tmp");
         tokio::fs::write(&stale_tmp_path, b"partial").await.unwrap();
 
-        let instances = list(&home).await;
+        let instances = try_list(&home).await.unwrap();
 
         assert!(instances.is_empty());
         assert!(!stale_path.exists());

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -119,6 +119,9 @@ pub(crate) async fn publish(
 }
 
 pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerInstance>> {
+    if !validate_existing_live_runner_instances_dir(home)? {
+        return Ok(Vec::new());
+    }
     remove_stale_records(home).await;
 
     let dir = home.live_runner_instances_dir();
@@ -178,6 +181,33 @@ pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerIns
             .then_with(|| left.config_path.cmp(&right.config_path))
     });
     Ok(instances)
+}
+
+fn validate_existing_live_runner_instances_dir(home: &HomePaths) -> RunnerResult<bool> {
+    let dir = home.live_runner_instances_dir();
+    match std::fs::symlink_metadata(&dir) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "stat live runner instances {}: {e}",
+                dir.display()
+            )));
+        }
+    }
+
+    crate::host_file::validate_dir(
+        &dir,
+        crate::host_file::DirMode::Private,
+        "live runner instances",
+    )
+    .map_err(|e| {
+        RunnerError::Internal(format!(
+            "validate live runner instances {}: {e}",
+            dir.display()
+        ))
+    })?;
+    Ok(true)
 }
 
 pub(crate) async fn is_current(
@@ -575,6 +605,28 @@ mod tests {
         let instances = try_list(&home).await.unwrap();
 
         assert!(instances.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn try_list_rejects_symlinked_registry_dir() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        std::fs::create_dir_all(dir.path().join("target")).unwrap();
+        std::fs::create_dir_all(dir.path().join("vm0-runner")).unwrap();
+        symlink(dir.path().join("target"), home.live_runner_instances_dir()).unwrap();
+
+        let error = match try_list(&home).await {
+            Ok(_) => panic!("expected symlinked registry dir to fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("validate live runner instances"),
+            "{error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -73,6 +73,12 @@ enum RecordForIdentity {
     InvalidForStaleProcess,
 }
 
+enum RecordRead {
+    Valid(LiveRunnerInstanceRecord),
+    Missing,
+    Invalid,
+}
+
 pub(crate) async fn publish(
     home: &HomePaths,
     metadata: LiveRunnerInstanceMetadata,
@@ -173,21 +179,31 @@ pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerIns
     Ok(instances)
 }
 
-pub(crate) async fn is_current(home: &HomePaths, instance: &LiveRunnerInstance) -> bool {
+pub(crate) async fn is_current(
+    home: &HomePaths,
+    instance: &LiveRunnerInstance,
+) -> RunnerResult<bool> {
     let identity = FileProcessIdentity {
         pid: instance.pid,
         starttime: instance.starttime,
     };
     let path = home.live_runner_instance_record_path(identity.pid, identity.starttime);
-    let Some(record) = read_valid_record_for_identity(&path, identity).await else {
-        return false;
+    let record = match read_record_for_identity(&path, identity).await {
+        RecordForIdentity::Valid(record) => record,
+        RecordForIdentity::InvalidForStaleProcess => return Ok(false),
+        RecordForIdentity::InvalidForLiveProcess => {
+            return Err(RunnerError::Internal(format!(
+                "live runner instance record {} is invalid for a live process identity",
+                path.display()
+            )));
+        }
     };
-    record.config_path == instance.config_path
+    Ok(record.config_path == instance.config_path
         && record.base_dir == instance.base_dir
         && record.runner_name == instance.runner_name
         && record.runner_group == instance.runner_group
         && record.subcommand == instance.subcommand
-        && record.started_at == instance.started_at
+        && record.started_at == instance.started_at)
 }
 
 impl LiveRunnerInstanceHandle {
@@ -215,6 +231,13 @@ impl LiveRunnerInstanceHandle {
 }
 
 async fn read_valid_record(path: &Path) -> Option<LiveRunnerInstanceRecord> {
+    match read_record(path).await {
+        RecordRead::Valid(record) => Some(record),
+        RecordRead::Missing | RecordRead::Invalid => None,
+    }
+}
+
+async fn read_record(path: &Path) -> RecordRead {
     let content = match crate::state_file::read_to_string(
         path,
         LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES,
@@ -223,23 +246,23 @@ async fn read_valid_record(path: &Path) -> Option<LiveRunnerInstanceRecord> {
     .await
     {
         Ok(Some(content)) => content,
-        Ok(None) => return None,
+        Ok(None) => return RecordRead::Missing,
         Err(e) => {
             tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner instance record");
-            return None;
+            return RecordRead::Invalid;
         }
     };
     let record: LiveRunnerInstanceRecord = match serde_json::from_str(&content) {
         Ok(record) => record,
         Err(e) => {
             tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner instance record");
-            return None;
+            return RecordRead::Invalid;
         }
     };
     if record_is_live(&record).await {
-        Some(record)
+        RecordRead::Valid(record)
     } else {
-        None
+        RecordRead::Invalid
     }
 }
 
@@ -286,21 +309,11 @@ async fn remove_stale_records(home: &HomePaths) {
     }
 }
 
-async fn read_valid_record_for_identity(
-    path: &Path,
-    identity: FileProcessIdentity,
-) -> Option<LiveRunnerInstanceRecord> {
-    match read_record_for_identity(path, identity).await {
-        RecordForIdentity::Valid(record) => Some(record),
-        RecordForIdentity::InvalidForLiveProcess | RecordForIdentity::InvalidForStaleProcess => {
-            None
-        }
-    }
-}
-
 async fn read_record_for_identity(path: &Path, identity: FileProcessIdentity) -> RecordForIdentity {
-    let Some(record) = read_valid_record(path).await else {
-        return invalid_record_for_identity(identity).await;
+    let record = match read_record(path).await {
+        RecordRead::Valid(record) => record,
+        RecordRead::Missing => return RecordForIdentity::InvalidForStaleProcess,
+        RecordRead::Invalid => return invalid_record_for_identity(identity).await,
     };
     if record.pid == identity.pid && record.starttime == identity.starttime {
         RecordForIdentity::Valid(record)
@@ -678,11 +691,11 @@ mod tests {
         let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
         let instance = try_list(&home).await.unwrap().into_iter().next().unwrap();
 
-        assert!(is_current(&home, &instance).await);
+        assert!(is_current(&home, &instance).await.unwrap());
 
         tokio::fs::remove_file(&handle.path).await.unwrap();
 
-        assert!(!is_current(&home, &instance).await);
+        assert!(!is_current(&home, &instance).await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -149,7 +149,7 @@ pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerIns
             continue;
         };
         let path = entry.path();
-        let record = match read_record_for_identity(&path, identity).await {
+        let record = match read_record_for_identity(&path, identity).await? {
             RecordForIdentity::Valid(record) => record,
             RecordForIdentity::InvalidForStaleProcess => continue,
             RecordForIdentity::InvalidForLiveProcess => {
@@ -189,7 +189,7 @@ pub(crate) async fn is_current(
         starttime: instance.starttime,
     };
     let path = home.live_runner_instance_record_path(identity.pid, identity.starttime);
-    let record = match read_record_for_identity(&path, identity).await {
+    let record = match read_record_for_identity(&path, identity).await? {
         RecordForIdentity::Valid(record) => record,
         RecordForIdentity::InvalidForStaleProcess => return Ok(false),
         RecordForIdentity::InvalidForLiveProcess => {
@@ -209,7 +209,7 @@ pub(crate) async fn is_current(
 
 impl LiveRunnerInstanceHandle {
     pub(crate) async fn remove_if_current(&self) -> RunnerResult<bool> {
-        match read_record(&self.path).await {
+        match read_record(&self.path).await? {
             RecordRead::Valid(record)
                 if record.boot_id == self.identity.boot_id
                     && record.pid == self.identity.pid
@@ -232,13 +232,13 @@ impl LiveRunnerInstanceHandle {
 
 #[cfg(test)]
 async fn read_valid_record(path: &Path) -> Option<LiveRunnerInstanceRecord> {
-    match read_record(path).await {
+    match read_record(path).await.expect("read live runner record") {
         RecordRead::Valid(record) => Some(record),
         RecordRead::Missing | RecordRead::InvalidFile | RecordRead::NotLive => None,
     }
 }
 
-async fn read_record(path: &Path) -> RecordRead {
+async fn read_record(path: &Path) -> RunnerResult<RecordRead> {
     let content = match crate::state_file::read_to_string(
         path,
         LIVE_RUNNER_INSTANCE_RECORD_MAX_BYTES,
@@ -247,23 +247,23 @@ async fn read_record(path: &Path) -> RecordRead {
     .await
     {
         Ok(Some(content)) => content,
-        Ok(None) => return RecordRead::Missing,
+        Ok(None) => return Ok(RecordRead::Missing),
         Err(e) => {
             tracing::debug!(path = %path.display(), error = %e, "ignoring unreadable live runner instance record");
-            return RecordRead::InvalidFile;
+            return Ok(RecordRead::InvalidFile);
         }
     };
     let record: LiveRunnerInstanceRecord = match serde_json::from_str(&content) {
         Ok(record) => record,
         Err(e) => {
             tracing::debug!(path = %path.display(), error = %e, "ignoring malformed live runner instance record");
-            return RecordRead::InvalidFile;
+            return Ok(RecordRead::InvalidFile);
         }
     };
-    if record_is_live(&record).await {
-        RecordRead::Valid(record)
+    if record_is_live(&record).await? {
+        Ok(RecordRead::Valid(record))
     } else {
-        RecordRead::NotLive
+        Ok(RecordRead::NotLive)
     }
 }
 
@@ -294,8 +294,15 @@ async fn remove_stale_records(home: &HomePaths) {
         let path = entry.path();
         if let Some(identity) = stable_record_identity_from_file_name(&file_name) {
             match read_record_for_identity(&path, identity).await {
-                RecordForIdentity::Valid(_) | RecordForIdentity::InvalidForLiveProcess => {}
-                RecordForIdentity::InvalidForStaleProcess => {
+                Err(e) => {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %e,
+                        "preserving live runner instance record after liveness check failed"
+                    );
+                }
+                Ok(RecordForIdentity::Valid(_)) | Ok(RecordForIdentity::InvalidForLiveProcess) => {}
+                Ok(RecordForIdentity::InvalidForStaleProcess) => {
                     remove_stale_file(&path, "stale live runner instance record").await;
                 }
             }
@@ -304,22 +311,35 @@ async fn remove_stale_records(home: &HomePaths) {
         let Some(identity) = atomic_tmp_record_identity_from_file_name(&file_name) else {
             continue;
         };
-        if !file_process_identity_is_live(identity).await {
-            remove_stale_file(&path, "stale live runner instance tmp file").await;
+        match file_process_identity_is_live(identity).await {
+            Ok(true) => {}
+            Ok(false) => {
+                remove_stale_file(&path, "stale live runner instance tmp file").await;
+            }
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "preserving live runner instance tmp file after liveness check failed"
+                );
+            }
         }
     }
 }
 
-async fn read_record_for_identity(path: &Path, identity: FileProcessIdentity) -> RecordForIdentity {
-    let record = match read_record(path).await {
+async fn read_record_for_identity(
+    path: &Path,
+    identity: FileProcessIdentity,
+) -> RunnerResult<RecordForIdentity> {
+    let record = match read_record(path).await? {
         RecordRead::Valid(record) => record,
-        RecordRead::Missing => return RecordForIdentity::InvalidForStaleProcess,
+        RecordRead::Missing => return Ok(RecordForIdentity::InvalidForStaleProcess),
         RecordRead::InvalidFile | RecordRead::NotLive => {
             return invalid_record_for_identity(identity).await;
         }
     };
     if record.pid == identity.pid && record.starttime == identity.starttime {
-        RecordForIdentity::Valid(record)
+        Ok(RecordForIdentity::Valid(record))
     } else {
         tracing::debug!(
             path = %path.display(),
@@ -333,11 +353,13 @@ async fn read_record_for_identity(path: &Path, identity: FileProcessIdentity) ->
     }
 }
 
-async fn invalid_record_for_identity(identity: FileProcessIdentity) -> RecordForIdentity {
-    if file_process_identity_is_live(identity).await {
-        RecordForIdentity::InvalidForLiveProcess
+async fn invalid_record_for_identity(
+    identity: FileProcessIdentity,
+) -> RunnerResult<RecordForIdentity> {
+    if file_process_identity_is_live(identity).await? {
+        Ok(RecordForIdentity::InvalidForLiveProcess)
     } else {
-        RecordForIdentity::InvalidForStaleProcess
+        Ok(RecordForIdentity::InvalidForStaleProcess)
     }
 }
 
@@ -373,7 +395,7 @@ fn atomic_tmp_record_identity_from_file_name(name: &OsStr) -> Option<FileProcess
     stable_record_identity_from_str(stable_name)
 }
 
-async fn record_is_live(record: &LiveRunnerInstanceRecord) -> bool {
+async fn record_is_live(record: &LiveRunnerInstanceRecord) -> RunnerResult<bool> {
     process_identity_is_live(ProcessIdentity {
         boot_id: record.boot_id.clone(),
         pid: record.pid,
@@ -383,24 +405,20 @@ async fn record_is_live(record: &LiveRunnerInstanceRecord) -> bool {
     .await
 }
 
-async fn file_process_identity_is_live(identity: FileProcessIdentity) -> bool {
-    let Ok(boot_id) = current_boot_id().await else {
-        return false;
-    };
+async fn file_process_identity_is_live(identity: FileProcessIdentity) -> RunnerResult<bool> {
+    let boot_id = current_boot_id().await?;
     let identity = ProcessIdentity {
         boot_id: boot_id.clone(),
         pid: identity.pid,
         starttime: identity.starttime,
         euid: current_euid(),
     };
-    process_identity_is_live_for_boot(&identity, &boot_id).await
+    Ok(process_identity_is_live_for_boot(&identity, &boot_id).await)
 }
 
-async fn process_identity_is_live(identity: ProcessIdentity) -> bool {
-    let Ok(boot_id) = current_boot_id().await else {
-        return false;
-    };
-    process_identity_is_live_for_boot(&identity, &boot_id).await
+async fn process_identity_is_live(identity: ProcessIdentity) -> RunnerResult<bool> {
+    let boot_id = current_boot_id().await?;
+    Ok(process_identity_is_live_for_boot(&identity, &boot_id).await)
 }
 
 async fn process_identity_is_live_for_boot(identity: &ProcessIdentity, boot_id: &str) -> bool {

--- a/crates/runner/src/live_runner_instances.rs
+++ b/crates/runner/src/live_runner_instances.rs
@@ -67,6 +67,12 @@ struct LiveRunnerInstanceRecord {
     started_at: String,
 }
 
+enum RecordForIdentity {
+    Valid(LiveRunnerInstanceRecord),
+    InvalidForLiveProcess,
+    InvalidForStaleProcess,
+}
+
 pub(crate) async fn publish(
     home: &HomePaths,
     metadata: LiveRunnerInstanceMetadata,
@@ -145,8 +151,16 @@ pub(crate) async fn try_list(home: &HomePaths) -> RunnerResult<Vec<LiveRunnerIns
         let Some(identity) = stable_record_identity_from_file_name(&entry.file_name()) else {
             continue;
         };
-        let Some(record) = read_valid_record_for_identity(&entry.path(), identity).await else {
-            continue;
+        let path = entry.path();
+        let record = match read_record_for_identity(&path, identity).await {
+            RecordForIdentity::Valid(record) => record,
+            RecordForIdentity::InvalidForStaleProcess => continue,
+            RecordForIdentity::InvalidForLiveProcess => {
+                return Err(RunnerError::Internal(format!(
+                    "live runner instance record {} is invalid for a live process identity",
+                    path.display()
+                )));
+            }
         };
         instances.push(LiveRunnerInstance {
             pid: record.pid,
@@ -265,11 +279,11 @@ async fn remove_stale_records(home: &HomePaths) {
         let file_name = entry.file_name();
         let path = entry.path();
         if let Some(identity) = stable_record_identity_from_file_name(&file_name) {
-            if read_valid_record_for_identity(&path, identity)
-                .await
-                .is_none()
-            {
-                remove_stale_file(&path, "stale live runner instance record").await;
+            match read_record_for_identity(&path, identity).await {
+                RecordForIdentity::Valid(_) | RecordForIdentity::InvalidForLiveProcess => {}
+                RecordForIdentity::InvalidForStaleProcess => {
+                    remove_stale_file(&path, "stale live runner instance record").await;
+                }
             }
             continue;
         }
@@ -286,9 +300,20 @@ async fn read_valid_record_for_identity(
     path: &Path,
     identity: FileProcessIdentity,
 ) -> Option<LiveRunnerInstanceRecord> {
-    let record = read_valid_record(path).await?;
+    match read_record_for_identity(path, identity).await {
+        RecordForIdentity::Valid(record) => Some(record),
+        RecordForIdentity::InvalidForLiveProcess | RecordForIdentity::InvalidForStaleProcess => {
+            None
+        }
+    }
+}
+
+async fn read_record_for_identity(path: &Path, identity: FileProcessIdentity) -> RecordForIdentity {
+    let Some(record) = read_valid_record(path).await else {
+        return invalid_record_for_identity(identity).await;
+    };
     if record.pid == identity.pid && record.starttime == identity.starttime {
-        Some(record)
+        RecordForIdentity::Valid(record)
     } else {
         tracing::debug!(
             path = %path.display(),
@@ -298,7 +323,15 @@ async fn read_valid_record_for_identity(
             file_starttime = identity.starttime,
             "ignoring live runner instance record whose contents do not match file name"
         );
-        None
+        invalid_record_for_identity(identity).await
+    }
+}
+
+async fn invalid_record_for_identity(identity: FileProcessIdentity) -> RecordForIdentity {
+    if file_process_identity_is_live(identity).await {
+        RecordForIdentity::InvalidForLiveProcess
+    } else {
+        RecordForIdentity::InvalidForStaleProcess
     }
 }
 
@@ -607,6 +640,27 @@ mod tests {
         let instances = list(&home).await;
 
         assert!(instances.is_empty());
+    }
+
+    #[tokio::test]
+    async fn try_list_fails_closed_for_invalid_record_with_live_file_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let handle = publish(&home, test_metadata(dir.path())).await.unwrap();
+        crate::state_file::write_private_atomic(&handle.path, b"{")
+            .await
+            .unwrap();
+
+        let error = match try_list(&home).await {
+            Ok(_) => panic!("expected invalid live record to fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("live process identity"),
+            "{error}"
+        );
+        assert!(handle.path.exists());
     }
 
     #[tokio::test]

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -2,6 +2,8 @@
 //!
 //! Shared by runner commands that need live host process facts, including
 //! `doctor`, `kill`, `gc`, and orphan reaping.
+//! Live runner identity is not inferred here; runner processes publish
+//! registry entries through `live_runner_instances`.
 
 mod ancestry;
 mod discovery;
@@ -13,8 +15,6 @@ pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_i
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{read_cmdline, read_cwd, read_process_stat};
-#[cfg(test)]
-pub(crate) use self::types::RunnerProcessInfo;
 pub(crate) use self::types::process_stat_is_live;
 pub use self::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -3,20 +3,8 @@ use std::path::{Path, PathBuf};
 use super::procfs::{read_cmdline, read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
 use super::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, ProcessStat, RunnerProcessInfo, process_stat_is_live,
+    MitmproxyProcessInfo, ProcessStat, process_stat_is_live,
 };
-
-/// Check whether argv looks like a runner `start`/`benchmark` command.
-fn is_runner_cmdline(argv: &[String]) -> bool {
-    if !argv.iter().any(|t| t == "start" || t == "benchmark") {
-        return false;
-    }
-
-    let Some(config_pos) = argv.iter().position(|t| t == "--config" || t == "-c") else {
-        return false;
-    };
-    argv.get(config_pos + 1).is_some()
-}
 
 /// Check if an argv belongs to a firecracker process.
 ///
@@ -132,19 +120,18 @@ async fn unidentified_firecracker_if_present(pid: u32) -> Option<FirecrackerProc
     Some(unidentified_firecracker_process(pid, read_ppid(pid).await))
 }
 
-/// Scan `/proc` once and discover all runner, firecracker, and mitmdump processes.
+/// Scan `/proc` once for sandbox child process facts.
+///
+/// Live runner identity is published by `live_runner_instances`; this scan
+/// intentionally does not infer runner identity from argv.
 pub async fn discover_all() -> DiscoveredProcesses {
     let procs = scan_proc_cmdlines().await;
 
-    let mut runners = Vec::new();
     let mut firecrackers = Vec::new();
     let mut mitmdumps = Vec::new();
     let mut dnsmasqs = Vec::new();
 
     for (pid, argv) in &procs {
-        if is_runner_cmdline(argv) {
-            runners.push(RunnerProcessInfo { pid: *pid });
-        }
         if is_firecracker_cmdline(argv) {
             firecrackers.push(*pid);
         }
@@ -207,7 +194,6 @@ pub async fn discover_all() -> DiscoveredProcesses {
     }
 
     DiscoveredProcesses {
-        runners,
         firecrackers: fc_infos,
         mitmdumps: mitm_infos,
         dnsmasqs,
@@ -230,61 +216,6 @@ mod tests {
 
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| (*s).to_string()).collect()
-    }
-
-    #[test]
-    fn detect_runner_start_cmdline() {
-        let a = argv(&[
-            "/var/lib/vm0-runner/bin/runner",
-            "start",
-            "--config",
-            "/data/runner-01/config.yaml",
-        ]);
-        assert!(is_runner_cmdline(&a));
-    }
-
-    #[test]
-    fn detect_runner_benchmark_cmdline() {
-        let a = argv(&[
-            "/usr/local/bin/runner",
-            "benchmark",
-            "--config",
-            "/etc/runner/bench.yaml",
-        ]);
-        assert!(is_runner_cmdline(&a));
-    }
-
-    #[test]
-    fn detect_runner_short_config_flag() {
-        let a = argv(&["runner", "start", "-c", "/data/runner.yaml"]);
-        assert!(is_runner_cmdline(&a));
-    }
-
-    #[test]
-    fn detect_runner_config_path_with_spaces() {
-        // Regression for #10479: a path argument containing spaces must stay
-        // as a single argv element, not be split into multiple tokens.
-        let a = argv(&["runner", "start", "--config", "/data/my config/config.yaml"]);
-        assert!(is_runner_cmdline(&a));
-    }
-
-    #[test]
-    fn detect_runner_no_config_returns_false() {
-        assert!(!is_runner_cmdline(&argv(&["runner", "start"])));
-    }
-
-    #[test]
-    fn detect_runner_no_subcommand_returns_false() {
-        assert!(!is_runner_cmdline(&argv(&[
-            "runner",
-            "--config",
-            "/data/config.yaml",
-        ])));
-    }
-
-    #[test]
-    fn detect_runner_empty_cmdline() {
-        assert!(!is_runner_cmdline(&[]));
     }
 
     #[test]

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -27,11 +27,6 @@ pub struct FirecrackerProcessIdentity {
     pub base_dir: Option<PathBuf>,
 }
 
-/// Info extracted from a runner process cmdline.
-pub struct RunnerProcessInfo {
-    pub pid: u32,
-}
-
 /// Info extracted from a firecracker process cmdline.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FirecrackerProcessInfo {
@@ -60,7 +55,6 @@ pub struct DnsmasqProcessInfo {
 
 /// All discovered process info from a single `/proc` scan.
 pub struct DiscoveredProcesses {
-    pub runners: Vec<RunnerProcessInfo>,
     pub firecrackers: Vec<FirecrackerProcessInfo>,
     pub mitmdumps: Vec<MitmproxyProcessInfo>,
     pub dnsmasqs: Vec<DnsmasqProcessInfo>,

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -95,9 +95,11 @@ pub(crate) async fn collect_active_run_mappings(
 }
 
 /// Collect active run mappings from the validated live runner registry.
-pub(crate) async fn collect_active_run_mappings_from_home(home: &HomePaths) -> ActiveRunMappings {
-    let runners = crate::live_runner_instances::list(home).await;
-    collect_active_run_mappings(&runners).await
+pub(crate) async fn collect_active_run_mappings_from_home(
+    home: &HomePaths,
+) -> RunnerResult<ActiveRunMappings> {
+    let runners = crate::live_runner_instances::try_list(home).await?;
+    Ok(collect_active_run_mappings(&runners).await)
 }
 
 /// Given a `run_id` prefix, find the unique matching active run from collected
@@ -356,7 +358,7 @@ mod tests {
         .await
         .unwrap();
 
-        let mappings = collect_active_run_mappings_from_home(&home).await;
+        let mappings = collect_active_run_mappings_from_home(&home).await.unwrap();
 
         assert_eq!(mappings.runners_total, 1);
         assert_eq!(mappings.runners_failed, 0);
@@ -365,6 +367,24 @@ mod tests {
             vec![("run-live".into(), "sandbox-live".into())]
         );
         assert!(handle.remove_if_current().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn collect_active_run_mappings_from_home_fails_when_registry_cannot_be_scanned() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        std::fs::create_dir_all(dir.path().join("home")).unwrap();
+        std::fs::write(home.live_runner_instances_dir(), b"not a directory").unwrap();
+
+        let error = match collect_active_run_mappings_from_home(&home).await {
+            Ok(_) => panic!("expected unreadable registry to fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("scan live runner instances"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -378,7 +378,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_active_run_mappings_from_home_fails_when_registry_cannot_be_scanned() {
+    async fn collect_active_run_mappings_from_home_fails_when_registry_cannot_be_validated() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().join("home"));
         std::fs::create_dir_all(dir.path().join("home")).unwrap();
@@ -390,7 +390,7 @@ mod tests {
         };
 
         assert!(
-            error.to_string().contains("scan live runner instances"),
+            error.to_string().contains("validate live runner instances"),
             "{error}"
         );
     }

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -126,10 +126,18 @@ pub(crate) fn resolve_run_mapping(
     matching.dedup();
 
     match matching.as_slice() {
-        [(run_id, sandbox_id)] => Ok(ResolvedRunMapping {
-            run_id: (*run_id).clone(),
-            sandbox_id: (*sandbox_id).clone(),
-        }),
+        [(run_id, sandbox_id)] => {
+            if mappings.runners_failed > 0 && run_id.as_str() != input {
+                return Err(RunnerError::Config(format!(
+                    "run prefix '{input}' matched run '{run_id}', but {} of {} trusted live runner status file(s) were unreadable; use the full run id or retry after checking warnings above",
+                    mappings.runners_failed, mappings.runners_total,
+                )));
+            }
+            Ok(ResolvedRunMapping {
+                run_id: (*run_id).clone(),
+                sandbox_id: (*sandbox_id).clone(),
+            })
+        }
         [] => {
             let mut msg = format!("no active run matches '{input}'");
             if mappings.runners_failed > 0 {
@@ -494,6 +502,32 @@ mod tests {
         assert!(msg.contains("2 of 3"), "{msg}");
         assert!(msg.contains("trusted live runner status"), "{msg}");
         assert!(msg.contains("unreadable"), "{msg}");
+    }
+
+    #[test]
+    fn run_prefix_unique_match_fails_when_some_runners_unreadable() {
+        let m = ActiveRunMappings {
+            entries: vec![("run-abcdef".into(), "sandbox-1".into())],
+            runners_total: 2,
+            runners_failed: 1,
+        };
+
+        let err = resolve_run_to_sandbox("run-abc", &m).unwrap_err();
+
+        assert!(err.to_string().contains("use the full run id"), "{err}");
+    }
+
+    #[test]
+    fn run_prefix_exact_match_succeeds_when_some_runners_unreadable() {
+        let m = ActiveRunMappings {
+            entries: vec![("run-abcdef".into(), "sandbox-1".into())],
+            runners_total: 2,
+            runners_failed: 1,
+        };
+
+        let sandbox_id = resolve_run_to_sandbox("run-abcdef", &m).unwrap();
+
+        assert_eq!(sandbox_id, "sandbox-1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove runner-like argv discovery from shared /proc process discovery
- use live runner registry entries for runner kill orphan owner PIDs
- update doctor/kill fixtures so live runner identity is registry-backed only

Closes #17265

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p runner process
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::kill
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::doctor
- cargo test --manifest-path crates/Cargo.toml -p runner run_resolution
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets
- cargo test --manifest-path crates/Cargo.toml -p runner