### PR TITLE
docs: add desktop testing guide

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -281,14 +281,15 @@ Don't render components directly—use `setupPage()` which mirrors `main.ts` sta
 
 ### App-Specific Guides
 
-| App                                         | Guide                                                    |
-| ------------------------------------------- | -------------------------------------------------------- |
-| CLI commands                                | [cli-testing.md](./testing/cli-testing.md)               |
-| CLI E2E (BATS)                              | [cli-e2e-testing.md](./testing/cli-e2e-testing.md)       |
-| API routes                                  | [api-testing.md](./testing/api-testing.md)               |
-| Web rewrite/middleware compatibility        | [api-testing.md](./testing/api-testing.md)               |
-| App UI                                      | [app-testing.md](./testing/app-testing.md)               |
-| Rust crates                                 | [rust-testing.md](./testing/rust-testing.md)             |
-| Python addon                                | [mitm-addon-testing.md](./testing/mitm-addon-testing.md) |
+| App                                  | Guide                                                    |
+| ------------------------------------ | -------------------------------------------------------- |
+| CLI commands                         | [cli-testing.md](./testing/cli-testing.md)               |
+| CLI E2E (BATS)                       | [cli-e2e-testing.md](./testing/cli-e2e-testing.md)       |
+| API routes                           | [api-testing.md](./testing/api-testing.md)               |
+| Web rewrite/middleware compatibility | [api-testing.md](./testing/api-testing.md)               |
+| App UI                               | [app-testing.md](./testing/app-testing.md)               |
+| Desktop app                          | [desktop-testing.md](./testing/desktop-testing.md)       |
+| Rust crates                          | [rust-testing.md](./testing/rust-testing.md)             |
+| Python addon                         | [mitm-addon-testing.md](./testing/mitm-addon-testing.md) |
 
 For general code quality rules (no `any`, no lint suppressions, etc.), see [bad-smell.md](./bad-smell.md).

