### PR TITLE
fix: stop publishing runner running status during startup

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -60,7 +60,7 @@ use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::SharedRunCancellationMap;
-use crate::status::{RunnerMode, StatusTracker};
+use crate::status::{RunnerMode, StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 mod active_sessions;
@@ -171,6 +171,7 @@ struct LiveRunnerPublishResources<'a> {
     kmsg_handle: kmsg_log::KmsgHandle,
     dns_handle: dns::DnsProxy,
     memory_prefetch: &'a mut prefetch::MemoryPrefetchTasks,
+    status: &'a StatusTracker,
 }
 
 async fn publish_live_runner_instance_or_shutdown_startup_resources(
@@ -194,9 +195,29 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
             resources.kmsg_handle.stop().await;
             resources.dns_handle.stop().await;
             resources.memory_prefetch.drain().await;
+            resources.status.set_mode(RunnerMode::Stopped).await;
             Err(e)
         }
     }
+}
+
+async fn shutdown_startup_resources_after_factory_failure(
+    provider: &dyn JobProvider,
+    mitm: &mut proxy::MitmProxy,
+    kmsg_handle: kmsg_log::KmsgHandle,
+    dns_handle: dns::DnsProxy,
+    memory_prefetch: &mut prefetch::MemoryPrefetchTasks,
+    status: &StatusTracker,
+) {
+    memory_prefetch.cancel();
+    provider.shutdown().await;
+    if let Err(e) = mitm.kill_now().await {
+        warn!(error = %e, "failed to kill proxy after factory startup failed");
+    }
+    kmsg_handle.stop().await;
+    dns_handle.stop().await;
+    memory_prefetch.drain().await;
+    status.set_mode(RunnerMode::Stopped).await;
 }
 
 /// Load config and run the main poll loop.
@@ -303,6 +324,8 @@ pub async fn run_start(
             );
         }
     }
+    let paths = RunnerPaths::new(runner_config.base_dir.clone());
+    remove_stale_status_file(&paths.status()).await?;
 
     // Load or generate a persistent runner identity (UUID).
     let runner_id = load_or_generate_runner_id(&runner_config.base_dir).await?;
@@ -358,7 +381,6 @@ pub async fn run_start(
         .unwrap_or(1);
 
     // Start proxy before factory so proxy_port is available for netns pool.
-    let paths = RunnerPaths::new(runner_config.base_dir.clone());
     let (mut mitm, mitm_crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(deps::MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),
@@ -475,7 +497,6 @@ pub async fn run_start(
         Some(mitm.port()),
         Some(dns_handle.port()),
     ));
-    status.write_initial().await;
 
     // Create provider — handles discovery + claim + complete
     let cancel = CancellationToken::new();
@@ -552,6 +573,7 @@ pub async fn run_start(
                 kmsg_handle,
                 dns_handle,
                 memory_prefetch: &mut memory_prefetch,
+                status: status.as_ref(),
             },
         )
         .await?;
@@ -1008,15 +1030,35 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         mut mitm,
         mut mitm_crash_rx,
     } = proxy;
+    let ShutdownHandles {
+        kmsg_handle,
+        dns_handle,
+        mut memory_prefetch,
+    } = shutdown;
 
-    let mut factories = start_factories(
+    let mut factories = match start_factories(
         &runner.profiles,
         &firecracker,
         &paths.base_dir,
         &paths.home,
         runtime.as_mut(),
     )
-    .await?;
+    .await
+    {
+        Ok(factories) => factories,
+        Err(e) => {
+            shutdown_startup_resources_after_factory_failure(
+                provider_state.provider.as_ref(),
+                &mut mitm,
+                kmsg_handle,
+                dns_handle,
+                &mut memory_prefetch,
+                shared.status.as_ref(),
+            )
+            .await;
+            return Err(e);
+        }
+    };
 
     let mut jobs: JoinSet<Option<RunId>> = JoinSet::new();
     // Tracked destroy tasks — JoinSet ensures we can await all in-flight
@@ -1354,11 +1396,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
-    let ShutdownHandles {
-        kmsg_handle,
-        dns_handle,
-        mut memory_prefetch,
-    } = shutdown;
     let teardown = TeardownTimer::start();
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -225,6 +225,14 @@ pub async fn run_start(
     args: StartArgs,
     runtime_provider: &dyn RuntimeProvider,
 ) -> RunnerResult<()> {
+    run_start_with_home(args, runtime_provider, HomePaths::new).await
+}
+
+async fn run_start_with_home(
+    args: StartArgs,
+    runtime_provider: &dyn RuntimeProvider,
+    load_home: impl FnOnce() -> RunnerResult<HomePaths>,
+) -> RunnerResult<()> {
     // Register lifecycle signals (SIGTERM/SIGINT/SIGUSR1/SIGUSR2) before
     // any slow startup work. Tokio's `signal()` installs the process-wide
     // `sigaction` handler on first call; until then the default disposition
@@ -298,7 +306,7 @@ pub async fn run_start(
             runner_config.base_dir.display()
         ))
     })?;
