### PR TITLE
fix: restore completed work hover state

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2658,13 +2658,13 @@ function CompletedWorkFoldRow({
 }) {
   const label = completedWorkLabel(groups);
   return (
-    <div data-chat-completed-work-fold>
+    <div data-chat-completed-work-fold className="-mx-2">
       <button
         type="button"
         aria-expanded={expanded}
         aria-label={expanded ? "Collapse work history" : "Expand work history"}
         onClick={onToggle}
-        className="flex h-5 w-full flex-col justify-center gap-1.5 text-left"
+        className="flex h-9 w-full flex-col justify-center gap-1.5 rounded-lg px-2 text-left transition-colors hover:bg-muted/40"
       >
         <span className="block h-px w-full bg-border/40" />
         <span className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- restore the completed work fold row hover background so it reads as clickable
- use the same negative-margin/padding alignment pattern as recommended follow-up buttons
- keep the finished-run divider structure inside the fold row

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx`
- `git diff --check`
