### PR TITLE
feat: backfill cached chat history

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import { readCachedMessagesBeforeUntilMiss } from "../idb-cached-chat-thread-data-source";
+import { testContext } from "../../__tests__/test-helpers.ts";
+
+function message(index: number): PagedChatMessage {
+  const id = `m${index.toString().padStart(3, "0")}`;
+  return {
+    id,
+    role: index % 2 === 0 ? "assistant" : "user",
+    content: `message ${index}`,
+    createdAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+  };
+}
+
+function range(start: number, end: number): PagedChatMessage[] {
+  return Array.from({ length: end - start + 1 }, (_, offset) => {
+    return message(start + offset);
+  });
+}
+
+function ids(messages: PagedChatMessage[]): string[] {
+  return messages.map((msg) => {
+    return msg.id;
+  });
+}
+
+describe("readCachedMessagesBeforeUntilMiss", () => {
+  const ctx = testContext();
+
+  it("keeps reading older cached pages until IndexedDB misses", async () => {
+    const calls: string[] = [];
+    const pages = new Map<string, PagedChatMessage[]>([
+      ["m151", range(101, 150)],
+      ["m101", range(51, 100)],
+      ["m051", []],
+    ]);
+    const signal = ctx.signal;
+
+    const result = await readCachedMessagesBeforeUntilMiss(
+      {
+        readBefore(_threadId, beforeId, limit, passedSignal) {
+          expect(limit).toBe(50);
+          expect(passedSignal).toBe(signal);
+          calls.push(beforeId);
+          return Promise.resolve(pages.get(beforeId) ?? []);
+        },
+      },
+      "thread-1",
+      "m151",
+      null,
+      signal,
+    );
+
+    expect(calls).toStrictEqual(["m151", "m101", "m051"]);
+    expect(result.pages).toBe(2);
+    expect(result.hasMore).toBeTruthy();
+    expect(ids(result.messages)).toStrictEqual(ids(range(51, 150)));
+  });
+
+  it("stops once the cached messages include the known thread start", async () => {
+    const calls: string[] = [];
+    const pages = new Map<string, PagedChatMessage[]>([
+      ["m151", range(101, 150)],
+      ["m101", range(51, 100)],
+      ["m051", []],
+    ]);
+    const signal = ctx.signal;
+
+    const result = await readCachedMessagesBeforeUntilMiss(
+      {
+        readBefore(_threadId, beforeId) {
+          calls.push(beforeId);
+          return Promise.resolve(pages.get(beforeId) ?? []);
+        },
+      },
+      "thread-1",
+      "m151",
+      "m051",
+      signal,
+    );
+
+    expect(calls).toStrictEqual(["m151", "m101"]);
+    expect(result.pages).toBe(2);
+    expect(result.hasMore).toBeFalsy();
+    expect(ids(result.messages)).toStrictEqual(ids(range(51, 150)));
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -17,8 +17,18 @@ import type {
 import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
 
 const L = logger("ChatIdbCache");
+const MESSAGE_PAGE_SIZE = 50;
 
 type Stores = ReturnType<typeof createIdbMessageStores>;
+
+interface CachedMessageReadStore {
+  readBefore(
+    threadId: string,
+    beforeId: string,
+    limit: number,
+    signal?: AbortSignal,
+  ): Promise<PagedChatMessage[]>;
+}
 
 function reachedStart(
   cached: PagedChatMessage[],
@@ -30,6 +40,56 @@ function reachedStart(
   return cached.some((m) => {
     return m.id === startMessageId;
   });
+}
+
+export async function readCachedMessagesBeforeUntilMiss(
+  readStore: CachedMessageReadStore,
+  threadId: string,
+  beforeId: string,
+  startMessageId: string | null,
+  signal: AbortSignal,
+): Promise<{ messages: PagedChatMessage[]; hasMore: boolean; pages: number }> {
+  let cursorId = beforeId;
+  const messagePages: PagedChatMessage[][] = [];
+  const seenIds = new Set<string>([beforeId]);
+
+  while (true) {
+    const page = await readStore.readBefore(
+      threadId,
+      cursorId,
+      MESSAGE_PAGE_SIZE,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const newMessages = page.filter((message) => {
+      return !seenIds.has(message.id);
+    });
+    if (newMessages.length === 0) {
+      break;
+    }
+
+    for (const message of newMessages) {
+      seenIds.add(message.id);
+    }
+    messagePages.unshift(newMessages);
+
+    if (
+      reachedStart(newMessages, startMessageId) ||
+      page.length < MESSAGE_PAGE_SIZE
+    ) {
+      break;
+    }
+
+    cursorId = newMessages[0]!.id;
+  }
+
+  const messages = messagePages.flat();
+  return {
+    messages,
+    hasMore: !reachedStart(messages, startMessageId),
+    pages: messagePages.length,
+  };
 }
 
 function createListMessagesBefore(
@@ -58,18 +118,24 @@ function createListMessagesBefore(
 
       const stores = getStores(userId, orgId);
       const readStore = stores.readStore;
-      const cached = await readStore.readBefore(tid, beforeId, 50, signal);
+      const meta = await readThreadMeta$(userId, orgId, tid, signal);
+      const cached = await readCachedMessagesBeforeUntilMiss(
+        readStore,
+        tid,
+        beforeId,
+        meta?.startMessageId ?? null,
+        signal,
+      );
 
-      if (cached.length > 0) {
-        const meta = await readThreadMeta$(userId, orgId, tid, signal);
-        const hasMore = !reachedStart(cached, meta?.startMessageId ?? null);
+      if (cached.messages.length > 0) {
         L.debug("listBefore:cacheHit", {
           threadId: tid,
           beforeId,
-          count: cached.length,
-          hasMore,
+          count: cached.messages.length,
+          pages: cached.pages,
+          hasMore: cached.hasMore,
         });
-        return { messages: cached, hasMore };
+        return { messages: cached.messages, hasMore: cached.hasMore };
       }
 
       L.debug("listBefore:cacheMiss", { threadId: tid, beforeId });
@@ -198,7 +264,7 @@ export function createIdbCachedDataSource(
 
     const stores = getStores(userId, orgId);
     const readStore = stores.readStore;
-    const cached = await readStore.readLatest(threadId, 50);
+    const cached = await readStore.readLatest(threadId, MESSAGE_PAGE_SIZE);
 
     if (cached.length > 0) {
       const meta = await readThreadMeta$(userId, orgId, threadId);


### PR DESCRIPTION
## Summary
- keep upward chat history loading on IndexedDB cache hits until cached older history is exhausted
- preserve existing remote fallback behavior when IndexedDB can no longer provide older messages
- add focused coverage for cached multi-page backfill and known-start termination

## Tests
- pnpm format
- pnpm turbo run lint --log-order grouped --concurrency=1
- NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types
- pnpm exec vitest run apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts