### PR TITLE
fix: let browser MITM traffic bypass firewall matcher

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -28,8 +28,8 @@ Request context
 - ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
   ``"claude-code"``. Read by model-provider usage protocol selection.
 - ``BROWSER_USER_AGENT``: ``bool`` written by ``request()`` for browser-looking
-  user agents. Read by request dispatch to skip auth mutation for that flow and
-  by network-log entry construction.
+  user agents. Read by request dispatch to skip the firewall credential flow for
+  that request and by network-log entry construction.
 
 Timing context
 --------------
@@ -42,8 +42,8 @@ Timing context
 Firewall and auth context
 -------------------------
 - ``FIREWALL_BASE``: ``str`` matched firewall base. Written by firewall match,
-  browser passthrough, matched firewall block, and auth paths. Read by logging,
-  auth cache invalidation, usage dispatch, and local error responses.
+  matched firewall block, and auth paths. Read by logging, auth cache
+  invalidation, usage dispatch, and local error responses.
 - ``FIREWALL_API_ID``: ``str`` API id or base fallback from the matched
   firewall. Read by auth handling and 401 cache invalidation.
 - ``FIREWALL_NAME``: ``str`` firewall connector/model name. Read by logging,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -385,27 +385,6 @@ def _is_browser_request(flow: http.HTTPFlow) -> bool:
     return _is_browser_user_agent(flow.request.headers.get("User-Agent"))
 
 
-def _record_browser_firewall_passthrough(
-    flow: http.HTTPFlow,
-    allow: matching.FirewallAllow,
-) -> None:
-    """Record a browser-looking UA allow without applying provider auth.
-
-    This path returns before ``handle_firewall_request()``, so mitmproxy does
-    not fetch or inject vm0 connector/model-provider tokens. Keep it
-    non-billable unless a future trusted browser path explicitly changes that
-    token boundary.
-    """
-    api_entry = allow.api_entry
-    flow.metadata[metadata_keys.FIREWALL_BASE] = api_entry["base"]
-    flow.metadata[metadata_keys.FIREWALL_NAME] = allow.name
-    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = allow.permission or ""
-    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = allow.rule or ""
-    flow.metadata[metadata_keys.FIREWALL_PARAMS] = allow.params
-    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-
-
 def _network_log_target(flow: http.HTTPFlow, original_url: str) -> tuple[str, str, int]:
     target = flow.metadata.get(metadata_keys.NETWORK_LOG_TARGET)
     if target is not None:
@@ -734,6 +713,16 @@ async def request(flow: http.HTTPFlow) -> None:
                 flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
                 return
 
+        if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+            # User-Agent is client-controlled. This is a credential-flow skip
+            # for browser-looking traffic, not proof that the request came from
+            # a trusted browser integration. Registry and authority validation
+            # have already run, but connector/model-provider auth is not fetched
+            # or injected on this path.
+            flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+            return
+
         # --- Step 3: Firewall match with permission check ---
         # Match base URL, then check permission rules before injecting auth headers.
         if compiled_firewalls:
@@ -784,13 +773,6 @@ async def request(flow: http.HTTPFlow) -> None:
                 )
                 return
             if isinstance(result, matching.FirewallAllow):
