### PR TITLE
feat: send low credit balance alerts

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -46,6 +46,7 @@ interface UsageFixture {
 interface AlertRow {
   readonly toAddresses: unknown;
   readonly template: unknown;
+  readonly headers: unknown;
   readonly status: string;
 }
 
@@ -56,6 +57,7 @@ interface CreditLowBalanceTemplate {
     readonly remainingCredits: number;
     readonly thresholdCredits: number;
     readonly billingUrl: string;
+    readonly unsubscribeUrl?: string;
   };
 }
 
@@ -99,7 +101,9 @@ function parseLowCreditTemplate(value: unknown): CreditLowBalanceTemplate {
     typeof value.props.orgName === "string" &&
     typeof value.props.remainingCredits === "number" &&
     typeof value.props.thresholdCredits === "number" &&
-    typeof value.props.billingUrl === "string"
+    typeof value.props.billingUrl === "string" &&
+    (value.props.unsubscribeUrl === undefined ||
+      typeof value.props.unsubscribeUrl === "string")
   ) {
     return {
       template: value.template,
@@ -108,10 +112,26 @@ function parseLowCreditTemplate(value: unknown): CreditLowBalanceTemplate {
         remainingCredits: value.props.remainingCredits,
         thresholdCredits: value.props.thresholdCredits,
         billingUrl: value.props.billingUrl,
+        unsubscribeUrl: value.props.unsubscribeUrl,
       },
     };
   }
   throw new Error("Expected credit low-balance email template");
