### PR TITLE
feat: show thread credit usage

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1429,6 +1429,21 @@ function aggregateThreadUsage(
   };
 }
 
+function createThreadUsageComputed({
+  allMessages$,
+  hasOlderHistory$,
+}: {
+  allMessages$: Computed<Promise<EnrichedChatMessage[]>>;
+  hasOlderHistory$: Computed<Promise<boolean>>;
+}): Computed<Promise<ChatMessageUsagePayload | undefined>> {
+  return computed(async (get): Promise<ChatMessageUsagePayload | undefined> => {
+    if (await get(hasOlderHistory$)) {
+      return undefined;
+    }
+    return aggregateThreadUsage(await get(allMessages$));
+  });
+}
+
 function createPagedMessages(
   threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
@@ -1472,12 +1487,6 @@ function createPagedMessages(
     },
   );
 
-  const threadUsage$ = computed(
-    async (get): Promise<ChatMessageUsagePayload | undefined> => {
-      return aggregateThreadUsage(await get(allMessages$));
-    },
-  );
-
   const earliestChatMessageId$ = computed(
     async (get): Promise<string | undefined> => {
       const messages = await get(allMessages$);
@@ -1516,6 +1525,11 @@ function createPagedMessages(
     }
     const initial = await get(initialPage$);
     return initial.hasHistoryBefore;
+  });
+
+  const threadUsage$ = createThreadUsageComputed({
+    allMessages$,
+    hasOlderHistory$,
   });
 
   const backfillHistoryBoundary$ = createBackfillHistoryBoundaryCommand({

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -39,6 +39,7 @@ import {
   type AttachFile,
   type GenerationTemplateRequest,
   type ChatThreadArtifactRun,
+  type ChatMessageUsagePayload,
   type ModelSelectionRequest,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -524,6 +525,7 @@ export interface ChatThreadSignals {
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
+  threadUsage$: Computed<Promise<ChatMessageUsagePayload | undefined>>;
   hasOlderHistory$: Computed<Promise<boolean>>;
   latestRunStatus$: Computed<Promise<string | null>>;
   allFinished$: Computed<Promise<boolean>>;
@@ -1320,6 +1322,113 @@ function createFetchNextPageCommand({
   });
 }
 
+function usageSettlementSortValue(
+  usage: ChatMessageUsagePayload,
+  createdAt: string,
+): number {
+  const timestamp = Date.parse(usage.settledAt ?? createdAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function aggregateThreadUsage(
+  messages: readonly PagedChatMessage[],
+): ChatMessageUsagePayload | undefined {
+  const latestByRunId = new Map<
+    string,
+    {
+      readonly usage: ChatMessageUsagePayload;
+      readonly sortValue: number;
+      readonly index: number;
+    }
+  >();
+
+  for (const [index, message] of messages.entries()) {
+    if (!isUsageMessage(message) || message.runId === undefined) {
+      continue;
+    }
+    const sortValue = usageSettlementSortValue(
+      message.usage,
+      message.createdAt,
+    );
+    const existing = latestByRunId.get(message.runId);
+    if (
+      existing === undefined ||
+      sortValue > existing.sortValue ||
+      (sortValue === existing.sortValue && index > existing.index)
+    ) {
+      latestByRunId.set(message.runId, {
+        usage: message.usage,
+        sortValue,
+        index,
+      });
+    }
+  }
+
+  if (latestByRunId.size === 0) {
+    return undefined;
+  }
+
+  let totalCredits = 0;
+  let latestSettledAt = "";
+  let latestSettledAtSortValue = Number.NEGATIVE_INFINITY;
+  const breakdownByKind = new Map<
+    string,
+    {
+      kind: string;
+      credits: number;
+      providers: Map<string, number>;
+    }
+  >();
+
+  for (const { usage } of latestByRunId.values()) {
+    totalCredits += usage.totalCredits;
+    const settledAtSortValue = usageSettlementSortValue(usage, usage.settledAt);
+    if (
+      latestSettledAt === "" ||
+      settledAtSortValue > latestSettledAtSortValue
+    ) {
+      latestSettledAt = usage.settledAt;
+      latestSettledAtSortValue = settledAtSortValue;
+    }
+    for (const kindBreakdown of usage.breakdown) {
+      let aggregate = breakdownByKind.get(kindBreakdown.kind);
+      if (aggregate === undefined) {
+        aggregate = {
+          kind: kindBreakdown.kind,
+          credits: 0,
+          providers: new Map<string, number>(),
+        };
+        breakdownByKind.set(kindBreakdown.kind, aggregate);
+      }
+      aggregate.credits += kindBreakdown.credits;
+      for (const providerBreakdown of kindBreakdown.providers) {
+        aggregate.providers.set(
+          providerBreakdown.provider,
+          (aggregate.providers.get(providerBreakdown.provider) ?? 0) +
+            providerBreakdown.credits,
+        );
+      }
+    }
+  }
+
+  return {
+    version: 1,
+    totalCredits,
+    settledAt: latestSettledAt,
+    breakdown: Array.from(breakdownByKind.values()).map((aggregate) => {
+      return {
+        kind: aggregate.kind,
+        credits: aggregate.credits,
+        providers: Array.from(aggregate.providers.entries()).map(
+          ([provider, credits]) => {
+            return { provider, credits };
+          },
+        ),
+      };
+    }),
+  };
+}
+
 function createPagedMessages(
   threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
@@ -1360,6 +1469,12 @@ function createPagedMessages(
   const groupedChatMessages$ = computed(
     async (get): Promise<GroupedChatMessageGroup[]> => {
       return groupMessagesForDisplay(await get(allMessages$));
+    },
+  );
+
+  const threadUsage$ = computed(
+    async (get): Promise<ChatMessageUsagePayload | undefined> => {
+      return aggregateThreadUsage(await get(allMessages$));
     },
   );
 
@@ -1449,6 +1564,7 @@ function createPagedMessages(
     latestAssistantTextCreatedAt$,
     allMessages$,
     groupedChatMessages$,
+    threadUsage$,
     rawMessages$,
     knownServerMessageIds$,
     hasOlderHistory$,
@@ -2441,6 +2557,7 @@ export function createChatThreadSignals(
     latestAssistantTextCreatedAt$,
     allMessages$,
     groupedChatMessages$,
+    threadUsage$,
     rawMessages$,
     knownServerMessageIds$,
     hasOlderHistory$,
@@ -2528,6 +2645,7 @@ export function createChatThreadSignals(
     latestChatMessageId$,
     latestAssistantTextCreatedAt$,
     groupedChatMessages$,
+    threadUsage$,
     hasOlderHistory$,
     latestRunStatus$,
     allFinished$: runTracking.allFinished$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1543,6 +1543,9 @@ describe("chat lifecycle", () => {
       expect(
         screen.queryByLabelText("Credit usage 123"),
       ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Thread credit usage 123"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -1713,6 +1716,135 @@ describe("chat lifecycle", () => {
       screen.findByLabelText("Credit usage 108"),
     ).resolves.toBeInTheDocument();
     expect(screen.queryByLabelText("Credit usage 12")).not.toBeInTheDocument();
+  });
+
+  it("shows aggregate thread credit usage from latest run settlements", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-aggregate-usage-chip",
+      chatMessages: [
+        {
+          id: "msg-thread-usage-user-a",
+          role: "user",
+          content: "Start usage run A",
+          runId: "run-thread-usage-a",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-thread-usage-assistant-a",
+          role: "assistant",
+          content: "Run A is ready.",
+          runId: "run-thread-usage-a",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-thread-usage-stale-a",
+          role: "assistant",
+          content: null,
+          runId: "run-thread-usage-a",
+          usage: {
+            version: 1,
+            totalCredits: 40,
+            settledAt: "2026-06-09T10:00:02Z",
+            breakdown: [
+              {
+                kind: "model/kimi-k2.5/tokens.input",
+                credits: 40,
+                providers: [{ provider: "moonshot", credits: 40 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+        {
+          id: "msg-thread-usage-latest-a",
+          role: "assistant",
+          content: null,
+          runId: "run-thread-usage-a",
+          usage: {
+            version: 1,
+            totalCredits: 55,
+            settledAt: "2026-06-09T10:00:04Z",
+            breakdown: [
+              {
+                kind: "model/kimi-k2.5/tokens.input",
+                credits: 45,
+                providers: [{ provider: "moonshot", credits: 45 }],
+              },
+              {
+                kind: "connector",
+                credits: 10,
+                providers: [{ provider: "x", credits: 10 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:04Z",
+        },
+        {
+          id: "msg-thread-usage-user-b",
+          role: "user",
+          content: "Start usage run B",
+          runId: "run-thread-usage-b",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+        {
+          id: "msg-thread-usage-assistant-b",
+          role: "assistant",
+          content: "Run B is ready.",
+          runId: "run-thread-usage-b",
+          createdAt: "2026-06-09T10:01:01Z",
+        },
+        {
+          id: "msg-thread-usage-latest-b",
+          role: "assistant",
+          content: null,
+          runId: "run-thread-usage-b",
+          usage: {
+            version: 1,
+            totalCredits: 70,
+            settledAt: "2026-06-09T10:01:02Z",
+            breakdown: [
+              {
+                kind: "image",
+                credits: 70,
+                providers: [{ provider: "gpt-image-2", credits: 70 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:01:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-aggregate-usage-chip",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunUsage]: true,
+      },
+    });
+
+    const threadCredit = await screen.findByLabelText(
+      "Thread credit usage 125",
+    );
+    const artifacts = screen.getByLabelText("Open artifacts");
+    expect(
+      threadCredit.compareDocumentPosition(artifacts) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.pointerEnter(threadCredit);
+
+    await waitFor(() => {
+      expect(screen.getByText("Thread credit usage")).toBeInTheDocument();
+      expect(screen.getAllByText("125").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Kimi K2.5")).toBeInTheDocument();
+      expect(screen.getAllByText("45").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getAllByText("10").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
+      expect(screen.getAllByText("70").length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText("40")).not.toBeInTheDocument();
+    });
   });
 
   it("keeps connector usage visible when completed work is folded", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1847,6 +1847,122 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("hides aggregate thread credit usage until older history is loaded", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-aggregate-usage-paginated-history",
+      historyMessages: [
+        {
+          id: "msg-thread-usage-history-user",
+          role: "user",
+          content: "Start older usage run",
+          runId: "run-thread-usage-history",
+          createdAt: "2026-06-08T10:00:00Z",
+        },
+        {
+          id: "msg-thread-usage-history-assistant",
+          role: "assistant",
+          content: "Earlier run is ready.",
+          runId: "run-thread-usage-history",
+          createdAt: "2026-06-08T10:00:01Z",
+        },
+        {
+          id: "msg-thread-usage-history-latest",
+          role: "assistant",
+          content: null,
+          runId: "run-thread-usage-history",
+          usage: {
+            version: 1,
+            totalCredits: 75,
+            settledAt: "2026-06-08T10:00:02Z",
+            breakdown: [
+              {
+                kind: "model/kimi-k2.5/tokens.input",
+                credits: 75,
+                providers: [{ provider: "moonshot", credits: 75 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-08T10:00:02Z",
+        },
+      ],
+      chatMessages: [
+        {
+          id: "msg-thread-usage-current-user",
+          role: "user",
+          content: "Start current usage run",
+          runId: "run-thread-usage-current",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-thread-usage-current-assistant",
+          role: "assistant",
+          content: "Current run is ready.",
+          runId: "run-thread-usage-current",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-thread-usage-current-latest",
+          role: "assistant",
+          content: null,
+          runId: "run-thread-usage-current",
+          usage: {
+            version: 1,
+            totalCredits: 50,
+            settledAt: "2026-06-09T10:00:02Z",
+            breakdown: [
+              {
+                kind: "image",
+                credits: 50,
+                providers: [{ provider: "gpt-image-2", credits: 50 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-aggregate-usage-paginated-history",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunUsage]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Current run is ready.")).toBeInTheDocument();
+      expect(buttonByText("Load history")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByLabelText("Thread credit usage 50"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Thread credit usage 125"),
+    ).not.toBeInTheDocument();
+
+    click(buttonByText("Load history"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Earlier run is ready.")).toBeInTheDocument();
+      expect(queryButtonByText("Load history")).not.toBeInTheDocument();
+    });
+
+    const threadCredit = await screen.findByLabelText(
+      "Thread credit usage 125",
+    );
+    fireEvent.pointerEnter(threadCredit);
+
+    await waitFor(() => {
+      expect(screen.getByText("Thread credit usage")).toBeInTheDocument();
+      expect(screen.getAllByText("125").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Kimi K2.5")).toBeInTheDocument();
+      expect(screen.getAllByText("75").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
+      expect(screen.getAllByText("50").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
   it("keeps connector usage visible when completed work is folded", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-usage-chip-folded-connector",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1079,6 +1079,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const features = useLastResolved(featureSwitch$);
   const githubPrTrackingEnabled =
     features?.[FeatureSwitchKey.ChatGithubPrTracking] ?? false;
+  const usageEnabled = features?.[FeatureSwitchKey.ChatRunUsage] ?? false;
   const agentId =
     threadDataLoadable.state === "hasData"
       ? (threadDataLoadable.data?.agentId ?? null)
@@ -1100,6 +1101,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         )}
       </div>
       <div className="hidden sm:flex items-center gap-0.5">
+        {usageEnabled && <ThreadUsageChip thread={thread} />}
         <AutomationMenuButton threadId={thread.threadId} />
         <ArtifactsButton thread={thread} />
         {githubPrTrackingEnabled && agentId && (
@@ -5733,19 +5735,19 @@ function buildRunUsageDisplayRows(
   return Array.from(rows.values());
 }
 
-function RunUsageChip({
-  runId,
+function UsageChip({
   usage,
+  title,
+  ariaLabel,
+  open,
+  setOpen,
 }: {
-  runId: string;
   usage: ChatMessageUsagePayload;
+  title: string;
+  ariaLabel: string;
+  open: boolean;
+  setOpen: (open: boolean) => void;
 }) {
-  const openRunId = useGet(runUsagePopoverOpenRunId$);
-  const setOpenRunId = useSet(setRunUsagePopoverOpenRunId$);
-  const open = openRunId === runId;
-  const setOpen = (nextOpen: boolean) => {
-    setOpenRunId(nextOpen ? runId : null);
-  };
   const total = formatCredits(usage.totalCredits);
   const displayRows = buildRunUsageDisplayRows(usage);
 
@@ -5755,7 +5757,7 @@ function RunUsageChip({
         <button
           type="button"
           className="inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground/70 hover:bg-accent hover:text-foreground transition-colors duration-150"
-          aria-label={`Credit usage ${total}`}
+          aria-label={`${ariaLabel} ${total}`}
           aria-expanded={open}
           aria-haspopup="dialog"
           onClick={() => {
@@ -5802,7 +5804,7 @@ function RunUsageChip({
         }}
       >
         <div className="flex items-center justify-between gap-3 text-sm font-medium">
-          <span>Credit usage</span>
+          <span>{title}</span>
           <span>{total}</span>
         </div>
         <div className="mt-3 flex flex-col gap-1.5">
@@ -5824,6 +5826,55 @@ function RunUsageChip({
         </div>
       </PopoverContent>
     </Popover>
+  );
+}
+
+const THREAD_USAGE_POPOVER_ID = "__thread_credit_usage__";
+
+function ThreadUsageChip({ thread }: { thread: ChatThreadSignals }) {
+  const usageLoadable = useLastLoadable(thread.threadUsage$);
+  const openRunId = useGet(runUsagePopoverOpenRunId$);
+  const setOpenRunId = useSet(setRunUsagePopoverOpenRunId$);
+  const usage =
+    usageLoadable.state === "hasData" ? usageLoadable.data : undefined;
+
+  if (usage === undefined) {
+    return null;
+  }
+
+  return (
+    <UsageChip
+      usage={usage}
+      title="Thread credit usage"
+      ariaLabel="Thread credit usage"
+      open={openRunId === THREAD_USAGE_POPOVER_ID}
+      setOpen={(open) => {
+        setOpenRunId(open ? THREAD_USAGE_POPOVER_ID : null);
+      }}
+    />
+  );
+}
+
+function RunUsageChip({
+  runId,
+  usage,
+}: {
+  runId: string;
+  usage: ChatMessageUsagePayload;
+}) {
+  const openRunId = useGet(runUsagePopoverOpenRunId$);
+  const setOpenRunId = useSet(setRunUsagePopoverOpenRunId$);
+
+  return (
+    <UsageChip
+      usage={usage}
+      title="Credit usage"
+      ariaLabel="Credit usage"
+      open={openRunId === runId}
+      setOpen={(open) => {
+        setOpenRunId(open ? runId : null);
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- Aggregate chat thread credit usage from the latest settlement for each run.
- Show a thread-level credit usage chip in the chat header before the artifacts/action icons.
- Add lifecycle coverage for a multi-run settlement sequence and the disabled feature-switch path.

## Verification
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "usage"
- pnpm -F @vm0/app check-types
- git diff --check

## Staging note
- Stripe test card 4242 passed checkout, but staging still returned tier=pro-suspend, credits=0, onboardingPaymentPending=true, so @ECHO chat verification remains blocked by onboarding/billing state.
