### PR TITLE
fix: reset stale chat idb cache

### DIFF
--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
@@ -1,0 +1,64 @@
+import type { IDBPDatabase } from "idb";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CHAT_MESSAGES_STORE,
+  CHAT_THREAD_META_STORE,
+  upgradeChatIdb,
+} from "./chat-idb-schema.ts";
+
+function fakeDb(existingStores: readonly string[]) {
+  const stores = new Set(existingStores);
+  const createdStores = new Map<
+    string,
+    {
+      createIndex: ReturnType<typeof vi.fn>;
+    }
+  >();
+  const deleteObjectStore = vi.fn((name: string) => {
+    stores.delete(name);
+  });
+  const createObjectStore = vi.fn((name: string) => {
+    stores.add(name);
+    const store = {
+      createIndex: vi.fn(),
+    };
+    createdStores.set(name, store);
+    return store;
+  });
+
+  return {
+    db: {
+      objectStoreNames: {
+        contains: (name: string) => stores.has(name),
+      },
+      deleteObjectStore,
+      createObjectStore,
+    } as unknown as IDBPDatabase,
+    createdStores,
+    createObjectStore,
+    deleteObjectStore,
+  };
+}
+
+describe("upgradeChatIdb", () => {
+  it("clears legacy chat cache when upgrading to v4", async () => {
+    const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
+      CHAT_MESSAGES_STORE,
+      CHAT_THREAD_META_STORE,
+    ]);
+
+    upgradeChatIdb(db, 3);
+
+    expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_MESSAGES_STORE);
+    expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_THREAD_META_STORE);
+    expect(createObjectStore).toHaveBeenCalledWith(CHAT_MESSAGES_STORE, {
+      keyPath: "id",
+    });
+    expect(createObjectStore).toHaveBeenCalledWith(CHAT_THREAD_META_STORE, {
+      keyPath: "threadId",
+    });
+    expect(
+      createdStores.get(CHAT_MESSAGES_STORE)?.createIndex,
+    ).toHaveBeenCalledWith("byThreadAndTime", ["threadId", "createdAt"]);
+  });
+});

--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
@@ -29,7 +29,9 @@ function fakeDb(existingStores: readonly string[]) {
   return {
     db: {
       objectStoreNames: {
-        contains: (name: string) => stores.has(name),
+        contains: (name: string) => {
+          return stores.has(name);
+        },
       },
       deleteObjectStore,
       createObjectStore,
@@ -41,7 +43,7 @@ function fakeDb(existingStores: readonly string[]) {
 }
 
 describe("upgradeChatIdb", () => {
-  it("clears legacy chat cache when upgrading to v4", async () => {
+  it("clears legacy chat cache when upgrading to v4", () => {
     const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
       CHAT_MESSAGES_STORE,
       CHAT_THREAD_META_STORE,

--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
@@ -1,0 +1,34 @@
+import type { IDBPDatabase } from "idb";
+
+const CHAT_IDB_CACHE_RESET_VERSION = 4;
+
+export const CHAT_IDB_VERSION = 4;
+export const CHAT_MESSAGES_STORE = "chat_messages";
+export const CHAT_THREAD_META_STORE = "chat_thread_agents";
+
+function createChatMessagesStore(db: IDBPDatabase): void {
+  const store = db.createObjectStore(CHAT_MESSAGES_STORE, { keyPath: "id" });
+  store.createIndex("byThreadAndTime", ["threadId", "createdAt"]);
+}
+
+function createThreadMetaStore(db: IDBPDatabase): void {
+  db.createObjectStore(CHAT_THREAD_META_STORE, { keyPath: "threadId" });
+}
+
+export function upgradeChatIdb(db: IDBPDatabase, oldVersion: number): void {
+  if (oldVersion < CHAT_IDB_CACHE_RESET_VERSION) {
+    if (db.objectStoreNames.contains(CHAT_MESSAGES_STORE)) {
+      db.deleteObjectStore(CHAT_MESSAGES_STORE);
+    }
+    if (db.objectStoreNames.contains(CHAT_THREAD_META_STORE)) {
+      db.deleteObjectStore(CHAT_THREAD_META_STORE);
+    }
+  }
+
+  if (!db.objectStoreNames.contains(CHAT_MESSAGES_STORE)) {
+    createChatMessagesStore(db);
+  }
+  if (!db.objectStoreNames.contains(CHAT_THREAD_META_STORE)) {
+    createThreadMetaStore(db);
+  }
+}

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -4,10 +4,13 @@ import {
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { logger } from "../log.ts";
+import {
+  CHAT_IDB_VERSION,
+  CHAT_MESSAGES_STORE,
+  upgradeChatIdb,
+} from "./chat-idb-schema.ts";
 
 const L = logger("ChatIdbCache");
-
-const DB_VERSION = 3;
 
 interface ChatMessageReadStore {
   readLatest(
@@ -61,7 +64,7 @@ function validateMessage(raw: unknown): PagedChatMessage {
 
 function createIdbMessageStores(userId: string, orgId: string) {
   const dbName = `vm0-chat-${userId}-${orgId}`;
-  const storeName = "chat_messages";
+  const storeName = CHAT_MESSAGES_STORE;
 
   let dbPromise: Promise<IDBPDatabase> | null = null;
 
@@ -72,16 +75,10 @@ function createIdbMessageStores(userId: string, orgId: string) {
       // the same DB at the same version. The upgrade callback creates every store
       // the schema currently defines, idempotently, so whichever module
       // triggers the version bump leaves a complete schema for the other.
-      dbPromise = openDB(dbName, DB_VERSION, {
-        upgrade(db) {
+      dbPromise = openDB(dbName, CHAT_IDB_VERSION, {
+        upgrade(db, oldVersion) {
           L.debug("openDB:upgrade", { dbName, storeName });
-          if (!db.objectStoreNames.contains(storeName)) {
-            const store = db.createObjectStore(storeName, { keyPath: "id" });
-            store.createIndex("byThreadAndTime", ["threadId", "createdAt"]);
-          }
-          if (!db.objectStoreNames.contains("chat_thread_agents")) {
-            db.createObjectStore("chat_thread_agents", { keyPath: "threadId" });
-          }
+          upgradeChatIdb(db, oldVersion);
         },
       });
     }

--- a/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
@@ -1,6 +1,11 @@
 import { openDB, type IDBPDatabase } from "idb";
 import { nowDate } from "../../lib/time.ts";
 import { logger } from "../log.ts";
+import {
+  CHAT_IDB_VERSION,
+  CHAT_THREAD_META_STORE,
+  upgradeChatIdb,
+} from "./chat-idb-schema.ts";
 
 const L = logger("ChatIdbThreadMeta");
 
@@ -41,9 +46,7 @@ function isThreadMetaRow(raw: unknown): raw is ThreadMetaRow {
 // IDB store name kept as `chat_thread_agents` for backward compatibility with
 // existing v2 databases. The row schema is forward-compatible: older rows
 // without `startMessageId` are still valid; new fields default to undefined.
-const STORE = "chat_thread_agents";
-const MESSAGE_STORE = "chat_messages";
-const DB_VERSION = 3;
+const STORE = CHAT_THREAD_META_STORE;
 
 const getDb = (() => {
   const cache: Record<string, Promise<IDBPDatabase>> = {};
@@ -54,21 +57,10 @@ const getDb = (() => {
       return existing;
     }
     L.debug("openDB", { dbName });
-    const promise = openDB(dbName, DB_VERSION, {
-      upgrade(db) {
+    const promise = openDB(dbName, CHAT_IDB_VERSION, {
+      upgrade(db, oldVersion) {
         L.debug("openDB:upgrade", { dbName });
-        if (!db.objectStoreNames.contains(MESSAGE_STORE)) {
-          const messageStore = db.createObjectStore(MESSAGE_STORE, {
-            keyPath: "id",
-          });
-          messageStore.createIndex("byThreadAndTime", [
-            "threadId",
-            "createdAt",
-          ]);
-        }
-        if (!db.objectStoreNames.contains(STORE)) {
-          db.createObjectStore(STORE, { keyPath: "threadId" });
-        }
+        upgradeChatIdb(db, oldVersion);
       },
     });
     cache[dbName] = promise;


### PR DESCRIPTION
## Summary

- add a shared chat IndexedDB schema/version helper for platform chat caches
- bump the chat cache DB to v4 and clear/recreate `chat_messages` plus `chat_thread_agents` so stale cached `schedule*` messages cannot break the new `automation*` schema
- cover the v3-to-v4 cache reset path with a targeted unit test

Fixes #17593

## Tests

- `pnpm exec prettier --write apps/platform/src/signals/external/chat-idb-schema.ts apps/platform/src/signals/external/chat-idb-schema.test.ts apps/platform/src/signals/external/idb-message-store.ts apps/platform/src/signals/external/idb-thread-meta-store.ts`
- `pnpm -F @vm0/app exec vitest run src/signals/external/chat-idb-schema.test.ts`
- `pnpm -F @vm0/app check-types`