### PR TITLE
fix: remove extra completed work divider

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1480,6 +1480,9 @@ describe("chat lifecycle", () => {
 
     const expandButton = await screen.findByLabelText("Expand work history");
     expect(expandButton).toHaveTextContent("Worked for 55s");
+    expect(expandButton.querySelectorAll('[aria-hidden="true"]')).toHaveLength(
+      1,
+    );
     const foldedAssistantGroup = expandButton.closest(
       '[data-role="assistant"]',
     ) as HTMLElement | null;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2685,10 +2685,9 @@ function CompletedWorkFoldRow({
         onClick={onToggle}
         className="flex h-9 w-full flex-col justify-center gap-1.5 rounded-lg px-2 text-left transition-colors hover:bg-muted/40"
       >
-        <span className="block h-px w-full bg-border/40" />
         <span className="flex items-center gap-2">
           <span className={RUN_SECTION_LABEL_CLASS}>{label}</span>
-          <span className="h-px flex-1 bg-border/40" />
+          <span aria-hidden className="h-px flex-1 bg-border/40" />
         </span>
       </button>
     </div>


### PR DESCRIPTION
## Summary
- remove the extra full-width divider above completed work fold labels
- keep only the divider to the right of the `Worked for ...` label
- add a regression assertion that completed work fold buttons render a single decorative divider

## Tests
- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`

## Notes
- `scripts/prepare.sh` installed dependencies but could not complete local env setup because this machine is missing `DATABASE_URL` and 1Password CLI/env values.
- `pnpm -F @vm0/app test -- src/views/zero-page/__tests__/chat-lifecycle.test.tsx` forwarded args after `--` and ran the app suite; unrelated schedule tests failed there. The targeted root-level Vitest command above passed.
