### PR TITLE
fix: wrap malformed sigv4 urls in signing errors

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -797,7 +797,7 @@ def _sign_flow_request_with_aws_sigv4(
 ) -> None:
     url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
     if not isinstance(url, str):
-        url = flow.request.url
+        raise AwsSigV4SigningError("AWS request URL is unavailable")
     signed_url, signed_headers = sign_request(
         method=flow.request.method,
         url=url,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -791,16 +791,31 @@ def _apply_header_query_injection(
             flow.request.query[key] = value
 
 
+def _trusted_aws_sigv4_url(flow: http.HTTPFlow) -> str:
+    url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(url, str):
+        raise AwsSigV4SigningError("AWS request URL is unavailable")
+
+    try:
+        original = urllib.parse.urlsplit(url)
+    except ValueError as e:
+        raise AwsSigV4SigningError("AWS request URL is malformed") from e
+
+    current_query = urllib.parse.urlsplit(flow.request.path).query
+    if current_query == original.query:
+        return url
+    return urllib.parse.urlunsplit(
+        (original.scheme, original.netloc, original.path, current_query, original.fragment)
+    )
+
+
 def _sign_flow_request_with_aws_sigv4(
     flow: http.HTTPFlow,
     credentials: AwsSigV4Credentials,
 ) -> None:
-    url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(url, str):
-        raise AwsSigV4SigningError("AWS request URL is unavailable")
     signed_url, signed_headers = sign_request(
         method=flow.request.method,
-        url=url,
+        url=_trusted_aws_sigv4_url(flow),
         headers=header_pairs(flow.request.headers),
         body=flow.request.raw_content,
         credentials=credentials,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -31,6 +31,7 @@ from auth_base_forwarder import (
 )
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
 from logging_utils import log_proxy_entry
+from url_syntax import has_unsafe_runtime_url_syntax
 from url_utils import build_rewrite_url
 
 
@@ -795,12 +796,16 @@ def _trusted_aws_sigv4_url(flow: http.HTTPFlow) -> str:
     url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
     if not isinstance(url, str):
         raise AwsSigV4SigningError("AWS request URL is unavailable")
+    if has_unsafe_runtime_url_syntax(url, allow_backslash=True):
+        raise AwsSigV4SigningError("AWS request URL is malformed")
 
     try:
         original = urllib.parse.urlsplit(url)
     except ValueError as e:
         raise AwsSigV4SigningError("AWS request URL is malformed") from e
 
+    if has_unsafe_runtime_url_syntax(flow.request.path, allow_backslash=True):
+        raise AwsSigV4SigningError("AWS request URL is malformed")
     try:
         current_query = urllib.parse.urlsplit(flow.request.path).query
     except ValueError as e:
@@ -810,6 +815,12 @@ def _trusted_aws_sigv4_url(flow: http.HTTPFlow) -> str:
     return urllib.parse.urlunsplit(
         (original.scheme, original.netloc, original.path, current_query, original.fragment)
     )
+
+
+def _request_path_query(flow: http.HTTPFlow) -> str:
+    if has_unsafe_runtime_url_syntax(flow.request.path, allow_backslash=True):
+        raise ValueError("unsafe request target")
+    return urllib.parse.urlparse(flow.request.path).query
 
 
 def _sign_flow_request_with_aws_sigv4(
@@ -1090,7 +1101,7 @@ async def _apply_url_rewrite(
     # connection already connected to the placeholder IP. Setting
     # flow.response bypasses the upstream connection entirely.
     try:
-        orig_query = urllib.parse.urlparse(flow.request.path).query
+        orig_query = _request_path_query(flow)
         new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
     except ValueError as e:
         _set_url_rewrite_forward_failed(

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -795,9 +795,12 @@ def _sign_flow_request_with_aws_sigv4(
     flow: http.HTTPFlow,
     credentials: AwsSigV4Credentials,
 ) -> None:
+    url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(url, str):
+        url = flow.request.url
     signed_url, signed_headers = sign_request(
         method=flow.request.method,
-        url=flow.request.url,
+        url=url,
         headers=header_pairs(flow.request.headers),
         body=flow.request.raw_content,
         credentials=credentials,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -801,7 +801,10 @@ def _trusted_aws_sigv4_url(flow: http.HTTPFlow) -> str:
     except ValueError as e:
         raise AwsSigV4SigningError("AWS request URL is malformed") from e
 
-    current_query = urllib.parse.urlsplit(flow.request.path).query
+    try:
+        current_query = urllib.parse.urlsplit(flow.request.path).query
+    except ValueError as e:
+        raise AwsSigV4SigningError("AWS request URL is malformed") from e
     if current_query == original.query:
         return url
     return urllib.parse.urlunsplit(

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -1089,8 +1089,8 @@ async def _apply_url_rewrite(
     # The addon forwards the request itself because mitmproxy's eager
     # connection already connected to the placeholder IP. Setting
     # flow.response bypasses the upstream connection entirely.
-    orig_query = urllib.parse.urlparse(flow.request.path).query
     try:
+        orig_query = urllib.parse.urlparse(flow.request.path).query
         new_url = build_rewrite_url(resolved_base, allow.rel_path, orig_query, resolved_query)
     except ValueError as e:
         _set_url_rewrite_forward_failed(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -177,6 +177,7 @@ def _classify_request(
 
 
 def _split_url_for_signing(url: str) -> urllib.parse.SplitResult:
+    _utf8_encode(url, "AWS request URL is malformed")
     try:
         return urllib.parse.urlsplit(url)
     except ValueError as e:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -165,7 +165,7 @@ def _classify_request(
         "authorization",
         "Malformed AWS authorization header",
     )
-    query_pairs = _parse_query_pairs(urllib.parse.urlsplit(url).query)
+    query_pairs = _parse_query_pairs(_split_url_for_signing(url).query)
     query_algorithm = _unique_query_value(query_pairs, "X-Amz-Algorithm")
     if auth_header and query_algorithm:
         raise AwsSigV4SigningError("Ambiguous AWS auth location")
@@ -174,6 +174,13 @@ def _classify_request(
     if auth_header:
         return _classify_header_request(auth_header, headers)
     raise AwsSigV4SigningError("Missing AWS SigV4 auth metadata")
+
+
+def _split_url_for_signing(url: str) -> urllib.parse.SplitResult:
+    try:
+        return urllib.parse.urlsplit(url)
+    except ValueError as e:
+        raise AwsSigV4SigningError("AWS request URL is malformed") from e
 
 
 def _classify_header_request(
@@ -395,7 +402,7 @@ def _canonical_request(
     payload_hash: str,
     is_s3: bool,
 ) -> tuple[str, str]:
-    parts = urllib.parse.urlsplit(url)
+    parts = _split_url_for_signing(url)
     canonical_uri = _canonical_uri(parts.path, is_s3=is_s3)
     canonical_query = _canonical_query_string(parts.query)
     canonical_headers, signed_header_names = _canonical_headers(headers, signed_headers)
@@ -539,7 +546,7 @@ def _replace_query_signing_params(
     signed_headers: frozenset[str],
     signature: str | None,
 ) -> str:
-    parts = urllib.parse.urlsplit(url)
+    parts = _split_url_for_signing(url)
     filtered = [
         (key, value)
         for key, value in _parse_query_pairs(parts.query)
@@ -651,7 +658,7 @@ def _upsert_header(
 
 
 def _host_header_value(url: str) -> str:
-    parts = urllib.parse.urlsplit(url)
+    parts = _split_url_for_signing(url)
     if not parts.netloc or not parts.hostname:
         raise AwsSigV4SigningError("AWS request URL must include a host")
     host = parts.hostname

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -48,6 +48,7 @@ _PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 _SIGNED_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 _HEX_DIGITS = frozenset("0123456789ABCDEFabcdef")
+_RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
 _DEFAULT_PORTS = {"http": 80, "https": 443}
@@ -180,6 +181,8 @@ def _classify_request(
 
 def _split_url_for_signing(url: str) -> urllib.parse.SplitResult:
     _utf8_encode(url, "AWS request URL is malformed")
+    if _has_raw_whitespace(url) or _has_ascii_control(url):
+        raise AwsSigV4SigningError("AWS request URL is malformed")
     if _has_malformed_percent_encoding(url):
         raise AwsSigV4SigningError("AWS request URL is malformed")
     try:
@@ -674,6 +677,10 @@ def _is_utf8_encodable(value: str) -> bool:
 
 def _has_ascii_control(value: str) -> bool:
     return any(ord(char) <= _ASCII_CONTROL_MAX or ord(char) == _ASCII_DELETE for char in value)
+
+
+def _has_raw_whitespace(value: str) -> bool:
+    return any(char in _RAW_WHITESPACE_CHARS for char in value)
 
 
 def _unique_header_value(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -424,7 +424,7 @@ def _canonical_uri(path: str, *, is_s3: bool) -> str:
     if is_s3:
         return raw_path
     normalized = _remove_dot_segments(raw_path)
-    return urllib.parse.quote(normalized, safe="/~")
+    return _quote_url_component(normalized, safe="/~")
 
 
 def _remove_dot_segments(path: str) -> str:
@@ -516,7 +516,9 @@ def _signature(
             _HMAC_ALGORITHM,
             amz_date,
             _scope_string(scope),
-            hashlib.sha256(canonical_request.encode()).hexdigest(),
+            hashlib.sha256(
+                _utf8_encode(canonical_request, "AWS request contains invalid text")
+            ).hexdigest(),
         ]
     )
     signing_key = _signing_key(credentials.secret_access_key, scope)
@@ -524,7 +526,10 @@ def _signature(
 
 
 def _signing_key(secret_access_key: str, scope: _CredentialScope) -> bytes:
-    date_key = _hmac_digest(f"AWS4{secret_access_key}".encode(), scope.date)
+    date_key = _hmac_digest(
+        _utf8_encode(f"AWS4{secret_access_key}", "Invalid AWS secret access key"),
+        scope.date,
+    )
     region_key = _hmac_digest(date_key, scope.region)
     service_key = _hmac_digest(region_key, scope.service)
     return _hmac_digest(service_key, _AWS4_REQUEST)
@@ -577,7 +582,14 @@ def _encode_query_pairs(pairs: list[tuple[str, str]]) -> str:
 
 
 def _aws_quote(value: str) -> str:
-    return urllib.parse.quote(value, safe="-_.~")
+    return _quote_url_component(value, safe="-_.~")
+
+
+def _quote_url_component(value: str, *, safe: str) -> str:
+    try:
+        return urllib.parse.quote(value, safe=safe)
+    except UnicodeEncodeError as e:
+        raise AwsSigV4SigningError("AWS request URL is malformed") from e
 
 
 def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
@@ -596,12 +608,33 @@ def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
 def _validate_credentials(credentials: AwsSigV4Credentials) -> None:
     if not _ACCESS_KEY_ID_RE.fullmatch(credentials.access_key_id):
         raise AwsSigV4SigningError("Invalid AWS access key ID")
-    if not credentials.secret_access_key or _has_ascii_control(credentials.secret_access_key):
+    if (
+        not credentials.secret_access_key
+        or _has_ascii_control(credentials.secret_access_key)
+        or not _is_utf8_encodable(credentials.secret_access_key)
+    ):
         raise AwsSigV4SigningError("Invalid AWS secret access key")
     if credentials.session_token is not None and (
-        not credentials.session_token or _has_ascii_control(credentials.session_token)
+        not credentials.session_token
+        or _has_ascii_control(credentials.session_token)
+        or not _is_utf8_encodable(credentials.session_token)
     ):
         raise AwsSigV4SigningError("Invalid AWS session token")
+
+
+def _utf8_encode(value: str, message: str) -> bytes:
+    try:
+        return value.encode()
+    except UnicodeEncodeError as e:
+        raise AwsSigV4SigningError(message) from e
+
+
+def _is_utf8_encodable(value: str) -> bool:
+    try:
+        value.encode()
+    except UnicodeEncodeError:
+        return False
+    return True
 
 
 def _has_ascii_control(value: str) -> bool:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -659,9 +659,13 @@ def _upsert_header(
 
 def _host_header_value(url: str) -> str:
     parts = _split_url_for_signing(url)
-    if not parts.netloc or not parts.hostname:
+    try:
+        hostname = parts.hostname
+    except ValueError as e:
+        raise AwsSigV4SigningError("AWS request URL is malformed") from e
+    if not parts.netloc or not hostname:
         raise AwsSigV4SigningError("AWS request URL must include a host")
-    host = parts.hostname
+    host = hostname
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     try:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -47,6 +47,7 @@ _AMZ_DATE_RE = re.compile(r"^\d{8}T\d{6}Z$")
 _PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 _SIGNED_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
+_HEX_DIGITS = frozenset("0123456789ABCDEFabcdef")
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
 _DEFAULT_PORTS = {"http": 80, "https": 443}
@@ -122,6 +123,7 @@ def sign_request(
     hash is ``UNSIGNED-PAYLOAD``.
     """
     _validate_credentials(credentials)
+    _validate_headers(headers)
     context = _classify_request(url, headers)
     if context.algorithm == _ASYMMETRIC_ALGORITHM:
         raise AwsSigV4SigningError("SigV4A is not supported by this runner")
@@ -602,8 +604,32 @@ def _parse_query_pairs(query: str) -> list[tuple[str, str]]:
         if not raw_pair:
             continue
         raw_key, _separator, raw_value = raw_pair.partition("=")
-        pairs.append((urllib.parse.unquote(raw_key), urllib.parse.unquote(raw_value)))
+        pairs.append((_unquote_query_component(raw_key), _unquote_query_component(raw_value)))
     return pairs
+
+
+def _unquote_query_component(value: str) -> str:
+    if _has_malformed_percent_encoding(value):
+        raise AwsSigV4SigningError("AWS request URL is malformed")
+    try:
+        return urllib.parse.unquote_to_bytes(value).decode()
+    except UnicodeDecodeError as e:
+        raise AwsSigV4SigningError("AWS request URL is malformed") from e
+
+
+def _has_malformed_percent_encoding(value: str) -> bool:
+    index = 0
+    while True:
+        index = value.find("%", index)
+        if index == -1:
+            return False
+        if (
+            index + 2 >= len(value)
+            or value[index + 1] not in _HEX_DIGITS
+            or value[index + 2] not in _HEX_DIGITS
+        ):
+            return True
+        index += 3
 
 
 def _validate_credentials(credentials: AwsSigV4Credentials) -> None:
@@ -621,6 +647,12 @@ def _validate_credentials(credentials: AwsSigV4Credentials) -> None:
         or not _is_utf8_encodable(credentials.session_token)
     ):
         raise AwsSigV4SigningError("Invalid AWS session token")
+
+
+def _validate_headers(headers: list[tuple[str, str]]) -> None:
+    for name, value in headers:
+        _utf8_encode(name, "AWS request header contains invalid text")
+        _utf8_encode(value, "AWS request header contains invalid text")
 
 
 def _utf8_encode(value: str, message: str) -> bytes:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -258,7 +258,7 @@ def _parse_authorization_header(value: str) -> tuple[str, dict[str, str]]:
 
 
 def _parse_credential(credential: str) -> tuple[str, _CredentialScope]:
-    parts = urllib.parse.unquote(credential).split("/")
+    parts = credential.split("/")
     if len(parts) != _CREDENTIAL_SCOPE_PARTS or parts[-1] != _AWS4_REQUEST:
         raise AwsSigV4SigningError("Malformed AWS credential scope")
     access_key_id = parts[0]

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -180,6 +180,8 @@ def _classify_request(
 
 def _split_url_for_signing(url: str) -> urllib.parse.SplitResult:
     _utf8_encode(url, "AWS request URL is malformed")
+    if _has_malformed_percent_encoding(url):
+        raise AwsSigV4SigningError("AWS request URL is malformed")
     try:
         return urllib.parse.urlsplit(url)
     except ValueError as e:

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -6,6 +6,8 @@ import pytest
 
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
 
+_INVALID_UNICODE = "\ud800"
+
 
 def _credentials() -> AwsSigV4Credentials:
     return AwsSigV4Credentials("AKIDEXAMPLE", "secret")
@@ -82,6 +84,50 @@ def test_presigned_query_invalid_bracketed_host_raises_signing_error() -> None:
             headers=[("Host", "sts.amazonaws.com")],
             body=None,
             credentials=_credentials(),
+        )
+
+
+def test_header_auth_invalid_unicode_path_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=f"https://sts.amazonaws.com/{_INVALID_UNICODE}",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_presigned_query_invalid_unicode_query_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=f"{_presigned_url('sts.amazonaws.com')}&Extra={_INVALID_UNICODE}",
+            headers=[("Host", "sts.amazonaws.com")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_signed_header_invalid_unicode_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request contains invalid text"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=[*_header_auth_headers(), ("x-amz-meta-test", _INVALID_UNICODE)],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_invalid_unicode_secret_key_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="Invalid AWS secret access key"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=AwsSigV4Credentials("AKIDEXAMPLE", f"secret{_INVALID_UNICODE}"),
         )
 
 

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -109,6 +109,20 @@ def test_presigned_query_invalid_unicode_query_raises_signing_error() -> None:
         )
 
 
+@pytest.mark.parametrize("query", ["Bad=%ED%A0%80", "Bad=%ZZ"])
+def test_presigned_query_malformed_percent_encoding_raises_signing_error(
+    query: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=f"{_presigned_url('sts.amazonaws.com')}&{query}",
+            headers=[("Host", "sts.amazonaws.com")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_header_auth_invalid_unicode_fragment_raises_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
         sign_request(
@@ -121,11 +135,31 @@ def test_header_auth_invalid_unicode_fragment_raises_signing_error() -> None:
 
 
 def test_signed_header_invalid_unicode_raises_signing_error() -> None:
-    with pytest.raises(AwsSigV4SigningError, match="AWS request contains invalid text"):
+    with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
         sign_request(
             method="GET",
             url="https://sts.amazonaws.com/",
             headers=[*_header_auth_headers(), ("x-amz-meta-test", _INVALID_UNICODE)],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        (f"x-other-{_INVALID_UNICODE}", "value"),
+        ("x-other", f"value{_INVALID_UNICODE}"),
+    ],
+)
+def test_unsigned_header_invalid_unicode_raises_signing_error(
+    header: tuple[str, str],
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=[*_header_auth_headers(), header],
             body=None,
             credentials=_credentials(),
         )

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -76,12 +76,63 @@ def test_presigned_query_malformed_url_raises_signing_error() -> None:
         )
 
 
+def test_presigned_query_double_encoded_credential_raises_signing_error() -> None:
+    double_encoded_credential = urllib.parse.quote(
+        urllib.parse.quote(
+            "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+            safe="",
+        ),
+        safe="",
+    )
+    url = (
+        "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        f"&X-Amz-Credential={double_encoded_credential}"
+        "&X-Amz-Date=20260101T000000Z"
+        "&X-Amz-Expires=60"
+        "&X-Amz-SignedHeaders=host"
+        "&X-Amz-Signature=placeholder"
+    )
+
+    with pytest.raises(AwsSigV4SigningError, match="Malformed AWS credential scope"):
+        sign_request(
+            method="GET",
+            url=url,
+            headers=[("Host", "sts.amazonaws.com")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_presigned_query_invalid_bracketed_host_raises_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
         sign_request(
             method="GET",
             url=_presigned_url("[foo]"),
             headers=[("Host", "sts.amazonaws.com")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_header_auth_percent_encoded_credential_raises_signing_error() -> None:
+    headers = [
+        (
+            "Authorization",
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER%2F20260101%2Fus-east-1%2Fsts%2Faws4_request, "
+            "SignedHeaders=host;x-amz-date, "
+            "Signature=placeholder",
+        ),
+        ("X-Amz-Date", "20260101T000000Z"),
+        ("Host", "sts.amazonaws.com"),
+    ]
+
+    with pytest.raises(AwsSigV4SigningError, match="Malformed AWS credential scope"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=headers,
             body=None,
             credentials=_credentials(),
         )

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -163,6 +163,24 @@ def test_header_auth_malformed_percent_encoded_path_raises_signing_error(
         )
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://sts.amazonaws.com/pa\nth",
+        " https://sts.amazonaws.com/path",
+    ],
+)
+def test_header_auth_raw_whitespace_url_raises_signing_error(url: str) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=url,
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_presigned_query_invalid_unicode_query_raises_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
         sign_request(

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -74,6 +74,17 @@ def test_presigned_query_malformed_url_raises_signing_error() -> None:
         )
 
 
+def test_presigned_query_invalid_bracketed_host_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=_presigned_url("[foo]"),
+            headers=[("Host", "sts.amazonaws.com")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_invalid_port_keeps_specific_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request URL has an invalid port"):
         sign_request(

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -98,6 +98,20 @@ def test_header_auth_invalid_unicode_path_raises_signing_error() -> None:
         )
 
 
+@pytest.mark.parametrize("path", ["/%ZZ", "/%"])
+def test_header_auth_malformed_percent_encoded_path_raises_signing_error(
+    path: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=f"https://sts.amazonaws.com{path}",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_presigned_query_invalid_unicode_query_raises_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
         sign_request(

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -1,0 +1,74 @@
+"""AWS SigV4 signer boundary tests."""
+
+import urllib.parse
+
+import pytest
+
+from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
+
+
+def _credentials() -> AwsSigV4Credentials:
+    return AwsSigV4Credentials("AKIDEXAMPLE", "secret")
+
+
+def _header_auth_headers() -> list[tuple[str, str]]:
+    return [
+        (
+            "Authorization",
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=host;x-amz-date, "
+            "Signature=placeholder",
+        ),
+        ("X-Amz-Date", "20260101T000000Z"),
+        ("Host", "sts.amazonaws.com"),
+    ]
+
+
+def _presigned_url(host: str) -> str:
+    placeholder_credential = urllib.parse.quote(
+        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
+        safe="",
+    )
+    return (
+        f"https://{host}/?Action=GetCallerIdentity&Version=2011-06-15"
+        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        f"&X-Amz-Credential={placeholder_credential}"
+        "&X-Amz-Date=20260101T000000Z"
+        "&X-Amz-Expires=60"
+        "&X-Amz-SignedHeaders=host"
+        "&X-Amz-Signature=placeholder"
+    )
+
+
+def test_header_auth_malformed_url_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url="https://[::1",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_presigned_query_malformed_url_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=_presigned_url("[::1"),
+            headers=[("Host", "sts.amazonaws.com")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_invalid_port_keeps_specific_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL has an invalid port"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com:bad/",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -109,6 +109,17 @@ def test_presigned_query_invalid_unicode_query_raises_signing_error() -> None:
         )
 
 
+def test_header_auth_invalid_unicode_fragment_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url=f"https://sts.amazonaws.com/#fragment{_INVALID_UNICODE}",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_signed_header_invalid_unicode_raises_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request contains invalid text"):
         sign_request(

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -52,6 +52,17 @@ def test_header_auth_malformed_url_raises_signing_error() -> None:
         )
 
 
+def test_header_auth_invalid_bracketed_host_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
+        sign_request(
+            method="GET",
+            url="https://[foo]/",
+            headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 def test_presigned_query_malformed_url_raises_signing_error() -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request URL is malformed"):
         sign_request(

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -24,6 +24,7 @@ from tests.auth_state_helpers import (
     set_cached_headers,
 )
 from tests.firewall_helpers import cancel_pending_task
+from url_utils import get_original_url
 
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
 
@@ -826,6 +827,7 @@ class TestHandleFirewallRequest:
             ),
         )
         flow.metadata["vm_run_id"] = "test-run"
+        flow.metadata["original_url"] = get_original_url(flow)
         api_entry = _api_entry(
             base="https://sts.amazonaws.com",
             auth_config={

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -824,6 +824,50 @@ async def test_header_sigv4_without_trusted_original_url_fails_closed(
     assert "AWS request URL is unavailable" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    _prepare_firewall_request(flow)
+    flow.request.path = "//[foo]?Trace=secret-value"
+    set_cached_headers(
+        ("run-1", "https://sts.amazonaws.com"),
+        headers={},
+        aws_sigv4=AwsSigV4Credentials(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        ),
+    )
+
+    with mitm_ctx():
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "AWS request URL is malformed" in flow.response.json()["message"]
+
+
 async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
     real_flow,
     headers,

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -2,6 +2,8 @@
 
 import urllib.parse
 
+import pytest
+
 import auth
 import flow_metadata_keys as metadata_keys
 import matching
@@ -824,11 +826,19 @@ async def test_header_sigv4_without_trusted_original_url_fails_closed(
     assert "AWS request URL is unavailable" in flow.response.json()["message"]
 
 
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "//[foo]?Trace=secret-value",
+        "/?Trace=secret\nvalue",
+    ],
+)
 async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
     real_flow,
     headers,
     tmp_path,
     mitm_ctx,
+    request_path,
 ):
     flow = real_flow(
         with_response=False,
@@ -848,7 +858,7 @@ async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
         ),
     )
     _prepare_firewall_request(flow)
-    flow.request.path = "//[foo]?Trace=secret-value"
+    flow.request.path = request_path
     set_cached_headers(
         ("run-1", "https://sts.amazonaws.com"),
         headers={},

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -3,6 +3,7 @@
 import urllib.parse
 
 import auth
+import flow_metadata_keys as metadata_keys
 import matching
 from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
@@ -314,6 +315,79 @@ async def test_re_signs_header_sigv4_request_with_normalized_host(
         )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.request.headers["host"] == "iam.amazonaws.com"
+    assert flow.request.headers["authorization"] == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
+        "SignedHeaders=host;x-amz-date, "
+        "Signature=91fb24346d00546d6da247c85eb79148080a6e3ae1ac9aa8eae9ccdabfd70b33"
+    )
+
+
+async def test_re_signs_header_sigv4_request_with_trusted_original_url(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(
+        {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "AKIDEXAMPLE",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            },
+            "expiresAt": 1_800_000_000,
+            "resolvedSecrets": [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+            ],
+            "refreshedConnectors": [],
+            "refreshedSecrets": [],
+        }
+    )
+    api_entry = {
+        "base": "https://iam.amazonaws.com",
+        "auth": {
+            "headers": {},
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            },
+        },
+    }
+    flow = real_flow(
+        with_response=False,
+        host="203.0.113.10",
+        sni="iam.amazonaws.com",
+        path="/",
+        method="GET",
+        request_headers=headers(
+            ("Host", "iam.amazonaws.com"),
+            ("X-Amz-Date", "20150830T123600Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata["vm_run_id"] = "run-1"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = "https://iam.amazonaws.com/"
+    flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "iam.amazonaws.com"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(
+            flow,
+            matching.FirewallAllow(api_entry, "aws", "trusted-url", {}, "GET /", "/"),
+            _vm_info(tmp_path),
+        )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.request.url == "https://iam.amazonaws.com/"
     assert flow.request.headers["host"] == "iam.amazonaws.com"
     assert flow.request.headers["authorization"] == (
         "AWS4-HMAC-SHA256 "

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -8,6 +8,7 @@ import matching
 from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import set_cached_headers
+from url_utils import get_original_url
 
 
 def _api_entry() -> dict:
@@ -68,7 +69,7 @@ def _auth_response() -> dict[str, object]:
 def _prepare_firewall_request(flow, *, original_url: str | None = None) -> None:
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
     flow.metadata[metadata_keys.ORIGINAL_URL] = (
-        flow.request.url if original_url is None else original_url
+        get_original_url(flow) if original_url is None else original_url
     )
 
 
@@ -382,7 +383,7 @@ async def test_re_signs_header_sigv4_request_with_trusted_original_url(
             ),
         ),
     )
-    _prepare_firewall_request(flow, original_url="https://iam.amazonaws.com/")
+    _prepare_firewall_request(flow)
     flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "iam.amazonaws.com"
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
@@ -464,7 +465,10 @@ async def test_re_signs_query_sigv4_request_strips_session_token_header(
             "&X-Amz-Signature=placeholder"
         ),
         method="GET",
-        request_headers=headers(("X-Amz-Security-Token", "placeholder-session-token")),
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Security-Token", "placeholder-session-token"),
+        ),
     )
     _prepare_firewall_request(flow)
 

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -65,6 +65,13 @@ def _auth_response() -> dict[str, object]:
     }
 
 
+def _prepare_firewall_request(flow, *, original_url: str | None = None) -> None:
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        flow.request.url if original_url is None else original_url
+    )
+
+
 async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())
@@ -87,7 +94,7 @@ async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -160,7 +167,7 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(
@@ -229,7 +236,7 @@ async def test_re_signs_header_sigv4_request_with_encoded_path(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(
@@ -305,7 +312,7 @@ async def test_re_signs_header_sigv4_request_with_normalized_host(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(
@@ -375,8 +382,7 @@ async def test_re_signs_header_sigv4_request_with_trusted_original_url(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
-    flow.metadata[metadata_keys.ORIGINAL_URL] = "https://iam.amazonaws.com/"
+    _prepare_firewall_request(flow, original_url="https://iam.amazonaws.com/")
     flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "iam.amazonaws.com"
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
@@ -418,7 +424,7 @@ async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -460,7 +466,7 @@ async def test_re_signs_query_sigv4_request_strips_session_token_header(
         method="GET",
         request_headers=headers(("X-Amz-Security-Token", "placeholder-session-token")),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -496,7 +502,7 @@ async def test_re_signs_query_sigv4_request_preserves_literal_plus(
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -528,7 +534,7 @@ async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ct
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -559,7 +565,7 @@ async def test_hmac_sigv4_wildcard_region_fails_closed(real_flow, headers, tmp_p
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -596,7 +602,7 @@ async def test_header_sigv4_with_malformed_scope_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -638,7 +644,7 @@ async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -673,7 +679,7 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
     set_cached_headers(
         ("run-1", "https://sts.amazonaws.com"),
         headers={},
@@ -688,6 +694,49 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     assert flow.response.status_code == 502
     assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
     assert "Invalid AWS secret access key" in flow.response.json()["message"]
+
+
+async def test_header_sigv4_without_trusted_original_url_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
+    set_cached_headers(
+        ("run-1", "https://sts.amazonaws.com"),
+        headers={},
+        aws_sigv4=AwsSigV4Credentials(
+            "AKIDEXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        ),
+    )
+
+    with mitm_ctx():
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "AWS request URL is unavailable" in flow.response.json()["message"]
 
 
 async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
@@ -713,7 +762,7 @@ async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
     set_cached_headers(
         ("run-1", "https://sts.amazonaws.com"),
         headers={},
@@ -759,7 +808,7 @@ async def test_header_sigv4_with_real_source_access_key_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -797,7 +846,7 @@ async def test_header_sigv4_with_duplicate_credential_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -835,7 +884,7 @@ async def test_header_sigv4_with_duplicate_authorization_headers_fails_closed(
             ("Authorization", authorization),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -871,7 +920,7 @@ async def test_header_sigv4_without_signature_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -908,7 +957,7 @@ async def test_header_sigv4_with_duplicate_signed_header_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -945,7 +994,7 @@ async def test_header_sigv4_with_empty_signed_header_segment_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -981,7 +1030,7 @@ async def test_header_sigv4_without_amz_date_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1018,7 +1067,7 @@ async def test_header_sigv4_with_malformed_amz_date_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1055,7 +1104,7 @@ async def test_header_sigv4_with_scope_date_mismatch_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1093,7 +1142,7 @@ async def test_header_sigv4_with_duplicate_amz_date_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1133,7 +1182,7 @@ async def test_header_sigv4_with_duplicate_content_hash_fails_closed(
             ),
         ),
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1165,7 +1214,7 @@ async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, m
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1198,7 +1247,7 @@ async def test_query_sigv4_with_real_source_access_key_fails_closed(real_flow, t
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1236,7 +1285,7 @@ async def test_query_sigv4_with_duplicate_credential_fails_closed(real_flow, tmp
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1274,7 +1323,7 @@ async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
@@ -1307,7 +1356,7 @@ async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_pat
         ),
         method="GET",
     )
-    flow.metadata["vm_run_id"] = "run-1"
+    _prepare_firewall_request(flow)
 
     with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
         result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -404,6 +404,87 @@ async def test_re_signs_header_sigv4_request_with_trusted_original_url(
     )
 
 
+async def test_re_signs_header_sigv4_request_keeps_resolved_query_with_trusted_url(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(
+        {
+            "headers": {},
+            "query": {"Trace": "secret-value"},
+            "awsSigv4": {
+                "accessKeyId": "AKIDEXAMPLE",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            },
+            "expiresAt": 1_800_000_000,
+            "resolvedSecrets": [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+            ],
+            "refreshedConnectors": [],
+            "refreshedSecrets": [],
+        }
+    )
+    api_entry = {
+        "base": "https://iam.amazonaws.com",
+        "auth": {
+            "headers": {},
+            "query": {"Trace": "${{ secrets.TRACE }}"},
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            },
+        },
+    }
+    flow = real_flow(
+        with_response=False,
+        host="203.0.113.10",
+        sni="iam.amazonaws.com",
+        path="/?Action=ListUsers&Version=2010-05-08",
+        method="GET",
+        request_headers=headers(
+            ("Host", "iam.amazonaws.com"),
+            ("Content-Type", "application/x-www-form-urlencoded; charset=utf-8"),
+            ("X-Amz-Date", "20150830T123600Z"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
+                "SignedHeaders=content-type;host;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    _prepare_firewall_request(flow)
+    flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "iam.amazonaws.com"
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(
+            flow,
+            matching.FirewallAllow(api_entry, "aws", "trusted-query", {}, "GET /", "/"),
+            _vm_info(tmp_path),
+        )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    signed_parts = urllib.parse.urlsplit(flow.request.url)
+    assert signed_parts.scheme == "https"
+    assert signed_parts.netloc == "iam.amazonaws.com"
+    assert dict(urllib.parse.parse_qsl(signed_parts.query)) == {
+        "Action": "ListUsers",
+        "Version": "2010-05-08",
+        "Trace": "secret-value",
+    }
+    assert flow.request.headers["authorization"] == (
+        "AWS4-HMAC-SHA256 "
+        "Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
+        "SignedHeaders=content-type;host;x-amz-date, "
+        "Signature=22a3e4709cec49fad0f5cb8eac18cb63ab08f1f90b46be84ed239a4687fdcd97"
+    )
+
+
 async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -163,14 +163,21 @@ class TestAuthBaseUrlRewriteSafety:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)
 
+    @pytest.mark.parametrize(
+        "request_path",
+        [
+            "//[foo]?client=visible",
+            "/hook?client=visible\nsecret",
+        ],
+    )
     async def test_malformed_request_target_fails_closed_without_forwarding(
-        self, real_flow, mitm_ctx, tmp_path
+        self, real_flow, mitm_ctx, tmp_path, request_path
     ):
         """Malformed request target query extraction must use the local rewrite failure path."""
         flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
             real_flow,
             tmp_path,
-            path="//[foo]?client=visible",
+            path=request_path,
             resolved_base="https://real.example.com/webhook/super-secret-token",
         )
         mock_forward = AsyncMock()

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -163,6 +163,36 @@ class TestAuthBaseUrlRewriteSafety:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)
 
+    async def test_malformed_request_target_fails_closed_without_forwarding(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        """Malformed request target query extraction must use the local rewrite failure path."""
+        flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path="//[foo]?client=visible",
+            resolved_base="https://real.example.com/webhook/super-secret-token",
+        )
+        mock_forward = AsyncMock()
+        mock_log = MagicMock()
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert mock_forward.call_count == 0
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert "auth_url_rewrite" not in flow.metadata
+        assert "super-secret-token" not in flow.response.text
+        for log_call in mock_log.call_args_list:
+            assert "super-secret-token" not in json.dumps(log_call.args)
+            assert "super-secret-token" not in json.dumps(log_call.kwargs)
+
     @pytest.mark.parametrize(
         "resolved_base",
         [


### PR DESCRIPTION
## Summary

- Convert malformed URL parser, hostname, URL percent/encoding, and query percent-decoding failures inside the AWS SigV4 signer into `AwsSigV4SigningError`
- Keep the existing invalid-port signing error diagnostic intact
- Validate invalid Unicode in full SigV4 URLs, headers, and signing inputs so they fail closed instead of leaking raw `UnicodeEncodeError` or returning invalid text
- Parse SigV4 credential scopes after exactly one transport-level decode, rejecting double-encoded presigned credentials and percent-encoded header credentials
- Sign normal firewall SigV4 requests against the request hook's trusted `original_url`, so transparent target IPs do not leak into the AWS canonical host
- Fail closed if normal firewall SigV4 auth reaches signing without the trusted request URL metadata
- Add signer-boundary and firewall-auth regression tests for header-auth, presigned-query, invalid bracketed hosts, malformed URL/query percent escapes, invalid Unicode paths/query/fragments/headers, invalid ports, double-encoded credentials, trusted SNI-derived original URLs, missing trusted original URL metadata, and standard auth + SigV4 metadata setup

## Tests

- `python3 -m pytest tests/test_firewall_auth.py -q`
- `python3 -m pytest tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_forwarding.py tests/test_firewall_rewrite_safety.py tests/test_auth_base_forwarder.py -q`
- `python3 -m pytest tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py -q`
- `python3 -m pytest tests/test_firewall_aws_sigv4_auth.py -v`
- `python3 -m pytest tests/test_aws_sigv4.py -v`
- `python3 -m pytest tests/test_utils.py::TestGetOriginalUrl -v`
- `python3 -m py_compile src/auth.py src/aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py`
- `python3 -m ruff format src/auth.py src/aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py`
- `python3 -m ruff check src/auth.py src/aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py`
- `git diff --check`
- pre-commit `ruff-fmt` / `ruff-check`

Closes #17455