### PR TITLE
feat: add tooltips to artifacts icon buttons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -213,6 +213,27 @@ export function ArtifactActionSeparator() {
   return <span className="mx-0.5 h-5 w-px shrink-0 bg-border/70" />;
 }
 
+export function ArtifactActionTooltip({
+  children,
+  label,
+  side = "bottom",
+}: {
+  children: ReactNode;
+  label: string;
+  side?: "top" | "right" | "bottom" | "left";
+}) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} className={ARTIFACT_FLOATING_LAYER_CLASS}>
+          <p className="text-xs">{label}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 export function ArtifactShareButton({
   ariaLabel = "Share",
   className,
@@ -225,33 +246,19 @@ export function ArtifactShareButton({
   url: string;
 }) {
   return (
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => {
-              detach(
-                shareArtifactUrl(url),
-                Reason.DomCallback,
-                "artifact share",
-              );
-            }}
-            aria-label={ariaLabel}
-            title={publicAttachmentUrl(url)}
-            className={iconButtonClassName(className)}
-          >
-            <IconShare size={iconSize} stroke={1.5} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent
-          side="top"
-          className={cn("!z-[10000]", ARTIFACT_FLOATING_LAYER_CLASS)}
-        >
-          <p className="text-xs">Share</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <ArtifactActionTooltip label={ariaLabel}>
+      <button
+        type="button"
+        onClick={() => {
+          detach(shareArtifactUrl(url), Reason.DomCallback, "artifact share");
+        }}
+        aria-label={ariaLabel}
+        title={publicAttachmentUrl(url)}
+        className={iconButtonClassName(className)}
+      >
+        <IconShare size={iconSize} stroke={1.5} />
+      </button>
+    </ArtifactActionTooltip>
   );
 }
 
@@ -440,22 +447,24 @@ export function ArtifactDownloadMenu({
         closeMenu();
       }}
     >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={ariaLabel}
-          aria-haspopup="menu"
-          aria-expanded={open}
-          className={iconButtonClassName(
-            cn(
-              "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground",
-              className,
-            ),
-          )}
-        >
-          <IconDownload size={iconSize} stroke={1.5} />
-        </button>
-      </PopoverTrigger>
+      <ArtifactActionTooltip label={ariaLabel}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={ariaLabel}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            className={iconButtonClassName(
+              cn(
+                "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground",
+                className,
+              ),
+            )}
+          >
+            <IconDownload size={iconSize} stroke={1.5} />
+          </button>
+        </PopoverTrigger>
+      </ArtifactActionTooltip>
       {open && (
         <PopoverOverlay
           data-testid="artifact-download-menu-dismiss-layer"

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -51,6 +51,7 @@ import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thre
 import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   ArtifactActionSeparator,
+  ArtifactActionTooltip,
   ArtifactDownloadMenu,
   ArtifactShareButton,
   type ArtifactDownloadSyncTarget,
@@ -378,14 +379,16 @@ function ArtifactSidebarHeader({
   return (
     <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
       {onBack && (
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="Back to all artifacts"
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-        >
-          <IconArrowLeft size={16} />
-        </button>
+        <ArtifactActionTooltip label="Back to all artifacts">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back to all artifacts"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          >
+            <IconArrowLeft size={16} />
+          </button>
+        </ArtifactActionTooltip>
       )}
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium text-foreground">
@@ -479,29 +482,33 @@ function ArtifactSidebarActions({
 
 function ArtifactEditPresentationAction({ onClick }: { onClick: () => void }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Edit presentation"
-      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-    >
-      <IconPencil size={16} stroke={1.5} />
-    </button>
+    <ArtifactActionTooltip label="Edit presentation">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label="Edit presentation"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      >
+        <IconPencil size={16} stroke={1.5} />
+      </button>
+    </ArtifactActionTooltip>
   );
 }
 
 function ArtifactOpenExternalAction({ url }: { url: string }) {
   return (
-    <a
-      href={publicAttachmentUrl(url)}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label="Open in new tab"
-      data-testid="artifact-sidebar-open-external"
-      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-    >
-      <IconExternalLink size={16} />
-    </a>
+    <ArtifactActionTooltip label="Open in new tab">
+      <a
+        href={publicAttachmentUrl(url)}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open in new tab"
+        data-testid="artifact-sidebar-open-external"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      >
+        <IconExternalLink size={16} />
+      </a>
+    </ArtifactActionTooltip>
   );
 }
 
@@ -513,34 +520,40 @@ function ArtifactFullscreenAction({
   onToggleFullscreen: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onToggleFullscreen}
-      aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-      data-testid="artifact-sidebar-fullscreen-toggle"
-      className="hidden xl:inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+    <ArtifactActionTooltip
+      label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
     >
-      {fullscreen ? (
-        <IconArrowsDiagonalMinimize2 size={16} />
-      ) : (
-        <IconArrowsDiagonal size={16} />
-      )}
-    </button>
+      <button
+        type="button"
+        onClick={onToggleFullscreen}
+        aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        data-testid="artifact-sidebar-fullscreen-toggle"
+        className="hidden xl:inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      >
+        {fullscreen ? (
+          <IconArrowsDiagonalMinimize2 size={16} />
+        ) : (
+          <IconArrowsDiagonal size={16} />
+        )}
+      </button>
+    </ArtifactActionTooltip>
   );
 }
 
 function ArtifactMoreActions({ onClose }: { onClose: () => void }) {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label="More artifact actions"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-        >
-          <IconDots size={16} />
-        </button>
-      </DropdownMenuTrigger>
+      <ArtifactActionTooltip label="More artifact actions">
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="More artifact actions"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          >
+            <IconDots size={16} />
+          </button>
+        </DropdownMenuTrigger>
+      </ArtifactActionTooltip>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={onClose}>Close preview</DropdownMenuItem>
       </DropdownMenuContent>
@@ -550,15 +563,17 @@ function ArtifactMoreActions({ onClose }: { onClose: () => void }) {
 
 function ArtifactCloseAction({ onClose }: { onClose: () => void }) {
   return (
-    <button
-      type="button"
-      onClick={onClose}
-      aria-label="Close artifact"
-      data-testid="artifact-sidebar-close"
-      className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-    >
-      <IconX size={16} />
-    </button>
+    <ArtifactActionTooltip label="Close artifact">
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close artifact"
+        data-testid="artifact-sidebar-close"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      >
+        <IconX size={16} />
+      </button>
+    </ArtifactActionTooltip>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1634,39 +1634,58 @@ function ChatArtifactInboxHeader({
           </span>
         )}
       </div>
-      <button
-        type="button"
-        onClick={onToggleSearch}
-        aria-label="Search artifacts"
-        aria-pressed={searchOpen}
-        className={cn(
-          "inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
-          searchOpen && "bg-muted/60 text-foreground",
-        )}
-      >
-        <IconSearch size={16} />
-      </button>
-      <button
-        type="button"
-        onClick={onToggleFullscreen}
-        aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-        data-testid="artifact-inbox-fullscreen-toggle"
-        className="hidden h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground xl:inline-flex"
-      >
-        {fullscreen ? (
-          <IconArrowsDiagonalMinimize2 size={16} />
-        ) : (
-          <IconArrowsDiagonal size={16} />
-        )}
-      </button>
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close artifacts"
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-      >
-        <IconX size={16} />
-      </button>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onToggleSearch}
+              aria-label="Search artifacts"
+              aria-pressed={searchOpen}
+              className={cn(
+                "inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
+                searchOpen && "bg-muted/60 text-foreground",
+              )}
+            >
+              <IconSearch size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Search artifacts</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onToggleFullscreen}
+              aria-label={fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+              data-testid="artifact-inbox-fullscreen-toggle"
+              className="hidden h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground xl:inline-flex"
+            >
+              {fullscreen ? (
+                <IconArrowsDiagonalMinimize2 size={16} />
+              ) : (
+                <IconArrowsDiagonal size={16} />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {fullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close artifacts"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            >
+              <IconX size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Close artifacts</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Icon buttons in the Artifacts feature relied on `aria-label` only, so hovering them showed no tooltip. Reported from the Artifacts inbox drawer header (search / expand / close), but the audit found the same gap across the single-artifact preview sidebar.

Before this PR, the **only** artifacts icon buttons with tooltips were the left-rail cube toggle (`ArtifactsButton`) and the Share button.

## Changes

Add a shared `ArtifactActionTooltip` wrapper (in `zero-artifact-actions.tsx`, matching the existing Share tooltip's floating-layer style) and apply it across the artifacts action surfaces:

- **Inbox drawer header** (`ChatArtifactInboxHeader`): Search, Fullscreen, Close
- **Preview sidebar** (`ArtifactSidebarActions`): Back, Open-external, Edit-presentation, Fullscreen, More-actions, Close
- **Shared Download menu** trigger (`ArtifactDownloadMenu`) — also covers the artifact lightbox toolbar

Also fixes `ArtifactShareButton`: its tooltip text was hardcoded to "Share" and ignored the `ariaLabel` prop, so it now reflects the actual label (e.g. "Share artifact").

The inbox-header tooltips reuse the local `Tooltip` pattern of the sibling `ArtifactsButton` (`side="bottom"`); the portaled preview/lightbox buttons use the floating-layer wrapper so tooltips render above fullscreen content.

## Testing

- `prettier --check` clean
- `oxlint` 0 warnings / 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)