### PR TITLE
fix: keep skill highlight aligned by replacing overlay with tiptap composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -473,6 +473,20 @@ function composerElementFrom(textarea: HTMLElement): HTMLElement {
   return composer;
 }
 
+// The slash-skill composer renders a TipTap contenteditable instead of a
+// textarea, so locate it directly rather than by placeholder.
+async function findComposerEditor(): Promise<HTMLElement> {
+  return await waitFor(() => {
+    const editor = document.querySelector(
+      '.zero-composer [contenteditable="true"]',
+    );
+    if (!(editor instanceof HTMLElement)) {
+      throw new Error("Composer editor not found");
+    }
+    return editor;
+  });
+}
+
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
 });
@@ -508,9 +522,8 @@ describe("chat composer models", () => {
       featureSwitches: { [FeatureSwitchKey.ChatSlashSkillCommands]: true },
     });
 
-    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
-    expect(textarea).not.toHaveClass("text-transparent");
-    await user.click(textarea);
+    const editor = await findComposerEditor();
+    await user.click(editor);
     await user.keyboard("/");
 
     const salesSuggestion = await screen.findByText("/sales-research");
@@ -518,26 +531,31 @@ describe("chat composer models", () => {
     expect(screen.getByText("/support-escalation")).toBeInTheDocument();
     expect(screen.queryByText("/deep-dive")).not.toBeInTheDocument();
     const slashSkillMenu = screen.getByTestId("slash-skill-menu");
-    expect(composerElementFrom(textarea)).toContain(slashSkillMenu);
+    expect(composerElementFrom(editor)).toContain(slashSkillMenu);
     expect(slashSkillMenu).toHaveAttribute("popover", "manual");
     expect(slashSkillMenu).toHaveClass("slash-skill-popover");
     expect(slashSkillMenu.closest(".slash-skill-anchor")).not.toBeNull();
 
     await user.keyboard("sales");
 
+    await waitFor(() => {
+      expect(screen.queryByText("/support-escalation")).not.toBeInTheDocument();
+    });
     expect(screen.getByText("/sales-research")).toBeInTheDocument();
-    expect(screen.queryByText("/support-escalation")).not.toBeInTheDocument();
 
     await user.keyboard("{Enter}");
 
-    expect(textarea).toHaveValue("/sales-research ");
+    await waitFor(() => {
+      expect(editor.textContent).toContain("/sales-research");
+    });
+    // The colored token is a real inline decoration in the same layer as the
+    // text (no overlay), so it stays aligned when the composer scrolls.
     const highlightedSkill = screen
       .getAllByText("/sales-research")
       .find((element) => {
         return element.tagName.toLowerCase() === "span";
       });
     expect(highlightedSkill).toHaveClass("text-primary");
-    expect(highlightedSkill).not.toHaveClass("font-medium");
   });
 
   it("does not suggest org skills that are not enabled on the current agent", async () => {
@@ -560,14 +578,14 @@ describe("chat composer models", () => {
       featureSwitches: { [FeatureSwitchKey.ChatSlashSkillCommands]: true },
     });
 
-    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
-    await user.click(textarea);
+    const editor = await findComposerEditor();
+    await user.click(editor);
     await user.keyboard("/");
 
     await waitFor(() => {
       expect(screen.queryByText("/deep-dive")).not.toBeInTheDocument();
     });
-    expect(textarea).toHaveValue("/");
+    expect(editor.textContent).toContain("/");
   });
 
   it("links to the skills page from the slash skill menu footer", async () => {
@@ -593,8 +611,8 @@ describe("chat composer models", () => {
       },
     });
 
-    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
-    await user.click(textarea);
+    const editor = await findComposerEditor();
+    await user.click(editor);
     await user.keyboard("/");
 
     await expect(
@@ -665,8 +683,8 @@ describe("chat composer models", () => {
       featureSwitches: { [FeatureSwitchKey.ChatSlashSkillCommands]: true },
     });
 
-    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
-    await user.click(textarea);
+    const editor = await findComposerEditor();
+    await user.click(editor);
     await user.keyboard("/");
     await expect(
       screen.findByText("/custom-skill-1"),

--- a/turbo/apps/platform/src/views/zero-page/composer-input-types.ts
+++ b/turbo/apps/platform/src/views/zero-page/composer-input-types.ts
@@ -1,0 +1,9 @@
+// Structural paste-event shape shared by the plain textarea composer and the
+// TipTap skill composer. Both a React ClipboardEvent<HTMLTextAreaElement> and a
+// native ClipboardEvent are assignable to this, so a single paste handler can
+// serve both input surfaces without casting.
+export interface ComposerPasteEvent {
+  readonly clipboardData: DataTransfer | null;
+  readonly currentTarget: HTMLElement;
+  preventDefault(): void;
+}

--- a/turbo/apps/platform/src/views/zero-page/slash-skill.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-skill.tsx
@@ -1,0 +1,190 @@
+// Slash-skill domain helpers and the suggestion menu, shared by the chat
+// composer. Kept in its own module so the textarea composer and the TipTap
+// skill composer can both reuse them without an import cycle.
+import { useSet } from "ccstate-react";
+import { IconChevronRight, IconFileText } from "@tabler/icons-react";
+import { cn } from "@vm0/ui";
+import type { ZeroAgentCustomSkill } from "@vm0/api-contracts/contracts/zero-agents";
+import { setSlashSkillMenuRef$ } from "../../signals/zero-page/zero-chat-composer.ts";
+import { Link } from "../router/link.tsx";
+
+export interface SlashSkillRange {
+  readonly start: number;
+  readonly end: number;
+  readonly query: string;
+}
+
+export interface ComposerSlashSkill extends ZeroAgentCustomSkill {
+  readonly token: string;
+}
+
+export function findActiveSlashSkillRange(
+  value: string,
+  caretIndex: number,
+): SlashSkillRange | null {
+  const beforeCaret = value.slice(0, caretIndex);
+  const match = /(?:^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);
+  if (!match) {
+    return null;
+  }
+
+  const query = match[1] ?? "";
+  const slashOffset = match[0].lastIndexOf("/");
+  const start = beforeCaret.length - match[0].length + slashOffset;
+  return { start, end: caretIndex, query };
+}
+
+export function matchesSkillQuery(
+  skill: ComposerSlashSkill,
+  query: string,
+): boolean {
+  if (!query) {
+    return true;
+  }
+
+  const normalizedQuery = query.toLowerCase();
+  return [skill.name, skill.displayName ?? "", skill.description ?? ""]
+    .join(" ")
+    .toLowerCase()
+    .includes(normalizedQuery);
+}
+
+export function skillTokenPattern(
+  skillNames: readonly string[],
+): RegExp | null {
+  if (skillNames.length === 0) {
+    return null;
+  }
+
+  const escaped = skillNames.map((name) => {
+    return name.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  });
+  return new RegExp(`/(?:${escaped.join("|")})(?=$|\\s)`, "g");
+}
+
+export function buildComposerSlashSkills({
+  agentSkillNames,
+  orgSkills,
+}: {
+  readonly agentSkillNames: readonly string[];
+  readonly orgSkills: readonly ZeroAgentCustomSkill[];
+}): readonly ComposerSlashSkill[] {
+  const metadataByName = new Map(
+    orgSkills.map((skill) => {
+      return [skill.name, skill];
+    }),
+  );
+  return agentSkillNames.map((name) => {
+    const metadata = metadataByName.get(name);
+    return {
+      name,
+      displayName: metadata?.displayName ?? null,
+      description: metadata?.description ?? null,
+      token: `/${name}`,
+    };
+  });
+}
+
+function slashSkillOptionId(skillName: string): string {
+  return `slash-skill-option-${skillName}`;
+}
+
+export function scrollSlashSkillIntoView(
+  skill: ComposerSlashSkill | undefined,
+): void {
+  if (!skill) {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    const option = document.getElementById(slashSkillOptionId(skill.name));
+    if (option && typeof option.scrollIntoView === "function") {
+      option.scrollIntoView({ block: "nearest" });
+    }
+  });
+}
+
+export function SlashSkillMenu({
+  skills,
+  loading,
+  selectedIndex,
+  showSkillsPageLink,
+  onSelect,
+}: {
+  readonly skills: readonly ComposerSlashSkill[];
+  readonly loading: boolean;
+  readonly selectedIndex: number;
+  readonly showSkillsPageLink: boolean;
+  readonly onSelect: (skill: ComposerSlashSkill) => void;
+}) {
+  const setMenuRef = useSet(setSlashSkillMenuRef$);
+
+  return (
+    <div
+      ref={setMenuRef}
+      popover="manual"
+      className="slash-skill-popover flex max-h-80 w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-md border border-border/70 bg-popover/95 text-popover-foreground shadow-lg backdrop-blur"
+      data-testid="slash-skill-menu"
+    >
+      <div className="px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">
+        Skills
+      </div>
+      {loading ? (
+        <div className="px-2.5 py-2 text-sm text-muted-foreground">
+          Loading skills...
+        </div>
+      ) : skills.length > 0 ? (
+        <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
+          {skills.map((skill, index) => {
+            const selected = index === selectedIndex;
+            return (
+              <button
+                id={slashSkillOptionId(skill.name)}
+                key={skill.name}
+                type="button"
+                className={cn(
+                  "flex w-full items-center rounded px-2 py-1.5 text-left transition-colors",
+                  selected ? "bg-accent" : "hover:bg-accent/60",
+                )}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  onSelect(skill);
+                }}
+              >
+                <span className="truncate font-mono text-sm text-primary">
+                  {skill.token}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
+          No matching skills
+        </div>
+      )}
+      {showSkillsPageLink && (
+        <div className="shrink-0 border-t border-border/60 bg-popover/95 p-1.5">
+          <Link
+            pathname="/skills"
+            className="flex h-9 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-accent"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <IconFileText
+                size={16}
+                stroke={1.8}
+                className="shrink-0 text-muted-foreground"
+              />
+              <span className="truncate">View all skills</span>
+            </span>
+            <IconChevronRight
+              size={16}
+              stroke={1.8}
+              className="shrink-0 text-muted-foreground"
+            />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -1,0 +1,442 @@
+// TipTap-based chat composer input. Skill mentions are colored with ProseMirror
+// inline decorations rather than a transparent-textarea + colored overlay, so the
+// color lives in the same layer as the text and moves/scrolls with it — there is
+// no second layer to keep aligned when the input scrolls (issue #17539).
+import {
+  useGet,
+  useSet,
+  useLastLoadable,
+  useLastResolved,
+} from "ccstate-react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { Extension, type Editor, type JSONContent } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey, type EditorState } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import type { KeyboardEventLike } from "@vm0/ui";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { currentChatAgent$ } from "../../signals/agent-chat.ts";
+import { orgSkills$ } from "../../signals/skills-page/skills-signals.ts";
+import {
+  slashSkillCaretIndex$,
+  setSlashSkillCaretIndex$,
+  selectedSlashSkillIndex$,
+  setSelectedSlashSkillIndex$,
+} from "../../signals/zero-page/zero-chat-composer.ts";
+import {
+  buildComposerSlashSkills,
+  findActiveSlashSkillRange,
+  matchesSkillQuery,
+  scrollSlashSkillIntoView,
+  skillTokenPattern,
+  SlashSkillMenu,
+  type ComposerSlashSkill,
+  type SlashSkillRange,
+} from "./slash-skill.tsx";
+import type { ComposerPasteEvent } from "./composer-input-types.ts";
+
+// Match the textarea metrics so swapping inputs is visually seamless. The editor
+// element itself scrolls (single layer), so there is no overlay to sync.
+const EDITOR_CONTENT_CLASS =
+  "w-full min-h-[96px] max-h-[200px] overflow-y-auto whitespace-pre-wrap " +
+  "break-words px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground " +
+  "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
+  "selection:bg-primary/20";
+
+const SKILL_HIGHLIGHT_CLASS = "text-primary";
+
+// Plain text -> document: one paragraph per line. Skill coloring is applied by
+// the decoration plugin, so the document stays plain text.
+function valueToDoc(value: string): JSONContent {
+  const content: JSONContent[] = value.split("\n").map((line) => {
+    return line.length > 0
+      ? { type: "paragraph", content: [{ type: "text", text: line }] }
+      : { type: "paragraph" };
+  });
+  return { type: "doc", content };
+}
+
+// Document -> plain string, with block and hard breaks as newlines, so the rest
+// of the chat keeps a plain string value.
+function docToString(editor: Editor): string {
+  return editor.getText({
+    blockSeparator: "\n",
+    textSerializers: {
+      hardBreak: () => {
+        return "\n";
+      },
+    },
+  });
+}
+
+// Caret position as an offset into the serialized string, so the existing
+// string-based slash-range detection can be reused unchanged.
+function caretStringIndex(editor: Editor): number {
+  const head = editor.state.selection.head;
+  return editor.state.doc.textBetween(0, head, "\n", (leafNode) => {
+    return leafNode.type.name === "hardBreak" ? "\n" : "";
+  }).length;
+}
+
+function buildSkillDecorations(
+  doc: ProseMirrorNode,
+  skillNames: readonly string[],
+): DecorationSet {
+  const pattern = skillTokenPattern(skillNames);
+  if (!pattern) {
+    return DecorationSet.empty;
+  }
+  const decorations: Decoration[] = [];
+  doc.descendants((node, pos) => {
+    const text = node.text;
+    if (!node.isText || !text) {
+      return;
+    }
+    for (const match of text.matchAll(pattern)) {
+      const start = pos + (match.index ?? 0);
+      decorations.push(
+        Decoration.inline(start, start + match[0].length, {
+          class: SKILL_HIGHLIGHT_CLASS,
+        }),
+      );
+    }
+  });
+  return DecorationSet.create(doc, decorations);
+}
+
+interface SkillHighlightStorage {
+  skillNames: readonly string[];
+}
+
+// Colors `/skill` tokens via inline decorations. The skill list is read from
+// mutable storage (kept current by the component) so the editor never has to be
+// rebuilt when the list loads or changes.
+const SkillHighlight = Extension.create<
+  { skillNames: readonly string[] },
+  SkillHighlightStorage
+>({
+  name: "skillHighlight",
+  addOptions() {
+    return { skillNames: [] };
+  },
+  addStorage() {
+    return { skillNames: this.options.skillNames };
+  },
+  addProseMirrorPlugins() {
+    const storage = this.storage;
+    return [
+      new Plugin({
+        key: new PluginKey("skillHighlight"),
+        props: {
+          decorations(state: EditorState) {
+            return buildSkillDecorations(state.doc, storage.skillNames);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+const STARTER_KIT = StarterKit.configure({
+  bold: false,
+  italic: false,
+  strike: false,
+  code: false,
+  codeBlock: false,
+  heading: false,
+  bulletList: false,
+  orderedList: false,
+  listItem: false,
+  blockquote: false,
+  horizontalRule: false,
+  link: false,
+  underline: false,
+  trailingNode: false,
+});
+
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const ua = navigator.userAgent;
+  return (
+    /iPad|iPhone|iPod/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
+// Replace the active `/query` text with the chosen token (plus a trailing space
+// unless one already follows). The decoration plugin colors it automatically.
+function insertSkillToken(
+  editor: Editor,
+  slashRange: SlashSkillRange,
+  input: string,
+  skill: ComposerSlashSkill,
+): void {
+  const head = editor.state.selection.head;
+  const span = slashRange.end - slashRange.start;
+  const suffix = input.slice(slashRange.end).startsWith(" ") ? "" : " ";
+  editor
+    .chain()
+    .focus()
+    .insertContentAt({ from: head - span, to: head }, [
+      { type: "text", text: `/${skill.name}${suffix}` },
+    ])
+    .run();
+}
+
+interface SlashMenuKeyContext {
+  readonly suggestions: readonly ComposerSlashSkill[];
+  readonly selectedIndex: number;
+  readonly setSelectedIndex: (index: number) => void;
+  readonly setCaretIndex: (index: number) => void;
+  readonly onInsert: (skill: ComposerSlashSkill) => void;
+}
+
+// Drives the suggestion menu from the keyboard. Returns true when it consumes the
+// event so the editor can stop handling that keystroke.
+function handleSlashMenuKey(
+  event: KeyboardEvent,
+  ctx: SlashMenuKeyContext,
+): boolean {
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    const next = Math.min(
+      ctx.selectedIndex + 1,
+      Math.max(ctx.suggestions.length - 1, 0),
+    );
+    ctx.setSelectedIndex(next);
+    scrollSlashSkillIntoView(ctx.suggestions[next]);
+    return true;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    const next = Math.max(ctx.selectedIndex - 1, 0);
+    ctx.setSelectedIndex(next);
+    scrollSlashSkillIntoView(ctx.suggestions[next]);
+    return true;
+  }
+  if ((event.key === "Enter" || event.key === "Tab") && ctx.suggestions[0]) {
+    event.preventDefault();
+    const skill =
+      ctx.suggestions[Math.min(ctx.selectedIndex, ctx.suggestions.length - 1)];
+    if (skill) {
+      ctx.onInsert(skill);
+    }
+    return true;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    ctx.setCaretIndex(-1);
+    return true;
+  }
+  return false;
+}
+
+interface EditorOptionsParams {
+  readonly input: string;
+  readonly skillNames: readonly string[];
+  readonly autoFocus: boolean | undefined;
+  readonly onInputChange: (value: string) => void;
+  readonly onPaste: (event: ComposerPasteEvent) => void;
+  readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
+  readonly setSelectedSkillIndex: (index: number) => void;
+  readonly setCaretIndex: (index: number) => void;
+  readonly onEditorKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+// Built fresh each render; useEditor applies it via setOptions so the handlers
+// always close over the latest props/state (no refs needed).
+function buildEditorOptions(
+  params: EditorOptionsParams,
+): Parameters<typeof useEditor>[0] {
+  return {
+    extensions: [
+      STARTER_KIT,
+      SkillHighlight.configure({ skillNames: params.skillNames }),
+    ],
+    content: valueToDoc(params.input),
+    autofocus: params.autoFocus && !isIOS() ? "end" : false,
+    shouldRerenderOnTransaction: false,
+    editorProps: {
+      attributes: { class: EDITOR_CONTENT_CLASS },
+      handleKeyDown: (_view, event) => {
+        return params.onEditorKeyDown(event);
+      },
+      handlePaste: (view, event) => {
+        params.onPaste({
+          clipboardData: event.clipboardData,
+          currentTarget: view.dom,
+          preventDefault: () => {
+            event.preventDefault();
+          },
+        });
+        return event.defaultPrevented;
+      },
+    },
+    onUpdate: ({ editor }) => {
+      const value = docToString(editor);
+      if (value !== params.input) {
+        params.onInputChange(value);
+      }
+      params.setSelectedSkillIndex(0);
+      params.setCaretIndex(caretStringIndex(editor));
+    },
+    onSelectionUpdate: ({ editor }) => {
+      params.setCaretIndex(caretStringIndex(editor));
+    },
+    onCreate: ({ editor }) => {
+      params.setInputRef?.(editor.view.dom);
+    },
+    onDestroy: () => {
+      params.setInputRef?.(null);
+    },
+  };
+}
+
+export function TiptapSkillComposer({
+  input,
+  onInputChange,
+  onDraftChange,
+  sending,
+  autoFocus,
+  setInputRef,
+  onKeyDown,
+  onPaste,
+}: {
+  readonly input: string;
+  readonly onInputChange: (value: string) => void;
+  readonly onDraftChange: (() => void) | undefined;
+  readonly sending: boolean | undefined;
+  readonly autoFocus: boolean | undefined;
+  readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
+  readonly onKeyDown: (event: KeyboardEventLike) => void;
+  readonly onPaste: (event: ComposerPasteEvent) => void;
+}) {
+  const caretIndex = useGet(slashSkillCaretIndex$);
+  const setCaretIndex = useSet(setSlashSkillCaretIndex$);
+  const selectedSkillIndex = useGet(selectedSlashSkillIndex$);
+  const setSelectedSkillIndex = useSet(setSelectedSlashSkillIndex$);
+  const currentAgent = useLastResolved(currentChatAgent$);
+  const features = useLastResolved(featureSwitch$);
+  const orgSkillsLoadable = useLastLoadable(orgSkills$);
+  const orgSkillsData =
+    orgSkillsLoadable.state === "hasData" ? orgSkillsLoadable.data : [];
+  const composerSkills = buildComposerSlashSkills({
+    agentSkillNames: currentAgent?.customSkills ?? [],
+    orgSkills: orgSkillsData,
+  });
+  const skillNames = composerSkills.map((skill) => {
+    return skill.name;
+  });
+
+  const slashRange = findActiveSlashSkillRange(input, caretIndex);
+  const suggestions = slashRange
+    ? composerSkills.filter((skill) => {
+        return matchesSkillQuery(skill, slashRange.query);
+      })
+    : [];
+  const isLoadingOrgSkills = orgSkillsLoadable.state === "loading";
+  const showSkillsPageLink = features?.[FeatureSwitchKey.SkillsViewer] ?? false;
+  const showSlashSkillMenu =
+    slashRange !== null &&
+    (isLoadingOrgSkills || composerSkills.length > 0 || showSkillsPageLink);
+
+  // Created once; useEditor refreshes its options via setOptions on every render,
+  // so the handlers always close over the latest props/state (no refs needed).
+  const editor = useEditor(
+    buildEditorOptions({
+      input,
+      skillNames,
+      autoFocus,
+      onInputChange,
+      onPaste,
+      setInputRef,
+      setSelectedSkillIndex,
+      setCaretIndex,
+      onEditorKeyDown: (event) => {
+        return handleEditorKeyDown(event);
+      },
+    }),
+  );
+
+  if (editor) {
+    // Keep the highlight plugin's skill list current without rebuilding the
+    // editor; decorations recompute on the next transaction.
+    const storage = (
+      editor.storage as unknown as Record<
+        string,
+        SkillHighlightStorage | undefined
+      >
+    ).skillHighlight;
+    if (storage) {
+      storage.skillNames = skillNames;
+    }
+    // Reconcile when the value changes outside of typing (draft restore, the
+    // send-clear, template insertion). Guarded so typing — where the serialized
+    // value already matches — never resets the caret. shouldRerenderOnTransaction
+    // is off, so this never triggers a React re-render.
+    if (docToString(editor) !== input) {
+      editor.commands.setContent(valueToDoc(input), { emitUpdate: false });
+    }
+  }
+
+  function insertSkill(skill: ComposerSlashSkill): void {
+    if (!editor || !slashRange) {
+      return;
+    }
+    insertSkillToken(editor, slashRange, input, skill);
+    onDraftChange?.();
+  }
+
+  function handleEditorKeyDown(event: KeyboardEvent): boolean {
+    if (
+      showSlashSkillMenu &&
+      handleSlashMenuKey(event, {
+        suggestions,
+        selectedIndex: selectedSkillIndex,
+        setSelectedIndex: setSelectedSkillIndex,
+        setCaretIndex,
+        onInsert: insertSkill,
+      })
+    ) {
+      return true;
+    }
+    // Defer to the parent for send / global shortcuts. If it consumes the event
+    // (e.g. Enter-to-send) it calls preventDefault; otherwise the editor handles
+    // the keystroke (e.g. Shift+Enter or mobile Enter inserts a newline).
+    onKeyDown(event);
+    return event.defaultPrevented;
+  }
+
+  return (
+    <div className="slash-skill-anchor relative">
+      {showSlashSkillMenu && (
+        <SlashSkillMenu
+          skills={suggestions}
+          loading={isLoadingOrgSkills}
+          selectedIndex={selectedSkillIndex}
+          showSkillsPageLink={showSkillsPageLink}
+          onSelect={(skill) => {
+            insertSkill(skill);
+          }}
+        />
+      )}
+      <div className="relative min-h-[96px]">
+        {input === "" && (
+          <div
+            className="pointer-events-none absolute left-0 top-0 px-4 pt-4 text-[0.9375rem] leading-6 text-muted-foreground/40"
+            aria-hidden="true"
+          >
+            {sending
+              ? "Type your next message…"
+              : "Ask me to automate workflows, manage tasks..."}
+          </div>
+        )}
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2,7 +2,6 @@
 // oxlint-disable max-lines-per-function
 import type {
   ChangeEvent,
-  ClipboardEvent,
   DragEvent,
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
@@ -22,7 +21,6 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconDeviceDesktop,
-  IconFileText,
   IconPresentation,
   IconEye,
   IconLoader2,
@@ -62,6 +60,7 @@ import {
   cn,
   matchShortcut,
   processShortcut,
+  type KeyboardEventLike,
 } from "@vm0/ui";
 import {
   bestEffort,
@@ -94,8 +93,9 @@ import type {
   GenerationTemplateRequest,
   PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import type { ZeroAgentCustomSkill } from "@vm0/api-contracts/contracts/zero-agents";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
+import { TiptapSkillComposer } from "./tiptap-skill-composer.tsx";
+import type { ComposerPasteEvent } from "./composer-input-types.ts";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
@@ -166,11 +166,6 @@ import {
   setComputerUsePopoverOpen$,
   templateCardHover$,
   setTemplateCardHover$,
-  slashSkillCaretIndex$,
-  setSlashSkillCaretIndex$,
-  selectedSlashSkillIndex$,
-  setSelectedSlashSkillIndex$,
-  setSlashSkillMenuRef$,
   type TemplatePickerVideoGroup,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
@@ -187,10 +182,7 @@ import {
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { readChatMessageFromClipboard } from "../../signals/zero-page/clipboard.ts";
-import { currentChatAgent$ } from "../../signals/agent-chat.ts";
-import { orgSkills$ } from "../../signals/skills-page/skills-signals.ts";
 import type { FeedbackItem } from "../../signals/zero-page/chat-feedback.ts";
-import { Link } from "../router/link.tsx";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 
@@ -2932,15 +2924,17 @@ function useResolvedComposerSignals(
 }
 
 function insertPastedText(
-  textarea: HTMLTextAreaElement,
+  target: HTMLElement,
   currentValue: string,
   pastedText: string,
 ): string {
-  if (!pastedText) {
+  // Only the plain textarea supports caret-based insertion. The TipTap composer
+  // inserts pasted text itself, so for it we leave the value unchanged here.
+  if (!pastedText || !(target instanceof HTMLTextAreaElement)) {
     return currentValue;
   }
-  const start = textarea.selectionStart;
-  const end = textarea.selectionEnd;
+  const start = target.selectionStart;
+  const end = target.selectionEnd;
   return `${currentValue.slice(0, start)}${pastedText}${currentValue.slice(end)}`;
 }
 
@@ -2970,216 +2964,6 @@ function toPersistedAttachments(
 
 type KeyboardSendAction = "none" | "send" | "queue";
 
-interface SlashSkillRange {
-  readonly start: number;
-  readonly end: number;
-  readonly query: string;
-}
-
-interface ComposerSlashSkill extends ZeroAgentCustomSkill {
-  readonly token: string;
-}
-
-function findActiveSlashSkillRange(
-  value: string,
-  caretIndex: number,
-): SlashSkillRange | null {
-  const beforeCaret = value.slice(0, caretIndex);
-  const match = /(?:^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);
-  if (!match) {
-    return null;
-  }
-
-  const query = match[1] ?? "";
-  const slashOffset = match[0].lastIndexOf("/");
-  const start = beforeCaret.length - match[0].length + slashOffset;
-  return { start, end: caretIndex, query };
-}
-
-function matchesSkillQuery(skill: ComposerSlashSkill, query: string): boolean {
-  if (!query) {
-    return true;
-  }
-
-  const normalizedQuery = query.toLowerCase();
-  return [skill.name, skill.displayName ?? "", skill.description ?? ""]
-    .join(" ")
-    .toLowerCase()
-    .includes(normalizedQuery);
-}
-
-function skillTokenPattern(skillNames: readonly string[]): RegExp | null {
-  if (skillNames.length === 0) {
-    return null;
-  }
-
-  const escaped = skillNames.map((name) => {
-    return name.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-  });
-  return new RegExp(`/(?:${escaped.join("|")})(?=$|\\s)`, "g");
-}
-
-function ComposerInputHighlight({
-  input,
-  skills,
-}: {
-  readonly input: string;
-  readonly skills: readonly ComposerSlashSkill[];
-}) {
-  const pattern = skillTokenPattern(
-    skills.map((skill) => {
-      return skill.name;
-    }),
-  );
-
-  if (!input || !pattern) {
-    return null;
-  }
-
-  const parts: { text: string; skill: boolean; start: number }[] = [];
-  let lastIndex = 0;
-  for (const match of input.matchAll(pattern)) {
-    const start = match.index ?? 0;
-    if (start > lastIndex) {
-      parts.push({
-        text: input.slice(lastIndex, start),
-        skill: false,
-        start: lastIndex,
-      });
-    }
-    parts.push({ text: match[0], skill: true, start });
-    lastIndex = start + match[0].length;
-  }
-
-  if (lastIndex < input.length) {
-    parts.push({
-      text: input.slice(lastIndex),
-      skill: false,
-      start: lastIndex,
-    });
-  }
-
-  return (
-    <div
-      className="pointer-events-none absolute inset-0 z-20 whitespace-pre-wrap break-words px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-transparent"
-      aria-hidden="true"
-    >
-      {parts.map((part) => {
-        return (
-          <span
-            key={`${part.start}:${part.skill ? "skill" : "text"}:${part.text}`}
-            className={part.skill ? "text-primary" : "text-transparent"}
-          >
-            {part.text}
-          </span>
-        );
-      })}
-    </div>
-  );
-}
-
-function SlashSkillMenu({
-  skills,
-  loading,
-  selectedIndex,
-  showSkillsPageLink,
-  onSelect,
-}: {
-  readonly skills: readonly ComposerSlashSkill[];
-  readonly loading: boolean;
-  readonly selectedIndex: number;
-  readonly showSkillsPageLink: boolean;
-  readonly onSelect: (skill: ComposerSlashSkill) => void;
-}) {
-  const setMenuRef = useSet(setSlashSkillMenuRef$);
-
-  return (
-    <div
-      ref={setMenuRef}
-      popover="manual"
-      className="slash-skill-popover flex max-h-80 w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-md border border-border/70 bg-popover/95 text-popover-foreground shadow-lg backdrop-blur"
-      data-testid="slash-skill-menu"
-    >
-      <div className="px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">
-        Skills
-      </div>
-      {loading ? (
-        <div className="px-2.5 py-2 text-sm text-muted-foreground">
-          Loading skills...
-        </div>
-      ) : skills.length > 0 ? (
-        <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
-          {skills.map((skill, index) => {
-            const selected = index === selectedIndex;
-            return (
-              <button
-                id={slashSkillOptionId(skill.name)}
-                key={skill.name}
-                type="button"
-                className={cn(
-                  "flex w-full items-center rounded px-2 py-1.5 text-left transition-colors",
-                  selected ? "bg-accent" : "hover:bg-accent/60",
-                )}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  onSelect(skill);
-                }}
-              >
-                <span className="truncate font-mono text-sm text-primary">
-                  {skill.token}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      ) : (
-        <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
-          No matching skills
-        </div>
-      )}
-      {showSkillsPageLink && (
-        <div className="shrink-0 border-t border-border/60 bg-popover/95 p-1.5">
-          <Link
-            pathname="/skills"
-            className="flex h-9 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-accent"
-          >
-            <span className="flex min-w-0 items-center gap-2">
-              <IconFileText
-                size={16}
-                stroke={1.8}
-                className="shrink-0 text-muted-foreground"
-              />
-              <span className="truncate">View all skills</span>
-            </span>
-            <IconChevronRight
-              size={16}
-              stroke={1.8}
-              className="shrink-0 text-muted-foreground"
-            />
-          </Link>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function slashSkillOptionId(skillName: string): string {
-  return `slash-skill-option-${skillName}`;
-}
-
-function scrollSlashSkillIntoView(skill: ComposerSlashSkill | undefined): void {
-  if (!skill) {
-    return;
-  }
-
-  window.requestAnimationFrame(() => {
-    const option = document.getElementById(slashSkillOptionId(skill.name));
-    if (option && typeof option.scrollIntoView === "function") {
-      option.scrollIntoView({ block: "nearest" });
-    }
-  });
-}
-
 function ComposerTextarea({
   input,
   onInputChange,
@@ -3196,8 +2980,8 @@ function ComposerTextarea({
   readonly sending: boolean | undefined;
   readonly autoFocus: boolean | undefined;
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
-  readonly onKeyDown: (e: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
-  readonly onPaste: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
+  readonly onKeyDown: (e: KeyboardEventLike) => void;
+  readonly onPaste: (e: ComposerPasteEvent) => void;
   readonly onAfterInputChange?: (textarea: HTMLTextAreaElement) => void;
   readonly onPointerSelectionChange?: (textarea: HTMLTextAreaElement) => void;
 }) {
@@ -3239,181 +3023,6 @@ function ComposerTextarea({
   );
 }
 
-function buildComposerSlashSkills({
-  agentSkillNames,
-  orgSkills,
-}: {
-  readonly agentSkillNames: readonly string[];
-  readonly orgSkills: readonly ZeroAgentCustomSkill[];
-}): readonly ComposerSlashSkill[] {
-  const metadataByName = new Map(
-    orgSkills.map((skill) => {
-      return [skill.name, skill];
-    }),
-  );
-  return agentSkillNames.map((name) => {
-    const metadata = metadataByName.get(name);
-    return {
-      name,
-      displayName: metadata?.displayName ?? null,
-      description: metadata?.description ?? null,
-      token: `/${name}`,
-    };
-  });
-}
-
-function SlashSkillComposerInput({
-  input,
-  onInputChange,
-  onDraftChange,
-  sending,
-  autoFocus,
-  setInputRef,
-  onKeyDown,
-  onPaste,
-}: {
-  readonly input: string;
-  readonly onInputChange: (value: string) => void;
-  readonly onDraftChange: (() => void) | undefined;
-  readonly sending: boolean | undefined;
-  readonly autoFocus: boolean | undefined;
-  readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
-  readonly onKeyDown: (e: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
-  readonly onPaste: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
-}) {
-  const caretIndex = useGet(slashSkillCaretIndex$);
-  const setCaretIndex = useSet(setSlashSkillCaretIndex$);
-  const selectedSkillIndex = useGet(selectedSlashSkillIndex$);
-  const setSelectedSkillIndex = useSet(setSelectedSlashSkillIndex$);
-  const currentAgent = useLastResolved(currentChatAgent$);
-  const features = useLastResolved(featureSwitch$);
-  const orgSkillsLoadable = useLastLoadable(orgSkills$);
-  const orgSkills =
-    orgSkillsLoadable.state === "hasData" ? orgSkillsLoadable.data : [];
-  const composerSkills = buildComposerSlashSkills({
-    agentSkillNames: currentAgent?.customSkills ?? [],
-    orgSkills,
-  });
-  const slashRange = findActiveSlashSkillRange(input, caretIndex);
-  const slashSkillSuggestions = slashRange
-    ? composerSkills.filter((skill) => {
-        return matchesSkillQuery(skill, slashRange.query);
-      })
-    : [];
-  const isLoadingOrgSkills = orgSkillsLoadable.state === "loading";
-  const showSkillsPageLink = features?.[FeatureSwitchKey.SkillsViewer] ?? false;
-  const showSlashSkillMenu =
-    slashRange !== null &&
-    (isLoadingOrgSkills || composerSkills.length > 0 || showSkillsPageLink);
-
-  const updateCaretIndex = (textarea: HTMLTextAreaElement) => {
-    setCaretIndex(textarea.selectionStart);
-  };
-
-  const insertSlashSkill = (
-    skill: ComposerSlashSkill,
-    textarea: HTMLTextAreaElement | null,
-  ) => {
-    if (!slashRange) {
-      return;
-    }
-
-    const suffix = input.slice(slashRange.end).startsWith(" ") ? "" : " ";
-    const nextInput = `${input.slice(0, slashRange.start)}${skill.token}${suffix}${input.slice(slashRange.end)}`;
-    const nextCaret = slashRange.start + skill.token.length + suffix.length;
-    onInputChange(nextInput);
-    onDraftChange?.();
-    setCaretIndex(nextCaret);
-    window.requestAnimationFrame(() => {
-      textarea?.setSelectionRange(nextCaret, nextCaret);
-      textarea?.focus();
-    });
-  };
-
-  const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-    if (!showSlashSkillMenu) {
-      onKeyDown(e);
-      return;
-    }
-
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      const nextIndex = Math.min(
-        selectedSkillIndex + 1,
-        Math.max(slashSkillSuggestions.length - 1, 0),
-      );
-      setSelectedSkillIndex(nextIndex);
-      scrollSlashSkillIntoView(slashSkillSuggestions[nextIndex]);
-      return;
-    }
-
-    if (e.key === "ArrowUp") {
-      e.preventDefault();
-      const nextIndex = Math.max(selectedSkillIndex - 1, 0);
-      setSelectedSkillIndex(nextIndex);
-      scrollSlashSkillIntoView(slashSkillSuggestions[nextIndex]);
-      return;
-    }
-
-    if ((e.key === "Enter" || e.key === "Tab") && slashSkillSuggestions[0]) {
-      e.preventDefault();
-      insertSlashSkill(
-        slashSkillSuggestions[
-          Math.min(selectedSkillIndex, slashSkillSuggestions.length - 1)
-        ]!,
-        e.currentTarget,
-      );
-      return;
-    }
-
-    if (e.key === "Escape") {
-      e.preventDefault();
-      setCaretIndex(-1);
-      return;
-    }
-
-    onKeyDown(e);
-  };
-
-  return (
-    <div className="slash-skill-anchor relative">
-      {showSlashSkillMenu && (
-        <SlashSkillMenu
-          skills={slashSkillSuggestions}
-          loading={isLoadingOrgSkills}
-          selectedIndex={selectedSkillIndex}
-          showSkillsPageLink={showSkillsPageLink}
-          onSelect={(skill) => {
-            insertSlashSkill(
-              skill,
-              document.activeElement instanceof HTMLTextAreaElement
-                ? document.activeElement
-                : null,
-            );
-          }}
-        />
-      )}
-      <div className="relative min-h-[96px]">
-        <ComposerInputHighlight input={input} skills={composerSkills} />
-        <ComposerTextarea
-          input={input}
-          onInputChange={onInputChange}
-          sending={sending}
-          autoFocus={autoFocus}
-          setInputRef={setInputRef}
-          onKeyDown={handleKeyDown}
-          onPaste={onPaste}
-          onAfterInputChange={(textarea) => {
-            setSelectedSkillIndex(0);
-            updateCaretIndex(textarea);
-          }}
-          onPointerSelectionChange={updateCaretIndex}
-        />
-      </div>
-    </div>
-  );
-}
-
 function ComposerInputSlot({
   input,
   onInputChange,
@@ -3430,8 +3039,8 @@ function ComposerInputSlot({
   readonly sending: boolean | undefined;
   readonly autoFocus: boolean | undefined;
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
-  readonly onKeyDown: (e: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
-  readonly onPaste: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
+  readonly onKeyDown: (e: KeyboardEventLike) => void;
+  readonly onPaste: (e: ComposerPasteEvent) => void;
 }) {
   const features = useLastResolved(featureSwitch$);
   const slashSkillCommandsEnabled =
@@ -3439,7 +3048,7 @@ function ComposerInputSlot({
 
   if (slashSkillCommandsEnabled) {
     return (
-      <SlashSkillComposerInput
+      <TiptapSkillComposer
         input={input}
         onInputChange={onInputChange}
         onDraftChange={onDraftChange}
@@ -3710,7 +3319,10 @@ export function ZeroChatComposer({
   const activeFeedback = resolveActiveFeedback(feedback);
 
   // File upload handlers (paste / drag-drop)
-  const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+  const handlePaste = (e: ComposerPasteEvent) => {
+    if (!e.clipboardData) {
+      return;
+    }
     const chatPayload = readChatMessageFromClipboard(e.clipboardData);
     if (chatPayload && chatPayload.attachments.length > 0) {
       const persistedAttachments = toPersistedAttachments(
@@ -3943,7 +3555,7 @@ export function ZeroChatComposer({
   const toggleSidebar = useSet(toggleSidebarOff$);
   const newChat = useSet(navigateToNewChat$);
 
-  const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: KeyboardEventLike) => {
     if (window.matchMedia("(pointer: coarse)").matches) {
       return;
     }


### PR DESCRIPTION
Closes #17539

## Problem

The chat composer highlighted `/skill` tokens with a **transparent `<textarea>` + a separate absolutely-positioned overlay** (`ComposerInputHighlight`). The overlay had no scroll synchronization, so as soon as the textarea scrolled internally (multi-line input on mobile), the colored token stayed put while the real text scrolled — the highlight drifted away from the text.

The root cause is structural: any two-layer "mirror" approach must keep two elements pixel-aligned, and CSS cannot read a `<textarea>`'s internal `scrollTop`.

## Fix

Replace the textarea + overlay with a **single-layer TipTap (ProseMirror) editor** and color tokens using **inline decorations**. The color now lives in the same layer as the text and moves/scrolls with it, so misalignment is impossible by construction.

Key properties:
- **Plain-text contract preserved** — the document stays plain text (decorations only paint color), so the rest of the chat still gets a plain string `input`. No changes to drafts, sending, or downstream consumers.
- **Live coloring parity** — any matching `/token` is colored as you type or paste (same as the old regex overlay), not only when picked from the menu.
- **Reuses existing UX** — the slash suggestion menu, filtering, keyboard navigation (↑/↓/Enter/Tab/Esc), and the "View all skills" link are unchanged.
- **No new dependencies** — TipTap 3 is already used by the instructions editor.
- Gated behind the existing `ChatSlashSkillCommands` feature switch; the plain-textarea path is untouched when the switch is off.

No React hooks are used in the view (per the codebase's ccstate convention): the editor lifecycle uses TipTap's `onCreate`/`onDestroy`, options refresh via `setOptions` each render, and the skill list is read from extension storage so the editor is never rebuilt.

## Files

- `slash-skill.tsx` (new) — slash-skill domain helpers + suggestion menu (moved out so both inputs can share them without an import cycle).
- `tiptap-skill-composer.tsx` (new) — the editor + the decoration highlight plugin.
- `composer-input-types.ts` (new) — structural paste-event type shared by the textarea and editor inputs.
- `zero-chat-composer.tsx` — wire `ComposerInputSlot` to the new composer; remove the overlay/old slash input; widen the shared keydown/paste handler types.
- composer tests updated to drive the contenteditable editor.

## Verification

- `pnpm -F @vm0/app check-types` — clean
- oxlint (+ type-aware) and eslint on changed files — clean
- `pnpm exec vitest run chat-composer-models-and-templates.test.tsx` — 22/22 pass (including the slash-skill suggest/insert/highlight/keyboard-scroll cases)

Per repo convention, full local vitest was not run; the PR pipeline covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)