### PR TITLE
fix: improve credit usage legend layout, kind colors, and bar hover

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -35,9 +35,10 @@
   --color-credit-plan-team: #6b8de3;
 
   /* Usage record kind breakdown segment colors — drawn from the Insights
-     card-palette hues so usage and insights read as one system. Image and
-     video sit far apart on the wheel (pink vs teal) since they co-occur. */
-  --color-usage-kind-model: #e24b6a;
+     card-palette hues so usage and insights read as one system. Model uses a
+     cool indigo so the dominant LLM segment separates cleanly from the pink
+     image hue; image and video also sit far apart (pink vs teal). */
+  --color-usage-kind-model: #5e6ad2;
   --color-usage-kind-image: #ec70a5;
   --color-usage-kind-video: #358a8e;
   --color-usage-kind-connector: #98928b;

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -200,7 +200,7 @@ function UsageBreakdownBar({ row, max }: { row: UsageRecordRow; max: number }) {
   // chat's size relative to the largest chat, so the bar reads as magnitude.
   // The kind colors live inside the fill, so one bar carries both size and mix.
   return (
-    <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-[hsl(var(--gray-50))]">
+    <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-foreground/8">
       <div
         className="flex h-full overflow-hidden rounded-full"
         style={{ width: `${(row.credits / max) * 100}%` }}
@@ -367,14 +367,14 @@ function UsageRecordSummary({
 }) {
   const kinds = Object.keys(KIND_META) as UsageRecordKind[];
   return (
-    <div className="px-5 py-3.5">
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-5 py-3.5">
       <p className="text-sm text-muted-foreground">
         <span className="font-medium text-foreground tabular-nums">
           {count} {count === 1 ? "chat" : "chats"}
         </span>{" "}
         · {formatCredits(totalCredits)} credits
       </p>
-      <div className="mt-2.5 flex flex-wrap items-center gap-x-3.5 gap-y-1.5">
+      <div className="flex flex-wrap items-center gap-x-3.5 gap-y-1.5">
         {kinds.map((kind) => {
           return (
             <span


### PR DESCRIPTION
Three fixes to the per-chat Credit usage panel (Personal model settings), from design feedback on the screenshot.

### 1. Legend placement
Moved the kind legend (LLM / Image / Video / Connectors / Other) to the right of the `N chats · credits` line as a single aligned row, instead of wrapping onto its own line below. The container is `flex-wrap` so on narrow widths the legend drops below the count gracefully (responsive).

### 2. Kind color collision
`LLM models` used `#e24b6a` (rose), sitting right next to `Image models` `#ec70a5` (pink) — the two were hard to tell apart. Recolored the dominant LLM segment to a cool indigo `#5e6ad2`, which also spreads the five categories more evenly across the wheel.

### 3. Bar track swallowed on hover
The bar track was `bg-[hsl(var(--gray-50))]`, identical to the row's hover background, so the rail disappeared on hover. Switched the track to a translucent foreground tint (`bg-foreground/8`) so it stays visible against both the card and the hover background, in light and dark mode.

No behavioral/API changes; styling only. No tests reference the changed strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)