### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.174"
+CLAUDE_CODE_VERSION="2.1.177"
 CODEX_CLI_VERSION="0.139.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.27.2"
+AGENT_BROWSER_VERSION="0.27.3"
 PNPM_VERSION="11.6.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Update pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`.

Updated:
- Claude Code CLI: `2.1.174` -> `2.1.177`
- agent-browser: `0.27.2` -> `0.27.3`

Checked and already current/no script change needed:
- Go: `1.26.4`
- OpenAI Codex CLI: `0.139.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- pnpm: `11.6.0`
- Node.js LTS track: `24.x`
- PostgreSQL major: `18`
- Debian Chromium package source: no newer Chromium package version found

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