--- a/docs/testing/desktop-testing.md
+++ b/docs/testing/desktop-testing.md
@@ -1,0 +1,162 @@
+# Desktop Testing Patterns
+
+This guide defines the integration-test boundaries for
+`turbo/apps/desktop`. It extends the project-wide rule: write tests at entry
+points, keep internal code real, and mock only external system boundaries.
+
+Desktop has more than one entry point. It is an Electron app, a renderer UI, a
+preload bridge, a companion CLI/daemon, and a native macOS helper. Tests should
+choose the smallest entry point that matches the behavior being protected.
+
+## Entry Points
+
+### Renderer App
+
+Renderer tests should enter through the Desktop UI, not through extracted
+formatters or internal helpers.
+
+Use this boundary for behavior in:
+
+- `src/renderer/App.tsx`
+- `src/renderer/computer-use-state.ts`
+- `src/desktop-bridge.ts`
+
+Mock the external bridge objects on `window`:
+
+- `window.vm0DesktopComputerUse`
+- `window.vm0DesktopAuth`
+
+Keep renderer modules real. Assert visible user behavior and bridge outcomes:
+
+- Signed-out users can start sign-in.
+- Signed-in users without an active workspace can select one.
+- Missing Accessibility or Screen Recording permissions show request/settings
+  actions.
+- Ready/offline, online, recovering, and error states expose the expected
+  controls.
+- Command history, app state, screenshots, and runtime errors render through the
+  UI.
+
+Do not export display helpers from the renderer just to unit-test them.
+
+### Preload And IPC Bridge
+
+Preload and IPC tests should exercise the bridge boundary between the renderer
+and Electron main process.
+
+Use this boundary for behavior in:
+
+- `src/preload.ts`
+- `src/computer-use-electron.ts`
+- `src/desktop-auth-electron.ts`
+
+Mock `electron` as the external runtime. Keep Desktop channel modules and
+validation logic real.
+
+Useful assertions include:
+
+- Computer Use IPC rejects calls from non-Desktop renderer URLs.
+- Desktop auth completion is accepted only from configured app origins.
+- Invalid bridge payloads are rejected, such as empty auth tokens or non-boolean
+  keep-awake values.
+- Subscribe and unsubscribe attach and detach the expected channels.
+- Change notifications are sent only to live windows.
+
+### CLI And Daemon
+
+The `vm0-computer` CLI should be tested by executing the built CLI, not by
+importing parser or formatter internals.
+
+Use this boundary for behavior in:
+
+- `src/vm0-computer.ts`
+- `src/computer-use-native.ts`
+
+Follow the existing pattern in `src/computer-use-native.test.ts`:
+
+- Build `dist/vm0-computer.js`.
+- Execute it with `execFile`.
+- Use real temp directories for daemon sockets, request logs, screenshots, and
+  app-state output.
+- Use fake helper executables to observe the native-helper protocol.
+
+Good CLI/daemon integration cases include:
+
+- `daemon start`, `daemon status`, and `daemon stop`.
+- Command failure when the daemon is unavailable.
+- Argument mapping for commands such as `click`, `type-text`, `press-key`, and
+  foreground recovery options.
+- Screenshot and app-state output written to the filesystem.
+
+### Native Helper Protocol
+
+The JavaScript native backend should be tested at the helper process protocol
+boundary. A fake helper process is the right test double because the helper is
+external to the JavaScript runtime.
+
+The Swift helper itself should keep using SwiftPM tests for native policy and
+algorithm behavior under `native/computer-use-helper/Tests`.
+
+### App Lifecycle And Packaged Artifacts
+
+Avoid wholesale unit tests for `src/main.ts`. Main process behavior should be
+covered through stable external boundaries:
+
+- Electron lifecycle events when a focused event harness exists.
+- IPC and preload bridge tests.
+- URL callback and second-instance behavior.
+- Packaged artifact verification in `.github/workflows/desktop.yml`.
+
+Keep artifact checks focused on observable package contents and platform
+configuration: bundled main/preload files, native helper executable presence,
+bundle identifiers, URL schemes, icons, runtime config inclusion or exclusion,
+and release/update packaging rules.
+
+## Mock Boundary
+
+Desktop tests may mock:
+
+- `electron`, because it is the external app runtime.
+- Fake native helper executables, because the helper is outside the JS process.
+- External HTTP/API boundaries when a test exercises network behavior.
+- Node process execution only when the behavior being tested is not the CLI
+  process boundary.
+
+Desktop tests should keep real:
+
+- Desktop source modules.
+- The filesystem, using temp directories.
+- CLI/daemon process execution when testing `vm0-computer`.
+- Channel constants, URL policy, payload validation, state machines, and bridge
+  wiring.
+
+Do not use relative internal `vi.mock()` paths for Desktop implementation
+modules.
+
+## Narrow Exceptions
+
+Pure or matrix-style tests are allowed only when the integration boundary would
+make the test much larger without adding equivalent confidence.
+
+Accepted examples:
+
+- Security and navigation policy matrices such as `window-policy.test.ts`.
+- Tray menu state matrices such as `desktop-tray-menu.test.ts`.
+- Native helper policy and algorithm tests in Swift.
+
+New exceptions should be justified by security risk, algorithmic complexity, or
+state-matrix size. Do not add unit tests just to raise coverage percentages.
+
+## CI Expectations
+
+Desktop PRs should use workspace-scoped checks:
+
+```bash
+pnpm -F @vm0/desktop check-types
+pnpm -F @vm0/desktop lint
+pnpm -F @vm0/desktop test
+pnpm -F @vm0/desktop test:native
+```
+
+Use narrower focused commands while iterating, then run the relevant full
+Desktop checks before opening or updating a PR.


### PR DESCRIPTION
## Summary

- add a Desktop-specific testing guide that defines entry-point integration boundaries
- document renderer bridge, IPC/preload, CLI/daemon, native helper, and packaged artifact test boundaries
- link the guide from the general testing docs

Part of #17493.

## Validation

- ./turbo/node_modules/.bin/prettier --check docs/testing.md docs/testing/desktop-testing.md
- git diff --check