### PR TITLE
fix: reserve usage webhook errors for final loss

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer.py
+++ b/crates/runner/mitm-addon/src/usage/buffer.py
@@ -1099,13 +1099,11 @@ def _log_flush_summaries(
         level = "error" if phase == "failed" else "info"
         message = f"Usage event buffer flush {phase}"
         if phase == "retained":
-            level = "warn"
             message = "Usage event buffer flush retained for retry"
         elif phase == "dropped":
             level = "error"
             message = "Usage event buffer flush dropped retained batches"
         elif phase == "enqueued" and summary.retained_webhook_batch_count:
-            level = "warn"
             message = "Usage event buffer flush retained webhook batches for retry"
         log_proxy_entry(
             summary.proxy_log_path,

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -184,7 +184,7 @@ def _do_post_webhook_attempts(
             if attempt < max_retries:
                 _log_webhook_entry(
                     proxy_log_path,
-                    "warn",
+                    "info",
                     f"Webhook POST to {url} attempt {attempt + 1} failed, retrying: {exc}",
                     url,
                     log_type,
@@ -197,7 +197,7 @@ def _do_post_webhook_attempts(
             else:
                 _log_webhook_entry(
                     proxy_log_path,
-                    "error",
+                    "info",
                     f"Webhook POST to {url} failed after {attempt + 1} attempts: {exc}",
                     url,
                     log_type,
@@ -205,13 +205,14 @@ def _do_post_webhook_attempts(
                     payload_bytes=payload_bytes,
                     attempt=attempt + 1,
                     error=str(exc),
+                    extra_fields={"delivery_outcome": _RETRYABLE_FAILURE},
                 )
                 return _RETRYABLE_FAILURE
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             if attempt < max_retries:
                 _log_webhook_entry(
                     proxy_log_path,
-                    "warn",
+                    "info",
                     f"Webhook POST to {url} attempt {attempt + 1} failed, retrying: {exc}",
                     url,
                     log_type,
@@ -224,7 +225,7 @@ def _do_post_webhook_attempts(
             else:
                 _log_webhook_entry(
                     proxy_log_path,
-                    "error",
+                    "info",
                     f"Webhook POST to {url} failed after {attempt + 1} attempts: {exc}",
                     url,
                     log_type,
@@ -232,6 +233,7 @@ def _do_post_webhook_attempts(
                     payload_bytes=payload_bytes,
                     attempt=attempt + 1,
                     error=str(exc),
+                    extra_fields={"delivery_outcome": _RETRYABLE_FAILURE},
                 )
                 return _RETRYABLE_FAILURE
         except Exception as exc:
@@ -349,12 +351,13 @@ def _enqueue_webhook(
     if admitted_count is None:
         _log_webhook_entry(
             proxy_log_path,
-            "warn",
+            "info",
             f"Webhook POST to {url} was not admitted because usage delivery is saturated",
             url,
             log_type,
             payload,
             extra_fields={
+                "reason": "delivery_saturated",
                 "webhook_delivery_capacity": MAX_PENDING_WEBHOOK_PAYLOADS,
                 "webhook_delivery_pending": _pending_delivery_payload_count(),
             },

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -74,7 +74,7 @@ def test_flush_logs_retained_webhook_batches(tmp_path):
     assert [entry["phase"] for entry in entries] == ["started", "enqueued"]
     assert entries[0]["dropped_webhook_batch_count"] == 0
     assert entries[0]["retained_webhook_batch_count"] == 0
-    assert entries[1]["level"] == "warn"
+    assert entries[1]["level"] == "info"
     assert entries[1]["message"] == "Usage event buffer flush retained webhook batches for retry"
     assert entries[1]["dropped_webhook_batch_count"] == 0
     assert entries[1]["retained_webhook_batch_count"] == 1
@@ -119,7 +119,7 @@ def test_flush_logs_delivery_retry_retained_counts(tmp_path):
     entries = flush_log_entries(proxy_log_path)
     assert [entry["phase"] for entry in entries] == ["started", "enqueued", "retained"]
     retained_entry = entries[2]
-    assert retained_entry["level"] == "warn"
+    assert retained_entry["level"] == "info"
     assert retained_entry["message"] == "Usage event buffer flush retained for retry"
     assert retained_entry["source_event_count"] == 2
     assert retained_entry["webhook_batch_count"] == 1

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -203,7 +203,7 @@ class TestUsageWebhookDelivery:
         assert usage_webhook_server.request_count == 2
         mock_sleep.assert_called_once_with(0.5)
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
-        assert [entry["level"] for entry in entries] == ["warn", "info"]
+        assert [entry["level"] for entry in entries] == ["info", "info"]
         assert [entry["attempt"] for entry in entries] == [1, 2]
         assert all(entry["url"] == usage_webhook_server.url("/x") for entry in entries)
         assert all(entry["type"] == "usage" for entry in entries)
@@ -235,6 +235,8 @@ class TestUsageWebhookDelivery:
         assert webhook.request_count == 2
         assert proxy_log.exists()
         assert "2 attempts" in proxy_log.read_text()
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert all(entry["level"] != "error" for entry in entries)
 
     def test_give_up_with_payload_collision_logs_body_free_summary(
         self, tmp_path, usage_webhook_server
@@ -255,7 +257,8 @@ class TestUsageWebhookDelivery:
 
         assert outcome == "retryable_failure"
         [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
-        assert entry["level"] == "error"
+        assert entry["level"] == "info"
+        assert entry["delivery_outcome"] == "retryable_failure"
         assert entry["attempt"] == 1
         assert "HTTP Error 500" in entry["error"]
         _assert_body_free_webhook_entry(
@@ -283,6 +286,9 @@ class TestUsageWebhookDelivery:
         assert outcome == "retryable_failure"
         assert usage_webhook_server.request_count == 2
         mock_sleep.assert_called_once_with(0.5)
+        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert [entry["level"] for entry in entries] == ["info", "info"]
+        assert entries[-1]["delivery_outcome"] == "retryable_failure"
 
     def test_http_400_is_permanent(self, tmp_path, usage_webhook_server):
         proxy_log = tmp_path / "proxy.jsonl"
@@ -458,7 +464,8 @@ class TestUsageWebhookDelivery:
 
         entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
         saturated_entry = entries[-1]
-        assert saturated_entry["level"] == "warn"
+        assert saturated_entry["level"] == "info"
+        assert saturated_entry["reason"] == "delivery_saturated"
         assert "not admitted" in saturated_entry["message"]
         assert "saturated" in saturated_entry["message"]
         assert "dropped" not in saturated_entry["message"]


### PR DESCRIPTION
## Summary
- Downgrade retryable usage webhook delivery attempts, retry exhaustion, saturation, and retained flush logs to `info`.
- Keep permanent failures, non-retryable local failures, enqueue failures, and retry-budget exhausted drops at `error`.
- Add structured retry/saturation fields for queryability without leaking payload bodies.

Closes #17459

## Tests
- `cd crates/runner/mitm-addon && /tmp/mitm-addon-venv-17459/bin/pytest tests/test_webhook.py tests/test_usage_buffer_logging.py tests/test_usage_buffer_timer_shutdown.py`
- `cd crates/runner/mitm-addon && /tmp/mitm-addon-venv-17459/bin/pytest -q`
- `cd crates/runner/mitm-addon && /tmp/mitm-addon-venv-17459/bin/ruff check .`
- `cd crates/runner/mitm-addon && /tmp/mitm-addon-venv-17459/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && VIRTUAL_ENV=/tmp/mitm-addon-venv-17459 PATH=/tmp/mitm-addon-venv-17459/bin:$PATH basedpyright -p .`
