### PR TITLE
fix: mask runtime guest-agent session ids

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -62,7 +62,7 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
     ];
 
     if !config.resume_id.is_empty() {
-        log_info!(LOG_TAG, "Resuming session: {}", config.resume_id);
+        log_info!(LOG_TAG, "Resuming session");
         args.push("--resume".to_string());
         args.push(config.resume_id.to_string());
     } else {
@@ -215,7 +215,7 @@ fn build_codex_args(
     }
 
     if !resume_id.is_empty() {
-        log_info!(LOG_TAG, "Resuming codex session: {resume_id}");
+        log_info!(LOG_TAG, "Resuming codex session");
         args.push("resume".to_string());
         args.push(resume_id.to_string());
         args.push("--".to_string());
@@ -250,6 +250,9 @@ fn build_codex_command(use_mock: bool) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static SYSTEM_LOG_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     fn disable_system_log() {
         guest_common::log::clear_system_log_file();
@@ -263,6 +266,7 @@ mod tests {
         settings: &str,
         prompt: &str,
     ) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_claude_args(ClaudeArgsConfig {
             model: "",
@@ -277,6 +281,7 @@ mod tests {
     }
 
     fn build_claude_args_for_model_test(model: &str, prompt: &str) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_claude_args(ClaudeArgsConfig {
             model,
@@ -291,6 +296,7 @@ mod tests {
     }
 
     fn build_claude_command_for_test(use_mock: bool) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_claude_command(use_mock)
     }
@@ -377,6 +383,32 @@ mod tests {
     }
 
     #[test]
+    fn build_claude_args_resume_log_omits_resume_id() {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        guest_common::log::set_system_log_file(system_log_path.to_string_lossy().as_ref());
+
+        let args = build_claude_args(ClaudeArgsConfig {
+            model: "",
+            resume_id: "sess-secret-123",
+            append_system_prompt: "",
+            disallowed_tools: "",
+            tools: "",
+            settings: "",
+            include_partial_messages: false,
+            prompt: "prompt",
+        });
+        guest_common::log::clear_system_log_file();
+        let system_log = std::fs::read_to_string(system_log_path).unwrap();
+
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"sess-secret-123".to_string()));
+        assert!(system_log.contains("Resuming session"));
+        assert!(!system_log.contains("sess-secret-123"));
+    }
+
+    #[test]
     fn build_claude_args_with_resume_and_append() {
         let args = build_claude_args_for_test("sess-123", "Be helpful.", "", "", "", "prompt");
         assert!(args.contains(&"--resume".to_string()));
@@ -403,6 +435,7 @@ mod tests {
     }
 
     fn build_codex_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_codex_args(model, resume_id, "", prompt)
     }
@@ -413,6 +446,7 @@ mod tests {
         append_system_prompt: &str,
         prompt: &str,
     ) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_codex_args(model, resume_id, append_system_prompt, prompt)
     }
@@ -423,8 +457,26 @@ mod tests {
     }
 
     fn build_codex_command_for_test(use_mock: bool) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_codex_command(use_mock)
+    }
+
+    #[test]
+    fn build_codex_args_resume_log_omits_resume_id() {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let system_log_path = tmp.path().join("system.log");
+        guest_common::log::set_system_log_file(system_log_path.to_string_lossy().as_ref());
+
+        let args = build_codex_args("", "thread-secret-123", "", "prompt");
+        guest_common::log::clear_system_log_file();
+        let system_log = std::fs::read_to_string(system_log_path).unwrap();
+
+        assert!(args.contains(&"resume".to_string()));
+        assert!(args.contains(&"thread-secret-123".to_string()));
+        assert!(system_log.contains("Resuming codex session"));
+        assert!(!system_log.contains("thread-secret-123"));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -280,6 +280,24 @@ mod tests {
         })
     }
 
+    fn build_claude_args_with_partial_messages_for_test(
+        include_partial_messages: bool,
+        prompt: &str,
+    ) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
+        disable_system_log();
+        build_claude_args(ClaudeArgsConfig {
+            model: "",
+            resume_id: "",
+            append_system_prompt: "",
+            disallowed_tools: "",
+            tools: "",
+            settings: "",
+            include_partial_messages,
+            prompt,
+        })
+    }
+
     fn build_claude_args_for_model_test(model: &str, prompt: &str) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
