### PR TITLE
style: remove worked duration chevron

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2666,14 +2666,6 @@ function CompletedWorkFoldRow({
         className="group flex h-9 w-full items-center gap-2 rounded-lg px-1 text-left transition-colors hover:bg-muted/40"
       >
         <span className={RUN_SECTION_LABEL_CLASS}>{label}</span>
-        <IconChevronRight
-          size={17}
-          stroke={1.7}
-          className={cn(
-            "shrink-0 text-muted-foreground/50 transition-[color,transform] duration-150 group-hover:text-muted-foreground",
-            expanded && "rotate-90",
-          )}
-        />
         <span className="h-px min-w-8 flex-1 bg-border/50 transition-colors group-hover:bg-border" />
       </button>
     </div>


### PR DESCRIPTION
## Summary
- Remove the chevron icon from the completed work fold row
- Keep the row clickable and preserve the divider/hover treatment

## Tests
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
- pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-thread-page.tsx --max-warnings 0
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-thread-page.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx