### PR TITLE
chore: bump idb schema version

### DIFF
--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -7,6 +7,8 @@ import { logger } from "../log.ts";
 
 const L = logger("ChatIdbCache");
 
+const DB_VERSION = 3;
+
 interface ChatMessageReadStore {
   readLatest(
     threadId: string,
@@ -66,11 +68,11 @@ function createIdbMessageStores(userId: string, orgId: string) {
   function getDb(): Promise<IDBPDatabase> {
     if (!dbPromise) {
       L.debug("openDB", { dbName, storeName });
-      // Schema is shared with idb-thread-agent-store.ts: both modules open
-      // the same DB at version 2. The upgrade callback creates every store
+      // Schema is shared with idb-thread-meta-store.ts: both modules open
+      // the same DB at the same version. The upgrade callback creates every store
       // the schema currently defines, idempotently, so whichever module
       // triggers the version bump leaves a complete schema for the other.
-      dbPromise = openDB(dbName, 2, {
+      dbPromise = openDB(dbName, DB_VERSION, {
         upgrade(db) {
           L.debug("openDB:upgrade", { dbName, storeName });
           if (!db.objectStoreNames.contains(storeName)) {

--- a/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
@@ -43,7 +43,7 @@ function isThreadMetaRow(raw: unknown): raw is ThreadMetaRow {
 // without `startMessageId` are still valid; new fields default to undefined.
 const STORE = "chat_thread_agents";
 const MESSAGE_STORE = "chat_messages";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 const getDb = (() => {
   const cache: Record<string, Promise<IDBPDatabase>> = {};


### PR DESCRIPTION
## Summary
- bump the shared chat IndexedDB schema version from 2 to 3
- keep both message and thread metadata store openers on the same DB version
- update the shared-schema comment to reference the current thread meta store file

## Tests
- pnpm exec prettier --write apps/platform/src/signals/external/idb-message-store.ts apps/platform/src/signals/external/idb-thread-meta-store.ts
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts