### PR TITLE
fix: cover pwa bottom safe area

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -451,7 +451,14 @@
         }
         .sk {
           height: 100dvh;
+          min-height: 100dvh;
           background: #fdfdfe;
+        }
+        @media (display-mode: standalone) {
+          .sk {
+            height: calc(100dvh + env(safe-area-inset-bottom, 0px));
+            min-height: calc(100dvh + env(safe-area-inset-bottom, 0px));
+          }
         }
         [data-theme="dark"] .sk {
           background: #19191b;

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -54,6 +54,22 @@
   --zero-desktop-titlebar-height: 48px;
 }
 
+.zero-viewport-shell {
+  height: 100dvh;
+  min-height: 100dvh;
+}
+
+@media (display-mode: standalone) {
+  .zero-viewport-shell {
+    height: calc(100dvh + var(--sab));
+    min-height: calc(100dvh + var(--sab));
+  }
+
+  .zero-pwa-fixed-cover {
+    bottom: calc(-1 * var(--sab));
+  }
+}
+
 .zero-sidebar-header {
   padding-top: calc(0.375rem + var(--sat));
 }

--- a/turbo/apps/platform/src/views/onboarding-page/onboarding-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding-page/onboarding-page.tsx
@@ -6,6 +6,8 @@ export function OnboardingPage() {
   const showOnboarding = useLastResolved(onboardingShowDialog$) ?? false;
 
   return (
-    <div className="h-dvh w-full">{showOnboarding && <ZeroOnboarding />}</div>
+    <div className="zero-viewport-shell w-full">
+      {showOnboarding && <ZeroOnboarding />}
+    </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -251,14 +251,14 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
   const setExpanded = useSet(setSidebarExpanded$);
 
   return (
-    <div className="zero-app flex h-dvh w-full bg-background">
+    <div className="zero-app zero-viewport-shell flex w-full bg-background">
       <OrgManageDialogMount />
       <SettingsDialogMount />
       <QueueDrawer />
       <ZeroSidebar />
       <div
         data-sidebar-expanded={expanded || undefined}
-        className="fixed inset-0 z-30 bg-black/40 hidden data-[sidebar-expanded]:max-md:block"
+        className="zero-pwa-fixed-cover fixed inset-0 z-30 bg-black/40 hidden data-[sidebar-expanded]:max-md:block"
         aria-label="Sidebar overlay"
         onClick={() => {
           return setExpanded(false);

--- a/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx
@@ -34,7 +34,7 @@ function BackLink() {
 
 function PageShell({ children }: { children: ReactNode }) {
   return (
-    <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
+    <div className="zero-app zero-viewport-shell flex w-full bg-background zero-workspace-bg">
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="zero-card w-full max-w-sm p-5 sm:p-8 flex flex-col items-center gap-6">
           {children}

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -992,7 +992,7 @@ function ArtifactPreviewDialogContent({
     <div
       ref={dialogRef}
       tabIndex={-1}
-      className={`zero-dialog-enter-overlay fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease ${
+      className={`zero-dialog-enter-overlay zero-pwa-fixed-cover fixed inset-0 z-[9999] isolate flex items-center justify-center bg-gray-900/45 outline-none transition-opacity duration-[180ms] ease ${
         visible
           ? "pointer-events-auto opacity-100"
           : "pointer-events-none opacity-0"
@@ -1009,7 +1009,7 @@ function ArtifactPreviewDialogContent({
           visible ? "translate-y-0" : "translate-y-2"
         } ${
           fullscreen
-            ? "h-dvh w-dvw rounded-none"
+            ? "zero-viewport-shell w-dvw rounded-none"
             : "h-[min(700px,86vh)] w-[min(980px,92vw)] rounded-2xl"
         }`}
         data-testid="attachment-lightbox-panel"

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -20,7 +20,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   const pageSignal = useGet(pageSignal$);
 
   return (
-    <div className="zero-app flex h-dvh w-full bg-background">
+    <div className="zero-app zero-viewport-shell flex w-full bg-background">
       <OrgManageDialog
         open={dialogOpen}
         onOpenChange={(open) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-github-connect-page.tsx
@@ -43,7 +43,7 @@ function BackLink() {
 
 function PageShell({ children }: { children: ReactNode }) {
   return (
-    <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
+    <div className="zero-app zero-viewport-shell flex w-full bg-background zero-workspace-bg">
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="zero-card w-full max-w-sm p-5 sm:p-8 flex flex-col items-center gap-6">
           {children}

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1162,7 +1162,7 @@ function OnboardingOrgSwitcher() {
 
 function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="zero-app flex h-dvh bg-muted/30 relative">
+    <div className="zero-app zero-viewport-shell flex bg-muted/30 relative">
       {/* Left panel — brand / illustration */}
       <OnboardingIllustrationPanel />
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -333,7 +333,7 @@ function ExpandedSidebar() {
     <aside
       data-sidebar-off={off || undefined}
       data-sidebar-expanded={expanded || undefined}
-      className="zero-nav hidden md:flex data-[sidebar-off]:md:hidden data-[sidebar-expanded]:max-md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:shadow-xl"
+      className="zero-nav zero-pwa-fixed-cover hidden md:flex data-[sidebar-off]:md:hidden data-[sidebar-expanded]:max-md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:h-auto max-md:shadow-xl"
     >
       <ExpandedHeader />
       <ExpandedMainNav />
@@ -482,7 +482,10 @@ function ExpandedFooter() {
   const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
   const { footerNav } = useResolvedNavItems();
   return (
-    <div className="p-2">
+    <div
+      className="px-2 pt-2"
+      style={{ paddingBottom: "calc(0.5rem + var(--sab))" }}
+    >
       <div className="flex flex-col gap-1">
         {footerNav.map(
           ({

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -35,7 +35,7 @@ function BackLink() {
 
 export function ZeroSlackConnectPage() {
   return (
-    <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
+    <div className="zero-app zero-viewport-shell flex w-full bg-background zero-workspace-bg">
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="zero-card w-full max-w-sm p-5 sm:p-8 flex flex-col items-center gap-6">
           <PageContent />

--- a/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx
@@ -47,7 +47,7 @@ function BackLink() {
 
 function PageShell({ children }: { children: ReactNode }) {
   return (
-    <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
+    <div className="zero-app zero-viewport-shell flex w-full bg-background zero-workspace-bg">
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="zero-card w-full max-w-sm p-5 sm:p-8 flex flex-col items-center gap-6">
           {children}


### PR DESCRIPTION
## Summary

- add a shared `zero-viewport-shell` class that extends full-height platform shells through the bottom safe area in standalone PWA mode
- extend fixed mobile overlays/sidebar panels through `--sab` so the drawer and backdrop do not stop above the iOS PWA bottom inset
- keep the expanded sidebar footer padded above the bottom safe area, and apply the same shell to connect/onboarding/fullscreen preview surfaces

Closes #17548

## Verification

- `pnpm exec prettier --check apps/platform/index.html apps/platform/src/views/css/index.css apps/platform/src/views/onboarding-page/onboarding-page.tsx apps/platform/src/views/zero-page/sidebar-layout.tsx apps/platform/src/views/zero-page/zero-agentphone-connect-page.tsx apps/platform/src/views/zero-page/zero-attachment-chips.tsx apps/platform/src/views/zero-page/zero-directed-shared.tsx apps/platform/src/views/zero-page/zero-github-connect-page.tsx apps/platform/src/views/zero-page/zero-onboarding.tsx apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/zero-slack-connect-page.tsx apps/platform/src/views/zero-page/zero-telegram-connect-page.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app build`

Note: local Chrome cannot fully reproduce iOS standalone PWA safe-area rendering; this fix targets the `display-mode: standalone` safe-area gap shown in the report.
