### PR TITLE
feat: redesign per-chat usage record with insights-style bars

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -259,6 +259,8 @@ describe("GET /api/zero/usage/record", () => {
 
     expect(response.body.rows).toHaveLength(3);
     expect(response.body.pagination.total).toBe(3);
+    // Range-wide credit total across all three rows (250 + 40 + 80).
+    expect(response.body.totalCredits).toBe(370);
     expect(response.body.period).not.toBeNull();
 
     expect(response.body.rows[0]?.source).toBe("chat");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -894,6 +894,7 @@ describe("GET /api/zero/usage/record", () => {
     expect(response.body).toStrictEqual({
       period: null,
       rows: [],
+      totalCredits: 0,
       pagination: { page: 1, pageSize: 20, total: 0 },
     });
   });

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -223,19 +223,23 @@ async function queryUsageRecordRows(
   });
 }
 
-async function queryUsageRecordTotal(
+async function queryUsageRecordTotals(
   db: Db,
   recordCte: string,
   sourceFilterLit: string | null,
-): Promise<number> {
+): Promise<{ total: number; totalCredits: number }> {
   const where = sourceFilterLit ? `WHERE source = ${sourceFilterLit}` : "";
-  const result = await db.execute<{ total: string }>(
+  const result = await db.execute<{ total: string; total_credits: string }>(
     sql.raw(`
       ${recordCte}
-      SELECT COUNT(*)::bigint AS total FROM record ${where}
+      SELECT COUNT(*)::bigint AS total, COALESCE(SUM(credits), 0)::bigint AS total_credits
+      FROM record ${where}
     `),
   );
-  return Number(result.rows[0]?.total ?? 0);
+  return {
+    total: Number(result.rows[0]?.total ?? 0),
+    totalCredits: Number(result.rows[0]?.total_credits ?? 0),
+  };
 }
 
 function rowKeyExpr(
@@ -372,6 +376,7 @@ export const zeroUsageRecord$ = command(
       return {
         period: null,
         rows: [],
+        totalCredits: 0,
         pagination: {
           page: args.page,
           pageSize: args.pageSize,
@@ -416,7 +421,11 @@ export const zeroUsageRecord$ = command(
       }),
     );
     signal.throwIfAborted();
-    const total = await queryUsageRecordTotal(db, recordCte, sourceFilterLit);
+    const { total, totalCredits } = await queryUsageRecordTotals(
+      db,
+      recordCte,
+      sourceFilterLit,
+    );
     signal.throwIfAborted();
 
     const emailMap =
@@ -462,6 +471,7 @@ export const zeroUsageRecord$ = command(
           lastActivityAt: row.lastActivityAt,
         };
       }),
+      totalCredits,
       pagination: {
         page: args.page,
         pageSize: args.pageSize,

--- a/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
@@ -16,6 +16,7 @@ const defaultResponse: UsageRecordResponse = {
     end: "2026-03-02T00:00:00.000Z",
   },
   rows: [],
+  totalCredits: 0,
   pagination: { page: 1, pageSize: 20, total: 0 },
 };
 
@@ -25,6 +26,7 @@ export function resetMockUsageRecord(): void {
   mockUsageRecordResponse = {
     period: defaultResponse.period,
     rows: [],
+    totalCredits: 0,
     pagination: { ...defaultResponse.pagination },
   };
 }
@@ -44,6 +46,9 @@ export const apiUsageRecordHandlers = [
     return respond(200, {
       period: mockUsageRecordResponse.period,
       rows: rows.slice(offset, offset + pageSize),
+      totalCredits: rows.reduce((sum, row) => {
+        return sum + row.credits;
+      }, 0),
       pagination: { page, pageSize, total: rows.length },
     });
   }),

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -34,12 +34,14 @@
   --color-credit-plan-pro: #edc43e;
   --color-credit-plan-team: #6b8de3;
 
-  /* Usage record kind breakdown segment colors */
-  --color-usage-kind-model: #6b8de3;
-  --color-usage-kind-image: #e88033;
-  --color-usage-kind-video: #3eb7b8;
-  --color-usage-kind-connector: #97918a;
-  --color-usage-kind-other: #edc43e;
+  /* Usage record kind breakdown segment colors — drawn from the Insights
+     card-palette hues so usage and insights read as one system. Image and
+     video sit far apart on the wheel (pink vs teal) since they co-occur. */
+  --color-usage-kind-model: #e24b6a;
+  --color-usage-kind-image: #ec70a5;
+  --color-usage-kind-video: #358a8e;
+  --color-usage-kind-connector: #98928b;
+  --color-usage-kind-other: #e1c43c;
 }
 
 /* Safe area insets as CSS custom properties — more reliable than direct env() in inline

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -114,6 +114,9 @@ function mockPersonalUsageStory(): string[] {
         end: "2026-04-01T00:00:00.000Z",
       },
       rows: rows.slice(offset, offset + query.pageSize),
+      totalCredits: rows.reduce((sum, row) => {
+        return sum + row.credits;
+      }, 0),
       pagination: {
         page: query.page,
         pageSize: query.pageSize,
@@ -141,7 +144,7 @@ describe("personal usage settings", () => {
       expect(screen.getByText("Quarterly planning chat")).toBeInTheDocument();
       expect(screen.getByText("Slack customer follow-up")).toBeInTheDocument();
     });
-    expect(screen.getByText("980 credits")).toBeInTheDocument();
+    expect(screen.getByText("980")).toBeInTheDocument();
     expect(screen.queryByText("Extended CLI audit")).not.toBeInTheDocument();
     expect(screen.queryByText("All sources")).not.toBeInTheDocument();
     expect(requestedRanges).toContain("today");

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -100,8 +100,10 @@ const RANGE_OPTIONS = [
   label: string;
 }[];
 
+// Row divider is an inset hairline (pseudo-element with horizontal margin) so
+// it doesn't run edge-to-edge into the card border.
 const ROW_CLASS =
-  "block px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border/50";
+  "relative block px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:before:absolute [&:not(:first-child)]:before:inset-x-5 [&:not(:first-child)]:before:top-0 [&:not(:first-child)]:before:border-t [&:not(:first-child)]:before:border-border/50 [&:not(:first-child)]:before:content-['']";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }
@@ -186,7 +188,7 @@ export function UsageRangeSelect({
   );
 }
 
-function UsageBreakdownBar({ row }: { row: UsageRecordRow }) {
+function UsageBreakdownBar({ row, max }: { row: UsageRecordRow; max: number }) {
   const segments = row.breakdown.filter((segment) => {
     return segment.credits > 0;
   });
@@ -194,56 +196,64 @@ function UsageBreakdownBar({ row }: { row: UsageRecordRow }) {
     return null;
   }
 
+  // Outer track is the full row width; the filled portion is scaled to this
+  // chat's size relative to the largest chat, so the bar reads as magnitude.
+  // The kind colors live inside the fill, so one bar carries both size and mix.
   return (
-    <div className="mt-2.5 flex h-2 w-full overflow-hidden rounded-full bg-muted/40">
-      {segments.map((segment) => {
-        const meta = KIND_META[segment.kind];
-        const width = `${(segment.credits / row.credits) * 100}%`;
-        return (
-          <Tooltip key={segment.kind}>
-            <TooltipTrigger asChild>
-              <div
-                className={`${meta.color} h-2 cursor-default first:rounded-l-full last:rounded-r-full transition-shadow hover:z-10 hover:ring-2 hover:ring-foreground/30`}
-                style={{ width }}
-                data-testid={`usage-kind-segment-${segment.kind}`}
-              />
-            </TooltipTrigger>
-            <TooltipContent
-              side="top"
-              sideOffset={8}
-              style={{
-                backgroundColor: "hsl(var(--popover))",
-                color: "hsl(var(--popover-foreground))",
-              }}
-              className="max-w-64 border shadow-md"
-            >
-              <div className="font-medium text-foreground">
-                {meta.label} - {segment.credits.toLocaleString()}
-              </div>
-              <div className="mt-1 flex flex-col gap-0.5">
-                {segment.providers.map((provider) => {
-                  return (
-                    <div
-                      key={provider.provider}
-                      className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
-                    >
-                      <span className="truncate">{provider.provider}</span>
-                      <span className="shrink-0 tabular-nums">
-                        {provider.credits.toLocaleString()}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        );
-      })}
+    <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-[hsl(var(--gray-50))]">
+      <div
+        className="flex h-full overflow-hidden rounded-full"
+        style={{ width: `${(row.credits / max) * 100}%` }}
+      >
+        {segments.map((segment) => {
+          const meta = KIND_META[segment.kind];
+          const width = `${(segment.credits / row.credits) * 100}%`;
+          return (
+            <Tooltip key={segment.kind}>
+              <TooltipTrigger asChild>
+                <div
+                  className={`${meta.color} h-full cursor-default first:rounded-l-full last:rounded-r-full transition-shadow hover:z-10 hover:ring-2 hover:ring-foreground/30`}
+                  style={{ width }}
+                  data-testid={`usage-kind-segment-${segment.kind}`}
+                />
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                sideOffset={8}
+                style={{
+                  backgroundColor: "hsl(var(--popover))",
+                  color: "hsl(var(--popover-foreground))",
+                }}
+                className="max-w-64 border shadow-md"
+              >
+                <div className="font-medium text-foreground">
+                  {meta.label} - {segment.credits.toLocaleString()}
+                </div>
+                <div className="mt-1 flex flex-col gap-0.5">
+                  {segment.providers.map((provider) => {
+                    return (
+                      <div
+                        key={provider.provider}
+                        className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
+                      >
+                        <span className="truncate">{provider.provider}</span>
+                        <span className="shrink-0 tabular-nums">
+                          {provider.credits.toLocaleString()}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
     </div>
   );
 }
 
-function UsageRow({ row }: { row: UsageRecordRow }) {
+function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
   const closeSettings = useSet(setSettingsDialogOpen$);
   const pageSignal = useGet(pageSignal$);
   const { label, Icon } = SOURCE_META[row.source];
@@ -255,7 +265,7 @@ function UsageRow({ row }: { row: UsageRecordRow }) {
     }
     detach(closeSettings(false, pageSignal), Reason.DomCallback);
   };
-  const credits = `${formatCredits(row.credits)} credits`;
+  const credits = formatCredits(row.credits);
   const inner = (
     <div className="flex min-w-0 items-start gap-3">
       <span
@@ -282,7 +292,7 @@ function UsageRow({ row }: { row: UsageRecordRow }) {
             {row.member.email}
           </span>
         ) : null}
-        <UsageBreakdownBar row={row} />
+        <UsageBreakdownBar row={row} max={max} />
       </span>
     </div>
   );
@@ -346,6 +356,95 @@ function emptyMessage(range: UsageRecordRange): string {
   return "No usage for this range yet.";
 }
 
+// Summary + type legend above the list. The credit total is range-wide (from
+// the server), so it stays correct as more pages load in.
+function UsageRecordSummary({
+  count,
+  totalCredits,
+}: {
+  count: number;
+  totalCredits: number;
+}) {
+  const kinds = Object.keys(KIND_META) as UsageRecordKind[];
+  return (
+    <div className="px-5 py-3.5">
+      <p className="text-sm text-muted-foreground">
+        <span className="font-medium text-foreground tabular-nums">
+          {count} {count === 1 ? "chat" : "chats"}
+        </span>{" "}
+        · {formatCredits(totalCredits)} credits
+      </p>
+      <div className="mt-2.5 flex flex-wrap items-center gap-x-3.5 gap-y-1.5">
+        {kinds.map((kind) => {
+          return (
+            <span
+              key={kind}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+            >
+              <span
+                className={`${KIND_META[kind].color} h-2 w-2 shrink-0 rounded-full`}
+              />
+              {KIND_META[kind].label}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function UsageRecordList({
+  data,
+  scope,
+}: {
+  data: UsageRecordResponse;
+  scope: UsageRecordScope;
+}) {
+  const loadMore = useSet(loadMoreUsageRecord$);
+  const maxCredits = Math.max(
+    1,
+    ...data.rows.map((row) => {
+      return row.credits;
+    }),
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <TooltipProvider delayDuration={100}>
+        <div
+          className="overflow-hidden rounded-xl bg-card"
+          style={{ border: CARD_BORDER }}
+        >
+          <UsageRecordSummary
+            count={data.pagination.total}
+            totalCredits={data.totalCredits}
+          />
+          {data.rows.map((row) => {
+            return (
+              <UsageRow key={usageRowKey(row)} row={row} max={maxCredits} />
+            );
+          })}
+        </div>
+      </TooltipProvider>
+      {data.rows.length < data.pagination.total && (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-9 rounded-lg text-muted-foreground hover:bg-[hsl(var(--gray-50))] hover:text-foreground"
+            onClick={() => {
+              loadMore(scope);
+            }}
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function UsageRecordContent({
   loadable,
   range,
@@ -355,8 +454,6 @@ function UsageRecordContent({
   range: UsageRecordRange;
   scope: UsageRecordScope;
 }) {
-  const loadMore = useSet(loadMoreUsageRecord$);
-
   return (
     <section className="flex flex-col gap-4">
       {loadable.state === "loading" && <UsageRecordSkeleton />}
@@ -369,33 +466,7 @@ function UsageRecordContent({
         (loadable.data.rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">{emptyMessage(range)}</p>
         ) : (
-          <div className="flex flex-col gap-3">
-            <TooltipProvider delayDuration={100}>
-              <div
-                className="overflow-hidden rounded-xl bg-card"
-                style={{ border: CARD_BORDER }}
-              >
-                {loadable.data.rows.map((row) => {
-                  return <UsageRow key={usageRowKey(row)} row={row} />;
-                })}
-              </div>
-            </TooltipProvider>
-            {loadable.data.rows.length < loadable.data.pagination.total && (
-              <div className="flex justify-center">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-9 rounded-lg text-muted-foreground hover:bg-[hsl(var(--gray-50))] hover:text-foreground"
-                  onClick={() => {
-                    loadMore(scope);
-                  }}
-                >
-                  Load more
-                </Button>
-              </div>
-            )}
-          </div>
+          <UsageRecordList data={loadable.data} scope={scope} />
         ))}
     </section>
   );

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -86,6 +86,9 @@ const usageRecordResponseSchema = z.object({
     })
     .nullable(),
   rows: z.array(usageRecordRowSchema),
+  // Total credits across the whole range (not just the current page), so the
+  // summary headline stays correct as more pages load in.
+  totalCredits: z.number(),
   pagination: z.object({
     page: z.number(),
     pageSize: z.number(),


### PR DESCRIPTION
## What

Redesigns the **per-chat usage record** (under Personal model settings) to match the Insights visual language. Design was iterated with Ming over several rounds; this ships the approved direction.

### Before → After
![before/after](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/510535d3-6a39-4356-9f89-899de513dd0a/out-pair.png)

### Final (approved)
![approved](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/15760962-04c1-41bc-98ee-57fb0db7f34a/rev3-a.png)

## Changes

- **Magnitude bars.** Each row's bar is now scaled to its credits relative to the largest chat in view, instead of a full-width bar that looked like a loading indicator and told you nothing about relative size. The kind-color segments live *inside* the scaled fill, so one thin bar carries both magnitude and composition.
- **Inset dividers.** Row hairlines no longer run edge-to-edge into the card border.
- **Summary header.** Adds `N chats · X credits` plus a per-type legend above the list. The credit total is a new **range-wide aggregate** (`totalCredits`) returned by the API, computed in the same query as the row count, so it stays correct as more pages load in (summing the loaded page would undercount).
- **Insights-derived colors.** The `usage-kind-*` tokens now use the Insights `getCardPalette` hues instead of the old burnt-orange/blue set. Image and video are kept far apart on the wheel (pink vs teal) since they co-occur in a single row. This also makes the Insights bar chart consistent.

## Scope notes

- Per-row text drops the redundant " credits" suffix (the total moved to the header); updated the frontend test accordingly.
- `usage-kind-*` are shared tokens, so the Insights bar chart/legend pick up the same palette — intended, keeps the usage area consistent.
- Team usage record (member rollup table) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)