### PR TITLE
docs: document cli failure diagnostic fields

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -98,8 +98,26 @@ fn chat_stream_delta_from_event(
 /// Bounded terminal failure detail extracted from CLI stdout JSONL.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CliFailureDiagnostic {
+    /// Terminal failure message selected from CLI stdout JSONL.
+    ///
+    /// When produced by [`execute_cli`], this message has already been
+    /// secret-masked, line-break escaped, and bounded before exposure.
     pub message: String,
+
+    /// High-level source of the stdout-derived failure detail.
+    ///
+    /// Values produced by [`execute_cli`] use `ClaudeResult` for Claude Code
+    /// terminal result events and `CodexJsonl` for Codex JSONL failure events.
+    /// The final run diagnostic may still prefer stderr when this stdout
+    /// message is generic.
     pub source: FailureDetailSource,
+
+    /// Optional structured failure reason parsed from supported CLI payloads.
+    ///
+    /// `None` means no supported structured reason was observed. A reason may
+    /// be carried independently from the selected display message, including
+    /// when a generic stdout message is replaced by a more specific message or
+    /// stderr fallback.
     pub failure_reason: Option<FailureReason>,
 }
 


### PR DESCRIPTION
## Summary

- Add field-level rustdoc for `CliFailureDiagnostic::message`, `source`, and `failure_reason`.
- Clarify the `execute_cli`-produced masking/bounding contract without changing runtime behavior.
- Document the high-level stdout diagnostic source and independent structured reason carry-forward semantics.

## Testing

- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/guest-agent/Cargo.toml --check`
- pre-commit lefthook: cargo fmt, cargo doc, cargo clippy

Closes #17557
