### PR TITLE
test(mitm-addon): split jsonl writer state tests

### DIFF
--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -47,9 +47,22 @@ def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
 
 def test_flush_prunes_completed_path_state(tmp_path):
     log_path = str(tmp_path / "net.jsonl")
+    flush_errors: queue.SimpleQueue[Exception] = queue.SimpleQueue()
+
+    def flush_log_path() -> None:
+        try:
+            jsonl_writer.flush_log_path(log_path)
+        except Exception as exc:
+            flush_errors.put(exc)
 
     jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
-    jsonl_writer.flush_log_path(log_path)
+    flush_thread = threading.Thread(target=flush_log_path, daemon=True)
+    flush_thread.start()
+    flush_thread.join(timeout=1)
+
+    assert not flush_thread.is_alive()
+    if not flush_errors.empty():
+        raise flush_errors.get_nowait()
 
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -31,8 +31,12 @@ def test_full_write_queue_warns_and_does_not_track_dropped_path_state(tmp_path):
 def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
     log_path = str(tmp_path / "proxy.jsonl")
 
+    def path_state_pruned() -> bool:
+        return log_path not in jsonl_writer._accepted_by_path and jsonl_writer._pending_bytes == 0
+
     jsonl_writer.write_jsonl_line(log_path, b'{"message":"done"}\n', "proxy")
-    jsonl_writer._queue.join()
+    with jsonl_writer._condition:
+        assert jsonl_writer._condition.wait_for(path_state_pruned, timeout=1)
 
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -47,7 +47,16 @@ def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
 
 def test_flush_prunes_completed_path_state(tmp_path):
     log_path = str(tmp_path / "net.jsonl")
+    append_started = threading.Event()
+    release_append = threading.Event()
+    flush_thread: threading.Thread | None = None
     flush_errors: queue.SimpleQueue[Exception] = queue.SimpleQueue()
+    original_append_lines = jsonl_writer._append_lines
+
+    def append_lines(path: str, content: bytes) -> None:
+        append_started.set()
+        release_append.wait()
+        original_append_lines(path, content)
 
     def flush_log_path() -> None:
         try:
@@ -55,11 +64,25 @@ def test_flush_prunes_completed_path_state(tmp_path):
         except Exception as exc:
             flush_errors.put(exc)
 
-    jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
-    flush_thread = threading.Thread(target=flush_log_path, daemon=True)
-    flush_thread.start()
-    flush_thread.join(timeout=1)
+    with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
+        try:
+            jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+            assert append_started.wait(timeout=1)
 
+            flush_thread = threading.Thread(target=flush_log_path, daemon=True)
+            flush_thread.start()
+
+            with jsonl_writer._condition:
+                assert jsonl_writer._condition.wait_for(
+                    lambda: jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 1,
+                    timeout=1,
+                )
+        finally:
+            release_append.set()
+            if flush_thread is not None:
+                flush_thread.join(timeout=1)
+
+    assert flush_thread is not None
     assert not flush_thread.is_alive()
     if not flush_errors.empty():
         raise flush_errors.get_nowait()

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -53,6 +53,7 @@ def test_flush_prunes_completed_path_state(tmp_path):
 
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
+    assert log_path not in jsonl_writer._flush_waiters_by_path
     assert jsonl_writer._pending_bytes == 0
 
 

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -61,7 +61,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     append_started = threading.Event()
     release_append = threading.Event()
     flush_threads: list[threading.Thread] = []
-    flush_errors: list[Exception] = []
+    flush_errors: queue.SimpleQueue[Exception] = queue.SimpleQueue()
     original_append_lines = jsonl_writer._append_lines
 
     def append_lines(path: str, content: bytes) -> None:
@@ -73,7 +73,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
         try:
             jsonl_writer.flush_log_path(log_path)
         except Exception as exc:
-            flush_errors.append(exc)
+            flush_errors.put(exc)
 
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
@@ -81,8 +81,8 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
             assert append_started.wait(timeout=1)
 
             flush_threads = [
-                threading.Thread(target=flush_log_path),
-                threading.Thread(target=flush_log_path),
+                threading.Thread(target=flush_log_path, daemon=True),
+                threading.Thread(target=flush_log_path, daemon=True),
             ]
             for thread in flush_threads:
                 thread.start()
@@ -100,7 +100,8 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     for thread in flush_threads:
         assert not thread.is_alive()
 
-    assert not flush_errors
+    if not flush_errors.empty():
+        raise flush_errors.get_nowait()
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -61,6 +61,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     append_started = threading.Event()
     release_append = threading.Event()
     flush_threads: list[threading.Thread] = []
+    flush_errors: list[Exception] = []
     original_append_lines = jsonl_writer._append_lines
 
     def append_lines(path: str, content: bytes) -> None:
@@ -68,14 +69,20 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
         release_append.wait()
         original_append_lines(path, content)
 
