### PR TITLE
feat: add desktop dmg release artifact

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -85,7 +85,10 @@ jobs:
           rm -rf apps/desktop/out
 
           pnpm -F @vm0/desktop build
-          node apps/desktop/scripts/run-forge-make-with-retry.js --platform darwin --arch arm64
+          node apps/desktop/scripts/run-forge-make-with-retry.js \
+            --platform darwin \
+            --arch arm64 \
+            --targets @electron-forge/maker-zip
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
@@ -191,7 +194,10 @@ jobs:
           NODE
 
           pnpm -F @vm0/desktop build
-          node apps/desktop/scripts/run-forge-make-with-retry.js --platform darwin --arch arm64
+          node apps/desktop/scripts/run-forge-make-with-retry.js \
+            --platform darwin \
+            --arch arm64 \
+            --targets @electron-forge/maker-zip
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -260,7 +260,7 @@ jobs:
           chmod 600 "$api_key_path"
           echo "path=$api_key_path" >> "$GITHUB_OUTPUT"
 
-      - name: Build signed and notarized macOS artifact
+      - name: Build signed and notarized macOS artifacts
         id: build-desktop
         env:
           VM0_DESKTOP_NOTARIZE: "true"
@@ -272,29 +272,69 @@ jobs:
           rm -rf apps/desktop/out
 
           pnpm -F @vm0/desktop build
-          node apps/desktop/scripts/run-forge-make-with-retry.js --platform darwin --arch arm64
+          node apps/desktop/scripts/run-forge-make-with-retry.js \
+            --platform darwin \
+            --arch arm64 \
+            --targets @electron-forge/maker-zip
 
           desktop_dir="$PWD/apps/desktop"
+          app_dir="$desktop_dir/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
           forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$DESKTOP_VERSION.zip"
-          artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+          zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+          dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
+          dmg_source="$RUNNER_TEMP/zero-desktop-dmg-source"
+          unsigned_dmg="$RUNNER_TEMP/Zero-darwin-arm64-$DESKTOP_VERSION.unsigned.dmg"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge zip artifact found: $forge_zip"
             find "$desktop_dir/out" -maxdepth 6 -type f -print || true
             exit 1
           fi
+          if [ ! -d "$app_dir" ]; then
+            echo "No packaged app found: $app_dir"
+            find "$desktop_dir/out" -maxdepth 4 -type d -print || true
+            exit 1
+          fi
 
-          cp "$forge_zip" "$artifact_path"
-          echo "path=$artifact_path" >> "$GITHUB_OUTPUT"
+          cp "$forge_zip" "$zip_artifact_path"
 
-      - name: Verify signed and notarized macOS artifact
+          rm -rf "$dmg_source" "$unsigned_dmg" "$dmg_artifact_path"
+          mkdir -p "$dmg_source"
+          ditto "$app_dir" "$dmg_source/Zero Computer Use.app"
+          ln -s /Applications "$dmg_source/Applications"
+          hdiutil create \
+            -volname "Zero Computer Use" \
+            -srcfolder "$dmg_source" \
+            -ov \
+            -format UDZO \
+            "$unsigned_dmg"
+          cp "$unsigned_dmg" "$dmg_artifact_path"
+          codesign --force --sign "$VM0_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
+          xcrun notarytool submit "$dmg_artifact_path" \
+            --key "$VM0_DESKTOP_NOTARIZE_API_KEY_PATH" \
+            --key-id "$VM0_DESKTOP_NOTARIZE_API_KEY_ID" \
+            --issuer "$VM0_DESKTOP_NOTARIZE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$dmg_artifact_path"
+
+          echo "zip_path=$zip_artifact_path" >> "$GITHUB_OUTPUT"
+          echo "dmg_path=$dmg_artifact_path" >> "$GITHUB_OUTPUT"
+
+      - name: Verify signed and notarized macOS artifacts
         run: |
-          artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+          zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
+          dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
           app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
+          dmg_mount="$RUNNER_TEMP/zero-desktop-dmg"
 
-          if [ ! -f "$artifact_path" ]; then
+          if [ ! -f "$zip_artifact_path" ]; then
             echo "No desktop zip artifact found"
