### PR TITLE
perf: resize R2 thumbnails in chat and galleries

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
+  r2ImageTransformUrl,
   VIDEO_STYLE_PRESETS,
 } from "@vm0/core";
 import {
@@ -1363,7 +1364,13 @@ describe("chat composer templates", () => {
       expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
       expect(
         screen.getByTitle(`${illustrationTemplate.title} illustration preview`),
-      ).toHaveAttribute("src", illustrationTemplate.previewImage);
+      ).toHaveAttribute(
+        "src",
+        r2ImageTransformUrl(illustrationTemplate.previewImage, {
+          width: 640,
+          height: 360,
+        }),
+      );
       expect(screen.getAllByTitle(/ illustration preview$/u)).toHaveLength(
         ILLUSTRATION_TEMPLATE_ITEMS.length,
       );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -99,6 +99,7 @@ import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
+  r2ImageTransformUrl,
   type IllustrationTemplateItem,
   type PresentationTemplateItem,
   VIDEO_STYLE_GROUPS,
@@ -335,6 +336,12 @@ type ComposerTemplatePicker = NonNullable<
   ZeroChatComposerProps["templatePicker"]
 >;
 type ComposerComputerUse = NonNullable<ZeroChatComposerProps["computerUse"]>;
+
+const TEMPLATE_CARD_PREVIEW_SIZE = { width: 640, height: 360 } as const;
+const TEMPLATE_DETAIL_PREVIEW_SIZE = { width: 1600, height: 900 } as const;
+const TEMPLATE_STRIP_THUMB_SIZE = { width: 200, height: 112 } as const;
+const ILLUSTRATION_DETAIL_PREVIEW_SIZE = { width: 1400, height: 1400 } as const;
+const SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE = { width: 40, height: 40 } as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -776,7 +783,10 @@ function VideoTemplatePreview({ item }: { item: VideoStylePreset }) {
   return (
     <video
       src={item.sampleVideoUrl}
-      poster={item.sampleVideoThumbnailUrl}
+      poster={r2ImageTransformUrl(
+        item.sampleVideoThumbnailUrl,
+        TEMPLATE_CARD_PREVIEW_SIZE,
+      )}
       className="h-full w-full object-cover"
       preload="none"
       playsInline
@@ -1059,7 +1069,9 @@ function TemplatePreview({
   item: PresentationTemplateItem;
   onPreview: (item: PresentationTemplateItem) => void;
 }) {
-  const slideImages = presentationTemplateSlideImages(item);
+  const slideImages = presentationTemplateSlideImages(item).map((imageUrl) => {
+    return r2ImageTransformUrl(imageUrl, TEMPLATE_CARD_PREVIEW_SIZE);
+  });
   const hover = useGet(templateCardHover$);
   const setHover = useSet(setTemplateCardHover$);
   const hoverSlideIndex = hover?.slug === item.slug ? hover.index : 0;
@@ -1229,6 +1241,9 @@ function TemplatePreviewPage({
     Math.min(selectedSlideIndex, slideImages.length - 1),
   );
   const selectedSlideImage = slideImages[safeSlideIndex];
+  const selectedSlidePreviewImage = selectedSlideImage
+    ? r2ImageTransformUrl(selectedSlideImage, TEMPLATE_DETAIL_PREVIEW_SIZE)
+    : selectedSlideImage;
   const hasMultipleSlides = slideImages.length > 1;
   const kind = formatPresentationTemplateKind(item.templateId);
 
@@ -1266,7 +1281,7 @@ function TemplatePreviewPage({
             </div>
             <img
               key={selectedSlideImage}
-              src={selectedSlideImage}
+              src={selectedSlidePreviewImage}
               title={`${item.title} preview slide ${safeSlideIndex + 1}`}
               alt=""
               className="aspect-[16/9] w-full object-cover"
@@ -1298,6 +1313,10 @@ function TemplatePreviewPage({
           <div className="mt-3 grid grid-cols-3 gap-2 sm:grid-cols-6">
             {slideImages.map((image, index) => {
               const selected = index === safeSlideIndex;
+              const thumbnailImage = r2ImageTransformUrl(
+                image,
+                TEMPLATE_STRIP_THUMB_SIZE,
+              );
               return (
                 <button
                   key={image}
@@ -1313,7 +1332,7 @@ function TemplatePreviewPage({
                   }}
                 >
                   <img
-                    src={image}
+                    src={thumbnailImage}
                     alt=""
                     className="aspect-[16/9] w-full object-cover"
                     loading="lazy"
@@ -1425,10 +1444,15 @@ function IllustrationTemplatePreview({
   item: IllustrationTemplateItem;
   onPreview: (item: IllustrationTemplateItem) => void;
 }) {
+  const previewImage = r2ImageTransformUrl(
+    item.previewImage,
+    TEMPLATE_CARD_PREVIEW_SIZE,
+  );
+
   return (
     <div className="relative h-44 shrink-0 overflow-hidden bg-muted">
       <img
-        src={item.previewImage}
+        src={previewImage}
         alt=""
         title={`${item.title} illustration preview`}
         className="absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100"
@@ -1438,7 +1462,7 @@ function IllustrationTemplatePreview({
         onLoad={(event) => {
           const image = event.currentTarget;
           detach(
-            markIllustrationPreviewImageLoaded(item.previewImage, image),
+            markIllustrationPreviewImageLoaded(previewImage, image),
             Reason.DomCallback,
           );
         }}
@@ -1577,6 +1601,9 @@ function IllustrationPreviewPage({
     Math.min(selectedImageIndex, images.length - 1),
   );
   const selectedImage = images[safeImageIndex];
+  const selectedPreviewImage = selectedImage
+    ? r2ImageTransformUrl(selectedImage, ILLUSTRATION_DETAIL_PREVIEW_SIZE)
+    : selectedImage;
 
   return (
     <>
@@ -1600,7 +1627,7 @@ function IllustrationPreviewPage({
           <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-muted">
             <img
               key={selectedImage}
-              src={selectedImage}
+              src={selectedPreviewImage}
               title={`${item.title} preview variant ${safeImageIndex + 1}`}
               alt=""
               className="h-full w-full object-contain"
@@ -1610,6 +1637,10 @@ function IllustrationPreviewPage({
           <div className="mt-3 flex shrink-0 max-w-full items-center gap-2 overflow-x-auto pb-1">
             {images.map((image, index) => {
               const selected = index === safeImageIndex;
+              const thumbnailImage = r2ImageTransformUrl(
+                image,
+                TEMPLATE_STRIP_THUMB_SIZE,
+              );
               return (
                 <button
                   key={image}
@@ -1625,7 +1656,7 @@ function IllustrationPreviewPage({
                   }}
                 >
                   <img
-                    src={image}
+                    src={thumbnailImage}
                     alt=""
                     className="h-full w-full object-cover"
                     loading="lazy"
@@ -2117,7 +2148,10 @@ function SelectedTemplateChip({
         <div className="inline-flex h-8 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/90 pl-1.5 pr-1 text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
           <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
             <img
-              src={item.previewImage}
+              src={r2ImageTransformUrl(
+                item.previewImage,
+                SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE,
+              )}
               alt=""
               className="h-full w-full object-cover"
               loading="lazy"
@@ -2196,7 +2230,10 @@ function SelectedIllustrationTemplateChip({
         <div className="inline-flex h-8 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/90 pl-1.5 pr-1 text-foreground shadow-[0_1px_2px_rgba(15,23,42,0.05)]">
           <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
             <img
-              src={item.previewImage}
+              src={r2ImageTransformUrl(
+                item.previewImage,
+                SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE,
+              )}
               alt=""
               className="h-full w-full object-cover"
               loading="lazy"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -72,6 +72,7 @@ import type {
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
+  r2ImageTransformUrl,
   VIDEO_STYLE_PRESETS,
 } from "@vm0/core";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
@@ -1323,7 +1324,7 @@ function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
   if (previewKind === "image") {
     return (
       <img
-        src={publicUrl}
+        src={r2ImageTransformUrl(publicUrl, { width: 96, height: 96 })}
         alt=""
         aria-hidden="true"
         className="h-full w-full object-cover"
@@ -1452,7 +1453,11 @@ function ChatImagePreviewLink({
   const imageLoadStatusRef = useSet(imageLoadStatusRef$);
   const setImageLoadStatus = useSet(setImageLoadStatus$);
   const imageUrl = publicAttachmentUrl(url);
-  const imageLoadKey = `chat-image-preview:${imageUrl}`;
+  const previewImageUrl = r2ImageTransformUrl(imageUrl, {
+    width: 800,
+    height: 720,
+  });
+  const imageLoadKey = `chat-image-preview:${previewImageUrl}`;
   const imageStatus = imageLoadStatuses[imageLoadKey] ?? "loading";
 
   const showPlaceholder = imageStatus !== "loaded";
@@ -1499,7 +1504,7 @@ function ChatImagePreviewLink({
       <img
         key={imageLoadKey}
         ref={imageLoadStatusRef}
-        src={imageUrl}
+        src={previewImageUrl}
         alt={alt}
         data-image-load-key={imageLoadKey}
         loading="lazy"

--- a/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
+++ b/turbo/apps/web/app/[locale]/illustration/IllustrationGalleryClient.tsx
@@ -6,6 +6,7 @@ import { Footer } from "../../components/Footer";
 import {
   illustrationAssetUrl,
   ILLUSTRATION_STYLES,
+  r2ImageTransformUrl,
   type IllustrationStyle,
 } from "@vm0/core";
 
@@ -13,6 +14,9 @@ interface LightboxState {
   style: IllustrationStyle;
   activeRef: string;
 }
+
+const ILLUSTRATION_CARD_IMAGE_SIZE = { width: 900 } as const;
+const ILLUSTRATION_REF_THUMB_SIZE = { width: 80, height: 80 } as const;
 
 export function IllustrationGalleryClient() {
   const [lightbox, setLightbox] = useState<LightboxState | null>(null);
@@ -132,7 +136,7 @@ function IllustrationCard({ style, onOpen }: CardProps) {
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={coverSrc}
+          src={r2ImageTransformUrl(coverSrc, ILLUSTRATION_CARD_IMAGE_SIZE)}
           width={style.width}
           height={style.height}
           alt={style.title}
@@ -164,7 +168,10 @@ function IllustrationCard({ style, onOpen }: CardProps) {
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={illustrationAssetUrl(`refs/${style.slug}/${ref}`)}
+                src={r2ImageTransformUrl(
+                  illustrationAssetUrl(`refs/${style.slug}/${ref}`),
+                  ILLUSTRATION_REF_THUMB_SIZE,
+                )}
                 loading="lazy"
                 alt=""
               />
@@ -240,7 +247,10 @@ function Lightbox({ state, onClose, onSelectRef }: LightboxProps) {
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={illustrationAssetUrl(`refs/${style.slug}/${ref}`)}
+                src={r2ImageTransformUrl(
+                  illustrationAssetUrl(`refs/${style.slug}/${ref}`),
+                  ILLUSTRATION_REF_THUMB_SIZE,
+                )}
                 loading="lazy"
                 alt=""
               />

--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
 import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { r2ImageTransformUrl } from "@vm0/core";
 import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
@@ -15,6 +16,7 @@ import {
 
 const MAX_WIDTH = 880;
 const PAGE_PADDING = 24;
+const PRESENTATION_PREVIEW_IMAGE_SIZE = { width: 1664, height: 824 } as const;
 
 function PresentationCard({
   item,
@@ -42,7 +44,10 @@ function PresentationCard({
       >
         <div className="relative aspect-[1280/633] overflow-hidden bg-[hsl(var(--gray-1))]">
           <Image
-            src={item.previewImage}
+            src={r2ImageTransformUrl(
+              item.previewImage,
+              PRESENTATION_PREVIEW_IMAGE_SIZE,
+            )}
             alt={item.title}
             fill
             sizes="(min-width: 880px) 832px, calc(100vw - 48px)"

--- a/turbo/apps/web/app/[locale]/report/ReportClient.tsx
+++ b/turbo/apps/web/app/[locale]/report/ReportClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import Image from "next/image";
 import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { r2ImageTransformUrl } from "@vm0/core";
 import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
@@ -12,6 +13,7 @@ import { REPORT_ITEMS, buildReportRemixHref, type ReportItem } from "./data";
 const MAX_WIDTH = 880;
 const PAGE_PADDING = 24;
 const REPORT_PREVIEW_SCROLL_SPEED = 28;
+const REPORT_PREVIEW_IMAGE_SIZE = { width: 1664 } as const;
 
 function ReportPreview({ item }: { item: ReportItem }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -80,7 +82,10 @@ function ReportPreview({ item }: { item: ReportItem }) {
         className="max-h-[640px] overflow-hidden sm:max-h-[720px]"
       >
         <Image
-          src={item.previewImage}
+          src={r2ImageTransformUrl(
+            item.previewImage,
+            REPORT_PREVIEW_IMAGE_SIZE,
+          )}
           alt={item.title}
           width={item.previewWidth}
           height={item.previewHeight}

--- a/turbo/apps/web/app/[locale]/sprite/SpriteClient.tsx
+++ b/turbo/apps/web/app/[locale]/sprite/SpriteClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { r2ImageTransformUrl } from "@vm0/core";
 import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
@@ -10,6 +11,7 @@ import { SPRITE_ITEMS, buildSpriteRemixHref, type SpriteItem } from "./data";
 
 const MAX_WIDTH = 880;
 const PAGE_PADDING = 24;
+const SPRITE_PREVIEW_IMAGE_SIZE = { width: 1664, height: 1170 } as const;
 
 function SpriteCard({ item, appUrl }: { item: SpriteItem; appUrl: string }) {
   const remixHref = buildSpriteRemixHref(item, appUrl);
@@ -29,7 +31,10 @@ function SpriteCard({ item, appUrl }: { item: SpriteItem; appUrl: string }) {
       >
         <div className="relative aspect-[1280/900] overflow-hidden bg-[hsl(var(--gray-1))]">
           <Image
-            src={item.previewImage}
+            src={r2ImageTransformUrl(
+              item.previewImage,
+              SPRITE_PREVIEW_IMAGE_SIZE,
+            )}
             alt={item.title}
             fill
             sizes="(min-width: 880px) 832px, calc(100vw - 48px)"

--- a/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
+++ b/turbo/apps/web/app/[locale]/web-design/WebDesignClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { r2ImageTransformUrl } from "@vm0/core";
 import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
 import { Particles } from "../../components/Particles";
@@ -10,6 +11,7 @@ import { GALLERY_ITEMS, buildGalleryRemixHref, type GalleryItem } from "./data";
 
 const MAX_WIDTH = 880;
 const PAGE_PADDING = 24;
+const GALLERY_PREVIEW_IMAGE_SIZE = { width: 1664, height: 1040 } as const;
 
 function GalleryCard({ item, appUrl }: { item: GalleryItem; appUrl: string }) {
   const remixHref = buildGalleryRemixHref(item, appUrl);
@@ -31,7 +33,10 @@ function GalleryCard({ item, appUrl }: { item: GalleryItem; appUrl: string }) {
         <div className="relative aspect-[16/10] overflow-hidden bg-[hsl(var(--gray-1))]">
           <div className="absolute inset-y-0 left-0 w-[calc(100%+18px)] transition-transform duration-300 group-hover:scale-[1.03]">
             <Image
-              src={item.previewImage}
+              src={r2ImageTransformUrl(
+                item.previewImage,
+                GALLERY_PREVIEW_IMAGE_SIZE,
+              )}
               alt={item.title}
               fill
               sizes="(min-width: 880px) 832px, calc(100vw - 48px)"

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -167,6 +167,10 @@ const nextConfig = {
       },
       {
         protocol: "https",
+        hostname: "cdn.vm7.io",
+      },
+      {
+        protocol: "https",
         hostname: "**.sites.vm0.io",
       },
     ],

--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { r2ImageTransformUrl } from "../r2-image-transform";
+
+describe("r2ImageTransformUrl", () => {
+  it("adds image transform directives for vm0 CDN artifact URLs", () => {
+    expect(
+      r2ImageTransformUrl("https://cdn.vm0.io/artifacts/user/id/image.png", {
+        width: 320,
+        height: 180,
+      }),
+    ).toBe(
+      "https://cdn.vm0.io/cdn-cgi/image/width=320,height=180,fit=scale-down/artifacts/user/id/image.png",
+    );
+  });
+
+  it("supports vm7 CDN artifact URLs", () => {
+    expect(
+      r2ImageTransformUrl("https://cdn.vm7.io/artifacts/user/id/image.jpg", {
+        width: 96,
+        height: 96,
+      }),
+    ).toBe(
+      "https://cdn.vm7.io/cdn-cgi/image/width=96,height=96,fit=scale-down/artifacts/user/id/image.jpg",
+    );
+  });
+
+  it("preserves search params and hashes", () => {
+    expect(
+      r2ImageTransformUrl(
+        "https://cdn.vm0.io/artifacts/user/id/image.png?token=abc#preview",
+        { width: 800 },
+      ),
+    ).toBe(
+      "https://cdn.vm0.io/cdn-cgi/image/width=800,fit=scale-down/artifacts/user/id/image.png?token=abc#preview",
+    );
+  });
+
+  it("leaves already transformed URLs untouched", () => {
+    const url =
+      "https://cdn.vm0.io/cdn-cgi/image/width=100,height=100,fit=scale-down/artifacts/user/id/image.png";
+
+    expect(r2ImageTransformUrl(url, { width: 400, height: 300 })).toBe(url);
+  });
+
+  it("leaves non-R2 URLs untouched", () => {
+    const url = "https://example.com/image.png";
+    expect(r2ImageTransformUrl(url, { width: 400, height: 300 })).toBe(url);
+    expect(r2ImageTransformUrl("/local/image.png", { width: 400 })).toBe(
+      "/local/image.png",
+    );
+  });
+});

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -39,6 +39,10 @@ export {
   type VideoStyleCategory,
 } from "./video-style-preset-items";
 export {
+  r2ImageTransformUrl,
+  type R2ImageTransformOptions,
+} from "./r2-image-transform";
+export {
   initContract,
   apiErrorSchema,
   ApiError,

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -1,0 +1,65 @@
+const R2_IMAGE_TRANSFORM_HOSTS = new Set(["cdn.vm0.io", "cdn.vm7.io"]);
+const R2_IMAGE_TRANSFORM_PREFIX = "/cdn-cgi/image/";
+
+export interface R2ImageTransformOptions {
+  readonly width?: number;
+  readonly height?: number;
+  readonly fit?: "scale-down";
+}
+
+function normalizedDimension(value: number | undefined): number | null {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return Math.round(value);
+}
+
+function r2ImageTransformDirectives(
+  options: R2ImageTransformOptions,
+): string | null {
+  const directives: string[] = [];
+  const width = normalizedDimension(options.width);
+  const height = normalizedDimension(options.height);
+
+  if (width !== null) {
+    directives.push(`width=${String(width)}`);
+  }
+  if (height !== null) {
+    directives.push(`height=${String(height)}`);
+  }
+  directives.push(`fit=${options.fit ?? "scale-down"}`);
+
+  return directives.length > 1 ? directives.join(",") : null;
+}
+
+function parseAbsoluteUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+export function r2ImageTransformUrl(
+  url: string,
+  options: R2ImageTransformOptions,
+): string {
+  const parsed = parseAbsoluteUrl(url);
+  if (parsed === null) {
+    return url;
+  }
+
+  if (
+    !R2_IMAGE_TRANSFORM_HOSTS.has(parsed.hostname) ||
+    parsed.pathname.startsWith(R2_IMAGE_TRANSFORM_PREFIX)
+  ) {
+    return url;
+  }
+
+  const directives = r2ImageTransformDirectives(options);
+  if (directives === null) {
+    return url;
+  }
+
+  return `${parsed.origin}${R2_IMAGE_TRANSFORM_PREFIX}${directives}${parsed.pathname}${parsed.search}${parsed.hash}`;
+}


### PR DESCRIPTION
## Summary
- Add a shared `r2ImageTransformUrl` helper for `cdn.vm0.io` and `cdn.vm7.io` R2 image transform URLs, while leaving non-CDN and already transformed URLs unchanged.
- Use transformed thumbnail URLs for web chat image previews, artifact preview badges, composer template cards, selected template chips, presentation preview slides, illustration previews, and video posters.
- Use transformed preview URLs across gallery-style web pages: Illustration, Web Design, Reports, Presentation, and Sprite; add `cdn.vm7.io` to Next image remote patterns.

## Tests
- `pnpm exec prettier --write <changed files>`
- `git diff --check`
- `pnpm --filter @vm0/core lint`
- `pnpm --filter web lint`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter web check-types`
- `pnpm --filter @vm0/app check-types`
- `pnpm --filter @vm0/core test -- src/__tests__/r2-image-transform.spec.ts`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "selects and removes an illustration style from the picker"`

## Notes
- An unfiltered run of `src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx` hit two unrelated existing failures: the slash picker keyboard selection timeout and the `/custom-skill-1` visible picker expectation. The targeted thumbnail test passes.