### PR TITLE
feat: polish inline feedback composer spacing and support attachments

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -8,6 +8,8 @@ import {
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
   chatThreadsContract,
+  type GenerationTemplateRequest,
+  type ModelSelectionRequest,
   type PagedChatMessage,
   type PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -76,6 +78,20 @@ interface QueuedMessageCapture {
   hasTextContent?: boolean;
   attachments?: PersistedAttachment[];
   clientMessageId: string;
+}
+
+interface RunCreateCapture {
+  prompt?: string;
+  attachFiles?: {
+    id: string;
+    filename: string;
+    contentType: string;
+    size: number;
+  }[];
+  hasTextContent?: boolean;
+  generationTemplate?: GenerationTemplateRequest;
+  modelSelection?: ModelSelectionRequest | null;
+  clientMessageId?: string;
 }
 
 interface PushBrowserMock {
@@ -709,6 +725,16 @@ function buttonByText(text: string): HTMLElement {
     throw new Error(`${text} button not found`);
   }
   return button;
+}
+
+function presentationTemplateLabel(
+  item: (typeof PRESENTATION_TEMPLATE_ITEMS)[number],
+): string {
+  const label = item.templateId
+    .replace(/^template:/, "")
+    .replace(/^html-ppt-/, "")
+    .replace(/-/g, " ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 function queryButtonByText(text: string): HTMLElement | null {
@@ -3084,6 +3110,135 @@ describe("chat lifecycle", () => {
     expect(
       screen.queryByPlaceholderText("What should change about this?"),
     ).not.toBeInTheDocument();
+  });
+
+  it("sends inline feedback with selected template and draft attachments", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_ITEMS[0]!;
+    const templateChipLabel = presentationTemplateLabel(template);
+    const assistantReply = "The launch summary needs more source context.";
+    const sentBodies: RunCreateCapture[] = [];
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      selectedModel: "claude-sonnet-4-6",
+      chatMessages: [
+        {
+          id: "msg-feedback-attachment-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-attachment",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-attachment-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-attachment",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentBodies.push(body);
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-feedback-brief",
+      filename: "feedback-brief.txt",
+      contentType: "text/plain",
+      size: 14,
+      url: "https://cdn.vm7.io/artifacts/test/upload-feedback-brief/feedback-brief.txt",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineFeedback]: true,
+        [FeatureSwitchKey.ChatTemplatePicker]: true,
+      },
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+
+    await user.click(await screen.findByLabelText("Template"));
+    await user.click(
+      await screen.findByLabelText(`Select template ${template.title}`),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(`Remove template ${templateChipLabel}`),
+      ).toBeInTheDocument();
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) {
+      throw new Error("file input not found");
+    }
+    await user.upload(
+      fileInput,
+      new File(["feedback notes"], "feedback-brief.txt", {
+        type: "text/plain",
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Remove feedback-brief.txt"),
+      ).toBeInTheDocument();
+    });
+
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+    await user.click(buttonByText("Provide feedback"));
+    window.getSelection()?.removeAllRanges();
+
+    await fill(
+      await screen.findByPlaceholderText("What should change about this?"),
+      "Use the attached brief as supporting context.",
+    );
+    expect(
+      screen.getByLabelText(`Remove template ${templateChipLabel}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Remove feedback-brief.txt"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Send feedback"));
+
+    await waitFor(() => {
+      expect(sentBodies[0]).toMatchObject({
+        attachFiles: [
+          {
+            id: "upload-feedback-brief",
+            filename: "feedback-brief.txt",
+            contentType: "text/plain",
+            size: 14,
+          },
+        ],
+        generationTemplate: {
+          type: "presentation",
+          selection: {
+            designSystemId: template.designSystemId,
+            templateId: template.templateId,
+          },
+        },
+        modelSelection: {
+          modelProviderId: "00000000-0000-4000-8000-000000000000",
+          selectedModel: "claude-sonnet-4-6",
+        },
+      });
+    });
+    const sentBody = sentBodies[0];
+    if (!sentBody) {
+      throw new Error("feedback send body not captured");
+    }
+    expect(sentBody?.prompt).toContain(
+      "Use the attached brief as supporting context.",
+    );
   });
 
   it("keeps committed inline feedback while drafting another selected comment", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -11,6 +11,7 @@ import {
   chatThreadMessagesContract,
   chatMessagesContract,
   type GenerationTemplateRequest,
+  type ModelSelectionRequest,
   type PagedChatMessage,
   type PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -322,6 +323,7 @@ export function mockChatLifecycle(
     historyMessages?: MockPagedMessage[];
     chatMessages?: MockPagedMessage[];
     threadTitle?: string | null;
+    selectedModel?: string | null;
     computerUseHostId?: string | null;
     activeRunIds?: string[];
     onQueuedMessageAppend?: (body: {
@@ -352,6 +354,15 @@ export function mockChatLifecycle(
     onRunCreate?: (body: {
       prompt?: string;
       clientMessageId?: string;
+      attachFiles?: {
+        id: string;
+        filename: string;
+        contentType: string;
+        size: number;
+      }[];
+      hasTextContent?: boolean;
+      generationTemplate?: GenerationTemplateRequest;
+      modelSelection?: ModelSelectionRequest | null;
       computerUseHostId?: string | null;
       revokesMessageId?: string;
     }) => void;
@@ -492,6 +503,15 @@ export function mockChatLifecycle(
   const startRunFromUserMessage = async (body: {
     prompt?: string;
     clientMessageId?: string;
+    attachFiles?: {
+      id: string;
+      filename: string;
+      contentType: string;
+      size: number;
+    }[];
+    hasTextContent?: boolean;
+    generationTemplate?: GenerationTemplateRequest;
+    modelSelection?: ModelSelectionRequest | null;
     computerUseHostId?: string | null;
     revokesMessageId?: string;
   }) => {
@@ -646,6 +666,7 @@ export function mockChatLifecycle(
       updatedAt: "2026-03-10T00:00:00Z",
       draftContent: null,
       draftAttachments: null,
+      selectedModel: options?.selectedModel ?? null,
       computerUseHostId: options?.computerUseHostId ?? null,
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -519,7 +519,7 @@ function ComposerFeedbackRow({
   onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
 }) {
   return (
-    <div className="border-b border-dashed border-border/60 pb-2 pt-1 last:border-b-0">
+    <div className="flex flex-col gap-1.5 border-b border-dashed border-border/60 py-1.5">
       <div className="flex items-center gap-2">
         <span className="h-4 w-[3px] shrink-0 bg-muted-foreground/30" />
         <span className="min-w-0 flex-1 truncate text-sm italic leading-snug text-muted-foreground">
@@ -544,7 +544,7 @@ function ComposerFeedbackRow({
         onKeyDown={onKeyDown}
         rows={1}
         placeholder="What should change about this?"
-        className="mt-1 w-full resize-none border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
+        className="w-full resize-none border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
       />
     </div>
   );
@@ -584,7 +584,7 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
           />
         );
       })}
-      <span className="px-1 pt-2 font-serif text-[13px] italic leading-snug text-muted-foreground/50">
+      <span className="px-1 pt-1.5 font-serif text-[13px] italic leading-snug text-muted-foreground/50">
         Select more text to add another comment
       </span>
     </div>
@@ -4267,23 +4267,26 @@ export function ZeroChatComposer({
         >
           <CardContent className="p-0">
             <div className="flex flex-col">
+              {/* Template + attachment chips are shared by both modes: a feedback
+                  turn can also carry a template or attachments, so they render
+                  above the feedback rows just as they do above the textarea. */}
+              <SelectedTemplateChipSlot
+                picker={templatePicker}
+                onDraftChange={onDraftChange}
+              />
+              {visibleAttachments.length > 0 && (
+                <AttachmentChips
+                  attachments={visibleAttachments}
+                  onRemove={(attachment) => {
+                    removeAttachment(attachment);
+                    onDraftChange?.();
+                  }}
+                />
+              )}
               {activeFeedback ? (
                 <ComposerFeedbackRows feedback={activeFeedback} />
               ) : (
                 <>
-                  <SelectedTemplateChipSlot
-                    picker={templatePicker}
-                    onDraftChange={onDraftChange}
-                  />
-                  {visibleAttachments.length > 0 && (
-                    <AttachmentChips
-                      attachments={visibleAttachments}
-                      onRemove={(attachment) => {
-                        removeAttachment(attachment);
-                        onDraftChange?.();
-                      }}
-                    />
-                  )}
                   <ComposerInputSlot
                     input={input}
                     onInputChange={onInputChange}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3376,6 +3376,7 @@ function useChatThreadComputerUse(thread: ChatThreadSignals) {
 // Returns undefined when the feature is off, so the composer keeps its textarea.
 function useChatThreadComposerFeedback(
   thread: ChatThreadSignals,
+  modelSelection: ModelProviderSelection | null,
 ): ComposerFeedback | undefined {
   const features = useLastResolved(featureSwitch$);
   const inlineFeedbackEnabled =
@@ -3420,7 +3421,7 @@ function useChatThreadComposerFeedback(
       detach(
         sendMessage(
           prompt,
-          null,
+          modelSelection,
           {
             includeDraftAttachments: true,
             ...(generationTemplate ? { generationTemplate } : {}),
@@ -3507,7 +3508,7 @@ function ChatThreadComposer({
     detach(scheduleDraftSync(pageSignal), Reason.DomCallback);
   };
 
-  const feedback = useChatThreadComposerFeedback(thread);
+  const feedback = useChatThreadComposerFeedback(thread, modelSelection);
 
   return (
     <footer

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3389,6 +3389,14 @@ function useChatThreadComposerFeedback(
   const dismiss = useSet(dismissFeedback$);
   const [, sendMessage] = useLoadableSet(thread.sendMessage$);
   const rootSignal = useGet(rootSignal$);
+  // A feedback turn can also carry the composer's template + attachments, so
+  // read the same per-thread template selection the normal send path uses.
+  const generationTemplateState = useGet(threadGenerationTemplate$);
+  const generationTemplate =
+    generationTemplateState?.threadId === thread.threadId
+      ? generationTemplateState.value
+      : undefined;
+  const setGenerationTemplate = useSet(setThreadGenerationTemplate$);
 
   // Feedback is owned by the thread it was drafted in; other threads keep their
   // own composer textarea so a draft never bleeds across chats.
@@ -3413,11 +3421,15 @@ function useChatThreadComposerFeedback(
         sendMessage(
           prompt,
           null,
-          { includeDraftAttachments: false },
+          {
+            includeDraftAttachments: true,
+            ...(generationTemplate ? { generationTemplate } : {}),
+          },
           rootSignal,
         ),
         Reason.DomCallback,
       );
+      setGenerationTemplate(thread.threadId, undefined);
       dismiss();
     },
     onDismiss: () => {


### PR DESCRIPTION
Addresses four UI notes on the inline-feedback composer (the text-selection "Provide feedback" tray docked inside the chat composer, gated behind the `ChatInlineFeedback` switch).

### Changes

1. **Even out the gaps around each comment input** — the space above the note (between the quote and the input) and below it (between the input and the dashed separator) were asymmetric (`mt-1` + `pb-2`). Switched the row to `flex flex-col gap-1.5` with symmetric `py-1.5`, so the note sits evenly between its quote and the dashed line.

2. **Keep the dashed separator on the last comment row** — removed `last:border-b-0` so every row, including the bottom one, ends on a dashed line. The "Select more text to add another comment" hint now sits directly under that final dashed line (top padding tightened to `pt-1.5`) instead of floating below with a larger gap — i.e. it reads as on the same dashed line.

3. **Support attachments and templates in feedback mode** — the template chip and attachment chips now render above the feedback rows (hoisted so both the textarea and feedback paths share them), and the feedback turn is dispatched with `includeDraftAttachments: true` plus the selected generation template, instead of dropping them. The selected template is cleared after the turn, matching the normal send path.

### Notes

- `prepareUserMessageFromDraft$` uses the passed feedback prompt (not the hidden draft input), so only attachments — never stale textarea text — are pulled into the feedback turn.
- Spacing values (1.5 = 6px) are a starting point; happy to nudge to taste in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)