+            find apps/desktop/out -maxdepth 5 -type f -print || true
+            exit 1
+          fi
+          if [ ! -f "$dmg_artifact_path" ]; then
+            echo "No desktop dmg artifact found"
             find apps/desktop/out -maxdepth 5 -type f -print || true
             exit 1
           fi
@@ -315,12 +355,47 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "$app_dir"
           codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
           xcrun stapler validate "$app_dir"
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
+          unzip -l "$zip_artifact_path" | grep -q "Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
+          codesign --verify --verbose=2 "$dmg_artifact_path"
+          codesign --display --verbose=4 "$dmg_artifact_path" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
+          xcrun stapler validate "$dmg_artifact_path"
+          hdiutil verify "$dmg_artifact_path"
 
-      - name: Upload Desktop artifact to GitHub Release
+          rm -rf "$dmg_mount"
+          mkdir -p "$dmg_mount"
+          hdiutil attach "$dmg_artifact_path" -nobrowse -readonly -mountpoint "$dmg_mount"
+          cleanup_dmg_mount() {
+            hdiutil detach "$dmg_mount"
+          }
+          trap cleanup_dmg_mount EXIT
+
+          if [ ! -d "$dmg_mount/Zero Computer Use.app" ]; then
+            echo "DMG should contain Zero Computer Use.app"
+            find "$dmg_mount" -maxdepth 2 -print || true
+            exit 1
+          fi
+          if [ ! -L "$dmg_mount/Applications" ]; then
+            echo "DMG should contain an Applications symlink"
+            find "$dmg_mount" -maxdepth 2 -print || true
+            exit 1
+          fi
+          if [ "$(readlink "$dmg_mount/Applications")" != "/Applications" ]; then
+            echo "DMG Applications symlink should point to /Applications"
+            readlink "$dmg_mount/Applications" || true
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=2 "$dmg_mount/Zero Computer Use.app"
+          xcrun stapler validate "$dmg_mount/Zero Computer Use.app"
+
+      - name: Upload Desktop artifacts to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$RELEASE_TAG" "${{ steps.build-desktop.outputs.path }}" --repo "${{ github.repository }}" --clobber
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            "${{ steps.build-desktop.outputs.zip_path }}" \
+            "${{ steps.build-desktop.outputs.dmg_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber
 
       - name: Publish Desktop update manifest
         env:
@@ -388,7 +463,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* ✅ Published signed macOS release\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Download macOS app>"
+                  text: "*Desktop App* ✅ Published signed macOS release\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.dmg|Download macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Auto-update ZIP>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -147,8 +147,12 @@ When release-please creates the `desktop-vX.Y.Z` GitHub Release, the
 matching tag, builds the production `Zero Computer Use.app`, signs it with the
 Developer ID Application certificate, notarizes it for direct distribution
 outside the Mac App Store, validates the stapled ticket, uploads
-`Zero-darwin-arm64-X.Y.Z.zip` to the matching GitHub Release, and updates the
-Desktop update manifest.
+`Zero-darwin-arm64-X.Y.Z.zip` and `Zero-darwin-arm64-X.Y.Z.dmg` to the matching
+GitHub Release, and updates the Desktop update manifest.
+
+Use the DMG for manual installation. It opens with `Zero Computer Use.app` and
+an `/Applications` symlink for drag-to-install. The update manifest continues to
+point at the ZIP artifact because the auto-update feed consumes ZIP releases.
 
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's


### PR DESCRIPTION
## Summary

- add a notarized macOS DMG artifact to the Desktop release job alongside the existing ZIP
- keep the Desktop auto-update manifest on the ZIP artifact while exposing the DMG for manual installs
- verify the DMG signature, notarization ticket, mount layout, app bundle, and `/Applications` symlink before upload
- keep Desktop release work outside the `builds-complete` promote barrier

Closes #17492

## Testing

- `pnpm install --frozen-lockfile --strict-peer-dependencies`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build`
- `VM0_DESKTOP_SIGNING_IDENTITY=- node apps/desktop/scripts/run-forge-make-with-retry.js --platform darwin --arch arm64 --targets @electron-forge/maker-zip`
- local `hdiutil` DMG layout/mount verification using the packaged app
- `pnpm format`
- workflow YAML parse for `.github/workflows/release-please.yml` and `.github/workflows/desktop.yml`
