### PR TITLE
fix: prevent pwa shell page scroll

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -454,12 +454,6 @@
           min-height: 100dvh;
           background: #fdfdfe;
         }
-        @media (display-mode: standalone) {
-          .sk {
-            height: calc(100dvh + env(safe-area-inset-bottom, 0px));
-            min-height: calc(100dvh + env(safe-area-inset-bottom, 0px));
-          }
-        }
         [data-theme="dark"] .sk {
           background: #19191b;
         }

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -60,11 +60,6 @@
 }
 
 @media (display-mode: standalone) {
-  .zero-viewport-shell {
-    height: calc(100dvh + var(--sab));
-    min-height: calc(100dvh + var(--sab));
-  }
-
   .zero-pwa-fixed-cover {
     bottom: calc(-1 * var(--sab));
   }


### PR DESCRIPTION
## Summary

- keep the app viewport shell and hydration skeleton at exactly `100dvh` in standalone PWA mode
- leave fixed PWA covers extending through the bottom safe area so drawer/backdrop coverage from #17550 stays intact
- prevent Safari PWA from creating a page-level scroll range that can push the chat composer safe-area padding below the visible viewport

## Verification

- `pnpm dlx prettier@3.6.2 --check apps/platform/index.html apps/platform/src/views/css/index.css`
- `git diff --check`

Note: Safari standalone PWA rendering is not available in this runtime; this fix is based on the layout rule that made the outer shell `100dvh + var(--sab)`, which creates the extra page-level scroll range described in the report.