### PR TITLE
fix: aggregate deleted chat usage records

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-record.test.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroUsageRecordContract } from "@vm0/api-contracts/contracts/zero-usage-record";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockNow, nowDate } from "../../../lib/time";
+import { writeDb$ } from "../../external/db";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -241,6 +244,147 @@ describe("GET /api/zero/usage/record", () => {
     expect(response.body.rows[2]?.source).toBe("chat");
     expect(response.body.rows[2]?.threadId).toBe(older.threadId);
     expect(response.body.rows[2]?.credits).toBe(80);
+  });
+
+  it("aggregates deleted chat threads into a synthetic usage row", async () => {
+    const fixture = await track(
+      store.set(seedUsageFixture$, {}, context.signal),
+    );
+
+    const deletedOlder = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Deleted older chat",
+        createdAt: createdAt(50),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: deletedOlder.runId,
+        inputTokens: 10,
+        outputTokens: 5,
+        creditsCharged: 20,
+      },
+      context.signal,
+    );
+
+    const current = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Current chat",
+        createdAt: createdAt(20),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: current.runId,
+        inputTokens: 20,
+        outputTokens: 20,
+        creditsCharged: 40,
+      },
+      context.signal,
+    );
+
+    const deletedNewer = await store.set(
+      seedChatThreadRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        title: "Deleted newer chat",
+        createdAt: createdAt(10),
+      },
+      context.signal,
+    );
+    await store.set(
+      insertModelUsage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: deletedNewer.runId,
+        inputTokens: 100,
+        outputTokens: 50,
+        creditsCharged: 80,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        runId: deletedNewer.runId,
+        kind: "image",
+        provider: "gpt-image-2",
+        category: "tokens.output.image",
+        quantity: 1,
+        creditsCharged: 30,
+      },
+      context.signal,
+    );
+
+    const db = store.set(writeDb$);
+    await db
+      .delete(chatThreads)
+      .where(eq(chatThreads.id, deletedOlder.threadId));
+    await db
+      .delete(chatThreads)
+      .where(eq(chatThreads.id, deletedNewer.threadId));
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const response = await accept(
+      apiClient().get({
+        query: { range: "7d", tz: "UTC" },
+        headers: authHeaders(),
+      }),
+      [200],
+    );
+
+    expect(response.body.rows).toHaveLength(2);
+    expect(response.body.pagination.total).toBe(2);
+    expect(response.body.totalCredits).toBe(170);
+
+    expect(response.body.rows[0]).toMatchObject({
+      source: "chat",
+      threadId: null,
+      runId: null,
+      title: "Deleted chats",
+      credits: 130,
+      tokens: 165,
+    });
+    expect(response.body.rows[0]?.breakdown).toStrictEqual([
+      {
+        kind: "model",
+        credits: 100,
+        providers: [{ provider: "claude-sonnet-4-6", credits: 100 }],
+      },
+      {
+        kind: "image",
+        credits: 30,
+        providers: [{ provider: "gpt-image-2", credits: 30 }],
+      },
+    ]);
+
+    expect(response.body.rows[1]).toMatchObject({
+      source: "chat",
+      threadId: current.threadId,
+      runId: null,
+      title: "Current chat",
+      credits: 40,
+      tokens: 40,
+    });
   });
 
   it("labels automation threads and filters by source", async () => {

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -103,7 +103,9 @@ function usageKindExpr(kind: string): string {
 
 // Per-source usage for one user in one org. `record` is the shared CTE so the
 // row query and the count query stay in sync. Threaded sources collapse to one
-// row per source/thread; everything else is one row per run.
+// row per source/thread. Deleted threaded rows, whose thread FK has been set to
+// NULL, collapse to one synthetic row per source/user. Everything else is one
+// row per run.
 function recordWith(
   userIdLit: string,
   orgIdLit: string,
@@ -161,6 +163,22 @@ function recordWith(
         AND r.source IN (${threadedSourceList})
       GROUP BY r.source, r.user_id, r.chat_thread_id, ct.title
     ),
+    deleted_threaded AS (
+      SELECT
+        CONCAT(r.source, ':deleted-thread:user:', r.user_id) AS row_key,
+        r.source,
+        r.user_id,
+        NULL::text AS thread_id,
+        NULL::text AS run_id,
+        'Deleted chats'::text AS title,
+        COALESCE(SUM(r.credits), 0)::bigint AS credits,
+        COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
+        MAX(r.created_at) AS last_activity
+      FROM runs r
+      WHERE r.chat_thread_id IS NULL
+        AND r.source IN (${threadedSourceList})
+      GROUP BY r.source, r.user_id
+    ),
     unthreaded AS (
       SELECT
         CONCAT(r.source, ':run:', r.run_id::text, ':user:', r.user_id) AS row_key,
@@ -173,12 +191,13 @@ function recordWith(
         COALESCE(SUM(r.tokens), 0)::bigint AS tokens,
         MAX(r.created_at) AS last_activity
       FROM runs r
-      WHERE r.chat_thread_id IS NULL
-        OR r.source NOT IN (${threadedSourceList})
+      WHERE r.source NOT IN (${threadedSourceList})
       GROUP BY r.run_id, r.source, r.user_id
     ),
     record AS (
       SELECT * FROM threaded
+      UNION ALL
+      SELECT * FROM deleted_threaded
       UNION ALL
       SELECT * FROM unthreaded
     )`;
@@ -253,6 +272,8 @@ function rowKeyExpr(
     CASE
       WHEN ${chatThreadId} IS NOT NULL AND ${source} IN (${threadedSourceList})
         THEN CONCAT(${source}, ':thread:', ${chatThreadId}::text, ':user:', ${userId})
+      WHEN ${chatThreadId} IS NULL AND ${source} IN (${threadedSourceList})
+        THEN CONCAT(${source}, ':deleted-thread:user:', ${userId})
       ELSE CONCAT(${source}, ':run:', ${runId}::text, ':user:', ${userId})
     END`;
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -60,8 +60,9 @@ const usageRecordMemberSchema = z.object({
 });
 
 // One usage row. Threaded sources (chat, automation) aggregate every run in the
-// thread into a single row that links to the thread; unthreaded sources are one
-// row per run that links to the run's activity detail. Ordered by most recent
+// thread into a single row that links to the thread. Deleted threaded sources
+// aggregate into a synthetic non-clickable row. Unthreaded sources are one row
+// per run that links to the run's activity detail. Ordered by most recent
 // activity so the list reads as a chronological record.
 const usageRecordRowSchema = z.object({
   source: usageRecordSourceSchema,


### PR DESCRIPTION
## Summary
- aggregate deleted threaded usage into a synthetic `Deleted chats` row in Credit balance usage records
- keep the synthetic row non-clickable by returning `threadId: null` and `runId: null`
- document the usage record contract behavior and add coverage for deleted chat aggregation/breakdowns

## Tests
- `pnpm format`
- `pnpm -F api run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api run check-types`
- `DATABASE_URL="postgresql://user@localhost:5432/vm0_test?options=-c%20timezone%3DUTC" pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-record.test.ts`

Notes: full workspace `pnpm turbo run lint --log-order grouped` was interrupted by a local SIGKILL in `api` type-aware lint; rerunning `api` lint alone passed. Full workspace `pnpm check-types` reached `api` then hit local Node heap OOM; rerunning `api` with a larger heap passed.