@@ -342,16 +360,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_include_partial_messages_before_prompt_separator() {
-        let args = build_claude_args(ClaudeArgsConfig {
-            model: "",
-            resume_id: "",
-            append_system_prompt: "",
-            disallowed_tools: "",
-            tools: "",
-            settings: "",
-            include_partial_messages: true,
-            prompt: "test",
-        });
+        let args = build_claude_args_with_partial_messages_for_test(true, "test");
         let flag_idx = args
             .iter()
             .position(|arg| arg == "--include-partial-messages")
@@ -367,16 +376,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_omits_partial_messages_when_disabled() {
-        let args = build_claude_args(ClaudeArgsConfig {
-            model: "",
-            resume_id: "",
-            append_system_prompt: "",
-            disallowed_tools: "",
-            tools: "",
-            settings: "",
-            include_partial_messages: false,
-            prompt: "test",
-        });
+        let args = build_claude_args_with_partial_messages_for_test(false, "test");
 
         assert!(!args.contains(&"--include-partial-messages".to_string()));
         assert_prompt_with_separator(&args, "test");

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -357,6 +357,7 @@ pub async fn execute_cli(
                             if event.get("type").and_then(serde_json::Value::as_str)
                                 == Some("stream_event")
                             {
+                                events::register_event_session_identifier(&event, masker);
                                 if event
                                     .get("parent_tool_use_id")
                                     .is_some_and(|value| !value.is_null())
@@ -437,7 +438,7 @@ pub async fn execute_cli(
                                 }
                                 if let Some(result) = event.get("result").and_then(|v| v.as_str())
                                 {
-                                    println!("{result}");
+                                    println!("{}", claude_result_for_stdout(result, masker));
                                 }
                                 // Arm the post-result reap deadline once per
                                 // run — see `TerminationState::should_arm_post_result`.
@@ -799,6 +800,10 @@ fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<
     Ok(())
 }
 
+fn claude_result_for_stdout(result: &str, masker: &SecretMasker) -> String {
+    masker.mask_string(result)
+}
+
 fn select_failure_diagnostic(
     existing: Option<&CliFailureDiagnostic>,
     candidate: CliFailureDiagnostic,
@@ -849,10 +854,13 @@ fn with_carried_failure_reason(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliFailureDiagnostic, select_failure_diagnostic, set_cli_current_dir,
-        with_carried_failure_reason,
+        CliFailureDiagnostic, chat_stream_delta_from_event, claude_result_for_stdout,
+        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
     };
+    use crate::events;
+    use crate::masker::SecretMasker;
     use agent_diagnostics::{FailureDetailSource, FailureReason};
+    use serde_json::json;
 
     #[tokio::test]
     async fn cli_current_dir_helper_sets_child_working_directory() {
@@ -897,6 +905,45 @@ mod tests {
             .expect_err("non-directory cwd should fail");
 
         assert!(err.to_string().contains("is not a directory"));
+    }
+
+    #[test]
+    fn claude_result_stdout_masks_runtime_session_id() {
+        let session_id = "result-session-secret-123";
+        let masker = SecretMasker::from_raw("");
+        masker.add_sensitive_value(session_id);
+
+        assert_eq!(
+            claude_result_for_stdout(&format!("failed for {session_id}"), &masker),
+            "failed for ***"
+        );
+    }
+
+    #[test]
+    fn stream_event_chat_delta_masks_top_level_session_id_from_same_event() {
+        let session_id = "stream-session-secret-123";
+        let masker = SecretMasker::from_raw("");
+        let event = json!({
+            "type": "stream_event",
+            "session_id": session_id,
+            "event": {
+                "type": "content_block_delta",
+                "delta": {
+                    "type": "text_delta",
+                    "text": format!("delta for {session_id}")
+                }
+            }
+        });
+
+        events::register_event_session_identifier(&event, &masker);
+        let delta = chat_stream_delta_from_event(
+            event.get("event").expect("stream event payload"),
+            "msg_01",
+            &masker,
+        )
+        .expect("chat delta");
+
+        assert_eq!(delta.text, "delta for ***");
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -156,6 +156,7 @@ pub async fn execute_cli(
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();
     let behavior = CliFrameworkBehavior::new(framework);
+    masker.add_sensitive_value(env::resume_session_id());
     log_info!(LOG_TAG, "Starting {} execution...", behavior.agent_type());
 
     let cmd = command::build_cli_command_for_framework(framework)?;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -474,7 +474,7 @@ pub async fn execute_cli(
                             }
                             // Capture checkpoint metadata before event payload preparation
                             // consumes and masks the event.
-                            events::capture_session_metadata(&event);
+                            events::capture_session_metadata(&event, masker);
 
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -412,6 +412,10 @@ pub async fn execute_cli(
                             if seq == 0 {
                                 timing::record_e2e_from_api("api_to_cli_init");
                             }
+                            // Capture checkpoint metadata and register any
+                            // event-local session identifier before logging
+                            // terminal diagnostics from the same event.
+                            events::capture_session_metadata(&event, masker);
                             // Print Claude Code final result to stdout if applicable.
                             if behavior.handles_claude_result_event(&event) {
                                 claude_result = Some(ClaudeResultSummary::from_event(&event));
@@ -473,10 +477,6 @@ pub async fn execute_cli(
                                     failure_diagnostic = Some(selected);
                                 }
                             }
-                            // Capture checkpoint metadata before event payload preparation
-                            // consumes and masks the event.
-                            events::capture_session_metadata(&event, masker);
-
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
                             if should_send_events {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -438,7 +438,10 @@ pub async fn execute_cli(
                                 }
                                 if let Some(result) = event.get("result").and_then(|v| v.as_str())
                                 {
-                                    println!("{}", claude_result_for_stdout(result, masker));
+                                    // Guest-agent stdout is captured as
+                                    // system-stream logs, so mask before
+                                    // printing Claude's final result.
+                                    println!("{}", masker.mask_string(result));
                                 }
                                 // Arm the post-result reap deadline once per
                                 // run — see `TerminationState::should_arm_post_result`.
@@ -800,10 +803,6 @@ fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<
     Ok(())
 }
 
-fn claude_result_for_stdout(result: &str, masker: &SecretMasker) -> String {
-    masker.mask_string(result)
-}
-
 fn select_failure_diagnostic(
     existing: Option<&CliFailureDiagnostic>,
     candidate: CliFailureDiagnostic,
@@ -854,8 +853,8 @@ fn with_carried_failure_reason(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliFailureDiagnostic, chat_stream_delta_from_event, claude_result_for_stdout,
-        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
+        CliFailureDiagnostic, chat_stream_delta_from_event, select_failure_diagnostic,
+        set_cli_current_dir, with_carried_failure_reason,
     };
     use crate::events;
     use crate::masker::SecretMasker;
@@ -905,18 +904,6 @@ mod tests {
             .expect_err("non-directory cwd should fail");
 
         assert!(err.to_string().contains("is not a directory"));
-    }
-
-    #[test]
-    fn claude_result_stdout_masks_runtime_session_id() {
-        let session_id = "result-session-secret-123";
-        let masker = SecretMasker::from_raw("");
-        masker.add_sensitive_value(session_id);
-
-        assert_eq!(
-            claude_result_for_stdout(&format!("failed for {session_id}"), &masker),
-            "failed for ***"
-        );
     }
 
     #[test]

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -405,12 +405,19 @@ pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
 
 fn register_event_session_identifier(event: &Value, masker: &SecretMasker) {
     let id = match Framework::from_env() {
-        Framework::ClaudeCode => raw_claude_session_id(event),
-        Framework::Codex => raw_codex_thread_id(event),
+        Framework::ClaudeCode => string_field(event, "session_id"),
+        Framework::Codex => string_field(event, "thread_id"),
     };
     if let Some(id) = id {
         masker.add_sensitive_value(id);
     }
+}
+
+fn string_field<'a>(event: &'a Value, field: &str) -> Option<&'a str> {
+    event
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
 }
 
 fn repair_missing_session_history_marker_from_existing_session(masker: &SecretMasker) {
@@ -508,11 +515,7 @@ fn raw_claude_session_id(event: &Value) -> Option<&str> {
     if event_type != "system" || subtype != "init" {
         return None;
     }
-    let session_id = event.get("session_id").and_then(|v| v.as_str())?;
-    if session_id.is_empty() {
-        return None;
-    }
-    Some(session_id)
+    string_field(event, "session_id")
 }
 
 fn claude_history_path_payload(session_id: &str) -> Option<String> {
@@ -560,11 +563,7 @@ fn raw_codex_thread_id(event: &Value) -> Option<&str> {
     if event_type != "thread.started" {
         return None;
     }
-    let thread_id = event.get("thread_id").and_then(|v| v.as_str())?;
-    if thread_id.is_empty() {
-        return None;
-    }
-    Some(thread_id)
+    string_field(event, "thread_id")
 }
 
 fn codex_history_marker_payload(thread_id: &str) -> String {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -365,7 +365,11 @@ pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
     // partial metadata write.
     match std::fs::read_to_string(paths::session_id_file()) {
         Ok(existing_session_id) => {
-            if existing_session_id.trim() == session_id {
+            let existing_session_id = existing_session_id.trim();
+            if !existing_session_id.is_empty() {
+                masker.add_sensitive_value(existing_session_id);
+            }
+            if existing_session_id == session_id {
                 ensure_session_history_marker(&history_path_payload);
             }
             return;

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -403,7 +403,7 @@ pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
     write_session_history_marker(&history_path_payload);
 }
 
-fn register_event_session_identifier(event: &Value, masker: &SecretMasker) {
+pub(crate) fn register_event_session_identifier(event: &Value, masker: &SecretMasker) {
     let id = match Framework::from_env() {
         Framework::ClaudeCode => string_field(event, "session_id"),
         Framework::Codex => string_field(event, "thread_id"),

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -43,7 +43,7 @@ pub async fn send_event(
     seq: u32,
     masker: &SecretMasker,
 ) -> Result<(), AgentError> {
-    capture_session_metadata(&event);
+    capture_session_metadata(&event, masker);
 
     if !http.has_api() {
         return Ok(());
@@ -349,15 +349,16 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 /// - Codex: `CODEX_SEARCH:{sessions_dir}:{thread_id}` marker — codex
 ///   doesn't write the session file until turn-completion, so resolution
 ///   is deferred to checkpoint time.
-pub(crate) fn capture_session_metadata(event: &Value) {
+pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
     let parsed = match Framework::from_env() {
         Framework::ClaudeCode => extract_claude_session_id(event),
         Framework::Codex => extract_codex_thread_id(event),
     };
     let Some((session_id, history_path_payload)) = parsed else {
-        repair_missing_session_history_marker_from_existing_session();
+        repair_missing_session_history_marker_from_existing_session(masker);
         return;
     };
+    masker.add_sensitive_value(&session_id);
 
     // Idempotency: only the first id-bearing event of the run wins, but allow
     // a retry of the same session to repair a missing history marker after a
@@ -380,7 +381,7 @@ pub(crate) fn capture_session_metadata(event: &Value) {
         }
     }
 
-    log_info!(LOG_TAG, "Captured session ID: {session_id}");
+    log_info!(LOG_TAG, "Captured session ID");
     match paths::write_private(paths::session_id_file(), &session_id) {
         Ok(()) => log_info!(
             LOG_TAG,
@@ -396,7 +397,7 @@ pub(crate) fn capture_session_metadata(event: &Value) {
     write_session_history_marker(&history_path_payload);
 }
 
-fn repair_missing_session_history_marker_from_existing_session() {
+fn repair_missing_session_history_marker_from_existing_session(masker: &SecretMasker) {
     if !should_write_session_history_marker() {
         return;
     }
@@ -415,6 +416,7 @@ fn repair_missing_session_history_marker_from_existing_session() {
     if session_id.is_empty() {
         return;
     }
+    masker.add_sensitive_value(&session_id);
     if let Some(history_path_payload) = history_path_payload_for_session_id(&session_id) {
         write_session_history_marker(&history_path_payload);
     }
@@ -445,14 +447,23 @@ fn write_session_history_marker(history_path_payload: &str) {
     match paths::write_private(paths::session_history_path_file(), history_path_payload) {
         Ok(()) => log_info!(
             LOG_TAG,
-            "Session history marker written to {}: {history_path_payload}",
-            paths::session_history_path_file()
+            "Session history marker written to {} ({})",
+            paths::session_history_path_file(),
+            session_history_marker_kind(history_path_payload)
         ),
         Err(e) => log_error!(
             LOG_TAG,
             "Failed to write session history marker to {}: {e}",
             paths::session_history_path_file()
         ),
+    }
+}
+
+fn session_history_marker_kind(history_path_payload: &str) -> &'static str {
+    if history_path_payload.starts_with("CODEX_SEARCH:") {
+        "codex"
+    } else {
+        "claude"
     }
 }
 

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -350,6 +350,8 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 ///   doesn't write the session file until turn-completion, so resolution
 ///   is deferred to checkpoint time.
 pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
+    register_event_session_identifier(event, masker);
+
     let parsed = match Framework::from_env() {
         Framework::ClaudeCode => extract_claude_session_id(event),
         Framework::Codex => extract_codex_thread_id(event),
@@ -399,6 +401,16 @@ pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
         ),
     }
     write_session_history_marker(&history_path_payload);
+}
+
+fn register_event_session_identifier(event: &Value, masker: &SecretMasker) {
+    let id = match Framework::from_env() {
+        Framework::ClaudeCode => raw_claude_session_id(event),
+        Framework::Codex => raw_codex_thread_id(event),
+    };
+    if let Some(id) = id {
+        masker.add_sensitive_value(id);
+    }
 }
 
 fn repair_missing_session_history_marker_from_existing_session(masker: &SecretMasker) {
@@ -484,6 +496,13 @@ fn history_path_payload_for_session_id(session_id: &str) -> Option<String> {
 /// Claude variant — matches `system/init` and computes the project-scoped
 /// jsonl path under `$HOME/.claude/projects/-{cwd}/`.
 fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
+    let session_id = raw_claude_session_id(event)?;
+    let history_path_payload = claude_history_path_payload(session_id)?;
+
+    Some((session_id.to_string(), history_path_payload))
+}
+
+fn raw_claude_session_id(event: &Value) -> Option<&str> {
     let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
     let subtype = event.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
     if event_type != "system" || subtype != "init" {
@@ -493,9 +512,7 @@ fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
     if session_id.is_empty() {
         return None;
     }
-    let history_path_payload = claude_history_path_payload(session_id)?;
-
-    Some((session_id.to_string(), history_path_payload))
+    Some(session_id)
 }
 
 fn claude_history_path_payload(session_id: &str) -> Option<String> {
@@ -531,15 +548,23 @@ fn is_valid_session_history_id(session_id: &str) -> bool {
 /// Codex variant — matches `thread.started` and emits a `CODEX_SEARCH:`
 /// marker pointing at `${HOME}/.codex/sessions` plus the thread_id.
 fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
+    let thread_id = raw_codex_thread_id(event)?;
+    let thread_id = crate::session_history::canonical_codex_thread_id(thread_id)?;
+    let marker = codex_history_marker_payload(&thread_id);
+
+    Some((thread_id, marker))
+}
+
+fn raw_codex_thread_id(event: &Value) -> Option<&str> {
     let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
     if event_type != "thread.started" {
         return None;
     }
     let thread_id = event.get("thread_id").and_then(|v| v.as_str())?;
-    let thread_id = crate::session_history::canonical_codex_thread_id(thread_id)?;
-    let marker = codex_history_marker_payload(&thread_id);
-
-    Some((thread_id, marker))
+    if thread_id.is_empty() {
+        return None;
+    }
+    Some(thread_id)
 }
 
 fn codex_history_marker_payload(thread_id: &str) -> String {

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -1,28 +1,43 @@
-//! Secret masking for event payloads and CLI diagnostics.
+//! Sensitive value masking for event payloads and CLI diagnostics.
 //!
 //! Reads `VM0_SECRET_VALUES` (comma-separated base64 values), pre-computes
 //! plain / base64 / URL-encoded variants for normal payload masking, and derives
-//! diagnostic-only multiline variants for bounded CLI stderr tails.
+//! diagnostic-only multiline variants for bounded CLI stderr tails. Runtime
+//! metadata such as CLI session identifiers can be registered after startup and
+//! uses the same matcher set.
 
 use crate::env;
 use aho_corasick::{AhoCorasick, MatchKind};
 use base64::Engine;
 use serde_json::Value;
-use std::{collections::HashSet, ops::Range};
+use std::{
+    collections::HashSet,
+    ops::Range,
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
 
 /// Minimum secret length to avoid false-positive masking.
 const MIN_SECRET_LEN: usize = 5;
 
-/// Holds pre-computed secret patterns for efficient masking.
+/// Holds pre-computed sensitive value patterns for efficient masking.
 ///
 /// Uses Aho-Corasick with leftmost-longest match semantics so that when one
-/// configured secret is a substring of another, the longer match wins and no
-/// partial secret survives. See issue #9778.
+/// configured value is a substring of another, the longer match wins and no
+/// partial sensitive value survives. See issue #9778.
 pub struct SecretMasker {
+    state: RwLock<MaskerState>,
+}
+
+struct MaskerState {
     matcher: Option<Matcher>,
     diagnostic_matcher: Option<Matcher>,
     url_encoded_matcher: Option<Matcher>,
     diagnostic_url_encoded_matcher: Option<Matcher>,
+    patterns: Vec<String>,
+    diagnostic_patterns: Vec<String>,
+    url_encoded_patterns: Vec<String>,
+    diagnostic_url_encoded_patterns: Vec<String>,
+    registered_values: HashSet<String>,
 }
 
 struct Matcher {
@@ -63,35 +78,23 @@ impl SecretMasker {
             .filter(|s| !s.is_empty())
             .collect();
 
-        let mut patterns = Vec::new();
-        let mut diagnostic_patterns = Vec::new();
-        let mut url_encoded_patterns = Vec::new();
-        let mut diagnostic_url_encoded_patterns = Vec::new();
+        let mut state = MaskerState::empty();
         for secret in &secrets {
-            if secret.len() < MIN_SECRET_LEN {
-                continue;
-            }
-            push_secret_patterns(secret, &mut patterns);
-            push_secret_patterns(secret, &mut diagnostic_patterns);
-            push_url_encoded_secret_pattern(secret, &mut url_encoded_patterns);
-            push_url_encoded_secret_pattern(secret, &mut diagnostic_url_encoded_patterns);
-            push_diagnostic_multiline_patterns(secret, &mut diagnostic_patterns);
+            state.add_sensitive_value_patterns(secret);
         }
-        Self::build_with_diagnostic_patterns(
-            patterns,
-            diagnostic_patterns,
-            url_encoded_patterns,
-            diagnostic_url_encoded_patterns,
-        )
+        state.rebuild_matchers();
+        Self::from_state(state)
+    }
+
+    pub(crate) fn add_sensitive_value(&self, value: &str) {
+        let mut state = self.write_state();
+        if state.add_sensitive_value_patterns(value) {
+            state.rebuild_matchers();
+        }
     }
 
     fn empty() -> Self {
-        Self {
-            matcher: None,
-            diagnostic_matcher: None,
-            url_encoded_matcher: None,
-            diagnostic_url_encoded_matcher: None,
-        }
+        Self::from_state(MaskerState::empty())
     }
 
     #[cfg(test)]
@@ -99,22 +102,19 @@ impl SecretMasker {
         Self::build_with_diagnostic_patterns(patterns.clone(), patterns, Vec::new(), Vec::new())
     }
 
+    #[cfg(test)]
     fn build_with_diagnostic_patterns(
         patterns: Vec<String>,
         diagnostic_patterns: Vec<String>,
         url_encoded_patterns: Vec<String>,
         diagnostic_url_encoded_patterns: Vec<String>,
     ) -> Self {
-        let matcher = Self::build_matcher(&patterns);
-        let diagnostic_matcher = Self::build_matcher(&diagnostic_patterns);
-        let url_encoded_matcher = Self::build_matcher(&url_encoded_patterns);
-        let diagnostic_url_encoded_matcher = Self::build_matcher(&diagnostic_url_encoded_patterns);
-        Self {
-            matcher,
-            diagnostic_matcher,
-            url_encoded_matcher,
-            diagnostic_url_encoded_matcher,
-        }
+        Self::from_state(MaskerState::from_pattern_sets(
+            patterns,
+            diagnostic_patterns,
+            url_encoded_patterns,
+            diagnostic_url_encoded_patterns,
+        ))
     }
 
     /// # Panics
@@ -143,8 +143,112 @@ impl SecretMasker {
         Some(Matcher { ac, replacements })
     }
 
+    fn from_state(state: MaskerState) -> Self {
+        Self {
+            state: RwLock::new(state),
+        }
+    }
+
+    fn read_state(&self) -> RwLockReadGuard<'_, MaskerState> {
+        self.state.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn write_state(&self) -> RwLockWriteGuard<'_, MaskerState> {
+        self.state.write().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Recursively mask secrets in a JSON value tree (in-place).
     pub fn mask_value(&self, val: &mut Value) {
+        self.read_state().mask_value(val);
+    }
+
+    /// Replace all secret patterns in a string with `***`.
+    ///
+    /// Uses leftmost-longest matching semantics: at each position, the
+    /// longest configured pattern wins, so a shorter secret that is a
+    /// substring of a longer one cannot strip a byte off the longer match.
+    pub fn mask_string(&self, s: &str) -> String {
+        self.masked_string(s).unwrap_or_else(|| s.to_string())
+    }
+
+    pub(crate) fn mask_owned_string(&self, s: String) -> String {
+        self.masked_string(&s).unwrap_or(s)
+    }
+
+    /// Mask diagnostic text while preserving the caller's line boundaries.
+    pub(crate) fn mask_diagnostic_lines(&self, lines: Vec<String>) -> Vec<String> {
+        self.read_state().mask_diagnostic_lines(lines)
+    }
+
+    #[cfg(test)]
+    fn mask_string_in_place(&self, s: &mut String) -> bool {
+        self.read_state().mask_string_in_place(s)
+    }
+
+    fn masked_string(&self, s: &str) -> Option<String> {
+        self.read_state().masked_string(s)
+    }
+}
+
+impl MaskerState {
+    fn empty() -> Self {
+        Self {
+            matcher: None,
+            diagnostic_matcher: None,
+            url_encoded_matcher: None,
+            diagnostic_url_encoded_matcher: None,
+            patterns: Vec::new(),
+            diagnostic_patterns: Vec::new(),
+            url_encoded_patterns: Vec::new(),
+            diagnostic_url_encoded_patterns: Vec::new(),
+            registered_values: HashSet::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_pattern_sets(
+        patterns: Vec<String>,
+        diagnostic_patterns: Vec<String>,
+        url_encoded_patterns: Vec<String>,
+        diagnostic_url_encoded_patterns: Vec<String>,
+    ) -> Self {
+        let mut state = Self {
+            matcher: None,
+            diagnostic_matcher: None,
+            url_encoded_matcher: None,
+            diagnostic_url_encoded_matcher: None,
+            patterns,
+            diagnostic_patterns,
+            url_encoded_patterns,
+            diagnostic_url_encoded_patterns,
+            registered_values: HashSet::new(),
+        };
+        state.rebuild_matchers();
+        state
+    }
+
+    fn add_sensitive_value_patterns(&mut self, value: &str) -> bool {
+        if value.len() < MIN_SECRET_LEN || !self.registered_values.insert(value.to_string()) {
+            return false;
+        }
+
+        push_secret_patterns(value, &mut self.patterns);
+        push_secret_patterns(value, &mut self.diagnostic_patterns);
+        push_url_encoded_secret_pattern(value, &mut self.url_encoded_patterns);
+        push_url_encoded_secret_pattern(value, &mut self.diagnostic_url_encoded_patterns);
+        push_diagnostic_multiline_patterns(value, &mut self.diagnostic_patterns);
+        true
+    }
+
+    fn rebuild_matchers(&mut self) {
+        self.matcher = SecretMasker::build_matcher(&self.patterns);
+        self.diagnostic_matcher = SecretMasker::build_matcher(&self.diagnostic_patterns);
+        self.url_encoded_matcher = SecretMasker::build_matcher(&self.url_encoded_patterns);
+        self.diagnostic_url_encoded_matcher =
+            SecretMasker::build_matcher(&self.diagnostic_url_encoded_patterns);
+    }
+
+    fn mask_value(&self, val: &mut Value) {
         if self.matcher.is_none() && self.url_encoded_matcher.is_none() {
             return;
         }
@@ -166,21 +270,7 @@ impl SecretMasker {
         }
     }
 
-    /// Replace all secret patterns in a string with `***`.
-    ///
-    /// Uses leftmost-longest matching semantics: at each position, the
-    /// longest configured pattern wins, so a shorter secret that is a
-    /// substring of a longer one cannot strip a byte off the longer match.
-    pub fn mask_string(&self, s: &str) -> String {
-        self.masked_string(s).unwrap_or_else(|| s.to_string())
-    }
-
-    pub(crate) fn mask_owned_string(&self, s: String) -> String {
-        self.masked_string(&s).unwrap_or(s)
-    }
-
-    /// Mask diagnostic text while preserving the caller's line boundaries.
-    pub(crate) fn mask_diagnostic_lines(&self, lines: Vec<String>) -> Vec<String> {
+    fn mask_diagnostic_lines(&self, lines: Vec<String>) -> Vec<String> {
         if self.diagnostic_matcher.is_none() && self.diagnostic_url_encoded_matcher.is_none() {
             return lines;
         }
@@ -539,6 +629,43 @@ mod tests {
         masker.mask_value(&mut val);
         assert_eq!(val["outer"]["inner"], "has *** inside");
         assert_eq!(val["list"][1], "***");
+    }
+
+    #[test]
+    fn runtime_sensitive_value_masks_existing_paths() {
+        let masker = SecretMasker::from_raw("");
+        let value = "session/value";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(value);
+
+        masker.add_sensitive_value(value);
+
+        let mut val = json!({
+            "plain": "contains session/value",
+            "encoded": encoded,
+            "url": "contains session%2fvalue",
+        });
+        masker.mask_value(&mut val);
+        assert_eq!(val["plain"], "contains ***");
+        assert_eq!(val["encoded"], "***");
+        assert_eq!(val["url"], "contains ***");
+        assert_eq!(masker.mask_string("session/value"), "***");
+        assert_eq!(
+            masker.mask_owned_string("system log session/value".to_string()),
+            "system log ***"
+        );
+        assert_eq!(
+            masker.mask_diagnostic_lines(vec!["stderr session/value".to_string()]),
+            vec!["stderr ***".to_string()]
+        );
+    }
+
+    #[test]
+    fn runtime_sensitive_value_skips_short_values() {
+        let masker = SecretMasker::from_raw("");
+
+        masker.add_sensitive_value("abcd");
+
+        assert_eq!(masker.mask_string("abcd"), "abcd");
     }
 
     #[test]

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -48,7 +48,9 @@ struct Matcher {
 impl SecretMasker {
     /// Build a masker from the `VM0_SECRET_VALUES` environment variable.
     pub fn from_env() -> Self {
-        Self::from_raw(env::secret_values())
+        let masker = Self::from_raw(env::secret_values());
+        masker.add_sensitive_value(env::resume_session_id());
+        masker
     }
 
     /// Build a masker from a raw comma-separated base64-encoded secret string.

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -21,7 +21,7 @@
 //! "the most recent file in the tree" would risk uploading an unrelated
 //! session as the resume context, which is a multi-tenant correctness
 //! hazard. The descriptive `Codex session file not found` error from
-//! `read_session_history` surfaces the failure instead.
+//! `read_session_history` surfaces the failure without logging the session id.
 
 use crate::error::AgentError;
 #[cfg(target_os = "linux")]
@@ -49,7 +49,7 @@ pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
     if let Some((sessions_dir, thread_id)) = decode_marker(trimmed) {
         return read_codex_session_history(&sessions_dir, thread_id)?.ok_or_else(|| {
             AgentError::Checkpoint(format!(
-                "Codex session file not found under {} for thread_id {thread_id}",
+                "Codex session file not found under {}",
                 sessions_dir.display()
             ))
         });
@@ -82,7 +82,7 @@ fn read_codex_session_history(
     if !codex_sessions_parent_is_usable(sessions_dir)? {
         return Ok(None);
     }
-    read_codex_session_history_impl(sessions_dir, thread_id, &id_norm)
+    read_codex_session_history_impl(sessions_dir, &id_norm)
 }
 
 pub(crate) fn normalize_codex_thread_id(thread_id: &str) -> Option<String> {
@@ -112,7 +112,6 @@ fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentErr
 #[cfg(not(target_os = "linux"))]
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
-    thread_id: &str,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     match std::fs::symlink_metadata(sessions_dir) {
@@ -123,7 +122,7 @@ fn read_codex_session_history_impl(
     }
 
     let mut found = None;
-    find_codex_session_file_recursive(sessions_dir, sessions_dir, thread_id, id_norm, &mut found)?;
+    find_codex_session_file_recursive(sessions_dir, sessions_dir, id_norm, &mut found)?;
     found
         .map(|session| read_history_bytes(&session.path))
         .transpose()
@@ -137,7 +136,6 @@ fn read_codex_session_history_impl(
 fn find_codex_session_file_recursive(
     root: &Path,
     dir: &Path,
-    thread_id: &str,
     id_norm: &str,
     found: &mut Option<ResolvedCodexSession>,
 ) -> Result<(), AgentError> {
@@ -159,19 +157,14 @@ fn find_codex_session_file_recursive(
             Err(err) => return Err(read_history_error(&path, err)),
         };
         if file_type.is_dir() {
-            find_codex_session_file_recursive(root, &path, thread_id, id_norm, found)?;
+            find_codex_session_file_recursive(root, &path, id_norm, found)?;
         } else if file_type.is_file()
             && path
                 .file_name()
                 .is_some_and(|name| codex_session_filename_matches(name, id_norm))
         {
-            if let Some(existing) = found.as_ref() {
-                return Err(duplicate_codex_session_error(
-                    root,
-                    thread_id,
-                    &existing.path,
-                    &path,
-                ));
+            if found.is_some() {
+                return Err(duplicate_codex_session_error(root));
             }
             *found = Some(ResolvedCodexSession { path });
         }
@@ -183,7 +176,6 @@ fn find_codex_session_file_recursive(
 #[cfg(target_os = "linux")]
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
-    thread_id: &str,
     id_norm: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     let root = match Dir::open(sessions_dir) {
@@ -196,7 +188,6 @@ fn read_codex_session_history_impl(
         &root,
         sessions_dir,
         sessions_dir,
-        thread_id,
         id_norm,
         &mut found,
     )?;
@@ -210,7 +201,6 @@ fn find_and_read_codex_session_file_recursive(
     dir: &Dir,
     root_path: &Path,
     dir_path: &Path,
-    thread_id: &str,
     id_norm: &str,
     found: &mut Option<ResolvedCodexSession>,
 ) -> Result<(), AgentError> {
@@ -239,9 +229,7 @@ fn find_and_read_codex_session_file_recursive(
                 Err(err) if should_skip_unusable_codex_entry(&err) => continue,
                 Err(err) => return Err(read_history_error(&path, err)),
             };
-            find_and_read_codex_session_file_recursive(
-                &child, root_path, &path, thread_id, id_norm, found,
-            )?;
+            find_and_read_codex_session_file_recursive(&child, root_path, &path, id_norm, found)?;
         } else if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
             let file = match dir.open_child_file(&name) {
                 Ok(file) => file,
@@ -254,13 +242,8 @@ fn find_and_read_codex_session_file_recursive(
             if !metadata.file_type().is_file() {
                 continue;
             }
-            if let Some(existing) = found.as_ref() {
-                return Err(duplicate_codex_session_error(
-                    root_path,
-                    thread_id,
-                    &existing.path,
-                    &path,
-                ));
+            if found.is_some() {
+                return Err(duplicate_codex_session_error(root_path));
             }
             *found = Some(ResolvedCodexSession { path, file });
         }
@@ -275,17 +258,10 @@ struct ResolvedCodexSession {
     file: File,
 }
 
-fn duplicate_codex_session_error(
-    root: &Path,
-    thread_id: &str,
-    first: &Path,
-    second: &Path,
-) -> AgentError {
+fn duplicate_codex_session_error(root: &Path) -> AgentError {
     AgentError::Checkpoint(format!(
-        "Multiple Codex session files found under {} for thread_id {thread_id}: {}, {}",
-        root.display(),
-        first.display(),
-        second.display()
+        "Multiple Codex session files found under {}",
+        root.display()
     ))
 }
 
@@ -330,11 +306,8 @@ fn read_history_bytes_from_file(path: &Path, mut file: File) -> Result<Vec<u8>, 
     decode_history_bytes(path, raw)
 }
 
-fn read_history_error(path: &Path, source: io::Error) -> AgentError {
-    AgentError::Checkpoint(format!(
-        "Failed to read session history at {}: {source}",
-        path.display()
-    ))
+fn read_history_error(_path: &Path, source: io::Error) -> AgentError {
+    AgentError::Checkpoint(format!("Failed to read session history: {source}"))
 }
 
 fn decode_history_bytes(path: &Path, raw: Vec<u8>) -> Result<Vec<u8>, AgentError> {
@@ -343,10 +316,7 @@ fn decode_history_bytes(path: &Path, raw: Vec<u8>) -> Result<Vec<u8>, AgentError
         .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
     {
         zstd::decode_all(raw.as_slice()).map_err(|e| {
-            AgentError::Checkpoint(format!(
-                "Failed to decompress zstd session history at {}: {e}",
-                path.display()
-            ))
+            AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
         })
     } else {
         Ok(raw)

--- a/crates/guest-agent/tests/cli_failure_diagnostic_session_id_masking.rs
+++ b/crates/guest-agent/tests/cli_failure_diagnostic_session_id_masking.rs
@@ -1,0 +1,93 @@
+//! Failure diagnostics must mask a session ID carried by the same JSONL event.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use serde_json::json;
+use std::time::Duration;
+
+struct SystemLogGuard;
+
+impl SystemLogGuard {
+    fn set(path: &std::path::Path) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
+#[tokio::test]
+async fn cli_failure_diagnostic_masks_session_id_from_same_event()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let session_id = "result-session-secret-123";
+    let prompt = format!(
+        "@ECHO@\n{}",
+        json!({
+            "type": "result",
+            "subtype": "error",
+            "session_id": session_id,
+            "is_error": true,
+            "duration_ms": 100,
+            "num_turns": 1,
+            "result": format!("failed for {session_id}"),
+            "total_cost_usd": 0,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        })
+    );
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
+    }
+
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log_guard = SystemLogGuard::set(&system_log_path);
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    let failure_diagnostic = cli_result
+        .failure_diagnostic
+        .as_ref()
+        .expect("result event should produce a failure diagnostic");
+    assert_eq!(failure_diagnostic.message, "failed for ***");
+    assert!(
+        !failure_diagnostic.message.contains(session_id),
+        "failure diagnostic leaked session id: {}",
+        failure_diagnostic.message
+    );
+
+    let system_log = std::fs::read_to_string(&system_log_path)?;
+    assert!(
+        system_log.contains("Claude JSONL failure result"),
+        "system log should include the failure diagnostic log, got: {system_log}"
+    );
+    assert!(
+        system_log.contains("failed for ***"),
+        "system log should mask the same-event session id, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(session_id),
+        "system log leaked session id: {system_log}"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_resume_id_stderr_masking.rs
+++ b/crates/guest-agent/tests/cli_resume_id_stderr_masking.rs
@@ -1,0 +1,53 @@
+//! Resume session IDs must be masked even when the CLI fails before emitting JSONL.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn cli_failure_masks_resume_session_id_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let resume_id = "resume-secret-123";
+
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            &format!("@fail-no-newline:resume failed for {resume_id}"),
+            3,
+            1,
+        )?;
+        std::env::set_var("VM0_RESUME_SESSION_ID", resume_id);
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 1);
+    let stderr = cli_result.stderr_lines.join("\n");
+    assert!(
+        stderr.contains("resume failed for ***"),
+        "stderr should mask resume session id, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains(resume_id),
+        "stderr leaked resume session id: {stderr}"
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -413,6 +413,10 @@ fn read_session_history_rejects_duplicate_codex_matches() {
         msg.contains("Multiple Codex session files found"),
         "expected duplicate-session error, got: {msg}"
     );
+    assert!(
+        !msg.contains(thread_id),
+        "duplicate-session error must not expose thread id, got: {msg}"
+    );
 }
 
 #[test]
@@ -454,6 +458,10 @@ fn read_session_history_rejects_duplicate_jsonl_and_zstd_matches() {
         msg.contains("Multiple Codex session files found"),
         "expected duplicate-session error, got: {msg}"
     );
+    assert!(
+        !msg.contains(thread_id),
+        "duplicate-session error must not expose thread id, got: {msg}"
+    );
 }
 
 #[test]
@@ -493,6 +501,47 @@ fn read_session_history_rejects_duplicate_before_reading_corrupt_zstd() {
     assert!(
         msg.contains("Multiple Codex session files found"),
         "expected duplicate-session error, got: {msg}"
+    );
+    assert!(
+        !msg.contains(thread_id),
+        "duplicate-session error must not expose thread id, got: {msg}"
+    );
+}
+
+#[test]
+fn read_session_history_corrupt_zstd_error_omits_thread_id() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{thread_id}.jsonl.zst"),
+        b"not zstd",
+    )
+    .unwrap();
+
+    let path_file = tmp.path().join("path.txt");
+    let marker = format!(
+        "CODEX_SEARCH:{}:{thread_id}",
+        sessions_dir.to_string_lossy()
+    );
+    std::fs::write(&path_file, marker.as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("corrupt zstd codex session must fail clearly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Failed to decompress zstd session history"),
+        "expected zstd decode error, got: {msg}"
+    );
+    assert!(
+        !msg.contains(thread_id),
+        "zstd decode error must not expose thread id, got: {msg}"
     );
 }
 
@@ -566,6 +615,10 @@ fn read_session_history_codex_marker_with_no_match_fails_fast() {
         msg.contains("Codex session file not found"),
         "expected fail-fast error, got: {msg}"
     );
+    assert!(
+        !msg.contains(unknown_id),
+        "missing-session error must not expose thread id, got: {msg}"
+    );
 }
 
 #[test]
@@ -623,6 +676,31 @@ fn read_session_history_codex_marker_rejects_short_thread_id() {
     assert!(
         msg.contains("Codex session file not found"),
         "expected malformed thread id to fail fast, got: {msg}"
+    );
+}
+
+#[test]
+fn read_session_history_read_error_omits_literal_session_path() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let session_id = "sess-secret-123";
+    let history = tmp.path().join(format!("{session_id}.jsonl"));
+    let path_file = tmp.path().join("path.txt");
+    std::fs::write(&path_file, history.to_string_lossy().as_bytes()).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("missing literal session history path must fail clearly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Failed to read session history"),
+        "expected read error, got: {msg}"
+    );
+    assert!(
+        !msg.contains(session_id),
+        "history read error must not expose session id, got: {msg}"
     );
 }
 

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -88,6 +88,21 @@ fn reset_session_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
 }
 
+struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    fn set(path: &Path) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}
+
 /// Build a `YYYY/MM/DD/` style nested path under `root` and write a file.
 ///
 /// Returns `Result<_, String>` rather than `unwrap`-ing because clippy's
@@ -114,11 +129,15 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();
+    let tmp = tempfile::tempdir().unwrap();
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     let masker = SecretMasker::from_raw("");
     let event = json!({
         "type": "thread.started",
-        "thread_id": "0193abcd-ef01-7234-89ab-cdef01234567"
+        "thread_id": thread_id
     });
 
     // No API token → send_event skips the HTTP POST but still captures
@@ -131,7 +150,7 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
 
     let stored_id =
         std::fs::read_to_string(guest_agent::paths::session_id_file()).expect("session id written");
-    assert_eq!(stored_id, "0193abcd-ef01-7234-89ab-cdef01234567");
+    assert_eq!(stored_id, thread_id);
 
     let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
         .expect("history-path file written");
@@ -144,8 +163,27 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
         "marker should embed the codex sessions dir, got: {marker}"
     );
     assert!(
-        marker.ends_with(":0193abcd-ef01-7234-89ab-cdef01234567"),
+        marker.ends_with(&format!(":{thread_id}")),
         "marker should end with the thread id, got: {marker}"
+    );
+    assert_eq!(masker.mask_string(thread_id), "***");
+
+    let system_log = std::fs::read_to_string(&system_log_path).expect("system log written");
+    assert!(
+        system_log.contains("Session history marker written to"),
+        "system log should confirm marker creation, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(thread_id),
+        "system log must not contain the raw thread id, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains("CODEX_SEARCH:"),
+        "system log must not contain the codex marker payload, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(&marker),
+        "system log must not contain the full marker payload, got: {system_log}"
     );
 }
 

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -307,6 +307,11 @@ fn send_event_codex_ignores_malformed_thread_id() {
             !Path::new(guest_agent::paths::session_id_file()).exists(),
             "malformed thread_id must not be persisted: {thread_id}"
         );
+        if thread_id.len() >= 5 {
+            assert_eq!(masker.mask_string(thread_id), "***");
+        } else {
+            assert_eq!(masker.mask_string(thread_id), thread_id);
+        }
     }
 }
 

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -6,7 +6,6 @@
 
 mod common;
 
-use base64::Engine;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
@@ -92,8 +91,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         then.status(200);
     });
 
-    let encoded_mock_session_prefix = base64::engine::general_purpose::STANDARD.encode("mock-");
-    let masker = SecretMasker::from_raw(&encoded_mock_session_prefix);
+    let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         guest_agent::cli::execute_cli(

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -213,6 +213,7 @@ async fn send_event_keeps_existing_session_metadata() {
         "/tmp/first-session.jsonl",
         "later id-bearing events must not replace checkpoint history metadata"
     );
+    assert_eq!(masker.mask_string("first-session"), "***");
     assert_eq!(masker.mask_string("second-session"), "***");
 
     mock.delete_async().await;

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -183,11 +183,13 @@ async fn send_event_keeps_existing_session_metadata() {
 
     let sid_file = guest_agent::paths::session_id_file();
     let hist_file = guest_agent::paths::session_history_path_file();
-    std::fs::write(sid_file, "first-session").unwrap();
-    std::fs::write(hist_file, "/tmp/first-session.jsonl").unwrap();
+    guest_agent::paths::write_private(sid_file, "first-session").unwrap();
+    guest_agent::paths::write_private(hist_file, "/tmp/first-session.jsonl").unwrap();
 
     let mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/events");
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""session_id":"***""#);
         then.status(200);
     });
 
@@ -211,6 +213,7 @@ async fn send_event_keeps_existing_session_metadata() {
         "/tmp/first-session.jsonl",
         "later id-bearing events must not replace checkpoint history metadata"
     );
+    assert_eq!(masker.mask_string("second-session"), "***");
 
     mock.delete_async().await;
 }
@@ -258,6 +261,7 @@ async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
             history.ends_with(&format!("/{session_id}.jsonl")),
             "repaired history marker should point at the existing session id, got: {history}"
         );
+        assert_eq!(masker.mask_string(session_id), "***");
     }
 
     mock.assert_calls_async(2).await;

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -99,9 +99,7 @@ async fn send_event_captures_session_metadata_before_masking() {
     });
 
     let session_id = "ses-secret-123";
-    let engine = base64::engine::general_purpose::STANDARD;
-    let encoded_session_id = engine.encode(session_id);
-    let masker = SecretMasker::from_raw(&encoded_session_id);
+    let masker = SecretMasker::from_raw("");
     let event = json!({
         "type": "system",
         "subtype": "init",
@@ -133,8 +131,16 @@ async fn send_event_captures_session_metadata_before_masking() {
         "system log should confirm session ID file creation, got: {system_log}"
     );
     assert!(
-        system_log.contains(&format!("Session history marker written to {hist_file}:")),
+        system_log.contains(&format!("Session history marker written to {hist_file}")),
         "system log should confirm session history marker creation, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(session_id),
+        "system log must not contain the raw session id, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(&history),
+        "system log must not contain the full session history marker payload, got: {system_log}"
     );
 
     mock.delete_async().await;

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -176,6 +176,46 @@ async fn prepare_event_does_not_capture_session_metadata() {
 }
 
 #[tokio::test]
+async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    let _session_files = SessionCheckpointFilesGuard::new();
+
+    let sid_file = guest_agent::paths::session_id_file();
+    let hist_file = guest_agent::paths::session_history_path_file();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""session_id":"***""#);
+        then.status(200);
+    });
+
+    let session_id = "bad/session-secret";
+    let masker = SecretMasker::from_raw("");
+    let event = json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": session_id
+    });
+    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+
+    assert!(result.is_ok());
+    mock.assert_calls_async(1).await;
+    assert_eq!(masker.mask_string(session_id), "***");
+    assert!(
+        !std::path::Path::new(sid_file).exists(),
+        "invalid session id must not be persisted"
+    );
+    assert!(
+        !std::path::Path::new(hist_file).exists(),
+        "invalid session id must not create a history marker"
+    );
+
+    mock.delete_async().await;
+}
+
+#[tokio::test]
 async fn send_event_keeps_existing_session_metadata() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let server = &*MOCK_SERVER;

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -133,6 +133,68 @@ async fn final_flush_uploads_log_emitted_immediately_before_it() {
     let _ = std::fs::remove_file(pos_file);
 }
 
+#[tokio::test]
+async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let server = &*MOCK_SERVER;
+    remove_telemetry_files();
+    let _session_files = SessionCheckpointFilesGuard::new();
+
+    let system_log = guest_agent::paths::system_log_file();
+    let pos_file = guest_agent::paths::telemetry_system_log_pos_file();
+    ensure_parent_dir(system_log);
+
+    let session_id = "telemetry-session-secret";
+    let event_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""session_id":"***""#);
+        then.status(200);
+    });
+    let raw_telemetry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes(session_id);
+        then.status(500);
+    });
+    let masked_telemetry_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes("system log ***");
+        then.status(200);
+    });
+
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry =
+        guest_agent::telemetry::Telemetry::spawn(std::sync::Arc::clone(&masker), http_client!());
+    let event = serde_json::json!({
+        "type": "system",
+        "subtype": "init",
+        "session_id": session_id
+    });
+    guest_agent::events::send_event(&http_client!(), event, 1, &masker)
+        .await
+        .expect("session event should be sent");
+
+    std::fs::write(system_log, format!("system log {session_id}\n"))
+        .expect("system log should be written");
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Final)
+        .await
+        .expect("final flush should upload masked log");
+    telemetry.shutdown().await;
+
+    event_mock.assert_calls_async(1).await;
+    raw_telemetry_mock.assert_calls_async(0).await;
+    masked_telemetry_mock.assert_calls_async(1).await;
+
+    event_mock.delete_async().await;
+    raw_telemetry_mock.delete_async().await;
+    masked_telemetry_mock.delete_async().await;
+    let _ = std::fs::remove_file(system_log);
+    let _ = std::fs::remove_file(pos_file);
+}
+
 /// Regression for #11008. Combines two distinct guarantees that
 /// together produce the "exactly one HTTP POST" assertion:
 ///


### PR DESCRIPTION
## Summary

Closes #17434.

- extend `SecretMasker` with runtime sensitive value registration for discovered Claude session IDs and Codex thread IDs
- register session identifiers during metadata capture before event payload masking, while preserving raw private checkpoint metadata
- stop logging raw session IDs and full session-history marker payloads
- add regression coverage for event payload masking, local system log redaction, Codex markers, telemetry upload masking, and CLI API-mode masking without preconfigured session secrets

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent send_event_captures_session_metadata_before_masking`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent send_event_extracts_codex_thread_id_and_writes_marker`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent telemetry_masks_runtime_session_id_registered_after_spawn`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent execute_cli_sends_events_and_captures_session_metadata`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent runtime_sensitive_value`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy, commitlint
