### PR TITLE
feat: filter slash skills by current agent

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -507,7 +507,7 @@ describe("chat composer models", () => {
       screen.findByText("/sales-research"),
     ).resolves.toBeInTheDocument();
     expect(screen.getByText("/support-escalation")).toBeInTheDocument();
-    expect(screen.getByText("/deep-dive")).toBeInTheDocument();
+    expect(screen.queryByText("/deep-dive")).not.toBeInTheDocument();
 
     await user.keyboard("sales");
 
@@ -526,7 +526,7 @@ describe("chat composer models", () => {
     expect(highlightedSkill).not.toHaveClass("font-medium");
   });
 
-  it("suggests org skills when the agent has no custom skills", async () => {
+  it("does not suggest org skills that are not enabled on the current agent", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.5");
     mockAgent({ customSkills: [] });
@@ -550,7 +550,10 @@ describe("chat composer models", () => {
     await user.click(textarea);
     await user.keyboard("/");
 
-    await expect(screen.findByText("/deep-dive")).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("/deep-dive")).not.toBeInTheDocument();
+    });
+    expect(textarea).toHaveValue("/");
   });
 
   it("hides slash skill suggestions when the feature switch is off", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -3449,16 +3449,7 @@ function buildComposerSlashSkills({
       return [skill.name, skill];
     }),
   );
-  const skillNames = Array.from(
-    new Set([
-      ...agentSkillNames,
-      ...orgSkills.map((skill) => {
-        return skill.name;
-      }),
-    ]),
-  );
-
-  return skillNames.map((name) => {
+  return agentSkillNames.map((name) => {
     const metadata = metadataByName.get(name);
     return {
       name,
@@ -3507,7 +3498,8 @@ function SlashSkillComposerInput({
       })
     : [];
   const isLoadingOrgSkills = orgSkillsLoadable.state === "loading";
-  const showSlashSkillMenu = slashRange !== null;
+  const showSlashSkillMenu =
+    slashRange !== null && (isLoadingOrgSkills || composerSkills.length > 0);
 
   const updateCaretIndex = (textarea: HTMLTextAreaElement) => {
     setCaretIndex(textarea.selectionStart);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -343,7 +343,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ChatSlashSkillCommands]: {
     maintainer: "bingjie@vm0.ai",
     description:
-      "Enable slash command suggestions for agent and org skills in the Zero chat composer.",
+      "Enable slash command suggestions for the current agent's skills in the Zero chat composer.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary
- filter slash command suggestions to only the current agent's enabled custom skills
- keep org skills as metadata only, so org-level skills are not shown for agents that have not enabled them
- update tests and feature switch description to match the filtered behavior

## Validation
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --run
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types

## Notes
- Commit hooks reported lefthook was not found in PATH during commit; equivalent checks above were run manually.