### PR TITLE
Polish desktop auth status pages

### DIFF
--- a/turbo/apps/web/app/desktop-auth/DesktopAuthStatusPage.tsx
+++ b/turbo/apps/web/app/desktop-auth/DesktopAuthStatusPage.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { IconAlertCircle, IconCheck, IconLoader2 } from "@tabler/icons-react";
+import Image from "next/image";
+
+type DesktopAuthStatusTone = "loading" | "waiting" | "success" | "error";
+
+interface DesktopAuthStatusPageProps {
+  readonly children?: ReactNode;
+  readonly description: string;
+  readonly title: string;
+  readonly tone?: DesktopAuthStatusTone;
+}
+
+function StatusIcon({
+  tone,
+}: {
+  readonly tone: DesktopAuthStatusTone;
+}): React.JSX.Element | null {
+  if (tone === "loading") {
+    return (
+      <IconLoader2
+        size={34}
+        className="animate-spin text-muted-foreground"
+        stroke={1.5}
+      />
+    );
+  }
+
+  if (tone === "success") {
+    return <IconCheck size={40} className="text-lime-600" stroke={1} />;
+  }
+
+  if (tone === "error") {
+    return (
+      <IconAlertCircle size={38} className="text-destructive" stroke={1.25} />
+    );
+  }
+
+  return null;
+}
+
+export function DesktopAuthStatusPage({
+  children,
+  description,
+  title,
+  tone = "loading",
+}: DesktopAuthStatusPageProps): React.JSX.Element {
+  const showIcon = tone !== "waiting";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="w-full max-w-md overflow-hidden rounded-xl border border-border bg-card">
+        <div className="flex flex-col items-center p-10">
+          <div className="mb-8 flex items-center gap-2">
+            <Image
+              src="/assets/vm0-logo-dark.svg"
+              alt="VM0"
+              width={82}
+              height={20}
+              priority
+              className="dark:hidden"
+            />
+            <Image
+              src="/assets/vm0-logo.svg"
+              alt="VM0"
+              width={82}
+              height={20}
+              priority
+              className="hidden dark:block"
+            />
+            <span className="text-2xl text-foreground">Platform</span>
+          </div>
+          {showIcon ? (
+            <div className="mb-4 flex items-center">
+              <StatusIcon tone={tone} />
+            </div>
+          ) : null}
+          <div className="mt-4 flex flex-col items-center gap-2 text-center">
+            <h1 className="text-lg font-medium leading-7 text-foreground">
+              {title}
+            </h1>
+            <p className="text-sm leading-5 text-muted-foreground">
+              {description}
+            </p>
+          </div>
+          {children ? <div className="mt-6 w-full">{children}</div> : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/web/app/desktop-auth/callback/DesktopAuthCallbackClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/callback/DesktopAuthCallbackClient.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { IconCheck } from "@tabler/icons-react";
-import Image from "next/image";
 import { useSearchParams } from "next/navigation";
+
+import { DesktopAuthStatusPage } from "../DesktopAuthStatusPage";
 
 interface HandoffResponse {
   readonly callbackUrl?: string;
@@ -108,71 +108,23 @@ async function getDesktopAuthHandoffStatus(
   return body.status;
 }
 
-function StatusCard({
-  children,
-}: {
-  readonly children: ReactNode;
-}): React.JSX.Element {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-6">
-      <div className="w-full max-w-[400px] overflow-hidden rounded-xl border border-border bg-card">
-        <div className="flex flex-col items-center p-10">
-          <div className="mb-8 flex items-center gap-2">
-            <Image
-              src="/assets/vm0-logo-dark.svg"
-              alt="VM0"
-              width={82}
-              height={20}
-              priority
-              className="dark:hidden"
-            />
-            <Image
-              src="/assets/vm0-logo.svg"
-              alt="VM0"
-              width={82}
-              height={20}
-              priority
-              className="hidden dark:block"
-            />
-            <span className="text-2xl text-foreground">Platform</span>
-          </div>
-          {children}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function WaitingStatus(): React.JSX.Element {
   return (
-    <StatusCard>
-      <div className="mt-4 flex flex-col items-center gap-2 text-center">
-        <h1 className="text-lg font-medium leading-7 text-foreground">
-          Waiting for Zero Computer Use
-        </h1>
-        <p className="text-sm leading-5 text-muted-foreground">
-          This page will update when desktop sign-in completes.
-        </p>
-      </div>
-    </StatusCard>
+    <DesktopAuthStatusPage
+      title="Waiting for Zero Computer Use"
+      description="This page will update when desktop sign-in completes."
+      tone="waiting"
+    />
   );
 }
 
 function CompletedStatus(): React.JSX.Element {
   return (
-    <StatusCard>
-      <div className="mt-4 flex flex-col items-center gap-4">
-        <IconCheck size={40} className="text-lime-600" stroke={1} />
-        <div className="flex flex-col items-center gap-2 text-center">
-          <h1 className="text-lg font-medium leading-7 text-foreground">
-            Zero Computer Use is signed in.
-          </h1>
-          <p className="text-sm leading-5 text-muted-foreground">
-            You can close this browser window and return to the app.
-          </p>
-        </div>
-      </div>
-    </StatusCard>
+    <DesktopAuthStatusPage
+      title="Zero Computer Use is signed in."
+      description="You can close this browser window and return to the app."
+      tone="success"
+    />
   );
 }
 
@@ -250,7 +202,11 @@ export function DesktopAuthCallbackClient() {
 
   if (error) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Error: {error}</p>
+      <DesktopAuthStatusPage
+        title="Desktop sign-in failed"
+        description={error}
+        tone="error"
+      />
     );
   }
 
@@ -263,6 +219,9 @@ export function DesktopAuthCallbackClient() {
   }
 
   return (
-    <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+    <DesktopAuthStatusPage
+      title="Signing in to Zero"
+      description="Connecting this browser session to Zero Computer Use."
+    />
   );
 }

--- a/turbo/apps/web/app/desktop-auth/callback/__tests__/DesktopAuthCallbackClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/callback/__tests__/DesktopAuthCallbackClient.test.tsx
@@ -75,7 +75,7 @@ describe("DesktopAuthCallbackClient", () => {
 
     render(<DesktopAuthCallbackClient />);
 
-    expect(screen.getByText("Signing in...")).toBeTruthy();
+    expect(screen.getByText("Signing in to Zero")).toBeTruthy();
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/desktop-auth/handoff", {
         method: "POST",

--- a/turbo/apps/web/app/desktop-auth/consume/DesktopAuthConsumeClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/consume/DesktopAuthConsumeClient.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useSignIn } from "@clerk/nextjs/legacy";
 
+import { DesktopAuthStatusPage } from "../DesktopAuthStatusPage";
+
 interface DesktopAuthConsumeClientProps {
   readonly code?: string;
   readonly errorMessage?: string;
@@ -81,11 +83,18 @@ export function DesktopAuthConsumeClient({
 
   if (error) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Error: {error}</p>
+      <DesktopAuthStatusPage
+        title="Desktop sign-in failed"
+        description={error}
+        tone="error"
+      />
     );
   }
 
   return (
-    <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+    <DesktopAuthStatusPage
+      title="Signing in to Zero"
+      description="Securing your desktop session before returning to the app."
+    />
   );
 }

--- a/turbo/apps/web/app/desktop-auth/consume/__tests__/DesktopAuthConsumeClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/consume/__tests__/DesktopAuthConsumeClient.test.tsx
@@ -46,6 +46,14 @@ vi.mock("@clerk/nextjs/legacy", () => {
   };
 });
 
+vi.mock("next/image", () => {
+  return {
+    default: ({ alt, src }: { alt: string; src: string }) => {
+      return <span data-alt={alt} data-src={src} />;
+    },
+  };
+});
+
 const fetchMock = vi.fn<typeof fetch>();
 
 describe("DesktopAuthConsumeClient", () => {
@@ -87,7 +95,7 @@ describe("DesktopAuthConsumeClient", () => {
   it("exchanges the desktop auth code and activates the Clerk session", async () => {
     render(<DesktopAuthConsumeClient code="desktop-code" />);
 
-    expect(screen.getByText("Signing in...")).toBeTruthy();
+    expect(screen.getByText("Signing in to Zero")).toBeTruthy();
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/desktop-auth/consume", {
         method: "POST",
@@ -135,9 +143,8 @@ describe("DesktopAuthConsumeClient", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Error: Missing desktop sign-in code."),
-    ).toBeTruthy();
+    expect(screen.getByText("Desktop sign-in failed")).toBeTruthy();
+    expect(screen.getByText("Missing desktop sign-in code.")).toBeTruthy();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/web/app/desktop-auth/select-org/DesktopAuthSelectOrgClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/select-org/DesktopAuthSelectOrgClient.tsx
@@ -8,6 +8,7 @@ import {
   completeDesktopAuth,
   completeDesktopAuthHandoff,
 } from "../completeDesktopAuth";
+import { DesktopAuthStatusPage } from "../DesktopAuthStatusPage";
 
 const DESKTOP_AUTH_START_PATH = "/desktop-auth/start";
 
@@ -84,81 +85,64 @@ export function DesktopAuthSelectOrgClient({
 
   if (error) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Error: {error}</p>
+      <DesktopAuthStatusPage
+        title="Desktop sign-in failed"
+        description={error}
+        tone="error"
+      />
     );
   }
 
   if (!isAuthLoaded || !organizationList.isLoaded) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+      <DesktopAuthStatusPage
+        title="Signing in to Zero"
+        description="Loading the workspaces available for Zero Computer Use."
+      />
     );
   }
 
   const memberships = organizationList.userMemberships.data ?? [];
   if (memberships.length === 0) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>
-        No workspaces are available.
-      </p>
+      <DesktopAuthStatusPage
+        title="No workspaces are available"
+        description="Create or join a workspace before connecting this Mac to Zero Computer Use."
+        tone="error"
+      />
     );
   }
 
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        padding: "2rem",
-        fontFamily:
-          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-        background: "#f8fafc",
-        color: "#111827",
-      }}
+    <DesktopAuthStatusPage
+      title="Select workspace"
+      description="Choose the workspace that should receive this Mac as a Computer Use runtime."
+      tone="waiting"
     >
-      <section
-        style={{
-          maxWidth: "28rem",
-          margin: "4rem auto",
-          display: "grid",
-          gap: "1rem",
-        }}
-      >
-        <h1 style={{ margin: 0, fontSize: "1.5rem", lineHeight: 1.25 }}>
-          Select workspace
-        </h1>
-        <div style={{ display: "grid", gap: "0.75rem" }}>
-          {memberships.map((membership) => {
-            const organization = membership.organization;
-            return (
-              <button
-                key={organization.id}
-                type="button"
-                onClick={() => {
-                  selectOrganization(organization.id);
-                }}
-                disabled={selectedOrgId !== null}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  minHeight: "3.25rem",
-                  border: "1px solid #d1d5db",
-                  borderRadius: "0.5rem",
-                  padding: "0.75rem 1rem",
-                  background: "#ffffff",
-                  color: "#111827",
-                  font: "inherit",
-                  cursor: selectedOrgId === null ? "pointer" : "wait",
-                }}
-              >
-                <span>{organization.name}</span>
-                {selectedOrgId === organization.id ? (
-                  <span style={{ color: "#64748b" }}>Signing in...</span>
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
-      </section>
-    </main>
+      <div className="grid gap-3">
+        {memberships.map((membership) => {
+          const organization = membership.organization;
+          return (
+            <button
+              key={organization.id}
+              type="button"
+              onClick={() => {
+                selectOrganization(organization.id);
+              }}
+              disabled={selectedOrgId !== null}
+              aria-busy={selectedOrgId === organization.id}
+              className="flex min-h-[3.25rem] items-center justify-between rounded-lg border border-border bg-background px-4 py-3 text-left text-sm text-foreground transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-80"
+            >
+              <span className="truncate">{organization.name}</span>
+              {selectedOrgId === organization.id ? (
+                <span className="ml-3 shrink-0 text-muted-foreground">
+                  Signing in...
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </DesktopAuthStatusPage>
   );
 }

--- a/turbo/apps/web/app/desktop-auth/select-org/__tests__/DesktopAuthSelectOrgClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/select-org/__tests__/DesktopAuthSelectOrgClient.test.tsx
@@ -72,6 +72,14 @@ vi.mock("next/navigation", () => {
   };
 });
 
+vi.mock("next/image", () => {
+  return {
+    default: ({ alt, src }: { alt: string; src: string }) => {
+      return <span data-alt={alt} data-src={src} />;
+    },
+  };
+});
+
 const fetchMock = vi.fn<typeof fetch>();
 
 function installDesktopAuthBridge() {

--- a/turbo/apps/web/app/desktop-auth/start/DesktopAuthStartClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/DesktopAuthStartClient.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useTheme } from "../../components/ThemeProvider";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { getClerkAppearance } from "../../components/auth/clerk-appearance";
+import { DesktopAuthStatusPage } from "../DesktopAuthStatusPage";
 
 const DESKTOP_AUTH_CALLBACK_PATH = "/desktop-auth/callback";
 const DESKTOP_AUTH_CALLBACK_SCHEME_PARAM = "callbackScheme";
@@ -45,7 +46,10 @@ export function DesktopAuthStartClient() {
 
   if (!isLoaded || isSignedIn) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+      <DesktopAuthStatusPage
+        title="Signing in to Zero"
+        description="Checking your browser session before continuing to Zero Computer Use."
+      />
     );
   }
 

--- a/turbo/apps/web/app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx
@@ -76,6 +76,35 @@ function mockMatchMedia() {
   });
 }
 
+function mockLocalStorage() {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => {
+      return store.get(key) ?? null;
+    },
+    key: (index: number) => {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+
+  Object.defineProperty(window, "localStorage", {
+    value: storage,
+    configurable: true,
+  });
+}
+
 function renderStartClient() {
   return render(
     <ThemeProvider>
@@ -89,7 +118,7 @@ describe("DesktopAuthStartClient", () => {
     clerkState.auth = { isLoaded: true, isSignedIn: false };
     clerkState.signInProps = null;
     clerkState.searchParams = new URLSearchParams();
-    localStorage.clear();
+    mockLocalStorage();
     document.documentElement.removeAttribute("data-theme");
     mockMatchMedia();
   });
@@ -138,7 +167,7 @@ describe("DesktopAuthStartClient", () => {
 
     renderStartClient();
 
-    expect(screen.getByText("Signing in...")).toBeTruthy();
+    expect(screen.getByText("Signing in to Zero")).toBeTruthy();
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith("/desktop-auth/callback");
     });

--- a/turbo/apps/web/app/desktop-auth/token/DesktopAuthTokenClient.tsx
+++ b/turbo/apps/web/app/desktop-auth/token/DesktopAuthTokenClient.tsx
@@ -8,6 +8,7 @@ import {
   completeDesktopAuth,
   completeDesktopAuthHandoff,
 } from "../completeDesktopAuth";
+import { DesktopAuthStatusPage } from "../DesktopAuthStatusPage";
 
 const DESKTOP_AUTH_START_PATH = "/desktop-auth/start";
 const DESKTOP_AUTH_SELECT_ORG_PATH = "/desktop-auth/select-org";
@@ -79,11 +80,18 @@ export function DesktopAuthTokenClient() {
 
   if (error) {
     return (
-      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Error: {error}</p>
+      <DesktopAuthStatusPage
+        title="Desktop sign-in failed"
+        description={error}
+        tone="error"
+      />
     );
   }
 
   return (
-    <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+    <DesktopAuthStatusPage
+      title="Signing in to Zero"
+      description="Finishing the secure handoff to Zero Computer Use."
+    />
   );
 }

--- a/turbo/apps/web/app/desktop-auth/token/__tests__/DesktopAuthTokenClient.test.tsx
+++ b/turbo/apps/web/app/desktop-auth/token/__tests__/DesktopAuthTokenClient.test.tsx
@@ -72,6 +72,14 @@ vi.mock("next/navigation", () => {
   };
 });
 
+vi.mock("next/image", () => {
+  return {
+    default: ({ alt, src }: { alt: string; src: string }) => {
+      return <span data-alt={alt} data-src={src} />;
+    },
+  };
+});
+
 const fetchMock = vi.fn<typeof fetch>();
 
 function installDesktopAuthBridge() {
@@ -131,7 +139,7 @@ describe("DesktopAuthTokenClient", () => {
 
     render(<DesktopAuthTokenClient />);
 
-    expect(screen.getByText("Signing in...")).toBeTruthy();
+    expect(screen.getByText("Signing in to Zero")).toBeTruthy();
     await waitFor(() => {
       expect(clerkState.auth.getToken).toHaveBeenCalledWith({
         skipCache: true,


### PR DESCRIPTION
## Summary
- Add a shared Desktop auth status page for branded loading, waiting, success, and error states
- Replace bare `Signing in...` / error fallback text across Desktop auth routes
- Bring workspace selection into the same branded status shell

## Validation
- `pnpm format`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm -F web exec vitest run app/desktop-auth/start/__tests__/DesktopAuthStartClient.test.tsx app/desktop-auth/callback/__tests__/DesktopAuthCallbackClient.test.tsx app/desktop-auth/consume/__tests__/DesktopAuthConsumeClient.test.tsx app/desktop-auth/token/__tests__/DesktopAuthTokenClient.test.tsx app/desktop-auth/select-org/__tests__/DesktopAuthSelectOrgClient.test.tsx`
- `pnpm knip --workspace web`
