### PR TITLE
fix: keep completed chat work folded during active runs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1368,6 +1368,71 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("keeps completed chat work folded while a later run is active", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-completed-before-active",
+      activeRunIds: ["run-work-folding-active-later"],
+      chatMessages: [
+        {
+          role: "user",
+          content: "Summarize the earlier launch",
+          runId: "run-work-folding-completed-before-active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: "Checking the earlier launch notes.",
+          runId: "run-work-folding-completed-before-active",
+          createdAt: "2026-06-09T10:00:10Z",
+        },
+        {
+          role: "assistant",
+          content: "The earlier launch summary is ready.",
+          runId: "run-work-folding-completed-before-active",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:20Z",
+        },
+        {
+          role: "user",
+          content: "Investigate the current launch",
+          runId: "run-work-folding-active-later",
+          createdAt: "2026-06-09T10:05:00Z",
+        },
+        {
+          role: "assistant",
+          content: "Checking the current launch notes.",
+          runId: "run-work-folding-active-later",
+          createdAt: "2026-06-09T10:05:10Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-completed-before-active",
+      featureSwitches: { [FeatureSwitchKey.ChatCompletedWorkFolding]: true },
+    });
+
+    const expandButtons = await screen.findAllByLabelText(
+      "Expand work history",
+    );
+    expect(expandButtons).toHaveLength(1);
+    expect(expandButtons[0]).toHaveTextContent("Worked for 20s");
+    expect(
+      screen.getByText("Summarize the earlier launch"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Checking the earlier launch notes.")).toBeNull();
+    expect(
+      screen.getByText("The earlier launch summary is ready."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Investigate the current launch"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Checking the current launch notes."),
+    ).toBeInTheDocument();
+  });
+
   it("folds completed chat work and toggles the hidden history", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-work-folding-completed",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2304,11 +2304,8 @@ function ChatThreadMessagesMain({
   const features = useLastResolved(featureSwitch$);
   const completedWorkFoldingEnabled =
     features?.[FeatureSwitchKey.ChatCompletedWorkFolding] ?? false;
-  const allFinishedLoadable = useLastLoadable(thread.allFinished$);
-  const allFinished =
-    allFinishedLoadable.state === "hasData" ? allFinishedLoadable.data : false;
   const completedWorkFolding = completedWorkFoldingEnabled
-    ? buildCompletedWorkFolding(activeGroups, allFinished)
+    ? buildCompletedWorkFolding(activeGroups)
     : null;
   const completedWorkExpandedKeys = useGet(completedWorkExpandedKeys$);
   const toggleCompletedWorkExpanded = useSet(toggleCompletedWorkExpanded$);
@@ -2504,17 +2501,32 @@ function isRenderableAssistantMessage(message: EnrichedChatMessage): boolean {
   );
 }
 
+function terminatedRunIdsForCompletedWork(
+  messages: readonly EnrichedChatMessage[],
+): Set<string> {
+  const terminatedRunIds = new Set<string>();
+  for (const message of messages) {
+    if (message.interruptsRunId !== undefined) {
+      terminatedRunIds.add(message.interruptsRunId);
+    }
+    if (
+      message.role === "assistant" &&
+      message.runId !== undefined &&
+      message.runLifecycleEvent !== undefined
+    ) {
+      terminatedRunIds.add(message.runId);
+    }
+  }
+  return terminatedRunIds;
+}
+
 function buildCompletedWorkFolding(
   groups: readonly GroupedChatMessageGroup[],
-  allFinished: boolean,
 ): CompletedWorkFolding | null {
-  if (!allFinished) {
-    return null;
-  }
-
   const messages = groups.flatMap((group) => {
     return group.messages;
   });
+  const terminatedRunIds = terminatedRunIdsForCompletedWork(messages);
   const visibleMessages: EnrichedChatMessage[] = [];
   const folds: CompletedWorkFold[] = [];
 
@@ -2532,6 +2544,12 @@ function buildCompletedWorkFolding(
     }
 
     const runMessages = messages.slice(index, endIndex);
+    if (!terminatedRunIds.has(runId)) {
+      visibleMessages.push(...runMessages);
+      index = endIndex;
+      continue;
+    }
+
     let finalMessageIndex = -1;
     for (let offset = runMessages.length - 1; offset >= 0; offset--) {
       if (isRenderableAssistantMessage(runMessages[offset]!)) {


### PR DESCRIPTION
## Summary
- fold completed chat runs based on per-run terminal state instead of thread-wide idle state
- keep active runs visible while preserving folded history for earlier completed runs
- add regression coverage for a completed run followed by a later active run

## Testing
- pnpm --dir turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- git diff --check
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_codex_chat_fold_test pnpm vitest (failed in unrelated schedule/jobs/desktop native/db/API tests; chat-lifecycle passed)