### PR TITLE
perf: trim chat thread list queries and cut sidebar broadcast fan-out

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -83,7 +83,7 @@ describe("CHAT-01 chat thread lifecycle", () => {
     const markedRead = await api.markThreadRead(actor, created.id);
     expect(markedRead).toStrictEqual({
       lastReadMessageId: null,
-      changed: false,
+      unreads: [],
     });
 
     await api.updateThreadModelSelection(actor, created.id, null);
@@ -161,7 +161,7 @@ describe("CHAT-01 chat thread lifecycle", () => {
 
     expect(readEmpty).toStrictEqual({
       lastReadMessageId: null,
-      changed: false,
+      unreads: [],
     });
 
     const pinnedList = await api.listThreads(owner, {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -125,11 +125,9 @@ describe("CHAT-01 chat thread lifecycle", () => {
     expectApiError(peerRead.body);
     expect(peerRead.body.error.code).toBe("NOT_FOUND");
 
-    const outsiderRead = await api.requestReadThread(
-      outsider,
-      thread.id,
-      [404],
-    );
+    const outsiderRead = await api.requestReadThread(outsider, thread.id, [
+      404,
+    ]);
     expectApiError(outsiderRead.body);
     expect(outsiderRead.body.error.code).toBe("NOT_FOUND");
 
@@ -177,7 +175,6 @@ describe("CHAT-01 chat thread lifecycle", () => {
       renamedAt: expect.any(String),
     });
     expect(pinnedList.threads).toStrictEqual([]);
-    expect(pinnedList.totalCount).toBe(0);
 
     let detail = await api.readThread(owner, thread.id);
     expect(detail.selectedModel).toBe("gpt-5.4-mini");
@@ -209,11 +206,9 @@ describe("CHAT-01 chat thread lifecycle", () => {
     expectApiError(peerPin.body);
     expect(peerPin.body.error.code).toBe("NOT_FOUND");
 
-    const peerMarkRead = await api.requestMarkThreadRead(
-      peer,
-      thread.id,
-      [404],
-    );
+    const peerMarkRead = await api.requestMarkThreadRead(peer, thread.id, [
+      404,
+    ]);
     expectApiError(peerMarkRead.body);
     expect(peerMarkRead.body.error.code).toBe("NOT_FOUND");
 
@@ -234,7 +229,6 @@ describe("CHAT-01 chat thread lifecycle", () => {
       title: "Pinned launch plan",
       pinnedAt: null,
     });
-    expect(unpinnedList.totalCount).toBe(1);
 
     detail = await api.readThread(owner, thread.id);
     expect(detail.selectedModel).toBeNull();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -589,7 +589,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
       id: readStateThreadId,
       isRead: false,
       running: false,
-      hasDraft: false,
       pinnedAt: null,
       renamedAt: null,
     });
@@ -618,12 +617,14 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     list = await chat.listThreads(owner, { agentId: agent.agentId });
     expect(list.threads[0]?.isRead).toBeTruthy();
 
-    // Draft flags through PATCH: text, attachments-only, empty, cleared.
+    // Draft flags through PATCH surface via the drafts endpoint: text,
+    // attachments-only, empty, cleared. Unknown ids are silently absent.
     await chat.patchThread(owner, readStateThreadId, {
       draftContent: "unsent text",
     });
-    list = await chat.listThreads(owner, { agentId: agent.agentId });
-    expect(list.threads[0]?.hasDraft).toBeTruthy();
+    expect(
+      await chat.listThreadDrafts(owner, [readStateThreadId, randomUUID()]),
+    ).toStrictEqual([readStateThreadId]);
 
     await chat.patchThread(owner, readStateThreadId, {
       draftContent: null,
@@ -637,15 +638,17 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
         },
       ],
     });
-    list = await chat.listThreads(owner, { agentId: agent.agentId });
-    expect(list.threads[0]?.hasDraft).toBeTruthy();
+    expect(
+      await chat.listThreadDrafts(owner, [readStateThreadId]),
+    ).toStrictEqual([readStateThreadId]);
 
     await chat.patchThread(owner, readStateThreadId, {
       draftContent: "",
       draftAttachments: null,
     });
-    list = await chat.listThreads(owner, { agentId: agent.agentId });
-    expect(list.threads[0]?.hasDraft).toBeFalsy();
+    expect(
+      await chat.listThreadDrafts(owner, [readStateThreadId]),
+    ).toStrictEqual([]);
 
     // Patch guards: unknown thread 404 (visible state untouched), peer 404.
     const patchUnknown = await chat.requestPatchThread(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -578,16 +578,16 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
       nextCursor: null,
     });
 
-    // Read state: a fresh thread is read, a no-credit message flips it to
-    // unread, and mark-read stores the latest visible message id.
+    // Read state lives in the unreads endpoint: a no-credit message makes
+    // the thread unread, mark-read stores the latest visible message id and
+    // returns the agent's fresh (now empty) unread snapshot.
     const readStateThreadId = await sendNoCreditMessage(owner, {
       agentId: agent.agentId,
       prompt: "unread until marked",
     });
-    let list = await chat.listThreads(owner, { agentId: agent.agentId });
+    const list = await chat.listThreads(owner, { agentId: agent.agentId });
     expect(list.threads[0]).toMatchObject({
       id: readStateThreadId,
-      isRead: false,
       running: false,
       pinnedAt: null,
       renamedAt: null,
@@ -598,6 +598,9 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     });
     expect(list.threads[0]?.createdAt).toStrictEqual(expect.any(String));
     expect(list.threads[0]?.updatedAt).toStrictEqual(expect.any(String));
+    expect(await chat.listThreadUnreads(owner, agent.agentId)).toStrictEqual([
+      { threadId: readStateThreadId, unreadAt: expect.any(String) },
+    ]);
 
     const page = await chat.listThreadMessages(owner, readStateThreadId);
     const latestAssistant = assistantMessages(page.messages).at(-1);
@@ -607,15 +610,16 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     const marked = await chat.markThreadRead(owner, readStateThreadId);
     expect(marked).toStrictEqual({
       lastReadMessageId: latestAssistant.id,
-      changed: true,
+      unreads: [],
     });
     const markedAgain = await chat.markThreadRead(owner, readStateThreadId);
     expect(markedAgain).toStrictEqual({
       lastReadMessageId: latestAssistant.id,
-      changed: false,
+      unreads: [],
     });
-    list = await chat.listThreads(owner, { agentId: agent.agentId });
-    expect(list.threads[0]?.isRead).toBeTruthy();
+    expect(await chat.listThreadUnreads(owner, agent.agentId)).toStrictEqual(
+      [],
+    );
 
     // Draft flags through PATCH surface via the drafts endpoint: text,
     // attachments-only, empty, cleared. Unknown ids are silently absent.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -186,11 +186,9 @@ async function completeChatRunOk(
     sandboxHeaders,
     [200],
   );
-  await webhooks.requestAgentComplete(
-    { runId, exitCode: 0 },
-    sandboxHeaders,
-    [200],
-  );
+  await webhooks.requestAgentComplete({ runId, exitCode: 0 }, sandboxHeaders, [
+    200,
+  ]);
 }
 
 async function cancelChatRun(actor: ApiTestUser, runId: string): Promise<void> {
@@ -431,11 +429,9 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     chatCallbacks.proxyChatCallbackToApp();
     const peer = bdd.user({ orgId: actor.orgId });
 
-    const unauthenticated = await chat.requestDeleteThread(
-      null,
-      randomUUID(),
-      [401],
-    );
+    const unauthenticated = await chat.requestDeleteThread(null, randomUUID(), [
+      401,
+    ]);
     expectApiError(unauthenticated.body);
     expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
 
@@ -446,11 +442,9 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       code: "NOT_FOUND",
     });
 
-    const malformed = await chat.requestDeleteThread(
-      actor,
-      "not-a-uuid",
-      [400],
-    );
+    const malformed = await chat.requestDeleteThread(actor, "not-a-uuid", [
+      400,
+    ]);
     expectApiError(malformed.body);
     expect(malformed.body.error.message).toContain("id");
 
@@ -474,7 +468,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     const mainListed = list.threads.find((thread) => {
       return thread.id === main.threadId;
     });
-    expect(mainListed).toMatchObject({ running: true, scheduleCount: 1 });
+    expect(mainListed).toMatchObject({ running: true });
 
     // A sibling thread whose run completes: terminal transition bumps the
     // thread's recency, and the running flag drops.
@@ -492,10 +486,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         return thread.id;
       }),
     ).toStrictEqual([sibling.threadId, main.threadId]);
-    expect(list.threads[0]).toMatchObject({
-      running: false,
-      scheduleCount: 0,
-    });
+    expect(list.threads[0]).toMatchObject({ running: false });
 
     // A third thread with its own pending run must survive the delete.
     const other = await sendChatRun(actor, {
@@ -503,11 +494,9 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       prompt: "other thread stays active",
     });
 
