### PR TITLE
fix(web): hide main composer input while inline feedback tray is open

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4284,18 +4284,18 @@ export function ZeroChatComposer({
                       }}
                     />
                   )}
+                  <ComposerInputSlot
+                    input={input}
+                    onInputChange={onInputChange}
+                    onDraftChange={onDraftChange}
+                    sending={sending}
+                    autoFocus={autoFocus}
+                    setInputRef={setInputRef}
+                    onKeyDown={handleKeyDown}
+                    onPaste={handlePaste}
+                  />
                 </>
               )}
-              <ComposerInputSlot
-                input={input}
-                onInputChange={onInputChange}
-                onDraftChange={onDraftChange}
-                sending={sending}
-                autoFocus={autoFocus}
-                setInputRef={setInputRef}
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-              />
               <div className="flex items-center justify-between gap-2 px-4 pb-3 pt-1">
                 <div className="flex items-center gap-1 text-muted-foreground sm:gap-1.5">
                   <TooltipProvider delayDuration={300}>


### PR DESCRIPTION
## Problem

When the inline feedback tray is open (you select assistant text → **Provide feedback**), the composer showed **two** input fields: the feedback note ("What should change about this?") **and** the main "Ask me to automate workflows, manage tasks…" textarea below it. The input looked duplicated.

<img width="600" alt="duplicate input" src="https://github.com/user-attachments/assets/placeholder" />

## Root cause

In the original layout the main textarea lived **inside** the `else` branch of the `activeFeedback ? … : …` conditional, so it was hidden while the feedback tray was active. A later refactor extracted the textarea into `ComposerInputSlot` and placed it **outside** the conditional, making it render in both modes.

## Fix

Render `ComposerInputSlot` only when not in feedback mode (moved back inside the `else` branch). Feedback mode now shows only the feedback note input; the toolbar (attach / connectors / model / send) stays in both modes, and **Send** is already wired to submit feedback. Pure JSX restructure — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)