### PR TITLE
refactor: retire the remaining schedule residue

### DIFF
--- a/e2e/playwright/tests/automation.spec.ts
+++ b/e2e/playwright/tests/automation.spec.ts
@@ -4,10 +4,7 @@ import { deriveAppUrl } from "../playwright.config";
 const appUrl = deriveAppUrl(process.env.VM0_API_URL!);
 
 test("navigate to automation page and verify heading", async ({ page }) => {
-  // Deliberately enter through the legacy /schedules path: it must keep
-  // redirecting to /automations (#17307), and the surface renders the
-  // Automations product noun.
-  await page.goto(`${appUrl}/schedules`);
+  await page.goto(`${appUrl}/automations`);
   await expect(page.getByRole("heading", { name: "Automations" })).toBeVisible(
     {
       timeout: 20_000,

--- a/turbo/apps/api/src/__tests__/api.bdd.md
+++ b/turbo/apps/api/src/__tests__/api.bdd.md
@@ -39,7 +39,7 @@ BDD helpers should be thin wrappers over route calls:
 - Connector helpers: `listConnectors`, `searchConnectors`, `readConnectorByType`, `startOAuth`, `completeOAuth`, `connectManualGrant`, `createCustomConnector`, `setConnectorSecret`, `deleteConnectorSecret`, `readIntegrationStatus`.
 - Billing and usage helpers: `readBillingStatus`, `startCheckout`, `openPortal`, `redeemCredit`, `readUsage`, `readUsageMembers`, `readUsageRuns`, `readInsights`, `runUsageCron`.
 - File and media helpers: `prepareUpload`, `completeUpload`, `readFile`, `readArtifact`, `readHostedContent`, `startImageGeneration`, `startVideoGeneration`, `startVoiceGeneration`, `readGenerationStatus`.
-- Schedule and webhook helpers: `createSchedule`, `readSchedule`, `listSchedules`, `enableSchedule`, `disableSchedule`, `runSchedule`, `deleteSchedule`, `postSignedCallback`, `postSignedWebhook`.
+- Automation and webhook helpers: `deployAutomation`, `listAutomations`, `enableAutomation`, `disableAutomation`, `runAutomationNow`, `deleteAutomation`, `postSignedCallback`, `postSignedWebhook`.
 
 If a helper cannot be implemented with API calls, mark the BDD case as `needs visible API/helper` and do not silently fall back to direct database setup.
 
@@ -628,7 +628,7 @@ Production-reachable but not API-constructible (recorded as explicit exceptions;
 
 These gaps must be closed before the corresponding old tests can be safely deleted:
 
-- ~~Billing and credit fixture setup that is visible through billing status.~~ Closed: `grantProEntitlement` in `helpers/api-bdd-runs-schedules.ts` moves an onboarded org to the pro tier with credits through the public Stripe `invoice.paid` webhook and verifies via billing status.
+- ~~Billing and credit fixture setup that is visible through billing status.~~ Closed: `grantProEntitlement` in `helpers/api-bdd-runs-automations.ts` moves an onboarded org to the pro tier with credits through the public Stripe `invoice.paid` webhook and verifies via billing status.
 - ~~vm0-managed-provider runs (`vm0_api_keys` has no public write API), the post-resolution vm0 gate, the vm0 billable arm, the nested trigger-agent family (zero tokens exclude `agent-run:write`), the custom-skill seed-volume override, and the agent provider pin (`zeroAgents.modelProviderId` has no public writer).~~ Removed from executable legacy coverage and recorded under Unreachable Code Candidates; `createZeroIntegrationRun$` coverage is owned by the alive `test-telegram-dispatch-probe.test.ts`.
 - `usage_pricing` has no write API: the priced settlement path (zero-credit-usage charge/expire/deduct plus the auto-recharge trigger) and the tier-less drain arm (org without `org_metadata`) were deleted with the legacy `webhooks-agent-complete.test.ts` remnant and recorded here.
 - Usage event creation through product APIs plus aggregation cron helpers.

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -46,50 +46,14 @@ const sandboxTokenPayloadSchema = jwtBaseSchema.extend({
   orgId: z.string().min(1),
 });
 
-// "automation:*" replaced "schedule:*" (#17307). In-flight zero tokens (2h
-// lifetime) may still carry the legacy names; they are accepted here and
-// normalized to their automation equivalents right after parse — a permanent
-// compatibility mapping in the authorization layer.
-type LegacyZeroCapability =
-  | "schedule:read"
-  | "schedule:write"
-  | "schedule:delete";
-
-const LEGACY_CAPABILITY_ALIASES: Readonly<
-  Record<LegacyZeroCapability, ZeroCapability>
-> = {
-  "schedule:read": "automation:read",
-  "schedule:write": "automation:write",
-  "schedule:delete": "automation:delete",
-};
-
-function isLegacyCapability(
-  value: ZeroCapability | LegacyZeroCapability,
-): value is LegacyZeroCapability {
-  return value in LEGACY_CAPABILITY_ALIASES;
-}
-
-const zeroCapabilitySchema = z.custom<ZeroCapability | LegacyZeroCapability>(
-  (value) => {
-    return (
-      typeof value === "string" &&
-      (value in LEGACY_CAPABILITY_ALIASES ||
-        ZERO_CAPABILITIES.some((capability) => {
-          return capability === value;
-        }))
-    );
-  },
-);
-
-function normalizeCapabilities(
-  capabilities: readonly (ZeroCapability | LegacyZeroCapability)[],
-): readonly ZeroCapability[] {
-  return capabilities.map((capability) => {
-    return isLegacyCapability(capability)
-      ? LEGACY_CAPABILITY_ALIASES[capability]
-      : capability;
-  });
-}
+const zeroCapabilitySchema = z.custom<ZeroCapability>((value) => {
+  return (
+    typeof value === "string" &&
+    ZERO_CAPABILITIES.some((capability) => {
+      return capability === value;
+    })
+  );
+});
 
 const zeroTokenPayloadSchema = jwtBaseSchema.extend({
   scope: z.literal("zero"),
@@ -226,7 +190,7 @@ export function verifyZeroToken(token: string): ZeroAuth | null {
     userId: parsed.data.userId,
     runId: parsed.data.runId,
     orgId: parsed.data.orgId,
-    capabilities: normalizeCapabilities(parsed.data.capabilities),
+    capabilities: parsed.data.capabilities,
     ...(parsed.data.computerUseHostId
       ? { computerUseHostId: parsed.data.computerUseHostId }
       : {}),

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -136,16 +136,13 @@ export async function publishThreadListChanged(userId: string): Promise<void> {
  * Best-effort: a failed publish must not fail the automation mutation that
  * triggers it. Payload is intentionally empty — the client re-fetches the
  * authoritative list on any delivery.
- *
- * The wire topic literal keeps the legacy "chatThreadSchedulesChanged" name
- * for compatibility with deployed platform listeners (#17307).
  */
 export async function publishChatThreadAutomationsChangedSafely(
   userId: string,
   threadId: string,
 ): Promise<void> {
   await tapError(
-    publishUserSignal([userId], `chatThreadSchedulesChanged:${threadId}`),
+    publishUserSignal([userId], `chatThreadAutomationsChanged:${threadId}`),
     (error) => {
       L.warn("Failed to publish chat thread automations changed signal", {
         threadId,

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -27,7 +27,7 @@ import {
   type AgentPhoneSendCapture,
 } from "./helpers/api-bdd-agentphone";
 import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const context = testContext();
@@ -56,7 +56,7 @@ interface LinkedAgentPhoneActor {
 
 async function entitledLinkedActor(): Promise<LinkedAgentPhoneActor> {
   const bdd = createBddApi(context);
-  const runs = createRunsSchedulesApi(context);
+  const runs = createRunsAutomationsApi(context);
   const integrations = createBddIntegrationApi(context);
   const ap = createAgentPhoneBddApi(context);
 
@@ -85,7 +85,7 @@ async function claimDispatchedRun(runnerGroup: string): Promise<{
   readonly appendSystemPrompt: string;
   readonly zeroToken: string | undefined;
 }> {
-  const runs = createRunsSchedulesApi(context);
+  const runs = createRunsAutomationsApi(context);
   await runs.heartbeatRunner(runnerGroup);
   let runId: string | undefined;
   await expect
@@ -112,7 +112,7 @@ async function pollDispatchedJob(runnerGroup: string): Promise<{
   readonly runId: string;
   readonly appendSystemPrompt: string;
 }> {
-  const runs = createRunsSchedulesApi(context);
+  const runs = createRunsAutomationsApi(context);
   await runs.heartbeatRunner(runnerGroup);
   let job:
     | Awaited<ReturnType<typeof runs.pollRunner>>["body"]["job"]
@@ -499,7 +499,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
 
   it("answers the slash-command surface over SMS with link state and model selection", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const integrations = createBddIntegrationApi(context);
     const ap = createAgentPhoneBddApi(context);
 
@@ -580,7 +580,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
   });
 
   it("handles the iMessage group lifecycle: mentions, stored context, ambient silence, and account-command guards", async () => {
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const integrations = createBddIntegrationApi(context);
     const ap = createAgentPhoneBddApi(context);
     const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
@@ -752,7 +752,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
 
   it("uploads and streams phone media with a real run-scoped zero token", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const integrations = createBddIntegrationApi(context);
     const ap = createAgentPhoneBddApi(context);
     const { actor, phone, runnerGroup, sends, storage } =

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -8,7 +8,7 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd-auth-org";
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 
 /*
 helper gap:
@@ -26,7 +26,7 @@ helper gap:
 const context = testContext();
 const api = createAuthOrgAgentsBddApi(context);
 const bdd = createBddApi(context);
-const runsApi = createRunsSchedulesApi(context);
+const runsApi = createRunsAutomationsApi(context);
 
 function shortId(): string {
   return randomUUID().replace(/-/g, "").slice(0, 10);

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.bdd.test.ts
@@ -14,10 +14,10 @@ import {
 } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import {
-  createRunsSchedulesApi,
+  createRunsAutomationsApi,
   signAutomationWebhook,
-  uniqueScheduleName,
-} from "./helpers/api-bdd-runs-schedules";
+  uniqueAutomationName,
+} from "./helpers/api-bdd-runs-automations";
 
 /**
  * AUTOMATIONS-02/03 and HOOK-02: the events-first automations surface (feature
@@ -28,7 +28,7 @@ import {
  * Shared-database isolation: this file never calls cron-execute-schedules (or
  * any other cron route) — those global sweeps are owned by
  * runs-schedules.bdd.test.ts. Every time automation created here is
- * enabled:false (runScheduleNow$ has no enabled gate, and a disabled row can
+ * enabled:false (runAutomationNow$ has no enabled gate, and a disabled row can
  * never be claimed by a foreign worker's execute-schedules sweep) and webhook
  * automations have no zero_agent_schedules row at all. No mockNow anywhere:
  * nothing here depends on due-time math.
@@ -48,7 +48,7 @@ async function entitledAutomationActor(): Promise<{
   readonly runnerGroup: string;
 }> {
   const bdd = createBddApi(context);
-  const api = createRunsSchedulesApi(context);
+  const api = createRunsAutomationsApi(context);
   const actor = bdd.user();
   bdd.acceptAgentStorageWrites();
   api.acceptStorageDownloads();
@@ -87,7 +87,7 @@ function automationRunIdFromThread(
 describe("AUTOMATIONS-02: webhook trigger feature-switch gating", () => {
   it("keeps webhook trigger creation gated while the automation resource stays mounted", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
 
     // Given a fresh user whose org/user has no webhook-trigger override (the
     // switch defaults to off). First test in this file: install the ably
@@ -146,13 +146,13 @@ describe("AUTOMATIONS-02: webhook trigger feature-switch gating", () => {
 
 describe("AUTOMATIONS-03: automation run-now dispatch", () => {
   it("dispatches a run-now automation visible through chat, claim, and queue", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
 
     // Given an entitled actor with the automations switch on
     const { actor, agentId, runnerGroup } = await entitledAutomationActor();
     const prompt = `Run the automation report ${randomUUID().slice(0, 8)}.`;
-    const automationName = uniqueScheduleName("bdd-auto-run");
+    const automationName = uniqueAutomationName("bdd-auto-run");
 
     // When the actor creates a disabled cron automation (enabled:false keeps
     // the row invisible to any foreign execute-schedules sweep on the shared
@@ -200,7 +200,7 @@ describe("AUTOMATIONS-03: automation run-now dispatch", () => {
     // automations surface
     expect(claim.prompt).toBe(prompt);
     expect(claim.appendSystemPrompt).toContain(
-      "You are currently running inside: Schedule",
+      "You are currently running inside: Automation",
     );
     expect(claim.appendSystemPrompt).toContain("Trigger type: manual");
     expect(claim.appendSystemPrompt).toContain("Automation tone.");
@@ -222,7 +222,7 @@ describe("AUTOMATIONS-03: automation run-now dispatch", () => {
     // When a disabled loop automation is run now, the manual fire still
     // belongs to the automation rather than to a specific trigger.
     const loopCreated = await api.createAutomation(actor, {
-      name: uniqueScheduleName("bdd-auto-loop"),
+      name: uniqueAutomationName("bdd-auto-loop"),
       agentId,
       intervalSeconds: 300,
       prompt,
@@ -248,7 +248,7 @@ describe("AUTOMATIONS-03: automation run-now dispatch", () => {
     // Then updating a missing automation reports not-found
     const updateMissingAutomation = await api.requestUpdateAutomationUnchecked(
       actor,
-      uniqueScheduleName("bdd-missing-auto"),
+      uniqueAutomationName("bdd-missing-auto"),
       {
         prompt,
       },
@@ -271,7 +271,7 @@ describe("AUTOMATIONS-03: automation run-now dispatch", () => {
 describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
   it("manages webhook automations and fires a signed inbound payload into a run", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
 
     // Given an entitled actor with two agents, plus an outsider with the
@@ -289,7 +289,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
     const missingAgent = await api.requestCreateWebhookAutomationUnchecked(
       actor,
       {
-        name: uniqueScheduleName("bdd-hook-missing-agent"),
+        name: uniqueAutomationName("bdd-hook-missing-agent"),
         instruction: "Handle it.",
         agentId: randomUUID(),
       },
@@ -305,7 +305,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
     const wrongAgentThread = await api.requestCreateWebhookAutomationUnchecked(
       actor,
       {
-        name: uniqueScheduleName("bdd-hook-wrong-thread"),
+        name: uniqueAutomationName("bdd-hook-wrong-thread"),
         instruction: "Handle it.",
         agentId,
         chatThreadId: threadOnAgentB.id,
@@ -318,7 +318,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
     // When linking an owned thread on the same agent
     const ownedThread = await chat.createThread(actor, { agentId });
     const linked = await api.createWebhookAutomation(actor, {
-      name: uniqueScheduleName("bdd-hook-linked"),
+      name: uniqueAutomationName("bdd-hook-linked"),
       instruction: "Summarize linked events.",
       agentId,
       chatThreadId: ownedThread.id,
@@ -344,7 +344,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
     // When minting the main webhook automation
     const instruction = `Summarize the incoming webhook event ${randomUUID().slice(0, 8)}.`;
     const created = await api.createWebhookAutomation(actor, {
-      name: uniqueScheduleName("bdd-hook-main"),
+      name: uniqueAutomationName("bdd-hook-main"),
       instruction,
       description: "On deploy",
       agentId,
@@ -381,7 +381,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
 
     // Then a disabled automation is indistinguishable from a missing one
     const disabled = await api.createWebhookAutomation(actor, {
-      name: uniqueScheduleName("bdd-hook-disabled"),
+      name: uniqueAutomationName("bdd-hook-disabled"),
       instruction: "Should never fire.",
       agentId,
       enabled: false,
@@ -464,7 +464,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
 
   it("surfaces run-creation failure of a signed dispatch as a throttled 429", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
 
     // Given a free-tier actor with no entitlement and no model provider
     const actor = bdd.user();
@@ -478,7 +478,7 @@ describe("HOOK-02: webhook automations fired by signed inbound HTTP", () => {
 
     // When a correctly signed payload fires the automation
     const created = await api.createWebhookAutomation(actor, {
-      name: uniqueScheduleName("bdd-hook-free"),
+      name: uniqueAutomationName("bdd-hook-free"),
       instruction: "Will not start.",
       agentId: agent.agentId,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -28,10 +28,10 @@ import {
 } from "../../services/crypto.utils";
 import { writeDb$ } from "../../external/db";
 import {
-  type SchedulesFixture,
-  deleteSchedulesScenario$,
-  seedSchedulesScenario$,
-} from "./helpers/zero-schedules";
+  type AutomationsFixture,
+  deleteAutomationsScenario$,
+  seedAutomationsScenario$,
+} from "./helpers/automations";
 import { decryptSecretForTests } from "./helpers/encrypt-secret";
 import { fakeKmsClient } from "./helpers/fake-kms-client";
 import {
@@ -66,14 +66,14 @@ function cronApi() {
   return setupApp({ context })(cronExecuteAutomationsContract);
 }
 
-const trackSchedules = createFixtureTracker<SchedulesFixture>((fixture) => {
-  return store.set(deleteSchedulesScenario$, fixture, context.signal);
+const trackAutomations = createFixtureTracker<AutomationsFixture>((fixture) => {
+  return store.set(deleteAutomationsScenario$, fixture, context.signal);
 });
 
 // Automations created through the API are not part of the schedule fixture, so
 // delete them by their org scope after each test. The trigger rows cascade
 // with the automation; the linked chat threads are removed explicitly.
-const trackCreatedAutomations = createFixtureTracker<SchedulesFixture>(
+const trackCreatedAutomations = createFixtureTracker<AutomationsFixture>(
   async (fixture) => {
     const db = store.set(writeDb$);
     const rows = await db
@@ -96,15 +96,15 @@ const trackExtraComposes = createFixtureTracker<string>(async (composeId) => {
   await db.delete(agentComposes).where(eq(agentComposes.id, composeId));
 });
 
-async function seedFixture(): Promise<SchedulesFixture> {
+async function seedFixture(): Promise<AutomationsFixture> {
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   // Pin the description generator to its deterministic template fallback: an
   // ambient key would make description-less creates call openrouter.ai live.
   mockOptionalEnv("OPENROUTER_API_KEY", undefined);
   context.mocks.s3.send.mockResolvedValue({});
   setSecretKmsClientForTests(fakeKmsClient().client);
-  const fixture = await trackSchedules(
-    store.set(seedSchedulesScenario$, { schedules: [] }, context.signal),
+  const fixture = await trackAutomations(
+    store.set(seedAutomationsScenario$, { automations: [] }, context.signal),
   );
   await trackCreatedAutomations(Promise.resolve(fixture));
   mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -112,7 +112,7 @@ async function seedFixture(): Promise<SchedulesFixture> {
 }
 
 async function enableWebhookTriggers(
-  fixture: SchedulesFixture,
+  fixture: AutomationsFixture,
   options?: { readonly webhookTriggers?: boolean },
 ): Promise<void> {
   const db = store.set(writeDb$);

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
@@ -24,7 +24,7 @@ import {
 } from "./helpers/api-bdd";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const context = testContext();
@@ -1560,7 +1560,7 @@ function sttFormData(
 describe("FILE-02: audio transcription v1 and Gemini generate-image provider contracts", () => {
   it("transcribes raw PCM through OpenAI behind the feature switch with the WAV byte contract", async () => {
     const { api, admin } = testActors();
-    const runsApi = createRunsSchedulesApi(context);
+    const runsApi = createRunsAutomationsApi(context);
     await runsApi.grantProEntitlement(admin);
     const authApi = createAuthOrgAgentsBddApi(context);
     const apiKey = await authApi.createApiKey(admin, {
@@ -1642,7 +1642,7 @@ describe("FILE-02: audio transcription v1 and Gemini generate-image provider con
     if (!admin.orgId) {
       throw new Error("Expected STT duration test user to have an org");
     }
-    const runsApi = createRunsSchedulesApi(context);
+    const runsApi = createRunsAutomationsApi(context);
     await runsApi.grantProEntitlement(admin);
 
     server.use(
@@ -1919,7 +1919,7 @@ describe("FILE-02: audio transcription v1 and Gemini generate-image provider con
 
   it("generates Gemini images behind configuration and no-image gates", async () => {
     const { api, admin } = testActors();
-    const runsApi = createRunsSchedulesApi(context);
+    const runsApi = createRunsAutomationsApi(context);
     await runsApi.grantProEntitlement(admin);
 
     context.mocks.googleGenAi.constructorArgs.mockClear();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -15,7 +15,7 @@ import { MODEL_FIRST_SELECTION_PROVIDER_ID } from "../../services/zero-model-sel
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 /**
@@ -29,7 +29,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const context = testContext();
 const bdd = createBddApi(context);
-const api = createRunsSchedulesApi(context);
+const api = createRunsAutomationsApi(context);
 const chat = createChatFilesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -33,7 +33,7 @@ import {
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -49,7 +49,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
 const bdd = createBddApi(context);
-const api = createRunsSchedulesApi(context);
+const api = createRunsAutomationsApi(context);
 const chat = createChatFilesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
@@ -344,7 +344,7 @@ async function disableComputerUse(actor: ApiTestUser): Promise<void> {
 
 /**
  * Raw chat send through the Hono app, for statuses the ts-rest contract does
- * not model (precedent: requestListAutomationsRaw in api-bdd-runs-schedules).
+ * not model (precedent: requestListAutomationsRaw in api-bdd-runs-automations).
  */
 async function requestSendMessageRaw(
   actor: ApiTestUser,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -41,9 +41,9 @@ import {
   mockGoogleDriveFilesList,
 } from "./helpers/api-bdd-connectors";
 import {
-  createRunsSchedulesApi,
-  uniqueScheduleName,
-} from "./helpers/api-bdd-runs-schedules";
+  createRunsAutomationsApi,
+  uniqueAutomationName,
+} from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
@@ -64,7 +64,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 const context = testContext();
 const store = createStore();
 const bdd = createBddApi(context);
-const api = createRunsSchedulesApi(context);
+const api = createRunsAutomationsApi(context);
 const chat = createChatFilesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
@@ -561,8 +561,8 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       prompt: "delete cascade anchor",
     });
     await claimChatRun(runnerGroup, main.runId);
-    const scheduleName = uniqueScheduleName("bdd-thread-linked");
-    await api.deploySchedule(actor, {
+    const scheduleName = uniqueAutomationName("bdd-thread-linked");
+    await api.deployAutomation(actor, {
       name: scheduleName,
       cronExpression: "0 9 * * *",
       timezone: "UTC",
@@ -612,9 +612,9 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       id: main.threadId,
     });
 
-    const schedulesBefore = await api.listSchedules(actor);
+    const schedulesBefore = await api.listAutomations(actor);
     expect(
-      schedulesBefore.schedules.some((schedule) => {
+      schedulesBefore.automations.some((schedule) => {
         return schedule.name === scheduleName;
       }),
     ).toBeTruthy();
@@ -631,9 +631,9 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     list = await chat.listThreads(actor, { agentId });
     expect(listedThreadIds(list)).not.toContain(main.threadId);
 
-    const schedulesAfter = await api.listSchedules(actor);
+    const schedulesAfter = await api.listAutomations(actor);
     expect(
-      schedulesAfter.schedules.some((schedule) => {
+      schedulesAfter.automations.some((schedule) => {
         return schedule.name === scheduleName;
       }),
     ).toBeFalsy();

--- a/turbo/apps/api/src/signals/routes/__tests__/composes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/composes.bdd.test.ts
@@ -23,7 +23,7 @@ import {
   zeroComposeDeleteToken,
 } from "./helpers/api-bdd-composes";
 import { mockClerkMembership } from "./helpers/api-bdd-github";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 
 /*
@@ -916,7 +916,7 @@ describe("COMPOSE-01 zero route errors", () => {
 
 describe("COMPOSE-01 delete protection and volume sweep", () => {
   it("blocks deletion while a run is pending and sweeps the instructions volume after", async () => {
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const actor = api.user();
     api.acceptAgentStorageWrites();
     runs.acceptStorageDownloads();

--- a/turbo/apps/api/src/signals/routes/__tests__/github-integration.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-integration.bdd.test.ts
@@ -7,7 +7,7 @@ import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   GITHUB_APP_CLIENT_ID,
@@ -822,7 +822,7 @@ describe("INT-03 G4: installation management", () => {
 describe("INT-03 G5: label listeners and capability tokens", () => {
   it("manages label listeners across roles and zero capability tokens", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const gh = createGithubBddApi(context);
 
     const actor = bdd.user();
@@ -1059,7 +1059,7 @@ describe("INT-03 G5: label listeners and capability tokens", () => {
 
 interface GithubRunHarness {
   readonly bdd: ReturnType<typeof createBddApi>;
-  readonly api: ReturnType<typeof createRunsSchedulesApi>;
+  readonly api: ReturnType<typeof createRunsAutomationsApi>;
   readonly webhooks: ReturnType<typeof createWebhookCallbackApi>;
   readonly gh: ReturnType<typeof createGithubBddApi>;
   readonly actor: ApiTestUser;
@@ -1074,7 +1074,7 @@ async function githubRunActor(
   senderGithubUserId: string,
 ): Promise<GithubRunHarness> {
   const bdd = createBddApi(context);
-  const api = createRunsSchedulesApi(context);
+  const api = createRunsAutomationsApi(context);
   const webhooks = createWebhookCallbackApi(context);
   const gh = createGithubBddApi(context);
 
@@ -1286,7 +1286,7 @@ async function waitForArrayLength<T>(
 }
 
 async function waitForRunnerJob(
-  api: ReturnType<typeof createRunsSchedulesApi>,
+  api: ReturnType<typeof createRunsAutomationsApi>,
   runnerGroup: string,
 ) {
   await api.heartbeatRunner(runnerGroup);
@@ -1307,7 +1307,7 @@ async function waitForRunnerJob(
 }
 
 async function waitForRunStatus(
-  api: ReturnType<typeof createRunsSchedulesApi>,
+  api: ReturnType<typeof createRunsAutomationsApi>,
   actor: ApiTestUser,
   runId: string,
   status: "cancelled" | "completed" | "failed" | "pending" | "running",
@@ -1381,7 +1381,7 @@ function runIdFromAuditComment(body: string): string {
 }
 
 async function claimNextGithubRun(
-  api: ReturnType<typeof createRunsSchedulesApi>,
+  api: ReturnType<typeof createRunsAutomationsApi>,
   runnerGroup: string,
 ): Promise<{
   readonly runId: string;
@@ -1419,7 +1419,7 @@ async function checkpointGithubRun(args: {
 }
 
 async function completeGithubRun(args: {
-  readonly api: ReturnType<typeof createRunsSchedulesApi>;
+  readonly api: ReturnType<typeof createRunsAutomationsApi>;
   readonly webhooks: ReturnType<typeof createWebhookCallbackApi>;
   readonly actor: ApiTestUser;
   readonly issueApi: CapturedIssueApi;
@@ -2089,7 +2089,7 @@ describe("HOOK-02/INT-03 G7: label dispatch context and trigger gating", () => {
 
   it("reports rejected and failed label dispatches through comments and callbacks", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const gh = createGithubBddApi(context);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -722,7 +722,7 @@ export function createComputerUseBddApi(context: TestContext) {
     },
 
     // Kept out of any shared safe-cron helper for the same shared-database
-    // reason as reconcileBillingCron in api-bdd-runs-schedules.ts: the
+    // reason as reconcileBillingCron in api-bdd-runs-automations.ts: the
     // screenshot-cleanup sweep is global (no org filter) and tombstones every
     // screenshot row older than the 30-day retention window. Only
     // computer-use.bdd.test.ts may invoke this cron, and only that file may

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -82,7 +82,7 @@ type ContractUpdateAutomationRequest = z.infer<
 type CreateTriggerRequest = z.infer<
   (typeof automationsByRefContract.addTrigger)["body"]
 >;
-type DeployScheduleRequest = {
+type DeployAutomationRequest = {
   readonly name: string;
   readonly cronExpression?: string;
   readonly atTime?: string;
@@ -95,9 +95,9 @@ type DeployScheduleRequest = {
   readonly enabled?: boolean;
   readonly chatThreadId?: string;
 };
-type CreateAutomationRequest = DeployScheduleRequest;
+type CreateAutomationRequest = DeployAutomationRequest;
 type UpdateAutomationRequest = Omit<
-  Partial<DeployScheduleRequest>,
+  Partial<DeployAutomationRequest>,
   "description" | "appendSystemPrompt"
 > & {
   readonly name?: string;
@@ -113,12 +113,9 @@ type CreateWebhookAutomationRequest = {
   readonly enabled?: boolean;
   readonly chatThreadId?: string;
 };
-type DeployScheduleResponse = {
-  readonly schedule: AutomationView;
+type DeployAutomationResponse = {
+  readonly automation: AutomationView;
   readonly created: boolean;
-};
-type ScheduleListResponse = {
-  readonly schedules: readonly AutomationView[];
 };
 type AutomationMutationResponse = {
   readonly automation: AutomationView;
@@ -282,7 +279,7 @@ function hasWebhookTrigger(automation: AutomationResponse): boolean {
   });
 }
 
-function scheduleResponseFromAutomation(
+function automationViewFromResponse(
   automation: AutomationResponse,
 ): AutomationView {
   const trigger = timeTriggerFor(automation);
@@ -324,7 +321,7 @@ function webhookResponseFromAutomation(
 
 function createTimeTriggerRequest(
   body: Pick<
-    DeployScheduleRequest,
+    DeployAutomationRequest,
     "cronExpression" | "atTime" | "intervalSeconds" | "timezone"
   >,
 ): CreateTriggerRequest | null {
@@ -382,7 +379,7 @@ function contractCreateAutomationBodyUnchecked(
     "prompt" in body &&
     "name" in body &&
     "agentId" in body &&
-    createTimeTriggerRequest(body as DeployScheduleRequest) !== null
+    createTimeTriggerRequest(body as DeployAutomationRequest) !== null
   ) {
     return contractCreateAutomationBody(body as CreateAutomationRequest);
   }
@@ -471,7 +468,7 @@ function runnerHeartbeatBody(
   };
 }
 
-export function createRunsSchedulesApi(context: TestContext) {
+export function createRunsAutomationsApi(context: TestContext) {
   return {
     configureRunnerGroup(): string {
       const group = `vm0/bdd-${randomUUID().slice(0, 8)}`;
@@ -1077,7 +1074,7 @@ export function createRunsSchedulesApi(context: TestContext) {
         [201],
       );
       return {
-        automation: scheduleResponseFromAutomation(response.body.automation),
+        automation: automationViewFromResponse(response.body.automation),
         created: true,
       };
     },
@@ -1106,7 +1103,7 @@ export function createRunsSchedulesApi(context: TestContext) {
       return {
         automations: response.body.automations
           .filter(hasTimeTrigger)
-          .map(scheduleResponseFromAutomation),
+          .map(automationViewFromResponse),
       };
     },
 
@@ -1174,7 +1171,7 @@ export function createRunsSchedulesApi(context: TestContext) {
         [200],
       );
       return {
-        automation: scheduleResponseFromAutomation(shown.body),
+        automation: automationViewFromResponse(shown.body),
         created: false,
       };
     },
@@ -1191,7 +1188,7 @@ export function createRunsSchedulesApi(context: TestContext) {
         }),
         [200],
       );
-      return scheduleResponseFromAutomation(response.body);
+      return automationViewFromResponse(response.body);
     },
 
     async disableAutomation(
@@ -1206,7 +1203,7 @@ export function createRunsSchedulesApi(context: TestContext) {
         }),
         [200],
       );
-      return scheduleResponseFromAutomation(response.body);
+      return automationViewFromResponse(response.body);
     },
 
     async requestRunAutomation(
@@ -1449,10 +1446,10 @@ export function createRunsSchedulesApi(context: TestContext) {
       return { status: response.status, body };
     },
 
-    async deploySchedule(
+    async deployAutomation(
       actor: ApiTestUser,
-      body: DeployScheduleRequest,
-    ): Promise<DeployScheduleResponse> {
+      body: DeployAutomationRequest,
+    ): Promise<DeployAutomationResponse> {
       const existingList = await accept(
         setupApp({ context })(automationsMainContract).list({
           headers: authenticate(context, actor),
@@ -1496,7 +1493,7 @@ export function createRunsSchedulesApi(context: TestContext) {
         }
         const nextTrigger = createTimeTriggerRequest(body);
         if (!nextTrigger) {
-          throw new Error("Schedule deployment requires a time trigger");
+          throw new Error("Automation deployment requires a time trigger");
         }
         await accept(
           setupApp({ context })(automationsByRefContract).addTrigger({
@@ -1534,7 +1531,7 @@ export function createRunsSchedulesApi(context: TestContext) {
           [200],
         );
         return {
-          schedule: scheduleResponseFromAutomation(shown.body),
+          automation: automationViewFromResponse(shown.body),
           created: false,
         };
       }
@@ -1547,12 +1544,12 @@ export function createRunsSchedulesApi(context: TestContext) {
         [201],
       );
       return {
-        schedule: scheduleResponseFromAutomation(response.body.automation),
+        automation: automationViewFromResponse(response.body.automation),
         created: true,
       };
     },
 
-    async requestDeployScheduleUnchecked(
+    async requestDeployAutomationUnchecked(
       actor: ApiTestUser | null,
       body: unknown,
       statuses: readonly (201 | 400 | 401 | 403 | 404)[],
@@ -1566,144 +1563,21 @@ export function createRunsSchedulesApi(context: TestContext) {
       );
     },
 
-    async listSchedules(actor: ApiTestUser): Promise<ScheduleListResponse> {
-      const response = await accept(
-        setupApp({ context })(automationsMainContract).list({
-          headers: authenticate(context, actor),
-        }),
-        [200],
-      );
-      return {
-        schedules: response.body.automations
-          .filter(hasTimeTrigger)
-          .map(scheduleResponseFromAutomation),
-      };
-    },
-
-    async requestListSchedules(
-      actor: ApiTestUser | null,
-      statuses: readonly (200 | 401 | 403)[],
-    ) {
-      return await accept(
-        setupApp({ context })(automationsMainContract).list({
-          headers: authenticate(context, actor),
-        }),
-        statuses,
-      );
-    },
-
-    async enableSchedule(
-      actor: ApiTestUser,
-      schedule: AutomationResourceRef,
-    ): Promise<AutomationView> {
-      const response = await accept(
-        setupApp({ context })(automationsByRefContract).enable({
-          headers: authenticate(context, actor),
-          params: { ref: automationRef(schedule) },
-          body: {},
-        }),
-        [200],
-      );
-      return scheduleResponseFromAutomation(response.body);
-    },
-
-    async disableSchedule(
-      actor: ApiTestUser,
-      schedule: AutomationResourceRef,
-    ): Promise<AutomationView> {
-      const response = await accept(
-        setupApp({ context })(automationsByRefContract).disable({
-          headers: authenticate(context, actor),
-          params: { ref: automationRef(schedule) },
-          body: {},
-        }),
-        [200],
-      );
-      return scheduleResponseFromAutomation(response.body);
-    },
-
-    async requestEnableSchedule(
-      actor: ApiTestUser | null,
-      schedule: AutomationResourceRef,
-      statuses: readonly (200 | 400 | 401 | 403 | 404)[],
-    ) {
-      return await accept(
-        setupApp({ context })(automationsByRefContract).enable({
-          headers: authenticate(context, actor),
-          params: { ref: automationRef(schedule) },
-          body: {},
-        }),
-        statuses,
-      );
-    },
-
-    async runScheduleNow(
-      actor: ApiTestUser,
-      scheduleId: string,
-      statuses: readonly (
-        | 201
-        | 400
-        | 401
-        | 402
-        | 403
-        | 404
-        | 409
-        | 429
-        | 503
-      )[],
-    ) {
-      return await accept(
-        setupApp({ context })(automationsByRefContract).run({
-          headers: authenticate(context, actor),
-          params: { ref: scheduleId },
-          body: {},
-        }),
-        statuses,
-      );
-    },
-
-    async deleteSchedule(
-      actor: ApiTestUser,
-      schedule: AutomationResourceRef,
-    ): Promise<void> {
-      await accept(
-        setupApp({ context })(automationsByRefContract).delete({
-          headers: authenticate(context, actor),
-          params: { ref: automationRef(schedule) },
-        }),
-        [204],
-      );
-    },
-
-    async requestDeleteSchedule(
-      actor: ApiTestUser | null,
-      schedule: AutomationResourceRef,
-      statuses: readonly (204 | 400 | 401 | 403 | 404)[],
-    ) {
-      return await accept(
-        setupApp({ context })(automationsByRefContract).delete({
-          headers: authenticate(context, actor),
-          params: { ref: automationRef(schedule) },
-        }),
-        statuses,
-      );
-    },
-
-    async requestDeleteScheduleAs(
+    async requestDeleteAutomationAs(
       authorization: string | undefined,
-      schedule: AutomationResourceRef,
+      automation: AutomationResourceRef,
       statuses: readonly (204 | 400 | 401 | 403 | 404)[],
     ) {
       return await accept(
         setupApp({ context })(automationsByRefContract).delete({
           headers: authorization === undefined ? {} : { authorization },
-          params: { ref: automationRef(schedule) },
+          params: { ref: automationRef(automation) },
         }),
         statuses,
       );
     },
 
-    async executeSchedulesCron(validAuth: boolean) {
+    async executeAutomationsCron(validAuth: boolean) {
       return await accept(
         setupApp({ context })(cronExecuteAutomationsContract).execute({
           headers: cronHeaders(validAuth),
@@ -1788,7 +1662,7 @@ export function createRunsSchedulesApi(context: TestContext) {
   };
 }
 
-export function uniqueScheduleName(prefix: string): string {
+export function uniqueAutomationName(prefix: string): string {
   return `${prefix}-${randomUUID().slice(0, 8)}`;
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
@@ -50,7 +50,7 @@ interface BearerCredential {
 /**
  * Session actor (Clerk mocks set on use) or a raw bearer token minted through
  * the API (PAT) or the test token signers (sandbox/zero). Precedent:
- * api-bdd-runs-schedules' raw-bearer run creation.
+ * api-bdd-runs-automations' raw-bearer run creation.
  */
 type Credential = ApiTestUser | BearerCredential;
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
@@ -27,7 +27,7 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../../../external/db";
 
-interface ScheduleSeed {
+interface AutomationSeed {
   readonly name: string;
   readonly prompt: string;
   readonly description?: string | null;
@@ -43,8 +43,8 @@ interface ScheduleSeed {
   readonly consecutiveFailures?: number;
 }
 
-interface SchedulesScenarioValues {
-  readonly schedules: readonly ScheduleSeed[];
+interface AutomationsScenarioValues {
+  readonly automations: readonly AutomationSeed[];
   readonly displayName?: string;
   readonly agentName?: string;
   readonly userName?: string | null;
@@ -53,7 +53,7 @@ interface SchedulesScenarioValues {
   readonly framework?: "claude-code" | "codex";
 }
 
-function resolveTriggerType(seed: ScheduleSeed): "cron" | "once" | "loop" {
+function resolveTriggerType(seed: AutomationSeed): "cron" | "once" | "loop" {
   if (seed.triggerType) {
     return seed.triggerType;
   }
@@ -66,11 +66,11 @@ function resolveTriggerType(seed: ScheduleSeed): "cron" | "once" | "loop" {
   return "loop";
 }
 
-export interface SchedulesFixture {
+export interface AutomationsFixture {
   readonly orgId: string;
   readonly userId: string;
   readonly composeId: string;
-  readonly scheduleIds: readonly string[];
+  readonly automationIds: readonly string[];
 }
 
 function agentEnvironment(
@@ -81,13 +81,13 @@ function agentEnvironment(
     : { ANTHROPIC_API_KEY: "test-key" };
 }
 
-// Schedules live on the events-first tables (phase 3 of #16847): seed an
+// Automations live on the events-first tables (phase 3 of #16847): seed an
 // automation (identity + intent) plus its single time trigger (recurrence +
 // runtime state). The returned id is the automation id.
-async function seedSchedule(
+async function seedAutomation(
   writeDb: Db,
   args: {
-    readonly seed: ScheduleSeed;
+    readonly seed: AutomationSeed;
     readonly composeId: string;
     readonly userId: string;
     readonly orgId: string;
@@ -98,7 +98,7 @@ async function seedSchedule(
     .values({ userId: args.userId, agentComposeId: args.composeId })
     .returning({ id: chatThreads.id });
   if (!thread) {
-    throw new Error("seedSchedule: chat thread insert returned no row");
+    throw new Error("seedAutomation: chat thread insert returned no row");
   }
   const enabled = args.seed.enabled ?? true;
   const [automation] = await writeDb
@@ -117,7 +117,7 @@ async function seedSchedule(
     })
     .returning({ id: automations.id });
   if (!automation) {
-    throw new Error("seedSchedule: automation insert returned no row");
+    throw new Error("seedAutomation: automation insert returned no row");
   }
   await writeDb.insert(automationTriggers).values({
     automationId: automation.id,
@@ -134,12 +134,12 @@ async function seedSchedule(
   return automation.id;
 }
 
-export const seedSchedulesScenario$ = command(
+export const seedAutomationsScenario$ = command(
   async (
     { set },
-    values: SchedulesScenarioValues,
+    values: AutomationsScenarioValues,
     signal: AbortSignal,
-  ): Promise<SchedulesFixture> => {
+  ): Promise<AutomationsFixture> => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     const composeId = randomUUID();
@@ -210,26 +210,26 @@ export const seedSchedulesScenario$ = command(
     });
     signal.throwIfAborted();
 
-    const scheduleIds: string[] = [];
-    for (const seed of values.schedules) {
-      const scheduleId = await seedSchedule(writeDb, {
+    const automationIds: string[] = [];
+    for (const seed of values.automations) {
+      const automationId = await seedAutomation(writeDb, {
         seed,
         composeId,
         userId,
         orgId,
       });
       signal.throwIfAborted();
-      scheduleIds.push(scheduleId);
+      automationIds.push(automationId);
     }
 
-    return { orgId, userId, composeId, scheduleIds };
+    return { orgId, userId, composeId, automationIds };
   },
 );
 
-export const deleteSchedulesScenario$ = command(
+export const deleteAutomationsScenario$ = command(
   async (
     { set },
-    fixture: SchedulesFixture,
+    fixture: AutomationsFixture,
     signal: AbortSignal,
   ): Promise<void> => {
     const writeDb = set(writeDb$);
@@ -259,11 +259,11 @@ export const deleteSchedulesScenario$ = command(
       signal.throwIfAborted();
     }
 
-    if (fixture.scheduleIds.length > 0) {
+    if (fixture.automationIds.length > 0) {
       // Trigger rows are removed by the FK cascade.
       await writeDb
         .delete(automations)
-        .where(inArray(automations.id, [...fixture.scheduleIds]));
+        .where(inArray(automations.id, [...fixture.automationIds]));
       signal.throwIfAborted();
     }
     if (runIds.length > 0) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-usage-insight.ts
@@ -40,7 +40,7 @@ interface SeedRunArgs {
   readonly userId: string;
   readonly composeId: string;
   readonly triggerSource?: string;
-  readonly scheduleId?: string;
+  readonly automationId?: string;
   readonly chatThreadId?: string;
   readonly status?: string;
   readonly prompt?: string;
@@ -54,7 +54,7 @@ interface SeedRunArgs {
   readonly lastEventSequence?: number | null;
 }
 
-interface SeedScheduleArgs {
+interface SeedAutomationArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -105,7 +105,7 @@ interface BonusUsageEvent {
   readonly status: string;
 }
 
-interface ScheduleBatchArgs {
+interface AutomationBatchArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly composeId: string;
@@ -383,7 +383,7 @@ export const seedRun$ = command(
     await db.insert(zeroRuns).values({
       id: run.id,
       triggerSource: args.triggerSource ?? "cli",
-      automationId: args.scheduleId ?? null,
+      automationId: args.automationId ?? null,
       chatThreadId: args.chatThreadId ?? null,
     });
     signal.throwIfAborted();
@@ -391,10 +391,10 @@ export const seedRun$ = command(
   },
 );
 
-export const seedSchedule$ = command(
+export const seedAutomation$ = command(
   async (
     { set },
-    args: SeedScheduleArgs,
+    args: SeedAutomationArgs,
     signal: AbortSignal,
   ): Promise<string> => {
     const db = set(writeDb$);
@@ -404,7 +404,7 @@ export const seedSchedule$ = command(
       .returning({ id: chatThreads.id });
     signal.throwIfAborted();
     if (!thread) {
-      throw new Error("seedSchedule$: chat thread insert returned no row");
+      throw new Error("seedAutomation$: chat thread insert returned no row");
     }
     const [row] = await db
       .insert(automations)
@@ -421,7 +421,7 @@ export const seedSchedule$ = command(
       .returning({ id: automations.id });
     signal.throwIfAborted();
     if (!row) {
-      throw new Error("seedSchedule$: insert returned no row");
+      throw new Error("seedAutomation$: insert returned no row");
     }
     return row.id;
   },
@@ -614,12 +614,12 @@ export const setUsageEventCreatedAt$ = command(
   },
 );
 
-export const seedScheduleBatch$ = command(
+export const seedAutomationBatch$ = command(
   async (
     { set },
-    args: ScheduleBatchArgs,
+    args: AutomationBatchArgs,
     signal: AbortSignal,
-  ): Promise<{ scheduleIds: string[] }> => {
+  ): Promise<{ automationIds: string[] }> => {
     const db = set(writeDb$);
     const indices = Array.from({ length: args.count }, (_, index) => {
       return index;
@@ -632,10 +632,10 @@ export const seedScheduleBatch$ = command(
           .returning({ id: chatThreads.id });
         if (!thread) {
           throw new Error(
-            "seedScheduleBatch$: chat thread insert returned no row",
+            "seedAutomationBatch$: chat thread insert returned no row",
           );
         }
-        const [scheduleRow] = await db
+        const [automationRow] = await db
           .insert(automations)
           .values({
             agentId: args.composeId,
@@ -647,9 +647,9 @@ export const seedScheduleBatch$ = command(
             chatThreadId: thread.id,
           })
           .returning({ id: automations.id });
-        if (!scheduleRow) {
+        if (!automationRow) {
           throw new Error(
-            "seedScheduleBatch$: schedule insert returned no row",
+            "seedAutomationBatch$: automation insert returned no row",
           );
         }
         const versionId = randomUUID();
@@ -671,7 +671,9 @@ export const seedScheduleBatch$ = command(
           })
           .returning({ id: agentSessions.id });
         if (!session) {
-          throw new Error("seedScheduleBatch$: session insert returned no row");
+          throw new Error(
+            "seedAutomationBatch$: session insert returned no row",
+          );
         }
         const [run] = await db
           .insert(agentRuns)
@@ -685,12 +687,12 @@ export const seedScheduleBatch$ = command(
           })
           .returning({ id: agentRuns.id });
         if (!run) {
-          throw new Error("seedScheduleBatch$: run insert returned no row");
+          throw new Error("seedAutomationBatch$: run insert returned no row");
         }
         await db.insert(zeroRuns).values({
           id: run.id,
           triggerSource: "automation",
-          automationId: scheduleRow.id,
+          automationId: automationRow.id,
         });
         const credits = args.creditsForIndex(index);
         await db.insert(usageEvent).values({
@@ -722,10 +724,10 @@ export const seedScheduleBatch$ = command(
             processedAt: bonus.status === "processed" ? nowDate() : null,
           });
         }
-        return scheduleRow.id;
+        return automationRow.id;
       }),
     );
     signal.throwIfAborted();
-    return { scheduleIds: results };
+    return { automationIds: results };
   },
 );

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -10,7 +10,7 @@ import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { hostedTextFile } from "./helpers/api-bdd-chat-files";
 import { createHostMapsBddApi } from "./helpers/api-bdd-host-maps";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 
 /*
 FILE-01 host APIs plus BILL-02/CHAIN-BILLING-MEDIA maps billing. Replaces the
@@ -400,7 +400,7 @@ describe("BILL-02/CHAIN-BILLING-MEDIA: maps operations settle credits through pu
   it("charges marked-up Google Maps prices across geocode, directions, places, and details [MAPS-A]", async () => {
     const bdd = createBddApi(context);
     const billing = createBillingMediaApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const admin = bdd.user();
     bdd.acceptAgentStorageWrites();
     await runs.grantProEntitlement(admin);
@@ -635,7 +635,7 @@ describe("CHAIN-BILLING-MEDIA/FILE-01: run-scoped zero-token attribution", () =>
     const bdd = createBddApi(context);
     const api = createHostMapsBddApi(context);
     const billing = createBillingMediaApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     runs.acceptStorageDownloads();

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -16,7 +16,7 @@ import {
   telegramLoginAuth,
   type ForwardedInternalCallback,
 } from "./helpers/api-bdd-integrations";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 /*
@@ -34,7 +34,7 @@ helper gap:
 const context = testContext();
 const bdd = createBddApi(context);
 const integrations = createBddIntegrationApi(context);
-const runs = createRunsSchedulesApi(context);
+const runs = createRunsAutomationsApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const TELEGRAM_BOT_ID = 99_887_766;
 const TELEGRAM_BOT_TOKEN = `${TELEGRAM_BOT_ID}:bdd-token`;

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -8,7 +8,7 @@ import { testContext } from "../../../__tests__/test-helpers";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 /*
@@ -20,7 +20,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
  * it from any other test file would race this file's far-past observation
  * windows on the shared database — the same single-file-ownership rule as the
  * email drain / billing reconcile / screenshot cleanup crons (see
- * runSafeCronRoutes in helpers/api-bdd-runs-schedules.ts).
+ * runSafeCronRoutes in helpers/api-bdd-runs-automations.ts).
  *
  * Shared-DB time design: the model-stats chain derives a random far-past UTC
  * day (2003-2009) per run and asserts rankings as baseline+delta, so leftovers
@@ -46,7 +46,7 @@ async function entitledRunActor(): Promise<{
   readonly agentId: string;
 }> {
   const bdd = createBddApi(context);
-  const api = createRunsSchedulesApi(context);
+  const api = createRunsAutomationsApi(context);
   const actor = bdd.user();
   bdd.acceptAgentStorageWrites();
   api.acceptStorageDownloads();
@@ -149,7 +149,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 
   it("aggregates sandbox model observations into public rankings and applies retention", async () => {
     const api = createOpsLogsApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const model = "claude-sonnet-4-6";
 
@@ -365,7 +365,7 @@ describe("BILL-02: model usage aggregation and public rankings", () => {
 describe("OPS-01: run log search via /api/logs/search", () => {
   it("searches run logs with keyword, context, filters, and pagination through the api", async () => {
     const api = createOpsLogsApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
     const created = await runs.createRun(actor, {
       agentId,
@@ -481,7 +481,7 @@ describe("OPS-01: run log search via /api/logs/search", () => {
 
   it("scopes log search to the caller's organization runs", async () => {
     const api = createOpsLogsApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const first = await entitledRunActor();
     const firstRun = await runs.createRun(first.actor, {
       agentId: first.agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -8,7 +8,7 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd-auth-org";
 import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { expectApiError } from "./helpers/api-bdd";
 
 /*
@@ -952,7 +952,7 @@ describe("ORG-01/AGENT-02: team listing and default-agent recovery", () => {
 
 describe("ORG-03: onboarding setup edges", () => {
   it("gates non-admins, validates connectors, and survives clerk slug conflicts [ONBOARD-F]", async () => {
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     api.acceptAgentStorageWrites();
 
     const unauthenticated = await api.requestSetupOnboarding(
@@ -1112,7 +1112,7 @@ describe("ORG-03: onboarding setup edges", () => {
 
 describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
   it("serves org and member reads to a claimed run's zero token and rejects org writes [ORG-TOKEN-G]", async () => {
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const admin = api.user();
     api.acceptAgentStorageWrites();
     runs.acceptStorageDownloads();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -34,7 +34,7 @@ import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import {
   callbackDeliveryWithStatus,
@@ -104,7 +104,7 @@ function inlineFirewallApis(
 }
 
 async function waitForRunStatus(
-  api: ReturnType<typeof createRunsSchedulesApi>,
+  api: ReturnType<typeof createRunsAutomationsApi>,
   actor: ApiTestUser,
   runId: string,
   status: string,
@@ -118,7 +118,7 @@ async function waitForRunStatus(
 }
 
 async function waitForRunQueueLength(
-  api: ReturnType<typeof createRunsSchedulesApi>,
+  api: ReturnType<typeof createRunsAutomationsApi>,
   actor: ApiTestUser,
   length: number,
 ) {
@@ -210,7 +210,7 @@ async function entitledRunActor(): Promise<{
   };
 }> {
   const bdd = createBddApi(context);
-  const api = createRunsSchedulesApi(context);
+  const api = createRunsAutomationsApi(context);
   const actor = bdd.user();
   bdd.acceptAgentStorageWrites();
   api.acceptStorageDownloads();
@@ -274,7 +274,7 @@ function assistantOutputEvent(
 
 describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks", () => {
   it("creates, dispatches, claims, reports, and completes a run through public APIs", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -388,7 +388,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
   });
 
   it("resumes the previous session when a run is created with the same sessionId", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
 
     const first = await api.createRun(actor, {
@@ -428,7 +428,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 describe("RUN-01: admission boundaries beyond request validation", () => {
   it("rejects runs for onboarded organizations that never gained an entitlement", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     api.configureRunnerGroup();
@@ -468,7 +468,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
   });
 
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
 
     const first = await api.createRun(actor, {
@@ -510,7 +510,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
   });
 
   it("removes cancelled runs from the claimable queue", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
 
     const run = await api.createRun(actor, {
@@ -533,7 +533,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
 
 describe("RUN-01: zero run request validation and token boundaries", () => {
   it("rejects invalid zero run requests and run-scoped tokens without agent-run:write", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     const unauthenticated = await api.requestCreateRun(
@@ -628,7 +628,7 @@ describe("RUN-01: zero run request validation and token boundaries", () => {
 
   it("limits private agents to their owner and infers the agent from a session", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
 
     const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
@@ -664,7 +664,7 @@ describe("RUN-01: zero run request validation and token boundaries", () => {
 describe("RUN-02: model provider selection and vm0 admission", () => {
   it("gates vm0 runs on billing state and on unexpired credit grants", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
 
     // An org that never went through onboarding has no billing state at all,
     // so vm0 runs are refused before provider resolution.
@@ -705,7 +705,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
   });
 
   it("injects codex multi-auth provider credentials and proves them via firewall auth", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -793,7 +793,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
   });
 
   it("uses the requested provider instead of the caller's personal default", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const misc = createMiscRoutesApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -825,7 +825,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
   });
 
   it("runs thread-pinned member-scope providers and mounts codex custom skills", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const bdd = createBddApi(context);
     const chat = createChatFilesBddApi(context);
     const misc = createMiscRoutesApi(context);
@@ -928,7 +928,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
 
 describe("RUN-02: stored connector injection into claimed runs", () => {
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -993,7 +993,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   });
 
   it("injects manual-grant api-token connectors and their optional variables", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -1040,7 +1040,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   });
 
   it("keeps refresh-owned connector secrets out of the sandbox environment", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -1072,7 +1072,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   });
 
   it("withholds platform secrets from the sandbox environment", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-bdd");
@@ -1109,7 +1109,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   });
 
   it("ignores plain user secrets named like connector tokens", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const authOrg = createAuthOrgAgentsBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -1143,7 +1143,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 
   it("resolves compose secret references into direct run environments", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const authOrg = createAuthOrgAgentsBddApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
@@ -1186,7 +1186,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 
 describe("RUN-02: custom connectors, grants, and network policies", () => {
   it("injects enabled custom connector firewalls with resolvable org secrets", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -1250,7 +1250,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
   });
 
   it("keeps connector-owned vars out of custom connector base urls", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const authOrg = createAuthOrgAgentsBddApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -1303,7 +1303,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
   it("applies, scopes, expires, and snapshots user permission grants", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const { actor, runnerGroup } = await entitledRunActor();
 
@@ -1458,7 +1458,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 describe("RUN-01: zero runner context, queue promotion, and skills", () => {
   it("injects agent identity, tool hints, and user info into the runner context", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
@@ -1558,7 +1558,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     "does not add chat stream context to %s-triggered runs",
     async (triggerSource) => {
       const bdd = createBddApi(context);
-      const api = createRunsSchedulesApi(context);
+      const api = createRunsAutomationsApi(context);
       const connectors = createConnectorBddApi(context);
       const actor = bdd.user();
       bdd.acceptAgentStorageWrites();
@@ -1600,7 +1600,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
   );
 
   it("promotes queued runs with feature flags and a fresh api start time", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const computerUse = createComputerUseBddApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -1672,7 +1672,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
 
   it("mounts custom skills for claude-code zero agents", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const misc = createMiscRoutesApi(context);
     const { actor, runnerGroup } = await entitledRunActor();
 
@@ -1711,7 +1711,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
 
 describe("RUN-03: cancellation of dispatched and terminal runs", () => {
   it("cancels a claimed running run and treats repeat cancellation as settled", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     const run = await api.createRun(actor, {
@@ -1736,7 +1736,7 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
 
 describe("RUN-03: user-runner protocol and runner authentication", () => {
   it("dispatches, scopes, and claims runs through user API keys", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const apiKey = await api.createApiKey(actor);
     const bearer = `Bearer ${apiKey.token}`;
@@ -1863,7 +1863,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
   });
 
   it("rejects runner calls with malformed, revoked, or wrong runner credentials", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const bdd = createBddApi(context);
     const actor = bdd.user();
     const pollBody = { group: "vm0/bdd-auth", profiles: ["vm0/default"] };
@@ -1909,7 +1909,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
   });
 
   it("drops queued jobs whose runs reached a terminal state before the claim", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
 
@@ -1948,7 +1948,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
 
   it("returns null claim secretValues for direct compose runs without stored secrets", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
@@ -2007,7 +2007,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
 
 describe("HOOK-01/RUN-03: terminal run callbacks dispatch on cancellation", () => {
   it("delivers, fails, and retries chat run callbacks through cancellation side effects", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, agentId } = await entitledRunActor();
     mockOptionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "bdd-bypass");
@@ -2120,7 +2120,7 @@ describe("HOOK-01: agent callback summaries through replayed deliveries", () => 
     "https://openrouter.ai/api/v1/chat/completions";
 
   it("summarizes completed runs replayed through the agent callback route", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -2262,7 +2262,7 @@ describe("HOOK-01: agent callback summaries through replayed deliveries", () => 
 
 describe("HOOK-02: event-consumer dispatch failures", () => {
   it("surfaces required event-consumer failures and recovers on retry", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
@@ -2306,7 +2306,7 @@ describe("HOOK-02: event-consumer dispatch failures", () => {
 
 describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () => {
   it("acknowledges late assistant events when completion cleanup already wrote the run sequence", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const chatCallbacks = createChatCallbacksApi(context);
@@ -2391,7 +2391,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
   }, 90_000);
 
   it("persists assistant events into the linked thread and swallows optional consumer failures", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -2622,7 +2622,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
 
 describe("BILL-02: usage reads for an entitled organization with runs", () => {
   it("exposes usage runs, members, and processed usage events through public reads", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -2676,7 +2676,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
 
   it("aggregates usage members across organization users", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -2794,7 +2794,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
 
 describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhooks", () => {
   it("reports artifacts, volumes, model usage, and telemetry through sandbox webhooks", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const storages = createStoragesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -2993,7 +2993,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
   it("fails a clean exit whose run never reported a checkpoint", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
 
@@ -3023,7 +3023,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
   });
 
   it("reports the settled status when a checkpoint-less completion races a cancellation", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
 
@@ -3048,7 +3048,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
   });
 
   it("keeps a cancelled run settled when its checkpointed completion arrives late", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
 
@@ -3092,7 +3092,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
 
   it("checkpoints direct compose runs without vars and canonicalizes usage by event model", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
@@ -3228,7 +3228,7 @@ describe("BILL-01: billing entitlement reconciliation cron", () => {
   }
 
   it("recovers payment-failed subscriptions that became active again", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const { actor, granted } = await entitledRunActor();
     await failSubscription(granted);
@@ -3276,7 +3276,7 @@ describe("BILL-01: billing entitlement reconciliation cron", () => {
   });
 
   it("keeps recently paid-through subscriptions and downgrades stale ones", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const { actor, granted } = await entitledRunActor();
     await failSubscription(granted);
@@ -3329,7 +3329,7 @@ describe("BILL-01: billing entitlement reconciliation cron", () => {
   });
 
   it("clears cancelled subscriptions during reconciliation", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const { actor, granted } = await entitledRunActor();
     await failSubscription(granted);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -15,9 +15,9 @@ import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { storageTextFile } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import {
-  createRunsSchedulesApi,
-  uniqueScheduleName,
-} from "./helpers/api-bdd-runs-schedules";
+  createRunsAutomationsApi,
+  uniqueAutomationName,
+} from "./helpers/api-bdd-runs-automations";
 import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
@@ -42,7 +42,7 @@ const UTF8_ENCODING = ["utf", "8"].join("-");
 
 const context = testContext();
 const bdd = createBddApi(context);
-const api = createRunsSchedulesApi(context);
+const api = createRunsAutomationsApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const reads = createRunReadsApi(context);
 
@@ -2205,8 +2205,8 @@ describe("RUN-04/OPS-01: zero run logs", () => {
 
     // A far-future yearly cron keeps the global execute-schedules sweep from
     // ever considering this schedule due; only run-now fires it.
-    const schedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-log-sched"),
+    const schedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-log-sched"),
       agentId: agentOne.agentId,
       cronExpression: "0 0 1 1 *",
       prompt: "scheduled run for logs",
@@ -2214,9 +2214,9 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       timezone: "UTC",
       enabled: true,
     });
-    const scheduleRun = await api.runScheduleNow(
+    const scheduleRun = await api.requestRunAutomation(
       actor,
-      schedule.schedule.id,
+      schedule.automation.id,
       [201],
     );
     if (scheduleRun.status !== 201) {
@@ -2270,7 +2270,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     });
     expect(scheduleEntry).toMatchObject({
       triggerSource: "automation",
-      scheduleId: schedule.schedule.id,
+      scheduleId: schedule.automation.id,
     });
 
     const pageOne = await reads.requestListLogs(actor, { limit: 1 }, [200]);
@@ -2393,7 +2393,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
 
     const byScheduleId = await reads.requestListLogs(
       actor,
-      { scheduleId: schedule.schedule.id, limit: 1 },
+      { scheduleId: schedule.automation.id, limit: 1 },
       [200],
     );
     if (byScheduleId.status !== 200) {
@@ -2422,7 +2422,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     expect(scheduleDetail.body).toMatchObject({
       id: scheduleRun.body.runId,
       triggerSource: "automation",
-      scheduleId: schedule.schedule.id,
+      scheduleId: schedule.automation.id,
     });
 
     const pendingRun = await api.createRun(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -21,9 +21,9 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createEmailApi } from "./helpers/api-bdd-email";
 import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import {
-  createRunsSchedulesApi,
-  uniqueScheduleName,
-} from "./helpers/api-bdd-runs-schedules";
+  createRunsAutomationsApi,
+  uniqueAutomationName,
+} from "./helpers/api-bdd-runs-automations";
 import {
   callbackDeliveryWithStatus,
   createWebhookCallbackApi,
@@ -183,7 +183,7 @@ async function createAgentWithModelProvider(actor: ApiTestUser): Promise<{
     visibility: "private",
   });
 
-  const api = createRunsSchedulesApi(context);
+  const api = createRunsAutomationsApi(context);
   await api.ensureOrgModelProvider(actor);
 
   return { agentId: agent.agentId };
@@ -213,7 +213,7 @@ async function entitledScheduleActor(): Promise<{
   readonly runnerGroup: string;
 }> {
   const bdd = createBddApi(context);
-  const api = createRunsSchedulesApi(context);
+  const api = createRunsAutomationsApi(context);
   const actor = bdd.user();
   bdd.acceptAgentStorageWrites();
   api.acceptStorageDownloads();
@@ -229,9 +229,9 @@ async function entitledScheduleActor(): Promise<{
   return { actor, agentId: agent.agentId, runnerGroup };
 }
 
-async function executeSchedulesCronOk(): Promise<void> {
+async function executeAutomationsCronOk(): Promise<void> {
   const response =
-    await createRunsSchedulesApi(context).executeSchedulesCron(true);
+    await createRunsAutomationsApi(context).executeAutomationsCron(true);
   if (response.status !== 200) {
     throw new Error("Expected execute schedules cron to succeed");
   }
@@ -301,7 +301,7 @@ function zeroToken(
 describe("RUN-01: run creation admission and validation", () => {
   it("rejects invalid or unauthorized run creation requests through API validation", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
 
     const unauthenticated = await api.requestCreateRun(
@@ -366,7 +366,7 @@ describe("RUN-01: run creation admission and validation", () => {
 describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", () => {
   it("sets up run prerequisites through APIs and exposes the no-credit admission boundary", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const { agentId } = await createAgentWithModelProvider(actor);
 
@@ -410,7 +410,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
   });
 
   it("keeps official runner held-session heartbeat and empty polling visible through public endpoints", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const runnerGroup = api.configureRunnerGroup();
     const heldSessionStates = [
       {
@@ -456,7 +456,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
   it("keeps missing run detail and context hidden for another organization", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const outsider = bdd.user();
     const missingRunId = randomUUID();
 
@@ -475,7 +475,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
   it("rejects runner metadata reads and job claims at unauthenticated, malformed, and missing boundaries", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const missingRunId = randomUUID();
     const invalidRunId = "not-a-run-id";
@@ -531,7 +531,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
   it("rejects malformed and unauthenticated runner, queue, read, context, and cancel requests", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const missingRunId = randomUUID();
     const invalidRunId = "not-a-run-id";
@@ -617,7 +617,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
   });
 
   it("issues runner realtime tokens only for authenticated vm0 runner groups", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
 
     const unauthenticated = await api.requestRunnerRealtimeToken(
       false,
@@ -676,17 +676,17 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
   it("creates, lists, enables, reaches manual run admission, disables, and deletes a schedule", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const outsider = bdd.user();
     const { agentId } = await createAgentWithModelProvider(actor);
-    const scheduleName = uniqueScheduleName("bdd-schedule");
+    const scheduleName = uniqueAutomationName("bdd-schedule");
 
-    const unauthorizedList = await api.requestListSchedules(null, [401]);
+    const unauthorizedList = await api.requestListAutomations(null, [401]);
     expectApiError(unauthorizedList.body);
     expect(unauthorizedList.body.error.code).toBe("UNAUTHORIZED");
 
-    const invalidBody = await api.requestDeployScheduleUnchecked(
+    const invalidBody = await api.requestDeployAutomationUnchecked(
       actor,
       {
         name: scheduleName,
@@ -699,7 +699,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     expectApiError(invalidBody.body);
     expect(invalidBody.body.error.code).toBe("BAD_REQUEST");
 
-    const deployed = await api.deploySchedule(actor, {
+    const deployed = await api.deployAutomation(actor, {
       name: scheduleName,
       agentId,
       intervalSeconds: 60,
@@ -709,7 +709,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
     });
     expect(deployed.created).toBeTruthy();
-    expect(deployed.schedule).toMatchObject({
+    expect(deployed.automation).toMatchObject({
       name: scheduleName,
       agentId,
       enabled: false,
@@ -717,39 +717,43 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       intervalSeconds: 60,
     });
 
-    const listedAfterCreate = await api.listSchedules(actor);
+    const listedAfterCreate = await api.listAutomations(actor);
     expect(
-      findSchedule(listedAfterCreate.schedules, deployed.schedule.id),
+      findSchedule(listedAfterCreate.automations, deployed.automation.id),
     ).toBeDefined();
 
-    const enabled = await api.enableSchedule(actor, deployed.schedule);
+    const enabled = await api.enableAutomation(actor, deployed.automation);
     expect(enabled.enabled).toBeTruthy();
     expect(enabled.nextRunAt).not.toBeNull();
 
-    const outsiderEnable = await api.requestEnableSchedule(
+    const outsiderEnable = await api.requestEnableAutomation(
       outsider,
-      deployed.schedule,
+      deployed.automation,
       [404],
     );
     expectApiError(outsiderEnable.body);
     expect(outsiderEnable.body.error.code).toBe("NOT_FOUND");
 
-    const runNow = await api.runScheduleNow(actor, deployed.schedule.id, [402]);
+    const runNow = await api.requestRunAutomation(
+      actor,
+      deployed.automation.id,
+      [402],
+    );
     expectApiError(runNow.body);
     expect(runNow.body.error.code).toBe("INSUFFICIENT_CREDITS");
 
-    const disabled = await api.disableSchedule(actor, deployed.schedule);
+    const disabled = await api.disableAutomation(actor, deployed.automation);
     expect(disabled.enabled).toBeFalsy();
 
-    await api.deleteSchedule(actor, deployed.schedule);
-    const listedAfterDelete = await api.listSchedules(actor);
+    await api.deleteAutomation(actor, deployed.automation);
+    const listedAfterDelete = await api.listAutomations(actor);
     expect(
-      findSchedule(listedAfterDelete.schedules, deployed.schedule.id),
+      findSchedule(listedAfterDelete.automations, deployed.automation.id),
     ).toBeUndefined();
 
-    const deleteAgain = await api.requestDeleteSchedule(
+    const deleteAgain = await api.requestDeleteAutomation(
       actor,
-      deployed.schedule,
+      deployed.automation,
       [404],
     );
     expectApiError(deleteAgain.body);
@@ -757,7 +761,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
   });
 
   it("manually runs a schedule through chat, claim, model, and grant surfaces", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledScheduleActor();
@@ -789,8 +793,8 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       action: "allow",
     });
 
-    const deployed = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-run-now"),
+    const deployed = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-run-now"),
       agentId,
       cronExpression: "0 9 * * *",
       prompt: "Manual run test",
@@ -800,9 +804,9 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
     });
 
-    const created = await api.runScheduleNow(
+    const created = await api.requestRunAutomation(
       actor,
-      deployed.schedule.id,
+      deployed.automation.id,
       [201],
     );
     if (created.status !== 201) {
@@ -812,17 +816,17 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
 
     const thread = await chat.listThreadMessages(
       actor,
-      deployed.schedule.chatThreadId,
+      deployed.automation.chatThreadId,
     );
     const userMessage = thread.messages.find((message) => {
       return message.role === "user" && message.runId === runId;
     });
     expect(userMessage).toMatchObject({
       content: "Manual run test",
-      scheduleTitle: deployed.schedule.name,
+      scheduleTitle: deployed.automation.name,
       scheduleSnapshot: {
-        id: deployed.schedule.id,
-        title: deployed.schedule.name,
+        id: deployed.automation.id,
+        title: deployed.automation.name,
         description: "Run-now schedule description",
       },
     });
@@ -832,7 +836,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     const claim = await api.claimRunnerJob(runId);
     expect(claim.prompt).toBe("Manual run test");
     expect(claim.appendSystemPrompt).toContain(
-      "# Current Integration\nYou are currently running inside: Schedule",
+      "# Current Integration\nYou are currently running inside: Automation",
     );
     expect(claim.appendSystemPrompt).toContain("Trigger type: manual");
     expect(claim.appendSystemPrompt).toContain(
@@ -842,26 +846,26 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     expect(claim.networkPolicies?.slack?.allow).toContain("chat:write");
     expect(claim.networkPolicies?.slack?.deny).not.toContain("chat:write");
 
-    const conflict = await api.runScheduleNow(
+    const conflict = await api.requestRunAutomation(
       actor,
-      deployed.schedule.id,
+      deployed.automation.id,
       [409],
     );
     expectApiError(conflict.body);
     expect(conflict.body.error.code).toBe("CONFLICT");
 
     await api.requestCancelRun(actor, runId, [200]);
-    await api.deleteSchedule(actor, deployed.schedule);
+    await api.deleteAutomation(actor, deployed.automation);
   });
 
   it("redeploys a cron schedule and exposes updated state through schedule list", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const { agentId } = await createAgentWithModelProvider(actor);
-    const scheduleName = uniqueScheduleName("bdd-cron-update");
+    const scheduleName = uniqueAutomationName("bdd-cron-update");
 
-    const deployed = await api.deploySchedule(actor, {
+    const deployed = await api.deployAutomation(actor, {
       name: scheduleName,
       agentId,
       cronExpression: "0 9 * * *",
@@ -871,7 +875,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
     });
     expect(deployed.created).toBeTruthy();
-    expect(deployed.schedule).toMatchObject({
+    expect(deployed.automation).toMatchObject({
       name: scheduleName,
       agentId,
       triggerType: "cron",
@@ -882,7 +886,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
     });
 
-    const updated = await api.deploySchedule(actor, {
+    const updated = await api.deployAutomation(actor, {
       name: scheduleName,
       agentId,
       cronExpression: "30 9 * * *",
@@ -892,9 +896,11 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
     });
     expect(updated.created).toBeFalsy();
-    expect(updated.schedule.id).toBe(deployed.schedule.id);
-    expect(updated.schedule.chatThreadId).toBe(deployed.schedule.chatThreadId);
-    expect(updated.schedule).toMatchObject({
+    expect(updated.automation.id).toBe(deployed.automation.id);
+    expect(updated.automation.chatThreadId).toBe(
+      deployed.automation.chatThreadId,
+    );
+    expect(updated.automation).toMatchObject({
       name: scheduleName,
       agentId,
       triggerType: "cron",
@@ -905,13 +911,16 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
     });
 
-    const listed = await api.listSchedules(actor);
-    const listedSchedule = findSchedule(listed.schedules, deployed.schedule.id);
+    const listed = await api.listAutomations(actor);
+    const listedSchedule = findSchedule(
+      listed.automations,
+      deployed.automation.id,
+    );
     if (!listedSchedule) {
       throw new Error("Expected redeployed schedule to be visible in list");
     }
     expect(listedSchedule).toMatchObject({
-      id: deployed.schedule.id,
+      id: deployed.automation.id,
       name: scheduleName,
       agentId,
       triggerType: "cron",
@@ -920,15 +929,15 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       prompt: "Run the updated morning report.",
       description: "Updated morning cron report",
       enabled: false,
-      chatThreadId: deployed.schedule.chatThreadId,
+      chatThreadId: deployed.automation.chatThreadId,
     });
 
-    await api.deleteSchedule(actor, updated.schedule);
+    await api.deleteAutomation(actor, updated.automation);
   });
 
   it("links schedules to chat threads and keeps mutation boundaries visible", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const actor = bdd.user();
     const outsider = bdd.user();
@@ -953,10 +962,10 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       title: "Outsider thread",
     });
 
-    const crossUserThread = await api.requestDeployScheduleUnchecked(
+    const crossUserThread = await api.requestDeployAutomationUnchecked(
       actor,
       {
-        name: uniqueScheduleName("bdd-cross-thread"),
+        name: uniqueAutomationName("bdd-cross-thread"),
         agentId,
         cronExpression: "0 9 * * *",
         prompt: "Should not link a foreign thread.",
@@ -970,8 +979,8 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     expect(crossUserThread.body.error.code).toBe("BAD_REQUEST");
 
     context.mocks.ably.publish.mockClear();
-    const linked = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-linked-thread"),
+    const linked = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-linked-thread"),
       agentId,
       cronExpression: "0 9 * * *",
       prompt: "Run the linked thread report.",
@@ -980,14 +989,14 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       enabled: false,
       chatThreadId: linkedThread.id,
     });
-    expect(linked.schedule.chatThreadId).toBe(linkedThread.id);
+    expect(linked.automation.chatThreadId).toBe(linkedThread.id);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      `chatThreadSchedulesChanged:${linkedThread.id}`,
+      `chatThreadAutomationsChanged:${linkedThread.id}`,
       null,
     );
 
-    const redeployed = await api.deploySchedule(actor, {
-      name: linked.schedule.name,
+    const redeployed = await api.deployAutomation(actor, {
+      name: linked.automation.name,
       agentId,
       cronExpression: "0 10 * * *",
       prompt: "Run the updated linked thread report.",
@@ -997,10 +1006,10 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       chatThreadId: otherThread.id,
     });
     expect(redeployed.created).toBeFalsy();
-    expect(redeployed.schedule.chatThreadId).toBe(linkedThread.id);
+    expect(redeployed.automation.chatThreadId).toBe(linkedThread.id);
 
-    const autoThreadSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-auto-thread"),
+    const autoThreadSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-auto-thread"),
       agentId,
       cronExpression: "0 11 * * *",
       prompt: "Run the auto-thread report.",
@@ -1010,14 +1019,14 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     });
     const autoThread = await chat.readThread(
       actor,
-      autoThreadSchedule.schedule.chatThreadId,
+      autoThreadSchedule.automation.chatThreadId,
     );
     expect(autoThread.title).toBe("Auto-created schedule thread");
 
-    const pastOnce = await api.requestDeployScheduleUnchecked(
+    const pastOnce = await api.requestDeployAutomationUnchecked(
       actor,
       {
-        name: uniqueScheduleName("bdd-past-once"),
+        name: uniqueAutomationName("bdd-past-once"),
         agentId,
         atTime: new Date(now() - 86_400_000).toISOString(),
         prompt: "Past one-time schedule",
@@ -1031,39 +1040,39 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     expect(pastOnce.body.error.code).toBe("BAD_REQUEST");
 
     const readOnlyToken = zeroToken(actor, ["automation:read"]);
-    const forbiddenDelete = await api.requestDeleteScheduleAs(
+    const forbiddenDelete = await api.requestDeleteAutomationAs(
       `Bearer ${readOnlyToken}`,
-      autoThreadSchedule.schedule,
+      autoThreadSchedule.automation,
       [403],
     );
     expectApiError(forbiddenDelete.body);
     expect(forbiddenDelete.body.error.code).toBe("FORBIDDEN");
 
-    const missingDelete = await api.requestDeleteSchedule(
+    const missingDelete = await api.requestDeleteAutomation(
       actor,
-      { name: uniqueScheduleName("bdd-missing-delete") },
+      { name: uniqueAutomationName("bdd-missing-delete") },
       [404],
     );
     expectApiError(missingDelete.body);
     expect(missingDelete.body.error.code).toBe("NOT_FOUND");
 
     context.mocks.ably.publish.mockClear();
-    await api.deleteSchedule(actor, linked.schedule);
+    await api.deleteAutomation(actor, linked.automation);
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      `chatThreadSchedulesChanged:${linkedThread.id}`,
+      `chatThreadAutomationsChanged:${linkedThread.id}`,
       null,
     );
-    await api.deleteSchedule(actor, autoThreadSchedule.schedule);
+    await api.deleteAutomation(actor, autoThreadSchedule.automation);
   });
 
   it("lets cron execution process a due loop schedule and exposes the transition through list", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const { agentId } = await createAgentWithModelProvider(actor);
-    const scheduleName = uniqueScheduleName("bdd-cron");
+    const scheduleName = uniqueAutomationName("bdd-cron");
 
-    const deployed = await api.deploySchedule(actor, {
+    const deployed = await api.deployAutomation(actor, {
       name: scheduleName,
       agentId,
       intervalSeconds: 1,
@@ -1072,9 +1081,9 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
       timezone: "UTC",
       enabled: true,
     });
-    expect(deployed.schedule.nextRunAt).not.toBeNull();
+    expect(deployed.automation.nextRunAt).not.toBeNull();
 
-    const cron = await api.executeSchedulesCron(true);
+    const cron = await api.executeAutomationsCron(true);
     if (cron.status !== 200) {
       throw new Error("Expected execute schedules cron to succeed");
     }
@@ -1082,9 +1091,9 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
     expect(cron.body.executed).toBe(0);
     expect(cron.body.skipped).toBeGreaterThanOrEqual(1);
 
-    const afterCron = await api.listSchedules(actor);
-    const schedule = afterCron.schedules.find((item) => {
-      return item.id === deployed.schedule.id;
+    const afterCron = await api.listAutomations(actor);
+    const schedule = afterCron.automations.find((item) => {
+      return item.id === deployed.automation.id;
     });
     expect(schedule?.lastRunAt).not.toBeNull();
     expect(schedule?.consecutiveFailures).toBeGreaterThanOrEqual(1);
@@ -1093,7 +1102,7 @@ describe("SCHED-01 and CHAIN-SCHEDULE: schedule lifecycle", () => {
 
 describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
   it("executes due cron and one-time schedules and exposes the runs through queue, chat, and runner reads", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledScheduleActor();
     const cronPrompt = "Run the scheduled morning report.";
@@ -1104,8 +1113,8 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     const base = now();
     mockNow(base);
 
-    const cronSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-exec-cron"),
+    const cronSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-exec-cron"),
       agentId,
       cronExpression: "*/5 * * * *",
       prompt: cronPrompt,
@@ -1114,10 +1123,10 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       timezone: "UTC",
       enabled: true,
     });
-    expect(cronSchedule.schedule.nextRunAt).not.toBeNull();
+    expect(cronSchedule.automation.nextRunAt).not.toBeNull();
 
-    const onceSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-exec-once"),
+    const onceSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-exec-once"),
       agentId,
       atTime: new Date(base + 5 * 60_000).toISOString(),
       prompt: oncePrompt,
@@ -1125,21 +1134,23 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       timezone: "UTC",
       enabled: true,
     });
-    expect(onceSchedule.schedule.nextRunAt).not.toBeNull();
+    expect(onceSchedule.automation.nextRunAt).not.toBeNull();
 
-    await executeSchedulesCronOk();
-    const preDue = await api.listSchedules(actor);
+    await executeAutomationsCronOk();
+    const preDue = await api.listAutomations(actor);
     expect(
-      mustFindSchedule(preDue.schedules, cronSchedule.schedule.id).lastRunAt,
+      mustFindSchedule(preDue.automations, cronSchedule.automation.id)
+        .lastRunAt,
     ).toBeNull();
     expect(
-      mustFindSchedule(preDue.schedules, onceSchedule.schedule.id).lastRunAt,
+      mustFindSchedule(preDue.automations, onceSchedule.automation.id)
+        .lastRunAt,
     ).toBeNull();
 
     mockNow(base + 6 * 60_000);
     const [firstCron, secondCron] = await Promise.all([
-      api.executeSchedulesCron(true),
-      api.executeSchedulesCron(true),
+      api.executeAutomationsCron(true),
+      api.executeAutomationsCron(true),
     ]);
     expect(firstCron.status).toBe(200);
     expect(secondCron.status).toBe(200);
@@ -1148,10 +1159,10 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     expect(queue.body.concurrency.active).toBe(2);
     expect(queue.body.queue).toHaveLength(0);
 
-    const afterDue = await api.listSchedules(actor);
+    const afterDue = await api.listAutomations(actor);
     const cronAfterDue = mustFindSchedule(
-      afterDue.schedules,
-      cronSchedule.schedule.id,
+      afterDue.automations,
+      cronSchedule.automation.id,
     );
     expect(cronAfterDue).toMatchObject({
       enabled: true,
@@ -1161,21 +1172,21 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     });
     expect(cronAfterDue.lastRunAt).not.toBeNull();
     const onceAfterDue = mustFindSchedule(
-      afterDue.schedules,
-      onceSchedule.schedule.id,
+      afterDue.automations,
+      onceSchedule.automation.id,
     );
     expect(onceAfterDue).toMatchObject({ enabled: false, nextRunAt: null });
     expect(onceAfterDue.lastRunAt).not.toBeNull();
 
     const cronThread = await chat.listThreadMessages(
       actor,
-      cronSchedule.schedule.chatThreadId,
+      cronSchedule.automation.chatThreadId,
     );
     const cronRunId = scheduleRunIdFromThread(cronThread.messages, cronPrompt);
     expect(hasQueueMarker(cronThread.messages, cronRunId)).toBeFalsy();
     const onceThread = await chat.listThreadMessages(
       actor,
-      onceSchedule.schedule.chatThreadId,
+      onceSchedule.automation.chatThreadId,
     );
     const onceRunId = scheduleRunIdFromThread(onceThread.messages, oncePrompt);
     expect(onceRunId).not.toBe(cronRunId);
@@ -1184,14 +1195,14 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     const claim = await api.claimRunnerJob(cronRunId);
     expect(claim.prompt).toBe(cronPrompt);
     expect(claim.appendSystemPrompt).toContain(
-      "# Current Integration\nYou are currently running inside: Schedule",
+      "# Current Integration\nYou are currently running inside: Automation",
     );
     expect(claim.appendSystemPrompt).toContain("Trigger type: cron");
     expect(claim.appendSystemPrompt).toContain("Always respond in formal tone");
 
-    const conflict = await api.runScheduleNow(
+    const conflict = await api.requestRunAutomation(
       actor,
-      cronSchedule.schedule.id,
+      cronSchedule.automation.id,
       [409],
     );
     expectApiError(conflict.body);
@@ -1202,20 +1213,20 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     await api.requestCancelRun(actor, onceRunId, [200]);
     const emptied = await api.readRunQueue(actor);
     expect(emptied.body.concurrency.active).toBe(0);
-    await api.deleteSchedule(actor, cronSchedule.schedule);
-    await api.deleteSchedule(actor, onceSchedule.schedule);
+    await api.deleteAutomation(actor, cronSchedule.automation);
+    await api.deleteAutomation(actor, onceSchedule.automation);
   });
 
   it("skips a due schedule while its previous run is active and executes it after the run terminates", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, agentId } = await entitledScheduleActor();
     const prompt = "Run the skip-check report.";
     const base = now();
     mockNow(base);
 
-    const deployed = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-skip-active"),
+    const deployed = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-skip-active"),
       agentId,
       cronExpression: "0 9 * * *",
       prompt,
@@ -1223,12 +1234,12 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       timezone: "UTC",
       enabled: true,
     });
-    const deployedNextRunAt = deployed.schedule.nextRunAt;
+    const deployedNextRunAt = deployed.automation.nextRunAt;
     expect(deployedNextRunAt).not.toBeNull();
 
-    const manualRun = await api.runScheduleNow(
+    const manualRun = await api.requestRunAutomation(
       actor,
-      deployed.schedule.id,
+      deployed.automation.id,
       [201],
     );
     if (manualRun.status !== 201) {
@@ -1238,34 +1249,34 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
 
     const afterManual = await chat.listThreadMessages(
       actor,
-      deployed.schedule.chatThreadId,
+      deployed.automation.chatThreadId,
     );
     expect(scheduleUserMessages(afterManual.messages, prompt)).toHaveLength(1);
 
     mockNow(base + 25 * 3_600_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
 
     const skipped = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      deployed.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      deployed.automation.id,
     );
     expect(skipped.lastRunAt).toBeNull();
     expect(skipped.nextRunAt).toBe(deployedNextRunAt);
     expect(skipped.consecutiveFailures).toBe(0);
 
     await api.requestCancelRun(actor, manualRunId, [200]);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
 
     const executed = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      deployed.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      deployed.automation.id,
     );
     expect(executed.lastRunAt).not.toBeNull();
     expect(executed.nextRunAt).toBeNull();
 
     const afterCron = await chat.listThreadMessages(
       actor,
-      deployed.schedule.chatThreadId,
+      deployed.automation.chatThreadId,
     );
     const cronMessages = scheduleUserMessages(afterCron.messages, prompt);
     expect(cronMessages).toHaveLength(2);
@@ -1282,11 +1293,11 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
 
     clearMockNow();
     await api.requestCancelRun(actor, cronRunId, [200]);
-    await api.deleteSchedule(actor, deployed.schedule);
+    await api.deleteAutomation(actor, deployed.automation);
   });
 
   it("queues scheduled runs at the org concurrency limit and disables a queued one-time schedule", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const { actor, agentId } = await entitledScheduleActor();
     const cronPrompt = "Run the queued cron report.";
@@ -1307,8 +1318,8 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     // real-time blocking runs still count against the concurrency limit.
     const base = now();
     mockNow(base);
-    const cronSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-queue-cron"),
+    const cronSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-queue-cron"),
       agentId,
       cronExpression: "*/5 * * * *",
       prompt: cronPrompt,
@@ -1316,8 +1327,8 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       timezone: "UTC",
       enabled: true,
     });
-    const onceSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-queue-once"),
+    const onceSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-queue-once"),
       agentId,
       atTime: new Date(base + 5 * 60_000).toISOString(),
       prompt: oncePrompt,
@@ -1327,7 +1338,7 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     });
 
     mockNow(base + 6 * 60_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
 
     const queue = await api.readRunQueue(actor);
     expect(queue.body.queue).toHaveLength(2);
@@ -1335,23 +1346,23 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       return entry.runId;
     });
 
-    const schedules = await api.listSchedules(actor);
+    const schedules = await api.listAutomations(actor);
     expect(
-      mustFindSchedule(schedules.schedules, cronSchedule.schedule.id),
+      mustFindSchedule(schedules.automations, cronSchedule.automation.id),
     ).toMatchObject({ enabled: true, retryStartedAt: null, nextRunAt: null });
     expect(
-      mustFindSchedule(schedules.schedules, onceSchedule.schedule.id),
+      mustFindSchedule(schedules.automations, onceSchedule.automation.id),
     ).toMatchObject({ enabled: false, nextRunAt: null });
 
     const cronThread = await chat.listThreadMessages(
       actor,
-      cronSchedule.schedule.chatThreadId,
+      cronSchedule.automation.chatThreadId,
     );
     const cronRunId = scheduleRunIdFromThread(cronThread.messages, cronPrompt);
     expect(hasQueueMarker(cronThread.messages, cronRunId)).toBeTruthy();
     const onceThread = await chat.listThreadMessages(
       actor,
-      onceSchedule.schedule.chatThreadId,
+      onceSchedule.automation.chatThreadId,
     );
     const onceRunId = scheduleRunIdFromThread(onceThread.messages, oncePrompt);
     expect(hasQueueMarker(onceThread.messages, onceRunId)).toBeTruthy();
@@ -1366,20 +1377,20 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     await api.requestCancelRun(actor, blockerTwo.runId, [200]);
     const emptied = await api.readRunQueue(actor);
     expect(emptied.body.concurrency.active).toBe(0);
-    await api.deleteSchedule(actor, cronSchedule.schedule);
-    await api.deleteSchedule(actor, onceSchedule.schedule);
+    await api.deleteAutomation(actor, cronSchedule.automation);
+    await api.deleteAutomation(actor, onceSchedule.automation);
   });
 
   it("advances loop and cron schedules after pre-run failures and auto-disables after three consecutive failures", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const { agentId } = await createAgentWithModelProvider(actor);
     const base = now();
     mockNow(base);
 
-    const loopSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-fail-loop"),
+    const loopSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-fail-loop"),
       agentId,
       intervalSeconds: 300,
       prompt: "Run the failing loop report.",
@@ -1387,12 +1398,12 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       timezone: "UTC",
       enabled: true,
     });
-    expect(loopSchedule.schedule.nextRunAt).not.toBeNull();
+    expect(loopSchedule.automation.nextRunAt).not.toBeNull();
 
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const afterFirst = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      loopSchedule.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      loopSchedule.automation.id,
     );
     expect(afterFirst.consecutiveFailures).toBe(1);
     expect(afterFirst.enabled).toBeTruthy();
@@ -1403,19 +1414,19 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
     expect(Date.parse(afterFirst.nextRunAt)).toBeGreaterThan(base);
 
     mockNow(base + 301_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const afterSecond = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      loopSchedule.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      loopSchedule.automation.id,
     );
     expect(afterSecond.consecutiveFailures).toBe(2);
     expect(afterSecond.enabled).toBeTruthy();
 
     mockNow(base + 602_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const afterThird = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      loopSchedule.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      loopSchedule.automation.id,
     );
     expect(afterThird).toMatchObject({
       consecutiveFailures: 3,
@@ -1423,8 +1434,8 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       nextRunAt: null,
     });
 
-    const cronSchedule = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-fail-cron"),
+    const cronSchedule = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-fail-cron"),
       agentId,
       cronExpression: "0 9 * * *",
       prompt: "Run the failing cron report.",
@@ -1433,10 +1444,10 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       enabled: true,
     });
     mockNow(base + 25 * 3_600_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const cronAfterFailure = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      cronSchedule.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      cronSchedule.automation.id,
     );
     expect(cronAfterFailure.consecutiveFailures).toBe(1);
     expect(cronAfterFailure.enabled).toBeTruthy();
@@ -1453,8 +1464,8 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       description: "Covers the schedule model-pin failure branch.",
       visibility: "private",
     });
-    const pinSchedule = await api.deploySchedule(pinActor, {
-      name: uniqueScheduleName("bdd-fail-pin"),
+    const pinSchedule = await api.deployAutomation(pinActor, {
+      name: uniqueAutomationName("bdd-fail-pin"),
       agentId: pinAgent.agentId,
       intervalSeconds: 300,
       prompt: "Run the pin-error report.",
@@ -1462,19 +1473,19 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
       timezone: "UTC",
       enabled: true,
     });
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const pinAfterFailure = mustFindSchedule(
-      (await api.listSchedules(pinActor)).schedules,
-      pinSchedule.schedule.id,
+      (await api.listAutomations(pinActor)).automations,
+      pinSchedule.automation.id,
     );
     expect(pinAfterFailure.consecutiveFailures).toBe(1);
     expect(pinAfterFailure.enabled).toBeTruthy();
     expect(pinAfterFailure.nextRunAt).not.toBeNull();
 
     clearMockNow();
-    await api.deleteSchedule(actor, loopSchedule.schedule);
-    await api.deleteSchedule(actor, cronSchedule.schedule);
-    await api.deleteSchedule(pinActor, pinSchedule.schedule);
+    await api.deleteAutomation(actor, loopSchedule.automation);
+    await api.deleteAutomation(actor, cronSchedule.automation);
+    await api.deleteAutomation(pinActor, pinSchedule.automation);
   });
 });
 
@@ -1545,7 +1556,7 @@ async function completeScheduleRun(
 
 describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", () => {
   it("advances and skips loop schedules through replayed reschedule callbacks", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledScheduleActor();
@@ -1556,8 +1567,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     mockNow(base);
     const deliveries = captureScheduleCallbackDeliveries(webhooks);
 
-    const deployed = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-loop-cb"),
+    const deployed = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-loop-cb"),
       agentId,
       intervalSeconds: 600,
       prompt,
@@ -1568,10 +1579,10 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
 
     // Fire the due schedule (the jump stays inside PENDING_RUN_TTL).
     mockNow(base + 601_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const thread = await chat.listThreadMessages(
       actor,
-      deployed.schedule.chatThreadId,
+      deployed.automation.chatThreadId,
     );
     const runId = scheduleRunIdFromThread(thread.messages, prompt);
 
@@ -1600,8 +1611,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     });
     expect(
       mustFindSchedule(
-        (await api.listSchedules(actor)).schedules,
-        deployed.schedule.id,
+        (await api.listAutomations(actor)).automations,
+        deployed.automation.id,
       ).consecutiveFailures,
     ).toBe(0);
 
@@ -1652,8 +1663,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     // The completion advance reads the interval from the database at replay
     // time: redeploy with a new interval, move the pinned clock (still inside
     // the signature tolerance), and replay the same captured delivery.
-    const redeployed = await api.deploySchedule(actor, {
-      name: deployed.schedule.name,
+    const redeployed = await api.deployAutomation(actor, {
+      name: deployed.automation.name,
       agentId,
       intervalSeconds: 1200,
       prompt,
@@ -1676,13 +1687,13 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     // the chat callback owns the summary (D9).
     expect(context.mocks.axiom.query.mock.calls).toHaveLength(queryCallsBefore);
     const advancedSchedule = mustFindSchedule(
-      (await api.listSchedules(actor)).schedules,
-      deployed.schedule.id,
+      (await api.listAutomations(actor)).automations,
+      deployed.automation.id,
     );
     expect(advancedSchedule).toMatchObject({
       consecutiveFailures: 0,
       enabled: true,
-      nextRunAt: redeployed.schedule.nextRunAt,
+      nextRunAt: redeployed.automation.nextRunAt,
     });
 
     // Signed-shape posts for unknown runs fail the callback lookup before
@@ -1693,7 +1704,7 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
         body: JSON.stringify({
           runId: randomUUID(),
           status: "completed",
-          payload: { scheduleId: deployed.schedule.id },
+          payload: { scheduleId: deployed.automation.id },
         }),
         headers: {
           "content-type": "application/json",
@@ -1705,7 +1716,7 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     expect(missingCallback.status).toBe(404);
 
     // Disabled and deleted schedules skip the completion advance.
-    await api.disableSchedule(actor, deployed.schedule);
+    await api.disableAutomation(actor, deployed.automation);
     const disabledReplay = await webhooks.replayInternalCallback(
       LOOP_CALLBACK_PATH,
       completedDelivery,
@@ -1715,7 +1726,7 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
       success: true,
       skipped: true,
     });
-    await api.deleteSchedule(actor, deployed.schedule);
+    await api.deleteAutomation(actor, deployed.automation);
     const deletedReplay = await webhooks.replayInternalCallback(
       LOOP_CALLBACK_PATH,
       completedDelivery,
@@ -1729,7 +1740,7 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
   });
 
   it("increments cron failures and auto-disables after three replayed failed callbacks", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledScheduleActor();
@@ -1738,8 +1749,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     mockNow(base);
     const deliveries = captureScheduleCallbackDeliveries(webhooks);
 
-    const deployed = await api.deploySchedule(actor, {
-      name: uniqueScheduleName("bdd-cron-cb"),
+    const deployed = await api.deployAutomation(actor, {
+      name: uniqueAutomationName("bdd-cron-cb"),
       agentId,
       cronExpression: "*/5 * * * *",
       prompt,
@@ -1749,10 +1760,10 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     });
 
     mockNow(base + 6 * 60_000);
-    await executeSchedulesCronOk();
+    await executeAutomationsCronOk();
     const thread = await chat.listThreadMessages(
       actor,
-      deployed.schedule.chatThreadId,
+      deployed.automation.chatThreadId,
     );
     const runId = scheduleRunIdFromThread(thread.messages, prompt);
 
@@ -1779,8 +1790,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     await expect(firstReplay.json()).resolves.toStrictEqual({ success: true });
     expect(
       mustFindSchedule(
-        (await api.listSchedules(actor)).schedules,
-        deployed.schedule.id,
+        (await api.listAutomations(actor)).automations,
+        deployed.automation.id,
       ),
     ).toMatchObject({
       consecutiveFailures: 1,
@@ -1795,8 +1806,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     expect(secondReplay.status).toBe(200);
     expect(
       mustFindSchedule(
-        (await api.listSchedules(actor)).schedules,
-        deployed.schedule.id,
+        (await api.listAutomations(actor)).automations,
+        deployed.automation.id,
       ),
     ).toMatchObject({ consecutiveFailures: 2, enabled: true });
 
@@ -1807,8 +1818,8 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     expect(thirdReplay.status).toBe(200);
     expect(
       mustFindSchedule(
-        (await api.listSchedules(actor)).schedules,
-        deployed.schedule.id,
+        (await api.listAutomations(actor)).automations,
+        deployed.automation.id,
       ),
     ).toMatchObject({
       consecutiveFailures: 3,
@@ -1827,7 +1838,7 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
       skipped: true,
     });
 
-    await api.deleteSchedule(actor, deployed.schedule);
+    await api.deleteAutomation(actor, deployed.automation);
     clearMockNow();
   });
 });
@@ -1835,11 +1846,11 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
 describe("AUTOMATIONS-01: automation lifecycle through the public API", () => {
   it("creates, lists, updates, toggles, runs, and deletes an automation through API requests", async () => {
     const bdd = createBddApi(context);
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
     const outsider = bdd.user();
     const { agentId } = await createAgentWithModelProvider(actor);
-    const automationName = uniqueScheduleName("bdd-automation");
+    const automationName = uniqueAutomationName("bdd-automation");
 
     await api.enableAutomations(actor);
     await api.enableAutomations(outsider);
@@ -1891,9 +1902,9 @@ describe("AUTOMATIONS-01: automation lifecycle through the public API", () => {
       enabled: false,
     });
 
-    const schedulesAfterCreate = await api.listSchedules(actor);
+    const schedulesAfterCreate = await api.listAutomations(actor);
     expect(
-      findSchedule(schedulesAfterCreate.schedules, created.automation.id),
+      findSchedule(schedulesAfterCreate.automations, created.automation.id),
     ).toMatchObject({
       id: created.automation.id,
       name: automationName,
@@ -1935,9 +1946,9 @@ describe("AUTOMATIONS-01: automation lifecycle through the public API", () => {
       enabled: false,
     });
 
-    const schedulesAfterUpdate = await api.listSchedules(actor);
+    const schedulesAfterUpdate = await api.listAutomations(actor);
     expect(
-      findSchedule(schedulesAfterUpdate.schedules, updated.automation.id),
+      findSchedule(schedulesAfterUpdate.automations, updated.automation.id),
     ).toMatchObject({
       id: updated.automation.id,
       name: automationName,
@@ -1975,9 +1986,9 @@ describe("AUTOMATIONS-01: automation lifecycle through the public API", () => {
     expect(
       findSchedule(listedAfterDelete.automations, updated.automation.id),
     ).toBeUndefined();
-    const schedulesAfterDelete = await api.listSchedules(actor);
+    const schedulesAfterDelete = await api.listAutomations(actor);
     expect(
-      findSchedule(schedulesAfterDelete.schedules, updated.automation.id),
+      findSchedule(schedulesAfterDelete.automations, updated.automation.id),
     ).toBeUndefined();
 
     const deleteAgain = await api.requestDeleteAutomation(
@@ -1992,9 +2003,9 @@ describe("AUTOMATIONS-01: automation lifecycle through the public API", () => {
 
 describe("SCHED-02: cron routes", () => {
   it("rejects invalid cron auth and accepts safe no-work cron routes with valid auth", async () => {
-    const api = createRunsSchedulesApi(context);
+    const api = createRunsAutomationsApi(context);
 
-    const invalidExecute = await api.executeSchedulesCron(false);
+    const invalidExecute = await api.executeAutomationsCron(false);
     if (invalidExecute.status !== 401) {
       throw new Error("Expected missing cron auth to be rejected");
     }
@@ -2016,7 +2027,7 @@ describe("SCHED-02: cron routes", () => {
       }),
     ).toBeTruthy();
 
-    const execute = await api.executeSchedulesCron(true);
+    const execute = await api.executeAutomationsCron(true);
     if (execute.status !== 200) {
       throw new Error("Expected execute schedules cron to succeed");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/storages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/storages.bdd.test.ts
@@ -7,7 +7,7 @@ import { testContext } from "../../../__tests__/test-helpers";
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { storageTextFile } from "./helpers/api-bdd-chat-files";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 
 /*
@@ -386,7 +386,7 @@ describe("FILE-01 storage prepare, commit, list, and download", () => {
   });
 
   it("scopes sandbox-token storage reads through the run organization", async () => {
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     runs.acceptStorageDownloads();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -22,7 +22,7 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
-import { createRunsSchedulesApi } from "./helpers/api-bdd-runs-schedules";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 const ORG_SENTINEL_USER_ID = "__org__";
@@ -53,7 +53,7 @@ async function firewallRun(): Promise<{
   readonly headers: { readonly authorization: string };
 }> {
   const bdd = createBddApi(context);
-  const runsApi = createRunsSchedulesApi(context);
+  const runsApi = createRunsAutomationsApi(context);
   const fw = createFirewallApi(context);
   const actor = bdd.user();
   bdd.acceptAgentStorageWrites();
@@ -373,7 +373,7 @@ describe("FW-3: billable firewall lease", () => {
 
   it("denies billable firewall auth after the subscription is deleted", async () => {
     const bdd = createBddApi(context);
-    const runsApi = createRunsSchedulesApi(context);
+    const runsApi = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const fw = createFirewallApi(context);
     const actor = bdd.user();
@@ -428,7 +428,7 @@ describe("FW-3: billable firewall lease", () => {
 
   it("denies billable firewall auth when the granted credits already expired", async () => {
     const bdd = createBddApi(context);
-    const runsApi = createRunsSchedulesApi(context);
+    const runsApi = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -19,9 +19,9 @@ import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createGithubBddApi, newGithubUserId } from "./helpers/api-bdd-github";
 import {
-  createRunsSchedulesApi,
-  uniqueScheduleName,
-} from "./helpers/api-bdd-runs-schedules";
+  createRunsAutomationsApi,
+  uniqueAutomationName,
+} from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
@@ -1380,7 +1380,7 @@ describe("WHCB-06: sandbox agent artifact webhook boundaries", () => {
 describe("WHCB-09: sandbox storage writes and checkpoint history blobs land in the run organization", () => {
   it("prepares, commits, dedups, and bounds sandbox storage writes for the run org", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const storages = createStoragesBddApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
@@ -1571,7 +1571,7 @@ describe("WHCB-09: sandbox storage writes and checkpoint history blobs land in t
 describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
   it("replays, expires, and auto-recharges subscription invoice credits", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const actor = bdd.user();
     const orgId = orgOf(actor);
@@ -1861,7 +1861,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
 
   it("upgrades to team, drains the queue, and cancels the replaced pro subscription", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const actor = bdd.user();
     const orgId = orgOf(actor);
@@ -2479,7 +2479,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
 
   it("restores and schedules cancellations through setup checkouts and schedule webhooks", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const actor = bdd.user();
     const orgId = orgOf(actor);
@@ -2805,7 +2805,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
 
   it("processes preview Stripe events only for the matching job ref", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const billing = createBillingMediaApi(context);
     const actor = bdd.user();
     const granted = await runs.grantProEntitlement(actor);
@@ -2890,7 +2890,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
 describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
   it("cleans up organization state after a verified organization.deleted event", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const gh = createGithubBddApi(context);
     api.configureClerkWebhookSecret();
     bdd.acceptAgentStorageWrites();
@@ -2919,15 +2919,15 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
         githubUserId: newGithubUserId(),
       },
     });
-    const schedule = await runs.deploySchedule(actor, {
-      name: uniqueScheduleName("teardown"),
+    const schedule = await runs.deployAutomation(actor, {
+      name: uniqueAutomationName("teardown"),
       agentId: agent.agentId,
       intervalSeconds: 3600,
       prompt: "scheduled teardown probe",
       timezone: "UTC",
       enabled: false,
     });
-    expect(schedule.schedule.name).toContain("teardown");
+    expect(schedule.automation.name).toContain("teardown");
     const botToken = await registerTelegramBot(actor, agent.agentId);
     await runs.upsertUserPermissionGrant(actor, {
       agentId: agent.agentId,
@@ -2938,7 +2938,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     await expect(
       runs.listUserPermissionGrants(actor, agent.agentId),
     ).resolves.toHaveLength(1);
-    expect((await runs.listSchedules(actor)).schedules).toHaveLength(1);
+    expect((await runs.listAutomations(actor)).automations).toHaveLength(1);
 
     // The first delivery hits a failing Stripe cancellation (a per-step
     // failure the cleanup continues over) and then a failing org S3 listing,
@@ -3017,7 +3017,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       await expect(bdd.listAgents(actor)).resolves.toStrictEqual([]);
     });
     await waitForExpectation(async () => {
-      expect((await runs.listSchedules(actor)).schedules).toStrictEqual([]);
+      expect((await runs.listAutomations(actor)).automations).toStrictEqual([]);
     });
 
     // An org without a live subscription skips the Stripe cancellation.
@@ -3045,7 +3045,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
 
   it("cleans up user state after a verified user.deleted event", async () => {
     const bdd = createBddApi(context);
-    const runs = createRunsSchedulesApi(context);
+    const runs = createRunsAutomationsApi(context);
     const gh = createGithubBddApi(context);
     api.configureClerkWebhookSecret();
     bdd.acceptAgentStorageWrites();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
@@ -678,7 +678,7 @@ describe("POST /api/zero/email/callbacks/reply", () => {
         to: ["sender@example.com", "teammate@example.com"],
         cc: ["cc@example.com"],
         replyTo: `reply+${thread.replyToken}@mail.example.com`,
-        subject: `Re: VM0 - Scheduled run for "${fx.agentName}" completed`,
+        subject: `Re: VM0 - Automation run for "${fx.agentName}" completed`,
         headers: expect.objectContaining({
           "In-Reply-To": "<inbound@example.com>",
           References: "<root@example.com> <inbound@example.com>",
@@ -824,7 +824,7 @@ describe("POST /api/zero/email/callbacks/reply", () => {
     const email = lastSentEmail();
     expect(email.to).toBe(fx.userEmail);
     expect(email.subject).toBe(
-      `Re: VM0 - Scheduled run for "${fx.agentName}" completed`,
+      `Re: VM0 - Automation run for "${fx.agentName}" completed`,
     );
     expect(email.html).toContain("Agent crashed");
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack-message.test.ts
@@ -25,7 +25,7 @@ import {
   deleteUsageInsightFixture$,
   seedCompose$,
   seedRun$,
-  seedSchedule$,
+  seedAutomation$,
   type UsageInsightFixture,
 } from "./helpers/zero-usage-insight";
 
@@ -396,15 +396,15 @@ describe("POST /api/zero/integrations/slack/message", () => {
     expect(footerCtx.elements![0]!.text).toBe("Sent via My Assistant");
   });
 
-  it("appends schedule, creator, and model in footer when run is triggered by a schedule", async () => {
+  it("appends automation, creator, and model in footer when run is triggered by an automation", async () => {
     const { orgId, userId, slackWorkspaceId } = await seedWithInstallation();
     const { composeId, agentId } = await store.set(
       seedCompose$,
       { orgId, userId, displayName: "My Assistant" },
       context.signal,
     );
-    const scheduleId = await store.set(
-      seedSchedule$,
+    const automationId = await store.set(
+      seedAutomation$,
       {
         orgId,
         userId,
@@ -420,7 +420,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
         orgId,
         userId,
         composeId,
-        scheduleId,
+        automationId,
         triggerSource: "automation",
       },
       context.signal,
@@ -460,7 +460,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     const footerCtx = blocks[blocks.length - 1]!;
     expect(footerCtx.type).toBe("context");
     expect(footerCtx.elements![0]!.text).toBe(
-      `Sent via My Assistant · Triggered by schedule "Daily standup summary" · Created by <@${slackUserId}> · Claude Sonnet 4.6`,
+      `Sent via My Assistant · Triggered by automation "Daily standup summary" · Created by <@${slackUserId}> · Claude Sonnet 4.6`,
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-usage-insight.test.ts
@@ -18,8 +18,8 @@ import {
   seedChatThread$,
   seedCompose$,
   seedRun$,
-  seedSchedule$,
-  seedScheduleBatch$,
+  seedAutomation$,
+  seedAutomationBatch$,
   seedUsageInsightFixture$,
   setUsageEventCreatedAt$,
   type UsageInsightFixture,
@@ -787,8 +787,8 @@ describe("GET /api/zero/usage/insight", () => {
       context.signal,
     );
 
-    const { scheduleIds } = await store.set(
-      seedScheduleBatch$,
+    const { automationIds } = await store.set(
+      seedAutomationBatch$,
       {
         orgId: fixture.orgId,
         userId: fixture.userId,
@@ -813,7 +813,7 @@ describe("GET /api/zero/usage/insight", () => {
       },
       context.signal,
     );
-    const eventBoostedAutomationId = scheduleIds[0];
+    const eventBoostedAutomationId = automationIds[0];
     expect(eventBoostedAutomationId).toBeDefined();
 
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -856,8 +856,8 @@ describe("GET /api/zero/usage/insight", () => {
       context.signal,
     );
 
-    const describedScheduleId = await store.set(
-      seedSchedule$,
+    const describedAutomationId = await store.set(
+      seedAutomation$,
       {
         orgId: fixture.orgId,
         userId: fixture.userId,
@@ -867,8 +867,8 @@ describe("GET /api/zero/usage/insight", () => {
       },
       context.signal,
     );
-    const undescribedScheduleId = await store.set(
-      seedSchedule$,
+    const undescribedAutomationId = await store.set(
+      seedAutomation$,
       {
         orgId: fixture.orgId,
         userId: fixture.userId,
@@ -878,9 +878,9 @@ describe("GET /api/zero/usage/insight", () => {
       context.signal,
     );
 
-    for (const [agentId, scheduleId] of [
-      [agentA, describedScheduleId],
-      [agentB, undescribedScheduleId],
+    for (const [agentId, automationId] of [
+      [agentA, describedAutomationId],
+      [agentB, undescribedAutomationId],
     ] as const) {
       const { runId } = await store.set(
         seedRun$,
@@ -889,7 +889,7 @@ describe("GET /api/zero/usage/insight", () => {
           userId: fixture.userId,
           composeId: agentId,
           triggerSource: "automation",
-          scheduleId,
+          automationId,
           status: "completed",
         },
         context.signal,
@@ -917,10 +917,10 @@ describe("GET /api/zero/usage/insight", () => {
     );
 
     const described = response.body.automations.find((s) => {
-      return s.automationId === describedScheduleId;
+      return s.automationId === describedAutomationId;
     });
     const undescribed = response.body.automations.find((s) => {
-      return s.automationId === undescribedScheduleId;
+      return s.automationId === undescribedAutomationId;
     });
     expect(described?.automationDescription).toBe("Daily morning brief");
     expect(undescribed?.automationDescription).toBeNull();
@@ -1398,7 +1398,7 @@ describe("GET /api/zero/usage/insight", () => {
     );
 
     await store.set(
-      seedScheduleBatch$,
+      seedAutomationBatch$,
       {
         orgId: fixture.orgId,
         userId: fixture.userId,

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
@@ -1188,7 +1188,7 @@ async function latestSessionForThreadFromDb(
     .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
     // D7 session-continuity exclusion (see latestSessionForThread in
     // zero-chat-messages.ts): only web-source runs join the chain, so an
-    // autoSend follow-up resumes the latest web session, not a scheduled one.
+    // autoSend follow-up resumes the latest web session, not an automation one.
     .where(
       and(
         eq(zeroRuns.chatThreadId, threadId),

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
@@ -55,13 +55,12 @@ function parseLoopPayload(payload: unknown): TriggerPayload | null {
 }
 
 /**
- * Completion callback for `automation_triggers` time rows — mirrors the schedule
- * callback's semantics 1:1, keyed on `trigger_id`: a completed run resets the
- * consecutive-failure counter, a failed run increments it (auto-disable at the
- * threshold), and the recurrence advances from completion time. The poller's
- * claim cleared `next_run_at`, so this callback is what reschedules the trigger.
- * `once` triggers were disabled at claim, so their callback lands in the
- * disabled-skip branch — same as the live schedule path.
+ * Completion callback for `automation_triggers` time rows, keyed on
+ * `trigger_id`: a completed run resets the consecutive-failure counter, a
+ * failed run increments it (auto-disable at the threshold), and the recurrence
+ * advances from completion time. The poller's claim cleared `next_run_at`, so
+ * this callback is what reschedules the trigger. `once` triggers were disabled
+ * at claim, so their callback lands in the disabled-skip branch.
  */
 function createTriggerCallbackHandler(
   parsePayload: (payload: unknown) => TriggerPayload | null,

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -715,7 +715,7 @@ async function latestSessionForThread(
     .innerJoin(agentRuns, eq(zeroRuns.id, agentRuns.id))
     // D7: only web-source runs join the thread's session-continuity chain, so a
     // chat-mode automation run (triggerSource "automation") never resumes a web
-    // session and a later web turn never resumes a scheduled one. The 'web'
+    // session and a later web turn never resumes an automation one. The 'web'
     // filter (before .limit) is mirrored in latestSessionForThreadFromDb
     // (internal-callbacks-chat.ts) and latestSessionIdForThread
     // (chat-thread-v1-send.service.ts) — keep them in sync. This is a
@@ -1096,13 +1096,13 @@ async function resolveStoredModelFirstPin(params: {
 }
 
 /**
- * Resolve the model pin for a chat-mode scheduled run from its linked thread:
+ * Resolve the model pin for a chat-mode automation run from its linked thread:
  * the thread's stored pin, else its first-run pin, else the org default. This
- * is deliberately decoupled from session state (a scheduled run is always
- * fresh) — do NOT route schedules through `resolveRunModelPin`, which falls
+ * is deliberately decoupled from session state (an automation run is always
+ * fresh) — do NOT route automation runs through `resolveRunModelPin`, which falls
  * back to the org default whenever the session is fresh.
  */
-export async function resolveScheduleChatThreadModelPin(params: {
+export async function resolveAutomationChatThreadModelPin(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
@@ -1666,11 +1666,11 @@ async function appendAssociatedUserMessage(params: {
   readonly revokesMessageId: string | undefined;
   readonly generationTemplate: IncomingGenerationTemplate;
   readonly appendQueueMarker: boolean;
-  // When false, the thread's in-progress draft is preserved. Scheduled posts
+  // When false, the thread's in-progress draft is preserved. Automation posts
   // are not user-initiated typing, so they must not clear the user's draft.
   readonly clearDraft: boolean;
-  // Set when this message is posted by a firing schedule. `scheduleSnapshot`
-  // snapshots the schedule's basic display details at send time so the bubble
+  // Set when this message is posted by a firing automation. `scheduleSnapshot`
+  // snapshots the automation's basic display details at send time so the bubble
   // keeps its label even after an edit/delete. `scheduleTitle` is retained for
   // legacy fallback display.
   readonly scheduleId?: string;
@@ -2246,12 +2246,11 @@ function scheduleAssociatedUserMessage(params: {
 /**
  * Post an automation run's prompt as a user chat message into its linked
  * thread and publish the realtime signals so the client surfaces the run.
- * Generalizes `postScheduleUserMessage` for the events-first automation path:
- * the prompt is the automation `instruction`. A time-automation fire passes the
- * schedule-chip fields (`scheduleId` links a mirrored automation's source
- * schedule for navigation; `scheduleSnapshot` keeps the label rendering after
- * edits/deletes) so the chat bubble matches the live schedule path; a webhook
- * fire omits them. Like the schedule path it preserves the thread draft (the
+ * Posts the chat bubble for an automation-fired run: the prompt is the
+ * automation `instruction`. A time-automation fire passes the chip fields
+ * (`scheduleId` links the source automation for navigation; `scheduleSnapshot`
+ * keeps the label rendering after edits/deletes); a webhook fire omits them.
+ * Like a time fire it preserves the thread draft (the
  * post is not user-initiated typing) and is awaited so the caller sees it
  * persisted.
  */

--- a/turbo/apps/api/src/signals/routes/zero-email-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/zero-email-callbacks.ts
@@ -194,7 +194,7 @@ const handleEmailReplyCallback$ = command(
         from: buildFromAddress(org.slug),
         to: emailTo,
         cc: emailCc,
-        subject: `Re: VM0 - Scheduled run for "${agent.name}" completed`,
+        subject: `Re: VM0 - Automation run for "${agent.name}" completed`,
         template: {
           template: "agent-reply",
           props: { agentName: agent.name, output, logsUrl, unsubscribeUrl },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -226,7 +226,6 @@ interface AdditionalVolume {
 
 interface ZeroRunMetadata {
   readonly triggerAgentId?: string;
-  readonly scheduleId?: string;
   // Run provenance: the automation + the trigger that fired this run (set by the
   // webhook inbound path). Persisted as first-class zero_runs columns.
   readonly automationId?: string;
@@ -2828,7 +2827,6 @@ async function insertZeroRunRecord(
   await tx.insert(zeroRuns).values({
     id: args.runId,
     triggerSource: args.body.triggerSource ?? "cli",
-    scheduleId: args.zeroRunMetadata?.scheduleId ?? null,
     automationId: args.zeroRunMetadata?.automationId ?? null,
     triggerId: args.zeroRunMetadata?.triggerId ?? null,
     triggerAgentId: args.zeroRunMetadata?.triggerAgentId ?? null,

--- a/turbo/apps/api/src/signals/services/automations.service.ts
+++ b/turbo/apps/api/src/signals/services/automations.service.ts
@@ -204,7 +204,7 @@ async function resolveTriggerInsert(args: {
     if (atTime <= currentTime) {
       return {
         kind: "bad_request",
-        message: `Scheduled time ${atTime.toISOString()} has already passed`,
+        message: `Cannot create the trigger: time ${atTime.toISOString()} has already passed`,
       };
     }
     return {
@@ -366,7 +366,7 @@ async function insertAutomationWithTrigger(
 
 /**
  * Create an automation (optionally with its first trigger): validate the
- * target agent through the same visibility gate the schedule deploy uses,
+ * target agent through the same visibility gate the automation deploy uses,
  * enforce the (agent, name, org, user) unique key up front, resolve the
  * chat-thread link (an owned existing thread or a server-created one — the
  * link is create-only), and persist the automation plus the optional sugar
@@ -442,7 +442,7 @@ export const createAutomation$ = command(
       triggerInsert = resolved.insert;
     }
 
-    // Parity with the legacy schedule deploy: an omitted description is
+    // Parity with the legacy deploy behavior: an omitted description is
     // generated (LLM with template fallback) so list views are never blank.
     const effectiveBody =
       body.description === undefined
@@ -763,7 +763,7 @@ function isTimeTriggerKind(kind: string): boolean {
 /**
  * Enable or disable an automation. Enabling recomputes `nextRunAt` for each
  * still-enabled time trigger (an expired one-time trigger is disabled instead)
- * so resumed schedules fire on their next occurrence rather than catching up.
+ * so resumed automations fire on their next occurrence rather than catching up.
  * Disabling flips only the automation flag: the automation gate suspends the
  * triggers without touching their rows (both the poller and the inbound
  * webhook dispatch check `automation.enabled && trigger.enabled`).
@@ -1048,7 +1048,7 @@ export const setTriggerEnabled$ = command(
       if (recompute.kind === "expired") {
         return {
           kind: "bad_request",
-          message: "Scheduled time has already passed",
+          message: "Cannot enable the automation: time has already passed",
         };
       }
       recomputedState = {

--- a/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
@@ -20,7 +20,7 @@ type InterpreterKind = "time" | "webhook" | "default";
  * Domain view of an Automation as the interpreter sees it. This is a thin
  * projection down to the fields needed to build an agent-run input: the prompt,
  * the append-prompt context, the agent / chat-thread linkage, and the recurrence
- * (for schedule reschedule callbacks). A webhook automation carries no
+ * (for time-trigger reschedule callbacks). A webhook automation carries no
  * recurrence — its `triggerType` is "webhook" and its `cronExpression` is null —
  * and supplies its dynamic payload through the trigger event instead.
  */
@@ -61,7 +61,7 @@ type ZeroRunInputMetadata = {
  * interpreter constructs from the Automation definition (and trigger event).
  * Runtime concerns resolved from live state (model pin, provider admission) are
  * layered on by the caller, not by the interpreter. `Metadata` is the
- * trigger-specific run-identity shape (schedule vs automation).
+ * trigger-specific run-identity shape.
  */
 interface ZeroRunInput<
   Metadata extends ZeroRunInputMetadata = ZeroRunInputMetadata,
@@ -89,13 +89,12 @@ export interface WebhookTriggerEvent {
 }
 
 /**
- * Trigger event for an automation-table time fire (the dormant trigger poller,
- * U4). Like the schedule time fire it is instruction-only — no inbound payload —
- * but it tags the run with the originating automation + the firing
- * `automation_triggers` row (run provenance, U3) instead of a schedule id, and
- * attaches the trigger-keyed reschedule callback (the claim cleared
- * `next_run_at`; the callback advances it). `triggerId` is the firing trigger
- * row.
+ * Trigger event for an automation-table time fire (the trigger poller, U4).
+ * It is instruction-only — no inbound payload — and tags the run with the
+ * originating automation + the firing `automation_triggers` row (run
+ * provenance, U3), attaching the trigger-keyed reschedule callback (the claim
+ * cleared `next_run_at`; the callback advances it). `triggerId` is the firing
+ * trigger row.
  */
 interface AutomationTimeTriggerEvent {
   readonly kind: "automation-time";
@@ -112,11 +111,10 @@ interface ManualTriggerEvent {
 }
 
 /**
- * The trigger that fired an Automation. A schedule time fire carries only the
- * schedule identity; an automation-table time fire carries the firing trigger
- * identity; a webhook fire carries the raw inbound payload; a manual fire
- * carries nothing. The interpreter keys its context/callbacks/metadata off
- * this discriminant.
+ * The trigger that fired an Automation. A time fire carries the firing
+ * trigger identity; a webhook fire carries the raw inbound payload; a manual
+ * fire carries nothing. The interpreter keys its context/callbacks/metadata
+ * off this discriminant.
  */
 type TriggerEvent =
   | AutomationTimeTriggerEvent
@@ -127,8 +125,7 @@ type TriggerEvent =
  * Maps an `automations` row (joined with its firing trigger) to the Automation
  * view the interpreter consumes. A webhook automation carries no recurrence, so
  * the time-only fields collapse to their inert values; its dynamic payload
- * arrives through the trigger event instead. Counterpart to
- * `scheduleToAutomation` for the webhook fire path.
+ * arrives through the trigger event instead.
  */
 export function webhookRowToAutomation(row: {
   readonly id: string;
@@ -157,9 +154,9 @@ export function webhookRowToAutomation(row: {
 /**
  * Maps an `automations` row (joined with its firing time trigger) to the
  * Automation view the interpreter consumes for an automation-table time fire
- * (the dormant trigger poller). The recurrence lives on the trigger row, so its
- * `kind` (cron/once/loop) and `cronExpression`/`timezone` are threaded in here.
- * Counterpart to `scheduleToAutomation` for the events-first time path.
+ * (the trigger poller). The recurrence lives on the trigger row, so its
+ * `kind` (cron/once/loop) and `cronExpression`/`timezone` are threaded in
+ * here.
  */
 export function automationRowToTimeAutomation(row: {
   readonly id: string;
@@ -192,7 +189,7 @@ export function automationRowToTimeAutomation(row: {
  * Maps an `automations` row to the Automation view the interpreter consumes for
  * a manual fire (the run-now endpoint). A manual fire is keyed off no
  * trigger row, so the recurrence fields collapse to their inert values and the
- * `triggerType` renders as "manual" in the schedule integration context.
+ * `triggerType` renders as "manual" in the automation integration context.
  */
 export function automationRowToManualAutomation(row: {
   readonly id: string;
@@ -218,23 +215,23 @@ export function automationRowToManualAutomation(row: {
   };
 }
 
-function buildSchedulePrompt(triggerType: string): string {
+function buildAutomationPrompt(triggerType: string): string {
   return [
     "# Current Integration",
-    "You are currently running inside: Schedule",
+    "You are currently running inside: Automation",
     `Trigger type: ${triggerType}`,
   ].join("\n");
 }
 
 /**
- * Schedule (time-fire) context: the integration header plus any user-provided
+ * Automation (time-fire) context: the integration header plus any user-provided
  * append prompt. Behavior-preserving extraction of the time interpreter.
  */
-function buildScheduleAppendSystemPrompt(automation: Automation): string {
+function buildAutomationAppendSystemPrompt(automation: Automation): string {
   const integrationContext = [
-    buildSchedulePrompt(automation.triggerType),
+    buildAutomationPrompt(automation.triggerType),
     "",
-    "This scheduled run is linked to a web chat thread. Everything you output is automatically shown to the user as a chat message in that thread.",
+    "This automated run is linked to a web chat thread. Everything you output is automatically shown to the user as a chat message in that thread.",
   ].join("\n");
   const baseAppendPrompt = automation.appendSystemPrompt ?? undefined;
   return baseAppendPrompt
@@ -339,9 +336,10 @@ function buildTriggerCallbacks(
  *   context as a fenced JSON block, and tags the run with the originating
  *   automation + trigger (run provenance). No reschedule callback (webhooks
  *   don't recur).
- * - A time fire (no raw payload) is instruction-only: it renders the schedule
- *   integration context plus any user append prompt, attaches the recurrence
- *   reschedule callback, and tags the run with the originating schedule.
+ * - A time fire (no raw payload) is instruction-only: it renders the
+ *   automation integration context plus any user append prompt, attaches the
+ *   recurrence reschedule callback, and tags the run with the originating
+ *   automation.
  *
  * Both fire paths attach the chat callback so the run renders as a web-chat turn
  * in the linked thread. One impl for now; the registry is deferred to the first
@@ -366,7 +364,7 @@ export class DefaultInterpreter {
       });
     }
 
-    // Manual fire: instruction-only schedule context, tagged with the
+    // Manual fire: instruction-only automation context, tagged with the
     // automation alone — no trigger was claimed, so there is no trigger
     // provenance and no reschedule callback, only the chat callback.
     if (triggerEvent.kind === "manual") {
@@ -374,13 +372,13 @@ export class DefaultInterpreter {
         prompt: automation.prompt,
         agentId: automation.agentId,
         chatThreadId: automation.chatThreadId,
-        appendSystemPrompt: buildScheduleAppendSystemPrompt(automation),
+        appendSystemPrompt: buildAutomationAppendSystemPrompt(automation),
         callbacks: [buildChatCallback(automation)],
         zeroRunMetadata: { automationId: automation.id },
       });
     }
 
-    // Time fire: instruction-only schedule context, tagged with the
+    // Time fire: instruction-only automation context, tagged with the
     // automation + firing trigger (provenance) and carrying the trigger-keyed
     // reschedule callback — the claim cleared next_run_at, the callback
     // advances it.
@@ -388,7 +386,7 @@ export class DefaultInterpreter {
       prompt: automation.prompt,
       agentId: automation.agentId,
       chatThreadId: automation.chatThreadId,
-      appendSystemPrompt: buildScheduleAppendSystemPrompt(automation),
+      appendSystemPrompt: buildAutomationAppendSystemPrompt(automation),
       callbacks: buildTriggerCallbacks(automation, triggerEvent.triggerId),
       zeroRunMetadata: {
         automationId: automation.id,

--- a/turbo/apps/api/src/signals/services/automations/describe.ts
+++ b/turbo/apps/api/src/signals/services/automations/describe.ts
@@ -122,11 +122,11 @@ export async function generateAutomationDescription(
         {
           role: "system",
           content:
-            "Write a one-sentence summary (max 120 chars) for a scheduled task as plain text -- no markdown, no quotes, no special formatting. Return only the summary.",
+            "Write a one-sentence summary (max 120 chars) for an automated task as plain text -- no markdown, no quotes, no special formatting. Return only the summary.",
         },
         {
           role: "user",
-          content: `Agent: ${agentName}\nSchedule: ${input.name}\nTrigger: ${triggerSummary(input)}\nPrompt: ${input.instruction.slice(0, 200)}`,
+          content: `Agent: ${agentName}\nAutomation: ${input.name}\nTrigger: ${triggerSummary(input)}\nPrompt: ${input.instruction.slice(0, 200)}`,
         },
       ],
       30,

--- a/turbo/apps/api/src/signals/services/automations/run-compat.ts
+++ b/turbo/apps/api/src/signals/services/automations/run-compat.ts
@@ -20,10 +20,10 @@ import {
 import { visibleJoinedZeroAgentCondition } from "../zero-agent-data.service";
 import {
   postAutomationUserMessage,
-  resolveScheduleChatThreadModelPin,
+  resolveAutomationChatThreadModelPin,
 } from "../../routes/zero-chat-messages";
 
-// The schedule chip on the run's chat bubble: the snapshot keeps the label
+// The automation chip on the run's chat bubble: the snapshot keeps the label
 // rendering after the automation is renamed, edited, or deleted.
 function chatMessageScheduleSnapshot(
   automation: typeof automations.$inferSelect,
@@ -112,7 +112,7 @@ export async function resolveAutomationRunModelContext(args: {
   readonly chatThreadId: string;
   readonly signal: AbortSignal;
 }): Promise<AutomationRunModelContext> {
-  const threadModelPin = await resolveScheduleChatThreadModelPin({
+  const threadModelPin = await resolveAutomationChatThreadModelPin({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
@@ -152,7 +152,7 @@ export async function resolveAutomationRunModelContext(args: {
 }
 
 // After a manual run is created: render it as a web-chat turn (with the
-// schedule chip), persist the resolved model fields, and stamp the run as
+// automation chip), persist the resolved model fields, and stamp the run as
 // lastRunId on every trigger of the automation so the per-trigger
 // skip-if-active checks (the poller and the run-now conflict) see the active
 // manual run: a manual fire belongs to no trigger in particular.

--- a/turbo/apps/api/src/signals/services/automations/time-trigger.ts
+++ b/turbo/apps/api/src/signals/services/automations/time-trigger.ts
@@ -76,7 +76,7 @@ export class TimeTrigger {
   /**
    * Next run after a completion callback (the run finished, success or failure).
    * Cron advances from the cron expression captured at dispatch (null when the
-   * one-time callback carried no expression); a loop advances by the schedule's
+   * one-time callback carried no expression); a loop advances by the trigger's
    * interval and requires one to be present. Disabling collapses the next run to
    * null.
    */
@@ -97,7 +97,7 @@ export class TimeTrigger {
         : null;
     }
     if (args.intervalSeconds === null) {
-      throw new Error("Loop schedule is missing intervalSeconds");
+      throw new Error("Loop trigger is missing intervalSeconds");
     }
     return new Date(args.completedAt.getTime() + args.intervalSeconds * 1000);
   }
@@ -105,7 +105,7 @@ export class TimeTrigger {
   /**
    * Next recurrence for an `automation_triggers` time row, computed from its kind:
    * cron advances to the next occurrence; loop advances by its interval; once does
-   * not recur. The same math the schedule path uses, applied to a trigger row.
+   * not recur, applied to a trigger row.
    * `null` is returned when the kind cannot recur (once, or a malformed time row).
    */
   private static nextTriggerRun(
@@ -127,13 +127,11 @@ export class TimeTrigger {
 
   /**
    * Claim a due `automation_triggers` time row via an optimistic lock on
-   * `nextRunAt` — the trigger-table counterpart of `evaluate`, mirroring the
-   * live schedule claim 1:1: clear the next run, stamp `lastRunAt`, and disable
-   * one-time triggers. The recurrence advance happens
-   * in the trigger completion callback (or `advanceTriggerAfterPreRunFailure`
-   * when the run was never created), exactly like the schedule path. Returns
-   * the claimed row, or null when another invocation won the race (the row's
-   * `nextRunAt` already moved).
+   * `nextRunAt`: clear the next run, stamp `lastRunAt`, and disable one-time
+   * triggers. The recurrence advance happens in the trigger completion
+   * callback (or `advanceTriggerAfterPreRunFailure` when the run was never
+   * created). Returns the claimed row, or null when another invocation won
+   * the race (the row's `nextRunAt` already moved).
    */
   async evaluateTrigger(args: {
     readonly db: Db;
@@ -159,11 +157,10 @@ export class TimeTrigger {
   }
 
   /**
-   * Next run for an `automation_triggers` time row after a pre-run failure in the
-   * poller (the run was never created) — the trigger-table counterpart of
-   * `advanceAfterPreRunFailure`. Cron advances to the next occurrence; a loop
-   * advances by its interval; once and interval-less loops do not reschedule.
-   * Disabling collapses the next run to null.
+   * Next run for an `automation_triggers` time row after a pre-run failure in
+   * the poller (the run was never created). Cron advances to the next
+   * occurrence; a loop advances by its interval; once and interval-less loops
+   * do not reschedule. Disabling collapses the next run to null.
    */
   advanceTriggerAfterPreRunFailure(args: {
     readonly trigger: TriggerRow;

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -10,7 +10,7 @@ import { now, nowDate } from "../../external/time";
 import { settle } from "../../utils";
 import {
   postAutomationUserMessage,
-  resolveScheduleChatThreadModelPin,
+  resolveAutomationChatThreadModelPin,
 } from "../../routes/zero-chat-messages";
 import {
   resolveModelFirstProviderAdmission,
@@ -35,8 +35,8 @@ type TriggerRow = typeof automationTriggers.$inferSelect;
 /**
  * The trigger row joined with its owning automation: everything the poller needs
  * to claim the recurrence (trigger columns) and build the run (automation
- * identity + instruction + linked thread). Mirrors the schedule row the live
- * poller reads, split across the two events-first tables.
+ * identity + instruction + linked thread), split across the two
+ * events-first tables.
  */
 interface DueTrigger {
   readonly trigger: TriggerRow;
@@ -120,7 +120,7 @@ function isInsufficientCreditsFailure(error: unknown): boolean {
 // Resolve the model context for a triggered run: the linked thread's model pin
 // (org default if unpinned) and the admitted provider. No user is present to
 // receive a model-config / credits error, so failures surface as run_error
-// (normalized to 400) feeding consecutiveFailures — the schedule poller's policy.
+// (normalized to 400) feeding consecutiveFailures.
 async function resolveTriggerRunModelContext(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -128,7 +128,7 @@ async function resolveTriggerRunModelContext(args: {
   readonly chatThreadId: string;
   readonly signal: AbortSignal;
 }): Promise<TriggerRunModelContext> {
-  const threadModelPin = await resolveScheduleChatThreadModelPin({
+  const threadModelPin = await resolveAutomationChatThreadModelPin({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
@@ -319,7 +319,7 @@ const runTriggerNow$ = command(
       return { kind: "run_error", response: result };
     }
 
-    // The schedule chip: the snapshot keeps the label rendering after edits
+    // The automation chip: the snapshot keeps the label rendering after edits
     // or deletes.
     await postAutomationUserMessage({
       db,
@@ -359,16 +359,13 @@ const runTriggerNow$ = command(
 );
 
 /**
- * Dormant time poller over `automation_triggers` — the events-first counterpart
- * of `executeDueSchedules$`, built for the (later, gated) cutover and NOT wired
- * to any live cron route in this slice. It mirrors the schedule poller's
- * semantics 1:1: scan enabled time triggers whose `next_run_at` is due, skip any
+ * Time poller over `automation_triggers`, run from the execute-automations
+ * cron route: scan enabled time triggers whose `next_run_at` is due, skip any
  * whose previous run is still active, optimistic-lock claim the due row (clears
  * `next_run_at`; disables once-triggers), then create the run via the default
  * interpreter (tagged with automation + trigger provenance, carrying the
  * trigger completion callback that advances the recurrence) and auto-disable a
- * trigger after consecutive pre-run failures. Nothing here changes live
- * execution; `executeDueSchedules$` remains the only schedule executor.
+ * trigger after consecutive pre-run failures.
  */
 export const executeDueTriggers$ = command(
   async ({ set }, signal: AbortSignal): Promise<ExecuteDueTriggersResult> => {

--- a/turbo/apps/api/src/signals/services/webhook-automations.service.ts
+++ b/turbo/apps/api/src/signals/services/webhook-automations.service.ts
@@ -34,7 +34,7 @@ export function mintWebhookSecret(): string {
  * A chat thread may be linked to a webhook automation only if it exists, is
  * owned by the same user, and belongs to the same agent. (Chat threads carry
  * only a userId, so org isolation is enforced via the user — same rule the
- * schedule surface applies.)
+ * automation surface applies.)
  */
 export async function isChatThreadLinkable(
   db: Db,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1486,10 +1486,10 @@ const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
 
 /**
  * Delete a chat thread after winding down everything attached to it. Deleting a
- * thread on its own leaves the linked schedules firing and any in-flight runs
+ * thread on its own leaves the linked automations firing and any in-flight runs
  * executing: `zero_runs.chatThreadId` is `ON DELETE SET NULL`, so a running run
  * simply loses its thread reference and keeps consuming credits. We therefore
- * follow the order: stop related schedules, cancel related active runs, then
+ * follow the order: stop related automations, cancel related active runs, then
  * delete the thread.
  *
  * Run cancellation has side effects that cannot participate in the thread's

--- a/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
@@ -32,7 +32,7 @@ async function resolveAgentLabel(
   return row?.displayName ?? row?.name ?? undefined;
 }
 
-async function resolveScheduleLabel(
+async function resolveAutomationLabel(
   db: ReadonlyDb,
   runId: string,
 ): Promise<string | undefined> {
@@ -101,10 +101,10 @@ export function slackMessageSendFooterText(args: {
     const runId = args.authRunId;
 
     const noop = (): void => {};
-    const [agentLabel, scheduleLabel, userMention, selectedModel] =
+    const [agentLabel, automationLabel, userMention, selectedModel] =
       await Promise.all([
         tapError(resolveAgentLabel(db, runId), noop),
-        tapError(resolveScheduleLabel(db, runId), noop),
+        tapError(resolveAutomationLabel(db, runId), noop),
         tapError(resolveUserMention(db, runId), noop),
         tapError(resolveSelectedModel(db, runId), noop),
       ]);
@@ -113,12 +113,12 @@ export function slackMessageSendFooterText(args: {
     if (agentLabel) {
       parts.push(`Sent via ${agentLabel}`);
     }
-    if (scheduleLabel) {
-      parts.push(`Triggered by schedule "${scheduleLabel}"`);
+    if (automationLabel) {
+      parts.push(`Triggered by automation "${automationLabel}"`);
     }
     if (userMention) {
       parts.push(
-        scheduleLabel
+        automationLabel
           ? `Created by ${userMention}`
           : `Triggered by ${userMention}`,
       );

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -100,7 +100,6 @@ interface RunCallback {
 
 interface ZeroRunMetadata {
   readonly triggerAgentId?: string;
-  readonly scheduleId?: string;
   readonly automationId?: string;
   readonly triggerId?: string;
 }

--- a/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
@@ -190,7 +190,7 @@ async function resolveRunAgentLabel(
   return row ? displayLabel(row) : undefined;
 }
 
-async function resolveRunScheduleLabel(
+async function resolveRunAutomationLabel(
   db: ReadonlyDb,
   runId: string,
 ): Promise<string | undefined> {
@@ -249,7 +249,7 @@ async function resolveRunSelectedModel(
 /**
  * Resolve the audit footer text appended to user-initiated Telegram messages.
  *
- * Preserves the legacy footer semantics for agent, schedule, triggering user,
+ * Preserves the legacy footer semantics for agent, automation, triggering user,
  * and selected model labels. Returns undefined when authRunId is undefined
  * (auth source has no run context) or when none of the four data points are
  * available.
@@ -264,10 +264,10 @@ export function telegramMessageSendFooterText(args: {
     }
     const db = get(db$);
 
-    const [agentLabel, scheduleLabel, userLabel, selectedModel] =
+    const [agentLabel, automationLabel, userLabel, selectedModel] =
       await Promise.all([
         resolveRunAgentLabel(db, args.authRunId),
-        resolveRunScheduleLabel(db, args.authRunId),
+        resolveRunAutomationLabel(db, args.authRunId),
         resolveRunUserLabel(db, {
           runId: args.authRunId,
           botId: args.botId,
@@ -279,12 +279,14 @@ export function telegramMessageSendFooterText(args: {
     if (agentLabel) {
       parts.push(`Sent via ${escapeHtml(agentLabel)}`);
     }
-    if (scheduleLabel) {
-      parts.push(`Triggered by schedule "${escapeHtml(scheduleLabel)}"`);
+    if (automationLabel) {
+      parts.push(`Triggered by automation "${escapeHtml(automationLabel)}"`);
     }
     if (userLabel) {
       parts.push(
-        scheduleLabel ? `Created by ${userLabel}` : `Triggered by ${userLabel}`,
+        automationLabel
+          ? `Created by ${userLabel}`
+          : `Triggered by ${userLabel}`,
       );
     }
     if (selectedModel) {

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -72,7 +72,7 @@ describe("decodeZeroTokenPayload", () => {
       runId: "run-1",
       orgId: "org-1",
       scope: "zero",
-      capabilities: ["agent:read", "schedule:read"],
+      capabilities: ["agent:read", "automation:read"],
       iat: 1000,
       exp: 2000,
     });
@@ -82,7 +82,7 @@ describe("decodeZeroTokenPayload", () => {
       runId: "run-1",
       orgId: "org-1",
       scope: "zero",
-      capabilities: ["agent:read", "schedule:read"],
+      capabilities: ["agent:read", "automation:read"],
       iat: 1000,
       exp: 2000,
     });
@@ -134,7 +134,7 @@ describe("registerZeroCommands", () => {
   it("should hide unmapped commands and show capable ones with valid token", () => {
     const token = buildZeroToken({
       scope: "zero",
-      capabilities: ["agent:read", "schedule:read", "schedule:write"],
+      capabilities: ["agent:read", "automation:read", "automation:write"],
     });
     vi.stubEnv("ZERO_TOKEN", token);
 
@@ -645,7 +645,7 @@ describe("registerZeroCommands", () => {
   it("should hide agent when agent:read capability is missing", () => {
     const token = buildZeroToken({
       scope: "zero",
-      capabilities: ["schedule:read"],
+      capabilities: ["automation:read"],
     });
     vi.stubEnv("ZERO_TOKEN", token);
 

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -106,7 +106,7 @@ describe("zero whoami command", () => {
         runId: "run-abc",
         orgId: "org-xyz",
         scope: "zero",
-        capabilities: ["agent:read", "agent:write", "schedule:read"],
+        capabilities: ["agent:read", "agent:write", "automation:read"],
         iat: 1000,
         exp: 2000,
       });
@@ -158,7 +158,7 @@ describe("zero whoami command", () => {
       ).toBe(true);
       expect(
         output.some((line) => {
-          return line.includes("schedule:read");
+          return line.includes("automation:read");
         }),
       ).toBe(true);
     });

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -52,10 +52,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   connector: "connector:read",
   // "schedule" is deliberately absent: the rename stub stays out of
   // token-scoped (agent) help but remains invokable and visible to humans.
-  // Tokens minted before #17307 carry "schedule:read"; newer ones carry
-  // "automation:read". Accept both so the command stays visible regardless
-  // of which side (API or CLI) deploys first.
-  automation: ["schedule:read", "automation:read"],
+  automation: "automation:read",
   doctor: null,
   credit: "billing:write",
   model: null,

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -300,18 +300,6 @@ const ROUTE_CONFIG = [
     setup: redirectWithId(ROUTES.activityDetail, "activityRunId"),
   },
   { path: "/chat/:id", setup: redirectWithId(ROUTES.chat, "threadId") },
-  { path: "/schedule", setup: redirectTo(ROUTES.automations) },
-  {
-    path: "/schedule/:id",
-    setup: redirectWithId(ROUTES.automationDetail, "scheduleId"),
-  },
-  // The surface moved from /schedules to /automations (#17307); old links
-  // and bookmarks redirect.
-  { path: "/schedules", setup: redirectTo(ROUTES.automations) },
-  {
-    path: "/schedules/:id",
-    setup: redirectWithId(ROUTES.automationDetail, "scheduleId"),
-  },
   { path: "/preferences", setup: redirectTo(ROUTES.settings) },
 
   {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -518,7 +518,7 @@ export interface ChatThreadSignals {
   setInputRef$: Command<(() => void) | undefined, [HTMLElement | null]>;
   focusInput$: Command<void, []>;
   // ── Draft sync ────────────────────────────────────────────────────────────
-  scheduleDraftSync$: Command<Promise<void>, [AbortSignal]>;
+  queueDraftSync$: Command<Promise<void>, [AbortSignal]>;
   // ── Paged messages (sole rendering path) ─────────────────────────────────
   earliestChatMessageId$: Computed<Promise<string | undefined>>;
   latestChatMessageId$: Computed<Promise<string | undefined>>;
@@ -855,7 +855,7 @@ function createDraftSync(
     },
   );
 
-  const scheduleDraftSync$ = command(async ({ set }, signal: AbortSignal) => {
+  const queueDraftSync$ = command(async ({ set }, signal: AbortSignal) => {
     const debouncedSignal = set(draftSyncReset$, signal);
     await set(debouncedSyncDraft$, debouncedSignal);
   });
@@ -873,7 +873,7 @@ function createDraftSync(
     );
   });
 
-  return { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ };
+  return { queueDraftSync$, cancelDraftSync$, flushDraftClear$ };
 }
 
 // ---------------------------------------------------------------------------
@@ -2432,7 +2432,7 @@ export function createChatThreadSignals(
     loadPagedHistory$,
   );
 
-  const { scheduleDraftSync$, cancelDraftSync$, flushDraftClear$ } =
+  const { queueDraftSync$, cancelDraftSync$, flushDraftClear$ } =
     createDraftSync(threadId, draft, dataSource);
   const runTracking = createRunTracking({
     threadId,
@@ -2499,7 +2499,7 @@ export function createChatThreadSignals(
     ...threadUi,
     setInputRef$,
     focusInput$,
-    scheduleDraftSync$,
+    queueDraftSync$,
     earliestChatMessageId$,
     latestChatMessageId$,
     latestAssistantTextCreatedAt$,

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -23,7 +23,7 @@ export const reloadHeaderAutomationMenu$ = command(({ get, set }) => {
 /**
  * All of the user's automations, for the chat-thread header automation menu. Read
  * via useLastLoadable; refetched on every menu open via reloadHeaderAutomationMenu$
- * and on realtime chatThreadSchedulesChanged signals. Consumers filter this to
+ * and on realtime chatThreadAutomationsChanged signals. Consumers filter this to
  * the automations linked to the current chat thread (see automationsForThread).
  */
 export const headerAutomationMenu$ = computed(

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -299,7 +299,7 @@ const subscribeRealtime$ = command(
       ),
       set(
         setAblyLoop$,
-        `chatThreadSchedulesChanged:${threadId}`,
+        `chatThreadAutomationsChanged:${threadId}`,
         handlers.onAutomationsChanged$,
         signal,
       ),

--- a/turbo/apps/platform/src/signals/zero-page/automations-api.ts
+++ b/turbo/apps/platform/src/signals/zero-page/automations-api.ts
@@ -18,7 +18,7 @@ import type { AutomationFormBody } from "./cron.ts";
 // manage carries exactly one time trigger (cron / once / loop), and the view
 // model stays `AutomationView` — the flat projection the pages were built
 // on. These helpers translate between that projection and the resource API
-// (automation + triggers[]), replacing the retired schedule surfaces (#17307).
+// (automation + triggers[]), replacing the retired single-trigger surfaces (#17307).
 // ---------------------------------------------------------------------------
 
 type TimeTrigger = Extract<

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/agent-name.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/agent-name.ts
@@ -31,11 +31,6 @@ function isValidTab(tab: string): boolean {
 function getInitialTab(): string {
   const params = new URLSearchParams(search());
   const tab = params.get("tab") ?? "";
-  // Legacy deep links predate the tab rename (#17307); keep them landing on
-  // the automations tab.
-  if (tab === "schedule") {
-    return "automations";
-  }
   return isValidTab(tab) ? tab : "authorization";
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/automation.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/automation.ts
@@ -108,7 +108,7 @@ function automationToTimeString(
   if (s.cronExpression) {
     return cronToTimeString(s.cronExpression, tz);
   }
-  return "Scheduled";
+  return "Upcoming";
 }
 
 // ---------------------------------------------------------------------------
@@ -209,7 +209,7 @@ export const saveAgentAutomation$ = command(
       if (
         isAtTimePast(params.date, String(params.hour), String(params.minute))
       ) {
-        throw new Error("Scheduled time must be in the future");
+        throw new Error("The selected time must be in the future");
       }
       const atTime = buildAtTime(
         params.date,

--- a/turbo/apps/platform/src/signals/zero-page/zero-automations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-automations.ts
@@ -29,7 +29,7 @@ import { now, nowDate } from "../../lib/time.ts";
 import { markDetachedErrorHandled, throwIfAbort } from "../utils.ts";
 import { userPreferences$ } from "./settings/user-preferences.ts";
 
-const AUTOMATION_TIME_PAST_MESSAGE = "Scheduled time must be in the future";
+const AUTOMATION_TIME_PAST_MESSAGE = "The selected time must be in the future";
 
 // ---------------------------------------------------------------------------
 // State
@@ -75,7 +75,7 @@ function automationToTimeString(
     return cronToTimeString(s.cronExpression, tz);
   }
 
-  return "Scheduled";
+  return "Upcoming";
 }
 
 function cronToTimeString(cron: string, timezone = "UTC"): string {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automation-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automation-detail-page.test.tsx
@@ -160,7 +160,7 @@ describe("zero automation detail page", () => {
     context.mocks.data.team([createZeroAgent()]);
     context.mocks.data.automations([]);
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(screen.getByText("Automation not found")).toBeInTheDocument();
@@ -175,7 +175,7 @@ describe("zero automation detail page", () => {
     const user = userEvent.setup({ delay: null });
     mockAutomationDetailStory();
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(
@@ -244,7 +244,7 @@ describe("zero automation detail page", () => {
   it("discards automation settings changes", async () => {
     mockAutomationDetailStory();
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(
@@ -276,7 +276,7 @@ describe("zero automation detail page", () => {
   it("updates automation schedule settings", async () => {
     mockAutomationDetailStory();
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(
@@ -326,7 +326,7 @@ describe("zero automation detail page", () => {
   it("filters automation run history", async () => {
     mockAutomationDetailStory();
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(
@@ -413,7 +413,7 @@ describe("zero automation detail page", () => {
       });
     });
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(
@@ -450,7 +450,7 @@ describe("zero automation detail page", () => {
     const user = userEvent.setup({ delay: null });
     mockAutomationDetailStory();
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(
@@ -495,7 +495,7 @@ describe("zero automation detail page", () => {
   it("runs and deletes an automation", async () => {
     mockAutomationDetailStory();
 
-    detachedSetupPage({ context, path: `/schedules/${scheduleId}` });
+    detachedSetupPage({ context, path: `/automations/${scheduleId}` });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -178,14 +178,12 @@ async function openAutomationList(): Promise<void> {
 
   await waitFor(() => {
     expect(screen.getByText("Instruction")).toBeInTheDocument();
-    expect(screen.getByText("Schedule at")).toBeInTheDocument();
+    expect(screen.getByText("Runs at")).toBeInTheDocument();
   });
 }
 
 async function openAutomationsList(): Promise<void> {
-  // The legacy /schedules path redirects to /automations (#17307); entering
-  // through it keeps the redirect covered.
-  detachedSetupPage({ context, path: "/schedules" });
+  detachedSetupPage({ context, path: "/automations" });
 
   await waitFor(() => {
     expect(
@@ -197,7 +195,7 @@ async function openAutomationsList(): Promise<void> {
 
   await waitFor(() => {
     expect(screen.getByText("Instruction")).toBeInTheDocument();
-    expect(screen.getByText("Schedule at")).toBeInTheDocument();
+    expect(screen.getByText("Runs at")).toBeInTheDocument();
   });
 }
 
@@ -406,7 +404,7 @@ describe("zero automations page", () => {
     click(tabByText("List"));
 
     await waitFor(() => {
-      expect(screen.getByText("No runs scheduled")).toBeInTheDocument();
+      expect(screen.getByText("No upcoming runs")).toBeInTheDocument();
       expect(
         screen.getByText(
           "Set up an automation and your agents will handle the rest.",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -517,9 +517,7 @@ describe("zero jobs page", () => {
       },
     );
 
-    // Legacy deep link: ?tab=schedule predates the tab rename (#17307) and
-    // must still land on the automations tab.
-    detachedSetupPage({ context, path: `/agents/${agentId}?tab=schedule` });
+    detachedSetupPage({ context, path: `/agents/${agentId}?tab=automations` });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/auto-focused-artifact-iframe.tsx
+++ b/turbo/apps/platform/src/views/zero-page/auto-focused-artifact-iframe.tsx
@@ -17,14 +17,14 @@ export function AutoFocusedArtifactIframe({
 }: AutoFocusedArtifactIframeProps) {
   const handleLoad: ReactEventHandler<HTMLIFrameElement> = (event) => {
     onLoad?.(event);
-    scheduleIframeFocus(event.currentTarget, focusKey, focusOnMount, "load");
+    deferIframeFocus(event.currentTarget, focusKey, focusOnMount, "load");
   };
 
   return (
     <iframe
       {...props}
       ref={(element) => {
-        scheduleIframeFocus(element, focusKey, focusOnMount, "mount");
+        deferIframeFocus(element, focusKey, focusOnMount, "mount");
       }}
       onLoad={handleLoad}
       tabIndex={focusOnMount && tabIndex === undefined ? -1 : tabIndex}
@@ -32,7 +32,7 @@ export function AutoFocusedArtifactIframe({
   );
 }
 
-function scheduleIframeFocus(
+function deferIframeFocus(
   element: HTMLIFrameElement | null,
   focusKey: string,
   focusOnMount: boolean,

--- a/turbo/apps/platform/src/views/zero-page/automation-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/automation-list-view.tsx
@@ -362,7 +362,7 @@ export function AutomationListView<T extends AutomationEntry>({
         />
         <div className="text-center">
           <p className="text-sm font-medium text-foreground">
-            No runs scheduled
+            No upcoming runs
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             Set up an automation and your agents will handle the rest.
@@ -433,7 +433,7 @@ export function AutomationListView<T extends AutomationEntry>({
                 className="py-3 px-2 min-w-[6.5rem] max-w-[9rem] align-middle font-medium"
                 scope="col"
               >
-                Schedule at
+                Runs at
               </th>
               {onToggle && (
                 <th

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/preference-section.tsx
@@ -193,7 +193,7 @@ export function PreferenceSection() {
       <section className="flex flex-col gap-3">
         <SettingsSectionHeading
           title="Time Zone"
-          description="Times shown to you and used for scheduled work."
+          description="Times shown to you and used for automation runs."
         />
         <TimezoneSettings />
       </section>

--- a/turbo/apps/platform/src/views/zero-page/zero-automation-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-automation-detail-page.tsx
@@ -377,7 +377,7 @@ function AutomationSettingsForm({
           </InlineSettingsRow>
 
           <InlineSettingsRow
-            label="Schedule"
+            label="Runs at"
             description="How often this task runs and at what local time."
           >
             <fieldset

--- a/turbo/apps/platform/src/views/zero-page/zero-automation-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-automation-tab.tsx
@@ -113,7 +113,7 @@ export function ZeroAutomationTab({
     <div className="mx-auto max-w-[900px]">
       <ZeroAutomationCard
         title={`${displayName}'s automations`}
-        subtitle={`Tasks you've scheduled with ${displayName} to run automatically.`}
+        subtitle={`Tasks you've set up with ${displayName} to run automatically.`}
         initialAutomations={entries}
         onSave={handleSave}
         onDelete={onDelete}

--- a/turbo/apps/platform/src/views/zero-page/zero-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-automations-page.tsx
@@ -353,7 +353,7 @@ function AutomationListSkeleton() {
               className="py-3 px-2 min-w-[6.5rem] max-w-[9rem] align-middle font-medium"
               scope="col"
             >
-              Schedule at
+              Runs at
             </th>
             <th
               className="py-3 px-3 w-16 text-center align-middle font-medium"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -946,7 +946,7 @@ function GithubPrTrackingButton({
   );
 }
 
-// Second line shown under each automation in the header menu: the next scheduled
+// Second line shown under each automation in the header menu: the next upcoming
 // run time, or a note that the automation is inactive when it has been disabled.
 function automationMenuSubline(automation: HeaderAutomationEntry): string {
   if (!automation.enabled) {
@@ -3446,7 +3446,7 @@ function ChatThreadComposer({
   const setInput = useSet(thread.draft.setInput$);
   const cancelRun = useSet(thread.cancelRun$);
   const setInputRef = useSet(thread.setInputRef$);
-  const scheduleDraftSync = useSet(thread.scheduleDraftSync$);
+  const queueDraftSync = useSet(thread.queueDraftSync$);
   const pageSignal = useGet(pageSignal$);
   const { selectedComputerUseHostId, computerUse } =
     useChatThreadComputerUse(thread);
@@ -3485,11 +3485,11 @@ function ChatThreadComposer({
 
   const handleInputChange = (text: string) => {
     setInput(text);
-    detach(scheduleDraftSync(pageSignal), Reason.DomCallback);
+    detach(queueDraftSync(pageSignal), Reason.DomCallback);
   };
 
   const handleDraftChange = () => {
-    detach(scheduleDraftSync(pageSignal), Reason.DomCallback);
+    detach(queueDraftSync(pageSignal), Reason.DomCallback);
   };
 
   const feedback = useChatThreadComposerFeedback(thread, modelSelection);
@@ -4967,7 +4967,7 @@ function automationMessageLabel(
     message.scheduleSnapshot?.description?.trim() ||
     message.scheduleSnapshot?.title?.trim() ||
     message.scheduleTitle?.trim() ||
-    "Scheduled run"
+    "Automation run"
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -81,7 +81,7 @@ const categories: readonly Category[] = [
       },
       {
         title: "Metabase dashboard digest",
-        description: "Dashboard snapshots posted to Slack on a schedule",
+        description: "Dashboard snapshots posted to Slack automatically",
         prompt:
           "Set up a weekly Metabase digest that snapshots key dashboards, captures charts, and posts them to Slack every Monday morning",
         connectors: ["metabase", "slack"],

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -535,7 +535,7 @@ const TRIAL_GALLERY_COPY: readonly TrialGalleryCopy[] = [
     id: "workflow",
     label: "Workflow",
     title: "Workflows that run themselves",
-    subtitle: "Daily briefs, scheduled alerts, weekly digests",
+    subtitle: "Daily briefs, recurring alerts, weekly digests",
   },
   {
     id: "website",

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -404,7 +404,7 @@ export const composesByIdContract = c.router({
 
   /**
    * DELETE /api/agent/composes/:id
-   * Delete agent compose and all associated resources (versions, schedules, permissions, etc.)
+   * Delete agent compose and all associated resources (versions, automations, permissions, etc.)
    * Returns 409 Conflict if agent has running or pending runs
    */
   delete: {

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-trigger.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-trigger.ts
@@ -24,8 +24,8 @@ export const triggerCronCallbackPayloadSchema = triggerLoopCallbackPayloadSchema
   .passthrough();
 
 /**
- * Completion callbacks for `automation_triggers` time rows — the trigger-table
- * counterpart of the schedule callbacks. The poller claims a due trigger by
+ * Completion callbacks for `automation_triggers` time rows. The poller
+ * claims a due trigger by
  * clearing `next_run_at`; this callback advances the recurrence after the run
  * finishes and owns the consecutive-failure bookkeeping (reset on success,
  * increment on failure, auto-disable at the threshold).

--- a/turbo/packages/api-services/src/errors.ts
+++ b/turbo/packages/api-services/src/errors.ts
@@ -86,13 +86,6 @@ export const conflict = makeApiError(
   "Resource already exists",
 );
 
-export const schedulePast = makeApiError(
-  "SchedulePastError",
-  "SCHEDULE_PAST",
-  400,
-  "Schedule time has already passed",
-);
-
 export const concurrentRunLimit = makeApiError(
   "ConcurrentRunLimitError",
   "TOO_MANY_REQUESTS",
@@ -211,12 +204,6 @@ export function isConflict(e: unknown): e is ReturnType<typeof conflict> {
 
 export function isForbidden(e: unknown): e is ReturnType<typeof forbidden> {
   return e instanceof Error && e.name === "ForbiddenError";
-}
-
-export function isSchedulePast(
-  e: unknown,
-): e is ReturnType<typeof schedulePast> {
-  return e instanceof Error && e.name === "SchedulePastError";
 }
 
 export function isConcurrentRunLimit(


### PR DESCRIPTION
## Summary

Sweep D1 of removing every remaining schedule concept (follow-up to the #17307 cleanups; code-only, no migrations — the physical columns follow in a phased train):

- **Capability aliases deleted**: zero tokens expire after 2 h and `automation:*` shipped >36 h ago, so no live token can carry `schedule:*`; the parser drops `LEGACY_CAPABILITY_ALIASES` and the CLI capability map collapses its transition entry.
- **Realtime topic renamed** to `chatThreadAutomationsChanged` (publisher + subscriber atomically); stale tabs lose live list updates until reload — self-healing.
- **Legacy redirects removed** (`/schedule`, `/schedule/:id`, `/schedules`, `/schedules/:id`) and the `?tab=schedule` mapping — old links 404 per the owner's decision; e2e/playwright enter via `/automations`.
- **`zero_runs.schedule_id` dead writer removed** (`ZeroRunMetadata.scheduleId` + the always-null insert). Verified in prod: all 6,523 rows carry ids of the dropped `zero_agent_schedules` table, the last write predates the legacy-surface deletion, and the logs API already serves `automation_id` under the `scheduleId` response field. The column itself drops in the final migration phase.
- **Wording**: "Schedule at"→"Runs at", "No runs scheduled"→"No upcoming runs", "Scheduled run"→"Automation run", `'Unnamed schedule'`→`'Unnamed automation'`, `scheduleDraftSync$`→`queueDraftSync$`, `scheduleIframeFocus`→`deferIframeFocus`, past-time errors and onboarding copy reworded; the describe prompt says "automated task".
- **Test helpers**: `zero-schedules.ts`→`automations.ts`, `api-bdd-runs-schedules.ts`→`api-bdd-runs-automations.ts`, `seedAutomation$` & co. across all importers + the BDD doc.

Untouched by design: DB schema columns (phased D2–D4), chat-message/banking wire fields (same train), Stripe `subscription_schedule` (Stripe's own API vocabulary), the CLI `zero schedule` rename stub (user-facing migration notice), generic scheduling verbs on non-product code (runner claim side-effects, setTimeout wrappers), marketing/connector copy.

## Test plan

- [x] Full API suite 141 files / 1886 tests green, full platform suite 93/684 green, full CLI suite 130/1218 green
- [x] `check-types` 13/13, `lint` 0 errors, `knip` clean, `format` run

Part of #17307

🤖 Generated with [Claude Code](https://claude.com/claude-code)