-    const peerDelete = await chat.requestDeleteThread(
-      peer,
-      main.threadId,
-      [404],
-    );
+    const peerDelete = await chat.requestDeleteThread(peer, main.threadId, [
+      404,
+    ]);
     expectApiError(peerDelete.body);
     expect(peerDelete.body.error.code).toBe("NOT_FOUND");
     await expect(chat.readThread(actor, main.threadId)).resolves.toMatchObject({
@@ -545,7 +534,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 });
 
 describe("CHAT-01 chat thread list pagination and read state", () => {
-  it("rejects list requests without an authenticated org and unknown agent scopes", async () => {
+  it("rejects unauthenticated list requests and yields empty lists for unknown agent scopes", async () => {
     const unauthenticated = await chat.requestListThreads(null, {}, [401]);
     expectApiError(unauthenticated.body);
     expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
@@ -558,15 +547,16 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     expectApiError(orgless.body);
     expect(orgless.body.error.code).toBe("UNAUTHORIZED");
 
-    const unknownAgent = await chat.requestListThreads(
-      bdd.user(),
-      { agentId: randomUUID() },
-      [404],
-    );
-    expectApiError(unknownAgent.body);
-    expect(unknownAgent.body.error).toStrictEqual({
-      message: "Agent not found",
-      code: "NOT_FOUND",
+    // An unknown agent scope is not an error: the list query scopes by
+    // org + agent compose id, so it simply yields an empty list.
+    const unknownAgent = await chat.listThreads(bdd.user(), {
+      agentId: randomUUID(),
+    });
+    expect(unknownAgent).toStrictEqual({
+      pinned: [],
+      threads: [],
+      hasMore: false,
+      nextCursor: null,
     });
   });
 
@@ -586,7 +576,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
       threads: [],
       hasMore: false,
       nextCursor: null,
-      totalCount: 0,
     });
 
     // Read state: a fresh thread is read, a no-credit message flips it to
@@ -601,7 +590,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
       isRead: false,
       running: false,
       hasDraft: false,
-      scheduleCount: 0,
       pinnedAt: null,
       renamedAt: null,
     });
@@ -690,19 +678,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     );
     expectApiError(patchMalformed.body);
 
-    // Schedules linked to a thread surface in scheduleCount.
-    const scheduleName = uniqueScheduleName("bdd-list-count");
-    await api.deploySchedule(owner, {
-      name: scheduleName,
-      cronExpression: "0 9 * * *",
-      timezone: "UTC",
-      prompt: "schedule count prompt",
-      agentId: agent.agentId,
-      chatThreadId: readStateThreadId,
-    });
-    list = await chat.listThreads(owner, { agentId: agent.agentId });
-    expect(list.threads[0]?.scheduleCount).toBe(1);
-
     // Pinned threads form their own segment, scoped by agentId.
     const pinnedThread = await chat.createThread(owner, {
       agentId: otherAgent.agentId,
@@ -721,7 +696,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     ).toStrictEqual([pinnedThread.id]);
     expect(unified.pinned[0]?.pinnedAt).toStrictEqual(expect.any(String));
     expect(listedThreadIds(unified)).toContain(readStateThreadId);
-    expect(unified.totalCount).toBe(1);
 
     // Cursor walk over three empty threads scoped to the second agent.
     const cursorThreadIds = [pinnedThread.id];
@@ -741,7 +715,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     expect(firstPage.threads).toHaveLength(2);
     expect(firstPage.hasMore).toBeTruthy();
     expect(firstPage.nextCursor).not.toBeNull();
-    expect(firstPage.totalCount).toBe(3);
     if (!firstPage.nextCursor) {
       throw new Error("Expected a next cursor on the first page");
     }
@@ -885,12 +858,9 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
 
 describe("CHAT-01 chat search", () => {
   it("rejects search without an org session or the chat-message:read capability", async () => {
-    const unauthenticated = await chat.requestSearchChat(
-      null,
-      "hello",
-      {},
-      [401],
-    );
+    const unauthenticated = await chat.requestSearchChat(null, "hello", {}, [
+      401,
+    ]);
     expectApiError(unauthenticated.body);
     expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
 
@@ -1266,11 +1236,9 @@ describe("CHAT-01 github pr tracking", () => {
     expectApiError(unauthenticated.body);
     expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
 
-    const featureOff = await chat.requestThreadGithubPrs(
-      actor,
-      thread.id,
-      [403],
-    );
+    const featureOff = await chat.requestThreadGithubPrs(actor, thread.id, [
+      403,
+    ]);
     expectApiError(featureOff.body);
     expect(featureOff.body.error.message).toBe(
       "GitHub PR tracking is not enabled",
@@ -1292,29 +1260,23 @@ describe("CHAT-01 github pr tracking", () => {
     // Authorized for the agent but never connected.
     mockGitHubConnectorOAuth();
     await api.enableAgentConnectors(actor, agent.agentId, ["github"]);
-    const notConnected = await chat.requestThreadGithubPrs(
-      actor,
-      thread.id,
-      [403],
-    );
+    const notConnected = await chat.requestThreadGithubPrs(actor, thread.id, [
+      403,
+    ]);
     expectApiError(notConnected.body);
     expect(notConnected.body.error.message).toBe(
       "GitHub connector is not connected",
     );
 
-    const malformed = await chat.requestThreadGithubPrs(
-      actor,
-      "not-a-uuid",
-      [404],
-    );
+    const malformed = await chat.requestThreadGithubPrs(actor, "not-a-uuid", [
+      404,
+    ]);
     expectApiError(malformed.body);
     expect(malformed.body.error.message).toBe("Chat thread not found");
 
-    const unknown = await chat.requestThreadGithubPrs(
-      actor,
-      randomUUID(),
-      [404],
-    );
+    const unknown = await chat.requestThreadGithubPrs(actor, randomUUID(), [
+      404,
+    ]);
     expectApiError(unknown.body);
     expect(unknown.body.error.code).toBe("NOT_FOUND");
 
@@ -1668,11 +1630,9 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
 
     // 401 matrix: missing header (web's phrasing), opaque bearer, revoked
     // and expired PATs.
-    const missingHeader = await chat.requestV1Thread(
-      undefined,
-      randomUUID(),
-      [401],
-    );
+    const missingHeader = await chat.requestV1Thread(undefined, randomUUID(), [
+      401,
+    ]);
     expectApiError(missingHeader.body);
     expect(missingHeader.body.error).toStrictEqual({
       message: "API key required",
@@ -1716,11 +1676,9 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
 
     // Sandbox tokens are rejected by token type.
     const sandboxBearer = `Bearer ${api.sandboxTokenForRun(owner, randomUUID())}`;
-    const sandboxThread = await chat.requestV1Thread(
-      sandboxBearer,
-      threadId,
-      [403],
-    );
+    const sandboxThread = await chat.requestV1Thread(sandboxBearer, threadId, [
+      403,
+    ]);
     expectApiError(sandboxThread.body);
     expect(sandboxThread.body.error.code).toBe("FORBIDDEN");
 
@@ -1732,11 +1690,9 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       createdAt: expect.any(String),
       updatedAt: expect.any(String),
     });
-    const missingThread = await chat.requestV1Thread(
-      bearer,
-      randomUUID(),
-      [404],
-    );
+    const missingThread = await chat.requestV1Thread(bearer, randomUUID(), [
+      404,
+    ]);
     expectApiError(missingThread.body);
 
     const intruder = bdd.user();
@@ -1933,12 +1889,9 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       });
     });
 
-    const v1Page = await chat.requestV1ThreadMessages(
-      bearer,
-      thread.id,
-      {},
-      [200],
-    );
+    const v1Page = await chat.requestV1ThreadMessages(bearer, thread.id, {}, [
+      200,
+    ]);
     if (v1Page.status !== 200) {
       throw new Error("Expected the v1 messages page after the send");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -439,7 +439,6 @@ export function createChatFilesBddApi(context: TestContext) {
       readonly threads: readonly ChatThreadListItem[];
       readonly hasMore: boolean;
       readonly nextCursor: string | null;
-      readonly totalCount: number;
     }> {
       const response = await accept(
         threadsClient().list({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -482,6 +482,20 @@ export function createChatFilesBddApi(context: TestContext) {
       return response.body.draftThreadIds;
     },
 
+    async listThreadUnreads(
+      actor: ApiTestUser,
+      agentId: string,
+    ): Promise<readonly { threadId: string; unreadAt: string }[]> {
+      const response = await accept(
+        threadsClient().unreads({
+          headers: authenticate(context, actor),
+          query: { agentId },
+        }),
+        [200],
+      );
+      return response.body.unreads;
+    },
+
     async readThread(
       actor: ApiTestUser,
       threadId: string,
@@ -655,7 +669,7 @@ export function createChatFilesBddApi(context: TestContext) {
       threadId: string,
     ): Promise<{
       readonly lastReadMessageId: string | null;
-      readonly changed: boolean;
+      readonly unreads: readonly { threadId: string; unreadAt: string }[];
     }> {
       const response = await accept(
         threadMarkReadClient().markRead({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -468,6 +468,20 @@ export function createChatFilesBddApi(context: TestContext) {
       );
     },
 
+    async listThreadDrafts(
+      actor: ApiTestUser,
+      threadIds: readonly string[],
+    ): Promise<readonly string[]> {
+      const response = await accept(
+        threadsClient().drafts({
+          headers: authenticate(context, actor),
+          query: { threadIds: threadIds.join(",") },
+        }),
+        [200],
+      );
+      return response.body.draftThreadIds;
+    },
+
     async readThread(
       actor: ApiTestUser,
       threadId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -294,11 +294,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(running.status).toBe("running");
     expect(running.startedAt).toBeDefined();
 
-    const reclaimed = await api.requestClaimRunnerJob(
-      true,
-      created.runId,
-      [404],
-    );
+    const reclaimed = await api.requestClaimRunnerJob(true, created.runId, [
+      404,
+    ]);
     expectApiError(reclaimed.body);
 
     const sandboxHeaders = {
@@ -366,11 +364,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
 
-    const uncancellable = await api.requestCancelRun(
-      actor,
-      created.runId,
-      [400],
-    );
+    const uncancellable = await api.requestCancelRun(actor, created.runId, [
+      400,
+    ]);
     expectApiError(uncancellable.body);
   });
 
@@ -1818,11 +1814,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       `Bearer vm0_official_${"f".repeat(64)}`,
     ];
     for (const authorization of rejectedAuthorizations) {
-      const poll = await api.requestPollRunnerAs(
-        authorization,
-        pollBody,
-        [401],
-      );
+      const poll = await api.requestPollRunnerAs(authorization, pollBody, [
+        401,
+      ]);
       expectApiError(poll.body);
       expect(poll.body.error.message).toBe("Authentication required");
     }
@@ -2437,7 +2431,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       [200],
     );
     const threadsAfter = await chat.listThreads(actor);
-    expect(threadsAfter.totalCount).toBe(threadsBefore.totalCount);
+    expect(threadsAfter.threads.length).toBe(threadsBefore.threads.length);
 
     await api.requestCancelRun(actor, detachedRun.runId, [200]);
     await api.requestCancelRun(actor, runId, [200]);

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1933,8 +1933,10 @@ async function publishChatMessageCreated(
   userId: string,
   threadId: string,
 ): Promise<void> {
+  // No threadListChanged: every caller is a user-initiated post into the
+  // user's own open thread, so the acting client already reloads locally
+  // and sidebar ordering only moves on run-terminal events.
   await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
-  await publishThreadListChanged(userId);
 }
 
 async function assertOwnedThread(
@@ -2234,7 +2236,9 @@ function scheduleAssociatedUserMessage(params: {
         [params.userId],
         `chatThreadRunCreated:${params.threadId}`,
       );
-      await publishThreadListChanged(params.userId);
+      // No threadListChanged here: the sending client reloads its own
+      // sidebar after the POST, sorting only moves on run-terminal events,
+      // and the terminal callback broadcasts to other clients.
     })(),
   );
 }

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -8,12 +8,12 @@ import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
 import { writeDb$ } from "../external/db";
-import {
-  publishThreadListChanged,
-  publishUserSignal,
-} from "../external/realtime";
+import { publishUserSignal } from "../external/realtime";
 import { notFound } from "../../lib/error";
-import { visibleChatMessageCondition } from "../services/zero-chat-thread.service";
+import {
+  visibleChatMessageCondition,
+  zeroChatThreadUnreads,
+} from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route";
 
 const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -24,7 +24,10 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const writeDb = set(writeDb$);
 
   const [thread] = await writeDb
-    .select({ lastReadMessageId: chatThreads.lastReadMessageId })
+    .select({
+      lastReadMessageId: chatThreads.lastReadMessageId,
+      agentComposeId: chatThreads.agentComposeId,
+    })
     .from(chatThreads)
     .where(
       and(eq(chatThreads.id, params.id), eq(chatThreads.userId, auth.userId)),
@@ -35,6 +38,16 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!thread) {
     return notFound("Chat thread not found");
   }
+
+  const agentUnreads = async () => {
+    const unreads = await get(
+      zeroChatThreadUnreads({
+        userId: auth.userId,
+        agentComposeId: thread.agentComposeId,
+      }),
+    );
+    return [...unreads];
+  };
 
   const [latest] = await writeDb
     .select({ id: chatMessages.id })
@@ -53,7 +66,10 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (thread.lastReadMessageId === latestMessageId) {
     return {
       status: 200 as const,
-      body: { lastReadMessageId: latestMessageId, changed: false },
+      body: {
+        lastReadMessageId: latestMessageId,
+        unreads: await agentUnreads(),
+      },
     };
   }
 
@@ -65,18 +81,19 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   signal.throwIfAborted();
 
+  // Per-thread read-cursor signal only. No threadListChanged broadcast: the
+  // caller syncs from the unread snapshot in this response, and other
+  // clients converge on their next unreads fetch.
   await publishUserSignal(
     [auth.userId],
     `chatThreadReadCursorUpdated:${params.id}`,
     { lastReadMessageId: latestMessageId },
   );
   signal.throwIfAborted();
-  await publishThreadListChanged(auth.userId);
-  signal.throwIfAborted();
 
   return {
     status: 200 as const,
-    body: { lastReadMessageId: latestMessageId, changed: true },
+    body: { lastReadMessageId: latestMessageId, unreads: await agentUnreads() },
   };
 });
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -15,7 +15,6 @@ import { authContext$, organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
 import { notFound } from "../../lib/error";
-import { zeroComposeExists } from "../services/zero-compose-data.service";
 import {
   applyGoogleDriveArtifactSyncStatuses,
   googleDriveArtifactStatusLookup,
@@ -113,15 +112,8 @@ const listChatThreadsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(chatThreadsContract.list));
 
-  if (query.agentId) {
-    const exists = await get(
-      zeroComposeExists({ orgId: auth.orgId, composeId: query.agentId }),
-    );
-    if (!exists) {
-      return notFound("Agent not found");
-    }
-  }
-
+  // No existence check on agentId: the list query already scopes by
+  // org + agentComposeId, so an unknown agent yields an empty list.
   const page = await get(
     zeroChatThreadList({
       userId: auth.userId,
@@ -139,7 +131,6 @@ const listChatThreadsInner$ = computed(async (get) => {
       threads: [...page.threads],
       hasMore: page.hasMore,
       nextCursor: page.nextCursor,
-      totalCount: page.totalCount,
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -23,6 +23,7 @@ import {
   zeroChatSearch,
   zeroChatThreadArtifacts,
   zeroChatThreadDetail,
+  zeroChatThreadDraftIds,
   zeroChatThreadList,
   zeroChatThreadMessagesPage,
 } from "../services/zero-chat-thread.service";
@@ -135,6 +136,21 @@ const listChatThreadsInner$ = computed(async (get) => {
   };
 });
 
+const listChatThreadDraftsInner$ = computed(async (get) => {
+  const auth = get(authContext$);
+  const query = get(queryOf(chatThreadsContract.drafts));
+
+  const threadIds = query.threadIds.split(",").filter(isValidChatThreadId);
+  const draftThreadIds = await get(
+    zeroChatThreadDraftIds({ userId: auth.userId, threadIds }),
+  );
+
+  return {
+    status: 200 as const,
+    body: { draftThreadIds: [...draftThreadIds] },
+  };
+});
+
 const listChatThreadArtifactsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadArtifactsContract.list));
@@ -239,6 +255,12 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
       { requireOrganization: true, missingOrganizationStatus: 401 },
       listChatThreadsInner$,
     ),
+  },
+  {
+    // Registered before the :id route so the literal "drafts" segment is
+    // never captured as a thread id.
+    route: chatThreadsContract.drafts,
+    handler: authRoute({}, listChatThreadDraftsInner$),
   },
   {
     route: chatThreadByIdContract.get,

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -26,6 +26,7 @@ import {
   zeroChatThreadDraftIds,
   zeroChatThreadList,
   zeroChatThreadMessagesPage,
+  zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
 import { zeroChatThreadGithubPrs$ } from "../services/chat-thread-github-prs.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
@@ -151,6 +152,20 @@ const listChatThreadDraftsInner$ = computed(async (get) => {
   };
 });
 
+const listChatThreadUnreadsInner$ = computed(async (get) => {
+  const auth = get(authContext$);
+  const query = get(queryOf(chatThreadsContract.unreads));
+
+  const unreads = await get(
+    zeroChatThreadUnreads({
+      userId: auth.userId,
+      agentComposeId: query.agentId,
+    }),
+  );
+
+  return { status: 200 as const, body: { unreads: [...unreads] } };
+});
+
 const listChatThreadArtifactsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadArtifactsContract.list));
@@ -257,10 +272,12 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     ),
   },
   {
-    // Registered before the :id route so the literal "drafts" segment is
-    // never captured as a thread id.
     route: chatThreadsContract.drafts,
     handler: authRoute({}, listChatThreadDraftsInner$),
+  },
+  {
+    route: chatThreadsContract.unreads,
+    handler: authRoute({}, listChatThreadUnreadsInner$),
   },
   {
     route: chatThreadByIdContract.get,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -782,13 +782,6 @@ function chatThreadListProjection(lastMessage: LastMessageSubquery) {
       WHERE ${zeroRuns.chatThreadId} = ${chatThreads.id}
         AND ${agentRuns.status} IN ('queued', 'pending', 'running')
     )`,
-    hasDraft: sql<boolean>`(
-      COALESCE(${chatThreads.draftContent}, '') <> ''
-      OR (
-        ${chatThreads.draftAttachments} IS NOT NULL
-        AND jsonb_array_length(${chatThreads.draftAttachments}) > 0
-      )
-    )`,
   } as const;
 }
 
@@ -804,7 +797,6 @@ type ChatThreadListRow = {
   readonly lastMessageAt: Date;
   readonly isRead: boolean;
   readonly running: boolean;
-  readonly hasDraft: boolean;
 };
 
 function rowToChatThreadListItem(
@@ -821,7 +813,6 @@ function rowToChatThreadListItem(
     updatedAt: thread.updatedAt.toISOString(),
     isRead: thread.isRead,
     running: thread.running,
-    hasDraft: thread.hasDraft,
     pinnedAt: thread.pinnedAt?.toISOString() ?? null,
     renamedAt: thread.renamedAt?.toISOString() ?? null,
   };
@@ -909,6 +900,41 @@ export function zeroChatThreadList(args: {
       hasMore,
       nextCursor,
     };
+  });
+}
+
+/**
+ * Of the given thread ids, the ones owned by the user that currently hold an
+ * unsent composer draft (non-empty `draftContent` or one+ `draftAttachments`).
+ */
+export function zeroChatThreadDraftIds(args: {
+  readonly userId: string;
+  readonly threadIds: readonly string[];
+}): Computed<Promise<readonly string[]>> {
+  return computed(async (get): Promise<readonly string[]> => {
+    if (args.threadIds.length === 0) {
+      return [];
+    }
+    const db = get(db$);
+    const rows = await db
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.userId, args.userId),
+          inArray(chatThreads.id, [...args.threadIds]),
+          sql`(
+            COALESCE(${chatThreads.draftContent}, '') <> ''
+            OR (
+              ${chatThreads.draftAttachments} IS NOT NULL
+              AND jsonb_array_length(${chatThreads.draftAttachments}) > 0
+            )
+          )`,
+        ),
+      );
+    return rows.map((row) => {
+      return row.id;
+    });
   });
 }
 
@@ -1434,29 +1460,13 @@ export const deleteChatThread$ = command(
 );
 
 /**
- * A thread "has a draft" when its draft text is non-empty OR it has at least
- * one attachment. Mirrors web's `hasDraftValue` helper exactly so the
- * conditional `threadListChanged` publish observable from web is preserved
- * bit-for-bit.
- */
-function hasDraftValue(
-  content: string | null,
-  attachments: readonly PersistedAttachment[] | null,
-): boolean {
-  return (
-    (content !== null && content !== "") ||
-    (attachments !== null && attachments.length > 0)
-  );
-}
-
-/**
  * Update a chat thread's draft content + attachments.
  *
  * Ownership check via the WHERE clause; missing or cross-user thread → returns
- * `{ updated: false }` so the route handler emits the correct 404. Publishes
- * `threadListChanged` only when the boolean `hasDraft` flag flips, so that
- * continued typing inside an already-drafting thread does not spam the
- * sidebar — same behaviour as web's `updateChatThreadDraft`.
+ * `{ updated: false }` so the route handler emits the correct 404. Draft
+ * changes do not publish `threadListChanged`: the editing client updates its
+ * own sidebar locally, and other clients pick the dot up from the drafts
+ * endpoint on their next list reload.
  */
 export const updateChatThreadDraft$ = command(
   async (
@@ -1471,26 +1481,7 @@ export const updateChatThreadDraft$ = command(
   ): Promise<{ readonly updated: boolean }> => {
     const writeDb = set(writeDb$);
 
-    const [before] = await writeDb
-      .select({
-        draftContent: chatThreads.draftContent,
-        draftAttachments: chatThreads.draftAttachments,
-      })
-      .from(chatThreads)
-      .where(
-        and(
-          eq(chatThreads.id, args.threadId),
-          eq(chatThreads.userId, args.userId),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-
-    if (!before) {
-      return { updated: false };
-    }
-
-    await writeDb
+    const updated = await writeDb
       .update(chatThreads)
       .set({
         draftContent: args.draftContent,
@@ -1503,19 +1494,10 @@ export const updateChatThreadDraft$ = command(
           eq(chatThreads.id, args.threadId),
           eq(chatThreads.userId, args.userId),
         ),
-      );
+      )
+      .returning({ id: chatThreads.id });
     signal.throwIfAborted();
 
-    const hadDraft = hasDraftValue(
-      before.draftContent,
-      before.draftAttachments as PersistedAttachment[] | null,
-    );
-    const hasDraft = hasDraftValue(args.draftContent, args.draftAttachments);
-    if (hadDraft !== hasDraft) {
-      await publishThreadListChanged(args.userId);
-      signal.throwIfAborted();
-    }
-
-    return { updated: true };
+    return { updated: updated.length > 0 };
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -738,7 +738,6 @@ interface ChatThreadListPage {
   readonly threads: readonly ChatThreadListItem[];
   readonly hasMore: boolean;
   readonly nextCursor: string | null;
-  readonly totalCount: number;
 }
 
 function lastVisibleMessageSubquery(db: Pick<Db, "select">) {
@@ -790,11 +789,6 @@ function chatThreadListProjection(lastMessage: LastMessageSubquery) {
         AND jsonb_array_length(${chatThreads.draftAttachments}) > 0
       )
     )`,
-    scheduleCount: sql<number>`(
-      SELECT COUNT(*)::int
-      FROM ${automations}
-      WHERE ${automations.chatThreadId} = ${chatThreads.id}
-    )`,
   } as const;
 }
 
@@ -811,7 +805,6 @@ type ChatThreadListRow = {
   readonly isRead: boolean;
   readonly running: boolean;
   readonly hasDraft: boolean;
-  readonly scheduleCount: number;
 };
 
 function rowToChatThreadListItem(
@@ -829,7 +822,6 @@ function rowToChatThreadListItem(
     isRead: thread.isRead,
     running: thread.running,
     hasDraft: thread.hasDraft,
-    scheduleCount: thread.scheduleCount,
     pinnedAt: thread.pinnedAt?.toISOString() ?? null,
     renamedAt: thread.renamedAt?.toISOString() ?? null,
   };
@@ -868,32 +860,38 @@ export function zeroChatThreadList(args: {
       scopedFilters.push(eq(chatThreads.agentComposeId, args.agentComposeId));
     }
 
-    // Pinned segment is only returned on the first page (no cursor).
-    // Honours the same agent scope as the non-pinned segment so the sidebar
-    // never surfaces another agent's pinned threads while you're viewing one.
-    const pinnedRows = cursor
-      ? []
-      : await db
-          .select(projection)
-          .from(chatThreads)
-          .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-          .leftJoinLateral(lastMessage, sql`true`)
-          .where(and(...scopedFilters, isNotNull(chatThreads.pinnedAt)))
-          .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id));
-
     const nonPinnedFilters = [...scopedFilters, isNull(chatThreads.pinnedAt)];
     if (cursor) {
       nonPinnedFilters.push(cursorAdvanceFilter(cursor));
     }
 
-    const nonPinnedRows = await db
-      .select(projection)
-      .from(chatThreads)
-      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-      .leftJoinLateral(lastMessage, sql`true`)
-      .where(and(...nonPinnedFilters))
-      .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id))
-      .limit(limit + 1);
+    // Pinned segment is only returned on the first page (no cursor).
+    // Honours the same agent scope as the non-pinned segment so the sidebar
+    // never surfaces another agent's pinned threads while you're viewing one.
+    // Both segments are independent, so they run in parallel to avoid
+    // stacking two sequential round-trips on this hot path.
+    const [pinnedRows, nonPinnedRows] = await Promise.all([
+      cursor
+        ? []
+        : db
+            .select(projection)
+            .from(chatThreads)
+            .innerJoin(
+              zeroAgents,
+              eq(zeroAgents.id, chatThreads.agentComposeId),
+            )
+            .leftJoinLateral(lastMessage, sql`true`)
+            .where(and(...scopedFilters, isNotNull(chatThreads.pinnedAt)))
+            .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id)),
+      db
+        .select(projection)
+        .from(chatThreads)
+        .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
+        .leftJoinLateral(lastMessage, sql`true`)
+        .where(and(...nonPinnedFilters))
+        .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id))
+        .limit(limit + 1),
+    ]);
 
     const hasMore = nonPinnedRows.length > limit;
     const pageRows = hasMore ? nonPinnedRows.slice(0, limit) : nonPinnedRows;
@@ -905,18 +903,11 @@ export function zeroChatThreadList(args: {
         })
       : null;
 
-    const [countRow] = await db
-      .select({ count: sql<number>`COUNT(*)::int` })
-      .from(chatThreads)
-      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-      .where(and(...scopedFilters, isNull(chatThreads.pinnedAt)));
-
     return {
       pinned: pinnedRows.map(rowToChatThreadListItem),
       threads: pageRows.map(rowToChatThreadListItem),
       hasMore,
       nextCursor,
-      totalCount: countRow?.count ?? 0,
     };
   });
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -758,9 +758,7 @@ function lastVisibleMessageSubquery(db: Pick<Db, "select">) {
     .as("last_message");
 }
 
