### PR TITLE
fix: bound retained usage webhook retries

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -724,7 +724,6 @@ class UsageEventBuffer:
                 admission_result = self._enqueue_pending_flush(pending_flush, trigger)
             except _BatchEnqueueError as exc:
                 timer_to_start = None
-                retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
                 with self._lock:
                     retain_result = self._state.complete_admission(
                         pending_flush, exc.admission_result
@@ -743,7 +742,6 @@ class UsageEventBuffer:
                 raise exc.original from exc
             except Exception:
                 timer_to_start = None
-                retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
                 with self._lock:
                     retain_result = self._state.fail_enqueue(pending_flush, flush_generation)
                     if trigger != "shutdown":
@@ -761,7 +759,6 @@ class UsageEventBuffer:
 
             flushed_batch_count += admission_result.admitted_batch_count
             timer_to_start = None
-            retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
             with self._lock:
                 retain_result = self._state.complete_admission(pending_flush, admission_result)
                 if retain_result.retained_batches and trigger != "shutdown":

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -43,6 +43,7 @@ MAX_AGGREGATE_BUCKETS = 100
 MAX_BUFFERED_WEBHOOK_BATCHES = 4
 MAX_SOURCE_IDEMPOTENCY_KEYS = 10_000
 USAGE_EVENT_BATCH_SIZE = 100
+MAX_RETAINED_USAGE_BATCH_RETRIES = 20
 _jitter_rng = random.SystemRandom()
 
 
@@ -121,6 +122,12 @@ class _FlushBatch:
     source_event_count: int
 
 
+@dataclass(frozen=True)
+class _PendingBatch:
+    batch: _FlushBatch
+    retained_retry_count: int = 0
+
+
 @dataclass
 class _FlushSummary:
     proxy_log_path: str
@@ -136,11 +143,14 @@ class _FlushSummary:
 
 @dataclass
 class _PendingFlush:
-    source_event_count: int
     flush_sequence: int
-    batches: list[_FlushBatch]
+    batches: list[_PendingBatch]
     summaries: list[_FlushSummary]
     retry_after_flush_generation: int = 0
+
+    @property
+    def source_event_count(self) -> int:
+        return sum(pending_batch.batch.source_event_count for pending_batch in self.batches)
 
 
 @dataclass
@@ -149,20 +159,27 @@ class _DeliveringFlush:
     trigger: UsageFlushTrigger
     flush_generation: int
     remaining_batch_count: int
-    retryable_failure: bool = False
+    retryable_batches: list[_PendingBatch] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class _DeliveryCompletion:
     pending_flush: _PendingFlush
     trigger: UsageFlushTrigger
-    retryable: bool
+    retained_batches: list[_PendingBatch]
+    dropped_batches: list[_PendingBatch]
 
 
 @dataclass(frozen=True)
 class _BatchAdmissionResult:
     admitted_batch_count: int
-    retained_batches: list[_FlushBatch]
+    retained_batches: list[_PendingBatch]
+
+
+@dataclass(frozen=True)
+class _RetainBatchesResult:
+    retained_batches: list[_PendingBatch]
+    dropped_batches: list[_PendingBatch]
 
 
 class _UsageBufferState:
@@ -327,15 +344,24 @@ class _UsageBufferState:
     def complete_enqueue(self) -> None:
         self._active_enqueue_count = max(0, self._active_enqueue_count - 1)
 
-    def fail_enqueue(self, pending_flush: _PendingFlush) -> None:
+    def fail_enqueue(
+        self, pending_flush: _PendingFlush, flush_generation: int
+    ) -> _RetainBatchesResult:
         if self._delivering_flushes.pop(id(pending_flush), None) is not None:
-            pending_flush.retry_after_flush_generation = 0
-            self._pending_flushes.insert(0, pending_flush)
+            retain_result = self._retain_batches_for_retry(
+                pending_flush.flush_sequence,
+                pending_flush.batches,
+                flush_generation,
+            )
+        else:
+            retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
         self.complete_enqueue()
+        return retain_result
 
     def record_delivery_outcome(
         self,
         pending_flush: _PendingFlush,
+        pending_batch: _PendingBatch,
         outcome: WebhookDeliveryOutcome,
     ) -> _DeliveryCompletion | None:
         delivering_flush = self._delivering_flushes.get(id(pending_flush))
@@ -343,37 +369,31 @@ class _UsageBufferState:
             return None
 
         if outcome == "retryable_failure":
-            delivering_flush.retryable_failure = True
+            delivering_flush.retryable_batches.append(pending_batch)
         delivering_flush.remaining_batch_count -= 1
         if delivering_flush.remaining_batch_count > 0:
             return None
 
         del self._delivering_flushes[id(pending_flush)]
         completed_flush = delivering_flush.pending_flush
-        if delivering_flush.retryable_failure:
-            completed_flush.retry_after_flush_generation = delivering_flush.flush_generation
-            self._pending_flushes.insert(0, completed_flush)
+        retain_result = self._retain_batches_for_retry(
+            completed_flush.flush_sequence,
+            delivering_flush.retryable_batches,
+            delivering_flush.flush_generation,
+        )
         return _DeliveryCompletion(
             pending_flush=completed_flush,
             trigger=delivering_flush.trigger,
-            retryable=delivering_flush.retryable_failure,
+            retained_batches=retain_result.retained_batches,
+            dropped_batches=retain_result.dropped_batches,
         )
 
     def complete_admission(
         self, pending_flush: _PendingFlush, admission_result: _BatchAdmissionResult
-    ) -> None:
+    ) -> _RetainBatchesResult:
         delivering_flush = self._delivering_flushes.get(id(pending_flush))
+        retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
         if delivering_flush is not None and admission_result.retained_batches:
-            retained_flush = _pending_flush_from_batches(
-                pending_flush.flush_sequence,
-                admission_result.retained_batches,
-            )
-            retained_flush.retry_after_flush_generation = delivering_flush.flush_generation
-            self._pending_flushes.insert(
-                0,
-                retained_flush,
-            )
-
             admitted_batches = pending_flush.batches[: admission_result.admitted_batch_count]
             completed_outcome_count = (
                 len(pending_flush.batches) - delivering_flush.remaining_batch_count
@@ -382,21 +402,61 @@ class _UsageBufferState:
                 admission_result.admitted_batch_count - completed_outcome_count
             )
             if admitted_batches and remaining_admitted_count > 0:
-                delivering_flush.pending_flush = _pending_flush_from_batches(
+                retain_result = self._retain_batches_for_retry(
+                    pending_flush.flush_sequence,
+                    admission_result.retained_batches,
+                    delivering_flush.flush_generation,
+                )
+                delivering_flush.pending_flush = _pending_flush_from_pending_batches(
                     pending_flush.flush_sequence,
                     admitted_batches,
                 )
                 delivering_flush.remaining_batch_count = remaining_admitted_count
             else:
+                retryable_batch_ids = {
+                    id(pending_batch) for pending_batch in delivering_flush.retryable_batches
+                }
+                batches_to_retain = [
+                    pending_batch
+                    for index, pending_batch in enumerate(pending_flush.batches)
+                    if index >= admission_result.admitted_batch_count
+                    or id(pending_batch) in retryable_batch_ids
+                ]
+                retain_result = self._retain_batches_for_retry(
+                    pending_flush.flush_sequence,
+                    batches_to_retain,
+                    delivering_flush.flush_generation,
+                )
                 del self._delivering_flushes[id(pending_flush)]
-                if admitted_batches and delivering_flush.retryable_failure:
-                    admitted_flush = _pending_flush_from_batches(
-                        pending_flush.flush_sequence,
-                        admitted_batches,
-                    )
-                    admitted_flush.retry_after_flush_generation = delivering_flush.flush_generation
-                    self._pending_flushes.insert(0, admitted_flush)
         self.complete_enqueue()
+        return retain_result
+
+    def _retain_batches_for_retry(
+        self,
+        flush_sequence: int,
+        pending_batches: list[_PendingBatch],
+        flush_generation: int,
+    ) -> _RetainBatchesResult:
+        retained_batches: list[_PendingBatch] = []
+        dropped_batches: list[_PendingBatch] = []
+        for pending_batch in pending_batches:
+            if pending_batch.retained_retry_count >= MAX_RETAINED_USAGE_BATCH_RETRIES:
+                dropped_batches.append(pending_batch)
+            else:
+                retained_batches.append(
+                    _PendingBatch(
+                        batch=pending_batch.batch,
+                        retained_retry_count=pending_batch.retained_retry_count + 1,
+                    )
+                )
+        if retained_batches:
+            retained_flush = _pending_flush_from_pending_batches(flush_sequence, retained_batches)
+            retained_flush.retry_after_flush_generation = flush_generation
+            self._pending_flushes.append(retained_flush)
+        return _RetainBatchesResult(
+            retained_batches=retained_batches,
+            dropped_batches=dropped_batches,
+        )
 
     def buffered_source_event_count(self) -> int:
         return (
@@ -649,22 +709,36 @@ class UsageEventBuffer:
                 admission_result = self._enqueue_pending_flush(pending_flush, trigger)
             except Exception:
                 timer_to_start = None
+                retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
                 with self._lock:
-                    self._state.fail_enqueue(pending_flush)
+                    retain_result = self._state.fail_enqueue(pending_flush, flush_generation)
                     if trigger != "shutdown":
                         timer_to_start = self._schedule_timer_if_buffered_locked()
                     self._sync_buffered_counter_locked()
+                if retain_result.dropped_batches:
+                    _log_dropped_batches(
+                        trigger,
+                        pending_flush.flush_sequence,
+                        retain_result.dropped_batches,
+                    )
                 if timer_to_start is not None:
                     timer_to_start.start()
                 raise
 
             flushed_batch_count += admission_result.admitted_batch_count
             timer_to_start = None
+            retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
             with self._lock:
-                self._state.complete_admission(pending_flush, admission_result)
-                if admission_result.retained_batches and trigger != "shutdown":
+                retain_result = self._state.complete_admission(pending_flush, admission_result)
+                if retain_result.retained_batches and trigger != "shutdown":
                     timer_to_start = self._schedule_timer_if_buffered_locked()
                 self._sync_buffered_counter_locked()
+            if retain_result.dropped_batches:
+                _log_dropped_batches(
+                    trigger,
+                    pending_flush.flush_sequence,
+                    retain_result.dropped_batches,
+                )
             if timer_to_start is not None:
                 timer_to_start.start()
             if admission_result.retained_batches:
@@ -683,7 +757,9 @@ class UsageEventBuffer:
             admission_result = _enqueue_batches(
                 pending_flush.batches,
                 self._enqueue_webhook if self._enqueue_webhook is not None else _enqueue_webhook,
-                self._make_delivery_outcome_callback(pending_flush),
+                lambda pending_batch: self._make_delivery_outcome_callback(
+                    pending_flush, pending_batch
+                ),
             )
             _apply_retained_batch_counts(pending_flush.summaries, admission_result.retained_batches)
             _log_flush_summaries(
@@ -708,31 +784,45 @@ class UsageEventBuffer:
     def _make_delivery_outcome_callback(
         self,
         pending_flush: _PendingFlush,
+        pending_batch: _PendingBatch,
     ) -> _DeliveryOutcomeCallback:
         def callback(outcome: WebhookDeliveryOutcome) -> None:
-            self._record_delivery_outcome(pending_flush, outcome)
+            self._record_delivery_outcome(pending_flush, pending_batch, outcome)
 
         return callback
 
     def _record_delivery_outcome(
         self,
         pending_flush: _PendingFlush,
+        pending_batch: _PendingBatch,
         outcome: WebhookDeliveryOutcome,
     ) -> None:
         timer_to_start: _TimerHandle | None = None
         completion: _DeliveryCompletion | None = None
         with self._lock:
-            completion = self._state.record_delivery_outcome(pending_flush, outcome)
-            if completion is not None and completion.retryable and completion.trigger != "shutdown":
+            completion = self._state.record_delivery_outcome(pending_flush, pending_batch, outcome)
+            if (
+                completion is not None
+                and completion.retained_batches
+                and completion.trigger != "shutdown"
+            ):
                 timer_to_start = self._schedule_timer_if_buffered_locked()
             self._sync_buffered_counter_locked()
 
-        if completion is not None and completion.retryable:
+        if completion is not None and completion.retained_batches:
             _log_flush_summaries(
                 "retained",
                 completion.trigger,
                 completion.pending_flush.flush_sequence,
-                completion.pending_flush.summaries,
+                _build_flush_summaries(
+                    [pending_batch.batch for pending_batch in completion.retained_batches]
+                ),
+            )
+        if completion is not None and completion.dropped_batches:
+            _log_dropped_batches(
+                completion.trigger,
+                completion.pending_flush.flush_sequence,
+                completion.dropped_batches,
             )
         if timer_to_start is not None:
             timer_to_start.start()
@@ -797,18 +887,19 @@ class UsageEventBuffer:
 
 
 def _enqueue_batches(
-    batches: list[_FlushBatch],
+    batches: list[_PendingBatch],
     enqueue_webhook: _EnqueueWebhook,
-    delivery_outcome_callback: _DeliveryOutcomeCallback,
+    delivery_outcome_callback: Callable[[_PendingBatch], _DeliveryOutcomeCallback],
 ) -> _BatchAdmissionResult:
-    for index, batch in enumerate(batches):
+    for index, pending_batch in enumerate(batches):
+        batch = pending_batch.batch
         admitted = enqueue_webhook(
             batch.url,
             batch.sandbox_token,
             batch.payload,
             batch.proxy_log_path,
             batch.log_type,
-            delivery_outcome_callback,
+            delivery_outcome_callback(pending_batch),
         )
         if admitted is False:
             return _BatchAdmissionResult(
@@ -823,11 +914,12 @@ def _enqueue_batches(
 
 def _apply_retained_batch_counts(
     summaries: Iterable[_FlushSummary],
-    retained_batches: Iterable[_FlushBatch],
+    retained_batches: Iterable[_PendingBatch],
 ) -> None:
     retained_batch_counts: dict[str, int] = {}
     retained_source_counts: dict[str, int] = {}
-    for batch in retained_batches:
+    for pending_batch in retained_batches:
+        batch = pending_batch.batch
         retained_batch_counts[batch.proxy_log_path] = (
             retained_batch_counts.get(batch.proxy_log_path, 0) + 1
         )
@@ -860,11 +952,19 @@ def _build_flush_summaries(batches: Iterable[_FlushBatch]) -> list[_FlushSummary
 
 
 def _pending_flush_from_batches(flush_sequence: int, batches: list[_FlushBatch]) -> _PendingFlush:
+    return _pending_flush_from_pending_batches(
+        flush_sequence,
+        [_PendingBatch(batch=batch) for batch in batches],
+    )
+
+
+def _pending_flush_from_pending_batches(
+    flush_sequence: int, batches: list[_PendingBatch]
+) -> _PendingFlush:
     return _PendingFlush(
-        source_event_count=sum(batch.source_event_count for batch in batches),
         flush_sequence=flush_sequence,
         batches=batches,
-        summaries=_build_flush_summaries(batches),
+        summaries=_build_flush_summaries([pending_batch.batch for pending_batch in batches]),
     )
 
 
@@ -875,7 +975,7 @@ def _destination_priority(destination: _DestinationKey) -> int:
 def _pending_flush_priority(pending_flush: _PendingFlush) -> int:
     if not pending_flush.batches:
         return 1
-    return min(_batch_priority(batch) for batch in pending_flush.batches)
+    return min(_batch_priority(pending_batch.batch) for pending_batch in pending_flush.batches)
 
 
 def _batch_priority(batch: _FlushBatch) -> int:
@@ -888,6 +988,25 @@ def _log_type_priority(log_type: str) -> int:
     return 1
 
 
+def _log_dropped_batches(
+    trigger: UsageFlushTrigger,
+    flush_sequence: int,
+    dropped_batches: list[_PendingBatch],
+) -> None:
+    if not dropped_batches:
+        return
+    _log_flush_summaries(
+        "dropped",
+        trigger,
+        flush_sequence,
+        _build_flush_summaries([pending_batch.batch for pending_batch in dropped_batches]),
+        reason="retry_budget_exhausted",
+        retained_retry_count=max(
+            pending_batch.retained_retry_count for pending_batch in dropped_batches
+        ),
+    )
+
+
 def _log_flush_summaries(
     phase: str,
     trigger: UsageFlushTrigger,
@@ -896,6 +1015,8 @@ def _log_flush_summaries(
     *,
     duration_ms: int | None = None,
     error_type: str | None = None,
+    reason: str | None = None,
+    retained_retry_count: int | None = None,
 ) -> None:
     for summary in summaries:
         if not summary.proxy_log_path:
@@ -919,15 +1040,25 @@ def _log_flush_summaries(
             "run_count": len(summary.run_ids),
             "destination_count": len(summary.destinations),
         }
+        if phase == "dropped":
+            extra["dropped_webhook_batch_count"] = summary.webhook_batch_count
+            extra["dropped_source_event_count"] = summary.source_event_count
         if duration_ms is not None:
             extra["duration_ms"] = duration_ms
         if error_type is not None:
             extra["error_type"] = error_type
+        if reason is not None:
+            extra["reason"] = reason
+        if retained_retry_count is not None:
+            extra["retained_retry_count"] = retained_retry_count
         level = "error" if phase == "failed" else "info"
         message = f"Usage event buffer flush {phase}"
         if phase == "retained":
             level = "warn"
             message = "Usage event buffer flush retained for retry"
+        elif phase == "dropped":
+            level = "error"
+            message = "Usage event buffer flush dropped retained batches"
         elif phase == "enqueued" and summary.retained_webhook_batch_count:
             level = "warn"
             message = "Usage event buffer flush retained webhook batches for retry"

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -376,9 +376,17 @@ class _UsageBufferState:
 
         del self._delivering_flushes[id(pending_flush)]
         completed_flush = delivering_flush.pending_flush
+        retryable_batch_ids = {
+            id(pending_batch) for pending_batch in delivering_flush.retryable_batches
+        }
+        retryable_batches = [
+            pending_batch
+            for pending_batch in completed_flush.batches
+            if id(pending_batch) in retryable_batch_ids
+        ]
         retain_result = self._retain_batches_for_retry(
             completed_flush.flush_sequence,
-            delivering_flush.retryable_batches,
+            retryable_batches,
             delivering_flush.flush_generation,
         )
         return _DeliveryCompletion(

--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -176,6 +176,13 @@ class _BatchAdmissionResult:
     retained_batches: list[_PendingBatch]
 
 
+class _BatchEnqueueError(Exception):
+    def __init__(self, original: Exception, admission_result: _BatchAdmissionResult) -> None:
+        super().__init__(str(original))
+        self.original = original
+        self.admission_result = admission_result
+
+
 @dataclass(frozen=True)
 class _RetainBatchesResult:
     retained_batches: list[_PendingBatch]
@@ -715,6 +722,25 @@ class UsageEventBuffer:
 
             try:
                 admission_result = self._enqueue_pending_flush(pending_flush, trigger)
+            except _BatchEnqueueError as exc:
+                timer_to_start = None
+                retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
+                with self._lock:
+                    retain_result = self._state.complete_admission(
+                        pending_flush, exc.admission_result
+                    )
+                    if retain_result.retained_batches and trigger != "shutdown":
+                        timer_to_start = self._schedule_timer_if_buffered_locked()
+                    self._sync_buffered_counter_locked()
+                if retain_result.dropped_batches:
+                    _log_dropped_batches(
+                        trigger,
+                        pending_flush.flush_sequence,
+                        retain_result.dropped_batches,
+                    )
+                if timer_to_start is not None:
+                    timer_to_start.start()
+                raise exc.original from exc
             except Exception:
                 timer_to_start = None
                 retain_result = _RetainBatchesResult(retained_batches=[], dropped_batches=[])
@@ -779,13 +805,18 @@ class UsageEventBuffer:
             )
             return admission_result
         except Exception as exc:
+            error_type = (
+                type(exc.original).__name__
+                if isinstance(exc, _BatchEnqueueError)
+                else type(exc).__name__
+            )
             _log_flush_summaries(
                 "failed",
                 trigger,
                 pending_flush.flush_sequence,
                 pending_flush.summaries,
                 duration_ms=_elapsed_ms(started_at),
-                error_type=type(exc).__name__,
+                error_type=error_type,
             )
             raise
 
@@ -901,14 +932,23 @@ def _enqueue_batches(
 ) -> _BatchAdmissionResult:
     for index, pending_batch in enumerate(batches):
         batch = pending_batch.batch
-        admitted = enqueue_webhook(
-            batch.url,
-            batch.sandbox_token,
-            batch.payload,
-            batch.proxy_log_path,
-            batch.log_type,
-            delivery_outcome_callback(pending_batch),
-        )
+        try:
+            admitted = enqueue_webhook(
+                batch.url,
+                batch.sandbox_token,
+                batch.payload,
+                batch.proxy_log_path,
+                batch.log_type,
+                delivery_outcome_callback(pending_batch),
+            )
+        except Exception as exc:
+            raise _BatchEnqueueError(
+                exc,
+                _BatchAdmissionResult(
+                    admitted_batch_count=index,
+                    retained_batches=batches[index:],
+                ),
+            ) from exc
         if admitted is False:
             return _BatchAdmissionResult(
                 admitted_batch_count=index,

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -391,6 +391,7 @@ def _enqueue_webhook(
         )
     except RuntimeError:
         # Executor shut down (done() already called during drain).
+        fallback_started = False
         try:
             log_proxy_entry(
                 proxy_log_path,
@@ -399,6 +400,7 @@ def _enqueue_webhook(
                 type=log_type,
                 url=url,
             )
+            fallback_started = True
             _post_webhook_with_retry(
                 url,
                 sandbox_token,
@@ -407,6 +409,10 @@ def _enqueue_webhook(
                 log_type,
                 delivery_outcome_callback=delivery_outcome_callback,
             )
+        except Exception:
+            if not fallback_started:
+                decrement_pending_reports()
+            raise
         finally:
             _release_delivery_capacity()
     except Exception:

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -187,6 +187,32 @@ class TestUsagePendingCounter:
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
 
+    def test_sync_fallback_log_failure_rolls_back_pending_report(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        with (
+            patch.object(
+                usage.webhook.usage_executor, "submit", side_effect=RuntimeError("shutdown")
+            ),
+            patch.object(
+                usage.webhook, "log_proxy_entry", side_effect=[None, OSError("disk full")]
+            ),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            usage.webhook._enqueue_webhook(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                {"runId": "run-1", "events": [{"category": "tokens.input", "quantity": 1}]},
+                str(tmp_path / "proxy.jsonl"),
+                "usage_event",
+            )
+
+        assert usage.counters._pending_reports == 0
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
+        usage.write_pending_snapshot(flush_request_id="request-1")
+        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+
     def test_saturated_usage_flush_keeps_buffered_pending_snapshot(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -53,13 +53,13 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
     assert_usage_buffer_drained(enqueue)
 
 
-def test_partial_flush_failure_retries_accepted_batches_with_same_idempotency_keys(tmp_path):
-    failed_payloads = []
+def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_success(tmp_path):
+    attempted_payloads = []
 
     def fail_second_batch(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, path, log_type
-        failed_payloads.append(payload)
-        if len(failed_payloads) == 2:
+        attempted_payloads.append(payload)
+        if len(attempted_payloads) == 2:
             raise OSError("second batch rejected")
 
     enqueue = RecordingEnqueue(side_effect=fail_second_batch)
@@ -84,23 +84,80 @@ def test_partial_flush_failure_retries_accepted_batches_with_same_idempotency_ke
         usage.flush_usage_events(trigger="test")
 
     assert enqueue.call_count == 2
-    assert [payload["runId"] for payload in failed_payloads] == ["run-1", "run-2"]
+    assert [payload["runId"] for payload in attempted_payloads] == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 1
 
     enqueue.side_effect = None
     enqueue.clear()
-    assert usage.flush_usage_events(trigger="test") == 2
+    assert usage.flush_usage_events(trigger="test") == 1
 
     retry_payloads = enqueue.payloads
-    assert [
-        flushed_event["idempotencyKey"]
-        for payload in retry_payloads
-        for flushed_event in payload["events"]
-    ] == [
-        flushed_event["idempotencyKey"]
-        for payload in failed_payloads
-        for flushed_event in payload["events"]
-    ]
+    assert [payload["runId"] for payload in retry_payloads] == ["run-2"]
+    assert (
+        retry_payloads[0]["events"][0]["idempotencyKey"]
+        == attempted_payloads[1]["events"][0]["idempotencyKey"]
+    )
     assert_usage_buffer_drained(enqueue)
+
+
+def test_partial_flush_failure_waits_for_unfinished_admitted_batch(tmp_path):
+    callbacks: list[DeliveryOutcomeCallback] = []
+    attempted_runs: list[str] = []
+    retry_runs: list[str] = []
+    retrying = False
+
+    def fail_second_batch(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        run_id = payload["runId"]
+        if retrying:
+            retry_runs.append(run_id)
+            delivery_outcome_callback("success")
+            return True
+        attempted_runs.append(run_id)
+        if run_id == "run-1":
+            callbacks.append(delivery_outcome_callback)
+            return True
+        raise OSError("second batch rejected")
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=fail_second_batch)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1")],
+        proxy_log_path,
+    )
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-2",
+        [event(source_key="source-2")],
+        proxy_log_path,
+    )
+
+    with pytest.raises(OSError, match="second batch rejected"):
+        usage.flush_usage_events(trigger="test")
+
+    assert attempted_runs == ["run-1", "run-2"]
+    assert usage.counters._buffered_usage_events == 2
+
+    callbacks[0]("success")
+    assert usage.counters._buffered_usage_events == 1
+
+    retrying = True
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    assert retry_runs == ["run-2"]
+    assert usage.counters._buffered_usage_events == 0
 
 
 def test_threshold_flush_failure_preserves_retryable_payload_with_same_idempotency_key(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -503,7 +503,7 @@ def test_retryable_delivery_failure_retains_flush_and_retries_with_same_key(
     assert usage_webhook_server.request_count == drained_request_count
 
 
-def test_partial_delivery_failure_retains_whole_flush_with_same_keys(
+def test_partial_delivery_failure_retains_only_failed_batch_with_same_key(
     tmp_path,
     sync_usage_executor,
     usage_webhook_server,
@@ -532,24 +532,128 @@ def test_partial_delivery_failure_retains_whole_flush_with_same_keys(
         usage_webhook_server.requests[1].json_body(),
     ]
     assert [body["runId"] for body in first_attempts] == ["run-a", "run-b"]
+    assert usage.counters._buffered_usage_events == 1
 
     usage_webhook_server.queue_response(204)
-    usage_webhook_server.queue_response(204)
-    assert usage.flush_usage_events(trigger="test") == 2
+    assert usage.flush_usage_events(trigger="test") == 1
 
-    retry_bodies = [
-        usage_webhook_server.requests[3].json_body(),
-        usage_webhook_server.requests[4].json_body(),
-    ]
-    assert [body["runId"] for body in retry_bodies] == ["run-a", "run-b"]
-    assert [body["events"][0]["idempotencyKey"] for body in retry_bodies] == [
-        body["events"][0]["idempotencyKey"] for body in first_attempts
-    ]
+    retry_body = usage_webhook_server.requests[3].json_body()
+    assert retry_body["runId"] == "run-b"
+    assert (
+        retry_body["events"][0]["idempotencyKey"]
+        == first_attempts[1]["events"][0]["idempotencyKey"]
+    )
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
     drained_request_count = usage_webhook_server.request_count
     assert usage.flush_usage_events(trigger="test") == 0
     assert usage_webhook_server.request_count == drained_request_count
+
+
+def test_same_priority_retained_batches_retry_fifo(tmp_path):
+    callbacks: list[DeliveryOutcomeCallback] = []
+    first_attempt_runs: list[str] = []
+    retry_runs: list[str] = []
+    retrying = False
+
+    def enqueue_webhook(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        if retrying:
+            retry_runs.append(payload["runId"])
+            delivery_outcome_callback("success")
+        else:
+            first_attempt_runs.append(payload["runId"])
+            callbacks.append(delivery_outcome_callback)
+        return True
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-a",
+        [event(source_key="source-a")],
+        str(proxy_log_path),
+    )
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-b",
+        [event(source_key="source-b")],
+        str(proxy_log_path),
+    )
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert first_attempt_runs == ["run-a", "run-b"]
+
+    callbacks[0]("retryable_failure")
+    callbacks[1]("retryable_failure")
+    assert usage.counters._buffered_usage_events == 2
+
+    retrying = True
+    assert usage.flush_usage_events(trigger="test") == 2
+
+    assert retry_runs == ["run-a", "run-b"]
+    assert usage.counters._buffered_usage_events == 0
+
+
+def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
+    tmp_path,
+):
+    retrying = False
+    first_attempt_runs: list[str] = []
+    retry_runs: list[str] = []
+
+    def enqueue_webhook(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        run_id = payload["runId"]
+        if retrying:
+            retry_runs.append(run_id)
+            delivery_outcome_callback("success")
+            return True
+        first_attempt_runs.append(run_id)
+        if run_id == "run-a":
+            delivery_outcome_callback("retryable_failure")
+            return True
+        return False
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    for run_id, source_key in (("run-a", "source-a"), ("run-b", "source-b")):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            run_id,
+            [event(source_key=source_key)],
+            str(proxy_log_path),
+        )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert first_attempt_runs == ["run-a", "run-b"]
+    assert usage.counters._buffered_usage_events == 2
+
+    retrying = True
+    assert usage.flush_usage_events(trigger="test") == 2
+
+    assert retry_runs == ["run-a", "run-b"]
+    assert usage.counters._buffered_usage_events == 0
 
 
 def test_delivery_in_progress_does_not_block_live_usage_snapshot(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -606,6 +606,55 @@ def test_same_priority_retained_batches_retry_fifo(tmp_path):
     assert usage.counters._buffered_usage_events == 0
 
 
+def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_callbacks(
+    tmp_path,
+):
+    callbacks: list[DeliveryOutcomeCallback] = []
+    retry_runs: list[str] = []
+    retrying = False
+
+    def enqueue_webhook(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: DeliveryOutcomeCallback,
+    ) -> bool:
+        del url, sandbox_token, path
+        assert log_type == "usage_event"
+        if retrying:
+            retry_runs.append(payload["runId"])
+            delivery_outcome_callback("success")
+        else:
+            callbacks.append(delivery_outcome_callback)
+        return True
+
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    for run_id, source_key in (("run-a", "source-a"), ("run-b", "source-b")):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            run_id,
+            [event(source_key=source_key)],
+            str(proxy_log_path),
+        )
+
+    assert usage.flush_usage_events(trigger="test") == 2
+    assert len(callbacks) == 2
+
+    callbacks[1]("retryable_failure")
+    callbacks[0]("retryable_failure")
+    assert usage.counters._buffered_usage_events == 2
+
+    retrying = True
+    assert usage.flush_usage_events(trigger="test") == 2
+
+    assert retry_runs == ["run-a", "run-b"]
+    assert usage.counters._buffered_usage_events == 0
+
+
 def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
     tmp_path,
 ):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -8,6 +8,7 @@ import pytest
 
 import usage
 import usage.buffer as usage_buffer
+from tests.pending_helpers import assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
 from tests.usage_helpers import RecordingTimer, install_recording_usage_timer
 
@@ -574,7 +575,9 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
 
 
 def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):
+    pending_path = tmp_path / "usage-pending"
     proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.set_pending_path(str(pending_path))
 
     def enqueue_retryable_failure(
         url: str,
@@ -608,6 +611,8 @@ def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):
         timers[1].callback()
 
     assert usage.counters._buffered_usage_events == 0
+    usage.write_pending_snapshot(flush_request_id="request-1")
+    assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
     assert len(timers) == 2
     entries = flush_log_entries(proxy_log_path)
     dropped_entries = [entry for entry in entries if entry["phase"] == "dropped"]

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -2,12 +2,13 @@
 
 import threading
 from collections.abc import Callable
+from unittest.mock import patch
 
 import pytest
 
 import usage
 import usage.buffer as usage_buffer
-from tests.usage_buffer_helpers import RecordingEnqueue, event
+from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
 from tests.usage_helpers import RecordingTimer, install_recording_usage_timer
 
 
@@ -570,6 +571,89 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
 
     assert enqueued_keys == [enqueued_keys[0], enqueued_keys[0]]
     assert usage.counters._buffered_usage_events == 0
+
+
+def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):
+    proxy_log_path = tmp_path / "proxy.jsonl"
+
+    def enqueue_retryable_failure(
+        url: str,
+        sandbox_token: str,
+        payload: dict,
+        path: str,
+        log_type: str,
+        delivery_outcome_callback: Callable[[usage.webhook.WebhookDeliveryOutcome], None],
+    ) -> bool:
+        del url, sandbox_token, payload, path
+        assert log_type == "usage_event"
+        delivery_outcome_callback("retryable_failure")
+        return True
+
+    with patch.object(usage_buffer, "MAX_RETAINED_USAGE_BATCH_RETRIES", 1):
+        timers = install_recording_usage_timer(enqueue_webhook=enqueue_retryable_failure)
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "secret-token",
+            "run-1",
+            [event(source_key="source-1", quantity=10)],
+            str(proxy_log_path),
+        )
+
+        timers[0].callback()
+
+        assert usage.counters._buffered_usage_events == 1
+        assert len(timers) == 2
+        assert timers[1].started is True
+
+        timers[1].callback()
+
+    assert usage.counters._buffered_usage_events == 0
+    assert len(timers) == 2
+    entries = flush_log_entries(proxy_log_path)
+    dropped_entries = [entry for entry in entries if entry["phase"] == "dropped"]
+    assert len(dropped_entries) == 1
+    assert dropped_entries[0]["level"] == "error"
+    assert dropped_entries[0]["reason"] == "retry_budget_exhausted"
+    assert dropped_entries[0]["source_event_count"] == 1
+    assert dropped_entries[0]["dropped_source_event_count"] == 1
+    assert dropped_entries[0]["dropped_webhook_batch_count"] == 1
+    assert dropped_entries[0]["retained_retry_count"] == 1
+    assert "secret-token" not in str(dropped_entries)
+
+
+def test_shutdown_saturated_retry_budget_exhaustion_drops_without_rescheduling_timer(
+    tmp_path,
+):
+    proxy_log_path = tmp_path / "proxy.jsonl"
+
+    with patch.object(usage_buffer, "MAX_RETAINED_USAGE_BATCH_RETRIES", 1):
+        enqueue = RecordingEnqueue(return_value=False)
+        timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "secret-token",
+            "run-1",
+            [event(source_key="source-1")],
+            str(proxy_log_path),
+        )
+
+        assert usage.flush_usage_events(trigger="shutdown") == 0
+        assert usage.counters._buffered_usage_events == 1
+        assert len(timers) == 1
+        assert timers[0].cancelled is True
+
+        enqueue.clear()
+        assert usage.flush_usage_events(trigger="shutdown") == 0
+
+    enqueue.assert_called_once()
+    assert usage.counters._buffered_usage_events == 0
+    assert len(timers) == 1
+    dropped_entries = [
+        entry for entry in flush_log_entries(proxy_log_path) if entry["phase"] == "dropped"
+    ]
+    assert len(dropped_entries) == 1
+    assert dropped_entries[0]["trigger"] == "shutdown"
+    assert dropped_entries[0]["reason"] == "retry_budget_exhausted"
 
 
 def test_threshold_flush_cancels_scheduled_timer_and_allows_reschedule(tmp_path):


### PR DESCRIPTION
## Summary
- add a fixed retained retry budget for usage webhook batches
- retain retryable failures at the webhook-batch boundary so successful sibling batches are not retried or later counted as dropped
- switch same-priority retained scheduling from LIFO to FIFO and add final retry-budget-exhausted drop logs

Fixes #17452

## Tests
- `source /tmp/vm3-mitm-addon-venv/bin/activate && pytest tests/test_usage_buffer_*.py`
- `source /tmp/vm3-mitm-addon-venv/bin/activate && pytest tests`
- `source /tmp/vm3-mitm-addon-venv/bin/activate && ruff check .`
- `source /tmp/vm3-mitm-addon-venv/bin/activate && ruff format --check .`
- `source /tmp/vm3-mitm-addon-venv/bin/activate && basedpyright -p .`