### PR TITLE
fix(vsock-guest): bound short-lived reconnect attempts

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -3,7 +3,7 @@ use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use vsock_proto::{
     self, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
@@ -32,8 +32,13 @@ const VSOCK_CID_HOST: u32 = 2;
 /// Read buffer size for the connection event loop (local tuning constant).
 const READ_BUFFER_SIZE: usize = 64 * 1024; // 64KB
 enum ConnectionEnd {
-    Closed,
+    Closed { stable: bool },
     Shutdown,
+}
+
+struct ConnectionFailure {
+    error: io::Error,
+    stable: bool,
 }
 
 enum ReconnectFailure {
@@ -57,6 +62,66 @@ impl Drop for ConnectionCancelGuard {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Release);
     }
+}
+
+struct ConnectionSession {
+    started_at: Instant,
+    handled_real_host_work: bool,
+}
+
+impl ConnectionSession {
+    fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+            handled_real_host_work: false,
+        }
+    }
+
+    fn mark_real_host_work(&mut self, msg_type: u8) {
+        if is_real_host_work_message(msg_type) {
+            self.handled_real_host_work = true;
+        }
+    }
+
+    fn is_stable(&self) -> bool {
+        connection_is_stable(self.started_at.elapsed(), self.handled_real_host_work)
+    }
+
+    fn closed(&self) -> ConnectionEnd {
+        ConnectionEnd::Closed {
+            stable: self.is_stable(),
+        }
+    }
+
+    fn failure(&self, error: io::Error) -> ConnectionFailure {
+        ConnectionFailure {
+            error,
+            stable: self.is_stable(),
+        }
+    }
+}
+
+fn unstable_connection_failure(error: io::Error) -> ConnectionFailure {
+    ConnectionFailure {
+        error,
+        stable: false,
+    }
+}
+
+fn connection_is_stable(elapsed: Duration, handled_real_host_work: bool) -> bool {
+    handled_real_host_work || elapsed >= STABLE_CONNECTION_MIN_DURATION
+}
+
+fn is_real_host_work_message(msg_type: u8) -> bool {
+    matches!(
+        msg_type,
+        MSG_EXEC_START
+            | MSG_EXEC_CANCEL
+            | MSG_EXEC_CONTROL
+            | MSG_WRITE_FILE
+            | MSG_QUIESCE_OPERATIONS
+            | MSG_RESUME_OPERATIONS
+    )
 }
 
 fn acquire_operation_guard(
@@ -400,13 +465,16 @@ pub fn connect_unix(path: &str) -> io::Result<UnixStream> {
 /// Handle connection - the main event loop
 /// Uses separate reader/writer to avoid deadlock between main loop and background threads
 pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
-    handle_connection_with_outcome(stream).map(|_| ())
+    match handle_connection_with_outcome(stream) {
+        Ok(_) => Ok(()),
+        Err(failure) => Err(failure.error),
+    }
 }
 
-fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEnd> {
+fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while worker threads write results.
-    let mut reader = stream.try_clone()?;
+    let mut reader = stream.try_clone().map_err(unstable_connection_failure)?;
     let writer = GuestWriter::new(stream);
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
@@ -415,16 +483,23 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
 
     // Send ready signal
     {
-        let ready = vsock_proto::encode(MSG_READY, 0, &[]).map_err(to_io_error)?;
-        writer.write_frame(&ready)?;
+        let ready = vsock_proto::encode(MSG_READY, 0, &[])
+            .map_err(to_io_error)
+            .map_err(unstable_connection_failure)?;
+        writer
+            .write_frame(&ready)
+            .map_err(unstable_connection_failure)?;
     }
     log("INFO", "Sent ready signal");
 
+    let mut session = ConnectionSession::new();
     let dispatcher = ConnectionDispatcher::new(writer, connection_cancel.clone());
     let mut buf = [0u8; READ_BUFFER_SIZE];
     loop {
         // Read from stream (reader is separate, no lock needed)
-        let n = reader.read(&mut buf)?;
+        let n = reader
+            .read(&mut buf)
+            .map_err(|error| session.failure(error))?;
 
         if n == 0 {
             break;
@@ -433,22 +508,37 @@ fn handle_connection_with_outcome(stream: UnixStream) -> io::Result<ConnectionEn
         // n <= buf.len() is guaranteed by read()
         for msg in decoder
             .decode(buf.get(..n).unwrap_or_default())
-            .map_err(to_io_error)?
+            .map_err(to_io_error)
+            .map_err(|error| session.failure(error))?
         {
-            if dispatcher.dispatch(&msg)? == DispatchOutcome::Shutdown {
+            if dispatcher
+                .dispatch(&msg)
+                .map_err(|error| session.failure(error))?
+                == DispatchOutcome::Shutdown
+            {
                 return Ok(ConnectionEnd::Shutdown);
             }
+            session.mark_real_host_work(msg.msg_type);
         }
     }
 
     log("INFO", "Host disconnected");
-    Ok(ConnectionEnd::Closed)
+    Ok(session.closed())
 }
 
 /// Maximum reconnection attempts before giving up
 const MAX_RECONNECT_ATTEMPTS: u32 = 50;
 /// Delay between reconnection attempts (10ms for fast reconnect after snapshot restore)
 const RECONNECT_DELAY_MS: u64 = 10;
+const STABLE_CONNECTION_MIN_DURATION: Duration = Duration::from_secs(1);
+
+fn next_reconnect_attempts(current_attempts: u32, connection_was_stable: bool) -> u32 {
+    if connection_was_stable {
+        1
+    } else {
+        current_attempts + 1
+    }
+}
 
 fn retry_or_fail(failure: ReconnectFailure, attempts: u32) -> io::Result<()> {
     if attempts >= MAX_RECONNECT_ATTEMPTS {
@@ -515,28 +605,32 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
     loop {
         let result = if let Some(path) = unix_socket {
             log("INFO", &format!("Connecting to Unix socket: {}...", path));
-            connect_unix(path).and_then(|stream| {
-                log("INFO", "Connected");
-                // Reset attempts on successful connection
-                attempts = 0;
-                handle_connection_with_outcome(stream)
-            })
+            connect_unix(path)
+                .map_err(unstable_connection_failure)
+                .and_then(|stream| {
+                    log("INFO", "Connected");
+                    handle_connection_with_outcome(stream)
+                })
         } else {
             log("INFO", "Connecting to host (CID=2)...");
-            connect_vsock().and_then(|stream| {
-                log("INFO", "Connected");
-                // Reset attempts on successful connection
-                attempts = 0;
-                handle_connection_with_outcome(stream)
-            })
+            connect_vsock()
+                .map_err(unstable_connection_failure)
+                .and_then(|stream| {
+                    log("INFO", "Connected");
+                    handle_connection_with_outcome(stream)
+                })
         };
-
-        attempts += 1;
 
         match result {
             Ok(ConnectionEnd::Shutdown) => return Ok(()),
-            Ok(ConnectionEnd::Closed) => retry_or_fail(ReconnectFailure::Closed, attempts)?,
-            Err(error) => retry_or_fail(ReconnectFailure::Error(error), attempts)?,
+            Ok(ConnectionEnd::Closed { stable }) => {
+                attempts = next_reconnect_attempts(attempts, stable);
+                retry_or_fail(ReconnectFailure::Closed, attempts)?;
+            }
+            Err(failure) => {
+                attempts = next_reconnect_attempts(attempts, failure.stable);
+                retry_or_fail(ReconnectFailure::Error(failure.error), attempts)?;
+            }
         }
     }
 }
@@ -544,6 +638,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vsock_proto::{MSG_PING, MSG_SHUTDOWN};
 
     #[test]
     fn retry_closed_failure_returns_connection_reset_when_exhausted() {
@@ -571,5 +666,45 @@ mod tests {
             assert_eq!(error.kind(), io::ErrorKind::TimedOut);
             assert_eq!(error.to_string(), "connection timed out");
         }
+    }
+
+    #[test]
+    fn connection_stability_requires_duration_or_real_work() {
+        assert!(!connection_is_stable(
+            STABLE_CONNECTION_MIN_DURATION - Duration::from_millis(1),
+            false
+        ));
+        assert!(connection_is_stable(STABLE_CONNECTION_MIN_DURATION, false));
+        assert!(connection_is_stable(Duration::ZERO, true));
+    }
+
+    #[test]
+    fn liveness_and_shutdown_messages_do_not_count_as_real_host_work() {
+        assert!(!is_real_host_work_message(MSG_PING));
+        assert!(!is_real_host_work_message(MSG_SHUTDOWN));
+    }
+
+    #[test]
+    fn operation_messages_count_as_real_host_work() {
+        for msg_type in [
+            MSG_EXEC_START,
+            MSG_EXEC_CANCEL,
+            MSG_EXEC_CONTROL,
+            MSG_WRITE_FILE,
+            MSG_QUIESCE_OPERATIONS,
+            MSG_RESUME_OPERATIONS,
+        ] {
+            assert!(is_real_host_work_message(msg_type));
+        }
+    }
+
+    #[test]
+    fn stable_connection_resets_reconnect_attempt_streak_before_counting_failure() {
+        assert_eq!(next_reconnect_attempts(20, true), 1);
+    }
+
+    #[test]
+    fn unstable_connection_continues_reconnect_attempt_streak() {
+        assert_eq!(next_reconnect_attempts(20, false), 21);
     }
 }

--- a/crates/vsock-guest/tests/connection/main.rs
+++ b/crates/vsock-guest/tests/connection/main.rs
@@ -10,5 +10,6 @@ mod support;
 mod basic;
 mod exec_operation;
 mod quiesce;
+mod reconnect;
 mod shutdown;
 mod write_file;

--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -2,13 +2,17 @@ use std::io::{self, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::mpsc;
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use vsock_guest::run;
-use vsock_proto::{self, MSG_PING, MSG_PONG};
+use vsock_proto::{
+    self, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+};
 
-use super::support::{read_and_discard_message, read_message, unique_socket_path};
+use super::support::{
+    read_and_discard_message, read_message, send_resume_operations, unique_socket_path,
+};
 
 const EXPECTED_RECONNECT_ATTEMPTS: usize = 50;
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -37,6 +41,53 @@ fn run_exhausts_reconnect_attempts_after_ping_only_disconnects() {
     });
 }
 
+#[test]
+fn run_resets_reconnect_attempts_after_real_host_work() {
+    let socket_path = unique_socket_path("reconnect-real-work-reset");
+    let listener = UnixListener::bind(socket_path.as_str()).unwrap();
+    let (done_rx, handle) = spawn_run_thread(socket_path.as_str());
+
+    for accepted in 1..EXPECTED_RECONNECT_ATTEMPTS {
+        let mut host_stream = accept_run_connection(&listener, &done_rx, accepted);
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        read_and_discard_message(&mut host_stream);
+        drop(host_stream);
+        assert_run_still_running(&done_rx, accepted);
+    }
+
+    let mut real_work_stream =
+        accept_run_connection(&listener, &done_rx, EXPECTED_RECONNECT_ATTEMPTS);
+    real_work_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    read_and_discard_message(&mut real_work_stream);
+    send_resume_operations(&mut real_work_stream, 9);
+    let resumed = read_message(&mut real_work_stream);
+    assert_eq!(resumed.msg_type, MSG_OPERATIONS_RESUMED);
+    assert_eq!(resumed.seq, 9);
+    drop(real_work_stream);
+
+    let mut shutdown_stream =
+        accept_run_connection(&listener, &done_rx, EXPECTED_RECONNECT_ATTEMPTS + 1);
+    shutdown_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    read_and_discard_message(&mut shutdown_stream);
+    let shutdown = vsock_proto::encode(MSG_SHUTDOWN, 10, &[]).unwrap();
+    shutdown_stream.write_all(&shutdown).unwrap();
+    let ack = read_message(&mut shutdown_stream);
+    assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
+    assert_eq!(ack.seq, 10);
+
+    let report = done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    drop(shutdown_stream);
+    drop(listener);
+    assert_eq!(report, Ok(()));
+    handle.join().unwrap().unwrap();
+}
+
 fn assert_run_exhausts_after_short_lived_connections(
     label: &str,
     mut handle_connection: impl FnMut(&mut UnixStream),
@@ -44,17 +95,7 @@ fn assert_run_exhausts_after_short_lived_connections(
     let socket_path = unique_socket_path(label);
     let listener = UnixListener::bind(socket_path.as_str()).unwrap();
 
-    let guest_socket_path = socket_path.as_str().to_owned();
-    let (done_tx, done_rx) = mpsc::channel();
-    let handle = thread::spawn(move || {
-        let result = run(Some(&guest_socket_path));
-        let report = result
-            .as_ref()
-            .map(|_| ())
-            .map_err(|error| (error.kind(), error.to_string()));
-        let _ = done_tx.send(report);
-        result
-    });
+    let (done_rx, handle) = spawn_run_thread(socket_path.as_str());
 
     for accepted in 1..=EXPECTED_RECONNECT_ATTEMPTS {
         let mut host_stream = accept_run_connection(&listener, &done_rx, accepted);
@@ -90,6 +131,21 @@ fn assert_run_exhausts_after_short_lived_connections(
     );
     assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
     assert_eq!(error.to_string(), "Max reconnect attempts reached");
+}
+
+fn spawn_run_thread(socket_path: &str) -> (mpsc::Receiver<RunReport>, JoinHandle<io::Result<()>>) {
+    let guest_socket_path = socket_path.to_owned();
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = run(Some(&guest_socket_path));
+        let report = result
+            .as_ref()
+            .map(|_| ())
+            .map_err(|error| (error.kind(), error.to_string()));
+        let _ = done_tx.send(report);
+        result
+    });
+    (done_rx, handle)
 }
 
 fn accept_run_connection(

--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -1,8 +1,9 @@
 use std::io::{self, Write};
+use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use vsock_guest::run;
 use vsock_proto::{self, MSG_PING, MSG_PONG};
@@ -10,6 +11,10 @@ use vsock_proto::{self, MSG_PING, MSG_PONG};
 use super::support::{read_and_discard_message, read_message, unique_socket_path};
 
 const EXPECTED_RECONNECT_ATTEMPTS: usize = 50;
+const ACCEPT_TIMEOUT: Duration = Duration::from_secs(5);
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+type RunReport = Result<(), (io::ErrorKind, String)>;
 
 #[test]
 fn run_exhausts_reconnect_attempts_after_immediate_disconnects() {
@@ -52,7 +57,7 @@ fn assert_run_exhausts_after_short_lived_connections(
     });
 
     for accepted in 1..=EXPECTED_RECONNECT_ATTEMPTS {
-        let (mut host_stream, _) = listener.accept().unwrap();
+        let mut host_stream = accept_run_connection(&listener, &done_rx, accepted);
         host_stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -60,10 +65,7 @@ fn assert_run_exhausts_after_short_lived_connections(
         drop(host_stream);
 
         if accepted < EXPECTED_RECONNECT_ATTEMPTS {
-            assert!(
-                done_rx.try_recv().is_err(),
-                "run() exited before exhausting reconnect attempts"
-            );
+            assert_run_still_running(&done_rx, accepted);
         }
     }
 
@@ -88,6 +90,83 @@ fn assert_run_exhausts_after_short_lived_connections(
     );
     assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
     assert_eq!(error.to_string(), "Max reconnect attempts reached");
+}
+
+fn accept_run_connection(
+    listener: &UnixListener,
+    done_rx: &mpsc::Receiver<RunReport>,
+    attempt: usize,
+) -> UnixStream {
+    let deadline = Instant::now()
+        .checked_add(ACCEPT_TIMEOUT)
+        .expect("accept timeout overflowed");
+
+    loop {
+        assert_run_still_running(done_rx, attempt.saturating_sub(1));
+
+        let now = Instant::now();
+        if now >= deadline {
+            panic!("run() did not open reconnect attempt {attempt} within {ACCEPT_TIMEOUT:?}");
+        }
+
+        if listener_has_pending_connection(listener, deadline.saturating_duration_since(now))
+            .unwrap()
+        {
+            return listener.accept().unwrap().0;
+        }
+    }
+}
+
+fn assert_run_still_running(done_rx: &mpsc::Receiver<RunReport>, completed_attempts: usize) {
+    match done_rx.try_recv() {
+        Ok(report) => panic!(
+            "run() exited after {completed_attempts} reconnect attempts before exhausting expected attempts: {report:?}"
+        ),
+        Err(mpsc::TryRecvError::Disconnected) => {
+            panic!("run() exited without reporting after {completed_attempts} reconnect attempts")
+        }
+        Err(mpsc::TryRecvError::Empty) => {}
+    }
+}
+
+fn listener_has_pending_connection(
+    listener: &UnixListener,
+    remaining: Duration,
+) -> io::Result<bool> {
+    let timeout = std::cmp::min(remaining, ACCEPT_POLL_INTERVAL)
+        .as_millis()
+        .max(1) as libc::c_int;
+    let mut pollfd = libc::pollfd {
+        fd: listener.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: pollfd points to one initialized listener descriptor entry, and
+    // the timeout is a bounded non-negative millisecond value.
+    let result = unsafe { libc::poll(&mut pollfd, 1 as libc::nfds_t, timeout) };
+    if result < 0 {
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::Interrupted {
+            return Ok(false);
+        }
+        return Err(error);
+    }
+    if result == 0 {
+        return Ok(false);
+    }
+    if pollfd.revents & libc::POLLNVAL != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "listener fd is invalid",
+        ));
+    }
+    if pollfd.revents & (libc::POLLERR | libc::POLLHUP) != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "listener is no longer accepting connections",
+        ));
+    }
+    Ok(pollfd.revents & libc::POLLIN != 0)
 }
 
 fn drain_pending_connections(listener: &UnixListener) {

--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -1,0 +1,102 @@
+use std::io::{self, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use vsock_guest::run;
+use vsock_proto::{self, MSG_PING, MSG_PONG};
+
+use super::support::{read_and_discard_message, read_message, unique_socket_path};
+
+const EXPECTED_RECONNECT_ATTEMPTS: usize = 50;
+
+#[test]
+fn run_exhausts_reconnect_attempts_after_immediate_disconnects() {
+    assert_run_exhausts_after_short_lived_connections(
+        "reconnect-immediate-disconnect",
+        read_and_discard_message,
+    );
+}
+
+#[test]
+fn run_exhausts_reconnect_attempts_after_ping_only_disconnects() {
+    assert_run_exhausts_after_short_lived_connections("reconnect-ping-only-disconnect", |stream| {
+        read_and_discard_message(stream);
+
+        let ping = vsock_proto::encode(MSG_PING, 7, &[]).unwrap();
+        stream.write_all(&ping).unwrap();
+        let pong = read_message(stream);
+        assert_eq!(pong.msg_type, MSG_PONG);
+        assert_eq!(pong.seq, 7);
+    });
+}
+
+fn assert_run_exhausts_after_short_lived_connections(
+    label: &str,
+    mut handle_connection: impl FnMut(&mut UnixStream),
+) {
+    let socket_path = unique_socket_path(label);
+    let listener = UnixListener::bind(socket_path.as_str()).unwrap();
+
+    let guest_socket_path = socket_path.as_str().to_owned();
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = run(Some(&guest_socket_path));
+        let report = result
+            .as_ref()
+            .map(|_| ())
+            .map_err(|error| (error.kind(), error.to_string()));
+        let _ = done_tx.send(report);
+        result
+    });
+
+    for accepted in 1..=EXPECTED_RECONNECT_ATTEMPTS {
+        let (mut host_stream, _) = listener.accept().unwrap();
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        handle_connection(&mut host_stream);
+        drop(host_stream);
+
+        if accepted < EXPECTED_RECONNECT_ATTEMPTS {
+            assert!(
+                done_rx.try_recv().is_err(),
+                "run() exited before exhausting reconnect attempts"
+            );
+        }
+    }
+
+    let report = match done_rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(report) => report,
+        Err(error) => {
+            drain_pending_connections(&listener);
+            drop(listener);
+            let _ = std::fs::remove_file(socket_path.as_str());
+            let result = handle.join().unwrap();
+            panic!(
+                "run() did not exit after {EXPECTED_RECONNECT_ATTEMPTS} short-lived connections: wait_error={error}, result={result:?}"
+            );
+        }
+    };
+    drop(listener);
+
+    let error = handle.join().unwrap().expect_err("run() should fail");
+    assert_eq!(
+        report,
+        Err((io::ErrorKind::ConnectionReset, error.to_string()))
+    );
+    assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(error.to_string(), "Max reconnect attempts reached");
+}
+
+fn drain_pending_connections(listener: &UnixListener) {
+    listener.set_nonblocking(true).unwrap();
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => drop(stream),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+            Err(_) => break,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Stop resetting vsock guest reconnect attempts on every successful socket connect.
- Treat a connection as stable only after `MSG_READY` is sent and it either lasts at least one second or handles real host work.
- Add reconnect regression coverage for immediate disconnects and ping-only short-lived sessions.

Closes #17555

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml -p vsock-guest --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`