-    let home = HomePaths::new()?;
+    let home = load_home()?;
     let mut base_dir_lock = lock::try_acquire(home.base_dir_lock(&base_dir_canonical))
         .await
         .map_err(|e| {
@@ -356,6 +364,27 @@ pub async fn run_start(
             log_paths.dir().display()
         ))
     })?;
+
+    // Create provider inputs before startup resources are allocated. These
+    // checks can fail due to config/filesystem state and should not leave
+    // runtime-owned pools behind.
+    let cancel = CancellationToken::new();
+    let http = HttpClient::new(HttpClientConfig {
+        api_url: server.url.clone(),
+        vercel_bypass: std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok(),
+    })?;
+    let name = runner_config.name;
+    let group = runner_config.group;
+    let cancel_tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let local_group_dir = if args.local {
+        let group_dir = home.groups_dir().join(&group);
+        std::fs::create_dir_all(&group_dir).map_err(|e| {
+            RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
+        })?;
+        Some(group_dir)
+    } else {
+        None
+    };
 
     // Start background prefetch of snapshot memory for all profiles.
     let mut memory_prefetch =
@@ -499,44 +528,33 @@ pub async fn run_start(
     ));
 
     // Create provider — handles discovery + claim + complete
-    let cancel = CancellationToken::new();
-    let http = HttpClient::new(HttpClientConfig {
-        api_url: server.url.clone(),
-        vercel_bypass: std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok(),
-    })?;
-    let name = runner_config.name;
-    let group = runner_config.group;
-    let cancel_tokens: SharedRunCancellationMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let (usage_flush_tx, usage_flush_rx) = mpsc::channel(1);
 
