### PR TITLE
fix: clarify custom skill sync guidance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1514,6 +1514,8 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       "zero doctor permission-change --help",
       "--duration 1h|24h|7d|always",
       "zero skill --help",
+      "do not edit mounted runtime copies",
+      "do not sync back or affect future runs",
       "zero developer-support --help",
       "zero maps --help",
     ]) {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -245,7 +245,7 @@ function buildAgentToolsPrompt(triggerSource: TriggerSource): string {
     "- Request permission changes: `zero doctor permission-change --help` to enable or disable a permission. For enable requests, pass `--duration 1h|24h|7d|always`: default to `--duration 1h` for one-off work, use `24h` or `7d` for longer user-approved work, and use `always` only when the user explicitly asks for persistent access.",
     "- Inspect yourself: `zero whoami` for identity and permissions, `zero agent view $ZERO_AGENT_ID --instructions` for your current settings.",
     "- When the user asks to change your behavior, update your own configuration (instructions, tone, description): `zero agent edit --help`.",
-    "- Manage custom skills: `zero skill --help`.",
+    "- Manage org custom skills with `zero skill --help`. To create or update synced skill content, use `zero skill create|edit <name> --dir <path>`; do not edit mounted runtime copies under `/home/user/.codex/skills` or `/home/user/.claude/skills`, because those changes do not sync back or affect future runs.",
     "- Report issues to the dev team: `zero developer-support --help`. Requires a two-step consent flow: (1) call without --consent-code to get a code, (2) ask the user to type it, (3) call again with --consent-code. Never submit without the user typing the consent code.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Clarify that org custom skills should be managed with `zero skill create|edit` for synced content updates.
- Warn agents not to edit mounted runtime copies under `/home/user/.codex/skills` or `/home/user/.claude/skills`, because those changes do not sync back or affect future runs.
- Extend the run lifecycle prompt assertions for the new guidance.

## Tests
- `pnpm format`
- `pnpm -F api exec oxlint src/signals/services/zero-runs-create.service.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec oxlint src/signals/services/zero-runs-create.service.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --type-aware -c ../../.oxlintrc.typeaware.json`
- `pnpm -F api exec eslint src/signals/services/zero-runs-create.service.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --max-warnings 0`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`

## Notes
- `pnpm turbo run lint --log-order grouped` was attempted, but local API type-aware lint was killed with `SIGKILL` from `tsgolint` on this small 3.8 GiB runtime. File-level lint passed.
- `DATABASE_URL=... pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` was attempted after local Postgres migration. The file still fails in this runtime because runner jobs are not queued locally (`Job not found in queue`), before the changed prompt assertions are reached.