### PR TITLE
refactor(guest-agent): share system log test guard

### DIFF
--- a/crates/guest-agent/tests/claude_result_failure_logging.rs
+++ b/crates/guest-agent/tests/claude_result_failure_logging.rs
@@ -6,25 +6,10 @@
 mod common;
 
 use agent_diagnostics::FailureDetailSource;
+use common::SystemLogOverrideGuard;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::Path;
 use std::time::Duration;
-
-struct SystemLogOverrideGuard;
-
-impl SystemLogOverrideGuard {
-    fn set(path: &Path) -> Self {
-        guest_common::log::set_system_log_file(path);
-        Self
-    }
-}
-
-impl Drop for SystemLogOverrideGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
-    }
-}
 
 #[tokio::test]
 async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/guest-agent/tests/cli_failure_diagnostic_session_id_masking.rs
+++ b/crates/guest-agent/tests/cli_failure_diagnostic_session_id_masking.rs
@@ -5,25 +5,11 @@
 
 mod common;
 
+use common::SystemLogOverrideGuard;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::json;
 use std::time::Duration;
-
-struct SystemLogGuard;
-
-impl SystemLogGuard {
-    fn set(path: &std::path::Path) -> Self {
-        guest_common::log::set_system_log_file(path);
-        Self
-    }
-}
-
-impl Drop for SystemLogGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
-    }
-}
 
 #[tokio::test]
 async fn cli_failure_diagnostic_masks_session_id_from_same_event()
@@ -51,7 +37,7 @@ async fn cli_failure_diagnostic_masks_session_id_from_same_event()
     }
 
     let system_log_path = tmp.path().join("system.log");
-    let _system_log_guard = SystemLogGuard::set(&system_log_path);
+    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -6,25 +6,11 @@
 mod common;
 
 use agent_diagnostics::{FailureDetailSource, FailureReason};
+use common::SystemLogOverrideGuard;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-
-struct SystemLogOverrideGuard;
-
-impl SystemLogOverrideGuard {
-    fn set(path: &Path) -> Self {
-        guest_common::log::set_system_log_file(path);
-        Self
-    }
-}
-
-impl Drop for SystemLogOverrideGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
-    }
-}
 
 #[tokio::test]
 async fn codex_jsonl_failure_events_are_reported() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -26,6 +26,9 @@
 //! - Negative path: a codex marker pointing at an empty sessions dir
 //!   surfaces the "file not found" error rather than a silent fallback.
 
+mod common;
+
+use common::SystemLogOverrideGuard;
 use serde_json::json;
 use std::path::Path;
 use std::sync::{LazyLock, Mutex, Once};
@@ -86,21 +89,6 @@ fn send_event_for_test(
 fn reset_session_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
-}
-
-struct SystemLogOverrideGuard;
-
-impl SystemLogOverrideGuard {
-    fn set(path: &Path) -> Self {
-        guest_common::log::set_system_log_file(path);
-        Self
-    }
-}
-
-impl Drop for SystemLogOverrideGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
-    }
 }
 
 /// Build a `YYYY/MM/DD/` style nested path under `root` and write a file.

--- a/crates/guest-agent/tests/codex_setup_stderr_masking.rs
+++ b/crates/guest-agent/tests/codex_setup_stderr_masking.rs
@@ -3,29 +3,17 @@
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.
 
+mod common;
+
 use api_contracts::generated::constants::model_provider_env::placeholders::OPENAI_API_KEY as OPENAI_API_KEY_PLACEHOLDER;
 use base64::Engine as _;
+use common::SystemLogOverrideGuard;
 use guest_agent::masker::SecretMasker;
 use std::path::Path;
 use std::time::Duration;
 
 const OTHER_SECRET: &str = "codex-setup-env-secret";
 const STDERR_OMITTED_LONG_LINE: &str = "[stderr line omitted: exceeded diagnostic size limit]";
-
-struct SystemLogOverrideGuard;
-
-impl SystemLogOverrideGuard {
-    fn set(path: &Path) -> Self {
-        guest_common::log::set_system_log_file(path);
-        Self
-    }
-}
-
-impl Drop for SystemLogOverrideGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
-    }
-}
 
 #[tokio::test]
 async fn codex_setup_stderr_masking_masks_failure() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -19,11 +19,15 @@
 
 #![allow(dead_code)] // consumed across multiple test binaries
 
