### PR TITLE
fix: hide cloudflare api-token auth method

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2549,10 +2549,17 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth"]);
   });
 
-  it("exposes Cloudflare auth methods by default", () => {
-    expect(getAvailableConnectorAuthMethodIds("cloudflare", {})).toStrictEqual([
+  it("keeps Cloudflare API-token configured but hidden by default", () => {
+    expect(getConfiguredConnectorAuthMethodIds("cloudflare")).toStrictEqual([
       "oauth",
       "api-token",
+    ]);
+    expect(getConnectorAuthMethod("cloudflare", "api-token")).toMatchObject({
+      visible: false,
+      grant: { kind: "manual" },
+    });
+    expect(getAvailableConnectorAuthMethodIds("cloudflare", {})).toStrictEqual([
+      "oauth",
     ]);
   });
 

--- a/turbo/packages/connectors/src/connectors/cloudflare.ts
+++ b/turbo/packages/connectors/src/connectors/cloudflare.ts
@@ -408,6 +408,7 @@ export const cloudflare = {
       },
       "api-token": {
         label: "API Token",
+        visible: false,
         helpText:
           "1. Log in to the [Cloudflare Dashboard](https://dash.cloudflare.com)\n2. Go to **My Profile** → **API Tokens**\n3. Click **Create Token** and configure the required permissions\n4. Copy the generated token",
         storage: {


### PR DESCRIPTION
## Summary
- hide the Cloudflare API-token auth method from new connector selection
- keep the API-token method configured so existing runtime env bindings remain compatible
- update connector visibility coverage for the hidden Cloudflare API-token method

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pre-commit hook: prettier, knip, workspace check-types