### PR TITLE
fix: make pinned chat indicator open menu

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -370,7 +370,11 @@ describe("zero sidebar", () => {
       ).toBeInTheDocument();
     });
 
-    openThreadMenu("Release plan");
+    click(
+      within(threadRowByTitle("Release plan")).getByTestId(
+        "chat-thread-pinned-indicator",
+      ),
+    );
     click(menuItemByText("Unpin chat"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -245,12 +245,14 @@ function ChatThreadMenu({
   isPinned,
   isHighlighted,
   hasOtherIndicator,
+  usePinnedIndicatorTrigger,
 }: {
   threadId: string;
   title: string | null;
   isPinned: boolean;
   isHighlighted: boolean;
   hasOtherIndicator: boolean;
+  usePinnedIndicatorTrigger: boolean;
 }) {
   const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
   const reloadAutomations = useSet(reloadHeaderAutomationMenu$);
@@ -276,6 +278,8 @@ function ChatThreadMenu({
     openRenameChatThreadDialog({ threadId, title });
   }
 
+  const showMobileTrigger = !hasOtherIndicator || usePinnedIndicatorTrigger;
+
   return (
     <TooltipProvider delayDuration={200}>
       <DropdownMenu>
@@ -284,7 +288,7 @@ function ChatThreadMenu({
             type="button"
             onClick={handleMenuTriggerClick}
             className={`peer pointer-events-auto absolute top-1 left-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md ${
-              hasOtherIndicator ? "invisible" : "visible"
+              showMobileTrigger ? "visible" : "invisible"
             } md:invisible md:group-hover:visible md:data-[state=open]:visible transition-opacity duration-150 ${
               isHighlighted
                 ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
@@ -296,8 +300,26 @@ function ChatThreadMenu({
           >
             <Tooltip>
               <TooltipTrigger asChild>
-                <span>
-                  <IconDots size={16} stroke={2} />
+                <span
+                  aria-label={usePinnedIndicatorTrigger ? "Pinned" : undefined}
+                  data-testid={
+                    usePinnedIndicatorTrigger
+                      ? "chat-thread-pinned-indicator"
+                      : undefined
+                  }
+                >
+                  {usePinnedIndicatorTrigger ? (
+                    <>
+                      <IconPin size={16} stroke={2} className="md:hidden" />
+                      <IconDots
+                        size={16}
+                        stroke={2}
+                        className="hidden md:block"
+                      />
+                    </>
+                  ) : (
+                    <IconDots size={16} stroke={2} />
+                  )}
                 </span>
               </TooltipTrigger>
               <TooltipContent side="bottom">
@@ -365,6 +387,7 @@ function ChatThreadSideDecorator({
     );
   }
   const hasOtherIndicator = indicatorState !== null || isPinned;
+  const usePinnedIndicatorTrigger = isPinned && indicatorState === null;
   return (
     <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
       <ChatThreadMenu
@@ -373,6 +396,7 @@ function ChatThreadSideDecorator({
         isPinned={isPinned}
         isHighlighted={isHighlighted}
         hasOtherIndicator={hasOtherIndicator}
+        usePinnedIndicatorTrigger={usePinnedIndicatorTrigger}
       />
       {indicatorState !== null ? (
         <span className="flex items-center justify-center group-hover:hidden peer-data-[state=open]:hidden">
@@ -384,8 +408,7 @@ function ChatThreadSideDecorator({
             <TooltipTrigger asChild>
               <span
                 aria-label="Pinned"
-                data-testid="chat-thread-pinned-indicator"
-                className="flex items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden"
+                className="hidden items-center justify-center text-sidebar-foreground/70 group-hover:hidden peer-data-[state=open]:hidden md:flex"
               >
                 <IconPin size={16} stroke={2} />
               </span>


### PR DESCRIPTION
## Summary
- make the pinned chat indicator act as the mobile dropdown trigger
- keep desktop behavior unchanged: pinned indicator at rest, menu trigger on hover
- add a sidebar regression test that opens the menu from the pinned indicator

## Tests
- pnpm exec prettier --check apps/platform/src/views/zero-page/sidebar-threads.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app exec oxlint src/views/zero-page/sidebar-threads.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app exec eslint src/views/zero-page/sidebar-threads.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app check-types