### PR TITLE
feat: add chat rename shortcut

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -46,6 +46,16 @@ export const setRenameDialogInput$ = command(({ set }, input: string) => {
   set(internalRenameDialogInput$, input);
 });
 
+export const openRenameChatThreadDialog$ = command(
+  (
+    { set },
+    { threadId, title }: { threadId: string; title: string | null | undefined },
+  ) => {
+    set(internalRenameDialogInput$, title?.trim() ?? "");
+    set(internalRenameDialogThreadId$, threadId);
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Session list collapse state (RecentChatSection) — persisted in localStorage
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -721,6 +721,14 @@ function chatScrollContainer(): HTMLElement {
   return element;
 }
 
+function chatComposerTextarea(): HTMLTextAreaElement {
+  const element = document.querySelector("[data-chat-composer] textarea");
+  if (!(element instanceof HTMLTextAreaElement)) {
+    throw new Error("Chat composer textarea not found");
+  }
+  return element;
+}
+
 function setScrollMetrics(
   element: HTMLElement,
   metrics: { scrollHeight: number; clientHeight: number },
@@ -2106,7 +2114,52 @@ describe("chat lifecycle", () => {
       expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
       expect(screen.getByText("Previous thread")).toBeInTheDocument();
       expect(screen.getByText("Next thread")).toBeInTheDocument();
+      expect(screen.getByText("Rename chat")).toBeInTheDocument();
+      expect(screen.getByText("F2")).toBeInTheDocument();
     });
+  });
+
+  it("opens the current chat rename dialog with F2", async () => {
+    mockResizeObserver();
+    mockKeyboardNavigationThreads();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Current keyboard thread")).toBeInTheDocument();
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    threadRegion.focus();
+    fireEvent.keyDown(threadRegion, { key: "F2" });
+
+    let dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
+      "Current keyboard thread",
+    );
+
+    click(buttonByText("Cancel"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Rename chat" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const composer = chatComposerTextarea();
+    composer.focus();
+    fireEvent.keyDown(composer, { key: "F2" });
+
+    dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
+      "Current keyboard thread",
+    );
   });
 
   it("opens run logs from assistant message actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -453,10 +453,10 @@ describe("zero sidebar", () => {
     click(menuItemByText("Rename chat"));
 
     const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
-    await fill(
-      within(dialog).getByPlaceholderText("Chat title"),
-      "Launch plan",
-    );
+    const titleInput = within(dialog).getByPlaceholderText("Chat title");
+    expect(titleInput).toHaveValue("Release plan");
+
+    await fill(titleInput, "Launch plan");
     click(buttonByText("Rename", dialog));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -81,6 +81,7 @@ import {
   schedulesForThread,
 } from "../../signals/chat-page/header-schedule-menu.ts";
 import {
+  openRenameChatThreadDialog$,
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
   renameDialogThreadId$,
@@ -235,11 +236,13 @@ function handleChatThreadClick(
 
 function ChatThreadMenu({
   threadId,
+  title,
   isPinned,
   isHighlighted,
   hasOtherIndicator,
 }: {
   threadId: string;
+  title: string | null;
   isPinned: boolean;
   isHighlighted: boolean;
   hasOtherIndicator: boolean;
@@ -247,8 +250,7 @@ function ChatThreadMenu({
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const pinChatThread = useSet(pinChatThread$);
   const unpinChatThread = useSet(unpinChatThread$);
-  const setRenameDialogThreadId = useSet(setRenameDialogThreadId$);
-  const setRenameDialogInput = useSet(setRenameDialogInput$);
+  const openRenameChatThreadDialog = useSet(openRenameChatThreadDialog$);
   const pageSignal = useGet(pageSignal$);
 
   function handleTogglePin() {
@@ -265,8 +267,7 @@ function ChatThreadMenu({
   }
 
   function openRenameDialog() {
-    setRenameDialogInput("");
-    setRenameDialogThreadId(threadId);
+    openRenameChatThreadDialog({ threadId, title });
   }
 
   return (
@@ -334,11 +335,13 @@ function ChatThreadMenu({
 
 function ChatThreadSideDecorator({
   threadId,
+  title,
   isPinned,
   isHighlighted,
   indicatorState,
 }: {
   threadId: string;
+  title: string | null;
   isPinned: boolean;
   isHighlighted: boolean;
   indicatorState: IndicatorState | null;
@@ -357,6 +360,7 @@ function ChatThreadSideDecorator({
     <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
       <ChatThreadMenu
         threadId={threadId}
+        title={title}
         isPinned={isPinned}
         isHighlighted={isHighlighted}
         hasOtherIndicator={hasOtherIndicator}
@@ -496,6 +500,7 @@ function ChatThreadItem({ session }: { session: ChatThreadListItem }) {
       <ChatThreadItemLink session={session} state={state} />
       <ChatThreadSideDecorator
         threadId={session.id}
+        title={session.title}
         isPinned={state.isPinned}
         isHighlighted={state.isHighlighted}
         indicatorState={state.indicatorState}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -178,6 +178,7 @@ import {
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
 import { ShortcutHelpDialog } from "../components/shortcut-help-dialog.tsx";
+import { openRenameChatThreadDialog$ } from "../../signals/zero-page/zero-sidebar-state.ts";
 
 import type {
   EnrichedChatMessage,
@@ -268,6 +269,7 @@ const CHAT_SHORTCUT_SECTIONS = [
       { key: "shift+/", label: "Show shortcuts" },
       { key: "mod+b", label: "Toggle sidebar" },
       { key: "mod+shift+o", label: "New chat" },
+      { key: "f2", label: "Rename chat" },
     ],
   },
   {
@@ -1992,17 +1994,41 @@ function ChatThread({
   thread: ChatThreadSignals;
   onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
 }) {
+  const openRenameDialog = useOpenCurrentChatThreadRenameDialog(thread);
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (matchShortcut("f2", event)) {
+      event.preventDefault();
+      openRenameDialog();
+      return;
+    }
+    onKeyDown(event);
+  };
+
   return (
     <section
       aria-label="Chat thread"
       className="flex min-w-0 basis-0 flex-1 flex-col min-h-0 bg-transparent focus:outline-none"
       data-chat-thread-container-id={thread.threadId}
-      onKeyDown={onKeyDown}
+      onKeyDown={handleKeyDown}
       tabIndex={-1}
     >
       <ChatThreadContent thread={thread} />
     </section>
   );
+}
+
+function useOpenCurrentChatThreadRenameDialog(thread: ChatThreadSignals) {
+  const openRenameChatThreadDialog = useSet(openRenameChatThreadDialog$);
+  const threadData = useLastResolved(thread.threadData$);
+  return () => {
+    openRenameChatThreadDialog({
+      threadId: thread.threadId,
+      title: threadData?.title,
+    });
+  };
 }
 
 // Drag the divider to resize the artifact preview against the chat thread.

--- a/turbo/packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts
+++ b/turbo/packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts
@@ -195,6 +195,10 @@ describe("getShortcutParts", () => {
     expect(getShortcutParts("space")).toEqual(["␣"]);
   });
 
+  it("renders F2 as an uppercase function key", () => {
+    expect(getShortcutParts("f2")).toEqual(["F2"]);
+  });
+
   it("renders mod as Ctrl in non-Mac environment", () => {
     expect(getShortcutParts("mod+k")).toEqual(["Ctrl", "k"]);
   });

--- a/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
+++ b/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
@@ -162,6 +162,7 @@ const KEY_DISPLAY_NAMES: Record<string, string> = {
   backspace: "⌫",
   tab: "⇥",
   space: "␣",
+  f2: "F2",
 };
 
 function formatKey(key: string): string {


### PR DESCRIPTION
## Summary
- add `F2` as a current chat shortcut to open the existing rename chat dialog
- reuse the sidebar rename dialog state and prefill the current title for shortcut and menu entry points
- show `F2` in the chat shortcut help and render it as an uppercase function-key keycap

## Validation
- `pnpm format`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts`
- `pnpm turbo run lint --log-order grouped --concurrency=1`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`

## Browser shortcut check
- Chrome and Safari official shortcut references do not list bare `F2` as a page-level browser shortcut; Chrome lists `Control+F2` separately, and Safari/Mac reserve function-key combinations like `Control-F2` rather than bare `F2`.
