### PR TITLE
fix: vertically center close button in templates dialog header

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2079,6 +2079,10 @@ function TemplatePickerDialog({
   const isPreviewing = Boolean(previewItem ?? illustrationPreviewItem);
   const dialogContentClassName = cn(
     "p-0 gap-0 overflow-hidden",
+    // The auto-rendered close button defaults to top-4, which is tuned for the
+    // default p-6 dialog. This dialog uses a custom py-4 header, so re-center the
+    // 36px (size-9) close button within the 50px header.
+    "[&>button[aria-label=Close]]:top-[7px]",
     isPreviewing ? "max-w-6xl" : "max-w-4xl",
   );
   const filteredPptItems = PRESENTATION_TEMPLATE_ITEMS.filter((item) => {


### PR DESCRIPTION
## Problem

In the Templates dialog (chat composer), the close (✕) button sits **below** the "Templates" title — its center is lower than the title's, and the hover background spills past the header's bottom border.

## Root cause

The shared `DialogContent` renders its close button at `absolute right-4 top-4` (16px). That offset is tuned for the default `p-6` (24px) dialogs, where the close button center lines up with the title.

This Templates dialog overrides the padding to `p-0` and uses a custom `py-4` (16px) header — so the header is only ~50px tall while the close button is 36px (`size-9`). At `top-4` the button's center lands ~9px below the title's center.

## Fix

Re-center the close button at `top-[7px]` **for this dialog only**, via a scoped class on `dialogContentClassName`. The shared `Dialog` component is left untouched, so all default `p-6` dialogs keep their correct alignment. This also fixes the preview header states, which share the same dialog and header padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)