### PR TITLE
fix: reject parent host file paths before walking

### DIFF
--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -138,6 +138,7 @@ fn open_dir_components(
             format!("empty {context} path"),
         ));
     }
+    validate_lexical_components(path)?;
 
     let expected_uid = nix::unistd::geteuid().as_raw();
     let start = if path.is_absolute() {
@@ -200,6 +201,31 @@ fn open_dir_components(
     }
 
     Ok(current)
+}
+
+fn validate_lexical_components(path: &Path) -> io::Result<()> {
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir | Component::Normal(_) => {}
+            Component::ParentDir => {
+                return Err(permission_denied(format!(
+                    "{} contains a parent directory segment",
+                    path.display()
+                )));
+            }
+            Component::Prefix(prefix) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{} contains unsupported path prefix {}",
+                        path.display(),
+                        prefix.as_os_str().to_string_lossy()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn open_dir_component(
@@ -473,4 +499,96 @@ fn permission_denied(message: String) -> io::Error {
 
 fn wrap_io(error: io::Error, context: String) -> io::Error {
     io::Error::new(error.kind(), format!("{context}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::os::unix::fs::symlink;
+
+    use super::*;
+
+    #[test]
+    fn ensure_dir_rejects_private_intermediate_symlink_without_touching_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error =
+            ensure_dir(&link.join("child"), DirMode::Private, "test directory").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!target.join("child").exists());
+    }
+
+    #[test]
+    fn ensure_dir_rejects_trusted_parent_intermediate_symlink_without_touching_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = ensure_dir(
+            &link.join("child"),
+            DirMode::TrustedParent,
+            "test directory",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!target.join("child").exists());
+    }
+
+    #[test]
+    fn ensure_dir_rejects_private_parent_segment_before_creating_missing_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("base");
+        std::fs::create_dir(&base).unwrap();
+
+        let error = ensure_dir(
+            &base.join("missing").join("..").join("leaf"),
+            DirMode::Private,
+            "test directory",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!base.join("missing").exists());
+        assert!(!base.join("leaf").exists());
+    }
+
+    #[test]
+    fn ensure_dir_rejects_trusted_parent_parent_segment_before_creating_missing_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("base");
+        std::fs::create_dir(&base).unwrap();
+
+        let error = ensure_dir(
+            &base.join("missing").join("..").join("leaf"),
+            DirMode::TrustedParent,
+            "test directory",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!base.join("missing").exists());
+        assert!(!base.join("leaf").exists());
+    }
+
+    #[test]
+    fn open_private_append_file_rejects_symlink_parent_without_touching_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = open_private_append_file(&link.join("log.jsonl"), false).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!target.join("log.jsonl").exists());
+    }
 }


### PR DESCRIPTION
## Summary

- Reject `..` and unsupported lexical path components before the host-file directory walker performs filesystem operations.
- Keep the existing fd-relative `openat + O_NOFOLLOW + fstat` walker for symlink, owner, and mode validation.
- Add direct `host_file` tests for intermediate symlink components and `..` paths under missing prefixes across `Private` and `TrustedParent` modes.

Fixes #17433

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner host_file`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