+    def flush_log_path() -> None:
+        try:
+            jsonl_writer.flush_log_path(log_path)
+        except Exception as exc:
+            flush_errors.append(exc)
+
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
             jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
             assert append_started.wait(timeout=1)
 
             flush_threads = [
-                threading.Thread(target=jsonl_writer.flush_log_path, args=(log_path,)),
-                threading.Thread(target=jsonl_writer.flush_log_path, args=(log_path,)),
+                threading.Thread(target=flush_log_path),
+                threading.Thread(target=flush_log_path),
             ]
             for thread in flush_threads:
                 thread.start()
@@ -93,6 +100,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     for thread in flush_threads:
         assert not thread.is_alive()
 
+    assert not flush_errors
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -1,0 +1,91 @@
+"""Tests for the asynchronous JSONL writer state machine."""
+
+import queue
+import threading
+from unittest.mock import MagicMock, patch
+
+import jsonl_writer
+
+
+def test_full_write_queue_warns_and_does_not_track_dropped_path_state(tmp_path):
+    log_path = str(tmp_path / "net.jsonl")
+    log = MagicMock()
+
+    with (
+        patch.object(jsonl_writer, "_ensure_worker_locked", return_value=True),
+        patch.object(jsonl_writer._queue, "put_nowait", side_effect=queue.Full),
+        patch.object(jsonl_writer.ctx, "log", log, create=True),
+    ):
+        jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+
+    log.warn.assert_called_once()
+    warning = log.warn.call_args.args[0]
+    assert warning == "Dropping network log because the JSONL writer backlog is full"
+    assert log_path not in jsonl_writer._accepted_by_path
+    assert log_path not in jsonl_writer._completed_by_path
+    assert log_path not in jsonl_writer._flush_waiters_by_path
+    assert not (tmp_path / "net.jsonl").exists()
+
+
+def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
+    log_path = str(tmp_path / "proxy.jsonl")
+
+    jsonl_writer.write_jsonl_line(log_path, b'{"message":"done"}\n', "proxy")
+    jsonl_writer._queue.join()
+
+    assert log_path not in jsonl_writer._accepted_by_path
+    assert log_path not in jsonl_writer._completed_by_path
+    assert log_path not in jsonl_writer._flush_waiters_by_path
+    assert (tmp_path / "proxy.jsonl").read_bytes().splitlines()
+
+
+def test_flush_prunes_completed_path_state(tmp_path):
+    log_path = str(tmp_path / "net.jsonl")
+
+    jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+    jsonl_writer.flush_log_path(log_path)
+
+    assert log_path not in jsonl_writer._accepted_by_path
+    assert log_path not in jsonl_writer._completed_by_path
+
+
+def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
+    log_path = str(tmp_path / "net.jsonl")
+    append_started = threading.Event()
+    release_append = threading.Event()
+    flush_threads: list[threading.Thread] = []
+    original_append_lines = jsonl_writer._append_lines
+
+    def append_lines(path: str, content: bytes) -> None:
+        append_started.set()
+        release_append.wait()
+        original_append_lines(path, content)
+
+    with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
+        try:
+            jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+            assert append_started.wait(timeout=1)
+
+            flush_threads = [
+                threading.Thread(target=jsonl_writer.flush_log_path, args=(log_path,)),
+                threading.Thread(target=jsonl_writer.flush_log_path, args=(log_path,)),
+            ]
+            for thread in flush_threads:
+                thread.start()
+
+            with jsonl_writer._condition:
+                assert jsonl_writer._condition.wait_for(
+                    lambda: jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 2,
+                    timeout=1,
+                )
+        finally:
+            release_append.set()
+            for thread in flush_threads:
+                thread.join(timeout=1)
+
+    for thread in flush_threads:
+        assert not thread.is_alive()
+
+    assert log_path not in jsonl_writer._accepted_by_path
+    assert log_path not in jsonl_writer._completed_by_path
+    assert log_path not in jsonl_writer._flush_waiters_by_path

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -24,7 +24,8 @@ def test_full_write_queue_warns_and_does_not_track_dropped_path_state(tmp_path):
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path
-    assert not (tmp_path / "net.jsonl").exists()
+    assert jsonl_writer._pending_bytes == 0
+    assert not (tmp_path / "net.jsonl").is_file()
 
 
 def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
@@ -36,6 +37,7 @@ def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path
+    assert jsonl_writer._pending_bytes == 0
     assert (tmp_path / "proxy.jsonl").read_bytes().splitlines()
 
 
@@ -47,6 +49,7 @@ def test_flush_prunes_completed_path_state(tmp_path):
 
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
+    assert jsonl_writer._pending_bytes == 0
 
 
 def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
@@ -89,3 +92,4 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path
+    assert jsonl_writer._pending_bytes == 0

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -1,13 +1,10 @@
 """Tests for mitm addon logging utilities."""
 
 import json
