### PR TITLE
fix(api): poll the org-teardown assertions in the clerk deletion test

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3002,9 +3002,18 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
         return deletedS3Keys.length;
       })
       .toBeGreaterThan(0);
-    await runs.requestReadRun(actor, run.runId, [404]);
-    await expect(bdd.listAgents(actor)).resolves.toStrictEqual([]);
-    expect((await runs.listSchedules(actor)).schedules).toStrictEqual([]);
+    // The redelivered webhook responds OK before the teardown finishes, so
+    // the resource deletions land asynchronously — poll instead of asserting
+    // a single snapshot.
+    await waitForExpectation(async () => {
+      await runs.requestReadRun(actor, run.runId, [404]);
+    });
+    await waitForExpectation(async () => {
+      await expect(bdd.listAgents(actor)).resolves.toStrictEqual([]);
+    });
+    await waitForExpectation(async () => {
+      expect((await runs.listSchedules(actor)).schedules).toStrictEqual([]);
+    });
 
     // An org without a live subscription skips the Stripe cancellation.
     const cancelCalls =


### PR DESCRIPTION
## Summary

Deflakes `WHCB-08: cleans up organization state after a verified organization.deleted event`, which ejected two unrelated PRs (#17401 branch CI, #17443 merge group) with:

```
AssertionError: expected [ { …(11) }, { …(11) } ] to strictly equal []
```

Root cause (correcting my first diagnosis in #17451): not cross-file DB pollution — the redelivered webhook returns `200 OK` **before** the teardown finishes, and the test asserts a single snapshot of the surviving run / agents / automations right after the S3-deletion poll. Under CI load the row deletions land a beat later and the snapshot sees the two agents still alive. The two failed-run payloads (exactly 2 items) match the two surviving agents.

Fix: the three post-redelivery assertions poll via the test's existing `waitForExpectation` helper, like the first-delivery assertions already do.

## Test plan

- [x] Suite green locally (28/28), `check-types`, `format`

Closes #17451

🤖 Generated with [Claude Code](https://claude.com/claude-code)