+}
+
+function parseHeaders(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    throw new Error("Expected email headers JSON to be an object");
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") {
+      throw new Error("Expected email header values to be strings");
+    }
+    headers[key] = entry;
+  }
+  return headers;
 }
 
 function mockCurrentOrgMembers(
@@ -342,6 +362,7 @@ async function lowCreditAlerts(fixture: UsageFixture): Promise<AlertRow[]> {
     .select({
       toAddresses: emailOutbox.toAddresses,
       template: emailOutbox.template,
+      headers: emailOutbox.headers,
       status: emailOutbox.status,
     })
     .from(emailOutbox)
@@ -377,7 +398,9 @@ async function createUsageFixture(
 
 beforeEach(() => {
   mockEnv("APP_URL", "https://app.vm0.test");
+  mockEnv("VM0_API_URL", "https://api.vm0.test");
   mockEnv("RESEND_FROM_DOMAIN", "mail.vm0.test");
+  mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
 });
 
 describe("processOrgUsageEvents$ low-credit alerts", () => {
@@ -390,12 +413,15 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     await processFixture(fixture);
 
     const alerts = await lowCreditAlerts(fixture);
+    const admin = fixture.members[0];
+    if (!admin) {
+      throw new Error("Expected fixture admin");
+    }
     expect(alerts).toHaveLength(1);
     expect(alerts[0]?.status).toBe("pending");
-    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([
-      fixture.members[0]?.email,
-    ]);
-    expect(parseLowCreditTemplate(alerts[0]?.template)).toStrictEqual({
+    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([admin.email]);
+    const template = parseLowCreditTemplate(alerts[0]?.template);
+    expect(template).toMatchObject({
       template: "credit-low-balance",
       props: {
         orgName: fixture.orgName,
@@ -405,6 +431,14 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
           "https://app.vm0.test/?settings=billing&billingView=credits",
       },
     });
+    expect(template.props.unsubscribeUrl).toContain(
+      `https://api.vm0.test/api/email/unsubscribe?token=${admin.userId}.`,
+    );
+    const headers = parseHeaders(alerts[0]?.headers);
+    expect(headers["List-Unsubscribe"]).toBe(
+      `<${template.props.unsubscribeUrl}>`,
+    );
+    expect(headers["List-Unsubscribe-Post"]).toBe("List-Unsubscribe=One-Click");
 
     const db = store.set(writeDb$);
     const [cachedAdmin] = await db
@@ -495,11 +529,18 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     await processFixture(fixture);
 
     const alerts = await lowCreditAlerts(fixture);
-    expect(alerts).toHaveLength(1);
-    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([
-      firstAdmin.email,
-      secondAdmin.email,
-    ]);
+    expect(alerts).toHaveLength(2);
+    const recipients = alerts
+      .flatMap((alert) => {
+        return parseAddresses(alert.toAddresses);
+      })
+      .sort();
+    expect(recipients).toStrictEqual(
+      [firstAdmin.email, secondAdmin.email].sort(),
+    );
+    for (const alert of alerts) {
+      expect(parseAddresses(alert.toAddresses)).toHaveLength(1);
+    }
   });
 
   it("does not enqueue an alert when the org has no current admin", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -1,0 +1,588 @@
+import { randomUUID } from "node:crypto";
+
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { emailOutbox } from "@vm0/db/schema/email-outbox";
+import { emailSuppressions } from "@vm0/db/schema/email-suppression";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { usageEvent } from "@vm0/db/schema/usage-event";
+import { usagePricing } from "@vm0/db/schema/usage-pricing";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { users } from "@vm0/db/schema/user";
+import { createStore } from "ccstate";
+import { asc, eq, inArray, sql } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { createFixtureTracker } from "../../routes/__tests__/helpers/zero-route-test";
+import { writeDb$ } from "../../external/db";
+import { nowDate } from "../../external/time";
+import { LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS } from "../zero-credit-low-balance-alert.service";
+import { processOrgUsageEvents$ } from "../zero-credit-usage.service";
+
+const context = testContext();
+const store = createStore();
+
+const TEST_KIND = "connector";
+const TEST_CATEGORY = "credit-low-balance-test";
+
+interface MemberFixture {
+  readonly userId: string;
+  readonly email: string;
+  readonly role: "org:admin" | "org:member";
+  readonly emailUnsubscribed?: boolean;
+}
+
+interface UsageFixture {
+  readonly orgId: string;
+  readonly orgName: string;
+  readonly provider: string;
+  readonly billingUserId: string;
+  readonly members: readonly MemberFixture[];
+}
+
+interface AlertRow {
+  readonly toAddresses: unknown;
+  readonly template: unknown;
+  readonly status: string;
+}
+
+interface CreditLowBalanceTemplate {
+  readonly template: "credit-low-balance";
+  readonly props: {
+    readonly orgName: string;
+    readonly remainingCredits: number;
+    readonly thresholdCredits: number;
+    readonly billingUrl: string;
+  };
+}
+
+function uniqueId(): string {
+  return randomUUID().replaceAll("-", "").slice(0, 12);
+}
+
+function member(role: MemberFixture["role"], email?: string): MemberFixture {
+  const id = uniqueId();
+  return {
+    userId: `user_credit_alert_${id}`,
+    email: email ?? `credit-alert-${id}@example.com`,
+    role,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseAddresses(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (
+    Array.isArray(value) &&
+    value.every((entry): entry is string => {
+      return typeof entry === "string";
+    })
+  ) {
+    return value;
+  }
+  throw new Error("Expected email address JSON to be a string or string array");
+}
+
+function parseLowCreditTemplate(value: unknown): CreditLowBalanceTemplate {
+  if (
+    isRecord(value) &&
+    value.template === "credit-low-balance" &&
+    isRecord(value.props) &&
+    typeof value.props.orgName === "string" &&
+    typeof value.props.remainingCredits === "number" &&
+    typeof value.props.thresholdCredits === "number" &&
+    typeof value.props.billingUrl === "string"
+  ) {
+    return {
+      template: value.template,
+      props: {
+        orgName: value.props.orgName,
+        remainingCredits: value.props.remainingCredits,
+        thresholdCredits: value.props.thresholdCredits,
+        billingUrl: value.props.billingUrl,
+      },
+    };
+  }
+  throw new Error("Expected credit low-balance email template");
+}
+
+function mockCurrentOrgMembers(
+  orgId: string,
+  members: readonly MemberFixture[],
+): void {
+  context.mocks.clerk.organizations.getOrganizationMembershipList.mockImplementation(
+    (args: unknown) => {
+      const input = isRecord(args) ? args : {};
+      const organizationId =
+        typeof input.organizationId === "string" ? input.organizationId : "";
+      const offset = typeof input.offset === "number" ? input.offset : 0;
+      const limit = typeof input.limit === "number" ? input.limit : 100;
+      const pageMembers = organizationId === orgId ? members : [];
+
+      return Promise.resolve({
+        data: pageMembers.slice(offset, offset + limit).map((entry) => {
+          return {
+            role: entry.role,
+            publicUserData: { userId: entry.userId },
+          };
+        }),
+      });
+    },
+  );
+}
+
+async function addUsageEvent(
+  fixture: UsageFixture,
+  chargeCredits: number,
+): Promise<void> {
+  const db = store.set(writeDb$);
+  await db.insert(usageEvent).values({
+    idempotencyKey: randomUUID(),
+    orgId: fixture.orgId,
+    userId: fixture.billingUserId,
+    kind: TEST_KIND,
+    provider: fixture.provider,
+    category: TEST_CATEGORY,
+    quantity: chargeCredits,
+  });
+}
+
+async function seedUsageFixture(options: {
+  readonly beforeCredits: number;
+  readonly chargeCredits: number;
+  readonly members?: readonly MemberFixture[];
+  readonly expiredCredits?: number;
+  readonly suppressEmails?: readonly string[];
+}): Promise<UsageFixture> {
+  const db = store.set(writeDb$);
+  const id = uniqueId();
+  const members = options.members ?? [member("org:admin")];
+  const fixture: UsageFixture = {
+    orgId: `org_credit_alert_${id}`,
+    orgName: `Credit Alert Org ${id}`,
+    provider: `credit-alert-${id}`,
+    billingUserId: members[0]?.userId ?? `user_credit_alert_billing_${id}`,
+    members,
+  };
+
+  await db
+    .insert(orgMetadata)
+    .values({
+      orgId: fixture.orgId,
+      credits: options.beforeCredits,
+      tier: "free",
+      autoRechargeEnabled: false,
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: options.beforeCredits,
+        tier: "free",
+        autoRechargeEnabled: false,
+        updatedAt: nowDate(),
+      },
+    });
+
+  await db
+    .insert(orgCache)
+    .values({
+      orgId: fixture.orgId,
+      slug: `credit-alert-${id}`,
+      name: fixture.orgName,
+      cachedAt: nowDate(),
+    })
+    .onConflictDoUpdate({
+      target: orgCache.orgId,
+      set: {
+        slug: `credit-alert-${id}`,
+        name: fixture.orgName,
+        cachedAt: nowDate(),
+      },
+    });
+
+  if (members.length > 0) {
+    await db
+      .insert(users)
+      .values(
+        members.map((entry) => {
+          return {
+            id: entry.userId,
+            emailUnsubscribed: entry.emailUnsubscribed ?? false,
+          };
+        }),
+      )
+      .onConflictDoUpdate({
+        target: users.id,
+        set: {
+          emailUnsubscribed: sql`excluded.email_unsubscribed`,
+          updatedAt: nowDate(),
+        },
+      });
+
+    await db
+      .insert(userCache)
+      .values(
+        members.map((entry) => {
+          return {
+            userId: entry.userId,
+            email: entry.email,
+            name: "Credit Alert Recipient",
+            cachedAt: nowDate(),
+          };
+        }),
+      )
+      .onConflictDoUpdate({
+        target: userCache.userId,
+        set: {
+          email: sql`excluded.email`,
+          name: sql`excluded.name`,
+          cachedAt: sql`excluded.cached_at`,
+        },
+      });
+  }
+
+  await db
+    .insert(usagePricing)
+    .values({
+      kind: TEST_KIND,
+      provider: fixture.provider,
+      category: TEST_CATEGORY,
+      unitPrice: 1,
+      unitSize: 1,
+    })
+    .onConflictDoUpdate({
+      target: [usagePricing.kind, usagePricing.provider, usagePricing.category],
+      set: {
+        unitPrice: 1,
+        unitSize: 1,
+        updatedAt: nowDate(),
+      },
+    });
+
+  if (options.expiredCredits) {
+    await db.insert(creditExpiresRecord).values({
+      orgId: fixture.orgId,
+      source: "subscription_renewal",
+      amount: options.expiredCredits,
+      remaining: options.expiredCredits,
+      expiresAt: new Date(nowDate().getTime() - 1000),
+    });
+  }
+
+  const suppressEmails = options.suppressEmails ?? [];
+  if (suppressEmails.length > 0) {
+    await db.insert(emailSuppressions).values(
+      suppressEmails.map((email) => {
+        return {
+          emailAddress: email,
+          reason: "bounced",
+        };
+      }),
+    );
+  }
+
+  await addUsageEvent(fixture, options.chargeCredits);
+  mockCurrentOrgMembers(fixture.orgId, members);
+  return fixture;
+}
+
+async function cleanupFixture(fixture: UsageFixture): Promise<void> {
+  const db = store.set(writeDb$);
+  const userIds = fixture.members.map((entry) => {
+    return entry.userId;
+  });
+  const emails = fixture.members.map((entry) => {
+    return entry.email.toLowerCase();
+  });
+
+  await db
+    .delete(emailOutbox)
+    .where(
+      sql`${emailOutbox.template}->'props'->>'orgName' = ${fixture.orgName}`,
+    );
+  if (emails.length > 0) {
+    await db.delete(emailSuppressions).where(
+      sql`lower(${emailSuppressions.emailAddress}) IN (${sql.join(
+        emails.map((email) => {
+          return sql`${email}`;
+        }),
+        sql`, `,
+      )})`,
+    );
+  }
+  await db
+    .delete(creditExpiresRecord)
+    .where(eq(creditExpiresRecord.orgId, fixture.orgId));
+  await db.delete(usageEvent).where(eq(usageEvent.orgId, fixture.orgId));
+  await db
+    .delete(usagePricing)
+    .where(eq(usagePricing.provider, fixture.provider));
+  await db
+    .delete(orgMembersCache)
+    .where(eq(orgMembersCache.orgId, fixture.orgId));
+  await db.delete(orgCache).where(eq(orgCache.orgId, fixture.orgId));
+  await db.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
+  if (userIds.length > 0) {
+    await db.delete(userCache).where(inArray(userCache.userId, userIds));
+    await db.delete(users).where(inArray(users.id, userIds));
+  }
+}
+
+async function lowCreditAlerts(fixture: UsageFixture): Promise<AlertRow[]> {
+  const db = store.set(writeDb$);
+  return await db
+    .select({
+      toAddresses: emailOutbox.toAddresses,
+      template: emailOutbox.template,
+      status: emailOutbox.status,
+    })
+    .from(emailOutbox)
+    .where(
+      sql`${emailOutbox.template}->'props'->>'orgName' = ${fixture.orgName}`,
+    )
+    .orderBy(asc(emailOutbox.createdAt));
+}
+
+async function orgCredits(orgId: string): Promise<number> {
+  const db = store.set(writeDb$);
+  const [metadata] = await db
+    .select({ credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return metadata?.credits ?? 0;
+}
+
+async function processFixture(fixture: UsageFixture): Promise<void> {
+  await store.set(processOrgUsageEvents$, fixture.orgId, context.signal);
+}
+
+const trackFixture = createFixtureTracker<UsageFixture>((fixture) => {
+  return cleanupFixture(fixture);
+});
+
+async function createUsageFixture(
+  options: Parameters<typeof seedUsageFixture>[0],
+): Promise<UsageFixture> {
+  return await trackFixture(seedUsageFixture(options));
+}
+
+beforeEach(() => {
+  mockEnv("APP_URL", "https://app.vm0.test");
+  mockEnv("RESEND_FROM_DOMAIN", "mail.vm0.test");
+});
+
+describe("processOrgUsageEvents$ low-credit alerts", () => {
+  it("enqueues a low-credit alert when usage crosses the threshold", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 1000,
+      chargeCredits: 1500,
+    });
+
+    await processFixture(fixture);
+
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.status).toBe("pending");
+    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([
+      fixture.members[0]?.email,
+    ]);
+    expect(parseLowCreditTemplate(alerts[0]?.template)).toStrictEqual({
+      template: "credit-low-balance",
+      props: {
+        orgName: fixture.orgName,
+        remainingCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 500,
+        thresholdCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS,
+        billingUrl:
+          "https://app.vm0.test/?settings=billing&billingView=credits",
+      },
+    });
+
+    const db = store.set(writeDb$);
+    const [cachedAdmin] = await db
+      .select({ role: orgMembersCache.role })
+      .from(orgMembersCache)
+      .where(eq(orgMembersCache.orgId, fixture.orgId))
+      .limit(1);
+    expect(cachedAdmin?.role).toBe("admin");
+  });
+
+  it("does not alert when usage leaves credits above the threshold", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 3000,
+      chargeCredits: 1000,
+    });
+
+    await processFixture(fixture);
+
+    await expect(orgCredits(fixture.orgId)).resolves.toBe(
+      LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 2000,
+    );
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+  });
+
+  it("does not alert when credits were already below the threshold", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 1000,
+      chargeCredits: 100,
+    });
+
+    await processFixture(fixture);
+
+    await expect(orgCredits(fixture.orgId)).resolves.toBe(
+      LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 1100,
+    );
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+  });
+
+  it("does not alert when credits start exactly at the threshold", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS,
+      chargeCredits: 1,
+    });
+
+    await processFixture(fixture);
+
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+  });
+
+  it("alerts again after credits are topped up and cross the threshold again", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 1000,
+      chargeCredits: 1200,
+    });
+
+    await processFixture(fixture);
+
+    const db = store.set(writeDb$);
+    await db
+      .update(orgMetadata)
+      .set({
+        credits: sql`${orgMetadata.credits} + 2000`,
+        updatedAt: nowDate(),
+      })
+      .where(eq(orgMetadata.orgId, fixture.orgId));
+    await addUsageEvent(fixture, 1900);
+
+    await processFixture(fixture);
+
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(2);
+    expect(
+      parseLowCreditTemplate(alerts[1]?.template).props.remainingCredits,
+    ).toBe(LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 100);
+  });
+
+  it("sends to current admin emails, deduped case-insensitively", async () => {
+    const firstAdmin = member("org:admin", "Admin@example.com");
+    const duplicateAdmin = member("org:admin", "admin@example.com");
+    const secondAdmin = member("org:admin", "billing-admin@example.com");
+    const nonAdmin = member("org:member", "member@example.com");
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+      members: [firstAdmin, duplicateAdmin, secondAdmin, nonAdmin],
+    });
+
+    await processFixture(fixture);
+
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(1);
+    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([
+      firstAdmin.email,
+      secondAdmin.email,
+    ]);
+  });
+
+  it("does not enqueue an alert when the org has no current admin", async () => {
+    const currentMember = member("org:member");
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+      members: [currentMember],
+    });
+    const db = store.set(writeDb$);
+    await db.insert(orgMembersCache).values({
+      orgId: fixture.orgId,
+      userId: `user_stale_admin_${uniqueId()}`,
+      role: "admin",
+      cachedAt: nowDate(),
+    });
+
+    await processFixture(fixture);
+
+    await expect(orgCredits(fixture.orgId)).resolves.toBe(
+      LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 100,
+    );
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+    await expect(
+      db
+        .select({ userId: orgMembersCache.userId, role: orgMembersCache.role })
+        .from(orgMembersCache)
+        .where(eq(orgMembersCache.orgId, fixture.orgId)),
+    ).resolves.toStrictEqual([
+      { userId: currentMember.userId, role: "member" },
+    ]);
+  });
+
+  it("does not enqueue an alert when the only current admin is unsubscribed", async () => {
+    const admin = {
+      ...member("org:admin"),
+      emailUnsubscribed: true,
+    };
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+      members: [admin],
+    });
+
+    await processFixture(fixture);
+
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+  });
+
+  it("filters suppressed admin emails without dropping other admin recipients", async () => {
+    const suppressedAdmin = member(
+      "org:admin",
+      `suppressed-${uniqueId()}@example.com`,
+    );
+    const activeAdmin = member("org:admin", "active-admin@example.com");
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+      members: [suppressedAdmin, activeAdmin],
+      suppressEmails: [suppressedAdmin.email.toUpperCase()],
+    });
+
+    await processFixture(fixture);
+
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(1);
+    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([
+      activeAdmin.email,
+    ]);
+  });
+
+  it("does not alert when expired credits move the effective starting balance below the threshold", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 1000,
+      chargeCredits: 500,
+      expiredCredits: 2000,
+    });
+
+    await processFixture(fixture);
+
+    await expect(orgCredits(fixture.orgId)).resolves.toBe(
+      LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 1500,
+    );
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -74,6 +74,18 @@ function member(role: MemberFixture["role"], email?: string): MemberFixture {
   };
 }
 