-import queue
-import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import flow_metadata_keys as metadata_keys
-import jsonl_writer
 import logging_utils
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
@@ -88,7 +85,7 @@ class TestLogNetworkEntry:
         log = MagicMock()
 
         with (
-            patch.object(jsonl_writer, "MAX_PENDING_JSONL_BYTES", 1),
+            patch.object(logging_utils.jsonl_writer, "MAX_PENDING_JSONL_BYTES", 1),
             patch.object(logging_utils.ctx, "log", log, create=True),
         ):
             logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
@@ -97,91 +94,6 @@ class TestLogNetworkEntry:
         warning = log.warn.call_args.args[0]
         assert warning == "Dropping network log because the JSONL writer backlog is full"
         assert not log_path.exists()
-
-    def test_full_write_queue_does_not_track_dropped_path_state(self, tmp_path):
-        log_path = str(tmp_path / "net.jsonl")
-        log = MagicMock()
-
-        with (
-            patch.object(jsonl_writer, "_ensure_worker_locked", return_value=True),
-            patch.object(jsonl_writer._queue, "put_nowait", side_effect=queue.Full),
-            patch.object(logging_utils.ctx, "log", log, create=True),
-        ):
-            logging_utils.log_network_entry(log_path, {"action": "ALLOW"})
-
-        log.warn.assert_called_once()
-        warning = log.warn.call_args.args[0]
-        assert warning == "Dropping network log because the JSONL writer backlog is full"
-        assert log_path not in jsonl_writer._accepted_by_path
-        assert log_path not in jsonl_writer._completed_by_path
-        assert log_path not in jsonl_writer._flush_waiters_by_path
-        assert not Path(log_path).exists()
-
-    def test_completed_write_prunes_path_state_without_explicit_flush(self, tmp_path):
-        log_path = str(tmp_path / "proxy.jsonl")
-
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_proxy_entry(log_path, "info", "done")
-            jsonl_writer._queue.join()
-
-        assert log_path not in jsonl_writer._accepted_by_path
-        assert log_path not in jsonl_writer._completed_by_path
-        assert log_path not in jsonl_writer._flush_waiters_by_path
-        assert Path(log_path).read_text().splitlines()
-
-    def test_flush_prunes_completed_path_state(self, tmp_path):
-        log_path = str(tmp_path / "net.jsonl")
-
-        with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
-            logging_utils.log_network_entry(log_path, {"action": "ALLOW"})
-            logging_utils.flush_log_path(log_path)
-
-        assert log_path not in jsonl_writer._accepted_by_path
-        assert log_path not in jsonl_writer._completed_by_path
-
-    def test_concurrent_flushes_prune_after_all_waiters_complete(self, tmp_path):
-        log_path = str(tmp_path / "net.jsonl")
-        append_started = threading.Event()
-        release_append = threading.Event()
-        flush_threads: list[threading.Thread] = []
-        original_append_lines = jsonl_writer._append_lines
-
-        def append_lines(path: str, content: bytes) -> None:
-            append_started.set()
-            release_append.wait()
-            original_append_lines(path, content)
-
-        with (
-            patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
-            patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
-        ):
-            try:
-                logging_utils.log_network_entry(log_path, {"action": "ALLOW"})
-                assert append_started.wait(timeout=1)
-
-                flush_threads = [
-                    threading.Thread(target=logging_utils.flush_log_path, args=(log_path,)),
-                    threading.Thread(target=logging_utils.flush_log_path, args=(log_path,)),
-                ]
-                for thread in flush_threads:
-                    thread.start()
-
-                with jsonl_writer._condition:
-                    assert jsonl_writer._condition.wait_for(
-                        lambda: jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 2,
-                        timeout=1,
-                    )
-            finally:
-                release_append.set()
-                for thread in flush_threads:
-                    thread.join(timeout=1)
-
-        for thread in flush_threads:
-            assert not thread.is_alive()
-
-        assert log_path not in jsonl_writer._accepted_by_path
-        assert log_path not in jsonl_writer._completed_by_path
-        assert log_path not in jsonl_writer._flush_waiters_by_path
 
 
 class TestAddFirewallMetadata:


### PR DESCRIPTION
## Summary

- Move JSONL writer state-machine coverage into a dedicated `test_jsonl_writer.py` file
- Keep `test_logging_utils.py` focused on logging wrapper behavior instead of writer private state
- Preserve coverage for dropped writes, path-state pruning, flush pruning, and concurrent flush waiter cleanup

Closes #17428

## Tests

- `python3 -m py_compile tests/test_logging_utils.py tests/test_jsonl_writer.py`
- `/tmp/mitm-addon-venv/bin/python -m pytest tests/test_logging_utils.py tests/test_jsonl_writer.py`
- `/tmp/mitm-addon-venv/bin/ruff check tests/test_logging_utils.py tests/test_jsonl_writer.py`
- `/tmp/mitm-addon-venv/bin/basedpyright -p . tests/test_logging_utils.py tests/test_jsonl_writer.py`