### PR TITLE
fix: classify non-code runner job failures

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -109,6 +109,8 @@ impl FailureClass {
 pub enum FailureReason {
     InsufficientCredits,
     InvalidApiKey,
+    InvalidCredentials,
+    ReconnectRequired,
     UsageLimit,
 }
 
@@ -118,6 +120,8 @@ impl FailureReason {
         match self {
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
+            Self::InvalidCredentials => "invalid_credentials",
+            Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
         }
     }
@@ -330,6 +334,40 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "invalid_api_key");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_invalid_credentials_reason() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::InvalidCredentials);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "invalid_credentials");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_reconnect_required_reason() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ReconnectRequired);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "reconnect_required");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -195,10 +195,10 @@ fn codex_error_message(error: Option<&Value>) -> Option<String> {
 
 fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     let error = error?;
-    if error.get("code").and_then(Value::as_str) == Some("invalid_api_key") {
+    if codex_error_code(error) == Some("invalid_api_key") {
         return Some(FailureReason::InvalidApiKey);
     }
-    if error.get("code").and_then(Value::as_str) == Some("TOKEN_REFRESH_FAILED")
+    if codex_error_code(error) == Some("TOKEN_REFRESH_FAILED")
         && error.get("failureReason").and_then(Value::as_str) == Some("reconnect_required")
         && has_exact_codex_oauth_connector(error)
     {
@@ -209,6 +209,13 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
 
 fn codex_event_failure_reason(event: &Value, error: Option<&Value>) -> Option<FailureReason> {
     codex_error_failure_reason(error).or_else(|| codex_error_failure_reason(Some(event)))
+}
+
+fn codex_error_code(value: &Value) -> Option<&str> {
+    value
+        .get("code")
+        .or_else(|| value.get("error"))
+        .and_then(Value::as_str)
 }
 
 fn has_exact_codex_oauth_connector(value: &Value) -> bool {
@@ -738,6 +745,27 @@ mod tests {
         let event = serde_json::json!({
             "type": "error",
             "code": "TOKEN_REFRESH_FAILED",
+            "message": "Access token expired and refresh failed for: codex-oauth-token.",
+            "connectors": ["codex-oauth-token"],
+            "failureReason": "reconnect_required"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "Access token expired and refresh failed for: codex-oauth-token."
+                    .to_string(),
+                failure_reason: Some(FailureReason::ReconnectRequired),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_event_top_level_error_string_reconnect_required_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "error",
+            "error": "TOKEN_REFRESH_FAILED",
             "message": "Access token expired and refresh failed for: codex-oauth-token.",
             "connectors": ["codex-oauth-token"],
             "failureReason": "reconnect_required"

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -775,6 +775,27 @@ mod tests {
     }
 
     #[test]
+    fn codex_error_event_multi_connector_reconnect_remains_unclassified() {
+        let event = serde_json::json!({
+            "type": "error",
+            "code": "TOKEN_REFRESH_FAILED",
+            "message": "Access token expired and refresh failed for: notion, codex-oauth-token.",
+            "connectors": ["notion", "codex-oauth-token"],
+            "failureReason": "reconnect_required"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "Access token expired and refresh failed for: notion, codex-oauth-token."
+                    .to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_failed_event_yields_failure_diagnostic() {
         let event = serde_json::json!({
             "type": "turn.failed",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -18,6 +18,7 @@ use std::path::{Component, Path};
 const LOG_TAG: &str = "sandbox:guest-agent";
 const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
 const FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX: &str = "...[truncated]";
+const CODEX_OAUTH_TOKEN_CONNECTOR: &str = "codex-oauth-token";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CodexFailureDiagnostic {
@@ -197,11 +198,27 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     if error.get("code").and_then(Value::as_str) == Some("invalid_api_key") {
         return Some(FailureReason::InvalidApiKey);
     }
+    if error.get("code").and_then(Value::as_str) == Some("TOKEN_REFRESH_FAILED")
+        && error.get("failureReason").and_then(Value::as_str) == Some("reconnect_required")
+        && has_exact_codex_oauth_connector(error)
+    {
+        return Some(FailureReason::ReconnectRequired);
+    }
     None
 }
 
 fn codex_event_failure_reason(event: &Value, error: Option<&Value>) -> Option<FailureReason> {
     codex_error_failure_reason(error).or_else(|| codex_error_failure_reason(Some(event)))
+}
+
+fn has_exact_codex_oauth_connector(value: &Value) -> bool {
+    value
+        .get("connectors")
+        .and_then(Value::as_array)
+        .is_some_and(|connectors| {
+            connectors.len() == 1
+                && connectors.first().and_then(Value::as_str) == Some(CODEX_OAUTH_TOKEN_CONNECTOR)
+        })
 }
 
 fn raw_message_from_field(value: Option<&Value>) -> Option<String> {
@@ -717,6 +734,47 @@ mod tests {
     }
 
     #[test]
+    fn codex_error_event_top_level_reconnect_required_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "error",
+            "code": "TOKEN_REFRESH_FAILED",
+            "message": "Access token expired and refresh failed for: codex-oauth-token.",
+            "connectors": ["codex-oauth-token"],
+            "failureReason": "reconnect_required"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "Access token expired and refresh failed for: codex-oauth-token."
+                    .to_string(),
+                failure_reason: Some(FailureReason::ReconnectRequired),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_event_upstream_provider_refresh_remains_unclassified() {
+        let event = serde_json::json!({
+            "type": "error",
+            "code": "TOKEN_REFRESH_FAILED",
+            "message": "Access token refresh failed for: codex-oauth-token.",
+            "connectors": ["codex-oauth-token"],
+            "failureReason": "upstream_provider"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "Access token refresh failed for: codex-oauth-token.".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_failed_event_yields_failure_diagnostic() {
         let event = serde_json::json!({
             "type": "turn.failed",
@@ -729,6 +787,29 @@ mod tests {
                 event_type: "turn.failed",
                 message: "turn failed from server".to_string(),
                 failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_reconnect_required_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "code": "TOKEN_REFRESH_FAILED",
+                "message": "Access token expired and refresh failed for: codex-oauth-token.",
+                "connectors": ["codex-oauth-token"],
+                "failureReason": "reconnect_required"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "Access token expired and refresh failed for: codex-oauth-token."
+                    .to_string(),
+                failure_reason: Some(FailureReason::ReconnectRequired),
             })
         );
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -195,10 +195,10 @@ fn codex_error_message(error: Option<&Value>) -> Option<String> {
 
 fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     let error = error?;
-    if codex_error_code(error) == Some("invalid_api_key") {
+    if error.get("code").and_then(Value::as_str) == Some("invalid_api_key") {
         return Some(FailureReason::InvalidApiKey);
     }
-    if codex_error_code(error) == Some("TOKEN_REFRESH_FAILED")
+    if codex_refresh_error_code(error) == Some("TOKEN_REFRESH_FAILED")
         && error.get("failureReason").and_then(Value::as_str) == Some("reconnect_required")
         && has_exact_codex_oauth_connector(error)
     {
@@ -211,7 +211,7 @@ fn codex_event_failure_reason(event: &Value, error: Option<&Value>) -> Option<Fa
     codex_error_failure_reason(error).or_else(|| codex_error_failure_reason(Some(event)))
 }
 
-fn codex_error_code(value: &Value) -> Option<&str> {
+fn codex_refresh_error_code(value: &Value) -> Option<&str> {
     value
         .get("code")
         .or_else(|| value.get("error"))
@@ -736,6 +736,24 @@ mod tests {
                 event_type: "error",
                 message: "Incorrect API key provided".to_string(),
                 failure_reason: Some(FailureReason::InvalidApiKey),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_event_error_string_invalid_api_key_remains_unclassified() {
+        let event = serde_json::json!({
+            "type": "error",
+            "error": "invalid_api_key",
+            "message": "Provider reported invalid_api_key in an error field"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "Provider reported invalid_api_key in an error field".to_string(),
+                failure_reason: None,
             })
         );
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -20,6 +20,7 @@ use agent_diagnostics::{
 };
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
+use serde_json::Value;
 use std::io::ErrorKind;
 use std::path::Path;
 use std::sync::Arc;
@@ -29,6 +30,7 @@ use tokio_util::sync::CancellationToken;
 const LOG_TAG: &str = "sandbox:guest-agent";
 const MAX_LOGGED_CLI_STDERR_LINES: usize = 20;
 const MAX_LOGGED_CLI_STDERR_LINE_BYTES: usize = 4096;
+const CODEX_OAUTH_TOKEN_CONNECTOR: &str = "codex-oauth-token";
 
 #[tokio::main]
 async fn main() {
@@ -343,11 +345,21 @@ fn classify_cli_failure_reason(
     if normalized.contains("402 insufficient credits") {
         return Some(FailureReason::InsufficientCredits);
     }
+    if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_invalid_credentials_error(&normalized)
+    {
+        return Some(FailureReason::InvalidCredentials);
+    }
     if matches!(framework, AgentFramework::Codex)
         && (normalized.contains("invalid_api_key")
             || normalized.contains("incorrect api key provided"))
     {
         return Some(FailureReason::InvalidApiKey);
+    }
+    if matches!(framework, AgentFramework::Codex)
+        && is_codex_oauth_reconnect_required_run_error(failure_message)
+    {
+        return Some(FailureReason::ReconnectRequired);
     }
     // Subscription/usage limits are an expected quota state for both Codex
     // (ChatGPT plan "usage limit") and Claude Code (Max plan "session limit" /
@@ -356,10 +368,86 @@ fn classify_cli_failure_reason(
     if normalized.contains("usage limit")
         || normalized.contains("session limit")
         || normalized.contains("weekly limit")
+        || (matches!(framework, AgentFramework::ClaudeCode)
+            && is_claude_subscription_access_disabled_error(&normalized))
     {
         return Some(FailureReason::UsageLimit);
     }
     None
+}
+
+fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
+    normalized.contains("failed to authenticate")
+        && normalized.contains("api error: 401 invalid authentication credentials")
+}
+
+fn is_claude_subscription_access_disabled_error(normalized: &str) -> bool {
+    normalized.contains("disabled claude subscription access") && normalized.contains("claude code")
+}
+
+fn is_codex_oauth_reconnect_required_run_error(error_message: &str) -> bool {
+    if !error_message.contains("TOKEN_REFRESH_FAILED")
+        || !error_message.contains(CODEX_OAUTH_TOKEN_CONNECTOR)
+        || !error_message.contains("reconnect_required")
+    {
+        return false;
+    }
+
+    let mut search_start = 0;
+    while let Some((value, end_index)) = parse_next_json_object(error_message, search_start) {
+        if value
+            .as_ref()
+            .is_some_and(is_codex_oauth_reconnect_required_value)
+        {
+            return true;
+        }
+        search_start = end_index;
+    }
+    false
+}
+
+fn parse_next_json_object(message: &str, search_start: usize) -> Option<(Option<Value>, usize)> {
+    let body_start = message[search_start.min(message.len())..]
+        .find('{')
+        .map(|offset| search_start + offset)?;
+    let mut stream = serde_json::Deserializer::from_str(&message[body_start..]).into_iter();
+
+    match stream.next() {
+        Some(Ok(value)) => Some((Some(value), body_start + stream.byte_offset())),
+        Some(Err(_)) | None => Some((None, body_start + 1)),
+    }
+}
+
+fn is_codex_oauth_reconnect_required_value(value: &Value) -> bool {
+    is_codex_oauth_reconnect_required_body(value)
+        || value
+            .get("error")
+            .is_some_and(is_codex_oauth_reconnect_required_envelope)
+}
+
+fn is_codex_oauth_reconnect_required_body(value: &Value) -> bool {
+    value.get("error").and_then(Value::as_str) == Some("TOKEN_REFRESH_FAILED")
+        && has_reconnect_required_payload(value)
+}
+
+fn is_codex_oauth_reconnect_required_envelope(value: &Value) -> bool {
+    value.get("code").and_then(Value::as_str) == Some("TOKEN_REFRESH_FAILED")
+        && has_reconnect_required_payload(value)
+}
+
+fn has_reconnect_required_payload(value: &Value) -> bool {
+    value.get("failureReason").and_then(Value::as_str) == Some("reconnect_required")
+        && has_exact_codex_oauth_connector(value)
+}
+
+fn has_exact_codex_oauth_connector(value: &Value) -> bool {
+    value
+        .get("connectors")
+        .and_then(Value::as_array)
+        .is_some_and(|connectors| {
+            connectors.len() == 1
+                && connectors.first().and_then(Value::as_str) == Some(CODEX_OAUTH_TOKEN_CONNECTOR)
+        })
 }
 
 fn diagnostic_session_history_status() -> SessionHistoryStatus {
@@ -1030,6 +1118,23 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_classifies_claude_invalid_credentials() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        );
+
+        assert_eq!(reason, Some(FailureReason::InvalidCredentials));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_generic_claude_401() {
+        let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, "401 unauthorized");
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
     fn cli_failure_reason_classifies_codex_usage_limit() {
         let reason = classify_cli_failure_reason(
             AgentFramework::Codex,
@@ -1083,6 +1188,66 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_classifies_codex_oauth_reconnect_required() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: codex-oauth-token. The connector may need to be reconnected.","permission":"model-provider:codex-oauth-token","base":"https://chatgpt.com/backend-api/codex","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses"#,
+        );
+
+        assert_eq!(reason, Some(FailureReason::ReconnectRequired));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_codex_oauth_reconnect_required_envelope() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"error":{"message":"Access token expired and refresh failed for: codex-oauth-token.","code":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}}"#,
+        );
+
+        assert_eq!(reason, Some(FailureReason::ReconnectRequired));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_codex_oauth_upstream_provider() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token after reconnect_required state.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"upstream_provider"}, url: https://chatgpt.com/backend-api/codex/responses"#,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_codex_oauth_refresh_without_failure_reason() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"]}, url: https://chatgpt.com/backend-api/codex/responses"#,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_non_codex_oauth_reconnect_required() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: zendesk.","permission":"connector:zendesk","connectors":["zendesk"],"failureReason":"reconnect_required"}, url: https://example.zendesk.com/api/v2/tickets"#,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_nested_codex_oauth_reconnect_required_payload() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"debug":{"error":"TOKEN_REFRESH_FAILED","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}}"#,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
     fn cli_failure_reason_prefers_message_classification_over_carried_reason() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -1114,6 +1279,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "Claude usage limit reached. Visit https://claude.ai/settings/usage.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::UsageLimit));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_subscription_access_disabled_as_usage_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
         );
 
         assert_eq!(reason, Some(FailureReason::UsageLimit));

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1208,6 +1208,26 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_classifies_codex_oauth_reconnect_required_after_metadata() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"request metadata {"traceId":"abc","status":502}: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: codex-oauth-token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses"#,
+        );
+
+        assert_eq!(reason, Some(FailureReason::ReconnectRequired));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_codex_oauth_reconnect_required_after_template_brace() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"request template {response_id: {"error":"TOKEN_REFRESH_FAILED","message":"Refresh failed for {codex} token.","permission":"model-provider:codex-oauth-token","connectors":["codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses"#,
+        );
+
+        assert_eq!(reason, Some(FailureReason::ReconnectRequired));
+    }
+
+    #[test]
     fn cli_failure_reason_ignores_codex_oauth_upstream_provider() {
         let reason = classify_cli_failure_reason(
             AgentFramework::Codex,
@@ -1232,6 +1252,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::Codex,
             r#"unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: zendesk.","permission":"connector:zendesk","connectors":["zendesk"],"failureReason":"reconnect_required"}, url: https://example.zendesk.com/api/v2/tickets"#,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_codex_oauth_multi_connector_reconnect_required() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            r#"unexpected status 502 Bad Gateway: {"error":"TOKEN_REFRESH_FAILED","message":"Access token expired and refresh failed for: notion, codex-oauth-token.","connectors":["notion","codex-oauth-token"],"failureReason":"reconnect_required"}, url: https://chatgpt.com/backend-api/codex/responses"#,
         );
 
         assert_eq!(reason, None);

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -704,6 +704,8 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
             Some(
                 FailureReason::InsufficientCredits
                     | FailureReason::InvalidApiKey
+                    | FailureReason::InvalidCredentials
+                    | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
             )
         ),
@@ -865,6 +867,8 @@ mod tests {
         for reason in [
             FailureReason::InsufficientCredits,
             FailureReason::InvalidApiKey,
+            FailureReason::InvalidCredentials,
+            FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {
             let diagnostic = job_failure_diagnostic(Some(reason));
@@ -916,7 +920,12 @@ mod tests {
 
     #[test]
     fn info_level_reason_on_non_cli_failure_logs_job_execution_failed_at_error() {
-        for reason in [FailureReason::InvalidApiKey, FailureReason::UsageLimit] {
+        for reason in [
+            FailureReason::InvalidApiKey,
+            FailureReason::InvalidCredentials,
+            FailureReason::ReconnectRequired,
+            FailureReason::UsageLimit,
+        ] {
             let diagnostic = FailureDiagnostic::new(
                 FailureClass::CheckpointFailed,
                 AgentFramework::Codex,


### PR DESCRIPTION
## Summary
- add explicit failure reasons for invalid credentials and reconnect-required connector state
- classify Claude Code auth/subscription failures and Codex OAuth reconnect-required refresh failures in guest-agent diagnostics
- log expected CLI credential/reconnect failures at info level while preserving error logging for non-CLI failures

Closes #17353

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check
- cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics -p guest-agent -p runner
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc