### PR TITLE
perf(mitm-addon): skip eventless responses delta parsing

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -49,6 +49,7 @@ _JSON_CONTROL_CHAR_MAX = 0x20
 _JSON_PREFILTER_MAX_DEPTH = 256
 _JSON_PREFILTER_MAX_STRING_BYTES = 1024
 _JSON_HEX_BYTES = frozenset(b"0123456789abcdefABCDEF")
+_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES = 4096
 
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_INPUT,
@@ -444,24 +445,39 @@ class _OpenAIResponsesSseUsageHandler:
     ) -> None:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
+        self._eventless_prefix: bytearray | None = None
+        self._discard_eventless_event = False
         self._on_parse_error = on_parse_error
 
     def should_capture_event(self, event_name: str | None) -> bool:
         return event_name is None or event_name in _RESPONSES_TERMINAL_USAGE_EVENTS
 
     def on_event_start(self, event_name: str | None) -> None:
-        self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
+        self._reset_event_state()
+        if event_name is None:
+            self._eventless_prefix = bytearray()
+            return
+        self._start_full_extractor()
 
     def on_data(self, chunk: bytes) -> None:
+        if self._discard_eventless_event:
+            return
         if self._extractor is not None:
             self._extractor.feed(chunk)
+            return
+        if self._eventless_prefix is not None:
+            self._feed_eventless_data(chunk)
 
     def on_data_separator(self) -> None:
         self.on_data(b"\n")
 
     def on_event_end(self, event_name: str | None) -> None:
+        if self._eventless_prefix is not None:
+            extractor = self._start_full_extractor()
+            extractor.feed(bytes(self._eventless_prefix))
+            self._eventless_prefix = None
         extractor = self._extractor
-        self._extractor = None
+        self._reset_event_state()
         if extractor is None:
             return
         result = extractor.finish()
@@ -477,7 +493,51 @@ class _OpenAIResponsesSseUsageHandler:
             self._on_parse_error(event_name, result.error)
 
     def on_event_discard(self, event_name: str | None) -> None:
+        self._reset_event_state()
+
+    def _reset_event_state(self) -> None:
         self._extractor = None
+        self._eventless_prefix = None
+        self._discard_eventless_event = False
+
+    def _start_full_extractor(self) -> JsonSelectiveExtractor:
+        self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
+        return self._extractor
+
+    def _feed_eventless_data(self, chunk: bytes) -> None:
+        prefix = self._eventless_prefix
+        if prefix is None:
+            return
+
+        remaining = max(_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES - len(prefix), 0)
+        captured_len = min(len(chunk), remaining)
+        if captured_len:
+            prefix.extend(chunk[:captured_len])
+
+        event_type = _classify_responses_event_type(bytes(prefix))
+        if event_type == _RESPONSES_EVENT_NON_TERMINAL:
+            self._eventless_prefix = None
+            self._discard_eventless_event = True
+            return
+
+        should_fallback = (
+            event_type == _RESPONSES_EVENT_TERMINAL
+            or captured_len < len(chunk)
+            or len(prefix) >= _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
+        )
+        if not should_fallback:
+            return
+
+        self._fallback_eventless_prefix_to_full_extractor()
+        if self._extractor is not None and captured_len < len(chunk):
+            self._extractor.feed(chunk[captured_len:])
+
+    def _fallback_eventless_prefix_to_full_extractor(self) -> None:
+        prefix = self._eventless_prefix
+        self._eventless_prefix = None
+        extractor = self._start_full_extractor()
+        if prefix:
+            extractor.feed(bytes(prefix))
 
 
 class OpenAIResponsesJsonUsageExtractor:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -49,6 +49,9 @@ _JSON_CONTROL_CHAR_MAX = 0x20
 _JSON_PREFILTER_MAX_DEPTH = 256
 _JSON_PREFILTER_MAX_STRING_BYTES = 1024
 _JSON_HEX_BYTES = frozenset(b"0123456789abcdefABCDEF")
+# Eventless SSE frames normally expose ``type`` near the top of the JSON body.
+# After this bounded prefix, fall back to the full streaming extractor so rare
+# terminal frames with late ``type`` fields still report usage.
 _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES = 4096
 
 _OPENAI_RESPONSES_USAGE_CATEGORIES = (

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -170,6 +170,16 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 4
 
+    def test_finish_flushes_eventless_response_completed_without_blank_line(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.4",'
+            b'"usage":{"output_tokens":14}}}'
+        )
+        parse.finish()
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 14
+
     def test_accepts_sse_fields_without_optional_space(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import usage.openai_responses as openai_responses
 from usage import (
     create_openai_responses_sse_usage_extractor,
 )
@@ -88,6 +89,62 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         assert usage["model"] == "gpt-5.4-mini"
         assert usage["tokens.input"] == 3
+
+    def test_eventless_non_terminal_skips_large_delta_before_full_extraction(self, monkeypatch):
+        real_extractor = openai_responses.JsonSelectiveExtractor
+        fed_chunks: list[bytes] = []
+
+        class TrackingExtractor:
+            def __init__(self, **kwargs):
+                self._inner = real_extractor(**kwargs)
+
+            def feed(self, chunk: bytes) -> None:
+                fed_chunks.append(chunk)
+                self._inner.feed(chunk)
+
+            def finish(self):
+                return self._inner.finish()
+
+        monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", TrackingExtractor)
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"type":"response.output_text.delta","delta":"'
+            + b"x" * 100_000
+            + b'"}\n\n'
+            + b'data: {"type":"response.completed","response":{"model":"gpt-5.4",'
+            + b'"usage":{"output_tokens":9}}}\n\n'
+        )
+
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 9
+        assert not any(b"x" * 1000 in chunk for chunk in fed_chunks)
+
+    def test_eventless_terminal_type_split_across_chunks_extracts_usage(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(b'data: {"type":"response.comp')
+        parse(
+            b'leted","response":{"id":"resp_split","model":"gpt-5.4",'
+            b'"usage":{"input_tokens":6,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "message_id": "resp_split",
+            "model": "gpt-5.4",
+            "tokens.input": 6,
+            "tokens.output": 4,
+        }
+
+    def test_eventless_type_after_prefix_bound_falls_back_to_full_extraction(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"padding":"'
+            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b'","type":"response.completed","response":{"model":"gpt-5.4",'
+            + b'"usage":{"output_tokens":8}}}\n\n'
+        )
+
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 8
 
     def test_finish_flushes_response_completed_without_blank_line(self):
         parse, usage = create_openai_responses_sse_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -135,6 +135,18 @@ class TestOpenAIResponsesSseUsageExtractor:
             "tokens.output": 4,
         }
 
+    def test_eventless_non_terminal_type_split_across_chunks_recovers(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(b'data: {"type":"response.output_text.')
+        parse(
+            b'delta","delta":"ignored"}\n\n'
+            b'data: {"type":"response.completed","response":{"model":"gpt-5.4",'
+            b'"usage":{"output_tokens":5}}}\n\n'
+        )
+
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 5
+
     def test_eventless_type_after_prefix_bound_falls_back_to_full_extraction(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -237,6 +237,15 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 4
 
+    def test_multidata_eventless_response_completed_event(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"type":"response.completed",\n'
+            b'data: "response":{"model":"gpt-5.4","usage":{"output_tokens":15}}}\n\n'
+        )
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 15
+
     def test_skips_large_irrelevant_events_without_buffering(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(b"event: response.output_text.delta\n")

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -107,17 +107,18 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", TrackingExtractor)
         parse, usage = create_openai_responses_sse_usage_extractor()
+        delta_payload = b'{"type":"response.output_text.delta","delta":"' + b"x" * 100_000 + b'"}'
         parse(
-            b'data: {"type":"response.output_text.delta","delta":"'
-            + b"x" * 100_000
-            + b'"}\n\n'
+            b"data: "
+            + delta_payload
+            + b"\n\n"
             + b'data: {"type":"response.completed","response":{"model":"gpt-5.4",'
             + b'"usage":{"output_tokens":9}}}\n\n'
         )
 
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 9
-        assert not any(b"x" * 1000 in chunk for chunk in fed_chunks)
+        assert delta_payload not in b"".join(fed_chunks)
 
     def test_eventless_terminal_type_split_across_chunks_extracts_usage(self):
         parse, usage = create_openai_responses_sse_usage_extractor()


### PR DESCRIPTION
## Summary

- Add a bounded eventless SSE prefix classifier for OpenAI Responses streams.
- Skip full usage JSON extraction for eventless non-terminal events once the top-level `type` is known.
- Preserve terminal, unknown, malformed, and late-`type` fallback behavior by replaying the bounded prefix into the existing extractor.

## Notes

This keeps `SseUsageScanner` provider-agnostic and avoids adding a new early-observe API to `JsonSelectiveExtractor`. The prefix bound is only an optimization threshold; unresolved eventless payloads fall back to the previous full extraction path.

Closes #17456

## Tests

- `ruff check src/usage/openai_responses.py tests/test_openai_responses_sse.py`
- `ruff format --check src/usage/openai_responses.py tests/test_openai_responses_sse.py`
- `python3 -m pytest tests/test_openai_responses_sse.py tests/test_openai_responses_event_json.py tests/test_sse.py`
- `python3 -m pytest tests/test_openai_responses_sse.py tests/test_openai_responses_event_json.py tests/test_openai_responses_json.py`