-type LastMessageSubquery = ReturnType<typeof lastVisibleMessageSubquery>;
-
-function chatThreadListProjection(lastMessage: LastMessageSubquery) {
+function chatThreadListProjection() {
   return {
     id: chatThreads.id,
     title: chatThreads.title,
@@ -771,10 +769,6 @@ function chatThreadListProjection(lastMessage: LastMessageSubquery) {
     pinnedAt: chatThreads.pinnedAt,
     renamedAt: chatThreads.renamedAt,
     lastMessageAt: chatThreads.lastMessageAt,
-    isRead: sql<boolean>`CASE
-      WHEN ${lastMessage.id} IS NULL THEN true
-      ELSE COALESCE(${chatThreads.lastReadMessageId} = ${lastMessage.id}, false)
-    END`,
     running: sql<boolean>`EXISTS (
       SELECT 1
       FROM ${zeroRuns}
@@ -795,7 +789,6 @@ type ChatThreadListRow = {
   readonly pinnedAt: Date | null;
   readonly renamedAt: Date | null;
   readonly lastMessageAt: Date;
-  readonly isRead: boolean;
   readonly running: boolean;
 };
 
@@ -811,7 +804,6 @@ function rowToChatThreadListItem(
     },
     createdAt: thread.createdAt.toISOString(),
     updatedAt: thread.updatedAt.toISOString(),
-    isRead: thread.isRead,
     running: thread.running,
     pinnedAt: thread.pinnedAt?.toISOString() ?? null,
     renamedAt: thread.renamedAt?.toISOString() ?? null,
@@ -840,8 +832,7 @@ export function zeroChatThreadList(args: {
     const limit = args.limit ?? SIDEBAR_CHAT_THREAD_LIMIT;
     const cursor = decodeChatThreadListCursor(args.cursor);
 
-    const lastMessage = lastVisibleMessageSubquery(db);
-    const projection = chatThreadListProjection(lastMessage);
+    const projection = chatThreadListProjection();
 
     const scopedFilters = [
       eq(chatThreads.userId, args.userId),
@@ -871,14 +862,12 @@ export function zeroChatThreadList(args: {
               zeroAgents,
               eq(zeroAgents.id, chatThreads.agentComposeId),
             )
-            .leftJoinLateral(lastMessage, sql`true`)
             .where(and(...scopedFilters, isNotNull(chatThreads.pinnedAt)))
             .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id)),
       db
         .select(projection)
         .from(chatThreads)
         .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-        .leftJoinLateral(lastMessage, sql`true`)
         .where(and(...nonPinnedFilters))
         .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id))
         .limit(limit + 1),
@@ -900,6 +889,48 @@ export function zeroChatThreadList(args: {
       hasMore,
       nextCursor,
     };
+  });
+}
+
+/**
+ * The user's unread threads under an agent, each with the creation time of
+ * the latest visible message — the one that made the thread unread. A thread
+ * is unread when it has at least one visible message and the read cursor
+ * (`lastReadMessageId`) doesn't point at the latest one.
+ */
+export function zeroChatThreadUnreads(args: {
+  readonly userId: string;
+  readonly agentComposeId: string;
+}): Computed<Promise<readonly { threadId: string; unreadAt: string }[]>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const lastMessage = lastVisibleMessageSubquery(db);
+    const rows = await db
+      .select({
+        threadId: chatThreads.id,
+        unreadAt: lastMessage.createdAt,
+      })
+      .from(chatThreads)
+      .leftJoinLateral(lastMessage, sql`true`)
+      .where(
+        and(
+          eq(chatThreads.userId, args.userId),
+          eq(chatThreads.agentComposeId, args.agentComposeId),
+          isNotNull(lastMessage.id),
+          or(
+            isNull(chatThreads.lastReadMessageId),
+            sql`${chatThreads.lastReadMessageId} <> ${lastMessage.id}`,
+          ),
+        ),
+      );
+    return rows.flatMap((row) => {
+      // Always present: the isNotNull(lastMessage.id) filter guarantees a
+      // joined row, but the left-lateral type keeps the column nullable.
+      if (row.unreadAt === null) {
+        return [];
+      }
+      return [{ threadId: row.threadId, unreadAt: row.unreadAt.toISOString() }];
+    });
   });
 }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -138,7 +138,7 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/zero/chat-threads/drafts
+  // GET /api/zero/chat-thread-drafts
   mockApi(chatThreadsContract.drafts, ({ respond }) => {
     return respond(200, { draftThreadIds: [] });
   }),
@@ -191,8 +191,13 @@ export const apiAgentsHandlers = [
     return respond(204);
   }),
 
+  // GET /api/zero/chat-thread-unreads
+  mockApi(chatThreadsContract.unreads, ({ respond }) => {
+    return respond(200, { unreads: [] });
+  }),
+
   // POST /api/zero/chat-threads/:id/mark-read
   mockApi(chatThreadMarkReadContract.markRead, ({ respond }) => {
-    return respond(200, { lastReadMessageId: null, changed: false });
+    return respond(200, { lastReadMessageId: null, unreads: [] });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -138,6 +138,11 @@ export const apiAgentsHandlers = [
     });
   }),
 
+  // GET /api/zero/chat-threads/drafts
+  mockApi(chatThreadsContract.drafts, ({ respond }) => {
+    return respond(200, { draftThreadIds: [] });
+  }),
+
   // POST /api/zero/chat-threads (create new thread)
   mockApi(chatThreadsContract.create, ({ body, respond }) => {
     return respond(201, {

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -135,7 +135,6 @@ export const apiAgentsHandlers = [
       threads: [],
       hasMore: false,
       nextCursor: null,
-      totalCount: 0,
     });
   }),
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1561,9 +1561,9 @@ function createMarkThreadReadIfNeeded({
     if (newLastReadId !== null) {
       set(locallyMarkedReadMessageId$, newLastReadId);
     }
-    // Server broadcasts `threadListChanged` via Ably on mark-read; the
-    // sidebar reloads from that channel. Bumping reloadChatThreads$ here too
-    // forces a redundant refetch that blocks subsequent keyboard navigation.
+    // No sidebar reload needed: markRead$ records an optimistic read mark
+    // and applies the response's unread snapshot, so the unread dot clears
+    // without refetching the thread list.
   });
 }
 
@@ -2064,7 +2064,9 @@ function createRecallMessage(deps: RecallMessageDeps) {
 }
 
 interface MessageCommandsDeps
-  extends SendMessageDeps, QueueMessageDeps, RecallMessageDeps {}
+  extends SendMessageDeps,
+    QueueMessageDeps,
+    RecallMessageDeps {}
 
 function createMessageCommands(deps: MessageCommandsDeps) {
   return {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -450,7 +450,6 @@ export const sidebarChatThreads$ = computed(
           agent: { id: thread.agentId, avatarUrl: null },
           createdAt: thread.createdAt,
           updatedAt: thread.createdAt,
-          isRead: true,
           running: thread.running,
         };
       });

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -11,6 +11,7 @@ import { nowDate } from "../../lib/time.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { logger } from "../log.ts";
+import { reloadSidebarDraftThreads$ } from "./sidebar-draft-threads.ts";
 import type { ChatThread } from "../agent-chat.ts";
 import type {
   CancelRunsArgs,
@@ -30,7 +31,7 @@ const L = logger("ChatThread");
 
 const patchDraft$ = command(
   async (
-    { get },
+    { get, set },
     { threadId, content, attachments }: PatchDraftArgs,
     signal: AbortSignal,
   ) => {
@@ -43,6 +44,8 @@ const patchDraft$ = command(
       }),
       [204],
     );
+    signal.throwIfAborted();
+    set(reloadSidebarDraftThreads$);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -12,6 +12,10 @@ import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { logger } from "../log.ts";
 import { reloadSidebarDraftThreads$ } from "./sidebar-draft-threads.ts";
+import {
+  applyUnreadSnapshot$,
+  recordOptimisticReadMark$,
+} from "./sidebar-unread-threads.ts";
 import type { ChatThread } from "../agent-chat.ts";
 import type {
   CancelRunsArgs,
@@ -240,10 +244,14 @@ const cancelRuns$ = command(
 
 const markRead$ = command(
   async (
-    { get },
+    { get, set },
     { threadId, latestMessageId }: MarkReadArgs,
     signal: AbortSignal,
   ): Promise<string | null> => {
+    // Optimistic: suppress this thread's sidebar unread dot immediately.
+    // The response's unread snapshot kicks the mark if a newer message
+    // already landed. Mark-read is not broadcast by the server.
+    set(recordOptimisticReadMark$, threadId);
     const client = get(zeroClient$)(chatThreadMarkReadContract);
     const result = await accept(
       client.markRead({
@@ -253,6 +261,7 @@ const markRead$ = command(
       [200],
     );
     signal.throwIfAborted();
+    set(applyUnreadSnapshot$, result.body.unreads);
     return result.body.lastReadMessageId ?? latestMessageId;
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-draft-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-draft-threads.ts
@@ -1,0 +1,47 @@
+import { command, computed, state } from "ccstate";
+import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { sidebarChatThreads$ } from "./optimistic-chat-thread-page.ts";
+
+const internalReloadSidebarDrafts$ = state(0);
+
+/**
+ * Bump after a local draft save so the sidebar draft dots refresh without a
+ * full thread-list reload. Draft changes are not broadcast by the server.
+ */
+export const reloadSidebarDraftThreads$ = command(({ set }) => {
+  set(internalReloadSidebarDrafts$, (n) => {
+    return n + 1;
+  });
+});
+
+/**
+ * Ids of the sidebar threads that hold an unsent composer draft. Fetched
+ * separately from the thread list so the list query stays cheap; the draft
+ * dot may render a beat after the rows themselves.
+ */
+export const sidebarDraftThreadIds$ = computed(
+  async (get): Promise<ReadonlySet<string>> => {
+    get(internalReloadSidebarDrafts$);
+    const threads = await get(sidebarChatThreads$);
+    if (threads.length === 0) {
+      return new Set();
+    }
+
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(
+      client.drafts({
+        query: {
+          threadIds: threads
+            .map((thread) => {
+              return thread.id;
+            })
+            .join(","),
+        },
+      }),
+      [200],
+    );
+    return new Set(result.body.draftThreadIds);
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -1,0 +1,86 @@
+import { command, computed, state } from "ccstate";
+import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { currentChatAgentId$ } from "../agent-chat.ts";
+import { reloadChatThreadsCounter$ } from "../chat-thread-list-reload.ts";
+
+type UnreadSnapshot = readonly { threadId: string; unreadAt: string }[];
+
+/**
+ * Local optimistic mark-read timestamps (threadId → epoch ms, recorded when
+ * the mark-read POST fires). A thread present in the server unread snapshot
+ * is still rendered as read while a local mark exists — until a snapshot
+ * reports an `unreadAt` NEWER than the mark, which means a fresh message
+ * arrived after the user read the thread and the optimistic entry must be
+ * kicked. This absorbs the race between mark-read and an in-flight unreads
+ * fetch without any server broadcast.
+ */
+const optimisticReadMarks$ = state<ReadonlyMap<string, number>>(new Map());
+
+export const recordOptimisticReadMark$ = command(
+  ({ get, set }, threadId: string) => {
+    const next = new Map(get(optimisticReadMarks$));
+    next.set(threadId, Date.now());
+    set(optimisticReadMarks$, next);
+  },
+);
+
+/**
+ * Kick optimistic marks that a server snapshot has overtaken. Called with
+ * the snapshot from a mark-read response so a message that landed between
+ * the fetch and the mark resurfaces immediately.
+ */
+export const applyUnreadSnapshot$ = command(
+  ({ get, set }, unreads: UnreadSnapshot) => {
+    const marks = get(optimisticReadMarks$);
+    if (marks.size === 0) {
+      return;
+    }
+    const next = new Map(marks);
+    for (const unread of unreads) {
+      const markedAt = next.get(unread.threadId);
+      if (markedAt !== undefined && Date.parse(unread.unreadAt) > markedAt) {
+        next.delete(unread.threadId);
+      }
+    }
+    if (next.size !== marks.size) {
+      set(optimisticReadMarks$, next);
+    }
+  },
+);
+
+/**
+ * Server unread snapshot for the current agent. Refetched alongside the
+ * thread list (same reload counter); mark-read does not broadcast, so reads
+ * by this client are reflected through `optimisticReadMarks$` instead.
+ */
+const fetchedUnreads$ = computed(async (get): Promise<UnreadSnapshot> => {
+  get(reloadChatThreadsCounter$);
+  const agentId = await get(currentChatAgentId$);
+  if (!agentId) {
+    return [];
+  }
+  const client = get(zeroClient$)(chatThreadsContract);
+  const result = await accept(client.unreads({ query: { agentId } }), [200]);
+  return result.body.unreads;
+});
+
+/**
+ * Thread ids to render with the sidebar unread dot: the server snapshot
+ * minus threads suppressed by a still-valid local mark.
+ */
+export const sidebarUnreadThreadIds$ = computed(
+  async (get): Promise<ReadonlySet<string>> => {
+    const unreads = await get(fetchedUnreads$);
+    const marks = get(optimisticReadMarks$);
+    const ids = new Set<string>();
+    for (const unread of unreads) {
+      const markedAt = marks.get(unread.threadId);
+      if (markedAt === undefined || Date.parse(unread.unreadAt) > markedAt) {
+        ids.add(unread.threadId);
+      }
+    }
+    return ids;
+  },
+);

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -28,7 +28,6 @@ function mockAPIs(): void {
       threads: [],
       hasMore: false,
       nextCursor: null,
-      totalCount: 0,
     });
   });
 }

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -196,7 +196,6 @@ function mockTeamAPIs(): void {
       threads: [],
       hasMore: false,
       nextCursor: null,
-      totalCount: 0,
     });
   });
   context.mocks.api(zeroComposesMainContract.getByName, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -61,7 +61,6 @@ function mockThreadDetails(): void {
       ],
       hasMore: false,
       nextCursor: null,
-      totalCount: 3,
     });
   });
   context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -31,7 +31,6 @@ function mockThreadDetails(): void {
           },
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:00:00Z",
-          isRead: true,
           running: false,
         },
         {
@@ -43,7 +42,6 @@ function mockThreadDetails(): void {
           },
           createdAt: "2026-03-10T00:01:00Z",
           updatedAt: "2026-03-10T00:01:00Z",
-          isRead: true,
           running: false,
         },
         {
@@ -55,7 +53,6 @@ function mockThreadDetails(): void {
           },
           createdAt: "2026-03-10T00:02:00Z",
           updatedAt: "2026-03-10T00:02:00Z",
-          isRead: true,
           running: false,
         },
       ],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3724,7 +3724,6 @@ describe("chat lifecycle", () => {
         ],
         hasMore: false,
         nextCursor: null,
-        totalCount: 2,
       });
     });
     context.mocks.api(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -241,7 +241,6 @@ function mockKeyboardNavigationThreads(): void {
             agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-06-01T00:00:00Z",
             updatedAt: `2026-06-01T00:0${index}:00Z`,
-            isRead: true,
             running: false,
             pinnedAt: null,
           };
@@ -459,7 +458,6 @@ function mockServerQueuedThreadStories(): void {
             agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-06-09T10:00:00Z",
             updatedAt: `2026-06-09T10:0${index}:00Z`,
-            isRead: true,
             running: thread.activeRunIds.length > 0,
             pinnedAt: null,
           };
@@ -498,7 +496,7 @@ function mockServerQueuedThreadStories(): void {
     },
   );
   context.mocks.api(chatThreadMarkReadContract.markRead, ({ respond }) => {
-    return respond(200, { lastReadMessageId: null, changed: false });
+    return respond(200, { lastReadMessageId: null, unreads: [] });
   });
 }
 
@@ -3709,7 +3707,6 @@ describe("chat lifecycle", () => {
             agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
-            isRead: true,
             running: true,
           },
           {
@@ -3718,7 +3715,6 @@ describe("chat lifecycle", () => {
             agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-10T00:01:00Z",
             updatedAt: "2026-03-10T00:01:00Z",
-            isRead: true,
             running: false,
           },
         ],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -158,7 +158,6 @@ interface ThreadListItem {
   agent: { id: string; avatarUrl: string | null };
   createdAt: string;
   updatedAt: string;
-  isRead: boolean;
   running: boolean;
   pinnedAt?: string | null;
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -99,7 +99,6 @@ export function mockSubagentThread(context: TestContext, threadId: string) {
       threads: [],
       hasMore: false,
       nextCursor: null,
-      totalCount: 0,
     });
   });
   context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
@@ -161,7 +160,6 @@ interface ThreadListItem {
   updatedAt: string;
   isRead: boolean;
   running: boolean;
-  scheduleCount?: number;
   pinnedAt?: string | null;
 }
 
@@ -184,7 +182,6 @@ export function splitChatThreadListResponse(
   threads: PagedThreadItem[];
   hasMore: boolean;
   nextCursor: string | null;
-  totalCount: number;
 } {
   const pinned = threads.filter((t) => {
     return t.pinnedAt !== null && t.pinnedAt !== undefined;
@@ -197,7 +194,6 @@ export function splitChatThreadListResponse(
     threads: nonPinned,
     hasMore: false,
     nextCursor: null,
-    totalCount: nonPinned.length,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -164,7 +164,6 @@ interface ThreadListItem {
 }
 
 type PagedThreadItem = ThreadListItem & {
-  hasDraft?: boolean;
   pinnedAt?: string | null;
   renamedAt?: string | null;
 };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -118,7 +118,6 @@ function setupChatThread({
       threads: [],
       hasMore: false,
       nextCursor: null,
-      totalCount: 0,
     });
   });
   if (artifactFiles) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -123,7 +123,6 @@ function createThread(
     agent: { id: AGENT_ID, avatarUrl: null },
     createdAt: "2026-03-10T00:00:00Z",
     updatedAt: "2026-03-10T00:00:00Z",
-    isRead: true,
     running: false,
     pinnedAt: null,
     ...overrides,
@@ -323,7 +322,6 @@ describe("zero sidebar", () => {
             agent: { id: AGENT_ID, avatarUrl: null },
             createdAt: "2026-03-10T00:00:00Z",
             updatedAt: "2026-03-10T00:00:00Z",
-            isRead: true,
             running: false,
           },
         ]),
@@ -378,12 +376,19 @@ describe("zero sidebar", () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([
       createThread(EXISTING_THREAD_ID, "Release plan"),
-      createThread(INCIDENT_THREAD_ID, "Incident notes", { isRead: false }),
+      createThread(INCIDENT_THREAD_ID, "Incident notes"),
       createThread(AUTOMATION_THREAD_ID, "Running analysis", { running: true }),
       createThread(ARCHIVED_THREAD_ID, "Draft brief"),
     ]);
     context.mocks.api(chatThreadsContract.drafts, ({ respond }) => {
       return respond(200, { draftThreadIds: [ARCHIVED_THREAD_ID] });
+    });
+    context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+      return respond(200, {
+        unreads: [
+          { threadId: INCIDENT_THREAD_ID, unreadAt: "2026-03-10T00:05:00Z" },
+        ],
+      });
     });
 
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -380,8 +380,11 @@ describe("zero sidebar", () => {
       createThread(EXISTING_THREAD_ID, "Release plan"),
       createThread(INCIDENT_THREAD_ID, "Incident notes", { isRead: false }),
       createThread(AUTOMATION_THREAD_ID, "Running analysis", { running: true }),
-      createThread(ARCHIVED_THREAD_ID, "Draft brief", { hasDraft: true }),
+      createThread(ARCHIVED_THREAD_ID, "Draft brief"),
     ]);
+    context.mocks.api(chatThreadsContract.drafts, ({ respond }) => {
+      return respond(200, { draftThreadIds: [ARCHIVED_THREAD_ID] });
+    });
 
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -246,14 +246,12 @@ function mockSidebarThreadStory(
         threads: extraThreads,
         hasMore: false,
         nextCursor: null,
-        totalCount: threads.length + extraThreads.length,
       });
     }
     return respond(200, {
       ...splitChatThreadListResponse(threads),
       hasMore: extraThreads.length > 0,
       nextCursor: extraThreads.length > 0 ? "next-page" : null,
-      totalCount: threads.length + extraThreads.length,
     });
   });
   context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
@@ -472,9 +470,7 @@ describe("zero sidebar", () => {
     mockSidebarThreadStory(
       [
         createThread(EXISTING_THREAD_ID, "Release plan"),
-        createThread(AUTOMATION_THREAD_ID, "Scheduled launch", {
-          scheduleCount: 2,
-        }),
+        createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
       ],
       [createThread(ARCHIVED_THREAD_ID, "Archived context")],
     );

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -79,6 +79,7 @@ import { setSidebarExpanded$ } from "../../signals/zero-page/zero-nav.ts";
 import {
   headerAutomationMenu$,
   automationsForThread,
+  reloadHeaderAutomationMenu$,
 } from "../../signals/chat-page/header-automation-menu.ts";
 import {
   pendingDeleteThreadId$,
@@ -245,6 +246,7 @@ function ChatThreadMenu({
   hasOtherIndicator: boolean;
 }) {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
+  const reloadAutomations = useSet(reloadHeaderAutomationMenu$);
   const pinChatThread = useSet(pinChatThread$);
   const unpinChatThread = useSet(unpinChatThread$);
   const setRenameDialogThreadId = useSet(setRenameDialogThreadId$);
@@ -319,6 +321,9 @@ function ChatThreadMenu({
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
+              // Refetch automations so the delete confirmation reflects the
+              // thread's current linked automations.
+              reloadAutomations();
               setPendingDeleteThreadId(threadId);
             }}
             className="text-destructive focus:text-destructive"
@@ -613,7 +618,6 @@ function DeleteChatThreadDialog() {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const deleteChatThread = useSet(deleteChatThread$);
   const pageSignal = useGet(pageSignal$);
-  const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
   const automationsLoadable = useLastLoadable(headerAutomationMenu$);
   const lastResolvedAutomations = useLastResolved(headerAutomationMenu$);
   const allAutomations =
@@ -621,16 +625,11 @@ function DeleteChatThreadDialog() {
       ? automationsLoadable.data
       : (lastResolvedAutomations ?? []);
 
-  const pendingDeleteThread = pendingDeleteThreadId
-    ? chatThreads.find((thread) => {
-        return thread.id === pendingDeleteThreadId;
-      })
-    : null;
-  const scheduleCount = pendingDeleteThread?.scheduleCount ?? 0;
-  const hasAutomations = scheduleCount > 0;
   const pendingDeleteAutomations = pendingDeleteThreadId
     ? automationsForThread(allAutomations, pendingDeleteThreadId)
     : [];
+  const scheduleCount = pendingDeleteAutomations.length;
+  const hasAutomations = scheduleCount > 0;
 
   function confirmDelete() {
     if (!pendingDeleteThreadId) {
@@ -663,7 +662,7 @@ function DeleteChatThreadDialog() {
               : "This will permanently delete this chat. Any task currently running in this chat will be stopped immediately. This action cannot be undone."}
           </DialogDescription>
         </DialogHeader>
-        {hasAutomations && pendingDeleteAutomations.length > 0 && (
+        {hasAutomations && (
           <div className="flex flex-col gap-1.5">
             <p className="text-sm font-medium">
               These automations will be deleted

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -3,6 +3,7 @@ import {
   useSet,
   useLastResolved,
   useLastLoadable,
+  useLoadable,
 } from "ccstate-react";
 import {
   IconPlus,
@@ -10,6 +11,7 @@ import {
   IconTrash,
   IconPencil,
   IconDots,
+  IconLoader2,
   IconPin,
   IconPinnedOff,
 } from "@tabler/icons-react";
@@ -81,6 +83,7 @@ import {
   automationsForThread,
   reloadHeaderAutomationMenu$,
 } from "../../signals/chat-page/header-automation-menu.ts";
+import { sidebarDraftThreadIds$ } from "../../signals/chat-page/sidebar-draft-threads.ts";
 import {
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
@@ -411,6 +414,7 @@ function useChatThreadItemState(session: ChatThreadListItem) {
   const loadRightThread = useSet(loadRightThread$);
   const unloadRightThread = useSet(unloadRightThread$);
   const pageSignal = useGet(pageSignal$);
+  const draftThreadIds = useLastResolved(sidebarDraftThreadIds$);
 
   const isPinned = session.pinnedAt !== null && session.pinnedAt !== undefined;
   const onChatPage = urlMainThreadId !== null;
@@ -422,7 +426,7 @@ function useChatThreadItemState(session: ChatThreadListItem) {
     threadId: session.id,
   });
   const indicatorState = getIndicatorState({
-    hasDraft: (session.hasDraft ?? false) && !isHighlighted,
+    hasDraft: (draftThreadIds?.has(session.id) ?? false) && !isHighlighted,
     isRunning: session.running,
     isUnread: !session.isRead && !isHighlighted,
   });
@@ -618,18 +622,19 @@ function DeleteChatThreadDialog() {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const deleteChatThread = useSet(deleteChatThread$);
   const pageSignal = useGet(pageSignal$);
-  const automationsLoadable = useLastLoadable(headerAutomationMenu$);
-  const lastResolvedAutomations = useLastResolved(headerAutomationMenu$);
+  // useLoadable (not useLastLoadable): the delete menu item bumps a refetch,
+  // and the dialog must reflect that in-flight check rather than render a
+  // stale automation list as if it were current.
+  const automationsLoadable = useLoadable(headerAutomationMenu$);
+  const checkingAutomations = automationsLoadable.state === "loading";
   const allAutomations =
-    automationsLoadable.state === "hasData"
-      ? automationsLoadable.data
-      : (lastResolvedAutomations ?? []);
+    automationsLoadable.state === "hasData" ? automationsLoadable.data : [];
 
   const pendingDeleteAutomations = pendingDeleteThreadId
     ? automationsForThread(allAutomations, pendingDeleteThreadId)
     : [];
   const scheduleCount = pendingDeleteAutomations.length;
-  const hasAutomations = scheduleCount > 0;
+  const hasAutomations = !checkingAutomations && scheduleCount > 0;
 
   function confirmDelete() {
     if (!pendingDeleteThreadId) {
@@ -662,6 +667,15 @@ function DeleteChatThreadDialog() {
               : "This will permanently delete this chat. Any task currently running in this chat will be stopped immediately. This action cannot be undone."}
           </DialogDescription>
         </DialogHeader>
+        {checkingAutomations && (
+          <div
+            className="flex items-center gap-2 text-sm text-muted-foreground"
+            data-testid="delete-chat-thread-checking"
+          >
+            <IconLoader2 size={16} className="animate-spin" />
+            Checking thread content…
+          </div>
+        )}
         {hasAutomations && (
           <div className="flex flex-col gap-1.5">
             <p className="text-sm font-medium">
@@ -690,7 +704,11 @@ function DeleteChatThreadDialog() {
           >
             Cancel
           </Button>
-          <Button variant="destructive" onClick={confirmDelete}>
+          <Button
+            variant="destructive"
+            disabled={checkingAutomations}
+            onClick={confirmDelete}
+          >
             {hasAutomations ? "Delete chat and automations" : "Delete"}
           </Button>
         </DialogFooter>

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -84,6 +84,7 @@ import {
   reloadHeaderAutomationMenu$,
 } from "../../signals/chat-page/header-automation-menu.ts";
 import { sidebarDraftThreadIds$ } from "../../signals/chat-page/sidebar-draft-threads.ts";
+import { sidebarUnreadThreadIds$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
 import {
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
@@ -415,6 +416,7 @@ function useChatThreadItemState(session: ChatThreadListItem) {
   const unloadRightThread = useSet(unloadRightThread$);
   const pageSignal = useGet(pageSignal$);
   const draftThreadIds = useLastResolved(sidebarDraftThreadIds$);
+  const unreadThreadIds = useLastResolved(sidebarUnreadThreadIds$);
 
   const isPinned = session.pinnedAt !== null && session.pinnedAt !== undefined;
   const onChatPage = urlMainThreadId !== null;
@@ -425,10 +427,12 @@ function useChatThreadItemState(session: ChatThreadListItem) {
     sidebarThreadId: urlSidebarThreadId,
     threadId: session.id,
   });
+  const isUnread =
+    (unreadThreadIds?.has(session.id) ?? false) && !isHighlighted;
   const indicatorState = getIndicatorState({
     hasDraft: (draftThreadIds?.has(session.id) ?? false) && !isHighlighted,
     isRunning: session.running,
-    isUnread: !session.isRead && !isHighlighted,
+    isUnread,
   });
 
   return {
@@ -437,7 +441,7 @@ function useChatThreadItemState(session: ChatThreadListItem) {
     isCurrentPage,
     isHighlighted,
     isPinned,
-    isUnread: !session.isRead && !isHighlighted,
+    isUnread,
     loadLeftThread,
     loadRightThread,
     onChatPage,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -122,12 +122,6 @@ const chatThreadListItemSchema = z.object({
    */
   hasDraft: z.boolean().optional(),
   /**
-   * Number of schedules linked to this chat thread. Drives the stronger delete
-   * confirmation copy before removing a scheduled chat thread. Optional for
-   * back-compat with fixtures predating the field.
-   */
-  scheduleCount: z.number().int().nonnegative().optional(),
-  /**
    * ISO timestamp at which the user pinned this thread. Null/undefined means
    * unpinned. Pinned threads sort above unpinned in the sidebar; both groups
    * keep recency order. Optional for back-compat with fixtures that predate
@@ -365,17 +359,11 @@ export const chatThreadsContract = c.router({
          * is false.
          */
         nextCursor: z.string().nullable(),
-        /**
-         * Total count of non-pinned threads matching the same scope as this
-         * query. Drives the sidebar "All Threads (N)" affordance.
-         */
-        totalCount: z.number().int(),
       }),
       401: apiErrorSchema,
-      404: apiErrorSchema,
     },
     summary:
-      "List chat threads. When agentId is omitted, returns every thread the caller owns scoped by orgId. Pinned threads are returned in full for the caller's org on the first page; non-pinned threads are cursor-paginated.",
+      "List chat threads. When agentId is omitted, returns every thread the caller owns scoped by orgId. An unknown agentId yields an empty list. Pinned threads are returned in full for the caller's org on the first page; non-pinned threads are cursor-paginated.",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -116,12 +116,6 @@ const chatThreadListItemSchema = z.object({
    */
   running: z.boolean(),
   /**
-   * True when the thread has draft composer content the user hasn't sent yet
-   * (non-empty `draftContent` or one+ `draftAttachments`). Drives the sidebar
-   * draft indicator. Optional for back-compat with fixtures predating the field.
-   */
-  hasDraft: z.boolean().optional(),
-  /**
    * ISO timestamp at which the user pinned this thread. Null/undefined means
    * unpinned. Pinned threads sort above unpinned in the sidebar; both groups
    * keep recency order. Optional for back-compat with fixtures that predate
@@ -364,6 +358,30 @@ export const chatThreadsContract = c.router({
     },
     summary:
       "List chat threads. When agentId is omitted, returns every thread the caller owns scoped by orgId. An unknown agentId yields an empty list. Pinned threads are returned in full for the caller's org on the first page; non-pinned threads are cursor-paginated.",
+  },
+  drafts: {
+    method: "GET",
+    path: "/api/zero/chat-threads/drafts",
+    headers: authHeadersSchema,
+    query: z.object({
+      /**
+       * Comma-separated chat thread ids to check. Ids the caller does not
+       * own (or that don't exist) are silently absent from the response.
+       */
+      threadIds: z.string().min(1),
+    }),
+    responses: {
+      200: z.object({
+        /**
+         * Subset of the requested thread ids that currently hold an unsent
+         * draft (non-empty `draftContent` or one+ `draftAttachments`).
+         */
+        draftThreadIds: z.array(z.string()),
+      }),
+      401: apiErrorSchema,
+    },
+    summary:
+      "Report which of the given chat threads hold an unsent composer draft. Fetched separately from the thread list so the sidebar draft dots don't gate the list query.",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -92,6 +92,21 @@ const persistedAttachmentSchema = z.object({
   size: z.number(),
 });
 
+/**
+ * Per-agent unread snapshot. `unreadAt` is the creation time of the latest
+ * visible message — the one that made the thread unread. Clients keep local
+ * optimistic mark-read timestamps and drop them whenever a snapshot reports
+ * an `unreadAt` newer than the local mark.
+ */
+const chatThreadUnreadsSchema = z.object({
+  unreads: z.array(
+    z.object({
+      threadId: z.string(),
+      unreadAt: z.string(),
+    }),
+  ),
+});
+
 const chatThreadListItemSchema = z.object({
   id: z.string(),
   title: z.string().nullable(),
@@ -104,11 +119,6 @@ const chatThreadListItemSchema = z.object({
   }),
   createdAt: z.string(),
   updatedAt: z.string(),
-  /**
-   * Read state of the thread's last message. `false` when the thread has no
-   * messages yet or the last message has not been marked read.
-   */
-  isRead: z.boolean(),
   /**
    * True when the thread has at least one non-terminal run
    * (queued / pending / running). Drives the sidebar running indicator,
@@ -361,7 +371,9 @@ export const chatThreadsContract = c.router({
   },
   drafts: {
     method: "GET",
-    path: "/api/zero/chat-threads/drafts",
+    // Sibling path (not nested under /chat-threads/) so it can never
+    // collide with the /chat-threads/:id route pattern.
+    path: "/api/zero/chat-thread-drafts",
     headers: authHeadersSchema,
     query: z.object({
       /**
@@ -382,6 +394,20 @@ export const chatThreadsContract = c.router({
     },
     summary:
       "Report which of the given chat threads hold an unsent composer draft. Fetched separately from the thread list so the sidebar draft dots don't gate the list query.",
+  },
+  unreads: {
+    method: "GET",
+    path: "/api/zero/chat-thread-unreads",
+    headers: authHeadersSchema,
+    query: z.object({
+      agentId: z.string().min(1),
+    }),
+    responses: {
+      200: chatThreadUnreadsSchema,
+      401: apiErrorSchema,
+    },
+    summary:
+      "List the caller's unread chat threads under an agent, each with the timestamp of the message that made it unread. Fetched separately from the thread list; mark-read returns the same snapshot so read state needs no broadcast.",
   },
 });
 
@@ -457,13 +483,19 @@ export const chatThreadMarkReadContract = c.router({
     responses: {
       200: z.object({
         lastReadMessageId: z.string().nullable(),
-        changed: z.boolean(),
+        /**
+         * Fresh unread snapshot for the thread's agent (same shape as the
+         * unreads endpoint), so the caller syncs read state from the response
+         * instead of a broadcast-triggered refetch.
+         */
+        unreads: chatThreadUnreadsSchema.shape.unreads,
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Mark a chat thread as read up to the latest message",
+    summary:
+      "Mark a chat thread as read up to the latest message and return the agent's unread snapshot",
   },
 });
 


### PR DESCRIPTION
## Summary

`GET /api/zero/chat-threads` is the hottest sidebar endpoint (~40k req/day, refetched on every `threadListChanged` delivery). This PR attacks both sides: the per-request query cost and the broadcast volume that triggers the refetches.

### Per-request cost (was 4 sequential DB round-trips + LATERAL join, now 2 parallel flat queries)

- **Parallelize** the pinned + non-pinned segment queries with `Promise.all` — no data dependency.
- **Drop `totalCount`** from the list response and its `COUNT(*) + JOIN` query. No client consumes the field.
- **Drop the `agent_composes` existence pre-check.** The list query already scopes by `org_id` + `agent_compose_id` via the `zero_agents` join, so an unknown `agentId` yields an empty list instead of 404 (create/send routes keep their checks).
- **Drop `scheduleCount`, `hasDraft`, and `isRead`** from list rows. Removing `isRead` removes the `last_message` LATERAL join from the hot query entirely — the list is now a flat scan over `chat_threads ⋈ zero_agents`.

### Broadcast volume (`threadListChanged` publishes)

- **Mark-read no longer broadcasts** (~5.5k/day, the single largest trigger). The response carries the agent's fresh unread snapshot instead; other clients converge on their next unreads fetch.
- **User message posts no longer broadcast** (normal send, recall, interrupt, queued, no-credit): the acting client reloads its own sidebar locally, and ordering (`last_message_at`) only moves on run-terminal events — whose callbacks keep broadcasting.
- **Draft saves no longer broadcast** and no longer run a before-SELECT to detect the `hasDraft` flip — the PATCH is a single UPDATE now.
- Run callbacks already only broadcast on terminal transitions (completed / failed / cancelled) and queue auto-send — verified, unchanged.

### Read state: per-agent unreads endpoint + optimistic marks

`GET /api/zero/chat-thread-unreads?agentId=...` returns the caller's unread thread ids under the agent, each with `unreadAt` — the creation time of the message that made it unread. Mark-read (`POST /:id/mark-read`) returns the same snapshot.

The client keeps **local optimistic mark-read timestamps**: a thread in the server snapshot renders as read while a local mark exists, and the mark is **kicked whenever a snapshot reports an `unreadAt` newer than the mark** — a fresh message arrived after the user read the thread. This absorbs the race between mark-read and an in-flight fetch with no broadcast and no clock coordination beyond the comparison.

### Drafts: batched endpoint

`GET /api/zero/chat-thread-drafts?threadIds=a,b,c` returns which of the given threads hold an unsent draft. The sidebar fetches it separately from the list (dot may render a beat late) and bumps it locally after each draft save.

Both new endpoints live on sibling paths (not nested under `/chat-threads/`) so they can never collide with the `/chat-threads/:id` route pattern.

### Delete-chat dialog: loading state + on-click fetch

The dialog already fetches the automations list (`headerAutomationMenu$`) for linked-automation titles; the count is now derived from that data instead of `scheduleCount`. Selecting "Delete chat" refetches, and the dialog renders the in-flight state with `useLoadable`: spinner + "Checking thread content…" with the **delete button disabled** until the check resolves.

### API semantics changes

- list with unknown `agentId` → `200` empty list (was `404`)
- list rows no longer include `totalCount`, `scheduleCount`, `hasDraft`, `isRead`
- new `GET /api/zero/chat-thread-drafts` and `GET /api/zero/chat-thread-unreads`
- mark-read response: `{ lastReadMessageId, unreads }` (was `{ lastReadMessageId, changed }`), no broadcast
- user posts / draft saves / mark-read no longer publish `threadListChanged`

## Test plan

- BDD: read-state flow migrated to the unreads endpoint (no-credit message → unread with timestamp, mark-read → empty snapshot, idempotent re-mark); draft flows on the drafts endpoint; unknown-agent list asserts empty-list semantics.
- Platform: unread/draft dot tests mock the new endpoints; delete-dialog test unchanged (copy derived from mocked automations); default empty mocks added to global handlers.
- Relying on CI for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
