### PR TITLE
chore: add sandbox create timing diagnostics

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2810,6 +2810,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tracing-test-support",
  "uuid",
  "vsock-host",
  "vsock-proto",

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1,7 +1,7 @@
 //! Sandbox preparation, reuse, and post-run cleanup glue.
 
 use std::panic::AssertUnwindSafe;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxConfig, SandboxFactory, SandboxId};
@@ -27,6 +27,8 @@ use crate::types::ExecutionContext;
 use crate::workspace_image_cache::{WorkspaceImageLease, WorkspaceImagePrepareRequest};
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+
+const SLOW_PROXY_REGISTER_THRESHOLD: Duration = Duration::from_secs(10);
 
 #[cfg(test)]
 pub(super) async fn execute_new_sandbox(
@@ -268,9 +270,25 @@ async fn create_started_sandbox(
     };
 
     let source_ip = sandbox.source_ip().to_string();
+    let proxy_register_started = Instant::now();
     let network_log_session = match register_proxy(config, context, &source_ip).await {
-        Ok(session) => session,
+        Ok(session) => {
+            log_proxy_register_success_if_slow(
+                context.run_id,
+                sandbox_id,
+                &params.profile_name,
+                proxy_register_started.elapsed(),
+            );
+            session
+        }
         Err(e) => {
+            log_proxy_register_failure(
+                context.run_id,
+                sandbox_id,
+                &params.profile_name,
+                proxy_register_started.elapsed(),
+                &e.to_string(),
+            );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
             destroy_sandbox_panic_safe(factory, sandbox).await;
             return Err(SandboxPrepareError::fatal(e));
@@ -554,6 +572,50 @@ pub(super) async fn register_proxy(
         .network_log_manager
         .register_source_ip(source_ip, network_log_path)
         .await)
+}
+
+pub(super) fn log_proxy_register_success_if_slow(
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    profile: &str,
+    elapsed: Duration,
+) {
+    if elapsed < SLOW_PROXY_REGISTER_THRESHOLD {
+        return;
+    }
+    warn!(
+        stage = "proxy_register",
+        elapsed_ms = duration_ms(elapsed),
+        threshold_ms = duration_ms(SLOW_PROXY_REGISTER_THRESHOLD),
+        success = true,
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        profile,
+        "slow proxy register"
+    );
+}
+
+pub(super) fn log_proxy_register_failure(
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    profile: &str,
+    elapsed: Duration,
+    error: &str,
+) {
+    warn!(
+        stage = "proxy_register",
+        elapsed_ms = duration_ms(elapsed),
+        success = false,
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        profile,
+        error,
+        "proxy register failed"
+    );
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis() as u64
 }
 
 /// Unregister a VM from the proxy registry.

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -273,7 +273,7 @@ async fn create_started_sandbox(
     let proxy_register_started = Instant::now();
     let network_log_session = match register_proxy(config, context, &source_ip).await {
         Ok(session) => {
-            log_proxy_register_success_if_slow(
+            log_proxy_register_success(
                 context.run_id,
                 sandbox_id,
                 &params.profile_name,
@@ -574,13 +574,23 @@ pub(super) async fn register_proxy(
         .await)
 }
 
-pub(super) fn log_proxy_register_success_if_slow(
+pub(super) fn log_proxy_register_success(
     run_id: RunId,
     sandbox_id: SandboxId,
     profile: &str,
     elapsed: Duration,
 ) {
     if elapsed < SLOW_PROXY_REGISTER_THRESHOLD {
+        info!(
+            stage = "proxy_register",
+            elapsed_ms = duration_ms(elapsed),
+            threshold_ms = duration_ms(SLOW_PROXY_REGISTER_THRESHOLD),
+            success = true,
+            run_id = %run_id,
+            sandbox_id = %sandbox_id,
+            profile,
+            "proxy register timing"
+        );
         return;
     }
     warn!(

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -28,7 +28,7 @@ use crate::workspace_image_cache::{WorkspaceImageLease, WorkspaceImagePrepareReq
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
-const SLOW_PROXY_REGISTER_THRESHOLD: Duration = Duration::from_secs(10);
+const SLOW_PROXY_REGISTER_THRESHOLD: Duration = Duration::from_secs(3);
 
 #[cfg(test)]
 pub(super) async fn execute_new_sandbox(

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -95,7 +95,7 @@ fn proxy_register_slow_success_warns_with_stable_fields() {
             RunId::nil(),
             SandboxId::from(uuid::Uuid::nil()),
             "vm0/default",
-            Duration::from_secs(10),
+            Duration::from_secs(3),
         );
     });
 
@@ -104,8 +104,8 @@ fn proxy_register_slow_success_warns_with_stable_fields() {
     assert_eq!(event.level, Level::WARN);
     assert_event_field(event, "message", "slow proxy register");
     assert_event_field(event, "stage", "proxy_register");
-    assert_event_field(event, "elapsed_ms", "10000");
-    assert_event_field(event, "threshold_ms", "10000");
+    assert_event_field(event, "elapsed_ms", "3000");
+    assert_event_field(event, "threshold_ms", "3000");
     assert_event_field(event, "success", "true");
     assert_event_field(event, "run_id", "00000000-0000-0000-0000-000000000000");
     assert_event_field(event, "sandbox_id", "00000000-0000-0000-0000-000000000000");

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -19,8 +19,7 @@ use super::super::env::{guest_user_env_dir_path, guest_user_env_file_path};
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
     execute_new_sandbox_with_prepared_notifier, execute_prepared_sandbox_run,
-    execute_reused_sandbox, log_proxy_register_failure, log_proxy_register_success_if_slow,
-    register_proxy,
+    execute_reused_sandbox, log_proxy_register_failure, log_proxy_register_success, register_proxy,
 };
 use super::super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JobParams,
@@ -75,9 +74,9 @@ async fn execute_inner_happy_path() {
 }
 
 #[test]
-fn proxy_register_fast_success_does_not_warn() {
+fn proxy_register_fast_success_logs_info() {
     let events = capture_proxy_register_events(|| {
-        log_proxy_register_success_if_slow(
+        log_proxy_register_success(
             RunId::nil(),
             SandboxId::from(uuid::Uuid::nil()),
             "vm0/default",
@@ -85,13 +84,23 @@ fn proxy_register_fast_success_does_not_warn() {
         );
     });
 
-    assert!(events.is_empty(), "unexpected events: {events:#?}");
+    assert_eq!(events.len(), 1, "events: {events:#?}");
+    let event = &events[0];
+    assert_eq!(event.level, Level::INFO);
+    assert_event_field(event, "message", "proxy register timing");
+    assert_event_field(event, "stage", "proxy_register");
+    assert_event_field(event, "elapsed_ms", "1000");
+    assert_event_field(event, "threshold_ms", "3000");
+    assert_event_field(event, "success", "true");
+    assert_event_field(event, "run_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(event, "sandbox_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(event, "profile", "vm0/default");
 }
 
 #[test]
 fn proxy_register_slow_success_warns_with_stable_fields() {
     let events = capture_proxy_register_events(|| {
-        log_proxy_register_success_if_slow(
+        log_proxy_register_success(
             RunId::nil(),
             SandboxId::from(uuid::Uuid::nil()),
             "vm0/default",

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -131,6 +131,8 @@ fn proxy_register_failure_warns_with_error() {
     assert_event_field(event, "stage", "proxy_register");
     assert_event_field(event, "elapsed_ms", "25");
     assert_event_field(event, "success", "false");
+    assert_event_field(event, "run_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(event, "sandbox_id", "00000000-0000-0000-0000-000000000000");
     assert_event_field(event, "profile", "vm0/default");
     assert_event_field(event, "error", "registry failed");
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use agent_diagnostics::FailureDiagnostic;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -18,7 +19,8 @@ use super::super::env::{guest_user_env_dir_path, guest_user_env_file_path};
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
     execute_new_sandbox_with_prepared_notifier, execute_prepared_sandbox_run,
-    execute_reused_sandbox, register_proxy,
+    execute_reused_sandbox, log_proxy_register_failure, log_proxy_register_success_if_slow,
+    register_proxy,
 };
 use super::super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JobParams,
@@ -26,11 +28,11 @@ use super::super::{
     SandboxPreparedNotifier, USER_ENV_FILE_ENV_KEY, execute_job, execute_job_reuse,
 };
 use super::support::{
-    DestroyPanicFactory, QueuedCopyFileSandbox, api_storage, assert_proxy_registry_empty,
-    create_overridden_sandbox, default_params, make_reusable_idle_sandbox, minimal_context,
-    run_execute_inner, sandbox_create_error, sandbox_exec_error, sandbox_write_file_error,
-    seed_workspace_image_cache, test_budget_lease, test_device_rate_limits, test_executor_config,
-    test_telemetry,
+    CapturedEvent, CapturedEvents, DestroyPanicFactory, QueuedCopyFileSandbox, api_storage,
+    assert_proxy_registry_empty, create_overridden_sandbox, default_params,
+    make_reusable_idle_sandbox, minimal_context, run_execute_inner, sandbox_create_error,
+    sandbox_exec_error, sandbox_write_file_error, seed_workspace_image_cache, test_budget_lease,
+    test_device_rate_limits, test_executor_config, test_telemetry,
 };
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
@@ -39,6 +41,23 @@ use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
     WorkspaceImagePrepareRequest,
 };
+use tracing::Level;
+use tracing_subscriber::prelude::*;
+
+fn capture_proxy_register_events(action: impl FnOnce()) -> Vec<CapturedEvent> {
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    tracing::subscriber::with_default(subscriber, action);
+    captured.entries()
+}
+
+fn assert_event_field(event: &CapturedEvent, field: &str, expected: &str) {
+    let actual = event
+        .fields
+        .get(field)
+        .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
+    assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
+}
 
 #[tokio::test]
 async fn execute_inner_happy_path() {
@@ -53,6 +72,67 @@ async fn execute_inner_happy_path() {
     assert_eq!(exit_code, 0);
     assert!(error_msg.is_none());
     assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[test]
+fn proxy_register_fast_success_does_not_warn() {
+    let events = capture_proxy_register_events(|| {
+        log_proxy_register_success_if_slow(
+            RunId::nil(),
+            SandboxId::from(uuid::Uuid::nil()),
+            "vm0/default",
+            Duration::from_secs(1),
+        );
+    });
+
+    assert!(events.is_empty(), "unexpected events: {events:#?}");
+}
+
+#[test]
+fn proxy_register_slow_success_warns_with_stable_fields() {
+    let events = capture_proxy_register_events(|| {
+        log_proxy_register_success_if_slow(
+            RunId::nil(),
+            SandboxId::from(uuid::Uuid::nil()),
+            "vm0/default",
+            Duration::from_secs(10),
+        );
+    });
+
+    assert_eq!(events.len(), 1, "events: {events:#?}");
+    let event = &events[0];
+    assert_eq!(event.level, Level::WARN);
+    assert_event_field(event, "message", "slow proxy register");
+    assert_event_field(event, "stage", "proxy_register");
+    assert_event_field(event, "elapsed_ms", "10000");
+    assert_event_field(event, "threshold_ms", "10000");
+    assert_event_field(event, "success", "true");
+    assert_event_field(event, "run_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(event, "sandbox_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(event, "profile", "vm0/default");
+}
+
+#[test]
+fn proxy_register_failure_warns_with_error() {
+    let events = capture_proxy_register_events(|| {
+        log_proxy_register_failure(
+            RunId::nil(),
+            SandboxId::from(uuid::Uuid::nil()),
+            "vm0/default",
+            Duration::from_millis(25),
+            "registry failed",
+        );
+    });
+
+    assert_eq!(events.len(), 1, "events: {events:#?}");
+    let event = &events[0];
+    assert_eq!(event.level, Level::WARN);
+    assert_event_field(event, "message", "proxy register failed");
+    assert_event_field(event, "stage", "proxy_register");
+    assert_event_field(event, "elapsed_ms", "25");
+    assert_event_field(event, "success", "false");
+    assert_event_field(event, "profile", "vm0/default");
+    assert_event_field(event, "error", "registry failed");
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -28,6 +28,7 @@ which.workspace = true
 clap = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+tracing-test-support.workspace = true
 tracing-subscriber.workspace = true
 
 [lints]

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::time::{Duration, Instant};
 
-use tracing::warn;
+use tracing::{info, warn};
 
 pub(super) const SLOW_SANDBOX_CREATE_THRESHOLD: Duration = Duration::from_secs(3);
 
@@ -131,8 +131,8 @@ impl SandboxCreateTiming {
         }
     }
 
-    pub(super) fn emit_slow_success_summary(&self) {
-        self.emit_slow_success_summary_with_total(self.started_at.elapsed());
+    pub(super) fn emit_success_summary(&self) {
+        self.emit_success_summary_with_total(self.started_at.elapsed());
     }
 
     #[cfg(test)]
@@ -161,8 +161,30 @@ impl SandboxCreateTiming {
         );
     }
 
-    fn emit_slow_success_summary_with_total(&self, total_elapsed: Duration) {
+    fn emit_success_summary_with_total(&self, total_elapsed: Duration) {
         if total_elapsed < SLOW_SANDBOX_CREATE_THRESHOLD {
+            info!(
+                stage = "sandbox_create",
+                total_elapsed_ms = duration_ms(total_elapsed),
+                threshold_ms = duration_ms(SLOW_SANDBOX_CREATE_THRESHOLD),
+                success = true,
+                sandbox_id = self.sandbox_id.as_str(),
+                profile = self.profile.as_str(),
+                workspace_drive_present = self.workspace_drive_present,
+                workspace_seed_image_used = self.workspace_seed_image_used,
+                cow_pool_acquire_ms = optional_duration_ms(self.durations.cow_pool_acquire),
+                workspace_dir_rename_ms = optional_duration_ms(self.durations.workspace_dir_rename),
+                workspace_drive_prepare_ms =
+                    optional_duration_ms(self.durations.workspace_drive_prepare),
+                workspace_seed_sparse_copy_ms =
+                    optional_duration_ms(self.durations.workspace_seed_sparse_copy),
+                workspace_fresh_format_ms =
+                    optional_duration_ms(self.durations.workspace_fresh_format),
+                sock_dir_prepare_ms = optional_duration_ms(self.durations.sock_dir_prepare),
+                netns_acquire_ms = optional_duration_ms(self.durations.netns_acquire),
+                nbd_cow_create_ms = optional_duration_ms(self.durations.nbd_cow_create),
+                "sandbox create timing"
+            );
             return;
         }
         warn!(
@@ -264,14 +286,25 @@ mod tests {
     }
 
     #[test]
-    fn fast_success_does_not_emit_warning() {
+    fn fast_success_emits_info_summary() {
         let timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
 
         let events = capture_events(|| {
-            timing.emit_slow_success_summary_with_total(SLOW_SANDBOX_CREATE_THRESHOLD / 2);
+            timing.emit_success_summary_with_total(SLOW_SANDBOX_CREATE_THRESHOLD / 2);
         });
 
-        assert!(events.is_empty(), "unexpected events: {events:#?}");
+        assert_eq!(events.len(), 1, "events: {events:#?}");
+        let event = &events[0];
+        assert_eq!(event.level, Level::INFO);
+        assert_field(event, "message", "sandbox create timing");
+        assert_field(event, "stage", "sandbox_create");
+        assert_field(event, "success", "true");
+        assert_field(event, "sandbox_id", "sandbox-1");
+        assert_field(event, "profile", "vm0/default");
+        assert_field(event, "total_elapsed_ms", "1500");
+        assert_field(event, "threshold_ms", "3000");
+        assert_field(event, "workspace_drive_present", "false");
+        assert_field(event, "workspace_seed_image_used", "false");
     }
 
     #[test]
@@ -303,7 +336,7 @@ mod tests {
         timing.record_stage_duration(SandboxCreateStage::NbdCowCreate, Duration::from_millis(70));
 
         let events = capture_events(|| {
-            timing.emit_slow_success_summary_with_total(SLOW_SANDBOX_CREATE_THRESHOLD);
+            timing.emit_success_summary_with_total(SLOW_SANDBOX_CREATE_THRESHOLD);
         });
 
         assert_eq!(events.len(), 1, "events: {events:#?}");

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -1,0 +1,317 @@
+use std::fmt;
+use std::time::{Duration, Instant};
+
+use tracing::warn;
+
+pub(super) const SLOW_SANDBOX_CREATE_THRESHOLD: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SandboxCreateStage {
+    CowPoolAcquire,
+    WorkspaceDirRename,
+    WorkspaceDrivePrepare,
+    WorkspaceSeedSparseCopy,
+    WorkspaceFreshFormat,
+    SockDirPrepare,
+    NetnsAcquire,
+    NbdCowCreate,
+}
+
+impl SandboxCreateStage {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::CowPoolAcquire => "cow_pool_acquire",
+            Self::WorkspaceDirRename => "workspace_dir_rename",
+            Self::WorkspaceDrivePrepare => "workspace_drive_prepare",
+            Self::WorkspaceSeedSparseCopy => "workspace_seed_sparse_copy",
+            Self::WorkspaceFreshFormat => "workspace_fresh_format",
+            Self::SockDirPrepare => "sock_dir_prepare",
+            Self::NetnsAcquire => "netns_acquire",
+            Self::NbdCowCreate => "nbd_cow_create",
+        }
+    }
+}
+
+#[derive(Default)]
+struct SandboxCreateStageDurations {
+    cow_pool_acquire: Option<Duration>,
+    workspace_dir_rename: Option<Duration>,
+    workspace_drive_prepare: Option<Duration>,
+    workspace_seed_sparse_copy: Option<Duration>,
+    workspace_fresh_format: Option<Duration>,
+    sock_dir_prepare: Option<Duration>,
+    netns_acquire: Option<Duration>,
+    nbd_cow_create: Option<Duration>,
+}
+
+impl SandboxCreateStageDurations {
+    fn set(&mut self, stage: SandboxCreateStage, duration: Duration) {
+        match stage {
+            SandboxCreateStage::CowPoolAcquire => self.cow_pool_acquire = Some(duration),
+            SandboxCreateStage::WorkspaceDirRename => self.workspace_dir_rename = Some(duration),
+            SandboxCreateStage::WorkspaceDrivePrepare => {
+                self.workspace_drive_prepare = Some(duration);
+            }
+            SandboxCreateStage::WorkspaceSeedSparseCopy => {
+                self.workspace_seed_sparse_copy = Some(duration);
+            }
+            SandboxCreateStage::WorkspaceFreshFormat => {
+                self.workspace_fresh_format = Some(duration)
+            }
+            SandboxCreateStage::SockDirPrepare => self.sock_dir_prepare = Some(duration),
+            SandboxCreateStage::NetnsAcquire => self.netns_acquire = Some(duration),
+            SandboxCreateStage::NbdCowCreate => self.nbd_cow_create = Some(duration),
+        }
+    }
+
+    #[cfg(test)]
+    fn get(&self, stage: SandboxCreateStage) -> Option<Duration> {
+        match stage {
+            SandboxCreateStage::CowPoolAcquire => self.cow_pool_acquire,
+            SandboxCreateStage::WorkspaceDirRename => self.workspace_dir_rename,
+            SandboxCreateStage::WorkspaceDrivePrepare => self.workspace_drive_prepare,
+            SandboxCreateStage::WorkspaceSeedSparseCopy => self.workspace_seed_sparse_copy,
+            SandboxCreateStage::WorkspaceFreshFormat => self.workspace_fresh_format,
+            SandboxCreateStage::SockDirPrepare => self.sock_dir_prepare,
+            SandboxCreateStage::NetnsAcquire => self.netns_acquire,
+            SandboxCreateStage::NbdCowCreate => self.nbd_cow_create,
+        }
+    }
+}
+
+pub(crate) struct SandboxCreateTiming {
+    sandbox_id: String,
+    profile: String,
+    started_at: Instant,
+    durations: SandboxCreateStageDurations,
+    workspace_drive_present: bool,
+    workspace_seed_image_used: bool,
+    failure_logged: bool,
+}
+
+impl SandboxCreateTiming {
+    pub(super) fn new(sandbox_id: String, profile: String) -> Self {
+        Self {
+            sandbox_id,
+            profile,
+            started_at: Instant::now(),
+            durations: SandboxCreateStageDurations::default(),
+            workspace_drive_present: false,
+            workspace_seed_image_used: false,
+            failure_logged: false,
+        }
+    }
+
+    pub(super) fn mark_workspace_drive_present(&mut self) {
+        self.workspace_drive_present = true;
+    }
+
+    pub(super) fn mark_workspace_seed_image_used(&mut self) {
+        self.workspace_seed_image_used = true;
+    }
+
+    pub(super) fn record_stage_result<T, E>(
+        &mut self,
+        stage: SandboxCreateStage,
+        started_at: Instant,
+        result: Result<T, E>,
+    ) -> Result<T, E>
+    where
+        E: fmt::Display,
+    {
+        let elapsed = started_at.elapsed();
+        self.record_stage_duration(stage, elapsed);
+        match result {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let message = error.to_string();
+                self.emit_stage_failure(stage, elapsed, &message);
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) fn emit_slow_success_summary(&self) {
+        self.emit_slow_success_summary_with_total(self.started_at.elapsed());
+    }
+
+    #[cfg(test)]
+    pub(super) fn stage_duration_for_test(&self, stage: SandboxCreateStage) -> Option<Duration> {
+        self.durations.get(stage)
+    }
+
+    fn record_stage_duration(&mut self, stage: SandboxCreateStage, duration: Duration) {
+        self.durations.set(stage, duration);
+    }
+
+    fn emit_stage_failure(&mut self, stage: SandboxCreateStage, elapsed: Duration, error: &str) {
+        if self.failure_logged {
+            return;
+        }
+        self.failure_logged = true;
+        warn!(
+            stage = stage.as_str(),
+            elapsed_ms = duration_ms(elapsed),
+            success = false,
+            sandbox_id = self.sandbox_id.as_str(),
+            profile = self.profile.as_str(),
+            error,
+            "sandbox create stage failed"
+        );
+    }
+
+    fn emit_slow_success_summary_with_total(&self, total_elapsed: Duration) {
+        if total_elapsed < SLOW_SANDBOX_CREATE_THRESHOLD {
+            return;
+        }
+        warn!(
+            stage = "sandbox_create",
+            total_elapsed_ms = duration_ms(total_elapsed),
+            threshold_ms = duration_ms(SLOW_SANDBOX_CREATE_THRESHOLD),
+            success = true,
+            sandbox_id = self.sandbox_id.as_str(),
+            profile = self.profile.as_str(),
+            workspace_drive_present = self.workspace_drive_present,
+            workspace_seed_image_used = self.workspace_seed_image_used,
+            cow_pool_acquire_ms = optional_duration_ms(self.durations.cow_pool_acquire),
+            workspace_dir_rename_ms = optional_duration_ms(self.durations.workspace_dir_rename),
+            workspace_drive_prepare_ms =
+                optional_duration_ms(self.durations.workspace_drive_prepare),
+            workspace_seed_sparse_copy_ms =
+                optional_duration_ms(self.durations.workspace_seed_sparse_copy),
+            workspace_fresh_format_ms = optional_duration_ms(self.durations.workspace_fresh_format),
+            sock_dir_prepare_ms = optional_duration_ms(self.durations.sock_dir_prepare),
+            netns_acquire_ms = optional_duration_ms(self.durations.netns_acquire),
+            nbd_cow_create_ms = optional_duration_ms(self.durations.nbd_cow_create),
+            "slow sandbox create"
+        );
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis() as u64
+}
+
+fn optional_duration_ms(duration: Option<Duration>) -> u64 {
+    duration.map_or(0, duration_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tracing::Level;
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::{CapturedEvent, CapturedEvents};
+
+    use super::*;
+
+    fn capture_events(action: impl FnOnce()) -> Vec<CapturedEvent> {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        tracing::subscriber::with_default(subscriber, action);
+        captured.entries()
+    }
+
+    fn assert_field(event: &CapturedEvent, field: &str, expected: &str) {
+        let actual = event
+            .fields
+            .get(field)
+            .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"));
+        assert_eq!(actual, expected, "field {field} mismatch; event={event:#?}");
+    }
+
+    #[test]
+    fn fast_success_does_not_emit_warning() {
+        let timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+
+        let events = capture_events(|| {
+            timing.emit_slow_success_summary_with_total(SLOW_SANDBOX_CREATE_THRESHOLD / 2);
+        });
+
+        assert!(events.is_empty(), "unexpected events: {events:#?}");
+    }
+
+    #[test]
+    fn slow_success_emits_summary_with_stable_fields() {
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        timing.mark_workspace_drive_present();
+        timing.mark_workspace_seed_image_used();
+        timing.record_stage_duration(
+            SandboxCreateStage::CowPoolAcquire,
+            Duration::from_millis(10),
+        );
+        timing.record_stage_duration(
+            SandboxCreateStage::WorkspaceDirRename,
+            Duration::from_millis(20),
+        );
+        timing.record_stage_duration(
+            SandboxCreateStage::WorkspaceDrivePrepare,
+            Duration::from_millis(30),
+        );
+        timing.record_stage_duration(
+            SandboxCreateStage::WorkspaceSeedSparseCopy,
+            Duration::from_millis(40),
+        );
+        timing.record_stage_duration(
+            SandboxCreateStage::SockDirPrepare,
+            Duration::from_millis(50),
+        );
+        timing.record_stage_duration(SandboxCreateStage::NetnsAcquire, Duration::from_millis(60));
+        timing.record_stage_duration(SandboxCreateStage::NbdCowCreate, Duration::from_millis(70));
+
+        let events = capture_events(|| {
+            timing.emit_slow_success_summary_with_total(SLOW_SANDBOX_CREATE_THRESHOLD);
+        });
+
+        assert_eq!(events.len(), 1, "events: {events:#?}");
+        let event = &events[0];
+        assert_eq!(event.level, Level::WARN);
+        assert_field(event, "message", "slow sandbox create");
+        assert_field(event, "stage", "sandbox_create");
+        assert_field(event, "success", "true");
+        assert_field(event, "sandbox_id", "sandbox-1");
+        assert_field(event, "profile", "vm0/default");
+        assert_field(event, "total_elapsed_ms", "10000");
+        assert_field(event, "threshold_ms", "10000");
+        assert_field(event, "workspace_drive_present", "true");
+        assert_field(event, "workspace_seed_image_used", "true");
+        assert_field(event, "cow_pool_acquire_ms", "10");
+        assert_field(event, "workspace_dir_rename_ms", "20");
+        assert_field(event, "workspace_drive_prepare_ms", "30");
+        assert_field(event, "workspace_seed_sparse_copy_ms", "40");
+        assert_field(event, "workspace_fresh_format_ms", "0");
+        assert_field(event, "sock_dir_prepare_ms", "50");
+        assert_field(event, "netns_acquire_ms", "60");
+        assert_field(event, "nbd_cow_create_ms", "70");
+    }
+
+    #[test]
+    fn stage_failure_emits_warning_once() {
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+
+        let events = capture_events(|| {
+            timing.emit_stage_failure(
+                SandboxCreateStage::WorkspaceSeedSparseCopy,
+                Duration::from_millis(25),
+                "copy failed",
+            );
+            timing.emit_stage_failure(
+                SandboxCreateStage::WorkspaceDrivePrepare,
+                Duration::from_millis(30),
+                "outer failed",
+            );
+        });
+
+        assert_eq!(events.len(), 1, "events: {events:#?}");
+        let event = &events[0];
+        assert_eq!(event.level, Level::WARN);
+        assert_field(event, "message", "sandbox create stage failed");
+        assert_field(event, "stage", "workspace_seed_sparse_copy");
+        assert_field(event, "elapsed_ms", "25");
+        assert_field(event, "success", "false");
+        assert_field(event, "sandbox_id", "sandbox-1");
+        assert_field(event, "profile", "vm0/default");
+        assert_field(event, "error", "copy failed");
+    }
+}

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -149,13 +149,14 @@ impl SandboxCreateTiming {
             return;
         }
         self.failure_logged = true;
+        let safe_error = sanitize_error_for_timing(error);
         warn!(
             stage = stage.as_str(),
             elapsed_ms = duration_ms(elapsed),
             success = false,
             sandbox_id = self.sandbox_id.as_str(),
             profile = self.profile.as_str(),
-            error,
+            error = safe_error.as_str(),
             "sandbox create stage failed"
         );
     }
@@ -194,6 +195,24 @@ fn duration_ms(duration: Duration) -> u64 {
 
 fn optional_duration_ms(duration: Option<Duration>) -> u64 {
     duration.map_or(0, duration_ms)
+}
+
+fn sanitize_error_for_timing(error: &str) -> String {
+    let first_line = error.lines().next().unwrap_or_default().trim();
+    let command_redacted = if let Some((prefix, _)) = first_line.split_once("command failed:") {
+        format!("{} command failed", prefix.trim_end())
+    } else {
+        first_line.to_owned()
+    };
+    redact_path_tokens(&command_redacted)
+}
+
+fn redact_path_tokens(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|token| if token.contains('/') { "<path>" } else { token })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[cfg(test)]
@@ -313,5 +332,44 @@ mod tests {
         assert_field(event, "sandbox_id", "sandbox-1");
         assert_field(event, "profile", "vm0/default");
         assert_field(event, "error", "copy failed");
+    }
+
+    #[test]
+    fn stage_failure_redacts_paths_and_command_argv() {
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+
+        let events = capture_events(|| {
+            timing.emit_stage_failure(
+                SandboxCreateStage::WorkspaceSeedSparseCopy,
+                Duration::from_millis(25),
+                "sandbox sandbox allocation initialization failed: copy workspace seed image: command failed: cp --sparse=always -- /tmp/source.ext4 /tmp/target.ext4\nsecret stderr",
+            );
+        });
+
+        assert_eq!(events.len(), 1, "events: {events:#?}");
+        let event = &events[0];
+        assert_field(
+            event,
+            "error",
+            "sandbox sandbox allocation initialization failed: copy workspace seed image: command failed",
+        );
+        assert!(!event.fields["error"].contains("/tmp"), "event={event:#?}");
+        assert!(!event.fields["error"].contains("cp --"), "event={event:#?}");
+        assert!(
+            !event.fields["error"].contains("secret stderr"),
+            "event={event:#?}"
+        );
+    }
+
+    #[test]
+    fn stage_failure_redacts_path_tokens() {
+        let error = sanitize_error_for_timing(
+            "workspace seed image size mismatch for /tmp/seed.ext4: expected 1 bytes, got 0 bytes",
+        );
+
+        assert_eq!(
+            error,
+            "workspace seed image size mismatch for <path> expected 1 bytes, got 0 bytes"
+        );
     }
 }

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -200,7 +200,12 @@ fn optional_duration_ms(duration: Option<Duration>) -> u64 {
 fn sanitize_error_for_timing(error: &str) -> String {
     let first_line = error.lines().next().unwrap_or_default().trim();
     let command_redacted = if let Some((prefix, _)) = first_line.split_once("command failed:") {
-        format!("{} command failed", prefix.trim_end())
+        let prefix = prefix.trim_end();
+        if prefix.is_empty() {
+            "command failed".to_owned()
+        } else {
+            format!("{prefix} command failed")
+        }
     } else {
         first_line.to_owned()
     };
@@ -210,9 +215,27 @@ fn sanitize_error_for_timing(error: &str) -> String {
 fn redact_path_tokens(value: &str) -> String {
     value
         .split_whitespace()
-        .map(|token| if token.contains('/') { "<path>" } else { token })
+        .map(|token| {
+            if is_path_like_token(token) {
+                "<path>"
+            } else {
+                token
+            }
+        })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn is_path_like_token(token: &str) -> bool {
+    let token =
+        token.trim_matches(|c: char| matches!(c, ':' | ',' | ';' | ')' | '(' | '"' | '\'' | '`'));
+    token.contains('/')
+        || token.contains('\\')
+        || token.starts_with('.')
+        || token.ends_with(".ext4")
+        || token.ends_with(".img")
+        || token.ends_with(".qcow2")
+        || token.ends_with(".raw")
 }
 
 #[cfg(test)]
@@ -362,9 +385,28 @@ mod tests {
     }
 
     #[test]
+    fn stage_failure_redacts_command_argv_without_prefix() {
+        let error = sanitize_error_for_timing("command failed: cp /tmp/source /tmp/target");
+
+        assert_eq!(error, "command failed");
+    }
+
+    #[test]
     fn stage_failure_redacts_path_tokens() {
         let error = sanitize_error_for_timing(
             "workspace seed image size mismatch for /tmp/seed.ext4: expected 1 bytes, got 0 bytes",
+        );
+
+        assert_eq!(
+            error,
+            "workspace seed image size mismatch for <path> expected 1 bytes, got 0 bytes"
+        );
+    }
+
+    #[test]
+    fn stage_failure_redacts_relative_image_path_tokens() {
+        let error = sanitize_error_for_timing(
+            "workspace seed image size mismatch for seed.ext4: expected 1 bytes, got 0 bytes",
         );
 
         assert_eq!(

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use tracing::warn;
 
-pub(super) const SLOW_SANDBOX_CREATE_THRESHOLD: Duration = Duration::from_secs(10);
+pub(super) const SLOW_SANDBOX_CREATE_THRESHOLD: Duration = Duration::from_secs(3);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SandboxCreateStage {
@@ -314,8 +314,8 @@ mod tests {
         assert_field(event, "success", "true");
         assert_field(event, "sandbox_id", "sandbox-1");
         assert_field(event, "profile", "vm0/default");
-        assert_field(event, "total_elapsed_ms", "10000");
-        assert_field(event, "threshold_ms", "10000");
+        assert_field(event, "total_elapsed_ms", "3000");
+        assert_field(event, "threshold_ms", "3000");
         assert_field(event, "workspace_drive_present", "true");
         assert_field(event, "workspace_seed_image_used", "true");
         assert_field(event, "cow_pool_acquire_ms", "10");

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -369,7 +369,7 @@ impl SandboxFactory for FirecrackerFactory {
                 return Err(e);
             }
         };
-        timing.emit_slow_success_summary();
+        timing.emit_success_summary();
         let SandboxCreateResources {
             sandbox_paths,
             sock_paths,

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -1,11 +1,12 @@
 mod cleanup_group;
 mod cow_cleanup;
+mod create_timing;
 mod create_transaction;
 mod invariant;
 mod leak_cleaner;
 
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use sandbox::{
@@ -19,13 +20,14 @@ use crate::config::{FirecrackerConfig, FirecrackerDeviceRateLimits};
 use crate::cow_cleanup::CowCleanupOutcome;
 use crate::factory::cleanup_group::{FactoryCleanupGroup, FactoryCleanupTaskKind};
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
+use crate::factory::create_timing::{SandboxCreateStage, SandboxCreateTiming};
 use crate::factory::create_transaction::{
     FactoryCreateRollbackCleanup, SandboxCreateResources, SandboxCreateTransaction,
     rollback_create_transaction,
 };
 use crate::factory::leak_cleaner::LeakCleaner;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
-use crate::paths::{FactoryPaths, RuntimePaths, SockPaths};
+use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
 use crate::sandbox::{FirecrackerSandbox, FirecrackerSandboxInit};
 
@@ -226,6 +228,7 @@ impl SandboxFactory for FirecrackerFactory {
         let device_rate_limits = convert_device_rate_limits(config.device_rate_limits.as_ref())?;
         let leak_tx = resources.leak_cleaner.sender();
         let id = config.id.to_string();
+        let mut timing = SandboxCreateTiming::new(id.clone(), self.config.profile.clone());
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
             netns_pool: resources.netns_pool.clone(),
@@ -236,74 +239,123 @@ impl SandboxFactory for FirecrackerFactory {
             async {
                 // Acquire a pre-warmed COW slot from the pool.
                 // The slot provides: workspace dir (already created) and cow file.
-                let slot = resources.cow_pool.acquire().await.map_err(|e| {
+                let stage_started = Instant::now();
+                let slot = match resources.cow_pool.acquire().await.map_err(|e| {
                     SandboxError::Initialization {
                         phase: SandboxInitializationPhase::SandboxAllocation,
                         message: format!("acquire COW slot: {e}"),
                     }
-                })?;
-                tx.track_slot(slot)?;
+                }) {
+                    Ok(slot) => slot,
+                    Err(e) => {
+                        return timing.record_stage_result(
+                            SandboxCreateStage::CowPoolAcquire,
+                            stage_started,
+                            Err(e),
+                        );
+                    }
+                };
+                timing.record_stage_result(
+                    SandboxCreateStage::CowPoolAcquire,
+                    stage_started,
+                    tx.track_slot(slot),
+                )?;
 
                 // The slot workspace is {workspaces_dir}/{slot_uuid}/.
                 // Rename to {workspaces_dir}/{sandbox_id}/ for doctor correlation.
-                let target_workspace = self.factory_paths.workspace(&id);
-                clean_stale_workspace_dir(&id, &target_workspace)?;
-                let slot_workspace = tx.begin_workspace_rename(target_workspace.clone())?;
-                // Keep rename cancellation-safe: tokio::fs::rename may keep
-                // running on the blocking pool after its future is dropped.
-                if let Err(e) = std::fs::rename(&slot_workspace, &target_workspace) {
-                    tx.abort_workspace_rename_after_error()?;
-                    return Err(SandboxError::Initialization {
-                        phase: SandboxInitializationPhase::SandboxAllocation,
-                        message: format!("rename workspace: {e}"),
-                    });
-                }
-                tx.finish_workspace_rename()?;
+                let stage_started = Instant::now();
+                let rename_result = (|| {
+                    let target_workspace = self.factory_paths.workspace(&id);
+                    clean_stale_workspace_dir(&id, &target_workspace)?;
+                    let slot_workspace = tx.begin_workspace_rename(target_workspace.clone())?;
+                    // Keep rename cancellation-safe: tokio::fs::rename may keep
+                    // running on the blocking pool after its future is dropped.
+                    if let Err(e) = std::fs::rename(&slot_workspace, &target_workspace) {
+                        tx.abort_workspace_rename_after_error()?;
+                        return Err(SandboxError::Initialization {
+                            phase: SandboxInitializationPhase::SandboxAllocation,
+                            message: format!("rename workspace: {e}"),
+                        });
+                    }
+                    tx.finish_workspace_rename()?;
+                    let cow_file = target_workspace.join("cow.img");
+                    let sandbox_paths = SandboxPaths::new(target_workspace);
+                    Ok((cow_file, sandbox_paths))
+                })();
+                let (cow_file, sandbox_paths) = timing.record_stage_result(
+                    SandboxCreateStage::WorkspaceDirRename,
+                    stage_started,
+                    rename_result,
+                )?;
 
                 // Recompute cow_file path after rename (the slot path no longer exists).
-                let cow_file = target_workspace.join("cow.img");
-                let sandbox_paths = crate::paths::SandboxPaths::new(target_workspace.clone());
                 if let Some(workspace_drive) = config.workspace_drive.as_ref() {
-                    prepare_workspace_drive_image(
+                    let stage_started = Instant::now();
+                    let prepare_result = prepare_workspace_drive_image(
                         &sandbox_paths.workspace_image(),
                         workspace_drive,
+                        Some(&mut timing),
                     )
-                    .await?;
+                    .await;
+                    timing.record_stage_result(
+                        SandboxCreateStage::WorkspaceDrivePrepare,
+                        stage_started,
+                        prepare_result,
+                    )?;
                 }
 
                 // Clean stale sock dir and create vsock directory.
+                let stage_started = Instant::now();
                 let sock_paths = SockPaths::new(self.runtime_paths.sock_dir(&id));
-                clean_stale_sock_dir(&id, sock_paths.dir())?;
-                tx.track_sock_dir(sock_paths.dir().to_owned());
-                if let Err(e) = tokio::fs::create_dir_all(sock_paths.vsock_dir()).await {
-                    return Err(SandboxError::Initialization {
-                        phase: SandboxInitializationPhase::SandboxAllocation,
-                        message: format!("mkdir vsock dir: {e}"),
-                    });
-                }
+                let sock_result = match clean_stale_sock_dir(&id, sock_paths.dir()) {
+                    Ok(()) => {
+                        tx.track_sock_dir(sock_paths.dir().to_owned());
+                        tokio::fs::create_dir_all(sock_paths.vsock_dir())
+                            .await
+                            .map_err(|e| SandboxError::Initialization {
+                                phase: SandboxInitializationPhase::SandboxAllocation,
+                                message: format!("mkdir vsock dir: {e}"),
+                            })
+                    }
+                    Err(e) => Err(e),
+                };
+                timing.record_stage_result(
+                    SandboxCreateStage::SockDirPrepare,
+                    stage_started,
+                    sock_result,
+                )?;
 
                 // Acquire a network namespace from the pool.
-                let network = resources.netns_pool.acquire().await.map_err(|e| {
-                    SandboxError::Initialization {
-                        phase: SandboxInitializationPhase::SandboxAllocation,
-                        message: format!("acquire netns: {e}"),
-                    }
-                })?;
+                let stage_started = Instant::now();
+                let network = timing.record_stage_result(
+                    SandboxCreateStage::NetnsAcquire,
+                    stage_started,
+                    resources.netns_pool.acquire().await.map_err(|e| {
+                        SandboxError::Initialization {
+                            phase: SandboxInitializationPhase::SandboxAllocation,
+                            message: format!("acquire netns: {e}"),
+                        }
+                    }),
+                )?;
                 tx.track_network(network);
 
                 // Create NBD COW device (~15ms via netlink, no subprocess).
-                let cow_device = self
-                    .device_pool
-                    .create_cow_device(
-                        &resources.base_image.path,
-                        &cow_file,
-                        resources.base_image.size,
-                    )
-                    .await
-                    .map_err(|e| SandboxError::Initialization {
-                        phase: SandboxInitializationPhase::SandboxAllocation,
-                        message: format!("create NBD COW device: {e}"),
-                    })?;
+                let stage_started = Instant::now();
+                let cow_device = timing.record_stage_result(
+                    SandboxCreateStage::NbdCowCreate,
+                    stage_started,
+                    self.device_pool
+                        .create_cow_device(
+                            &resources.base_image.path,
+                            &cow_file,
+                            resources.base_image.size,
+                        )
+                        .await
+                        .map_err(|e| SandboxError::Initialization {
+                            phase: SandboxInitializationPhase::SandboxAllocation,
+                            message: format!("create NBD COW device: {e}"),
+                        }),
+                )?;
                 tx.track_cow_device(cow_device);
 
                 tx.commit()
@@ -317,6 +369,7 @@ impl SandboxFactory for FirecrackerFactory {
                 return Err(e);
             }
         };
+        timing.emit_slow_success_summary();
         let SandboxCreateResources {
             sandbox_paths,
             sock_paths,
@@ -336,7 +389,6 @@ impl SandboxFactory for FirecrackerFactory {
             device_rate_limits,
             leak_tx,
         });
-
         Ok(Box::new(sandbox))
     }
 
@@ -419,7 +471,12 @@ fn clean_stale_workspace_dir(id: &str, target_workspace: &Path) -> sandbox::Resu
 pub(crate) async fn prepare_workspace_drive_image(
     path: &Path,
     config: &sandbox::WorkspaceDriveConfig,
+    mut timing: Option<&mut SandboxCreateTiming>,
 ) -> sandbox::Result<()> {
+    if let Some(timing) = timing.as_deref_mut() {
+        timing.mark_workspace_drive_present();
+    }
+
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
@@ -430,10 +487,14 @@ pub(crate) async fn prepare_workspace_drive_image(
     }
 
     if let Some(source_image) = config.seed_image.as_ref() {
+        if let Some(timing) = timing.as_deref_mut() {
+            timing.mark_workspace_seed_image_used();
+        }
         return copy_workspace_drive_seed_image(
             path,
             source_image,
             workspace_drive_size_bytes(config.size_mb),
+            timing,
         )
         .await;
     }
@@ -456,7 +517,8 @@ pub(crate) async fn prepare_workspace_drive_image(
         phase: SandboxInitializationPhase::SandboxAllocation,
         message: format!("workspace image path is not UTF-8: {}", path.display()),
     })?;
-    command::exec_with_timeout(
+    let stage_started = Instant::now();
+    let result = command::exec_with_timeout(
         "mkfs.ext4",
         &["-F", "-q", path_str],
         Duration::from_secs(60),
@@ -465,7 +527,16 @@ pub(crate) async fn prepare_workspace_drive_image(
     .map_err(|e| SandboxError::Initialization {
         phase: SandboxInitializationPhase::SandboxAllocation,
         message: format!("format workspace image: {e}"),
-    })?;
+    });
+    if let Some(timing) = timing {
+        timing.record_stage_result(
+            SandboxCreateStage::WorkspaceFreshFormat,
+            stage_started,
+            result,
+        )
+    } else {
+        result
+    }?;
     Ok(())
 }
 
@@ -473,6 +544,7 @@ async fn copy_workspace_drive_seed_image(
     target: &Path,
     source: &Path,
     expected_size_bytes: u64,
+    timing: Option<&mut SandboxCreateTiming>,
 ) -> sandbox::Result<()> {
     let source_metadata =
         tokio::fs::metadata(source)
@@ -518,7 +590,8 @@ async fn copy_workspace_drive_seed_image(
             message: format!("workspace image path is not UTF-8: {}", target.display()),
         })?;
 
-    command::exec_with_timeout(
+    let stage_started = Instant::now();
+    let result = command::exec_with_timeout(
         "cp",
         &["--sparse=always", "--", source_str, target_str],
         Duration::from_secs(300),
@@ -527,7 +600,16 @@ async fn copy_workspace_drive_seed_image(
     .map_err(|e| SandboxError::Initialization {
         phase: SandboxInitializationPhase::SandboxAllocation,
         message: format!("copy workspace seed image: {e}"),
-    })?;
+    });
+    if let Some(timing) = timing {
+        timing.record_stage_result(
+            SandboxCreateStage::WorkspaceSeedSparseCopy,
+            stage_started,
+            result,
+        )
+    } else {
+        result
+    }?;
 
     let target_metadata =
         tokio::fs::metadata(target)
@@ -666,6 +748,7 @@ mod tests {
     async fn prepare_workspace_drive_image_without_seed_formats_fresh_image() {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp.path().join("nested").join("workspace.ext4");
+        let mut timing = SandboxCreateTiming::new("sandbox".into(), "vm0/default".into());
 
         prepare_workspace_drive_image(
             &target,
@@ -673,12 +756,23 @@ mod tests {
                 size_mb: 16,
                 seed_image: None,
             },
+            Some(&mut timing),
         )
         .await
         .unwrap();
 
         let metadata = tokio::fs::metadata(&target).await.unwrap();
         assert_eq!(metadata.len(), workspace_drive_size_bytes(16));
+        assert!(
+            timing
+                .stage_duration_for_test(SandboxCreateStage::WorkspaceFreshFormat)
+                .is_some()
+        );
+        assert!(
+            timing
+                .stage_duration_for_test(SandboxCreateStage::WorkspaceSeedSparseCopy)
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -688,6 +782,7 @@ mod tests {
         let target = tmp.path().join("nested").join("workspace.ext4");
         let marker_offset = 4096;
         let marker = b"vm0";
+        let mut timing = SandboxCreateTiming::new("sandbox".into(), "vm0/default".into());
 
         let mut source_file = tokio::fs::File::create(&source).await.unwrap();
         source_file
@@ -708,12 +803,23 @@ mod tests {
                 size_mb: 1,
                 seed_image: Some(source.clone()),
             },
+            Some(&mut timing),
         )
         .await
         .unwrap();
 
         let metadata = tokio::fs::metadata(&target).await.unwrap();
         assert_eq!(metadata.len(), workspace_drive_size_bytes(1));
+        assert!(
+            timing
+                .stage_duration_for_test(SandboxCreateStage::WorkspaceSeedSparseCopy)
+                .is_some()
+        );
+        assert!(
+            timing
+                .stage_duration_for_test(SandboxCreateStage::WorkspaceFreshFormat)
+                .is_none()
+        );
 
         let mut target_file = tokio::fs::File::open(&target).await.unwrap();
         target_file
@@ -744,6 +850,7 @@ mod tests {
                 size_mb: 1,
                 seed_image: Some(source),
             },
+            None,
         )
         .await
         .unwrap_err();

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -256,6 +256,7 @@ impl SnapshotAttempt {
                 size_mb: config.workspace_disk_mb,
                 seed_image: None,
             },
+            None,
         )
         .await
         {


### PR DESCRIPTION
## Summary
- add aggregated sandbox creation timing diagnostics with slow-success and failure warnings
- include workspace drive, seed copy, fresh format, netns, sock dir, COW pool, and NBD COW stages
- add proxy registration timing diagnostics at the runner layer

Closes #17472

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner sandbox_run`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- pre-commit hook: cargo fmt, cargo doc, cargo clippy