-                if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-                    # User-Agent is client-controlled. This branch is an auth
-                    # mutation skip for browser-looking traffic, not proof that
-                    # the request came from a trusted browser integration.
-                    _record_browser_firewall_passthrough(flow, result)
-                    return
-
                 _maybe_track_usage_flow(
                     flow,
                     is_billable_firewall(result.name, vm_info),

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -503,7 +503,7 @@ async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(
 async def test_browser_firewall_match_skips_auth_injection(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs pass through without connector auth mutation."""
+    """Browser-looking UAs pass through without entering the credential flow."""
     pending_path = tmp_path / "usage-pending"
     usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
     reg_path = _write_registry(
@@ -548,13 +548,10 @@ async def test_browser_firewall_match_skips_auth_injection(
     assert flow.response is None
     assert "Authorization" not in flow.request.headers
     assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
-    assert flow.metadata["firewall_name"] == "stripe"
-    assert flow.metadata["firewall_permission"] == ""
-    assert flow.metadata["firewall_rule_match"] == ""
-    assert flow.metadata["firewall_params"] == {}
     assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["browser_user_agent"] is True
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
     assert "firewall_api_id" not in flow.metadata
     assert "auth_resolved_secrets" not in flow.metadata
     assert "auth_url_rewrite" not in flow.metadata
@@ -571,6 +568,7 @@ async def test_browser_firewall_match_skips_auth_injection(
     mitm_addon.response(flow)
     network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
     assert network_log_entry["browser_user_agent"] is True
+    assert "firewall_base" not in network_log_entry
 
 
 async def test_non_browser_firewall_match_still_injects_auth(
@@ -622,10 +620,10 @@ async def test_non_browser_firewall_match_still_injects_auth(
     assert flow.metadata["firewall_name"] == "stripe"
 
 
-async def test_browser_firewall_match_does_not_bypass_denied_unknown_policy(
+async def test_browser_firewall_match_bypasses_denied_unknown_policy(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UA only skips auth mutation after firewall allow."""
+    """Browser-looking UAs skip the firewall matcher for unknown endpoints."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -664,16 +662,77 @@ async def test_browser_firewall_match_does_not_bypass_denied_unknown_policy(
         await mitm_addon.request(flow)
 
     mock_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 403
+    assert flow.response is None
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
-    assert flow.metadata["firewall_name"] == "stripe"
+    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["browser_user_agent"] is True
-    body = json.loads(flow.response.content)
-    assert body["error"] == "permission_denied"
-    assert body["reason"] == "unknown_endpoint"
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
+
+
+async def test_browser_firewall_match_bypasses_explicit_denied_permission(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    """Browser-looking UAs pass through even when a matched permission is denied."""
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="stripe",
+            billable_firewalls=["stripe"],
+            api_entry={
+                "base": "https://api.stripe.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.STRIPE_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "payment_method_write",
+                        "rules": ["POST /v1/payment_methods"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": [],
+                "deny": ["payment_method_write"],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.stripe.com",
+        method="POST",
+        path="/v1/payment_methods",
+        request_headers=headers(
+            ("Host", "api.stripe.com"),
+            ("User-Agent", _BROWSER_USER_AGENT),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as mock_headers,
+    ):
+        await mitm_addon.request(flow)
+
+    mock_headers.assert_not_called()
+    assert flow.response is None
+    assert "Authorization" not in flow.request.headers
+    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata["firewall_billable"] is False
+    assert flow.metadata["browser_user_agent"] is True
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
+    assert "firewall_api_id" not in flow.metadata
+
+    flow.response = mitm_addon.http.Response.make(200)
+    mitm_addon.response(flow)
+    network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
+    assert network_log_entry["browser_user_agent"] is True
+    assert "firewall_base" not in network_log_entry
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- return browser-looking MITM requests as plain passthrough before the compiled firewall matcher
- keep registry, authority validation, VM0 API auto-allow, and network-log browser tagging intact
- update browser firewall dispatch tests for unknown-policy and explicit denied-permission passthrough

Closes #17515

## Tests
- `.venv/bin/pytest tests/test_request_handler_firewall_dispatch.py::test_browser_firewall_match_skips_auth_injection tests/test_request_handler_firewall_dispatch.py::test_browser_firewall_match_bypasses_denied_unknown_policy tests/test_request_handler_firewall_dispatch.py::test_browser_firewall_match_bypasses_explicit_denied_permission`
- `.venv/bin/pytest tests/test_request_handler_firewall_dispatch.py`
- `.venv/bin/pytest tests/`
- `.venv/bin/ruff check src tests/test_request_handler_firewall_dispatch.py`
- `.venv/bin/ruff format --check src tests/test_request_handler_firewall_dispatch.py`
- `.venv/bin/basedpyright src tests/test_request_handler_firewall_dispatch.py`