+function uniqueMembersByUserId(
+  members: readonly MemberFixture[],
+): MemberFixture[] {
+  return [
+    ...new Map(
+      members.map((entry) => {
+        return [entry.userId, entry];
+      }),
+    ).values(),
+  ];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -228,11 +240,12 @@ async function seedUsageFixture(options: {
       },
     });
 
-  if (members.length > 0) {
+  const uniqueMembers = uniqueMembersByUserId(members);
+  if (uniqueMembers.length > 0) {
     await db
       .insert(users)
       .values(
-        members.map((entry) => {
+        uniqueMembers.map((entry) => {
           return {
             id: entry.userId,
             emailUnsubscribed: entry.emailUnsubscribed ?? false,
@@ -250,7 +263,7 @@ async function seedUsageFixture(options: {
     await db
       .insert(userCache)
       .values(
-        members.map((entry) => {
+        uniqueMembers.map((entry) => {
           return {
             userId: entry.userId,
             email: entry.email,
@@ -556,6 +569,33 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     for (const alert of alerts) {
       expect(parseAddresses(alert.toAddresses)).toHaveLength(1);
     }
+  });
+
+  it("keeps admin in the member cache when duplicate membership rows disagree", async () => {
+    const admin = member("org:admin", "duplicate-role-admin@example.com");
+    const duplicateMember = {
+      ...admin,
+      role: "org:member" as const,
+    };
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+      members: [admin, duplicateMember],
+    });
+
+    await processFixture(fixture);
+
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(1);
+    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([admin.email]);
+
+    const db = store.set(writeDb$);
+    const [cachedMember] = await db
+      .select({ role: orgMembersCache.role })
+      .from(orgMembersCache)
+      .where(eq(orgMembersCache.orgId, fixture.orgId))
+      .limit(1);
+    expect(cachedMember?.role).toBe("admin");
   });
 
   it("pages current org memberships before selecting admin recipients", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -662,6 +662,23 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     ]);
   });
 
+  it("does not roll back usage when alert recipient lookup fails", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValueOnce(
+      new Error("Clerk unavailable"),
+    );
+
+    await expect(processFixture(fixture)).resolves.toBeUndefined();
+
+    await expect(orgCredits(fixture.orgId)).resolves.toBe(
+      LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS - 100,
+    );
+    await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
+  });
+
   it("does not enqueue an alert when the only current admin is unsubscribed", async () => {
     const admin = {
       ...member("org:admin"),

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -543,6 +543,35 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     }
   });
 
+  it("pages current org memberships before selecting admin recipients", async () => {
+    const pagedAdmin = member("org:admin", "paged-admin@example.com");
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 600,
+      chargeCredits: 700,
+      members: [
+        ...Array.from({ length: 100 }, () => {
+          return member("org:member");
+        }),
+        pagedAdmin,
+      ],
+    });
+
+    await processFixture(fixture);
+
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledWith({
+      organizationId: fixture.orgId,
+      limit: 100,
+      offset: 100,
+    });
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(1);
+    expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([
+      pagedAdmin.email,
+    ]);
+  });
+
   it("does not enqueue an alert when the org has no current admin", async () => {
     const currentMember = member("org:member");
     const fixture = await createUsageFixture({

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -488,6 +488,21 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     await expect(lowCreditAlerts(fixture)).resolves.toStrictEqual([]);
   });
 
+  it("alerts when usage lands exactly on the threshold from above", async () => {
+    const fixture = await createUsageFixture({
+      beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 1,
+      chargeCredits: 1,
+    });
+
+    await processFixture(fixture);
+
+    const alerts = await lowCreditAlerts(fixture);
+    expect(alerts).toHaveLength(1);
+    expect(
+      parseLowCreditTemplate(alerts[0]?.template).props.remainingCredits,
+    ).toBe(LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS);
+  });
+
   it("alerts again after credits are topped up and cross the threshold again", async () => {
     const fixture = await createUsageFixture({
       beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 1000,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -48,6 +48,7 @@ interface AlertRow {
   readonly template: unknown;
   readonly headers: unknown;
   readonly status: string;
+  readonly subject: string;
 }
 
 interface CreditLowBalanceTemplate {
@@ -377,6 +378,7 @@ async function lowCreditAlerts(fixture: UsageFixture): Promise<AlertRow[]> {
       template: emailOutbox.template,
       headers: emailOutbox.headers,
       status: emailOutbox.status,
+      subject: emailOutbox.subject,
     })
     .from(emailOutbox)
     .where(
@@ -432,6 +434,7 @@ describe("processOrgUsageEvents$ low-credit alerts", () => {
     }
     expect(alerts).toHaveLength(1);
     expect(alerts[0]?.status).toBe("pending");
+    expect(alerts[0]?.subject).toBe("Your credit balance is running low");
     expect(parseAddresses(alerts[0]?.toAddresses)).toStrictEqual([admin.email]);
     const template = parseLowCreditTemplate(alerts[0]?.template);
     expect(template).toMatchObject({

--- a/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-credit-usage.service.test.ts
@@ -420,6 +420,7 @@ beforeEach(() => {
 
 describe("processOrgUsageEvents$ low-credit alerts", () => {
   it("enqueues a low-credit alert when usage crosses the threshold", async () => {
+    mockEnv("APP_URL", "https://app.vm0.test/");
     const fixture = await createUsageFixture({
       beforeCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS + 1000,
       chargeCredits: 1500,

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -16,6 +16,7 @@ import {
   buildFromAddress,
   buildUnsubscribeHeaders,
   buildUnsubscribeUrl,
+  CREDIT_LOW_BALANCE_EMAIL_SUBJECT,
   getUserEmail,
   type EmailTemplate,
 } from "./zero-email-common.service";
@@ -309,7 +310,7 @@ export const enqueueCreditLowBalanceAlert$ = command(
           fromAddress: buildFromAddress("vm0"),
           toAddresses: recipient.email,
           ccAddresses: null,
-          subject: "Your VM0 credits are running low",
+          subject: CREDIT_LOW_BALANCE_EMAIL_SUBJECT,
           replyTo: null,
           headers: buildUnsubscribeHeaders(unsubscribeUrl),
           template,

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -14,6 +14,8 @@ import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
 import {
   buildFromAddress,
+  buildUnsubscribeHeaders,
+  buildUnsubscribeUrl,
   getUserEmail,
   type EmailTemplate,
 } from "./zero-email-common.service";
@@ -263,42 +265,46 @@ export const enqueueCreditLowBalanceAlert$ = command(
     );
     signal.throwIfAborted();
 
-    const toAddresses = recipients
-      .map((recipient) => {
-        return recipient.email;
-      })
-      .filter((email) => {
-        return !suppressed.has(email.toLowerCase());
-      });
-    if (toAddresses.length === 0) {
+    const deliverableRecipients = recipients.filter((recipient) => {
+      return !suppressed.has(recipient.email.toLowerCase());
+    });
+    if (deliverableRecipients.length === 0) {
       L.warn("No eligible org admin recipients for low-credit alert", {
         orgId: args.orgId,
       });
       return;
     }
 
-    const template = {
-      template: "credit-low-balance",
-      props: {
-        orgName: await orgDisplayName(db, args.orgId),
-        remainingCredits: args.remainingCredits,
-        thresholdCredits: args.thresholdCredits,
-        billingUrl: `${env("APP_URL")}/?settings=billing&billingView=credits`,
-      },
-    } satisfies EmailTemplate;
+    const orgName = await orgDisplayName(db, args.orgId);
     signal.throwIfAborted();
+    const billingUrl = `${env("APP_URL")}/?settings=billing&billingView=credits`;
 
-    await db.insert(emailOutbox).values({
-      fromAddress: buildFromAddress("vm0"),
-      toAddresses,
-      ccAddresses: null,
-      subject: "Your VM0 credits are running low",
-      replyTo: null,
-      headers: null,
-      template,
-      postSendAction: null,
-      status: "pending",
-      attempts: 0,
-    });
+    await db.insert(emailOutbox).values(
+      deliverableRecipients.map((recipient) => {
+        const unsubscribeUrl = buildUnsubscribeUrl(recipient.userId);
+        const template = {
+          template: "credit-low-balance",
+          props: {
+            orgName,
+            remainingCredits: args.remainingCredits,
+            thresholdCredits: args.thresholdCredits,
+            billingUrl,
+            unsubscribeUrl,
+          },
+        } satisfies EmailTemplate;
+        return {
+          fromAddress: buildFromAddress("vm0"),
+          toAddresses: recipient.email,
+          ccAddresses: null,
+          subject: "Your VM0 credits are running low",
+          replyTo: null,
+          headers: buildUnsubscribeHeaders(unsubscribeUrl),
+          template,
+          postSendAction: null,
+          status: "pending",
+          attempts: 0,
+        };
+      }),
+    );
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -31,6 +31,10 @@ export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
 const L = logger("CreditLowBalanceAlert");
 const ORG_MEMBERSHIP_PAGE_SIZE = 100;
 
+function billingCreditsUrl(): string {
+  return `${env("APP_URL").replace(/\/$/, "")}/?settings=billing&billingView=credits`;
+}
+
 export interface CreditLowBalanceAlertArgs {
   readonly orgId: string;
   readonly remainingCredits: number;
@@ -291,7 +295,7 @@ export const enqueueCreditLowBalanceAlert$ = command(
 
     const orgName = await orgDisplayName(db, args.orgId);
     signal.throwIfAborted();
-    const billingUrl = `${env("APP_URL")}/?settings=billing&billingView=credits`;
+    const billingUrl = billingCreditsUrl();
 
     await db.insert(emailOutbox).values(
       deliverableRecipients.map((recipient) => {

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -41,6 +41,13 @@ interface Recipient {
   readonly email: string;
 }
 
+interface OrgMemberCacheRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly role: "admin" | "member";
+  readonly cachedAt: Date;
+}
+
 async function listCurrentOrgMemberships(
   clerk: ClerkClient,
   orgId: string,
@@ -72,20 +79,21 @@ async function refreshOrgMemberCache(
   orgId: string,
   memberships: readonly OrganizationMembership[],
 ): Promise<void> {
-  const rows = memberships.flatMap((membership) => {
+  const cachedAt = nowDate();
+  const rowsByUserId = new Map<string, OrgMemberCacheRow>();
+  for (const membership of memberships) {
     const userId = membershipUserId(membership);
     if (!userId) {
-      return [];
+      continue;
     }
-    return [
-      {
-        orgId,
-        userId,
-        role: membership.role === "org:admin" ? "admin" : "member",
-        cachedAt: nowDate(),
-      },
-    ];
-  });
+    rowsByUserId.set(userId, {
+      orgId,
+      userId,
+      role: membership.role === "org:admin" ? "admin" : "member",
+      cachedAt,
+    });
+  }
+  const rows = [...rowsByUserId.values()];
 
   await db.transaction(async (tx) => {
     if (rows.length > 0) {

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -1,0 +1,304 @@
+import type { createClerkClient } from "@clerk/backend";
+import { command } from "ccstate";
+import { emailOutbox } from "@vm0/db/schema/email-outbox";
+import { emailSuppressions } from "@vm0/db/schema/email-suppression";
+import { orgCache } from "@vm0/db/schema/org-cache";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { users } from "@vm0/db/schema/user";
+import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { clerk$ } from "../external/clerk";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import {
+  buildFromAddress,
+  getUserEmail,
+  type EmailTemplate,
+} from "./zero-email-common.service";
+
+type ClerkClient = ReturnType<typeof createClerkClient>;
+type OrganizationMembership = Awaited<
+  ReturnType<ClerkClient["organizations"]["getOrganizationMembershipList"]>
+>["data"][number];
+
+export const LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS = 5000;
+
+const L = logger("CreditLowBalanceAlert");
+const ORG_MEMBERSHIP_PAGE_SIZE = 100;
+
+export interface CreditLowBalanceAlertArgs {
+  readonly orgId: string;
+  readonly remainingCredits: number;
+  readonly thresholdCredits: number;
+}
+
+interface Recipient {
+  readonly userId: string;
+  readonly email: string;
+}
+
+async function listCurrentOrgMemberships(
+  clerk: ClerkClient,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<OrganizationMembership[]> {
+  const memberships: OrganizationMembership[] = [];
+  for (let offset = 0; ; offset += ORG_MEMBERSHIP_PAGE_SIZE) {
+    const page = await clerk.organizations.getOrganizationMembershipList({
+      organizationId: orgId,
+      limit: ORG_MEMBERSHIP_PAGE_SIZE,
+      offset,
+    });
+    signal.throwIfAborted();
+    memberships.push(...page.data);
+    if (page.data.length < ORG_MEMBERSHIP_PAGE_SIZE) {
+      return memberships;
+    }
+  }
+}
+
+function membershipUserId(
+  membership: OrganizationMembership,
+): string | undefined {
+  return membership.publicUserData?.userId;
+}
+
+async function refreshOrgMemberCache(
+  db: Db,
+  orgId: string,
+  memberships: readonly OrganizationMembership[],
+): Promise<void> {
+  const rows = memberships.flatMap((membership) => {
+    const userId = membershipUserId(membership);
+    if (!userId) {
+      return [];
+    }
+    return [
+      {
+        orgId,
+        userId,
+        role: membership.role === "org:admin" ? "admin" : "member",
+        cachedAt: nowDate(),
+      },
+    ];
+  });
+
+  await db.transaction(async (tx) => {
+    if (rows.length > 0) {
+      await tx
+        .insert(orgMembersCache)
+        .values(rows)
+        .onConflictDoUpdate({
+          target: [orgMembersCache.orgId, orgMembersCache.userId],
+          set: {
+            role: sql`excluded.role`,
+            cachedAt: sql`excluded.cached_at`,
+          },
+        });
+
+      await tx.delete(orgMembersCache).where(
+        and(
+          eq(orgMembersCache.orgId, orgId),
+          notInArray(
+            orgMembersCache.userId,
+            rows.map((row) => {
+              return row.userId;
+            }),
+          ),
+        ),
+      );
+      return;
+    }
+
+    await tx.delete(orgMembersCache).where(eq(orgMembersCache.orgId, orgId));
+  });
+}
+
+function adminUserIds(
+  memberships: readonly OrganizationMembership[],
+): string[] {
+  return [
+    ...new Set(
+      memberships.flatMap((membership) => {
+        if (membership.role !== "org:admin") {
+          return [];
+        }
+        const userId = membershipUserId(membership);
+        return userId ? [userId] : [];
+      }),
+    ),
+  ];
+}
+
+async function subscribedUserIds(
+  db: Db,
+  userIds: readonly string[],
+): Promise<Set<string>> {
+  if (userIds.length === 0) {
+    return new Set();
+  }
+
+  const unsubscribedRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(
+      and(
+        inArray(users.id, [...userIds].sort()),
+        eq(users.emailUnsubscribed, true),
+      ),
+    );
+  const unsubscribed = new Set(
+    unsubscribedRows.map((row) => {
+      return row.id;
+    }),
+  );
+  return new Set(
+    userIds.filter((userId) => {
+      return !unsubscribed.has(userId);
+    }),
+  );
+}
+
+async function resolveRecipients(
+  db: Db,
+  clerk: ClerkClient,
+  userIds: readonly string[],
+  signal: AbortSignal,
+): Promise<Recipient[]> {
+  const eligibleUserIds = await subscribedUserIds(db, userIds);
+  signal.throwIfAborted();
+
+  const byEmail = new Map<string, Recipient>();
+  for (const userId of userIds) {
+    if (!eligibleUserIds.has(userId)) {
+      continue;
+    }
+
+    const email = await getUserEmail(db, clerk, userId);
+    signal.throwIfAborted();
+    if (!email) {
+      continue;
+    }
+
+    const key = email.toLowerCase();
+    if (!byEmail.has(key)) {
+      byEmail.set(key, { userId, email });
+    }
+  }
+  return [...byEmail.values()];
+}
+
+async function suppressedEmailKeys(
+  db: Db,
+  emails: readonly string[],
+): Promise<Set<string>> {
+  if (emails.length === 0) {
+    return new Set();
+  }
+
+  const lowerEmails = emails.map((email) => {
+    return email.toLowerCase();
+  });
+  const rows = await db
+    .select({ emailAddress: emailSuppressions.emailAddress })
+    .from(emailSuppressions)
+    .where(
+      sql`lower(${emailSuppressions.emailAddress}) IN (${sql.join(
+        lowerEmails.map((email) => {
+          return sql`${email}`;
+        }),
+        sql`, `,
+      )})`,
+    );
+
+  return new Set(
+    rows.map((row) => {
+      return row.emailAddress.toLowerCase();
+    }),
+  );
+}
+
+async function orgDisplayName(db: Db, orgId: string): Promise<string> {
+  const [cached] = await db
+    .select({ name: orgCache.name })
+    .from(orgCache)
+    .where(eq(orgCache.orgId, orgId))
+    .limit(1);
+  const name = cached?.name.trim();
+  return name || "Your organization";
+}
+
+export const enqueueCreditLowBalanceAlert$ = command(
+  async (
+    { get, set },
+    args: CreditLowBalanceAlertArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const db = set(writeDb$);
+    const clerk = get(clerk$);
+    const memberships = await listCurrentOrgMemberships(
+      clerk,
+      args.orgId,
+      signal,
+    );
+    await refreshOrgMemberCache(db, args.orgId, memberships);
+    signal.throwIfAborted();
+
+    const userIds = adminUserIds(memberships);
+    if (userIds.length === 0) {
+      L.warn("No current org admin recipients for low-credit alert", {
+        orgId: args.orgId,
+      });
+      return;
+    }
+
+    const recipients = await resolveRecipients(db, clerk, userIds, signal);
+    const suppressed = await suppressedEmailKeys(
+      db,
+      recipients.map((recipient) => {
+        return recipient.email;
+      }),
+    );
+    signal.throwIfAborted();
+
+    const toAddresses = recipients
+      .map((recipient) => {
+        return recipient.email;
+      })
+      .filter((email) => {
+        return !suppressed.has(email.toLowerCase());
+      });
+    if (toAddresses.length === 0) {
+      L.warn("No eligible org admin recipients for low-credit alert", {
+        orgId: args.orgId,
+      });
+      return;
+    }
+
+    const template = {
+      template: "credit-low-balance",
+      props: {
+        orgName: await orgDisplayName(db, args.orgId),
+        remainingCredits: args.remainingCredits,
+        thresholdCredits: args.thresholdCredits,
+        billingUrl: `${env("APP_URL")}/?settings=billing&billingView=credits`,
+      },
+    } satisfies EmailTemplate;
+    signal.throwIfAborted();
+
+    await db.insert(emailOutbox).values({
+      fromAddress: buildFromAddress("vm0"),
+      toAddresses,
+      ccAddresses: null,
+      subject: "Your VM0 credits are running low",
+      replyTo: null,
+      headers: null,
+      template,
+      postSendAction: null,
+      status: "pending",
+      attempts: 0,
+    });
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-low-balance-alert.service.ts
@@ -86,10 +86,15 @@ async function refreshOrgMemberCache(
     if (!userId) {
       continue;
     }
+    const role = membership.role === "org:admin" ? "admin" : "member";
+    const existing = rowsByUserId.get(userId);
+    if (existing?.role === "admin") {
+      continue;
+    }
     rowsByUserId.set(userId, {
       orgId,
       userId,
-      role: membership.role === "org:admin" ? "admin" : "member",
+      role,
       cachedAt,
     });
   }

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -10,6 +10,11 @@ import { nowDate } from "../external/time";
 import { logger } from "../../lib/log";
 import { tapError } from "../utils";
 import { maybeEmitRunUsageMessage$ } from "./zero-chat-usage-message.service";
+import {
+  enqueueCreditLowBalanceAlert$,
+  LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS,
+  type CreditLowBalanceAlertArgs,
+} from "./zero-credit-low-balance-alert.service";
 import { triggerAutoRecharge$ } from "./zero-credit-recharge.service";
 
 const L = logger("CreditUsage");
@@ -27,6 +32,15 @@ async function deductOrgCredits(
         ON CONFLICT (org_id)
         DO UPDATE SET credits = org_metadata.credits - ${amount}, updated_at = now()`,
   );
+}
+
+async function getOrgCredits(tx: WriteTx, orgId: string): Promise<number> {
+  const [metadata] = await tx
+    .select({ credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return metadata?.credits ?? 0;
 }
 
 async function expireCredits(tx: WriteTx, orgId: string): Promise<number> {
@@ -112,6 +126,131 @@ async function deductFromExpiresRecords(
   // If left > 0, the excess comes from non-expiring credits — that's fine.
 }
 
+interface ProcessOrgUsageEventsResult {
+  readonly totalCredits: number;
+  readonly runIds: readonly string[];
+  readonly lowBalanceAlert: CreditLowBalanceAlertArgs | null;
+}
+
+async function processOrgUsageEventsInTransaction(
+  tx: WriteTx,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<ProcessOrgUsageEventsResult> {
+  // Same advisory key as web: 'credit_' prefix + orgId.
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
+  );
+
+  const pendingRecords = await tx
+    .select()
+    .from(usageEvent)
+    .where(and(eq(usageEvent.orgId, orgId), eq(usageEvent.status, "pending")));
+
+  if (pendingRecords.length === 0) {
+    return { totalCredits: 0, runIds: [], lowBalanceAlert: null };
+  }
+  const runIds = [
+    ...new Set(
+      pendingRecords.flatMap((record) => {
+        return record.runId ? [record.runId] : [];
+      }),
+    ),
+  ];
+
+  const pricingRecords = await tx.select().from(usagePricing);
+  const pricingByKey = new Map(
+    pricingRecords.map((p) => {
+      return [`${p.kind}|${p.provider}|${p.category}`, p];
+    }),
+  );
+
+  let totalCredits = 0;
+  for (const record of pendingRecords) {
+    const exactPricing = pricingByKey.get(
+      `${record.kind}|${record.provider}|${record.category}`,
+    );
+    const pricing =
+      exactPricing ??
+      pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
+
+    if (!pricing) {
+      await tx
+        .update(usageEvent)
+        .set({
+          creditsCharged: 0,
+          status: "processed",
+          processedAt: nowDate(),
+          billingError: "missing_pricing",
+        })
+        .where(eq(usageEvent.id, record.id));
+      L.error("Missing usage_pricing — charged zero", {
+        orgId,
+        runId: record.runId,
+        idempotencyKey: record.idempotencyKey,
+        userId: record.userId,
+        kind: record.kind,
+        provider: record.provider,
+        category: record.category,
+        quantity: record.quantity,
+      });
+      continue;
+    }
+
+    if (!exactPricing) {
+      L.error("Missing usage_pricing — billed at fallback rate", {
+        orgId,
+        runId: record.runId,
+        idempotencyKey: record.idempotencyKey,
+        userId: record.userId,
+        kind: record.kind,
+        provider: record.provider,
+        category: record.category,
+        quantity: record.quantity,
+        fallbackUnitPrice: pricing.unitPrice,
+      });
+    }
+
+    const creditsCharged = Math.ceil(
+      (record.quantity * pricing.unitPrice) / pricing.unitSize,
+    );
+    await tx
+      .update(usageEvent)
+      .set({
+        creditsCharged,
+        status: "processed",
+        processedAt: nowDate(),
+        billingError: exactPricing ? null : "fallback_pricing",
+      })
+      .where(eq(usageEvent.id, record.id));
+    totalCredits += creditsCharged;
+  }
+  signal.throwIfAborted();
+
+  let lowBalanceAlert: CreditLowBalanceAlertArgs | null = null;
+  if (totalCredits > 0) {
+    // Order matters: settle expired credits BEFORE the new deduction.
+    const beforeCredits = await getOrgCredits(tx, orgId);
+    const totalExpired = await expireCredits(tx, orgId);
+    const effectiveBeforeCredits = Math.max(beforeCredits - totalExpired, 0);
+    await deductOrgCredits(tx, orgId, totalCredits);
+    const afterCredits = await getOrgCredits(tx, orgId);
+    await deductFromExpiresRecords(tx, orgId, totalCredits);
+    if (
+      effectiveBeforeCredits > LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS &&
+      afterCredits <= LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS
+    ) {
+      lowBalanceAlert = {
+        orgId,
+        remainingCredits: afterCredits,
+        thresholdCredits: LOW_CREDIT_EMAIL_ALERT_THRESHOLD_CREDITS,
+      };
+    }
+  }
+  signal.throwIfAborted();
+  return { totalCredits, runIds, lowBalanceAlert };
+}
+
 /**
  * Atomically process pending usage_event records for an org and deduct
  * the total from the org's credit balance.
@@ -134,110 +273,11 @@ export const processOrgUsageEvents$ = command(
   async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {
     const writeDb = set(writeDb$);
 
-    const { totalCredits, runIds } = await writeDb.transaction(async (tx) => {
-      // Same advisory key as web: 'credit_' prefix + orgId.
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext('credit_' || ${orgId}))`,
-      );
-
-      const pendingRecords = await tx
-        .select()
-        .from(usageEvent)
-        .where(
-          and(eq(usageEvent.orgId, orgId), eq(usageEvent.status, "pending")),
-        );
-
-      if (pendingRecords.length === 0) {
-        return { totalCredits: 0, runIds: [] };
-      }
-      const runIds = [
-        ...new Set(
-          pendingRecords.flatMap((record) => {
-            return record.runId ? [record.runId] : [];
-          }),
-        ),
-      ];
-
-      const pricingRecords = await tx.select().from(usagePricing);
-      const pricingByKey = new Map(
-        pricingRecords.map((p) => {
-          return [`${p.kind}|${p.provider}|${p.category}`, p];
-        }),
-      );
-
-      let totalCredits = 0;
-      for (const record of pendingRecords) {
-        const exactPricing = pricingByKey.get(
-          `${record.kind}|${record.provider}|${record.category}`,
-        );
-        const pricing =
-          exactPricing ??
-          pricingByKey.get(`${record.kind}|${record.provider}|__fallback__`);
-
-        if (!pricing) {
-          await tx
-            .update(usageEvent)
-            .set({
-              creditsCharged: 0,
-              status: "processed",
-              processedAt: nowDate(),
-              billingError: "missing_pricing",
-            })
-            .where(eq(usageEvent.id, record.id));
-          L.error("Missing usage_pricing — charged zero", {
-            orgId,
-            runId: record.runId,
-            idempotencyKey: record.idempotencyKey,
-            userId: record.userId,
-            kind: record.kind,
-            provider: record.provider,
-            category: record.category,
-            quantity: record.quantity,
-          });
-          continue;
-        }
-
-        if (!exactPricing) {
-          L.error("Missing usage_pricing — billed at fallback rate", {
-            orgId,
-            runId: record.runId,
-            idempotencyKey: record.idempotencyKey,
-            userId: record.userId,
-            kind: record.kind,
-            provider: record.provider,
-            category: record.category,
-            quantity: record.quantity,
-            fallbackUnitPrice: pricing.unitPrice,
-          });
-        }
-
-        const creditsCharged = Math.ceil(
-          (record.quantity * pricing.unitPrice) / pricing.unitSize,
-        );
-        await tx
-          .update(usageEvent)
-          .set({
-            creditsCharged,
-            status: "processed",
-            processedAt: nowDate(),
-            billingError: exactPricing ? null : "fallback_pricing",
-          })
-          .where(eq(usageEvent.id, record.id));
-        totalCredits += creditsCharged;
-      }
-      signal.throwIfAborted();
-
-      if (totalCredits > 0) {
-        // Order matters: settle expired credits BEFORE the new
-        // deduction. expireCredits zeros out rows whose expires_at <=
-        // now() so deductFromExpiresRecords doesn't touch them.
-        await expireCredits(tx, orgId);
-        await deductOrgCredits(tx, orgId, totalCredits);
-        await deductFromExpiresRecords(tx, orgId, totalCredits);
-      }
-      signal.throwIfAborted();
-      return { totalCredits, runIds };
-    });
+    const { totalCredits, runIds, lowBalanceAlert } = await writeDb.transaction(
+      (tx) => {
+        return processOrgUsageEventsInTransaction(tx, orgId, signal);
+      },
+    );
     signal.throwIfAborted();
 
     if (totalCredits > 0) {
@@ -246,6 +286,19 @@ export const processOrgUsageEvents$ = command(
       // its own errors (clearPendingFlag in catch); the await here is
       // bounded by the route handler's outer waitUntil envelope.
       await set(triggerAutoRecharge$, orgId, signal);
+      signal.throwIfAborted();
+    }
+
+    if (lowBalanceAlert) {
+      await tapError(
+        set(enqueueCreditLowBalanceAlert$, lowBalanceAlert, signal),
+        (error) => {
+          L.error("Failed to enqueue low-credit alert after usage processing", {
+            orgId,
+            error,
+          });
+        },
+      );
       signal.throwIfAborted();
     }
 

--- a/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-credit-usage.service.ts
@@ -263,11 +263,15 @@ async function processOrgUsageEventsInTransaction(
  * verbatim same key string as web so api and web serialize correctly on
  * the same org during rollout.
  *
- * After the transaction commits and credits are deducted, fires
- * `triggerAutoRecharge$` for Stripe top-up when the balance crosses the
- * recharge threshold (bounded by the route handler's outer waitUntil
- * envelope so end-user latency is unaffected). Errors in the Stripe path
- * are caught inside the trigger Command (clearPendingFlag in catch).
+ * After the transaction commits and credits are deducted, runs post-billing
+ * side effects outside the credit transaction:
+ * - `triggerAutoRecharge$` for Stripe top-up when the balance crosses the
+ *   recharge threshold.
+ * - `enqueueCreditLowBalanceAlert$` when usage crosses the low-credit email
+ *   threshold.
+ *
+ * Both side effects are bounded by the route handler's outer waitUntil
+ * envelope. Low-balance alert failures are logged without affecting billing.
  */
 export const processOrgUsageEvents$ = command(
   async ({ set }, orgId: string, signal: AbortSignal): Promise<void> => {

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -126,6 +126,7 @@ interface CreditLowBalanceTemplate {
     readonly remainingCredits: number;
     readonly thresholdCredits: number;
     readonly billingUrl: string;
+    readonly unsubscribeUrl?: string;
   };
 }
 
@@ -454,6 +455,11 @@ function renderTemplate(template: EmailTemplate): string {
         template.props.remainingCredits.toLocaleString("en-US");
       const thresholdCredits =
         template.props.thresholdCredits.toLocaleString("en-US");
+      const unsubscribe = template.props.unsubscribeUrl
+        ? `<p><a href="${escapeHtml(
+            template.props.unsubscribeUrl,
+          )}">Unsubscribe</a></p>`
+        : "";
       return `<main><h1>Your VM0 credits are running low</h1><p>${escapeHtml(
         template.props.orgName,
       )} has ${escapeHtml(
@@ -462,7 +468,7 @@ function renderTemplate(template: EmailTemplate): string {
         thresholdCredits,
       )} credits or less.</p><p><a href="${escapeHtml(
         template.props.billingUrl,
-      )}">Manage billing</a></p></main>`;
+      )}">Manage billing</a></p>${unsubscribe}</main>`;
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -45,6 +45,8 @@ const OUTBOX_TTL_MS = 15 * 60 * 1000;
 const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
 const PRESIGNED_URL_EXPIRY = 3600;
 const R2_PATH_PREFIX = "email-attachments";
+export const CREDIT_LOW_BALANCE_EMAIL_SUBJECT =
+  "Your credit balance is running low";
 
 export type HandlerResult =
   | { readonly ok: true }
@@ -460,7 +462,7 @@ function renderTemplate(template: EmailTemplate): string {
             template.props.unsubscribeUrl,
           )}">Unsubscribe</a></p>`
         : "";
-      return `<main><h1>Your VM0 credits are running low</h1><p>${escapeHtml(
+      return `<main><h1>${CREDIT_LOW_BALANCE_EMAIL_SUBJECT}</h1><p>${escapeHtml(
         template.props.orgName,
       )} has ${escapeHtml(
         remainingCredits,

--- a/turbo/apps/api/src/signals/services/zero-email-common.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-email-common.service.ts
@@ -119,11 +119,22 @@ interface DeveloperSupportTemplate {
   };
 }
 
-type EmailTemplate =
+interface CreditLowBalanceTemplate {
+  readonly template: "credit-low-balance";
+  readonly props: {
+    readonly orgName: string;
+    readonly remainingCredits: number;
+    readonly thresholdCredits: number;
+    readonly billingUrl: string;
+  };
+}
+
+export type EmailTemplate =
   | AgentReplyTemplate
   | InboundErrorTemplate
   | DataExportReadyTemplate
-  | DeveloperSupportTemplate;
+  | DeveloperSupportTemplate
+  | CreditLowBalanceTemplate;
 
 interface SaveThreadSessionAction {
   readonly action: "save_thread_session";
@@ -437,6 +448,21 @@ function renderTemplate(template: EmailTemplate): string {
       )}">Download bundle</a></p><p>Expires ${escapeHtml(
         template.props.expiresAt,
       )}</p></main>`;
+    }
+    case "credit-low-balance": {
+      const remainingCredits =
+        template.props.remainingCredits.toLocaleString("en-US");
+      const thresholdCredits =
+        template.props.thresholdCredits.toLocaleString("en-US");
+      return `<main><h1>Your VM0 credits are running low</h1><p>${escapeHtml(
+        template.props.orgName,
+      )} has ${escapeHtml(
+        remainingCredits,
+      )} credits remaining.</p><p>This alert is sent when an org reaches ${escapeHtml(
+        thresholdCredits,
+      )} credits or less.</p><p><a href="${escapeHtml(
+        template.props.billingUrl,
+      )}">Manage billing</a></p></main>`;
     }
   }
 }


### PR DESCRIPTION
## Summary\n- enqueue a low-credit email alert when usage crosses below 5,000 credits\n- resolve current org admins from Clerk, refresh membership cache, and filter unsubscribed/suppressed recipients\n- add the credit low-balance email template and integration coverage around threshold, recipient, and expired-credit cases\n\n## Tests\n- pnpm -F api exec vitest run src/signals/services/__tests__/zero-credit-usage.service.test.ts\n- pnpm -F api check-types\n- pnpm -F api lint\n- pnpm knip --workspace api\n\nCloses #17404