### PR TITLE
fix(guest-mock-claude): prevent session id collisions

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1340,6 +1340,7 @@ dependencies = [
  "libc",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/guest-mock-claude/Cargo.toml
+++ b/crates/guest-mock-claude/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 api-contracts.workspace = true
 libc.workspace = true
 serde_json.workspace = true
+uuid = { workspace = true, features = ["v7"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/guest-mock-claude/src/transcript.rs
+++ b/crates/guest-mock-claude/src/transcript.rs
@@ -2,15 +2,11 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use serde_json::{Value, json};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
-/// Generate a mock session ID: `mock-{timestamp_micros}`.
+/// Generate a mock session ID: `mock-{uuid-v7}`.
 pub(crate) fn generate_session_id() -> String {
-    let micros = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_micros();
-    format!("mock-{micros}")
+    format!("mock-{}", Uuid::now_v7())
 }
 
 pub(crate) fn is_valid_session_history_id(session_id: &str) -> bool {
@@ -168,6 +164,7 @@ pub(crate) fn tool_result_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn session_history_path_structure() {
@@ -239,11 +236,37 @@ mod tests {
     }
 
     #[test]
-    fn session_id_unique() {
-        let id1 = generate_session_id();
-        // Small sleep to ensure different timestamp
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        let id2 = generate_session_id();
-        assert_ne!(id1, id2);
+    fn session_id_has_canonical_uuid_suffix() {
+        let id = generate_session_id();
+        let suffix = id.strip_prefix("mock-").expect("mock prefix");
+        let parsed = Uuid::parse_str(suffix).expect("uuid suffix");
+
+        assert_eq!(parsed.to_string(), suffix);
+    }
+
+    #[test]
+    fn session_id_unique_without_sleep() {
+        let mut ids = HashSet::new();
+
+        for _ in 0..1024 {
+            let id = generate_session_id();
+            assert!(ids.insert(id), "generated duplicate session id");
+        }
+    }
+
+    #[test]
+    fn session_id_unique_across_threads() {
+        let handles = (0..16)
+            .map(|_| {
+                std::thread::spawn(|| (0..64).map(|_| generate_session_id()).collect::<Vec<_>>())
+            })
+            .collect::<Vec<_>>();
+        let mut ids = HashSet::new();
+
+        for handle in handles {
+            for id in handle.join().expect("session id worker should not panic") {
+                assert!(ids.insert(id), "generated duplicate session id");
+            }
+        }
     }
 }

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,5 +1,6 @@
+use std::collections::HashSet;
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use serde_json::Value;
 
@@ -163,6 +164,43 @@ fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std
         events[4].get("is_error").and_then(Value::as_bool),
         Some(false)
     );
+    Ok(())
+}
+
+#[test]
+fn concurrent_stream_json_ids_are_unique() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let children = (0..16)
+        .map(|_| {
+            let mut command = mock_claude();
+            command
+                .env("HOME", home.path())
+                .args(["--output-format", "stream-json", "--", "true"])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut session_ids = HashSet::new();
+
+    for child in children {
+        let output = child.wait_with_output()?;
+        assert!(
+            output.status.success(),
+            "expected success, stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(output.stderr.is_empty());
+
+        let events = parse_jsonl(&output.stdout)?;
+        let session_id = init_session_id(&events)?;
+        assert!(
+            session_ids.insert(session_id.clone()),
+            "duplicate session id: {session_id}"
+        );
+        assert!(expected_history_path(home.path(), &session_id).exists());
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Generate mock Claude session IDs as `mock-{uuid-v7}` instead of timestamp-only IDs.
- Replace the sleep-based uniqueness test with no-sleep sequential and thread-level uniqueness coverage.
- Add a process-level integration test for concurrent `guest-mock-claude` invocations sharing one temp `HOME`.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --check --package guest-mock-claude`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`

Closes #17425
