### PR TITLE
feat: gate API keys settings for staff

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -1,7 +1,9 @@
 import { command, computed, state } from "ccstate";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
+import { featureSwitch$ } from "../../external/feature-switch.ts";
 import {
   initProfileName$,
   setActiveOrgManageTab$,
@@ -177,6 +179,8 @@ export const checkUnifiedSettingsParam$ = command(
     const opensBuyCredits = section === "billing" && billingView === "credits";
     const isAdmin = await get(isOrgAdmin$);
     signal.throwIfAborted();
+    const features = get(featureSwitch$);
+    const apiKeysEnabled = Boolean(features[FeatureSwitchKey.ApiKeys]);
 
     const orgManageTab = orgManageTabForSettingsSection(section);
     if (orgManageTab && isAdmin) {
@@ -198,6 +202,7 @@ export const checkUnifiedSettingsParam$ = command(
 
     const resolved: SettingsSection =
       !isSettingsSection(section) ||
+      (section === "api-keys" && !apiKeysEnabled) ||
       (!isAdmin && isAdminOnlySettingsSection(section))
         ? "preference"
         : section;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-api-keys-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-api-keys-page.test.tsx
@@ -108,8 +108,10 @@ describe("zero API keys page", () => {
       ).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("button", { name: "API Keys" }),
-    ).not.toBeInTheDocument();
+      queryAllByRoleFast("button").find((button) => {
+        return button.textContent?.replace(/\s+/g, " ").trim() === "API Keys";
+      }),
+    ).toBeUndefined();
     expect(
       screen.queryByText("Create and manage API keys for programmatic access."),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-api-keys-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-api-keys-page.test.tsx
@@ -93,6 +93,28 @@ function mockApiKeyStory(): void {
 }
 
 describe("zero API keys page", () => {
+  it("hides the settings dialog entry when the API keys feature is disabled", async () => {
+    detachedSetupPage({
+      context,
+      path: "/?settings=api-keys",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Settings" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Preference" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "API Keys" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Create and manage API keys for programmatic access."),
+    ).not.toBeInTheDocument();
+  });
+
   it("creates, copies, and revokes an API key from the settings page", async () => {
     context.mocks.browser.clipboardWriteText();
     mockApiKeyStory();

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -24,8 +24,10 @@ import {
   IconKey,
   IconUsers,
 } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import {
   isAdminOnlySettingsSection,
   settingsActiveSection$,
@@ -210,12 +212,20 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);
   const externalProfileModalOpen = useGet(externalProfileModalOpen$);
+  const features = useGet(featureSwitch$);
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const apiKeysEnabled = Boolean(features[FeatureSwitchKey.ApiKeys]);
+  const personalGroup: SidebarGroup = {
+    ...PERSONAL_GROUP,
+    items: PERSONAL_GROUP.items.filter((item) => {
+      return item.id !== "api-keys" || apiKeysEnabled;
+    }),
+  };
 
   const sidebarGroups: readonly SidebarGroup[] = [
-    PERSONAL_GROUP,
+    personalGroup,
     ...(isAdmin ? [WORKSPACE_GROUP] : []),
     MODELS_GROUP,
     billingGroup(isAdmin),
@@ -223,7 +233,8 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
   // If the user lost admin while the dialog is open, fall back to a safe section
   const resolvedSection: SettingsSection =
-    !isAdmin && isAdminOnlySettingsSection(activeSection)
+    (!apiKeysEnabled && activeSection === "api-keys") ||
+    (!isAdmin && isAdminOnlySettingsSection(activeSection))
       ? "preference"
       : activeSection;
   const meta =

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -40,6 +40,11 @@ describe("isFeatureEnabled", () => {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ApiKeys, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
   });
 
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
@@ -50,6 +55,11 @@ describe("isFeatureEnabled", () => {
     ).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.SkillsViewer, {
+        orgId: "org_nonexistent",
+      }),
+    ).toBe(false);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ApiKeys, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
@@ -101,6 +111,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
@@ -112,6 +123,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -254,6 +254,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Gate the custom /settings/api-keys UI for issuing personal access tokens used by the /api/v1 public surface. When disabled, the settings page redirects to / and the sidebar menu item is hidden. The backend /api/v1 verification does NOT consult this flag — previously issued PATs continue to work.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary\n- enable the API keys feature switch for staff orgs\n- hide the settings dialog API Keys entry when the feature is disabled\n- fall back from ?settings=api-keys to Preference when disabled\n\n## Tests\n- pnpm exec vitest run src/views/zero-page/__tests__/zero-api-keys-page.test.tsx\n- pnpm -F @vm0/core test -- feature-switch.test.ts\n- pnpm -F @vm0/app check-types\n- pnpm -F @vm0/core check-types\n- pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx apps/platform/src/signals/zero-page/settings/settings-dialog.ts apps/platform/src/views/zero-page/__tests__/zero-api-keys-page.test.tsx