### PR TITLE
fix: show thread credit usage on mobile

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1823,16 +1823,30 @@ describe("chat lifecycle", () => {
       },
     });
 
-    const threadCredit = await screen.findByLabelText(
+    const threadCredits = await screen.findAllByLabelText(
       "Thread credit usage 125",
     );
+    expect(threadCredits.length).toBeGreaterThanOrEqual(2);
+
     const artifacts = screen.getByLabelText("Open artifacts");
+    const desktopThreadCredit = within(
+      artifacts.parentElement as HTMLElement,
+    ).getByLabelText("Thread credit usage 125");
     expect(
-      threadCredit.compareDocumentPosition(artifacts) &
+      desktopThreadCredit.compareDocumentPosition(artifacts) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
-    fireEvent.pointerEnter(threadCredit);
+    const mobileArtifacts = screen.getByLabelText("Open mobile artifacts");
+    const mobileThreadCredit = within(
+      mobileArtifacts.parentElement as HTMLElement,
+    ).getByLabelText("Thread credit usage 125");
+    expect(
+      mobileThreadCredit.compareDocumentPosition(mobileArtifacts) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.pointerEnter(desktopThreadCredit);
 
     await waitFor(() => {
       expect(screen.getByText("Thread credit usage")).toBeInTheDocument();
@@ -1948,9 +1962,14 @@ describe("chat lifecycle", () => {
       expect(queryButtonByText("Load history")).not.toBeInTheDocument();
     });
 
-    const threadCredit = await screen.findByLabelText(
+    const threadCredits = await screen.findAllByLabelText(
       "Thread credit usage 125",
     );
+    expect(threadCredits.length).toBeGreaterThanOrEqual(2);
+    const artifacts = screen.getByLabelText("Open artifacts");
+    const threadCredit = within(
+      artifacts.parentElement as HTMLElement,
+    ).getByLabelText("Thread credit usage 125");
     fireEvent.pointerEnter(threadCredit);
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -6,10 +6,14 @@ import {
   useLastResolved,
 } from "ccstate-react";
 import { IconMenu2, IconPackage, IconUserPlus } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import { cn } from "@vm0/ui";
 import { ZeroSidebar } from "./zero-sidebar.tsx";
-import { AutomationMenuButton } from "./zero-chat-thread-page.tsx";
+import {
+  AutomationMenuButton,
+  ThreadUsageChip,
+} from "./zero-chat-thread-page.tsx";
 import { currentChatAgent$ } from "../../signals/agent-chat.ts";
 import {
   currentLeftThread$,
@@ -51,6 +55,9 @@ import {
   currentArtifactInboxThreadId$,
   openArtifactInbox$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+
+const MOBILE_THREAD_USAGE_POPOVER_ID = "__mobile_thread_credit_usage__";
 
 function AgentAvatarInTopBar() {
   const agent = useLastResolved(currentChatAgent$);
@@ -151,11 +158,32 @@ function MobileAutomationButtonLeaf() {
   );
 }
 
+function MobileThreadUsageChipLeaf() {
+  const features = useLastResolved(featureSwitch$);
+  const usageEnabled = features?.[FeatureSwitchKey.ChatRunUsage] ?? false;
+  const leftThread = useGet(currentLeftThread$);
+  const rightThread = useGet(currentRightThread$);
+  const thread = leftThread ?? rightThread;
+
+  if (!usageEnabled || !thread) {
+    return null;
+  }
+
+  return (
+    <ThreadUsageChip
+      thread={thread}
+      contentAlign="end"
+      popoverId={MOBILE_THREAD_USAGE_POPOVER_ID}
+    />
+  );
+}
+
 function MobileTopBarActions({ activeId }: { activeId: RouteKey | null }) {
   const inChatRoute = isChatRoute(activeId);
   const showInviteFallback = inChatRoute && activeId !== "chat";
   return (
     <>
+      {inChatRoute && <MobileThreadUsageChipLeaf />}
       {inChatRoute && <MobileAutomationButtonLeaf />}
       {inChatRoute && <MobileArtifactsButtonLeaf />}
       {showInviteFallback && <InviteButtonLeaf />}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5739,12 +5739,14 @@ function UsageChip({
   usage,
   title,
   ariaLabel,
+  contentAlign = "start",
   open,
   setOpen,
 }: {
   usage: ChatMessageUsagePayload;
   title: string;
   ariaLabel: string;
+  contentAlign?: "start" | "center" | "end";
   open: boolean;
   setOpen: (open: boolean) => void;
 }) {
@@ -5788,7 +5790,7 @@ function UsageChip({
       </PopoverAnchor>
       <PopoverContent
         side="bottom"
-        align="start"
+        align={contentAlign}
         className="w-72 p-3"
         onPointerEnter={() => {
           setOpen(true);
@@ -5831,7 +5833,15 @@ function UsageChip({
 
 const THREAD_USAGE_POPOVER_ID = "__thread_credit_usage__";
 
-function ThreadUsageChip({ thread }: { thread: ChatThreadSignals }) {
+export function ThreadUsageChip({
+  thread,
+  contentAlign,
+  popoverId = THREAD_USAGE_POPOVER_ID,
+}: {
+  thread: ChatThreadSignals;
+  contentAlign?: "start" | "center" | "end";
+  popoverId?: string;
+}) {
   const usageLoadable = useLastLoadable(thread.threadUsage$);
   const openRunId = useGet(runUsagePopoverOpenRunId$);
   const setOpenRunId = useSet(setRunUsagePopoverOpenRunId$);
@@ -5847,9 +5857,10 @@ function ThreadUsageChip({ thread }: { thread: ChatThreadSignals }) {
       usage={usage}
       title="Thread credit usage"
       ariaLabel="Thread credit usage"
-      open={openRunId === THREAD_USAGE_POPOVER_ID}
+      contentAlign={contentAlign}
+      open={openRunId === popoverId}
       setOpen={(open) => {
-        setOpenRunId(open ? THREAD_USAGE_POPOVER_ID : null);
+        setOpenRunId(open ? popoverId : null);
       }}
     />
   );


### PR DESCRIPTION
## Summary
- Add the thread credit usage chip to the mobile top bar action cluster before automation/artifacts.
- Keep it gated by FeatureSwitchKey.ChatRunUsage on mobile as well as desktop.
- Give mobile its own popover id and end-aligned content so the breakdown does not conflict with the desktop instance or overflow off the right edge.

## Verification
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "usage"
- pnpm -F @vm0/app check-types
- git diff --check
