### PR TITLE
style: align worked duration label style

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1009,7 +1009,18 @@ describe("CHAT-02: dispatch failure", () => {
       payload: { threadId: sent.body.threadId, agentId },
     });
 
-    const messages = await chat.listThreadMessages(actor, sent.body.threadId);
+    const messages = await waitForThreadMessages(
+      actor,
+      sent.body.threadId,
+      (items) => {
+        return assistantMessages(items).some((message) => {
+          return (
+            message.runId === sent.body.runId &&
+            message.runLifecycleEvent === "failed"
+          );
+        });
+      },
+    );
     const failedMarker = assistantMessages(messages.messages).find(
       (message) => {
         return (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2635,6 +2635,9 @@ function completedWorkLabel(
   return `Worked for ${formatCompactDuration(elapsedSeconds)}`;
 }
 
+const RUN_SECTION_LABEL_CLASS =
+  "shrink-0 font-serif text-[13px] italic text-muted-foreground/50";
+
 function CompletedWorkFoldRow({
   groups,
   expanded,
@@ -2652,14 +2655,14 @@ function CompletedWorkFoldRow({
         aria-expanded={expanded}
         aria-label={expanded ? "Collapse work history" : "Expand work history"}
         onClick={onToggle}
-        className="group flex h-9 w-full items-center gap-2 rounded-lg px-1 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+        className="group flex h-9 w-full items-center gap-2 rounded-lg px-1 text-left transition-colors hover:bg-muted/40"
       >
-        <span className="min-w-0 shrink-0">{label}</span>
+        <span className={RUN_SECTION_LABEL_CLASS}>{label}</span>
         <IconChevronRight
           size={17}
           stroke={1.7}
           className={cn(
-            "shrink-0 transition-transform duration-150",
+            "shrink-0 text-muted-foreground/50 transition-[color,transform] duration-150 group-hover:text-muted-foreground",
             expanded && "rotate-90",
           )}
         />
@@ -3644,9 +3647,7 @@ function FinishedRunRow({
       <div className="flex h-5 flex-col justify-center gap-1.5">
         <div className="h-px w-full bg-border/40" />
         <div className="flex items-center gap-2">
-          <p className="text-[13px] italic text-muted-foreground/50 font-serif shrink-0">
-            {label}
-          </p>
+          <p className={RUN_SECTION_LABEL_CLASS}>{label}</p>
           <div className="h-px flex-1 bg-border/40" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Reuse the finished-run label typography/color for completed work fold labels
- Keep the fold row hover background while preventing the label from turning darker on hover

## Tests
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
- pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-thread-page.tsx --max-warnings 0
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-thread-page.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx