### PR TITLE
fix: show google oauth warning for all oauth connectors

### DIFF
--- a/turbo/apps/platform/src/lib/google-security-warning.ts
+++ b/turbo/apps/platform/src/lib/google-security-warning.ts
@@ -1,23 +1,10 @@
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
 
 export function shouldShowGoogleSecurityWarningNotice(
   type: ConnectorType,
 ): boolean {
-  switch (type) {
-    case "gmail":
-    case "google-ads":
-    case "google-calendar":
-    case "google-docs":
-    case "google-drive":
-    case "google-meet":
-    case "google-search-console":
-    case "google-sheets": {
-      return true;
-    }
-    default: {
-      return false;
-    }
-  }
+  return isGoogleOAuthConnector(type);
 }
 
 export function shouldShowMetaAdsReviewNotice(type: ConnectorType): boolean {


### PR DESCRIPTION
## Summary
- Reuse the shared Google OAuth connector predicate for the Google security warning notice
- Ensure Google OAuth connectors such as Google Cloud and Google Analytics show the warning without maintaining a separate platform allowlist
- Keep Google Maps out of this OAuth warning path because it is currently an API key/manual connector, not a Google OAuth connector

## Validation
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint

Note: local pre-commit was blocked by an unrelated existing knip finding in apps/desktop/package.json (@testing-library/dom). The commit was created without hooks so this PR stays scoped to the platform warning change.