### PR TITLE
fix: place expanded work below fold header

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -58,6 +58,19 @@ const HISTORY_THREAD_ID = "b0000000-0000-4000-a000-000000000705";
 const CHAT_PATH = `/chats/${THREAD_ID}`;
 const AGENT_CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 
+function expectTextBefore(
+  container: HTMLElement,
+  before: string,
+  after: string,
+) {
+  const text = container.textContent ?? "";
+  const beforeIndex = text.indexOf(before);
+  const afterIndex = text.indexOf(after);
+  expect(beforeIndex).toBeGreaterThanOrEqual(0);
+  expect(afterIndex).toBeGreaterThanOrEqual(0);
+  expect(beforeIndex).toBeLessThan(afterIndex);
+}
+
 interface QueuedMessageCapture {
   content?: string;
   hasTextContent?: boolean;
@@ -1489,6 +1502,16 @@ describe("chat lifecycle", () => {
       expect(
         within(foldedAssistantGroup!).getAllByLabelText("View agent profile"),
       ).toHaveLength(1);
+      expectTextBefore(
+        foldedAssistantGroup!,
+        "Worked for 55s",
+        "Checking launch status.",
+      );
+      expectTextBefore(
+        foldedAssistantGroup!,
+        "Checking launch status.",
+        "Launch status is summarized.",
+      );
       expect(screen.getByLabelText("Collapse work history")).toHaveAttribute(
         "aria-expanded",
         "true",
@@ -1659,6 +1682,16 @@ describe("chat lifecycle", () => {
       expect(
         within(secondAssistantGroup!).getAllByLabelText("View agent profile"),
       ).toHaveLength(1);
+      expectTextBefore(
+        secondAssistantGroup!,
+        "Worked for 55s",
+        "Checking the second launch notes.",
+      );
+      expectTextBefore(
+        secondAssistantGroup!,
+        "Checking the second launch notes.",
+        "The second launch summary is ready.",
+      );
       expect(screen.getByLabelText("Collapse work history")).toHaveAttribute(
         "aria-expanded",
         "true",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5466,6 +5466,13 @@ function PagedAssistantGroup({
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
         <div className="relative flex flex-col gap-3">
+          {completedWorkFold && (
+            <CompletedWorkFoldRow
+              groups={completedWorkFold.groups}
+              expanded={completedWorkFold.expanded}
+              onToggle={completedWorkFold.onToggle}
+            />
+          )}
           {completedWorkFold?.expanded
             ? completedWorkFold.hiddenGroups.map((hiddenGroup) => {
                 return (
@@ -5479,13 +5486,6 @@ function PagedAssistantGroup({
                 );
               })
             : null}
-          {completedWorkFold && (
-            <CompletedWorkFoldRow
-              groups={completedWorkFold.groups}
-              expanded={completedWorkFold.expanded}
-              onToggle={completedWorkFold.onToggle}
-            />
-          )}
           {group.messages.map((msg) => {
             return <PagedAssistantMessageItem key={msg.id} message={msg} />;
           })}


### PR DESCRIPTION
## Summary\n- keep the completed-work fold header before expanded work history\n- preserve the single assistant group/avatar layout from #17410\n- add regression assertions for expanded work ordering in single-run and multi-run cases\n\n## Verification\n- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx\n- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx\n- pnpm -F @vm0/app check-types\n- pnpm -F @vm0/app lint\n\nNote: the first lint attempt was run concurrently with typecheck/test and the type-aware lint subprocess was SIGKILLed by local resource pressure; rerunning lint alone passed cleanly.