### PR TITLE
fix: set fable effort to low

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -42,6 +42,7 @@ fn push_comma_separated_flag_values(args: &mut Vec<String>, flag: &str, values: 
 
 /// Build the argument list from explicit parameters (testable).
 fn build_claude_args(
+    model: &str,
     resume_id: &str,
     append_system_prompt: &str,
     disallowed_tools: &str,
@@ -78,6 +79,11 @@ fn build_claude_args(
         args.push(settings.to_string());
     }
 
+    if let Some(effort) = default_claude_effort_for_model(model) {
+        args.push("--effort".to_string());
+        args.push(effort.to_string());
+    }
+
     // "--" terminates option parsing so Commander.js variadic options
     // (--disallowed-tools, --tools) do not consume the prompt.
     args.push("--".to_string());
@@ -85,8 +91,18 @@ fn build_claude_args(
     args
 }
 
+/// Per-model default for Claude Code's `--effort` flag.
+fn default_claude_effort_for_model(model: &str) -> Option<&'static str> {
+    let bare = model.strip_prefix("anthropic/").unwrap_or(model);
+    match bare {
+        "claude-fable-5" | "fable" => Some("low"),
+        _ => None,
+    }
+}
+
 fn build_claude_command(use_mock: bool) -> Vec<String> {
     let args = build_claude_args(
+        env::anthropic_model(),
         env::resume_session_id(),
         env::append_system_prompt(),
         env::disallowed_tools(),
@@ -241,6 +257,7 @@ mod tests {
     ) -> Vec<String> {
         disable_system_log();
         build_claude_args(
+            "",
             resume_id,
             append_system_prompt,
             disallowed_tools,
@@ -248,6 +265,11 @@ mod tests {
             settings,
             prompt,
         )
+    }
+
+    fn build_claude_args_for_model_test(model: &str, prompt: &str) -> Vec<String> {
+        disable_system_log();
+        build_claude_args(model, "", "", "", "", "", prompt)
     }
 
     fn build_claude_command_for_test(use_mock: bool) -> Vec<String> {
@@ -570,6 +592,32 @@ mod tests {
     fn build_claude_args_empty_settings_omitted() {
         let args = build_claude_args_for_test("", "", "", "", "", "test");
         assert!(!args.contains(&"--settings".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_fable_defaults_effort_low() {
+        for model in ["claude-fable-5", "anthropic/claude-fable-5", "fable"] {
+            let args = build_claude_args_for_model_test(model, "p");
+            let effort_idx = args.iter().position(|a| a == "--effort").unwrap();
+            assert_eq!(args[effort_idx + 1], "low");
+            assert_prompt_with_separator(&args, "p");
+        }
+    }
+
+    #[test]
+    fn build_claude_args_non_fable_omits_effort() {
+        for model in [
+            "",
+            "claude-sonnet-4-6",
+            "anthropic/claude-sonnet-4.6",
+            "claude-opus-4-8",
+        ] {
+            let args = build_claude_args_for_model_test(model, "p");
+            assert!(
+                !args.iter().any(|arg| arg == "--effort"),
+                "unexpected effort default for model {model:?}: {args:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -479,6 +479,10 @@ pub fn openai_api_key() -> &'static str {
 pub fn openai_model() -> &'static str {
     user_env_value("OPENAI_MODEL")
 }
+/// Anthropic model from loaded user env; empty string means unset.
+pub fn anthropic_model() -> &'static str {
+    user_env_value("ANTHROPIC_MODEL")
+}
 /// ChatGPT workspace account id from loaded user env; empty string
 /// means unset. Presence is the signal that the sandbox is running in
 /// codex-oauth mode (see `is_codex_oauth_mode`); the value itself is

--- a/crates/guest-mock-claude/src/args.rs
+++ b/crates/guest-mock-claude/src/args.rs
@@ -30,7 +30,7 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
                     i += 1;
                 }
             }
-            "--resume" | "--append-system-prompt" => {
+            "--resume" | "--append-system-prompt" | "--effort" => {
                 // Parsed for CLI compat but not used by mock-claude
                 skip_flag_value(args, &mut i);
             }
@@ -178,6 +178,16 @@ mod tests {
     #[test]
     fn parse_args_settings_skipped() {
         let args: Vec<String> = vec!["--settings", r#"{"permissions":{}}"#, "echo hi"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let result = parse_args(&args);
+        assert_eq!(result.prompt, "echo hi");
+    }
+
+    #[test]
+    fn parse_args_effort_skipped() {
+        let args: Vec<String> = vec!["--effort", "low", "echo hi"]
             .into_iter()
             .map(String::from)
             .collect();


### PR DESCRIPTION
## Summary
- default Claude Code runs using Claude Fable 5 to `--effort low`
- keep other Claude models from receiving an effort override
- teach guest-mock-claude to skip the new `--effort` flag

## Tests
- `cargo fmt --check`
- `cargo test -p guest-agent build_claude_args_fable_defaults_effort_low --lib`
- `cargo test -p guest-agent build_claude_args_non_fable_omits_effort --lib`
- `cargo test -p guest-mock-claude parse_args_effort_skipped`
- `cargo clippy -p guest-agent -p guest-mock-claude --all-targets -- -D warnings`