+mod system_log;
+
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+
+pub type SystemLogOverrideGuard = system_log::SystemLogOverrideGuard;
 
 /// 128 + SIGTERM(15). Rust / glibc's default signal handler maps a
 /// SIGTERM-terminated process to this exit code.

--- a/crates/guest-agent/tests/common/system_log.rs
+++ b/crates/guest-agent/tests/common/system_log.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+#[must_use]
+pub struct SystemLogOverrideGuard;
+
+impl SystemLogOverrideGuard {
+    pub fn set(path: impl AsRef<Path>) -> Self {
+        guest_common::log::set_system_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SystemLogOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::log::clear_system_log_file();
+    }
+}

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -85,7 +85,6 @@ async fn send_event_captures_session_metadata_before_masking() {
     let _session_files = SessionCheckpointFilesGuard::new();
     let tmp = tempfile::tempdir().unwrap();
     let system_log_path = tmp.path().join("system.log");
-    let system_log_path = system_log_path.to_string_lossy().into_owned();
     let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
     let sid_file = guest_agent::paths::session_id_file();

--- a/crates/guest-agent/tests/integration/mod.rs
+++ b/crates/guest-agent/tests/integration/mod.rs
@@ -3,6 +3,9 @@
 // serialises correctly (each runtime owns its own OS thread).
 #![allow(clippy::await_holding_lock)]
 
+#[path = "../common/mod.rs"]
+mod common;
+
 #[macro_use]
 mod support;
 

--- a/crates/guest-agent/tests/integration/presigned_upload.rs
+++ b/crates/guest-agent/tests/integration/presigned_upload.rs
@@ -160,7 +160,6 @@ async fn put_presigned_transport_error_does_not_log_presigned_url() {
 
     let tmp = tempfile::tempdir().unwrap();
     let system_log_path = tmp.path().join("system.log");
-    let system_log_path = system_log_path.to_string_lossy().into_owned();
     let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
     let signature = "super-secret-signature";

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -7,6 +7,8 @@ use std::sync::{
 use std::time::Duration;
 use tokio::sync::Notify;
 
+pub(crate) use crate::common::SystemLogOverrideGuard;
+
 /// Shared mock server - env vars are set once before any `LazyLock` in the
 /// library is accessed, so environment-backed guest-agent state resolves to
 /// test values.
@@ -155,21 +157,6 @@ impl MockCallObserver {
             "timed out waiting for {context}: expected at least {expected} mock calls, observed {} after {timeout:?}",
             self.calls(),
         );
-    }
-}
-
-pub(crate) struct SystemLogOverrideGuard;
-
-impl SystemLogOverrideGuard {
-    pub(crate) fn set(path: &str) -> Self {
-        guest_common::log::set_system_log_file(path);
-        Self
-    }
-}
-
-impl Drop for SystemLogOverrideGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
     }
 }
 

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use common::SystemLogOverrideGuard;
 use guest_agent::error::AgentError;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
@@ -12,21 +13,6 @@ use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
-
-struct SystemLogOverrideGuard;
-
-impl SystemLogOverrideGuard {
-    fn set(path: &std::path::Path) -> Self {
-        guest_common::log::set_system_log_file(path.to_string_lossy().as_ref());
-        Self
-    }
-}
-
-impl Drop for SystemLogOverrideGuard {
-    fn drop(&mut self) {
-        guest_common::log::clear_system_log_file();
-    }
-}
 
 fn cleanup_session_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());


### PR DESCRIPTION
## Summary

- add a shared guest-agent test `SystemLogOverrideGuard`
- reuse it from standalone and integration guest-agent tests
- remove obsolete string conversion for system log path overrides

Closes #17559

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration --test codex_jsonl_failure_logging --test claude_result_failure_logging --test codex_setup_stderr_masking --test codex_session_resume --test no_api_mode --test cli_failure_diagnostic_session_id_masking`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
