### PR TITLE
fix: preserve chat usage display by run

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -912,7 +912,7 @@ function mergeIntoGroups(
     }
 
     const last = result[result.length - 1];
-    if (last && last.role === msg.role) {
+    if (last && shouldMergeIntoGroup(last, msg)) {
       last.messages.push(msg);
       positionById.set(msg.id, {
         groupIdx: result.length - 1,
@@ -928,6 +928,32 @@ function mergeIntoGroups(
     }
   }
   return result;
+}
+
+function firstRunIdForGroup(
+  group: GroupedChatMessageGroup,
+): string | undefined {
+  return group.messages.find((message) => {
+    return message.runId !== undefined;
+  })?.runId;
+}
+
+function shouldMergeIntoGroup(
+  group: GroupedChatMessageGroup,
+  msg: EnrichedChatMessage,
+): boolean {
+  if (group.role !== msg.role) {
+    return false;
+  }
+  if (group.role !== "assistant") {
+    return true;
+  }
+
+  const groupRunId = firstRunIdForGroup(group);
+  if (groupRunId === undefined || msg.runId === undefined) {
+    return true;
+  }
+  return groupRunId === msg.runId;
 }
 
 function groupMessagesForDisplay(
@@ -961,9 +987,7 @@ function groupMessagesForDisplay(
     if (group.role !== "assistant") {
       return group;
     }
-    const runId = group.messages.find((message) => {
-      return message.runId !== undefined;
-    })?.runId;
+    const runId = firstRunIdForGroup(group);
     const usage = runId === undefined ? undefined : usageByRunId.get(runId);
     return usage === undefined ? group : { ...group, usage };
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1715,6 +1715,189 @@ describe("chat lifecycle", () => {
     expect(screen.queryByLabelText("Credit usage 12")).not.toBeInTheDocument();
   });
 
+  it("keeps connector usage visible when completed work is folded", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-usage-chip-folded-connector",
+      chatMessages: [
+        {
+          id: "msg-usage-folded-user",
+          role: "user",
+          content: "Use the connector",
+          runId: "run-usage-folded-connector",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-usage-folded-work",
+          role: "assistant",
+          content: "Inspecting connector results.",
+          runId: "run-usage-folded-connector",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-usage-folded-final",
+          role: "assistant",
+          content: "Connector usage is ready.",
+          runId: "run-usage-folded-connector",
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+        {
+          id: "msg-usage-folded-usage",
+          role: "assistant",
+          content: null,
+          runId: "run-usage-folded-connector",
+          usage: {
+            version: 1,
+            totalCredits: 108,
+            settledAt: "2026-06-09T10:00:03Z",
+            breakdown: [
+              {
+                kind: "connector",
+                credits: 108,
+                providers: [{ provider: "x", credits: 108 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:03Z",
+        },
+        {
+          id: "msg-usage-folded-completed",
+          role: "assistant",
+          content: null,
+          runId: "run-usage-folded-connector",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:04Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-usage-chip-folded-connector",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunUsage]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText("Connector usage is ready."),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByText("Inspecting connector results."),
+    ).not.toBeInTheDocument();
+
+    const connectorCredit = await screen.findByLabelText("Credit usage 108");
+    fireEvent.pointerEnter(connectorCredit);
+
+    await waitFor(() => {
+      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getAllByText("108").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("keeps connector usage attached to consecutive assistant runs", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-usage-chip-consecutive-runs",
+      chatMessages: [
+        {
+          id: "msg-usage-consecutive-user",
+          role: "user",
+          content: "Summarize two runs",
+          runId: "run-usage-model",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-usage-consecutive-model-assistant",
+          role: "assistant",
+          content: "Model usage is ready.",
+          runId: "run-usage-model",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-usage-consecutive-model",
+          role: "assistant",
+          content: null,
+          runId: "run-usage-model",
+          usage: {
+            version: 1,
+            totalCredits: 12,
+            settledAt: "2026-06-09T10:00:02Z",
+            breakdown: [
+              {
+                kind: "model/gpt-5.5/tokens.output",
+                credits: 12,
+                providers: [{ provider: "openai", credits: 12 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+        {
+          id: "msg-usage-consecutive-model-completed",
+          role: "assistant",
+          content: null,
+          runId: "run-usage-model",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:03Z",
+        },
+        {
+          id: "msg-usage-consecutive-connector-assistant",
+          role: "assistant",
+          content: "Connector usage is ready.",
+          runId: "run-usage-connector",
+          createdAt: "2026-06-09T10:00:04Z",
+        },
+        {
+          id: "msg-usage-consecutive-connector",
+          role: "assistant",
+          content: null,
+          runId: "run-usage-connector",
+          usage: {
+            version: 1,
+            totalCredits: 108,
+            settledAt: "2026-06-09T10:00:05Z",
+            breakdown: [
+              {
+                kind: "connector",
+                credits: 108,
+                providers: [{ provider: "x", credits: 108 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:05Z",
+        },
+        {
+          id: "msg-usage-consecutive-connector-completed",
+          role: "assistant",
+          content: null,
+          runId: "run-usage-connector",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:06Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-usage-chip-consecutive-runs",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunUsage]: true,
+      },
+    });
+
+    await expect(
+      screen.findByLabelText("Credit usage 12"),
+    ).resolves.toBeInTheDocument();
+    const connectorCredit = await screen.findByLabelText("Credit usage 108");
+
+    fireEvent.pointerEnter(connectorCredit);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connector usage is ready.")).toBeInTheDocument();
+      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getAllByText("108").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
   it("stops a server-queued run and recalls queued follow-up messages", async () => {
     const interrupts: string[] = [];
     const recalls: string[] = [];

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2509,6 +2509,44 @@ function groupMessagesForCompletedWorkDisplay(
   return groups;
 }
 
+function firstRunIdForMessages(
+  messages: readonly EnrichedChatMessage[],
+): string | undefined {
+  return messages.find((message) => {
+    return message.runId !== undefined;
+  })?.runId;
+}
+
+function usageByRunIdFromGroups(
+  groups: readonly GroupedChatMessageGroup[],
+): Map<string, ChatMessageUsagePayload> {
+  const usageByRunId = new Map<string, ChatMessageUsagePayload>();
+  for (const group of groups) {
+    if (group.role !== "assistant" || group.usage === undefined) {
+      continue;
+    }
+    const runId = firstRunIdForMessages(group.messages);
+    if (runId !== undefined) {
+      usageByRunId.set(runId, group.usage);
+    }
+  }
+  return usageByRunId;
+}
+
+function attachUsageToCompletedWorkGroups(
+  groups: readonly GroupedChatMessageGroup[],
+  usageByRunId: ReadonlyMap<string, ChatMessageUsagePayload>,
+): GroupedChatMessageGroup[] {
+  return groups.map((group) => {
+    if (group.role !== "assistant") {
+      return group;
+    }
+    const runId = firstRunIdForMessages(group.messages);
+    const usage = runId === undefined ? undefined : usageByRunId.get(runId);
+    return usage === undefined ? group : { ...group, usage };
+  });
+}
+
 function isRenderableAssistantMessage(message: EnrichedChatMessage): boolean {
   return (
     message.role === "assistant" &&
@@ -2538,6 +2576,7 @@ function terminatedRunIdsForCompletedWork(
 function buildCompletedWorkFolding(
   groups: readonly GroupedChatMessageGroup[],
 ): CompletedWorkFolding | null {
+  const usageByRunId = usageByRunIdFromGroups(groups);
   const messages = groups.flatMap((group) => {
     return group.messages;
   });
@@ -2620,9 +2659,12 @@ function buildCompletedWorkFolding(
     }),
   );
   return {
-    visibleGroups: groupMessagesForCompletedWorkDisplay(
-      visibleMessages,
-      foldFinalMessageIds,
+    visibleGroups: attachUsageToCompletedWorkGroups(
+      groupMessagesForCompletedWorkDisplay(
+        visibleMessages,
+        foldFinalMessageIds,
+      ),
+      usageByRunId,
     ),
     foldsByFinalMessageId: new Map(
       folds.map((fold) => {


### PR DESCRIPTION
## Summary
- keep run usage attached after completed work folding rebuilds visible chat groups
- split consecutive assistant groups by runId so usage chips do not attach to the wrong run
- add chat lifecycle regressions for folded connector usage and consecutive assistant runs

## Tests
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --testNamePattern "keeps connector usage"
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec prettier --check src/signals/chat-page/create-chat-thread.ts src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- git diff --check