### PR TITLE
fix: distinguish preparing runner jobs from running sandboxes

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -40,8 +40,8 @@ const RECHECK_DELAY: Duration = Duration::from_secs(3);
 /// when anomalies persist across all attempts; zero overhead when healthy).
 const RECHECK_MAX_ATTEMPTS: u32 = 3;
 
-/// Grace period where a freshly claimed new-sandbox run may not have spawned
-/// Firecracker yet.
+/// Grace period where a freshly claimed new-sandbox run may still be preparing
+/// and may not have a stable Firecracker process yet.
 const PREPARING_NO_PROCESS_GRACE: Duration = Duration::from_secs(120);
 
 /// A detected anomaly that carries enough context to recheck itself.
@@ -335,7 +335,8 @@ struct JobReport {
 enum JobStatus {
     /// Active run with a matching firecracker process.
     Running { run_id: String, pid: u32 },
-    /// Active run is preparing a fresh sandbox; Firecracker is not expected yet.
+    /// Active run is still preparing a fresh sandbox; Firecracker may not exist
+    /// or may not be ready yet.
     Preparing { run_id: String },
     /// Active run whose firecracker process is missing.
     NoProcess { run_id: String },

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -11,6 +11,7 @@ use crate::error::RunnerResult;
 use crate::live_runner_instances::LiveRunnerInstance;
 use crate::paths::HomePaths;
 use crate::process;
+use chrono::{DateTime, Utc};
 use clap::Args;
 use serde::Deserialize;
 
@@ -38,6 +39,10 @@ const RECHECK_DELAY: Duration = Duration::from_secs(3);
 /// Worst-case latency: `RECHECK_MAX_ATTEMPTS × RECHECK_DELAY` = 9 s (only
 /// when anomalies persist across all attempts; zero overhead when healthy).
 const RECHECK_MAX_ATTEMPTS: u32 = 3;
+
+/// Grace period where a freshly claimed new-sandbox run may not have spawned
+/// Firecracker yet.
+const PREPARING_NO_PROCESS_GRACE: Duration = Duration::from_secs(120);
 
 /// A detected anomaly that carries enough context to recheck itself.
 enum Warning {
@@ -205,11 +210,9 @@ impl Warning {
                 if fc_found {
                     return false;
                 }
-                // Resolved if the run itself is no longer active. We key on
-                // `run_id`, not `sandbox_id`: if the run finished and its
-                // sandbox got reused by another run, the reused sandbox is
-                // that other run's concern — this warning pertains to the
-                // original run and should clear.
+                // Resolved if the original run/sandbox mapping is no longer
+                // active. If the run finished or the same run id points at a
+                // replacement sandbox, this warning no longer applies.
                 //
                 // On status-read failure we clear (return `false`) rather
                 // than persist: if the runner's status.json is gone, any
@@ -217,7 +220,11 @@ impl Warning {
                 // instead, and keeping a stale run-centric warning would
                 // be noise.
                 match read_status(base_dir).await {
-                    Some(st) => st.active_runs.iter().any(|r| r.run_id == *run_id),
+                    Some(st) => st
+                        .active_runs
+                        .iter()
+                        .find(|r| r.run_id == *run_id && r.sandbox_id == *sandbox_id)
+                        .is_some_and(|active| missing_firecracker_should_warn(active, Utc::now())),
                     None => false,
                 }
             }
@@ -328,6 +335,8 @@ struct JobReport {
 enum JobStatus {
     /// Active run with a matching firecracker process.
     Running { run_id: String, pid: u32 },
+    /// Active run is preparing a fresh sandbox; Firecracker is not expected yet.
+    Preparing { run_id: String },
     /// Active run whose firecracker process is missing.
     NoProcess { run_id: String },
     /// Firecracker process present but not recorded in status.json.
@@ -811,6 +820,24 @@ struct StatusFile {
 struct ActiveRun {
     run_id: String,
     sandbox_id: String,
+    phase: Option<String>,
+    phase_started_at: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ActiveRunPhase {
+    Preparing,
+    Running,
+}
+
+impl ActiveRun {
+    fn phase(&self) -> ActiveRunPhase {
+        match self.phase.as_deref() {
+            Some("preparing") => ActiveRunPhase::Preparing,
+            Some("running") | None => ActiveRunPhase::Running,
+            Some(_) => ActiveRunPhase::Running,
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -884,6 +911,27 @@ async fn check_api(config: &RunnerConfig) -> Option<bool> {
 // Job correlation
 // ---------------------------------------------------------------------------
 
+fn missing_firecracker_should_warn(active: &ActiveRun, now: DateTime<Utc>) -> bool {
+    match active.phase() {
+        ActiveRunPhase::Running => true,
+        ActiveRunPhase::Preparing => preparing_run_is_stale(active, now),
+    }
+}
+
+fn preparing_run_is_stale(active: &ActiveRun, now: DateTime<Utc>) -> bool {
+    let Some(phase_started_at) = active.phase_started_at.as_deref() else {
+        return true;
+    };
+    let Ok(started_at) = DateTime::parse_from_rfc3339(phase_started_at) else {
+        return true;
+    };
+    let elapsed = now.signed_duration_since(started_at.with_timezone(&Utc));
+    match elapsed.to_std() {
+        Ok(elapsed) => elapsed >= PREPARING_NO_PROCESS_GRACE,
+        Err(_) => false,
+    }
+}
+
 fn correlate_jobs(
     status: &StatusInfo,
     base_dir: &Path,
@@ -899,6 +947,7 @@ fn correlate_jobs(
         .collect();
 
     // For each active run, find the FC hosting its sandbox_id.
+    let now = Utc::now();
     for active in &status.active_runs {
         let fc = my_fcs.iter().find(|p| p.sandbox_id == active.sandbox_id);
         let status_variant = match fc {
@@ -907,13 +956,19 @@ fn correlate_jobs(
                 pid: p.pid,
             },
             None => {
-                warnings.push(Warning::NoFirecrackerForRun {
-                    run_id: active.run_id.clone(),
-                    sandbox_id: active.sandbox_id.clone(),
-                    base_dir: base_dir.to_path_buf(),
-                });
-                JobStatus::NoProcess {
-                    run_id: active.run_id.clone(),
+                if missing_firecracker_should_warn(active, now) {
+                    warnings.push(Warning::NoFirecrackerForRun {
+                        run_id: active.run_id.clone(),
+                        sandbox_id: active.sandbox_id.clone(),
+                        base_dir: base_dir.to_path_buf(),
+                    });
+                    JobStatus::NoProcess {
+                        run_id: active.run_id.clone(),
+                    }
+                } else {
+                    JobStatus::Preparing {
+                        run_id: active.run_id.clone(),
+                    }
                 }
             }
         };
@@ -1164,7 +1219,9 @@ fn print_report(
                 .filter(|j| {
                     matches!(
                         j.status,
-                        JobStatus::Running { .. } | JobStatus::NoProcess { .. }
+                        JobStatus::Running { .. }
+                            | JobStatus::Preparing { .. }
+                            | JobStatus::NoProcess { .. }
                     )
                 })
                 .count();
@@ -1173,6 +1230,9 @@ fn print_report(
                 match &job.status {
                     JobStatus::Running { run_id, pid } => {
                         println!("      - run {run_id} -> PID {pid}");
+                    }
+                    JobStatus::Preparing { run_id } => {
+                        println!("      - run {run_id} -> PREPARING");
                     }
                     JobStatus::NoProcess { run_id } => {
                         println!("      - run {run_id} -> NO PROCESS");
@@ -1322,17 +1382,54 @@ mod tests {
         assert_eq!(parse_netns_list_line("vm0-ns-ff-00"), None);
     }
 
+    fn legacy_active_run(run_id: &str, sandbox_id: &str) -> ActiveRun {
+        ActiveRun {
+            run_id: run_id.into(),
+            sandbox_id: sandbox_id.into(),
+            phase: None,
+            phase_started_at: None,
+        }
+    }
+
+    fn phased_active_run(
+        run_id: &str,
+        sandbox_id: &str,
+        phase: &str,
+        phase_started_at: Option<String>,
+    ) -> ActiveRun {
+        ActiveRun {
+            run_id: run_id.into(),
+            sandbox_id: sandbox_id.into(),
+            phase: Some(phase.into()),
+            phase_started_at,
+        }
+    }
+
+    fn phase_started_at_ago(age: Duration) -> String {
+        let age = chrono::Duration::from_std(age).unwrap();
+        (Utc::now() - age)
+            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+            .to_string()
+    }
+
     fn status_info(active: Vec<(&str, &str)>, idle_sandboxes: Vec<&str>) -> StatusInfo {
+        status_info_with_active_runs(
+            active
+                .into_iter()
+                .map(|(run_id, sandbox_id)| legacy_active_run(run_id, sandbox_id))
+                .collect(),
+            idle_sandboxes,
+        )
+    }
+
+    fn status_info_with_active_runs(
+        active_runs: Vec<ActiveRun>,
+        idle_sandboxes: Vec<&str>,
+    ) -> StatusInfo {
         StatusInfo {
             mode: "running".into(),
             started_at: "2026-01-01T00:00:00.000Z".into(),
-            active_runs: active
-                .into_iter()
-                .map(|(r, s)| ActiveRun {
-                    run_id: r.into(),
-                    sandbox_id: s.into(),
-                })
-                .collect(),
+            active_runs,
             // Tests only need sandbox_id lookup for idle VMs; synthesize a
             // placeholder session_id.
             idle_vms: idle_sandboxes
@@ -1422,6 +1519,80 @@ mod tests {
         assert!(msg.contains("no firecracker"), "{msg}");
         assert!(msg.contains("run-x"), "{msg}");
         assert!(msg.contains("sandbox-x"), "{msg}");
+    }
+
+    #[test]
+    fn correlate_preparing_active_without_fc_within_grace_does_not_warn() {
+        let status = status_info_with_active_runs(
+            vec![phased_active_run(
+                "run-prep",
+                "sandbox-prep",
+                "preparing",
+                Some(phase_started_at_ago(Duration::from_secs(5))),
+            )],
+            vec![],
+        );
+        let fc: Vec<process::FirecrackerProcessInfo> = vec![];
+
+        let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
+
+        assert_eq!(jobs.len(), 1);
+        assert!(warnings.is_empty());
+        assert!(matches!(
+            jobs.first().unwrap().status,
+            JobStatus::Preparing { .. }
+        ));
+    }
+
+    #[test]
+    fn correlate_preparing_active_without_fc_beyond_grace_warns() {
+        let status = status_info_with_active_runs(
+            vec![phased_active_run(
+                "run-stale",
+                "sandbox-stale",
+                "preparing",
+                Some(phase_started_at_ago(
+                    PREPARING_NO_PROCESS_GRACE + Duration::from_secs(1),
+                )),
+            )],
+            vec![],
+        );
+        let fc: Vec<process::FirecrackerProcessInfo> = vec![];
+
+        let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
+
+        assert_eq!(jobs.len(), 1);
+        assert!(matches!(
+            jobs.first().unwrap().status,
+            JobStatus::NoProcess { .. }
+        ));
+        assert_eq!(warnings.len(), 1);
+        let msg = warnings[0].to_string();
+        assert!(msg.contains("run-stale"), "{msg}");
+        assert!(msg.contains("sandbox-stale"), "{msg}");
+    }
+
+    #[test]
+    fn correlate_preparing_active_without_timestamp_warns() {
+        let status = status_info_with_active_runs(
+            vec![phased_active_run(
+                "run-missing-ts",
+                "sandbox-missing-ts",
+                "preparing",
+                None,
+            )],
+            vec![],
+        );
+        let fc: Vec<process::FirecrackerProcessInfo> = vec![];
+
+        let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
+
+        assert_eq!(jobs.len(), 1);
+        assert!(matches!(
+            jobs.first().unwrap().status,
+            JobStatus::NoProcess { .. }
+        ));
+        assert_eq!(warnings.len(), 1);
     }
 
     #[test]
@@ -1553,6 +1724,98 @@ mod tests {
         };
         // R1 is still active and there's no FC in fresh. Warning persists.
         assert!(warning.persists(&empty_fresh(), &[]).await);
+    }
+
+    #[tokio::test]
+    async fn no_firecracker_for_run_clears_for_preparing_run_within_grace() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        let phase_started_at = phase_started_at_ago(Duration::from_secs(10));
+        write_status_json(
+            &base_dir.join("status.json"),
+            &format!(
+                r#"{{
+                    "mode": "running",
+                    "max_concurrent": 4,
+                    "active_runs": [
+                        {{
+                            "run_id": "R1",
+                            "sandbox_id": "S1",
+                            "phase": "preparing",
+                            "phase_started_at": "{phase_started_at}"
+                        }}
+                    ],
+                    "started_at": "2026-01-01T00:00:00.000Z",
+                    "updated_at": "2026-01-01T00:00:00.000Z"
+                }}"#
+            ),
+        );
+
+        let warning = Warning::NoFirecrackerForRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            base_dir: base_dir.clone(),
+        };
+        assert!(!warning.persists(&empty_fresh(), &[]).await);
+    }
+
+    #[tokio::test]
+    async fn no_firecracker_for_run_persists_for_stale_preparing_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        let phase_started_at =
+            phase_started_at_ago(PREPARING_NO_PROCESS_GRACE + Duration::from_secs(1));
+        write_status_json(
+            &base_dir.join("status.json"),
+            &format!(
+                r#"{{
+                    "mode": "running",
+                    "max_concurrent": 4,
+                    "active_runs": [
+                        {{
+                            "run_id": "R1",
+                            "sandbox_id": "S1",
+                            "phase": "preparing",
+                            "phase_started_at": "{phase_started_at}"
+                        }}
+                    ],
+                    "started_at": "2026-01-01T00:00:00.000Z",
+                    "updated_at": "2026-01-01T00:00:00.000Z"
+                }}"#
+            ),
+        );
+
+        let warning = Warning::NoFirecrackerForRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            base_dir: base_dir.clone(),
+        };
+        assert!(warning.persists(&empty_fresh(), &[]).await);
+    }
+
+    #[tokio::test]
+    async fn no_firecracker_for_run_clears_when_same_run_points_to_new_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        write_status_json(
+            &base_dir.join("status.json"),
+            r#"{
+                "mode": "running",
+                "max_concurrent": 4,
+                "active_runs": [
+                    {"run_id": "R1", "sandbox_id": "S2"}
+                ],
+                "started_at": "2026-01-01T00:00:00.000Z",
+                "updated_at": "2026-01-01T00:00:00.000Z"
+            }"#,
+        );
+
+        let warning = Warning::NoFirecrackerForRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            base_dir: base_dir.clone(),
+        };
+        assert!(!warning.persists(&empty_fresh(), &[]).await);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -60,6 +60,12 @@ enum Warning {
         sandbox_id: String,
         base_dir: PathBuf,
     },
+    /// status.json lists a run that has remained in preparing too long.
+    StalePreparingRun {
+        run_id: String,
+        sandbox_id: String,
+        base_dir: PathBuf,
+    },
     /// A firecracker process exists but its sandbox_id is not tracked in
     /// either `active_runs` or `idle_vms` for this runner.
     FirecrackerNotInStatus {
@@ -108,6 +114,11 @@ impl fmt::Display for Warning {
                     f,
                     "no firecracker process for run {run_id} (sandbox {sandbox_id})"
                 )
+            }
+            Self::StalePreparingRun {
+                run_id, sandbox_id, ..
+            } => {
+                write!(f, "run {run_id} stuck preparing (sandbox {sandbox_id})")
             }
             Self::FirecrackerNotInStatus {
                 pid, sandbox_id, ..
@@ -204,10 +215,7 @@ impl Warning {
                 base_dir,
             } => {
                 // Resolved if firecracker process now exists for this sandbox_id.
-                let fc_found = fresh.firecrackers.iter().any(|f| {
-                    f.sandbox_id == *sandbox_id && f.base_dir.as_deref() == Some(base_dir.as_path())
-                });
-                if fc_found {
+                if firecracker_found_for_sandbox(fresh, sandbox_id, base_dir) {
                     return false;
                 }
                 // Resolved if the original run/sandbox mapping is no longer
@@ -224,10 +232,26 @@ impl Warning {
                         .active_runs
                         .iter()
                         .find(|r| r.run_id == *run_id && r.sandbox_id == *sandbox_id)
-                        .is_some_and(|active| missing_firecracker_should_warn(active, Utc::now())),
+                        .is_some_and(|active| active.phase() == ActiveRunPhase::Running),
                     None => false,
                 }
             }
+            Self::StalePreparingRun {
+                run_id,
+                sandbox_id,
+                base_dir,
+            } => match read_status(base_dir).await {
+                Some(st) => st
+                    .active_runs
+                    .iter()
+                    .find(|r| r.run_id == *run_id && r.sandbox_id == *sandbox_id)
+                    .is_some_and(|active| {
+                        active_run_is_stale_preparing(active, Utc::now())
+                            || (active.phase() == ActiveRunPhase::Running
+                                && !firecracker_found_for_sandbox(fresh, sandbox_id, base_dir))
+                    }),
+                None => false,
+            },
             Self::FirecrackerNotInStatus {
                 pid,
                 sandbox_id,
@@ -284,6 +308,17 @@ fn pid_exists(pid: u32) -> bool {
     Path::new(&format!("/proc/{pid}")).exists()
 }
 
+fn firecracker_found_for_sandbox(
+    fresh: &process::DiscoveredProcesses,
+    sandbox_id: &str,
+    base_dir: &Path,
+) -> bool {
+    fresh
+        .firecrackers
+        .iter()
+        .any(|f| f.sandbox_id == sandbox_id && f.base_dir.as_deref() == Some(base_dir))
+}
+
 // ---------------------------------------------------------------------------
 // Report structs
 // ---------------------------------------------------------------------------
@@ -337,7 +372,7 @@ enum JobStatus {
     Running { run_id: String, pid: u32 },
     /// Active run is still preparing a fresh sandbox; Firecracker may not exist
     /// or may not be ready yet.
-    Preparing { run_id: String },
+    Preparing { run_id: String, pid: Option<u32> },
     /// Active run whose firecracker process is missing.
     NoProcess { run_id: String },
     /// Firecracker process present but not recorded in status.json.
@@ -912,13 +947,6 @@ async fn check_api(config: &RunnerConfig) -> Option<bool> {
 // Job correlation
 // ---------------------------------------------------------------------------
 
-fn missing_firecracker_should_warn(active: &ActiveRun, now: DateTime<Utc>) -> bool {
-    match active.phase() {
-        ActiveRunPhase::Running => true,
-        ActiveRunPhase::Preparing => preparing_run_is_stale(active, now),
-    }
-}
-
 fn preparing_run_is_stale(active: &ActiveRun, now: DateTime<Utc>) -> bool {
     let Some(phase_started_at) = active.phase_started_at.as_deref() else {
         return true;
@@ -931,6 +959,10 @@ fn preparing_run_is_stale(active: &ActiveRun, now: DateTime<Utc>) -> bool {
         Ok(elapsed) => elapsed >= PREPARING_NO_PROCESS_GRACE,
         Err(_) => false,
     }
+}
+
+fn active_run_is_stale_preparing(active: &ActiveRun, now: DateTime<Utc>) -> bool {
+    active.phase() == ActiveRunPhase::Preparing && preparing_run_is_stale(active, now)
 }
 
 fn correlate_jobs(
@@ -951,13 +983,13 @@ fn correlate_jobs(
     let now = Utc::now();
     for active in &status.active_runs {
         let fc = my_fcs.iter().find(|p| p.sandbox_id == active.sandbox_id);
-        let status_variant = match fc {
-            Some(p) => JobStatus::Running {
-                run_id: active.run_id.clone(),
-                pid: p.pid,
-            },
-            None => {
-                if missing_firecracker_should_warn(active, now) {
+        let status_variant = match active.phase() {
+            ActiveRunPhase::Running => match fc {
+                Some(p) => JobStatus::Running {
+                    run_id: active.run_id.clone(),
+                    pid: p.pid,
+                },
+                None => {
                     warnings.push(Warning::NoFirecrackerForRun {
                         run_id: active.run_id.clone(),
                         sandbox_id: active.sandbox_id.clone(),
@@ -966,10 +998,25 @@ fn correlate_jobs(
                     JobStatus::NoProcess {
                         run_id: active.run_id.clone(),
                     }
-                } else {
-                    JobStatus::Preparing {
+                }
+            },
+            ActiveRunPhase::Preparing => {
+                if preparing_run_is_stale(active, now) {
+                    warnings.push(Warning::StalePreparingRun {
                         run_id: active.run_id.clone(),
-                    }
+                        sandbox_id: active.sandbox_id.clone(),
+                        base_dir: base_dir.to_path_buf(),
+                    });
+                }
+                match fc {
+                    Some(p) => JobStatus::Preparing {
+                        run_id: active.run_id.clone(),
+                        pid: Some(p.pid),
+                    },
+                    None => JobStatus::Preparing {
+                        run_id: active.run_id.clone(),
+                        pid: None,
+                    },
                 }
             }
         };
@@ -1232,8 +1279,12 @@ fn print_report(
                     JobStatus::Running { run_id, pid } => {
                         println!("      - run {run_id} -> PID {pid}");
                     }
-                    JobStatus::Preparing { run_id } => {
-                        println!("      - run {run_id} -> PREPARING");
+                    JobStatus::Preparing { run_id, pid } => {
+                        if let Some(pid) = pid {
+                            println!("      - run {run_id} -> PREPARING (PID {pid})");
+                        } else {
+                            println!("      - run {run_id} -> PREPARING");
+                        }
                     }
                     JobStatus::NoProcess { run_id } => {
                         println!("      - run {run_id} -> NO PROCESS");
@@ -1565,12 +1616,67 @@ mod tests {
         assert_eq!(jobs.len(), 1);
         assert!(matches!(
             jobs.first().unwrap().status,
-            JobStatus::NoProcess { .. }
+            JobStatus::Preparing { pid: None, .. }
         ));
         assert_eq!(warnings.len(), 1);
         let msg = warnings[0].to_string();
+        assert!(msg.contains("stuck preparing"), "{msg}");
         assert!(msg.contains("run-stale"), "{msg}");
         assert!(msg.contains("sandbox-stale"), "{msg}");
+    }
+
+    #[test]
+    fn correlate_preparing_active_with_fc_within_grace_stays_preparing() {
+        let status = status_info_with_active_runs(
+            vec![phased_active_run(
+                "run-prep",
+                "sandbox-prep",
+                "preparing",
+                Some(phase_started_at_ago(Duration::from_secs(5))),
+            )],
+            vec![],
+        );
+        let fc = vec![fc_info(123, "sandbox-prep", "/data/r1")];
+
+        let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
+
+        assert_eq!(jobs.len(), 1);
+        assert!(warnings.is_empty());
+        let JobStatus::Preparing { run_id, pid } = &jobs.first().unwrap().status else {
+            panic!("expected preparing job");
+        };
+        assert_eq!(run_id, "run-prep");
+        assert_eq!(*pid, Some(123));
+    }
+
+    #[test]
+    fn correlate_preparing_active_with_fc_beyond_grace_warns() {
+        let status = status_info_with_active_runs(
+            vec![phased_active_run(
+                "run-stale-with-fc",
+                "sandbox-stale-with-fc",
+                "preparing",
+                Some(phase_started_at_ago(
+                    PREPARING_NO_PROCESS_GRACE + Duration::from_secs(1),
+                )),
+            )],
+            vec![],
+        );
+        let fc = vec![fc_info(456, "sandbox-stale-with-fc", "/data/r1")];
+
+        let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
+
+        assert_eq!(jobs.len(), 1);
+        let JobStatus::Preparing { run_id, pid } = &jobs.first().unwrap().status else {
+            panic!("expected preparing job");
+        };
+        assert_eq!(run_id, "run-stale-with-fc");
+        assert_eq!(*pid, Some(456));
+        assert_eq!(warnings.len(), 1);
+        let msg = warnings[0].to_string();
+        assert!(msg.contains("stuck preparing"), "{msg}");
+        assert!(msg.contains("run-stale-with-fc"), "{msg}");
+        assert!(msg.contains("sandbox-stale-with-fc"), "{msg}");
     }
 
     #[test]
@@ -1591,7 +1697,7 @@ mod tests {
         assert_eq!(jobs.len(), 1);
         assert!(matches!(
             jobs.first().unwrap().status,
-            JobStatus::NoProcess { .. }
+            JobStatus::Preparing { pid: None, .. }
         ));
         assert_eq!(warnings.len(), 1);
     }
@@ -1664,6 +1770,24 @@ mod tests {
     fn empty_fresh() -> process::DiscoveredProcesses {
         process::DiscoveredProcesses {
             firecrackers: vec![],
+            mitmdumps: vec![],
+            dnsmasqs: vec![],
+        }
+    }
+
+    fn fresh_with_firecracker(
+        pid: u32,
+        sandbox_id: &str,
+        base_dir: &Path,
+    ) -> process::DiscoveredProcesses {
+        process::DiscoveredProcesses {
+            firecrackers: vec![process::FirecrackerProcessInfo {
+                pid,
+                ppid: None,
+                sandbox_id: sandbox_id.into(),
+                base_dir: Some(base_dir.to_path_buf()),
+                identity: None,
+            }],
             mitmdumps: vec![],
             dnsmasqs: vec![],
         }
@@ -1761,7 +1885,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_firecracker_for_run_persists_for_stale_preparing_run() {
+    async fn no_firecracker_for_run_clears_for_stale_preparing_run() {
         let dir = tempfile::tempdir().unwrap();
         let base_dir = dir.path().to_path_buf();
         let phase_started_at =
@@ -1787,6 +1911,104 @@ mod tests {
         );
 
         let warning = Warning::NoFirecrackerForRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            base_dir: base_dir.clone(),
+        };
+        assert!(!warning.persists(&empty_fresh(), &[]).await);
+    }
+
+    #[tokio::test]
+    async fn stale_preparing_run_persists_while_run_remains_stale_preparing() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        let phase_started_at =
+            phase_started_at_ago(PREPARING_NO_PROCESS_GRACE + Duration::from_secs(1));
+        write_status_json(
+            &base_dir.join("status.json"),
+            &format!(
+                r#"{{
+                    "mode": "running",
+                    "max_concurrent": 4,
+                    "active_runs": [
+                        {{
+                            "run_id": "R1",
+                            "sandbox_id": "S1",
+                            "phase": "preparing",
+                            "phase_started_at": "{phase_started_at}"
+                        }}
+                    ],
+                    "started_at": "2026-01-01T00:00:00.000Z",
+                    "updated_at": "2026-01-01T00:00:00.000Z"
+                }}"#
+            ),
+        );
+
+        let warning = Warning::StalePreparingRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            base_dir: base_dir.clone(),
+        };
+        assert!(warning.persists(&empty_fresh(), &[]).await);
+    }
+
+    #[tokio::test]
+    async fn stale_preparing_run_clears_after_phase_changes_to_running_with_firecracker() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        write_status_json(
+            &base_dir.join("status.json"),
+            r#"{
+                "mode": "running",
+                "max_concurrent": 4,
+                "active_runs": [
+                    {
+                        "run_id": "R1",
+                        "sandbox_id": "S1",
+                        "phase": "running",
+                        "phase_started_at": "2026-01-01T00:00:00.000Z"
+                    }
+                ],
+                "started_at": "2026-01-01T00:00:00.000Z",
+                "updated_at": "2026-01-01T00:00:00.000Z"
+            }"#,
+        );
+
+        let warning = Warning::StalePreparingRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            base_dir: base_dir.clone(),
+        };
+        assert!(
+            !warning
+                .persists(&fresh_with_firecracker(123, "S1", &base_dir), &[])
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_preparing_run_persists_after_phase_changes_to_running_without_firecracker() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_dir = dir.path().to_path_buf();
+        write_status_json(
+            &base_dir.join("status.json"),
+            r#"{
+                "mode": "running",
+                "max_concurrent": 4,
+                "active_runs": [
+                    {
+                        "run_id": "R1",
+                        "sandbox_id": "S1",
+                        "phase": "running",
+                        "phase_started_at": "2026-01-01T00:00:00.000Z"
+                    }
+                ],
+                "started_at": "2026-01-01T00:00:00.000Z",
+                "updated_at": "2026-01-01T00:00:00.000Z"
+            }"#,
+        );
+
+        let warning = Warning::StalePreparingRun {
             run_id: "R1".into(),
             sandbox_id: "S1".into(),
             base_dir: base_dir.clone(),
@@ -2043,6 +2265,16 @@ mod tests {
         assert_eq!(
             w.to_string(),
             "no firecracker process for run abc-123 (sandbox sbox-abc)"
+        );
+
+        let w = Warning::StalePreparingRun {
+            run_id: "prep-123".into(),
+            sandbox_id: "sbox-prep".into(),
+            base_dir: PathBuf::from("/data/r1"),
+        };
+        assert_eq!(
+            w.to_string(),
+            "run prep-123 stuck preparing (sandbox sbox-prep)"
         );
 
         let w = Warning::FirecrackerNotInStatus {

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -2505,8 +2505,18 @@ mod tests {
             "mode": "running",
             "max_concurrent": 4,
             "active_runs": [
-                {"run_id":"0191c4e0-0000-7000-8000-000000000001","sandbox_id":"aaaaaaaa-0000-7000-8000-000000000001"},
-                {"run_id":"0191c4e0-0000-7000-8000-000000000002","sandbox_id":"aaaaaaaa-0000-7000-8000-000000000002"}
+                {
+                    "run_id":"0191c4e0-0000-7000-8000-000000000001",
+                    "sandbox_id":"aaaaaaaa-0000-7000-8000-000000000001",
+                    "phase":"preparing",
+                    "phase_started_at":"2026-04-13T00:00:01.000Z"
+                },
+                {
+                    "run_id":"0191c4e0-0000-7000-8000-000000000002",
+                    "sandbox_id":"aaaaaaaa-0000-7000-8000-000000000002",
+                    "phase":"running",
+                    "phase_started_at":"2026-04-13T00:00:02.000Z"
+                }
             ],
             "idle_vms": [
                 {"session_id":"sess-1","sandbox_id":"bbbbbbbb-0000-7000-8000-000000000001"}

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -110,7 +110,7 @@ pub(super) async fn add_run_with_idle_status_snapshot(
     snapshot: IdlePoolSnapshot,
 ) {
     let applied = status
-        .add_run_with_idle_info_at_revision(
+        .add_running_run_with_idle_info_at_revision(
             run_id,
             sandbox_id,
             snapshot.revision,

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -103,7 +103,7 @@ pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: I
     }
 }
 
-pub(super) async fn add_run_with_idle_status_snapshot(
+pub(super) async fn add_running_run_with_idle_status_snapshot(
     status: &StatusTracker,
     run_id: RunId,
     sandbox_id: SandboxId,
@@ -121,6 +121,28 @@ pub(super) async fn add_run_with_idle_status_snapshot(
         info!(
             revision = snapshot.revision,
             "ignored stale idle pool status snapshot while adding active run"
+        );
+    }
+}
+
+pub(super) async fn add_preparing_run_with_idle_status_snapshot(
+    status: &StatusTracker,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    snapshot: IdlePoolSnapshot,
+) {
+    let applied = status
+        .add_preparing_run_with_idle_info_at_revision(
+            run_id,
+            sandbox_id,
+            snapshot.revision,
+            snapshot.idle_vms,
+        )
+        .await;
+    if !applied {
+        info!(
+            revision = snapshot.revision,
+            "ignored stale idle pool status snapshot while adding preparing run"
         );
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -134,7 +134,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     if let Some(snapshot) = idle_snapshot {
         add_run_with_idle_status_snapshot(ctx.status, run_id, sandbox_id, snapshot).await;
     } else {
-        ctx.status.add_run(run_id, sandbox_id).await;
+        ctx.status.add_preparing_run(run_id, sandbox_id).await;
     }
 
     let job_profile = JobProfile {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -15,7 +15,8 @@ use super::active_sessions::ActiveSessionGuard;
 use super::factory_lifecycle::SharedFactory;
 use super::heartbeat::current_held_session_states;
 use super::idle_lifecycle::{
-    SharedIdlePool, add_run_with_idle_status_snapshot, spawn_idle_destroy_job,
+    SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
+    add_running_run_with_idle_status_snapshot, spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
@@ -131,11 +132,14 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         Some(entry) => entry.sandbox_id(),
         None => SandboxId::new_v4(),
     };
-    if let Some(snapshot) = idle_snapshot {
-        add_run_with_idle_status_snapshot(ctx.status, run_id, sandbox_id, snapshot).await;
-    } else {
-        ctx.status.add_preparing_run(run_id, sandbox_id).await;
-    }
+    publish_active_run_status(
+        ctx.status,
+        run_id,
+        sandbox_id,
+        reuse_entry.is_some(),
+        idle_snapshot,
+    )
+    .await;
 
     let job_profile = JobProfile {
         profile_name,
@@ -160,6 +164,24 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         ctx.spawn_ctx,
         ctx.jobs,
     );
+}
+
+async fn publish_active_run_status(
+    status: &StatusTracker,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    reused_idle: bool,
+    idle_snapshot: Option<IdlePoolSnapshot>,
+) {
+    if let Some(snapshot) = idle_snapshot {
+        if reused_idle {
+            add_running_run_with_idle_status_snapshot(status, run_id, sandbox_id, snapshot).await;
+        } else {
+            add_preparing_run_with_idle_status_snapshot(status, run_id, sandbox_id, snapshot).await;
+        }
+    } else {
+        status.add_preparing_run(run_id, sandbox_id).await;
+    }
 }
 
 async fn claim_with_local_admission(
@@ -358,5 +380,67 @@ async fn try_reuse_from_pool(
             );
             (None, job_lease, SandboxReuseResult::PoolMiss, None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::status::IdleVm;
+
+    fn read_active_run_phase(path: &std::path::Path) -> String {
+        let raw = std::fs::read_to_string(path).unwrap();
+        let status: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        status["active_runs"][0]["phase"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn idle_snapshot() -> IdlePoolSnapshot {
+        IdlePoolSnapshot {
+            revision: 1,
+            idle_vms: vec![IdleVm {
+                session_id: "sess-removed-from-pool".into(),
+                sandbox_id: SandboxId::new_v4(),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_active_run_status_writes_preparing_after_reuse_miss_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+
+        publish_active_run_status(
+            &status,
+            RunId::new_v4(),
+            SandboxId::new_v4(),
+            false,
+            Some(idle_snapshot()),
+        )
+        .await;
+
+        assert_eq!(read_active_run_phase(&status_path), "preparing");
+    }
+
+    #[tokio::test]
+    async fn publish_active_run_status_writes_running_for_reused_idle_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let status_path = dir.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 4, None, None);
+
+        publish_active_run_status(
+            &status,
+            RunId::new_v4(),
+            SandboxId::new_v4(),
+            true,
+            Some(idle_snapshot()),
+        )
+        .await;
+
+        assert_eq!(read_active_run_phase(&status_path), "running");
     }
 }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -99,6 +99,7 @@ struct ExecutorInvocation {
     reuse_result: SandboxReuseResult,
     cancel: CancellationToken,
     sandbox_token: String,
+    sandbox_started: Option<executor::SandboxStartNotifier>,
 }
 
 struct ExecutorPhaseOutcome {
@@ -121,6 +122,7 @@ impl ExecutorInvocation {
             reuse_result,
             cancel,
             sandbox_token,
+            sandbox_started,
         } = self;
         let exec_config_for_panic = Arc::clone(&exec_config);
         let cancel_for_executor = cancel.clone();
@@ -138,7 +140,7 @@ impl ExecutorInvocation {
                 )
                 .await
             } else {
-                executor::execute_job(
+                executor::execute_job_with_start_notifier(
                     &**factory,
                     context,
                     executor::NewSandboxDispatch {
@@ -148,6 +150,7 @@ impl ExecutorInvocation {
                     &exec_config,
                     &params,
                     cancel_for_executor,
+                    sandbox_started,
                 )
                 .await
             }
@@ -476,6 +479,29 @@ pub(super) fn spawn_job(
     // into the executor phase, so snapshot the token before spawning.
     let sandbox_token = context.sandbox_token.clone();
     let reused = reuse_entry.is_some();
+    let sandbox_started = if reused {
+        None
+    } else {
+        let status_for_started = Arc::clone(&status);
+        Some(executor::SandboxStartNotifier::new(
+            move |run_id, sandbox_id| {
+                let status = Arc::clone(&status_for_started);
+                async move {
+                    if !status
+                        .mark_run_running_if_matching(run_id, sandbox_id)
+                        .await
+                    {
+                        warn!(
+                            run_id = %run_id,
+                            sandbox_id = %sandbox_id,
+                            "sandbox started after active run status changed"
+                        );
+                    }
+                }
+                .boxed()
+            },
+        ))
+    };
     let executor = ExecutorInvocation {
         run_id,
         sandbox_id,
@@ -487,6 +513,7 @@ pub(super) fn spawn_job(
         reuse_result,
         cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
+        sandbox_started,
     };
     let finalization = FinalizationPhase {
         run_id,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -99,7 +99,7 @@ struct ExecutorInvocation {
     reuse_result: SandboxReuseResult,
     cancel: CancellationToken,
     sandbox_token: String,
-    sandbox_started: Option<executor::SandboxStartNotifier>,
+    sandbox_prepared: Option<executor::SandboxPreparedNotifier>,
 }
 
 struct ExecutorPhaseOutcome {
@@ -122,7 +122,7 @@ impl ExecutorInvocation {
             reuse_result,
             cancel,
             sandbox_token,
-            sandbox_started,
+            sandbox_prepared,
         } = self;
         let exec_config_for_panic = Arc::clone(&exec_config);
         let cancel_for_executor = cancel.clone();
@@ -140,7 +140,7 @@ impl ExecutorInvocation {
                 )
                 .await
             } else {
-                executor::execute_job_with_start_notifier(
+                executor::execute_job_with_prepared_notifier(
                     &**factory,
                     context,
                     executor::NewSandboxDispatch {
@@ -150,7 +150,7 @@ impl ExecutorInvocation {
                     &exec_config,
                     &params,
                     cancel_for_executor,
-                    sandbox_started,
+                    sandbox_prepared,
                 )
                 .await
             }
@@ -479,13 +479,13 @@ pub(super) fn spawn_job(
     // into the executor phase, so snapshot the token before spawning.
     let sandbox_token = context.sandbox_token.clone();
     let reused = reuse_entry.is_some();
-    let sandbox_started = if reused {
+    let sandbox_prepared = if reused {
         None
     } else {
-        let status_for_started = Arc::clone(&status);
-        Some(executor::SandboxStartNotifier::new(
+        let status_for_prepared = Arc::clone(&status);
+        Some(executor::SandboxPreparedNotifier::new(
             move |run_id, sandbox_id| {
-                let status = Arc::clone(&status_for_started);
+                let status = Arc::clone(&status_for_prepared);
                 async move {
                     if !status
                         .mark_run_running_if_matching(run_id, sandbox_id)
@@ -494,7 +494,7 @@ pub(super) fn spawn_job(
                         warn!(
                             run_id = %run_id,
                             sandbox_id = %sandbox_id,
-                            "sandbox started after active run status changed"
+                            "sandbox prepared after active run status changed"
                         );
                     }
                 }
@@ -513,7 +513,7 @@ pub(super) fn spawn_job(
         reuse_result,
         cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
-        sandbox_started,
+        sandbox_prepared,
     };
     let finalization = FinalizationPhase {
         run_id,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -4,11 +4,11 @@
 //! budget reservation. The executor owns the sandbox-side run flow, while the
 //! caller owns provider completion and the final sandbox lifecycle decision.
 //!
-//! There are two public entry points:
-//! - `execute_job` starts a fresh Firecracker VM.
-//! - `execute_job_reuse` runs in a kept-alive idle VM.
+//! The fresh path starts a new Firecracker VM and can notify the caller once
+//! the VM process is expected to exist. The reuse path runs in a kept-alive
+//! idle VM.
 //!
-//! Both entry points return `ExecuteOutcome` plus a pending `JobTelemetry`
+//! Both paths return `ExecuteOutcome` plus a pending `JobTelemetry`
 //! buffer. When `ExecuteOutcome::sandbox` is `Some`, the sandbox is still alive
 //! and the caller decides whether to park it for reuse or destroy it. The
 //! caller also flushes telemetry after firing `provider.complete`, so the

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -4,9 +4,9 @@
 //! budget reservation. The executor owns the sandbox-side run flow, while the
 //! caller owns provider completion and the final sandbox lifecycle decision.
 //!
-//! The fresh path starts a new Firecracker VM and can notify the caller once
-//! the VM process is expected to exist. The reuse path runs in a kept-alive
-//! idle VM.
+//! The fresh path starts and prepares a new Firecracker VM and can notify the
+//! caller once the VM is ready to run the job. The reuse path runs in a
+//! kept-alive idle VM.
 //!
 //! Both paths return `ExecuteOutcome` plus a pending `JobTelemetry`
 //! buffer. When `ExecuteOutcome::sandbox` is `Some`, the sandbox is still alive
@@ -37,7 +37,7 @@ pub(crate) use guest_state::{fix_guest_clock, reseed_guest_entropy};
 use agent_run::ProcessCancelTimeouts;
 use env::validate_execution_context_before_sandbox;
 use sandbox_run::{
-    NewSandboxHooks, execute_new_sandbox_with_start_notifier, execute_reused_sandbox,
+    NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
     workspace_image_promotable,
 };
 use telemetry::{record_api_latency, record_reuse_result};
@@ -154,11 +154,11 @@ pub struct JobParams {
 }
 
 #[derive(Clone)]
-pub(crate) struct SandboxStartNotifier {
+pub(crate) struct SandboxPreparedNotifier {
     callback: Arc<dyn Fn(RunId, SandboxId) -> BoxFuture<'static, ()> + Send + Sync>,
 }
 
-impl SandboxStartNotifier {
+impl SandboxPreparedNotifier {
     pub(crate) fn new(
         callback: impl Fn(RunId, SandboxId) -> BoxFuture<'static, ()> + Send + Sync + 'static,
     ) -> Self {
@@ -307,17 +307,18 @@ pub async fn execute_job(
     params: &JobParams,
     cancel: CancellationToken,
 ) -> (ExecuteOutcome, JobTelemetry) {
-    execute_job_with_start_notifier(factory, context, dispatch, config, params, cancel, None).await
+    execute_job_with_prepared_notifier(factory, context, dispatch, config, params, cancel, None)
+        .await
 }
 
-pub(crate) async fn execute_job_with_start_notifier(
+pub(crate) async fn execute_job_with_prepared_notifier(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
     dispatch: NewSandboxDispatch,
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
-    sandbox_started: Option<SandboxStartNotifier>,
+    sandbox_prepared: Option<SandboxPreparedNotifier>,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
@@ -337,7 +338,7 @@ pub(crate) async fn execute_job_with_start_notifier(
             guest_session_id: None,
         }
     } else {
-        match execute_new_sandbox_with_start_notifier(
+        match execute_new_sandbox_with_prepared_notifier(
             factory,
             &context,
             dispatch,
@@ -346,7 +347,7 @@ pub(crate) async fn execute_job_with_start_notifier(
             &mut telemetry,
             NewSandboxHooks {
                 cancel,
-                sandbox_started: sandbox_started.as_ref(),
+                sandbox_prepared: sandbox_prepared.as_ref(),
             },
         )
         .await

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -15,9 +15,11 @@
 //! user-visible completion signal is not blocked on best-effort uploads.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use agent_diagnostics::FailureDiagnostic;
+use futures_util::future::BoxFuture;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
 use tokio_util::sync::CancellationToken;
 
@@ -34,7 +36,10 @@ pub(crate) use guest_state::{fix_guest_clock, reseed_guest_entropy};
 
 use agent_run::ProcessCancelTimeouts;
 use env::validate_execution_context_before_sandbox;
-use sandbox_run::{execute_new_sandbox, execute_reused_sandbox, workspace_image_promotable};
+use sandbox_run::{
+    NewSandboxHooks, execute_new_sandbox_with_start_notifier, execute_reused_sandbox,
+    workspace_image_promotable,
+};
 use telemetry::{record_api_latency, record_reuse_result};
 
 use crate::ids::RunId;
@@ -146,6 +151,25 @@ pub struct JobParams {
     pub workspace_disk_mb: u32,
     pub restore_guest_state: bool,
     pub device_rate_limits: Option<sandbox::DeviceRateLimits>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SandboxStartNotifier {
+    callback: Arc<dyn Fn(RunId, SandboxId) -> BoxFuture<'static, ()> + Send + Sync>,
+}
+
+impl SandboxStartNotifier {
+    pub(crate) fn new(
+        callback: impl Fn(RunId, SandboxId) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            callback: Arc::new(callback),
+        }
+    }
+
+    async fn notify(&self, run_id: RunId, sandbox_id: SandboxId) {
+        (self.callback)(run_id, sandbox_id).await;
+    }
 }
 
 /// Outcome of a job execution, including the sandbox for possible reuse.
@@ -274,6 +298,7 @@ fn agent_exit_failure_message(exit_code: i32) -> String {
 }
 
 /// uploads (~383 ms saved per job).
+#[cfg(test)]
 pub async fn execute_job(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
@@ -281,6 +306,18 @@ pub async fn execute_job(
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
+) -> (ExecuteOutcome, JobTelemetry) {
+    execute_job_with_start_notifier(factory, context, dispatch, config, params, cancel, None).await
+}
+
+pub(crate) async fn execute_job_with_start_notifier(
+    factory: &dyn SandboxFactory,
+    context: ExecutionContext,
+    dispatch: NewSandboxDispatch,
+    config: &ExecutorConfig,
+    params: &JobParams,
+    cancel: CancellationToken,
+    sandbox_started: Option<SandboxStartNotifier>,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
@@ -300,14 +337,17 @@ pub async fn execute_job(
             guest_session_id: None,
         }
     } else {
-        match execute_new_sandbox(
+        match execute_new_sandbox_with_start_notifier(
             factory,
             &context,
             dispatch,
             config,
             params,
             &mut telemetry,
-            cancel,
+            NewSandboxHooks {
+                cancel,
+                sandbox_started: sandbox_started.as_ref(),
+            },
         )
         .await
         {
@@ -332,8 +372,8 @@ pub async fn execute_job(
 /// Skips create + start. Re-registers proxy, fixes clock, then runs the agent.
 /// Returns [`ExecuteOutcome`] with the sandbox still alive plus the pending
 /// [`JobTelemetry`] buffer — the caller (`spawn_job` in `cmd/start/job_spawn.rs`)
-/// must flush telemetry after firing `provider.complete` (see [`execute_job`] for
-/// rationale).
+/// must flush telemetry after firing `provider.complete`, matching the fresh
+/// sandbox path's completion ordering.
 pub async fn execute_job_reuse(
     idle_sandbox: ReusableIdleSandbox,
     context: ExecutionContext,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -17,7 +17,7 @@ use super::env::normalized_cli_agent_type;
 use super::telemetry::record_workspace_cache_result;
 use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,
-    RunnerResult, SandboxReuseResult, SandboxStartNotifier,
+    RunnerResult, SandboxPreparedNotifier, SandboxReuseResult,
 };
 use crate::ids::RunId;
 use crate::network_log_manager::NetworkLogSession;
@@ -38,7 +38,7 @@ pub(super) async fn execute_new_sandbox(
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<ExecuteOutcome> {
-    execute_new_sandbox_with_start_notifier(
+    execute_new_sandbox_with_prepared_notifier(
         factory,
         context,
         dispatch,
@@ -47,13 +47,13 @@ pub(super) async fn execute_new_sandbox(
         telemetry,
         NewSandboxHooks {
             cancel,
-            sandbox_started: None,
+            sandbox_prepared: None,
         },
     )
     .await
 }
 
-pub(super) async fn execute_new_sandbox_with_start_notifier(
+pub(super) async fn execute_new_sandbox_with_prepared_notifier(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
     dispatch: NewSandboxDispatch,
@@ -68,7 +68,7 @@ pub(super) async fn execute_new_sandbox_with_start_notifier(
     } = dispatch;
     let NewSandboxHooks {
         cancel,
-        sandbox_started,
+        sandbox_prepared,
     } = hooks;
     let mut workspace_image = prepare_workspace_image(
         context,
@@ -88,7 +88,7 @@ pub(super) async fn execute_new_sandbox_with_start_notifier(
         telemetry,
         StartSandboxOptions {
             workspace_image: workspace_image.as_ref(),
-            sandbox_started,
+            sandbox_prepared,
         },
     )
     .await
@@ -123,7 +123,7 @@ pub(super) async fn execute_new_sandbox_with_start_notifier(
                 telemetry,
                 StartSandboxOptions {
                     workspace_image: None,
-                    sandbox_started,
+                    sandbox_prepared,
                 },
             )
             .await
@@ -169,12 +169,12 @@ pub(super) struct SandboxPrepareError {
 
 pub(super) struct NewSandboxHooks<'a> {
     pub(super) cancel: CancellationToken,
-    pub(super) sandbox_started: Option<&'a SandboxStartNotifier>,
+    pub(super) sandbox_prepared: Option<&'a SandboxPreparedNotifier>,
 }
 
 struct StartSandboxOptions<'a> {
     workspace_image: Option<&'a WorkspaceImageLease>,
-    sandbox_started: Option<&'a SandboxStartNotifier>,
+    sandbox_prepared: Option<&'a SandboxPreparedNotifier>,
 }
 
 impl SandboxPrepareError {
@@ -237,7 +237,7 @@ async fn create_started_sandbox(
 ) -> Result<PreparedSandboxRun, SandboxPrepareError> {
     let StartSandboxOptions {
         workspace_image,
-        sandbox_started,
+        sandbox_prepared,
     } = options;
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
@@ -292,9 +292,6 @@ async fn create_started_sandbox(
         destroy_sandbox_panic_safe(factory, sandbox).await;
         return Err(SandboxPrepareError::retry(e.into()));
     }
-    if let Some(notifier) = sandbox_started {
-        notifier.notify(context.run_id, sandbox_id).await;
-    }
     telemetry.record("vm_create", t.elapsed(), true, None);
 
     let mount_started = Instant::now();
@@ -319,6 +316,9 @@ async fn create_started_sandbox(
         return Err(SandboxPrepareError::retry(e));
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
+    if let Some(notifier) = sandbox_prepared {
+        notifier.notify(context.run_id, sandbox_id).await;
+    }
 
     Ok(PreparedSandboxRun {
         sandbox,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -17,7 +17,7 @@ use super::env::normalized_cli_agent_type;
 use super::telemetry::record_workspace_cache_result;
 use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,
-    RunnerResult, SandboxReuseResult,
+    RunnerResult, SandboxReuseResult, SandboxStartNotifier,
 };
 use crate::ids::RunId;
 use crate::network_log_manager::NetworkLogSession;
@@ -28,6 +28,7 @@ use crate::workspace_image_cache::{WorkspaceImageLease, WorkspaceImagePrepareReq
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
+#[cfg(test)]
 pub(super) async fn execute_new_sandbox(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
@@ -37,10 +38,38 @@ pub(super) async fn execute_new_sandbox(
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<ExecuteOutcome> {
+    execute_new_sandbox_with_start_notifier(
+        factory,
+        context,
+        dispatch,
+        config,
+        params,
+        telemetry,
+        NewSandboxHooks {
+            cancel,
+            sandbox_started: None,
+        },
+    )
+    .await
+}
+
+pub(super) async fn execute_new_sandbox_with_start_notifier(
+    factory: &dyn SandboxFactory,
+    context: &ExecutionContext,
+    dispatch: NewSandboxDispatch,
+    config: &ExecutorConfig,
+    params: &JobParams,
+    telemetry: &mut JobTelemetry,
+    hooks: NewSandboxHooks<'_>,
+) -> RunnerResult<ExecuteOutcome> {
     let NewSandboxDispatch {
         id: sandbox_id,
         reuse_result,
     } = dispatch;
+    let NewSandboxHooks {
+        cancel,
+        sandbox_started,
+    } = hooks;
     let mut workspace_image = prepare_workspace_image(
         context,
         sandbox_id,
@@ -57,7 +86,10 @@ pub(super) async fn execute_new_sandbox(
         config,
         params,
         telemetry,
-        workspace_image.as_ref(),
+        StartSandboxOptions {
+            workspace_image: workspace_image.as_ref(),
+            sandbox_started,
+        },
     )
     .await
     {
@@ -83,7 +115,16 @@ pub(super) async fn execute_new_sandbox(
             );
             workspace_image = None;
             create_started_sandbox(
-                factory, context, sandbox_id, config, params, telemetry, None,
+                factory,
+                context,
+                sandbox_id,
+                config,
+                params,
+                telemetry,
+                StartSandboxOptions {
+                    workspace_image: None,
+                    sandbox_started,
+                },
             )
             .await
             .map_err(|e| e.error)?
@@ -124,6 +165,16 @@ pub(super) struct PreparedSandboxRun {
 pub(super) struct SandboxPrepareError {
     error: RunnerError,
     retry_without_workspace_image: bool,
+}
+
+pub(super) struct NewSandboxHooks<'a> {
+    pub(super) cancel: CancellationToken,
+    pub(super) sandbox_started: Option<&'a SandboxStartNotifier>,
+}
+
+struct StartSandboxOptions<'a> {
+    workspace_image: Option<&'a WorkspaceImageLease>,
+    sandbox_started: Option<&'a SandboxStartNotifier>,
 }
 
 impl SandboxPrepareError {
@@ -175,15 +226,19 @@ pub(super) fn workspace_image_promotable(
         .is_some_and(|image| image.can_attempt_promotion(context.session_id().or(guest_session_id)))
 }
 
-pub(super) async fn create_started_sandbox(
+async fn create_started_sandbox(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
     sandbox_id: SandboxId,
     config: &ExecutorConfig,
     params: &JobParams,
     telemetry: &mut JobTelemetry,
-    workspace_image: Option<&WorkspaceImageLease>,
+    options: StartSandboxOptions<'_>,
 ) -> Result<PreparedSandboxRun, SandboxPrepareError> {
+    let StartSandboxOptions {
+        workspace_image,
+        sandbox_started,
+    } = options;
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
         resources: sandbox::ResourceLimits {
@@ -236,6 +291,9 @@ pub(super) async fn create_started_sandbox(
             .await;
         destroy_sandbox_panic_safe(factory, sandbox).await;
         return Err(SandboxPrepareError::retry(e.into()));
+    }
+    if let Some(notifier) = sandbox_started {
+        notifier.notify(context.run_id, sandbox_id).await;
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -1,10 +1,12 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use agent_diagnostics::FailureDiagnostic;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use api_contracts::generated::types::runners::storage::StorageManifest;
+use futures_util::FutureExt;
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, ProcessControlMode, ProcessExit, ProcessOutputChunk,
     ProcessOutputMode, ProcessTerminationKind, Sandbox, SandboxError, SandboxFactory, SandboxId,
@@ -14,13 +16,14 @@ use sandbox_mock::{MockSandbox, MockSandboxFactory};
 use super::super::agent_run::RunStart;
 use super::super::env::{guest_user_env_dir_path, guest_user_env_file_path};
 use super::super::sandbox_run::{
-    PreparedSandboxRun, execute_new_sandbox, execute_prepared_sandbox_run, execute_reused_sandbox,
+    NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
+    execute_new_sandbox_with_start_notifier, execute_prepared_sandbox_run, execute_reused_sandbox,
     register_proxy,
 };
 use super::super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JobParams,
     NewSandboxDispatch, STDOUT_STREAM_LIMIT_MARKER, STDOUT_STREAM_OVERFLOW_MARKER,
-    USER_ENV_FILE_ENV_KEY, execute_job, execute_job_reuse,
+    SandboxStartNotifier, USER_ENV_FILE_ENV_KEY, execute_job, execute_job_reuse,
 };
 use super::support::{
     DestroyPanicFactory, QueuedCopyFileSandbox, api_storage, assert_proxy_registry_empty,
@@ -88,6 +91,90 @@ async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_
         overrides.start_process_calls().is_empty(),
         "agent must not start when proxy registry registration fails"
     );
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_notifies_after_successful_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = MockSandboxFactory::new();
+    let ctx = minimal_context();
+    let sandbox_id = SandboxId::new_v4();
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let notifications_for_callback = Arc::clone(&notifications);
+    let expected_run_id = ctx.run_id;
+    let notifier = SandboxStartNotifier::new(move |run_id, started_sandbox_id| {
+        let notifications = Arc::clone(&notifications_for_callback);
+        async move {
+            assert_eq!(run_id, expected_run_id);
+            assert_eq!(started_sandbox_id, sandbox_id);
+            notifications.fetch_add(1, Ordering::SeqCst);
+        }
+        .boxed()
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox_with_start_notifier(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: sandbox_id,
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        NewSandboxHooks {
+            cancel: tokio_util::sync::CancellationToken::new(),
+            sandbox_started: Some(&notifier),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(notifications.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_does_not_notify_before_start_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    tokio::fs::remove_file(dir.path().join("proxy-registry.json"))
+        .await
+        .unwrap();
+    let factory = MockSandboxFactory::new();
+    let ctx = minimal_context();
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let notifications_for_callback = Arc::clone(&notifications);
+    let notifier = SandboxStartNotifier::new(move |_run_id, _sandbox_id| {
+        let notifications = Arc::clone(&notifications_for_callback);
+        async move {
+            notifications.fetch_add(1, Ordering::SeqCst);
+        }
+        .boxed()
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox_with_start_notifier(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        NewSandboxHooks {
+            cancel: tokio_util::sync::CancellationToken::new(),
+            sandbox_started: Some(&notifier),
+        },
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(notifications.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -17,13 +17,13 @@ use super::super::agent_run::RunStart;
 use super::super::env::{guest_user_env_dir_path, guest_user_env_file_path};
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
-    execute_new_sandbox_with_start_notifier, execute_prepared_sandbox_run, execute_reused_sandbox,
-    register_proxy,
+    execute_new_sandbox_with_prepared_notifier, execute_prepared_sandbox_run,
+    execute_reused_sandbox, register_proxy,
 };
 use super::super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JobParams,
     NewSandboxDispatch, STDOUT_STREAM_LIMIT_MARKER, STDOUT_STREAM_OVERFLOW_MARKER,
-    SandboxStartNotifier, USER_ENV_FILE_ENV_KEY, execute_job, execute_job_reuse,
+    SandboxPreparedNotifier, USER_ENV_FILE_ENV_KEY, execute_job, execute_job_reuse,
 };
 use super::support::{
     DestroyPanicFactory, QueuedCopyFileSandbox, api_storage, assert_proxy_registry_empty,
@@ -94,7 +94,7 @@ async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_
 }
 
 #[tokio::test]
-async fn execute_new_sandbox_notifies_after_successful_start() {
+async fn execute_new_sandbox_notifies_after_successful_prepare() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let factory = MockSandboxFactory::new();
@@ -103,18 +103,18 @@ async fn execute_new_sandbox_notifies_after_successful_start() {
     let notifications = Arc::new(AtomicUsize::new(0));
     let notifications_for_callback = Arc::clone(&notifications);
     let expected_run_id = ctx.run_id;
-    let notifier = SandboxStartNotifier::new(move |run_id, started_sandbox_id| {
+    let notifier = SandboxPreparedNotifier::new(move |run_id, prepared_sandbox_id| {
         let notifications = Arc::clone(&notifications_for_callback);
         async move {
             assert_eq!(run_id, expected_run_id);
-            assert_eq!(started_sandbox_id, sandbox_id);
+            assert_eq!(prepared_sandbox_id, sandbox_id);
             notifications.fetch_add(1, Ordering::SeqCst);
         }
         .boxed()
     });
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let outcome = execute_new_sandbox_with_start_notifier(
+    let outcome = execute_new_sandbox_with_prepared_notifier(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -126,7 +126,7 @@ async fn execute_new_sandbox_notifies_after_successful_start() {
         &mut telemetry,
         NewSandboxHooks {
             cancel: tokio_util::sync::CancellationToken::new(),
-            sandbox_started: Some(&notifier),
+            sandbox_prepared: Some(&notifier),
         },
     )
     .await
@@ -147,7 +147,7 @@ async fn execute_new_sandbox_does_not_notify_before_start_failure() {
     let ctx = minimal_context();
     let notifications = Arc::new(AtomicUsize::new(0));
     let notifications_for_callback = Arc::clone(&notifications);
-    let notifier = SandboxStartNotifier::new(move |_run_id, _sandbox_id| {
+    let notifier = SandboxPreparedNotifier::new(move |_run_id, _sandbox_id| {
         let notifications = Arc::clone(&notifications_for_callback);
         async move {
             notifications.fetch_add(1, Ordering::SeqCst);
@@ -156,7 +156,7 @@ async fn execute_new_sandbox_does_not_notify_before_start_failure() {
     });
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let result = execute_new_sandbox_with_start_notifier(
+    let result = execute_new_sandbox_with_prepared_notifier(
         &factory,
         &ctx,
         NewSandboxDispatch {
@@ -168,7 +168,52 @@ async fn execute_new_sandbox_does_not_notify_before_start_failure() {
         &mut telemetry,
         NewSandboxHooks {
             cancel: tokio_util::sync::CancellationToken::new(),
-            sandbox_started: Some(&notifier),
+            sandbox_prepared: Some(&notifier),
+        },
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(notifications.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_does_not_notify_after_post_start_prepare_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "mount -t ext4".to_string(),
+        exit_code: 64,
+        stdout: Vec::new(),
+        stderr: b"mount denied".to_vec(),
+    });
+    let factory = MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let notifications_for_callback = Arc::clone(&notifications);
+    let notifier = SandboxPreparedNotifier::new(move |_run_id, _sandbox_id| {
+        let notifications = Arc::clone(&notifications_for_callback);
+        async move {
+            notifications.fetch_add(1, Ordering::SeqCst);
+        }
+        .boxed()
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = execute_new_sandbox_with_prepared_notifier(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        NewSandboxHooks {
+            cancel: tokio_util::sync::CancellationToken::new(),
+            sandbox_prepared: Some(&notifier),
         },
     )
     .await;

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -224,6 +224,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_active_runs_ignores_phase_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let status = r#"{
+            "mode": "running",
+            "active_runs": [
+                {
+                    "run_id": "R1",
+                    "sandbox_id": "S1",
+                    "phase": "preparing",
+                    "phase_started_at": "2026-01-01T00:00:00.000Z"
+                },
+                {
+                    "run_id": "R2",
+                    "sandbox_id": "S2",
+                    "phase": "running",
+                    "phase_started_at": "2026-01-01T00:00:01.000Z"
+                }
+            ],
+            "started_at": "2026-01-01T00:00:00.000Z"
+        }"#;
+        std::fs::write(dir.path().join("status.json"), status).unwrap();
+
+        let runs = read_active_runs(dir.path()).await.unwrap();
+
+        assert_eq!(
+            runs,
+            vec![("R1".into(), "S1".into()), ("R2".into(), "S2".into())]
+        );
+    }
+
+    #[tokio::test]
     async fn read_active_runs_missing_field_defaults_empty() {
         let dir = tempfile::tempdir().unwrap();
         // status.json without active_runs field — serde(default) kicks in

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -165,8 +165,9 @@ impl StatusTracker {
         self.add_running_run(run_id, sandbox_id).await;
     }
 
-    /// Register an active run that has been claimed but whose Firecracker VM is
-    /// not expected to exist yet.
+    /// Register an active run that has been claimed while its fresh sandbox is
+    /// still being prepared. Its Firecracker process may not exist or be ready
+    /// yet.
     pub async fn add_preparing_run(&self, run_id: RunId, sandbox_id: SandboxId) {
         self.add_run_with_phase(run_id, sandbox_id, ActiveRunPhase::Preparing)
             .await;

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -33,10 +33,27 @@ pub enum RunnerMode {
 /// that identifies the Firecracker VM hosting it. After sandbox reuse these
 /// differ: the VM keeps its original `sandbox_id` while each successive job
 /// has a fresh `run_id`.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ActiveRunPhase {
+    Preparing,
+    Running,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct ActiveRun {
     pub run_id: RunId,
     pub sandbox_id: SandboxId,
+    pub phase: ActiveRunPhase,
+    #[serde(serialize_with = "serialize_iso")]
+    pub phase_started_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+struct ActiveRunState {
+    sandbox_id: SandboxId,
+    phase: ActiveRunPhase,
+    phase_started_at: DateTime<Utc>,
 }
 
 /// One parked (idle) sandbox's identity: the `session_id` it's keyed by in
@@ -85,13 +102,13 @@ pub struct StatusTracker {
 
 struct MutableState {
     mode: RunnerMode,
-    /// Map of run_id → sandbox_id for all active runs. Keyed by run_id so
+    /// Map of run_id → active run state for all active runs. Keyed by run_id so
     /// conditional active-run removal stays O(log n); the paired `sandbox_id`
     /// is the join key used by doctor and kill to find the FC process.
     ///
     /// BTreeMap (not HashMap) for deterministic iteration order — status.json
     /// output should be stable across runs for readability and diffing.
-    active_runs: BTreeMap<RunId, SandboxId>,
+    active_runs: BTreeMap<RunId, ActiveRunState>,
     /// Monotonic idle pool mutation revision last reflected in `idle_vms`.
     ///
     /// Idle pool callers snapshot under the pool lock, drop it, then write
@@ -139,11 +156,44 @@ impl StatusTracker {
         self.write_status(&state).await;
     }
 
-    /// Register an active run and flush the status file. On duplicate
-    /// `run_id`, the previous `sandbox_id` is overwritten.
+    /// Register an active run as running and flush the status file.
+    ///
+    /// This preserves the old helper semantics for tests and cleanup fixtures.
+    /// Freshly claimed new-sandbox jobs should use [`add_preparing_run`].
+    #[cfg(test)]
     pub async fn add_run(&self, run_id: RunId, sandbox_id: SandboxId) {
+        self.add_running_run(run_id, sandbox_id).await;
+    }
+
+    /// Register an active run that has been claimed but whose Firecracker VM is
+    /// not expected to exist yet.
+    pub async fn add_preparing_run(&self, run_id: RunId, sandbox_id: SandboxId) {
+        self.add_run_with_phase(run_id, sandbox_id, ActiveRunPhase::Preparing)
+            .await;
+    }
+
+    /// Register an active run whose Firecracker VM should already exist.
+    #[cfg(test)]
+    pub async fn add_running_run(&self, run_id: RunId, sandbox_id: SandboxId) {
+        self.add_run_with_phase(run_id, sandbox_id, ActiveRunPhase::Running)
+            .await;
+    }
+
+    async fn add_run_with_phase(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+        phase: ActiveRunPhase,
+    ) {
         let mut state = self.state.lock().await;
-        state.active_runs.insert(run_id, sandbox_id);
+        state.active_runs.insert(
+            run_id,
+            ActiveRunState {
+                sandbox_id,
+                phase,
+                phase_started_at: Utc::now(),
+            },
+        );
         self.write_status(&state).await;
     }
 
@@ -154,7 +204,9 @@ impl StatusTracker {
     /// This avoids a transient status.json gap during idle reuse where a sandbox
     /// has been removed from `idle_vms` but has not yet appeared in
     /// `active_runs`.
-    pub async fn add_run_with_idle_info_at_revision(
+    /// Register a running active run and replace the idle VM list in the same
+    /// status write if the idle snapshot is current.
+    pub async fn add_running_run_with_idle_info_at_revision(
         &self,
         run_id: RunId,
         sandbox_id: SandboxId,
@@ -162,10 +214,33 @@ impl StatusTracker {
         idle_vms: Vec<IdleVm>,
     ) -> bool {
         let mut state = self.state.lock().await;
-        state.active_runs.insert(run_id, sandbox_id);
+        state.active_runs.insert(
+            run_id,
+            ActiveRunState {
+                sandbox_id,
+                phase: ActiveRunPhase::Running,
+                phase_started_at: Utc::now(),
+            },
+        );
         let applied = apply_idle_info_at_revision(&mut state, revision, idle_vms);
         self.write_status(&state).await;
         applied
+    }
+
+    /// Transition a preparing active run to running only if it still points at
+    /// the expected sandbox.
+    pub async fn mark_run_running_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
+        let mut state = self.state.lock().await;
+        let Some(current) = state.active_runs.get_mut(&run_id) else {
+            return false;
+        };
+        if current.sandbox_id != sandbox_id {
+            return false;
+        }
+        current.phase = ActiveRunPhase::Running;
+        current.phase_started_at = Utc::now();
+        self.write_status(&state).await;
+        true
     }
 
     /// Drop an active run only if it still points at the expected sandbox.
@@ -174,8 +249,7 @@ impl StatusTracker {
     /// `run_id` with a different sandbox.
     pub async fn remove_run_if_matching(&self, run_id: RunId, sandbox_id: SandboxId) -> bool {
         let mut state = self.state.lock().await;
-        let removed =
-            matches!(state.active_runs.get(&run_id), Some(current) if *current == sandbox_id);
+        let removed = matches!(state.active_runs.get(&run_id), Some(current) if current.sandbox_id == sandbox_id);
         if removed {
             state.active_runs.remove(&run_id);
             self.write_status(&state).await;
@@ -209,9 +283,11 @@ impl StatusTracker {
         let active_runs: Vec<ActiveRun> = state
             .active_runs
             .iter()
-            .map(|(rid, sid)| ActiveRun {
-                run_id: *rid,
-                sandbox_id: *sid,
+            .map(|(run_id, active)| ActiveRun {
+                run_id: *run_id,
+                sandbox_id: active.sandbox_id,
+                phase: active.phase,
+                phase_started_at: active.phase_started_at,
             })
             .collect();
 
@@ -332,6 +408,67 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0]["run_id"], run_id.to_string());
         assert_eq!(runs[0]["sandbox_id"], sandbox_id.to_string());
+        assert_eq!(runs[0]["phase"], "running");
+        assert!(runs[0]["phase_started_at"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn add_preparing_run_records_phase_and_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+
+        tracker.write_initial().await;
+        tracker.add_preparing_run(run_id, sandbox_id).await;
+
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["run_id"], run_id.to_string());
+        assert_eq!(runs[0]["sandbox_id"], sandbox_id.to_string());
+        assert_eq!(runs[0]["phase"], "preparing");
+        let phase_started_at = runs[0]["phase_started_at"].as_str().unwrap();
+        assert!(chrono::DateTime::parse_from_rfc3339(phase_started_at).is_ok());
+    }
+
+    #[tokio::test]
+    async fn mark_run_running_if_matching_updates_only_matching_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+
+        let run_id = RunId::new_v4();
+        let stale_sandbox_id = SandboxId::new_v4();
+        let current_sandbox_id = SandboxId::new_v4();
+
+        tracker.write_initial().await;
+        tracker.add_preparing_run(run_id, stale_sandbox_id).await;
+        tracker.add_preparing_run(run_id, current_sandbox_id).await;
+
+        assert!(
+            !tracker
+                .mark_run_running_if_matching(run_id, stale_sandbox_id)
+                .await
+        );
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["sandbox_id"], current_sandbox_id.to_string());
+        assert_eq!(runs[0]["phase"], "preparing");
+
+        assert!(
+            tracker
+                .mark_run_running_if_matching(run_id, current_sandbox_id)
+                .await
+        );
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["sandbox_id"], current_sandbox_id.to_string());
+        assert_eq!(runs[0]["phase"], "running");
     }
 
     #[tokio::test]
@@ -587,7 +724,7 @@ mod tests {
         );
         assert!(
             !tracker
-                .add_run_with_idle_info_at_revision(
+                .add_running_run_with_idle_info_at_revision(
                     run_id,
                     active_id,
                     1,
@@ -604,6 +741,7 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0]["run_id"], run_id.to_string());
         assert_eq!(runs[0]["sandbox_id"], active_id.to_string());
+        assert_eq!(runs[0]["phase"], "running");
         let vms = status["idle_vms"].as_array().unwrap();
         assert_eq!(vms.len(), 1);
         assert_eq!(vms[0]["session_id"], "fresh");

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -213,12 +213,49 @@ impl StatusTracker {
         revision: u64,
         idle_vms: Vec<IdleVm>,
     ) -> bool {
+        self.add_run_with_idle_info_at_revision(
+            run_id,
+            sandbox_id,
+            ActiveRunPhase::Running,
+            revision,
+            idle_vms,
+        )
+        .await
+    }
+
+    /// Register a preparing active run and replace the idle VM list in the
+    /// same status write if the idle snapshot is current.
+    pub async fn add_preparing_run_with_idle_info_at_revision(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+        revision: u64,
+        idle_vms: Vec<IdleVm>,
+    ) -> bool {
+        self.add_run_with_idle_info_at_revision(
+            run_id,
+            sandbox_id,
+            ActiveRunPhase::Preparing,
+            revision,
+            idle_vms,
+        )
+        .await
+    }
+
+    async fn add_run_with_idle_info_at_revision(
+        &self,
+        run_id: RunId,
+        sandbox_id: SandboxId,
+        phase: ActiveRunPhase,
+        revision: u64,
+        idle_vms: Vec<IdleVm>,
+    ) -> bool {
         let mut state = self.state.lock().await;
         state.active_runs.insert(
             run_id,
             ActiveRunState {
                 sandbox_id,
-                phase: ActiveRunPhase::Running,
+                phase,
                 phase_started_at: Utc::now(),
             },
         );
@@ -745,6 +782,42 @@ mod tests {
         let vms = status["idle_vms"].as_array().unwrap();
         assert_eq!(vms.len(), 1);
         assert_eq!(vms[0]["session_id"], "fresh");
+        assert_eq!(vms[0]["sandbox_id"], idle_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn add_preparing_run_with_idle_info_revision_records_preparing_phase() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+        let idle_id = SandboxId::new_v4();
+        let run_id = RunId::new_v4();
+        let active_id = SandboxId::new_v4();
+
+        tracker.write_initial().await;
+        assert!(
+            tracker
+                .add_preparing_run_with_idle_info_at_revision(
+                    run_id,
+                    active_id,
+                    1,
+                    vec![IdleVm {
+                        session_id: "fresh-create-after-reuse-miss".into(),
+                        sandbox_id: idle_id,
+                    }],
+                )
+                .await
+        );
+
+        let status = read_status(&path);
+        let runs = status["active_runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["run_id"], run_id.to_string());
+        assert_eq!(runs[0]["sandbox_id"], active_id.to_string());
+        assert_eq!(runs[0]["phase"], "preparing");
+        let vms = status["idle_vms"].as_array().unwrap();
+        assert_eq!(vms.len(), 1);
+        assert_eq!(vms[0]["session_id"], "fresh-create-after-reuse-miss");
         assert_eq!(vms[0]["sandbox_id"], idle_id.to_string());
     }
 


### PR DESCRIPTION
## Summary
- add active run phases and per-phase timestamps to runner status
- write fresh claims as preparing, reused sandboxes as running, and mark fresh runs running after sandbox start
- make runner doctor suppress missing-Firecracker warnings only for preparing runs within grace while keeping stale/running detection strict

## Testing
- cargo test --manifest-path crates/runner/Cargo.toml
- cargo fmt --manifest-path crates/runner/Cargo.toml -- --check
- git diff --check
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc

Fixes #17474

Note: segmented timing instrumentation remains tracked separately in #17472.