### PR TITLE
fix: render chat image previews at natural aspect ratio

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1457,6 +1457,12 @@ type ChatImagePreviewLinkProps = {
 const CHAT_INLINE_MEDIA_PREVIEW_CLASS =
   "inline-flex aspect-[16/10] w-[min(100%,400px)] items-center justify-center rounded-lg border border-foreground/10 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
 
+// Images render at their natural aspect ratio so screenshots that are not 16:10
+// no longer letterbox against a muted fill (the gray edges). The hairline border
+// hugs the actual image; width and height are capped to keep the thread tidy.
+const CHAT_INLINE_IMAGE_PREVIEW_CLASS =
+  "max-h-[360px] max-w-[min(100%,400px)] rounded-lg border border-foreground/10 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+
 function ChatImagePreviewLink({
   alt,
   ariaLabel,
@@ -3863,12 +3869,12 @@ function BodyContentBlocks({
               key={block.id}
               alt={block.preview.filename}
               ariaLabel={`Preview ${block.preview.filename}`}
-              imageClassName="h-full w-full object-contain"
-              linkClassName={`${CHAT_INLINE_MEDIA_PREVIEW_CLASS} bg-muted/30`}
+              imageClassName="block h-auto w-auto max-h-[360px] max-w-full object-contain"
+              linkClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
               onPreview={() => {
                 openLightbox(block.preview.url);
               }}
-              placeholderClassName="h-full w-full"
+              placeholderClassName="aspect-[4/3] w-[min(100%,260px)]"
               url={block.preview.url}
             />
           );
@@ -5104,12 +5110,12 @@ function UserMessageAttachments({
               key={a.url}
               alt={a.filename}
               ariaLabel={`Preview ${a.filename}`}
-              imageClassName="h-full w-full object-contain"
-              linkClassName={`${CHAT_INLINE_MEDIA_PREVIEW_CLASS} bg-muted/30`}
+              imageClassName="block h-auto w-auto max-h-[360px] max-w-full object-contain"
+              linkClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
               onPreview={() => {
                 onImageClick(a.url);
               }}
-              placeholderClassName="h-full w-full"
+              placeholderClassName="aspect-[4/3] w-[min(100%,260px)]"
               url={a.url}
             />
           );


### PR DESCRIPTION
## Problem

Inline chat image previews looked muddy: screenshots showed gray edges around the image. Reported by Ming with a near-square screenshot.

**Root cause** — `ChatImagePreviewLink` (`zero-chat-thread-page.tsx`) forced every image into a fixed `aspect-[16/10]` box (`CHAT_INLINE_MEDIA_PREVIEW_CLASS`) with a `bg-muted/30` fill and `object-contain`. When a screenshot isn't 16:10, `object-contain` letterboxes it and the `muted/30` fill shows through as gray bars on the sides — on top of the `border-foreground/10` hairline. That double effect is the "灰边".

## Fix — natural fit

Images now get a dedicated `CHAT_INLINE_IMAGE_PREVIEW_CLASS`:
- No forced `aspect-[16/10]`, no `bg-muted/30` fill.
- Image renders at its **own aspect ratio**, capped to `max-w-[min(100%,400px)]` and `max-h-[360px]`.
- The hairline border (`border-foreground/10`) + `rounded-lg` + hover/shadow now hug the actual image edge, so there are no letterbox bars at any aspect ratio.
- The loading skeleton gets an explicit `aspect-[4/3] w-[min(100%,260px)]` box (the link no longer has an intrinsic size while the image loads).

**Video previews are intentionally unchanged** — they keep the 16:10 `CHAT_INLINE_MEDIA_PREVIEW_CLASS`.

## Verification

Rendered the exact production classes against near-square (the reported case), wide, and tall images, plus the loading state — the border hugs the image in every case and no gray bars appear. Mockup decision board (Before/After + directions) was reviewed with Ming, who picked **natural fit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)