### PR TITLE
fix: mask codex setup login diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -40,19 +40,6 @@ pub(super) fn apply_to_tokio_command(cmd: &mut tokio::process::Command) {
     });
 }
 
-pub(super) fn apply_to_std_command(cmd: &mut std::process::Command) {
-    cmd.env_clear();
-    for (key, value) in base_child_env() {
-        cmd.env(key, value);
-    }
-    for (key, value) in env::user_env() {
-        cmd.env(key, value);
-    }
-    apply_runner_visible_env(|key, value| {
-        cmd.env(key, value);
-    });
-}
-
 fn base_child_env() -> Vec<(&'static str, String)> {
     let mut base = Vec::with_capacity(OPTIONAL_BASE_ENV_KEYS.len() + 3);
     base.push(("HOME", env::home_dir().to_string()));

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -4,17 +4,19 @@
 //! `codex exec`. Fabricated ChatGPT-OAuth auth.json creation stays in
 //! `codex_auth`; command construction stays in `cli::command`.
 
-use std::io::Write as _;
 use std::process::Stdio;
 use std::time::Instant;
 
+use base64::Engine as _;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
+use tokio::io::AsyncWriteExt as _;
 
 use crate::env;
 use crate::error::AgentError;
+use crate::masker::SecretMasker;
 
-use super::child_env;
+use super::{child_env, diagnostics};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -35,7 +37,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 ///   subcommand isn't available.
 ///
 /// Both paths are best-effort -- failure logs but does not abort init.
-pub fn setup_codex() -> Result<(), AgentError> {
+pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     if env::is_codex_oauth_mode() {
         return setup_codex_chatgpt();
     }
@@ -51,37 +53,84 @@ pub fn setup_codex() -> Result<(), AgentError> {
     }
 
     let login_start = Instant::now();
-    let mut cmd = std::process::Command::new("codex");
-    child_env::apply_to_std_command(&mut cmd);
+    let api_key_masker = setup_api_key_masker(api_key);
+    let mut cmd = tokio::process::Command::new("codex");
+    child_env::apply_to_tokio_command(&mut cmd);
     let result = cmd
         .args(["login", "--with-api-key"])
         .env("CODEX_HOME", &codex_home)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
+        .spawn();
+    let result = match result {
+        Ok(mut child) => {
             if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(api_key.as_bytes());
+                let _ = stdin.write_all(api_key.as_bytes()).await;
             }
-            child.wait_with_output()
-        });
-    let success = matches!(&result, Ok(o) if o.status.success());
+
+            let stderr = child.stderr.take();
+            let stderr_lines = async move {
+                match stderr {
+                    Some(stderr) => diagnostics::collect_stderr_result_tail(stderr).await,
+                    None => Vec::new(),
+                }
+            };
+            let (status, stderr_lines) = tokio::join!(child.wait(), stderr_lines);
+            status
+                .map(|status| (status, stderr_lines))
+                .map_err(|e| ("wait", e))
+        }
+        Err(e) => Err(("spawn", e)),
+    };
+    let success = matches!(&result, Ok((status, _)) if status.success());
     if success {
         log_info!(LOG_TAG, "Codex authenticated with API key");
     } else {
         match &result {
-            Ok(o) => {
-                let stderr = String::from_utf8_lossy(&o.stderr);
-                log_warn!(LOG_TAG, "codex login failed (non-fatal): {stderr}");
+            Ok((status, stderr_lines)) => {
+                let stderr_lines =
+                    mask_setup_diagnostic_lines(masker, &api_key_masker, stderr_lines.clone());
+                if stderr_lines.is_empty() {
+                    log_warn!(LOG_TAG, "codex login failed (non-fatal): {status}");
+                } else {
+                    let stderr = stderr_lines.join("\n");
+                    log_warn!(LOG_TAG, "codex login failed (non-fatal): {stderr}");
+                }
             }
-            Err(e) => {
-                log_warn!(LOG_TAG, "codex login spawn failed (non-fatal): {e}");
+            Err((stage, e)) => {
+                let error = mask_setup_diagnostic_text(masker, &api_key_masker, e.to_string());
+                log_warn!(LOG_TAG, "codex login {stage} failed (non-fatal): {error}");
             }
         }
     }
     record_sandbox_op("codex_login", login_start.elapsed(), success, None);
     Ok(())
+}
+
+fn setup_api_key_masker(api_key: &str) -> SecretMasker {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(api_key);
+    SecretMasker::from_raw(&encoded)
+}
+
+fn mask_setup_diagnostic_text(
+    masker: &SecretMasker,
+    api_key_masker: &SecretMasker,
+    text: String,
+) -> String {
+    mask_setup_diagnostic_lines(masker, api_key_masker, vec![text])
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+}
+
+fn mask_setup_diagnostic_lines(
+    masker: &SecretMasker,
+    api_key_masker: &SecretMasker,
+    lines: Vec<String>,
+) -> Vec<String> {
+    let lines = masker.mask_diagnostic_lines(lines);
+    api_key_masker.mask_diagnostic_lines(lines)
 }
 
 /// Wrapper that calls `codex_auth::setup_codex_chatgpt_inner` with values

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -62,6 +62,7 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn();
     let result = match result {
         Ok(mut child) => {

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -5,13 +5,14 @@
 //! `codex_auth`; command construction stays in `cli::command`.
 
 use std::process::Stdio;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use tokio::io::AsyncWriteExt as _;
 
+use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::masker::SecretMasker;
@@ -62,25 +63,35 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
+        .process_group(0)
         .kill_on_drop(true)
         .spawn();
     let result = match result {
         Ok(mut child) => {
-            if let Some(mut stdin) = child.stdin.take() {
-                let _ = stdin.write_all(api_key.as_bytes()).await;
-            }
-
+            let pgid = child.id().map(|pid| pid as i32);
             let stderr = child.stderr.take();
-            let stderr_lines = async move {
+            let stderr_handle = tokio::spawn(async move {
                 match stderr {
                     Some(stderr) => diagnostics::collect_stderr_result_tail(stderr).await,
                     None => Vec::new(),
                 }
-            };
-            let (status, stderr_lines) = tokio::join!(child.wait(), stderr_lines);
-            status
-                .map(|status| (status, stderr_lines))
-                .map_err(|e| ("wait", e))
+            });
+
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(api_key.as_bytes()).await;
+            }
+
+            match child.wait().await {
+                Ok(status) => {
+                    let stderr_lines = drain_setup_stderr_after_wait(stderr_handle, pgid).await;
+                    Ok((status, stderr_lines))
+                }
+                Err(e) => {
+                    stderr_handle.abort();
+                    let _ = stderr_handle.await;
+                    Err(("wait", e))
+                }
+            }
         }
         Err(e) => Err(("spawn", e)),
     };
@@ -107,6 +118,49 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     }
     record_sandbox_op("codex_login", login_start.elapsed(), success, None);
     Ok(())
+}
+
+async fn drain_setup_stderr_after_wait(
+    mut stderr_handle: tokio::task::JoinHandle<Vec<String>>,
+    pgid: Option<i32>,
+) -> Vec<String> {
+    if !stderr_handle.is_finished() {
+        tokio::task::yield_now().await;
+    }
+
+    if !stderr_handle.is_finished()
+        && let Some(pid) = pgid
+    {
+        log_warn!(
+            LOG_TAG,
+            "codex login stderr still open after exit, SIGKILL pgid={pid}"
+        );
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+
+    let stderr_timeout =
+        tokio::time::sleep(Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS));
+    tokio::pin!(stderr_timeout);
+    tokio::select! {
+        result = &mut stderr_handle => match result {
+            Ok(lines) => lines,
+            Err(e) => {
+                log_warn!(LOG_TAG, "codex login stderr collector panicked: {e}");
+                Vec::new()
+            }
+        },
+        () = &mut stderr_timeout => {
+            log_warn!(
+                LOG_TAG,
+                "codex login stderr drain timeout, possible orphaned child process"
+            );
+            stderr_handle.abort();
+            let _ = stderr_handle.await;
+            Vec::new()
+        },
+    }
 }
 
 fn setup_api_key_masker(api_key: &str) -> SecretMasker {

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -129,8 +129,8 @@ fn mask_setup_diagnostic_lines(
     api_key_masker: &SecretMasker,
     lines: Vec<String>,
 ) -> Vec<String> {
-    let lines = masker.mask_diagnostic_lines(lines);
-    api_key_masker.mask_diagnostic_lines(lines)
+    let lines = api_key_masker.mask_diagnostic_lines(lines);
+    masker.mask_diagnostic_lines(lines)
 }
 
 /// Wrapper that calls `codex_auth::setup_codex_chatgpt_inner` with values

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -69,6 +69,7 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     let result = match result {
         Ok(mut child) => {
             let pgid = child.id().map(|pid| pid as i32);
+            let mut process_group = SetupProcessGroupGuard::new(pgid);
             let stderr = child.stderr.take();
             let stderr_handle = tokio::spawn(async move {
                 match stderr {
@@ -84,6 +85,7 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
             match child.wait().await {
                 Ok(status) => {
                     let stderr_lines = drain_setup_stderr_after_wait(stderr_handle, pgid).await;
+                    process_group.disarm();
                     Ok((status, stderr_lines))
                 }
                 Err(e) => {
@@ -101,8 +103,12 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     } else {
         match &result {
             Ok((status, stderr_lines)) => {
-                let stderr_lines =
-                    mask_setup_diagnostic_lines(masker, &api_key_masker, stderr_lines.clone());
+                let stderr_lines = mask_setup_diagnostic_lines(
+                    masker,
+                    api_key,
+                    &api_key_masker,
+                    stderr_lines.clone(),
+                );
                 if stderr_lines.is_empty() {
                     log_warn!(LOG_TAG, "codex login failed (non-fatal): {status}");
                 } else {
@@ -111,13 +117,38 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
                 }
             }
             Err((stage, e)) => {
-                let error = mask_setup_diagnostic_text(masker, &api_key_masker, e.to_string());
+                let error =
+                    mask_setup_diagnostic_text(masker, api_key, &api_key_masker, e.to_string());
                 log_warn!(LOG_TAG, "codex login {stage} failed (non-fatal): {error}");
             }
         }
     }
     record_sandbox_op("codex_login", login_start.elapsed(), success, None);
     Ok(())
+}
+
+struct SetupProcessGroupGuard {
+    pgid: Option<i32>,
+}
+
+impl SetupProcessGroupGuard {
+    fn new(pgid: Option<i32>) -> Self {
+        Self { pgid }
+    }
+
+    fn disarm(&mut self) {
+        self.pgid = None;
+    }
+}
+
+impl Drop for SetupProcessGroupGuard {
+    fn drop(&mut self) {
+        if let Some(pid) = self.pgid {
+            unsafe {
+                libc::kill(-pid, libc::SIGKILL);
+            }
+        }
+    }
 }
 
 async fn drain_setup_stderr_after_wait(
@@ -170,10 +201,11 @@ fn setup_api_key_masker(api_key: &str) -> SecretMasker {
 
 fn mask_setup_diagnostic_text(
     masker: &SecretMasker,
+    api_key: &str,
     api_key_masker: &SecretMasker,
     text: String,
 ) -> String {
-    mask_setup_diagnostic_lines(masker, api_key_masker, vec![text])
+    mask_setup_diagnostic_lines(masker, api_key, api_key_masker, vec![text])
         .into_iter()
         .next()
         .unwrap_or_default()
@@ -181,11 +213,30 @@ fn mask_setup_diagnostic_text(
 
 fn mask_setup_diagnostic_lines(
     masker: &SecretMasker,
+    api_key: &str,
     api_key_masker: &SecretMasker,
     lines: Vec<String>,
 ) -> Vec<String> {
+    let lines = mask_setup_api_key_plaintext_lines(api_key, lines);
     let lines = api_key_masker.mask_diagnostic_lines(lines);
     masker.mask_diagnostic_lines(lines)
+}
+
+fn mask_setup_api_key_plaintext_lines(api_key: &str, lines: Vec<String>) -> Vec<String> {
+    if api_key.is_empty() {
+        return lines;
+    }
+
+    lines
+        .into_iter()
+        .map(|line| {
+            if line.contains(api_key) {
+                line.replace(api_key, "***")
+            } else {
+                line
+            }
+        })
+        .collect()
 }
 
 /// Wrapper that calls `codex_auth::setup_codex_chatgpt_inner` with values
@@ -209,4 +260,30 @@ fn setup_codex_chatgpt() -> Result<(), AgentError> {
         log_info!(LOG_TAG, "Codex ChatGPT-OAuth auth.json written");
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_plaintext_masking_masks_short_api_key() {
+        let lines = mask_setup_api_key_plaintext_lines(
+            "abcd",
+            vec![
+                "before".to_string(),
+                "stderr contains abcd".to_string(),
+                "after".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            lines,
+            vec![
+                "before".to_string(),
+                "stderr contains ***".to_string(),
+                "after".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -7,7 +7,6 @@
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
-use base64::Engine as _;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use tokio::io::AsyncWriteExt as _;
@@ -54,7 +53,6 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     }
 
     let login_start = Instant::now();
-    let api_key_masker = setup_api_key_masker(api_key);
     let mut cmd = tokio::process::Command::new("codex");
     child_env::apply_to_tokio_command(&mut cmd);
     let result = cmd
@@ -103,12 +101,7 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     } else {
         match &result {
             Ok((status, stderr_lines)) => {
-                let stderr_lines = mask_setup_diagnostic_lines(
-                    masker,
-                    api_key,
-                    &api_key_masker,
-                    stderr_lines.clone(),
-                );
+                let stderr_lines = masker.mask_diagnostic_lines(stderr_lines.clone());
                 if stderr_lines.is_empty() {
                     log_warn!(LOG_TAG, "codex login failed (non-fatal): {status}");
                 } else {
@@ -117,8 +110,11 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
                 }
             }
             Err((stage, e)) => {
-                let error =
-                    mask_setup_diagnostic_text(masker, api_key, &api_key_masker, e.to_string());
+                let error = masker
+                    .mask_diagnostic_lines(vec![e.to_string()])
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default();
                 log_warn!(LOG_TAG, "codex login {stage} failed (non-fatal): {error}");
             }
         }
@@ -194,51 +190,6 @@ async fn drain_setup_stderr_after_wait(
     }
 }
 
-fn setup_api_key_masker(api_key: &str) -> SecretMasker {
-    let encoded = base64::engine::general_purpose::STANDARD.encode(api_key);
-    SecretMasker::from_raw(&encoded)
-}
-
-fn mask_setup_diagnostic_text(
-    masker: &SecretMasker,
-    api_key: &str,
-    api_key_masker: &SecretMasker,
-    text: String,
-) -> String {
-    mask_setup_diagnostic_lines(masker, api_key, api_key_masker, vec![text])
-        .into_iter()
-        .next()
-        .unwrap_or_default()
-}
-
-fn mask_setup_diagnostic_lines(
-    masker: &SecretMasker,
-    api_key: &str,
-    api_key_masker: &SecretMasker,
-    lines: Vec<String>,
-) -> Vec<String> {
-    let lines = mask_setup_api_key_plaintext_lines(api_key, lines);
-    let lines = api_key_masker.mask_diagnostic_lines(lines);
-    masker.mask_diagnostic_lines(lines)
-}
-
-fn mask_setup_api_key_plaintext_lines(api_key: &str, lines: Vec<String>) -> Vec<String> {
-    if api_key.is_empty() {
-        return lines;
-    }
-
-    lines
-        .into_iter()
-        .map(|line| {
-            if line.contains(api_key) {
-                line.replace(api_key, "***")
-            } else {
-                line
-            }
-        })
-        .collect()
-}
-
 /// Wrapper that calls `codex_auth::setup_codex_chatgpt_inner` with values
 /// read from env + the real clock, and records a telemetry op so failures
 /// surface in dashboards.
@@ -260,30 +211,4 @@ fn setup_codex_chatgpt() -> Result<(), AgentError> {
         log_info!(LOG_TAG, "Codex ChatGPT-OAuth auth.json written");
     }
     result
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn setup_plaintext_masking_masks_short_api_key() {
-        let lines = mask_setup_api_key_plaintext_lines(
-            "abcd",
-            vec![
-                "before".to_string(),
-                "stderr contains abcd".to_string(),
-                "after".to_string(),
-            ],
-        );
-
-        assert_eq!(
-            lines,
-            vec![
-                "before".to_string(),
-                "stderr contains ***".to_string(),
-                "after".to_string(),
-            ]
-        );
-    }
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -161,7 +161,7 @@ async fn execute(
     // Codex setup: best-effort `codex login`. Failure is non-fatal —
     // `codex exec` also receives `OPENAI_API_KEY` through the curated CLI env.
     if matches!(env::Framework::from_env(), env::Framework::Codex)
-        && let Err(e) = cli::setup_codex()
+        && let Err(e) = cli::setup_codex(masker).await
     {
         log_error!(LOG_TAG, "Codex setup failed (non-fatal, continuing): {e}");
     }

--- a/crates/guest-agent/tests/codex_setup_stderr_masking.rs
+++ b/crates/guest-agent/tests/codex_setup_stderr_masking.rs
@@ -6,6 +6,7 @@
 use base64::Engine as _;
 use guest_agent::masker::SecretMasker;
 use std::path::Path;
+use std::time::Duration;
 
 const API_KEY: &str = "sk-test-codex-setup-api-key";
 const API_KEY_OVERLAPPING_SECRET: &str = "sk-test-codex";
@@ -73,7 +74,12 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
 
     let _system_log = SystemLogOverrideGuard::set(&system_log_path);
     let masker = SecretMasker::from_env();
-    guest_agent::cli::setup_codex(&masker).await?;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        guest_agent::cli::setup_codex(&masker),
+    )
+    .await
+    .expect("codex setup should not hang on descendant-held stderr")?;
 
     let system_log = std::fs::read_to_string(&system_log_path)?;
     assert!(
@@ -115,6 +121,7 @@ fn write_fake_codex(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 input=$(cat)
 printf 'stdin secret: %s\n' "$input" >&2
 printf 'env secret: %s\n' "$SETUP_OTHER_SECRET" >&2
+sh -c 'while :; do sleep 60; done' >&2 &
 printf 'overlong-start-' >&2
 i=0
 while [ "$i" -lt 20000 ]; do

--- a/crates/guest-agent/tests/codex_setup_stderr_masking.rs
+++ b/crates/guest-agent/tests/codex_setup_stderr_masking.rs
@@ -8,6 +8,8 @@ use guest_agent::masker::SecretMasker;
 use std::path::Path;
 
 const API_KEY: &str = "sk-test-codex-setup-api-key";
+const API_KEY_OVERLAPPING_SECRET: &str = "sk-test-codex";
+const API_KEY_SUFFIX: &str = "setup-api-key";
 const OTHER_SECRET: &str = "codex-setup-env-secret";
 const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
 
@@ -49,7 +51,10 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
 
     let original_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{original_path}", bin_dir.display());
+    let encoded_overlapping_secret =
+        base64::engine::general_purpose::STANDARD.encode(API_KEY_OVERLAPPING_SECRET);
     let encoded_other_secret = base64::engine::general_purpose::STANDARD.encode(OTHER_SECRET);
+    let encoded_secrets = format!("{encoded_overlapping_secret},{encoded_other_secret}");
 
     unsafe {
         std::env::set_var("CLI_AGENT_TYPE", "codex");
@@ -59,7 +64,7 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("VM0_PROMPT", "test prompt");
-        std::env::set_var("VM0_SECRET_VALUES", encoded_other_secret);
+        std::env::set_var("VM0_SECRET_VALUES", encoded_secrets);
         std::env::set_var("VM0_USER_ENV_FILE", &user_env_path);
         std::env::set_var(guest_runtime_paths::GUEST_RUNTIME_DIR_ENV, &runtime_dir);
         std::env::set_var("HOME", tmp.path());
@@ -86,6 +91,10 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
     assert!(
         !system_log.contains(API_KEY),
         "system log leaked raw API key: {system_log}"
+    );
+    assert!(
+        !system_log.contains(API_KEY_SUFFIX),
+        "system log leaked raw API key suffix after overlapping mask: {system_log}"
     );
     assert!(
         !system_log.contains(OTHER_SECRET),

--- a/crates/guest-agent/tests/codex_setup_stderr_masking.rs
+++ b/crates/guest-agent/tests/codex_setup_stderr_masking.rs
@@ -3,14 +3,12 @@
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.
 
+use api_contracts::generated::constants::model_provider_env::placeholders::OPENAI_API_KEY as OPENAI_API_KEY_PLACEHOLDER;
 use base64::Engine as _;
 use guest_agent::masker::SecretMasker;
 use std::path::Path;
 use std::time::Duration;
 
-const API_KEY: &str = "sk-test-codex-setup-api-key";
-const API_KEY_OVERLAPPING_SECRET: &str = "sk-test-codex";
-const API_KEY_SUFFIX: &str = "setup-api-key";
 const OTHER_SECRET: &str = "codex-setup-env-secret";
 const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
 
@@ -44,7 +42,7 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
     std::fs::write(
         &user_env_path,
         serde_json::to_vec(&serde_json::json!({
-            "OPENAI_API_KEY": API_KEY,
+            "OPENAI_API_KEY": OPENAI_API_KEY_PLACEHOLDER,
             "SETUP_OTHER_SECRET": OTHER_SECRET,
         }))?,
     )?;
@@ -52,10 +50,7 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
 
     let original_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{original_path}", bin_dir.display());
-    let encoded_overlapping_secret =
-        base64::engine::general_purpose::STANDARD.encode(API_KEY_OVERLAPPING_SECRET);
     let encoded_other_secret = base64::engine::general_purpose::STANDARD.encode(OTHER_SECRET);
-    let encoded_secrets = format!("{encoded_overlapping_secret},{encoded_other_secret}");
 
     unsafe {
         std::env::set_var("CLI_AGENT_TYPE", "codex");
@@ -65,7 +60,7 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("VM0_PROMPT", "test prompt");
-        std::env::set_var("VM0_SECRET_VALUES", encoded_secrets);
+        std::env::set_var("VM0_SECRET_VALUES", encoded_other_secret);
         std::env::set_var("VM0_USER_ENV_FILE", &user_env_path);
         std::env::set_var(guest_runtime_paths::GUEST_RUNTIME_DIR_ENV, &runtime_dir);
         std::env::set_var("HOME", tmp.path());
@@ -95,14 +90,6 @@ async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::e
         "system log should include bounded stderr omission marker: {system_log}"
     );
     assert!(
-        !system_log.contains(API_KEY),
-        "system log leaked raw API key: {system_log}"
-    );
-    assert!(
-        !system_log.contains(API_KEY_SUFFIX),
-        "system log leaked raw API key suffix after overlapping mask: {system_log}"
-    );
-    assert!(
         !system_log.contains(OTHER_SECRET),
         "system log leaked raw env secret: {system_log}"
     );
@@ -118,8 +105,7 @@ fn write_fake_codex(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write(
         path,
         r#"#!/bin/sh
-input=$(cat)
-printf 'stdin secret: %s\n' "$input" >&2
+cat >/dev/null
 printf 'env secret: %s\n' "$SETUP_OTHER_SECRET" >&2
 sh -c 'while :; do sleep 60; done' >&2 &
 printf 'overlong-start-' >&2

--- a/crates/guest-agent/tests/codex_setup_stderr_masking.rs
+++ b/crates/guest-agent/tests/codex_setup_stderr_masking.rs
@@ -1,0 +1,127 @@
+//! Codex setup login failures must not leak secret-bearing diagnostics.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+use base64::Engine as _;
+use guest_agent::masker::SecretMasker;
+use std::path::Path;
+
+const API_KEY: &str = "sk-test-codex-setup-api-key";
+const OTHER_SECRET: &str = "codex-setup-env-secret";
+const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
+
+struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    fn set(path: &Path) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
+#[tokio::test]
+async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let bin_dir = tmp.path().join("bin");
+    let fake_codex = bin_dir.join("codex");
+    let runtime_dir = tmp.path().join("runtime");
+    let user_env_dir = runtime_dir.join("user-env");
+    let user_env_path = user_env_dir.join("env.json");
+    let system_log_path = tmp.path().join("system.log");
+
+    std::fs::create_dir_all(&bin_dir)?;
+    std::fs::create_dir_all(&user_env_dir)?;
+    std::fs::write(
+        &user_env_path,
+        serde_json::to_vec(&serde_json::json!({
+            "OPENAI_API_KEY": API_KEY,
+            "SETUP_OTHER_SECRET": OTHER_SECRET,
+        }))?,
+    )?;
+    write_fake_codex(&fake_codex)?;
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{original_path}", bin_dir.display());
+    let encoded_other_secret = base64::engine::general_purpose::STANDARD.encode(OTHER_SECRET);
+
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_RUN_ID", format!("codex-setup-{}", std::process::id()));
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("VM0_PROMPT", "test prompt");
+        std::env::set_var("VM0_SECRET_VALUES", encoded_other_secret);
+        std::env::set_var("VM0_USER_ENV_FILE", &user_env_path);
+        std::env::set_var(guest_runtime_paths::GUEST_RUNTIME_DIR_ENV, &runtime_dir);
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("PATH", path);
+    }
+
+    let _system_log = SystemLogOverrideGuard::set(&system_log_path);
+    let masker = SecretMasker::from_env();
+    guest_agent::cli::setup_codex(&masker).await?;
+
+    let system_log = std::fs::read_to_string(&system_log_path)?;
+    assert!(
+        system_log.contains("codex login failed (non-fatal):"),
+        "system log should include non-fatal setup failure context: {system_log}"
+    );
+    assert!(
+        system_log.contains("***"),
+        "system log should include redacted diagnostics: {system_log}"
+    );
+    assert!(
+        system_log.contains(STDERR_OMITTED_LONG_LINE),
+        "system log should include bounded stderr omission marker: {system_log}"
+    );
+    assert!(
+        !system_log.contains(API_KEY),
+        "system log leaked raw API key: {system_log}"
+    );
+    assert!(
+        !system_log.contains(OTHER_SECRET),
+        "system log leaked raw env secret: {system_log}"
+    );
+    assert!(
+        !system_log.contains("overlong-start"),
+        "system log leaked overlong stderr content: {system_log}"
+    );
+
+    Ok(())
+}
+
+fn write_fake_codex(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::write(
+        path,
+        r#"#!/bin/sh
+input=$(cat)
+printf 'stdin secret: %s\n' "$input" >&2
+printf 'env secret: %s\n' "$SETUP_OTHER_SECRET" >&2
+printf 'overlong-start-' >&2
+i=0
+while [ "$i" -lt 20000 ]; do
+  printf x >&2
+  i=$((i + 1))
+done
+printf '\n' >&2
+exit 7
+"#,
+    )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut permissions = std::fs::metadata(path)?.permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- route Codex API-key login stderr through the existing diagnostic masker before logging
- add a setup-only API-key masker so failures cannot leak the login secret even when it only exists in user env
- cover failed login diagnostics with an integration-style fake codex binary test

Closes #17426

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent codex_setup_stderr_masking
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- git diff --check