-    let (provider, group_name): (Arc<dyn JobProvider>, String) = if args.local {
-        let group_dir = home.groups_dir().join(&group);
-        std::fs::create_dir_all(&group_dir).map_err(|e| {
-            RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
-        })?;
-        let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
-        let provider = LocalProvider::new(
-            group_dir,
-            profiles,
-            cancel.clone(),
-            Arc::clone(&cancel_tokens),
-        );
-        (provider, group)
-    } else {
-        let group_name = group.clone();
-        let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
-        let provider = ApiProvider::new(
-            http.clone(),
-            server.token,
-            group,
-            profiles,
-            runner_id.clone(),
-            cancel.clone(),
-            Arc::clone(&cancel_tokens),
-        )
-        .await;
-        (provider, group_name)
-    };
+    let (provider, group_name): (Arc<dyn JobProvider>, String) =
+        if let Some(group_dir) = local_group_dir {
+            let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
+            let provider = LocalProvider::new(
+                group_dir,
+                profiles,
+                cancel.clone(),
+                Arc::clone(&cancel_tokens),
+            );
+            (provider, group)
+        } else {
+            let group_name = group.clone();
+            let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
+            let provider = ApiProvider::new(
+                http.clone(),
+                server.token,
+                group,
+                profiles,
+                runner_id.clone(),
+                cancel.clone(),
+                Arc::clone(&cancel_tokens),
+            )
+            .await;
+            (provider, group_name)
+        };
 
     let exec_config = Arc::new(ExecutorConfig {
         api_url: server.url,

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -92,6 +92,23 @@ impl sandbox::SandboxRuntime for FactoryFailingRuntime {
     }
 }
 
+struct CountingRuntimeProvider {
+    create_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl sandbox::RuntimeProvider for CountingRuntimeProvider {
+    async fn create_runtime(
+        &self,
+        _config: sandbox::RuntimeConfig,
+    ) -> sandbox::Result<Box<dyn sandbox::SandboxRuntime>> {
+        self.create_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Box::new(ShutdownRecordingRuntime {
+            shutdowns: Arc::new(AtomicUsize::new(0)),
+        }))
+    }
+}
+
 struct BlockingFactoryRuntime {
     entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
     release: tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
@@ -336,6 +353,109 @@ async fn factory_startup_failure_stops_status_and_cleans_startup_resources() {
     assert_eq!(create_calls.load(Ordering::SeqCst), 1);
     assert_eq!(runtime_shutdowns.load(Ordering::SeqCst), 1);
     wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
+}
+
+#[tokio::test]
+async fn local_provider_setup_failure_does_not_create_runtime() {
+    const ROOTFS_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const SNAPSHOT_HASH: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().join("home"));
+    let home_parent = home
+        .groups_dir()
+        .parent()
+        .expect("groups dir should have a parent")
+        .to_path_buf();
+    tokio::fs::create_dir_all(&home_parent).await.unwrap();
+    tokio::fs::write(home.groups_dir(), b"not a directory")
+        .await
+        .unwrap();
+
+    let rootfs = crate::paths::RootfsPaths::new(&home, ROOTFS_HASH);
+    let snapshot = rootfs.snapshot(SNAPSHOT_HASH);
+    tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+    tokio::fs::write(rootfs.rootfs(), b"").await.unwrap();
+    for path in [
+        snapshot.snapshot_bin(),
+        snapshot.memory_bin(),
+        snapshot.cow_img(),
+        snapshot.cow_bitmap(),
+    ] {
+        tokio::fs::write(path, b"").await.unwrap();
+    }
+    tokio::fs::write(
+        snapshot.complete_marker(),
+        sandbox_fc::SNAPSHOT_COMPLETE_MARKER_CONTENT,
+    )
+    .await
+    .unwrap();
+
+    let ca_dir = dir.path().join("ca");
+    let firecracker = dir.path().join("firecracker");
+    let kernel = dir.path().join("vmlinux");
+    tokio::fs::create_dir_all(&ca_dir).await.unwrap();
+    tokio::fs::write(&firecracker, b"").await.unwrap();
+    tokio::fs::write(&kernel, b"").await.unwrap();
+
+    let base_dir = dir.path().join("base");
+    let config_path = dir.path().join("runner.yaml");
+    tokio::fs::write(
+        &config_path,
+        format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {firecracker}
+  kernel: {kernel}
+sandbox:
+  max_concurrent: 1
+profiles:
+  vm0/default:
+    rootfs_hash: {ROOTFS_HASH}
+    snapshot_hash: {SNAPSHOT_HASH}
+    vcpu: 2
+    memory_mb: 4096
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 10240
+server:
+  url: http://localhost:0
+  token: token
+"#,
+            base_dir = base_dir.display(),
+            ca_dir = ca_dir.display(),
+            firecracker = firecracker.display(),
+            kernel = kernel.display(),
+        ),
+    )
+    .await
+    .unwrap();
+
+    let create_calls = Arc::new(AtomicUsize::new(0));
+    let provider = CountingRuntimeProvider {
+        create_calls: Arc::clone(&create_calls),
+    };
+    let error = run_start_with_home(
+        StartArgs {
+            config: config_path,
+            api_url: None,
+            token: None,
+            local: true,
+        },
+        &provider,
+        || Ok(home),
+    )
+    .await
+    .expect_err("local provider setup should fail before runtime creation");
+
+    assert!(
+        error.to_string().contains("create group dir"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(create_calls.load(Ordering::SeqCst), 0);
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -2,9 +2,9 @@ use super::super::*;
 use super::support::{
     assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
     mock_run_config_with_api_url, mock_run_config_with_delay, mock_run_config_with_overrides,
-    push_job, shutdown, test_profiles, wait_budget_count, wait_budget_exhausted_reactor,
-    wait_cancel_token, wait_cancel_token_removed, wait_discover_entered, wait_parking_state,
-    wait_status_mode, wait_usage_flush_requested,
+    mock_run_config_with_runtime, push_job, shutdown, test_profiles, wait_budget_count,
+    wait_budget_exhausted_reactor, wait_cancel_token, wait_cancel_token_removed,
+    wait_discover_entered, wait_parking_state, wait_status_mode, wait_usage_flush_requested,
 };
 
 use super::super::signals::{SignalController, SignalHandlerTask, handle_resume_signal};
@@ -13,6 +13,7 @@ use crate::provider::{ClaimedJob, CompletionAuth, JobCandidate};
 use crate::types::{HeartbeatState, HeldSessionState, SandboxReuseResult};
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 struct ShutdownRecordingProvider {
@@ -68,6 +69,84 @@ impl sandbox::SandboxRuntime for ShutdownRecordingRuntime {
     }
 }
 
+struct FactoryFailingRuntime {
+    create_calls: Arc<AtomicUsize>,
+    shutdowns: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl sandbox::SandboxRuntime for FactoryFailingRuntime {
+    async fn create_factory(
+        &self,
+        _config: sandbox::FactoryConfig,
+    ) -> sandbox::Result<Box<dyn sandbox::SandboxFactory>> {
+        self.create_calls.fetch_add(1, Ordering::SeqCst);
+        Err(sandbox::SandboxError::Initialization {
+            phase: sandbox::SandboxInitializationPhase::Factory,
+            message: "factory failed".into(),
+        })
+    }
+
+    async fn shutdown(&mut self) {
+        self.shutdowns.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+struct BlockingFactoryRuntime {
+    entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    release: tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+}
+
+impl BlockingFactoryRuntime {
+    fn new(
+        entered: tokio::sync::oneshot::Sender<()>,
+        release: tokio::sync::oneshot::Receiver<()>,
+    ) -> Self {
+        Self {
+            entered: Mutex::new(Some(entered)),
+            release: tokio::sync::Mutex::new(Some(release)),
+        }
+    }
+}
+
+#[async_trait]
+impl sandbox::SandboxRuntime for BlockingFactoryRuntime {
+    async fn create_factory(
+        &self,
+        _config: sandbox::FactoryConfig,
+    ) -> sandbox::Result<Box<dyn sandbox::SandboxFactory>> {
+        if let Some(entered) = self
+            .entered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            let _ = entered.send(());
+        }
+        let release = {
+            let mut guard = self.release.lock().await;
+            guard.take().expect("factory release should be configured")
+        };
+        let _ = release.await;
+        Ok(Box::new(sandbox_mock::MockSandboxFactory::new()))
+    }
+
+    async fn shutdown(&mut self) {}
+}
+
+async fn status_mode_if_exists(status_path: &std::path::Path) -> Option<String> {
+    let raw = match tokio::fs::read_to_string(status_path).await {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => panic!("failed to read status file {}: {e}", status_path.display()),
+    };
+    let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    status
+        .get("mode")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
 fn usage_pending_path(base_dir: &std::path::Path) -> std::path::PathBuf {
     base_dir.join("mitm-addon").join("usage-pending")
 }
@@ -120,6 +199,8 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
     let mut runtime = ShutdownRecordingRuntime {
         shutdowns: Arc::clone(&runtime_shutdowns),
     };
+    let status_path = dir.path().join("status.json");
+    let status = StatusTracker::new(status_path.clone(), 4, None, None);
     let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
     let mut ignore_term_child = tokio::process::Command::new("python3")
         .arg("-c")
@@ -178,6 +259,7 @@ while True:
                 kmsg_handle: crate::kmsg_log::KmsgHandle::noop(),
                 dns_handle: crate::dns::DnsProxy::noop(),
                 memory_prefetch: &mut memory_prefetch,
+                status: &status,
             },
         ),
     )
@@ -203,6 +285,57 @@ while True:
         !std::path::Path::new(&format!("/proc/{proxy_child_pid}")).exists(),
         "proxy child should be killed and reaped during cleanup"
     );
+    wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
+}
+
+#[tokio::test]
+async fn startup_does_not_publish_running_before_factories_are_ready() {
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let runtime = BlockingFactoryRuntime::new(entered_tx, release_rx);
+    let (config, env) =
+        mock_run_config_with_runtime(test_profiles(), 8, 32768, 4, Box::new(runtime));
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    tokio::time::timeout(Duration::from_secs(2), entered_rx)
+        .await
+        .expect("factory startup should be entered")
+        .expect("factory startup should report entry");
+    assert_ne!(
+        status_mode_if_exists(&status_path).await.as_deref(),
+        Some("running"),
+        "runner must not publish running before factories are ready",
+    );
+
+    release_tx
+        .send(())
+        .expect("runner should still be waiting for factory release");
+    wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn factory_startup_failure_stops_status_and_cleans_startup_resources() {
+    let create_calls = Arc::new(AtomicUsize::new(0));
+    let runtime_shutdowns = Arc::new(AtomicUsize::new(0));
+    let runtime = FactoryFailingRuntime {
+        create_calls: Arc::clone(&create_calls),
+        shutdowns: Arc::clone(&runtime_shutdowns),
+    };
+    let (config, env) =
+        mock_run_config_with_runtime(test_profiles(), 8, 32768, 4, Box::new(runtime));
+    let status_path = env._temp_dir.path().join("status.json");
+
+    let error = run(config).await.expect_err("factory startup should fail");
+
+    assert!(
+        error.to_string().contains("factory failed"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(create_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(runtime_shutdowns.load(Ordering::SeqCst), 1);
+    wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -111,6 +111,24 @@ fn build_mock_run_config(
     )
 }
 
+pub(in super::super) fn mock_run_config_with_runtime(
+    profiles: BTreeMap<String, config::ProfileConfig>,
+    budget_vcpu: u32,
+    budget_memory_mb: u32,
+    max_concurrent: usize,
+    runtime: Box<dyn sandbox::SandboxRuntime>,
+) -> (RunConfig, MockRunEnv) {
+    build_mock_run_config_with_runtime(
+        profiles,
+        budget_vcpu,
+        budget_memory_mb,
+        max_concurrent,
+        MockJobProvider::new,
+        runtime,
+        "http://localhost:0",
+    )
+}
+
 /// Variant that points the runner's HTTP client at an explicit URL. Used by
 /// tests that spin up an `httpmock::MockServer` to observe webhook traffic.
 pub(in super::super) fn mock_run_config_with_api_url(

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -6,7 +6,7 @@ mod wait;
 
 pub(super) use self::env::{
     MockRunEnv, mock_run_config, mock_run_config_with_api_url, mock_run_config_with_delay,
-    mock_run_config_with_overrides, test_profiles, two_profiles,
+    mock_run_config_with_overrides, mock_run_config_with_runtime, test_profiles, two_profiles,
 };
 pub(super) use self::idle_pool::{
     TestParkedIdleCandidateSpec, seed_idle_pool, seed_idle_pool_expired,

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use sandbox::SandboxId;
@@ -7,6 +7,7 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 use tracing::warn;
 
+use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 
 /// Runner lifecycle state.
@@ -240,6 +241,21 @@ impl StatusTracker {
     }
 }
 
+/// Remove a status file from a previous runner process, if present.
+///
+/// Called only after the new process owns the runner base-dir lock. This clears
+/// stale `running` snapshots before startup has reached the main reactor.
+pub async fn remove_stale_status_file(path: &Path) -> RunnerResult<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RunnerError::Config(format!(
+            "remove stale status file {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
 fn apply_idle_info_at_revision(
     state: &mut MutableState,
     revision: u64,
@@ -300,6 +316,42 @@ mod tests {
         );
         let status = read_status(&path);
         assert_eq!(status["mode"], "running");
+    }
+
+    #[tokio::test]
+    async fn remove_stale_status_file_ignores_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+
+        remove_stale_status_file(&path).await.unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn remove_stale_status_file_removes_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        std::fs::write(&path, r#"{"mode":"running"}"#).unwrap();
+
+        remove_stale_status_file(&path).await.unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remove_stale_status_file_removes_symlink_without_touching_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let target = dir.path().join("target-status");
+        std::fs::write(&target, b"keep me").unwrap();
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        remove_stale_status_file(&path).await.unwrap();
+
+        assert!(!path.exists());
+        assert_eq!(std::fs::read(&target).unwrap(), b"keep me");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- clear stale runner status after acquiring the base_dir lock
- delay publishing `running` until sandbox factories are ready
- write `stopped` after live-runner publish or factory startup failures finish cleanup
- cover stale status cleanup, publish failure, factory failure, and startup publication timing

Closes #17430

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner remove_stale_status_file`
- `cargo test --manifest-path crates/Cargo.toml -p runner live_runner_instance_publish_failure_shuts_down_startup_resources`
- `cargo test --manifest-path crates/Cargo.toml -p runner startup_does_not_publish_running_before_factories_are_ready`
- `cargo test --manifest-path crates/Cargo.toml -p runner factory_startup_failure_stops_status_and_cleans_startup_resources`
- `cargo test --manifest-path crates/Cargo.toml -p runner status`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`