### PR TITLE
fix: isolate completed work hover scope

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1484,6 +1484,7 @@ describe("chat lifecycle", () => {
       '[data-role="assistant"]',
     ) as HTMLElement | null;
     expect(foldedAssistantGroup).not.toBeNull();
+    expect(foldedAssistantGroup).not.toHaveClass("group");
     expect(
       within(foldedAssistantGroup!).getAllByLabelText("View agent profile"),
     ).toHaveLength(1);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5479,7 +5479,7 @@ function PagedAssistantGroup({
     <div
       id={groupElementId}
       data-role="assistant"
-      className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
+      className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
     >
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />


### PR DESCRIPTION
## Summary

- remove the generic Tailwind group scope from assistant message groups so completed work rows only use their own hover state
- add a regression assertion for the completed work folding DOM boundary

## Tests

- pnpm install --frozen-lockfile
- pnpm format
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
