### PR TITLE
fix(mitm-addon): cap auth base bodies before buffering

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -258,8 +258,7 @@ def _set_matched_firewall_failure_response(
     # an auth or forwarding error when the firewall granted the request but
     # the addon could not fulfill it. See #10493.
     firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = action
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = error_code
+    _mark_matched_firewall_failure(flow, action=action, error_code=error_code)
     body: dict[str, object] = {
         "error": error_code,
         "message": message,
@@ -275,6 +274,16 @@ def _set_matched_firewall_failure_response(
         json.dumps(body).encode(),
         {"Content-Type": "application/json"},
     )
+
+
+def _mark_matched_firewall_failure(
+    flow: http.HTTPFlow,
+    *,
+    action: str,
+    error_code: str,
+) -> None:
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = action
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = error_code
 
 
 def request_force_refresh(cache_key: tuple[str, str]) -> None:
@@ -865,10 +874,9 @@ def _request_body_exceeds_auth_base_limit(flow: http.HTTPFlow) -> bool:
     return body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES
 
 
-def _set_auth_base_request_too_large(
+def _log_auth_base_request_too_large(
     flow: http.HTTPFlow,
     *,
-    allow: matching.FirewallAllow,
     proxy_log_path: str,
     firewall_base: str,
     observed_size: int | None = None,
@@ -886,6 +894,22 @@ def _set_auth_base_request_too_large(
         request_body_size_bytes=observed_size,
         request_body_limit_bytes=MAX_AUTH_BASE_REQUEST_BODY_BYTES,
     )
+
+
+def _set_auth_base_request_too_large(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+    observed_size: int | None = None,
+) -> None:
+    _log_auth_base_request_too_large(
+        flow,
+        proxy_log_path=proxy_log_path,
+        firewall_base=firewall_base,
+        observed_size=observed_size,
+    )
     _set_matched_firewall_failure_response(
         flow,
         status=413,
@@ -896,33 +920,35 @@ def _set_auth_base_request_too_large(
     )
 
 
-def set_auth_base_request_too_large(
+def mark_auth_base_request_too_large(
     flow: http.HTTPFlow,
     *,
-    allow: matching.FirewallAllow,
     proxy_log_path: str,
     firewall_base: str,
     observed_size: int,
 ) -> None:
-    """Set the auth.base oversized-body response before request buffering."""
-    _set_auth_base_request_too_large(
+    """Record an auth.base oversized-body failure before killing the flow."""
+    _log_auth_base_request_too_large(
         flow,
-        allow=allow,
         proxy_log_path=proxy_log_path,
         firewall_base=firewall_base,
         observed_size=observed_size,
     )
+    _mark_matched_firewall_failure(
+        flow,
+        action="ALLOW",
+        error_code="auth_base_request_body_too_large",
+    )
 
 
-def set_auth_base_request_length_required(
+def mark_auth_base_request_length_required(
     flow: http.HTTPFlow,
     *,
-    allow: matching.FirewallAllow,
     proxy_log_path: str,
     firewall_base: str,
     reason: str,
 ) -> None:
-    """Reject auth.base body framing that cannot prove a bounded request body."""
+    """Record unbounded auth.base body framing before killing the flow."""
     flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
     log_proxy_entry(
         proxy_log_path,
@@ -933,13 +959,10 @@ def set_auth_base_request_length_required(
         framing_error=reason,
         request_body_limit_bytes=MAX_AUTH_BASE_REQUEST_BODY_BYTES,
     )
-    _set_matched_firewall_failure_response(
+    _mark_matched_firewall_failure(
         flow,
-        status=411,
         action="ALLOW",
         error_code="auth_base_request_body_length_required",
-        message="auth.base request body requires a valid Content-Length",
-        permission=allow.name,
     )
 
 

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -204,6 +204,15 @@ def _prepare_firewall_metadata(
     flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = vm_info.get("modelUsageProvider")
 
 
+def prepare_firewall_metadata(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> None:
+    """Store matched-firewall metadata for callers outside this module."""
+    _prepare_firewall_metadata(flow, allow, vm_info)
+
+
 def _build_firewall_auth_context(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
@@ -862,9 +871,11 @@ def _set_auth_base_request_too_large(
     allow: matching.FirewallAllow,
     proxy_log_path: str,
     firewall_base: str,
+    observed_size: int | None = None,
 ) -> None:
-    body = flow.request.raw_content
-    observed_size = len(body) if body is not None else 0
+    if observed_size is None:
+        body = flow.request.raw_content
+        observed_size = len(body) if body is not None else 0
     flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
     log_proxy_entry(
         proxy_log_path,
@@ -881,6 +892,53 @@ def _set_auth_base_request_too_large(
         action="ALLOW",
         error_code="auth_base_request_body_too_large",
         message="auth.base request body too large",
+        permission=allow.name,
+    )
+
+
+def set_auth_base_request_too_large(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+    observed_size: int,
+) -> None:
+    """Set the auth.base oversized-body response before request buffering."""
+    _set_auth_base_request_too_large(
+        flow,
+        allow=allow,
+        proxy_log_path=proxy_log_path,
+        firewall_base=firewall_base,
+        observed_size=observed_size,
+    )
+
+
+def set_auth_base_request_length_required(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+    reason: str,
+) -> None:
+    """Reject auth.base body framing that cannot prove a bounded request body."""
+    flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "auth.base request body requires a valid Content-Length",
+        type="firewall",
+        firewall_base=firewall_base,
+        framing_error=reason,
+        request_body_limit_bytes=MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=411,
+        action="ALLOW",
+        error_code="auth_base_request_body_length_required",
+        message="auth.base request body requires a valid Content-Length",
         permission=allow.name,
     )
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -155,7 +155,6 @@ _RequestClassificationKind = Literal[
     "allow",
 ]
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
-_AUTH_BASE_REQUEST_CLASSIFICATION = "_auth_base_request_classification"
 _REQUEST_HEADERS_LOCAL_RESPONSE = "_request_headers_local_response"
 
 
@@ -1186,17 +1185,16 @@ def client_disconnected(client: connection.Client) -> None:
 
 def requestheaders(flow: http.HTTPFlow) -> None:
     """Reject unbounded auth.base request bodies before mitmproxy buffers them."""
+    body_check = _auth_base_body_header_check(flow)
+    if body_check.kind == "ok":
+        return
+
     classification = _classify_request(flow)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
     if classification.kind != "firewall_allow" or allow is None or vm_info is None:
         return
     if not _firewall_allow_auth_base(allow):
-        return
-
-    flow.metadata[_AUTH_BASE_REQUEST_CLASSIFICATION] = classification
-    body_check = _auth_base_body_header_check(flow)
-    if body_check.kind == "ok":
         return
 
     _start_request_timing(flow)
@@ -1275,9 +1273,7 @@ async def request(flow: http.HTTPFlow) -> None:
     if flow.metadata.get(_REQUEST_HEADERS_LOCAL_RESPONSE):
         return
 
-    classification = flow.metadata.pop(_AUTH_BASE_REQUEST_CLASSIFICATION, None)
-    if not isinstance(classification, _RequestClassification):
-        classification = _classify_request(flow)
+    classification = _classify_request(flow)
 
     if _classification_needs_request_timing(classification):
         _start_request_timing(flow)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -56,7 +56,10 @@ from auth import (
     clear_cached_firewall_headers,
     handle_firewall_request,
     is_billable_firewall,
+    prepare_firewall_metadata,
     request_force_refresh,
+    set_auth_base_request_length_required,
+    set_auth_base_request_too_large,
 )
 from logging_utils import (
     add_firewall_metadata,
@@ -138,6 +141,22 @@ _TlsAdmissionKind = Literal[
     "invalid_registry_vm",
     "registry_unavailable",
 ]
+_RequestClassificationKind = Literal[
+    "no_client_ip",
+    "pass_through",
+    "registry_unavailable",
+    "stale_tls_admission",
+    "invalid_registry_vm",
+    "authority_denied",
+    "api_allow",
+    "browser_allow",
+    "firewall_block",
+    "firewall_allow",
+    "allow",
+]
+_AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
+_AUTH_BASE_REQUEST_CLASSIFICATION = "_auth_base_request_classification"
+_REQUEST_HEADERS_LOCAL_RESPONSE = "_request_headers_local_response"
 
 
 @dataclass(frozen=True)
@@ -145,6 +164,25 @@ class _TlsAdmission:
     client_ip: str
     kind: _TlsAdmissionKind
     run_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _RequestClassification:
+    kind: _RequestClassificationKind
+    vm_info: dict | None = None
+    registry_unavailable: registry.RegistryUnavailable | None = None
+    invalid_vm: registry.InvalidVmEntry | None = None
+    authority_error: AuthorityValidationError | None = None
+    firewall_block: matching.FirewallBlock | None = None
+    firewall_allow: matching.FirewallAllow | None = None
+    stale_tls_reason: str = ""
+
+
+@dataclass(frozen=True)
+class _AuthBaseBodyCheck:
+    kind: _AuthBaseBodyCheckKind
+    observed_size: int = 0
+    reason: str = ""
 
 
 _tls_admissions: dict[str, _TlsAdmission] = {}
@@ -436,6 +474,210 @@ def _active_firewall_names(vm_info: dict) -> set[str]:
         if isinstance(name, str) and name:
             names.add(name)
     return names
+
+
+def _store_registered_request_metadata(
+    flow: http.HTTPFlow,
+    *,
+    vm_info: dict,
+    run_id: str,
+) -> None:
+    flow.metadata[metadata_keys.VM_RUN_ID] = run_id
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
+    flow.metadata[metadata_keys.CAPTURE_BODY] = vm_info.get("captureNetworkBodies", False)
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = vm_info.get("sandboxToken", "")
+    flow.metadata[metadata_keys.CLI_AGENT_TYPE] = vm_info.get("cliAgentType") or "claude-code"
+
+
+def _store_trusted_authority_metadata(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+    host: str,
+    port: int,
+) -> None:
+    flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = host
+    _set_network_log_target(
+        flow,
+        url=original_url,
+        host=host,
+        port=port,
+    )
+
+
+def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
+    client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
+    tls_admission = _tls_admission_for_client(flow.client_conn)
+
+    if not client_ip:
+        if tls_admission is not None:
+            return _RequestClassification(
+                kind="stale_tls_admission",
+                stale_tls_reason="client_ip_missing",
+            )
+        return _RequestClassification(kind="no_client_ip")
+
+    registry_state = registry.load_registry_state(get_registry_path())
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        return _RequestClassification(
+            kind="registry_unavailable",
+            registry_unavailable=registry_state,
+        )
+
+    if tls_admission is not None and tls_admission.client_ip != client_ip:
+        return _RequestClassification(
+            kind="stale_tls_admission",
+            stale_tls_reason="client_ip_mismatch",
+        )
+
+    vm_info = registry_state.vms.get(client_ip)
+    if vm_info is None:
+        invalid_vm = registry_state.invalid_vms.get(client_ip)
+        if invalid_vm is not None:
+            return _RequestClassification(
+                kind="invalid_registry_vm",
+                invalid_vm=invalid_vm,
+            )
+        if tls_admission is not None:
+            return _RequestClassification(
+                kind="stale_tls_admission",
+                stale_tls_reason="registry_entry_missing",
+            )
+        return _RequestClassification(kind="pass_through")
+
+    run_id = vm_info.get("runId", "")
+    if (
+        tls_admission is not None
+        and tls_admission.run_id is not None
+        and tls_admission.run_id != run_id
+    ):
+        return _RequestClassification(
+            kind="stale_tls_admission",
+            vm_info=vm_info,
+            stale_tls_reason="run_id_mismatch",
+        )
+
+    _store_registered_request_metadata(flow, vm_info=vm_info, run_id=run_id)
+
+    if _is_browser_request(flow):
+        flow.metadata[metadata_keys.BROWSER_USER_AGENT] = True
+
+    try:
+        trusted_authority = get_trusted_authority(flow)
+    except AuthorityValidationError as e:
+        return _RequestClassification(
+            kind="authority_denied",
+            vm_info=vm_info,
+            authority_error=e,
+        )
+
+    original_url = trusted_authority.url
+    _store_trusted_authority_metadata(
+        flow,
+        original_url=original_url,
+        host=trusted_authority.host,
+        port=trusted_authority.port,
+    )
+
+    hostname = trusted_authority.host.lower()
+    api_url = get_api_url()
+    if api_url:
+        parsed_api = urllib.parse.urlparse(api_url)
+        api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
+        if (
+            api_hostname
+            and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
+            and not flow.request.path.startswith("/api/test/")
+        ):
+            return _RequestClassification(kind="api_allow", vm_info=vm_info)
+
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+        return _RequestClassification(kind="browser_allow", vm_info=vm_info)
+
+    compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
+    compiled_network_policies = registry_state.compiled_network_policies[client_ip]
+    if compiled_firewalls:
+        result = matching.match_compiled_firewall_request(
+            original_url,
+            flow.request.method,
+            compiled_firewalls,
+            compiled_network_policies,
+        )
+        if isinstance(result, matching.FirewallBlock):
+            return _RequestClassification(
+                kind="firewall_block",
+                vm_info=vm_info,
+                firewall_block=result,
+            )
+        if isinstance(result, matching.FirewallAllow):
+            return _RequestClassification(
+                kind="firewall_allow",
+                vm_info=vm_info,
+                firewall_allow=result,
+            )
+
+    return _RequestClassification(kind="allow", vm_info=vm_info)
+
+
+def _classification_needs_request_timing(classification: _RequestClassification) -> bool:
+    return classification.kind in (
+        "authority_denied",
+        "api_allow",
+        "browser_allow",
+        "firewall_block",
+        "firewall_allow",
+        "allow",
+    )
+
+
+def _start_request_timing(flow: http.HTTPFlow) -> None:
+    if metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata:
+        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
+
+
+def _firewall_allow_auth_base(allow: matching.FirewallAllow) -> str | None:
+    auth_config = allow.api_entry.get("auth", {})
+    auth_base = auth_config.get("base") if isinstance(auth_config, dict) else None
+    return auth_base if isinstance(auth_base, str) and auth_base else None
+
+
+def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
+    if flow.request.headers.get_all("Transfer-Encoding"):
+        return _AuthBaseBodyCheck(kind="length_required", reason="transfer_encoding")
+
+    raw_content_lengths = flow.request.headers.get_all("Content-Length")
+    if not raw_content_lengths:
+        return _AuthBaseBodyCheck(kind="ok")
+
+    parsed_length: int | None = None
+    for raw_content_length in raw_content_lengths:
+        for part in raw_content_length.split(","):
+            candidate = _parse_auth_base_content_length_part(part)
+            if candidate is None:
+                return _AuthBaseBodyCheck(kind="length_required", reason="invalid_content_length")
+            if parsed_length is None:
+                parsed_length = candidate
+            elif parsed_length != candidate:
+                return _AuthBaseBodyCheck(
+                    kind="length_required",
+                    reason="conflicting_content_length",
+                )
+
+    observed_size = parsed_length if parsed_length is not None else 0
+    if observed_size > auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES:
+        return _AuthBaseBodyCheck(kind="too_large", observed_size=observed_size)
+    return _AuthBaseBodyCheck(kind="ok", observed_size=observed_size)
+
+
+def _parse_auth_base_content_length_part(value: str) -> int | None:
+    value = value.strip(" \t")
+    if not value:
+        return None
+    if not value.isascii() or not value.isdecimal():
+        return None
+    return int(value)
 
 
 def _record_connector_diagnostic_candidate(
@@ -942,6 +1184,85 @@ def client_disconnected(client: connection.Client) -> None:
 # ============================================================================
 
 
+def requestheaders(flow: http.HTTPFlow) -> None:
+    """Reject unbounded auth.base request bodies before mitmproxy buffers them."""
+    classification = _classify_request(flow)
+    allow = classification.firewall_allow
+    vm_info = classification.vm_info
+    if classification.kind != "firewall_allow" or allow is None or vm_info is None:
+        return
+    if not _firewall_allow_auth_base(allow):
+        return
+
+    flow.metadata[_AUTH_BASE_REQUEST_CLASSIFICATION] = classification
+    body_check = _auth_base_body_header_check(flow)
+    if body_check.kind == "ok":
+        return
+
+    _start_request_timing(flow)
+    prepare_firewall_metadata(flow, allow, vm_info)
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+    if body_check.kind == "too_large":
+        set_auth_base_request_too_large(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+            observed_size=body_check.observed_size,
+        )
+    else:
+        set_auth_base_request_length_required(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+            reason=body_check.reason,
+        )
+    flow.metadata[_REQUEST_HEADERS_LOCAL_RESPONSE] = True
+
+
+def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    if result.reason == "malformed_network_policy":
+        block_message = "malformed network policy"
+        response_message = "Request blocked: malformed network policy"
+    elif result.reason == "unsafe_path":
+        block_message = "unsafe path"
+        response_message = "Request blocked: unsafe path"
+    else:
+        block_message = "no matching permission"
+        response_message = "Request blocked: no matching permission rule"
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        f"Firewall {result.name}: {block_message} for {result.method} {result.path}",
+        type="firewall_block",
+        name=result.name,
+        reason=result.reason,
+    )
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
+    flow.metadata[metadata_keys.FIREWALL_BASE] = result.base
+    flow.metadata[metadata_keys.FIREWALL_NAME] = result.name
+    error_body = json.dumps(
+        {
+            "error": "permission_denied",
+            "message": response_message,
+            "method": result.method,
+            "path": result.path,
+            "name": result.name,
+            "permissions": list(result.permissions),
+            "reason": result.reason,
+            "base": result.base,
+        }
+    )
+    flow.response = http.Response.make(
+        403,
+        error_body.encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
 async def request(flow: http.HTTPFlow) -> None:
     """
     Intercept request: inject firewall auth headers for configured firewall rules.
@@ -951,104 +1272,44 @@ async def request(flow: http.HTTPFlow) -> None:
     2. VM0 API auto-allow (agent must always reach the platform)
     3. Firewall match (inject auth headers for allowed requests)
     """
-    # Get client IP (source VM)
-    client_ip = flow.client_conn.peername[0] if flow.client_conn.peername else None
-    tls_admission = _tls_admission_for_client(flow.client_conn)
-
-    if not client_ip:
-        if tls_admission is not None:
-            _block_stale_tls_admission(flow, reason="client_ip_missing")
-            return
-        ctx.log.warn("No client IP available, passing through")
+    if flow.metadata.get(_REQUEST_HEADERS_LOCAL_RESPONSE):
         return
 
-    registry_state = registry.load_registry_state(get_registry_path())
-    if isinstance(registry_state, registry.RegistryUnavailable):
-        _block_registry_unavailable(flow, registry_state)
-        return
+    classification = flow.metadata.pop(_AUTH_BASE_REQUEST_CLASSIFICATION, None)
+    if not isinstance(classification, _RequestClassification):
+        classification = _classify_request(flow)
 
-    if tls_admission is not None and tls_admission.client_ip != client_ip:
-        _block_stale_tls_admission(flow, reason="client_ip_mismatch")
-        return
-
-    # Look up VM info from registry. This pass-through path is valid only after
-    # the registry file loaded successfully; unavailable registry is blocked above.
-    vm_info = registry_state.vms.get(client_ip)
-    if vm_info is None:
-        invalid_vm = registry_state.invalid_vms.get(client_ip)
-        if invalid_vm is not None:
-            _block_invalid_registry_vm(flow, invalid_vm)
-            return
-        if tls_admission is not None:
-            _block_stale_tls_admission(flow, reason="registry_entry_missing")
-            return
-        # Not a registered VM, pass through without proxying
-        return
-
-    run_id = vm_info.get("runId", "")
-    if (
-        tls_admission is not None
-        and tls_admission.run_id is not None
-        and tls_admission.run_id != run_id
-    ):
-        _block_stale_tls_admission(flow, reason="run_id_mismatch")
-        return
-    compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
-    compiled_network_policies = registry_state.compiled_network_policies[client_ip]
-
-    # Track request start time after early returns so unregistered flows do not carry it.
-    flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
+    if _classification_needs_request_timing(classification):
+        _start_request_timing(flow)
 
     try:
-        # Store info for response handler
-        flow.metadata[metadata_keys.VM_RUN_ID] = run_id
-        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = vm_info.get("networkLogPath", "")
-        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
-        flow.metadata[metadata_keys.CAPTURE_BODY] = vm_info.get("captureNetworkBodies", False)
-        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = vm_info.get("sandboxToken", "")
-        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = vm_info.get("cliAgentType") or "claude-code"
-
-        if _is_browser_request(flow):
-            flow.metadata[metadata_keys.BROWSER_USER_AGENT] = True
-
-        try:
-            trusted_authority = get_trusted_authority(flow)
-        except AuthorityValidationError as e:
-            _block_authority_validation_error(flow, e)
+        if classification.kind == "no_client_ip":
+            ctx.log.warn("No client IP available, passing through")
             return
-
-        original_url = trusted_authority.url
-        flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
-        flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
-        _set_network_log_target(
-            flow,
-            url=original_url,
-            host=trusted_authority.host,
-            port=trusted_authority.port,
-        )
-
-        hostname = trusted_authority.host.lower()
-
-        # --- Step 2: Auto-allow VM0 API requests ---
-        # The agent MUST be able to communicate with the platform (heartbeat,
-        # logs, CLI auth, etc.). Exception: `/api/test/*` routes exist only to
-        # exercise the firewall pipeline itself (e.g. the test-oauth provider),
-        # so they must go through Step 3 and get their auth injected by the
-        # matching firewall — otherwise the E2E tests that back them would
-        # auto-allow past the thing they're supposed to exercise.
-        api_url = get_api_url()
-        if api_url:
-            parsed_api = urllib.parse.urlparse(api_url)
-            api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
-            if (
-                api_hostname
-                and (hostname == api_hostname or hostname.endswith(f".{api_hostname}"))
-                and not flow.request.path.startswith("/api/test/")
-            ):
-                flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-                return
-
-        if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+        if classification.kind == "registry_unavailable":
+            unavailable = classification.registry_unavailable
+            if unavailable is not None:
+                _block_registry_unavailable(flow, unavailable)
+            return
+        if classification.kind == "stale_tls_admission":
+            _block_stale_tls_admission(flow, reason=classification.stale_tls_reason)
+            return
+        if classification.kind == "invalid_registry_vm":
+            invalid_vm = classification.invalid_vm
+            if invalid_vm is not None:
+                _block_invalid_registry_vm(flow, invalid_vm)
+            return
+        if classification.kind == "pass_through":
+            return
+        if classification.kind == "authority_denied":
+            authority_error = classification.authority_error
+            if authority_error is not None:
+                _block_authority_validation_error(flow, authority_error)
+            return
+        if classification.kind == "api_allow":
+            flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+            return
+        if classification.kind == "browser_allow":
             # User-Agent is client-controlled. This is a credential-flow skip
             # for browser-looking traffic, not proof that the request came from
             # a trusted browser integration. Registry and authority validation
@@ -1057,74 +1318,33 @@ async def request(flow: http.HTTPFlow) -> None:
             flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
             flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
             return
-
-        # --- Step 3: Firewall match with permission check ---
-        # Match base URL, then check permission rules before injecting auth headers.
-        if compiled_firewalls:
-            result = matching.match_compiled_firewall_request(
-                original_url,
-                flow.request.method,
-                compiled_firewalls,
-                compiled_network_policies,
+        if classification.kind == "firewall_block":
+            firewall_block = classification.firewall_block
+            if firewall_block is not None:
+                _set_firewall_block_response(flow, firewall_block)
+            return
+        if classification.kind == "firewall_allow":
+            allow = classification.firewall_allow
+            vm_info = classification.vm_info
+            if allow is None or vm_info is None:
+                return
+            _maybe_track_usage_flow(
+                flow,
+                is_billable_firewall(allow.name, vm_info),
+                _is_model_provider_usage_observable(allow.name, vm_info),
             )
-            if isinstance(result, matching.FirewallBlock):
-                proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-                if result.reason == "malformed_network_policy":
-                    block_message = "malformed network policy"
-                    response_message = "Request blocked: malformed network policy"
-                elif result.reason == "unsafe_path":
-                    block_message = "unsafe path"
-                    response_message = "Request blocked: unsafe path"
-                else:
-                    block_message = "no matching permission"
-                    response_message = "Request blocked: no matching permission rule"
-                log_proxy_entry(
-                    proxy_log_path,
-                    "warn",
-                    f"Firewall {result.name}: {block_message} for {result.method} {result.path}",
-                    type="firewall_block",
-                    name=result.name,
-                    reason=result.reason,
-                )
-                flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
-                flow.metadata[metadata_keys.FIREWALL_BASE] = result.base
-                flow.metadata[metadata_keys.FIREWALL_NAME] = result.name
-                error_body = json.dumps(
-                    {
-                        "error": "permission_denied",
-                        "message": response_message,
-                        "method": result.method,
-                        "path": result.path,
-                        "name": result.name,
-                        "permissions": list(result.permissions),
-                        "reason": result.reason,
-                        "base": result.base,
-                    }
-                )
-                flow.response = http.Response.make(
-                    403,
-                    error_body.encode(),
-                    {"Content-Type": "application/json"},
-                )
-                return
-            if isinstance(result, matching.FirewallAllow):
-                _maybe_track_usage_flow(
-                    flow,
-                    is_billable_firewall(result.name, vm_info),
-                    _is_model_provider_usage_observable(result.name, vm_info),
-                )
-                auth_result = await handle_firewall_request(flow, result, vm_info)
-                if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
-                    # Local firewall/auth errors never reach a provider. They only
-                    # need pre-tracking to keep shutdown from racing while auth is
-                    # resolving, so release as soon as the local response exists.
-                    _release_tracked_usage_flow(flow)
-                return
+            auth_result = await handle_firewall_request(flow, allow, vm_info)
+            if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
+                # Local firewall/auth errors never reach a provider. They only
+                # need pre-tracking to keep shutdown from racing while auth is
+                # resolving, so release as soon as the local response exists.
+                _release_tracked_usage_flow(flow)
+            return
 
-        # No active firewall match — pass through directly. If the URL belongs
-        # to a built-in connector that is not active in this run, record only a
-        # diagnostic candidate. Response/error hooks decide whether a failed
-        # request should expose an agent-visible diagnostic body.
+        vm_info = classification.vm_info
+        if vm_info is None:
+            return
+        original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
         if not flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
             candidate = builtin_connector_diagnostics.find_candidate(
                 original_url,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -128,6 +128,7 @@ _AUTH_SCHEMES_REQUIRING_CREDENTIAL = frozenset(
         "token",
     )
 )
+_AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD", "OPTIONS", "TRACE"))
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
 _MAX_SAFE_NETWORK_LOG_SIZE_DIGITS = len(str(_MAX_SAFE_NETWORK_LOG_SIZE))
@@ -648,6 +649,8 @@ def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
 
     raw_content_lengths = flow.request.headers.get_all("Content-Length")
     if not raw_content_lengths:
+        if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
+            return _AuthBaseBodyCheck(kind="length_required", reason="missing_content_length")
         return _AuthBaseBodyCheck(kind="ok")
 
     parsed_length: int | None = None
@@ -676,7 +679,11 @@ def _parse_auth_base_content_length_part(value: str) -> int | None:
         return None
     if not value.isascii() or not value.isdecimal():
         return None
-    return int(value)
+    normalized = value.lstrip("0") or "0"
+    limit_text = str(auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES)
+    if len(normalized) > len(limit_text):
+        return auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1
+    return int(normalized)
 
 
 def _record_connector_diagnostic_candidate(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -56,10 +56,10 @@ from auth import (
     clear_cached_firewall_headers,
     handle_firewall_request,
     is_billable_firewall,
+    mark_auth_base_request_length_required,
+    mark_auth_base_request_too_large,
     prepare_firewall_metadata,
     request_force_refresh,
-    set_auth_base_request_length_required,
-    set_auth_base_request_too_large,
 )
 from logging_utils import (
     add_firewall_metadata,
@@ -156,7 +156,7 @@ _RequestClassificationKind = Literal[
     "allow",
 ]
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
-_REQUEST_HEADERS_LOCAL_RESPONSE = "_request_headers_local_response"
+_REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 
 
 @dataclass(frozen=True)
@@ -1191,7 +1191,7 @@ def client_disconnected(client: connection.Client) -> None:
 
 
 def requestheaders(flow: http.HTTPFlow) -> None:
-    """Reject unbounded auth.base request bodies before mitmproxy buffers them."""
+    """Terminate unsafe auth.base request bodies before mitmproxy buffers them."""
     body_check = _auth_base_body_header_check(flow)
     if body_check.kind == "ok":
         return
@@ -1209,22 +1209,21 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
     if body_check.kind == "too_large":
-        set_auth_base_request_too_large(
+        mark_auth_base_request_too_large(
             flow,
-            allow=allow,
             proxy_log_path=proxy_log_path,
             firewall_base=firewall_base,
             observed_size=body_check.observed_size,
         )
     else:
-        set_auth_base_request_length_required(
+        mark_auth_base_request_length_required(
             flow,
-            allow=allow,
             proxy_log_path=proxy_log_path,
             firewall_base=firewall_base,
             reason=body_check.reason,
         )
-    flow.metadata[_REQUEST_HEADERS_LOCAL_RESPONSE] = True
+    flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+    flow.kill()
 
 
 def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:
@@ -1277,7 +1276,7 @@ async def request(flow: http.HTTPFlow) -> None:
     2. VM0 API auto-allow (agent must always reach the platform)
     3. Firewall match (inject auth headers for allowed requests)
     """
-    if flow.metadata.get(_REQUEST_HEADERS_LOCAL_RESPONSE):
+    if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         return
 
     classification = _classify_request(flow)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -128,7 +128,7 @@ _AUTH_SCHEMES_REQUIRING_CREDENTIAL = frozenset(
         "token",
     )
 )
-_AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD", "OPTIONS", "TRACE"))
+_AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
 _MAX_SAFE_NETWORK_LOG_SIZE_DIGITS = len(str(_MAX_SAFE_NETWORK_LOG_SIZE))

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -613,24 +613,28 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
 
 
 @pytest.mark.parametrize(
-    "request_header_pairs",
+    ("method", "request_header_pairs"),
     [
-        [],
-        [("Transfer-Encoding", "chunked")],
-        [("Content-Length", "not-a-number")],
-        [("Content-Length", "-1")],
-        [("Content-Length", "4"), ("Content-Length", "5")],
+        ("POST", []),
+        ("PUT", []),
+        ("PATCH", []),
+        ("OPTIONS", []),
+        ("TRACE", []),
+        ("POST", [("Transfer-Encoding", "chunked")]),
+        ("POST", [("Content-Length", "not-a-number")]),
+        ("POST", [("Content-Length", "-1")]),
+        ("POST", [("Content-Length", "4"), ("Content-Length", "5")]),
     ],
 )
 async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
-    tmp_path, real_flow, mitm_ctx, headers, request_header_pairs
+    tmp_path, real_flow, mitm_ctx, headers, method, request_header_pairs
 ):
     reg_path = _write_auth_base_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="placeholder.example.com",
-        method="POST",
+        method=method,
         path="/",
         request_headers=headers(
             ("Host", "placeholder.example.com"),
@@ -712,15 +716,16 @@ async def test_auth_base_requestheaders_accepts_matching_duplicate_content_lengt
     assert flow.response is None
 
 
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
 async def test_auth_base_requestheaders_accepts_no_body_framing(
-    tmp_path, real_flow, mitm_ctx, headers
+    tmp_path, real_flow, mitm_ctx, headers, method
 ):
     reg_path = _write_auth_base_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
         client_ip="10.200.0.5",
         host="placeholder.example.com",
-        method="GET",
+        method=method,
         path="/",
         request_headers=headers(("Host", "placeholder.example.com")),
     )

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -700,7 +700,30 @@ async def test_auth_base_requestheaders_accepts_no_body_framing(
     assert flow.response is None
 
 
-async def test_auth_base_requestheaders_accepts_body_at_limit_and_reuses_match(
+async def test_requestheaders_skips_registry_for_bounded_body_headers(real_flow, headers):
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", "4"),
+        ),
+    )
+
+    with patch.object(
+        mitm_addon.registry,
+        "load_registry_state",
+        side_effect=AssertionError("requestheaders should not load the registry"),
+    ):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.response is None
+
+
+async def test_auth_base_requestheaders_accepts_body_at_limit(
     tmp_path, real_flow, mitm_ctx, headers
 ):
     reg_path = _write_auth_base_firewall_registry(tmp_path)

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from mitmproxy.flow import Error
 
 import auth
 import flow_metadata_keys as metadata_keys
@@ -562,7 +563,6 @@ async def test_oversized_auth_base_request_does_not_capture_request_body(
 async def test_auth_base_requestheaders_rejects_oversized_content_length_before_auth(
     tmp_path, real_flow, mitm_ctx, headers
 ):
-    request_body = b'{"secret":"super-secret-body"}'
     reg_path = _write_auth_base_firewall_registry(
         tmp_path,
         vm_fields={"captureNetworkBodies": True},
@@ -578,7 +578,6 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
             ("Content-Type", "application/json"),
             ("Content-Length", str(auth.MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1)),
         ),
-        request_body=request_body,
     )
     get_headers = AsyncMock()
 
@@ -588,28 +587,24 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
     ):
         mitm_addon.requestheaders(flow)
         await mitm_addon.request(flow)
-        mitm_addon.response(flow)
+        mitm_addon.error(flow)
 
     get_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 413
+    assert flow.response is None
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.live is False
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
-    body = json.loads(flow.response.content)
-    assert body == {
-        "error": "auth_base_request_body_too_large",
-        "message": "auth.base request body too large",
-        "permission": "webhook",
-        "base": "https://placeholder.example.com",
-    }
 
     network_log_text = (tmp_path / "net.jsonl").read_text()
-    assert "super-secret-body" not in network_log_text
     network_log_entry = json.loads(network_log_text)
+    assert network_log_entry["error"] == Error.KILLED_MESSAGE
+    assert network_log_entry["request_size"] == 0
     assert "request_body" not in network_log_entry
     assert network_log_entry["firewall_error"] == "auth_base_request_body_too_large"
 
     proxy_log_text = (tmp_path / "proxy.jsonl").read_text()
-    assert "super-secret-body" not in proxy_log_text
+    assert "auth.base request body too large" in proxy_log_text
 
 
 @pytest.mark.parametrize(
@@ -651,16 +646,11 @@ async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
         await mitm_addon.request(flow)
 
     get_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 411
+    assert flow.response is None
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.live is False
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == ("auth_base_request_body_length_required")
-    body = json.loads(flow.response.content)
-    assert body == {
-        "error": "auth_base_request_body_length_required",
-        "message": "auth.base request body requires a valid Content-Length",
-        "permission": "webhook",
-        "base": "https://placeholder.example.com",
-    }
 
 
 async def test_auth_base_requestheaders_rejects_extreme_content_length_before_auth(
@@ -688,8 +678,10 @@ async def test_auth_base_requestheaders_rejects_extreme_content_length_before_au
         await mitm_addon.request(flow)
 
     get_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 413
+    assert flow.response is None
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.live is False
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
 
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -23,6 +23,32 @@ _BROWSER_USER_AGENT = (
 )
 
 
+def _write_auth_base_firewall_registry(
+    tmp_path,
+    *,
+    vm_fields: dict[str, object] | None = None,
+):
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="webhook",
+            api_entry={
+                "base": "https://placeholder.example.com",
+                "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
+                "permissions": [{"name": "send", "rules": ["ANY /"]}],
+            },
+            network_policy={
+                "allow": ["send"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields=vm_fields,
+        ),
+    )
+
+
 async def test_firewall_match_calls_handler(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
@@ -531,6 +557,216 @@ async def test_oversized_auth_base_request_does_not_capture_request_body(
 
     proxy_log_text = (tmp_path / "proxy.jsonl").read_text()
     assert "super-secret-body" not in proxy_log_text
+
+
+async def test_auth_base_requestheaders_rejects_oversized_content_length_before_auth(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    request_body = b'{"secret":"super-secret-body"}'
+    reg_path = _write_auth_base_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(auth.MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1)),
+        ),
+        request_body=request_body,
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 413
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
+    body = json.loads(flow.response.content)
+    assert body == {
+        "error": "auth_base_request_body_too_large",
+        "message": "auth.base request body too large",
+        "permission": "webhook",
+        "base": "https://placeholder.example.com",
+    }
+
+    network_log_text = (tmp_path / "net.jsonl").read_text()
+    assert "super-secret-body" not in network_log_text
+    network_log_entry = json.loads(network_log_text)
+    assert "request_body" not in network_log_entry
+    assert network_log_entry["firewall_error"] == "auth_base_request_body_too_large"
+
+    proxy_log_text = (tmp_path / "proxy.jsonl").read_text()
+    assert "super-secret-body" not in proxy_log_text
+
+
+@pytest.mark.parametrize(
+    "request_header_pairs",
+    [
+        [("Transfer-Encoding", "chunked")],
+        [("Content-Length", "not-a-number")],
+        [("Content-Length", "-1")],
+        [("Content-Length", "4"), ("Content-Length", "5")],
+    ],
+)
+async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
+    tmp_path, real_flow, mitm_ctx, headers, request_header_pairs
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            *request_header_pairs,
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 411
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == ("auth_base_request_body_length_required")
+    body = json.loads(flow.response.content)
+    assert body == {
+        "error": "auth_base_request_body_length_required",
+        "message": "auth.base request body requires a valid Content-Length",
+        "permission": "webhook",
+        "base": "https://placeholder.example.com",
+    }
+
+
+async def test_auth_base_requestheaders_accepts_matching_duplicate_content_length(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", "4"),
+            ("Content-Length", "4"),
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.response is None
+
+
+async def test_auth_base_requestheaders_accepts_no_body_framing(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="GET",
+        path="/",
+        request_headers=headers(("Host", "placeholder.example.com")),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert flow.response is None
+
+
+async def test_auth_base_requestheaders_accepts_body_at_limit_and_reuses_match(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(auth.MAX_AUTH_BASE_REQUEST_BODY_BYTES)),
+        ),
+        request_body=b"ok",
+    )
+    token_meta = {
+        "headers": {},
+        "base": "https://real.example.com/webhook",
+        "resolved_secrets": ["WEBHOOK_URL"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+    mock_forward = AsyncMock(return_value=(200, b"ok", {}))
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+        patch.object(auth, "forward_request", mock_forward),
+    ):
+        mitm_addon.requestheaders(flow)
+        assert flow.response is None
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 200
+    assert mock_forward.call_args is not None
+    assert mock_forward.call_args[0][3] == b"ok"
+
+
+async def test_non_auth_base_requestheaders_ignores_unbounded_body_framing(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+        method="POST",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("Transfer-Encoding", "chunked"),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as mock_headers,
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert mock_headers.await_count == 1
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
 async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -713,14 +713,11 @@ async def test_requestheaders_skips_registry_for_bounded_body_headers(real_flow,
         ),
     )
 
-    with patch.object(
-        mitm_addon.registry,
-        "load_registry_state",
-        side_effect=AssertionError("requestheaders should not load the registry"),
-    ):
-        mitm_addon.requestheaders(flow)
+    mitm_addon.requestheaders(flow)
 
     assert flow.response is None
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
 
 
 async def test_auth_base_requestheaders_accepts_body_at_limit(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -615,6 +615,7 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
 @pytest.mark.parametrize(
     "request_header_pairs",
     [
+        [],
         [("Transfer-Encoding", "chunked")],
         [("Content-Length", "not-a-number")],
         [("Content-Length", "-1")],
@@ -656,6 +657,36 @@ async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
         "permission": "webhook",
         "base": "https://placeholder.example.com",
     }
+
+
+async def test_auth_base_requestheaders_rejects_extreme_content_length_before_auth(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", "9" * 5000),
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 413
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
 
 
 async def test_auth_base_requestheaders_accepts_matching_duplicate_content_length(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -792,8 +792,15 @@ async def test_auth_base_requestheaders_accepts_body_at_limit(
     assert mock_forward.call_args[0][3] == b"ok"
 
 
-async def test_non_auth_base_requestheaders_ignores_unbounded_body_framing(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+@pytest.mark.parametrize(
+    "request_header_pairs",
+    [
+        [],
+        [("Transfer-Encoding", "chunked")],
+    ],
+)
+async def test_non_auth_base_requestheaders_ignores_auth_base_body_contract(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, request_header_pairs
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
@@ -804,7 +811,7 @@ async def test_non_auth_base_requestheaders_ignores_unbounded_body_framing(
         method="POST",
         request_headers=headers(
             ("Host", "api.github.com"),
-            ("Transfer-Encoding", "chunked"),
+            *request_header_pairs,
         ),
     )
 


### PR DESCRIPTION
## Summary

- add requestheaders classification for auth.base firewall matches before request body buffering
- reject oversized auth.base Content-Length values and ambiguous body framing before auth resolution
- keep request-phase and forwarder-phase auth.base body guards as defense in depth

## Tests

- PYTHONPATH=/tmp/vm0-mitm-addon-deps:/workspaces/vm4/crates/runner/mitm-addon/src /tmp/vm0-mitm-addon-deps/bin/pytest tests/test_request_handler_firewall_dispatch.py tests/test_firewall_rewrite_forwarding.py tests/test_auth_base_forwarder.py -q
- PYTHONPATH=/tmp/vm0-mitm-addon-deps:/workspaces/vm4/crates/runner/mitm-addon/src /tmp/vm0-mitm-addon-deps/bin/ruff check .
- PYTHONPATH=/tmp/vm0-mitm-addon-deps:/workspaces/vm4/crates/runner/mitm-addon/src /tmp/vm0-mitm-addon-deps/bin/ruff format --check .
- PYTHONPATH=/tmp/vm0-mitm-addon-deps:/workspaces/vm4/crates/runner/mitm-addon/src /tmp/vm0-mitm-addon-deps/bin/basedpyright -p .
- PYTHONPATH=/tmp/vm0-mitm-addon-deps:/workspaces/vm4/crates/runner/mitm-addon/src /tmp/vm0-mitm-addon-deps/bin/pytest tests/ -q

Closes #17565