### PR TITLE
fix: seed deepseek dev api key

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -248,6 +248,7 @@ DEV_MODEL_OPENAI_KEY=op://Development/openai/OPENAI_API_KEY
 DEV_MODEL_MOONSHOT_KEY=op://Development/moonshot/DEV_MODEL_MOONSHOT_KEY
 DEV_MODEL_ZAI_KEY=op://Development/z.ai/DEV_MODEL_ZAI_KEY
 DEV_MODEL_MINIMAX_KEY=op://Development/minimax/DEV_MODEL_MINIMAX_KEY
+DEV_MODEL_DEEPSEEK_KEY=op://Development/deepseek/DEEPSEEK_LOCAL_DEV_KEY
 
 # Optional: Gemini Developer API key (for /api/generate-image in local dev).
 # Production uses Vertex AI via OIDC federation; see GCP_* vars injected by CI.

--- a/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { buildVm0ApiKeys } from "../dev-seed";
+
+function readEnvFrom(
+  values: Readonly<Record<string, string | undefined>>,
+): (name: string) => string | undefined {
+  return (name) => {
+    return values[name];
+  };
+}
+
+function buildDeepSeekKeys(
+  values: Readonly<Record<string, string | undefined>>,
+): ReturnType<typeof buildVm0ApiKeys> {
+  return buildVm0ApiKeys(readEnvFrom(values), () => {
+    // Suppress expected skip logs for vendors that are not configured in tests.
+  }).filter((key) => {
+    return key.vendor === "deepseek";
+  });
+}
+
+describe("buildVm0ApiKeys", () => {
+  it("builds DeepSeek dev seed rows from DEV_MODEL_DEEPSEEK_KEY", () => {
+    const deepSeekKeys = buildDeepSeekKeys({
+      DEV_MODEL_DEEPSEEK_KEY: "dev-deepseek-key",
+      DEEPSEEK_API_KEY: "provider-deepseek-key",
+    });
+
+    expect(deepSeekKeys.length).toBeGreaterThan(0);
+    expect(deepSeekKeys).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          apiKey: "dev-deepseek-key",
+          label: "dev-seed",
+          model: "deepseek-v4-pro",
+          vendor: "deepseek",
+        }),
+      ]),
+    );
+    expect(
+      new Set(
+        deepSeekKeys.map((key) => {
+          return key.apiKey;
+        }),
+      ),
+    ).toStrictEqual(new Set(["dev-deepseek-key"]));
+  });
+
+  it("falls back to DEEPSEEK_API_KEY for DeepSeek dev seed rows", () => {
+    const deepSeekKeys = buildDeepSeekKeys({
+      DEV_MODEL_DEEPSEEK_KEY: "",
+      DEEPSEEK_API_KEY: "provider-deepseek-key",
+    });
+
+    expect(deepSeekKeys.length).toBeGreaterThan(0);
+    expect(deepSeekKeys).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          apiKey: "provider-deepseek-key",
+          label: "dev-seed",
+          model: "deepseek-v4-pro",
+          vendor: "deepseek",
+        }),
+      ]),
+    );
+    expect(
+      new Set(
+        deepSeekKeys.map((key) => {
+          return key.apiKey;
+        }),
+      ),
+    ).toStrictEqual(new Set(["provider-deepseek-key"]));
+  });
+});

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -34,6 +34,7 @@ function writeLine(message: string): void {
  *   DEV_MODEL_{VENDOR_UPPER}_KEY (e.g., DEV_MODEL_ANTHROPIC_KEY, DEV_MODEL_OPENAI_KEY)
  * OpenAI also falls back to OPENAI_API_KEY because local dev already uses it
  * for platform OpenAI features.
+ * DeepSeek also falls back to DEEPSEEK_API_KEY to match the provider secret name.
  */
 
 /** 1 USD = 1000 credits */
@@ -399,6 +400,17 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
   ]),
 ];
 
+function getVendorApiKeyEnvVars(vendor: string): string[] {
+  const envVar = `DEV_MODEL_${vendor.toUpperCase()}_KEY`;
+  if (vendor === "openai") {
+    return [envVar, "OPENAI_API_KEY"];
+  }
+  if (vendor === "deepseek") {
+    return [envVar, "DEEPSEEK_API_KEY"];
+  }
+  return [envVar];
+}
+
 /**
  * Build vm0_api_keys entries from environment variables.
  * Vendor-to-model mapping is derived from VM0_MODEL_TO_PROVIDER
@@ -415,8 +427,7 @@ function buildVm0ApiKeys(): (typeof vm0ApiKeys.$inferInsert)[] {
 
   const keys: (typeof vm0ApiKeys.$inferInsert)[] = [];
   for (const [vendor, models] of vendorModels) {
-    const envVar = `DEV_MODEL_${vendor.toUpperCase()}_KEY`;
-    const envVars = vendor === "openai" ? [envVar, "OPENAI_API_KEY"] : [envVar];
+    const envVars = getVendorApiKeyEnvVars(vendor);
     const apiKey = envVars
       .map((name) => {
         return optionalEnv(name);

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env tsx
 
+import { pathToFileURL } from "node:url";
+
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-providers";
 import { resolveSkillRef } from "@vm0/core/github-url";
@@ -411,12 +413,18 @@ function getVendorApiKeyEnvVars(vendor: string): string[] {
   return [envVar];
 }
 
+type OptionalEnvReader = (name: string) => string | undefined;
+type LineWriter = (message: string) => void;
+
 /**
  * Build vm0_api_keys entries from environment variables.
  * Vendor-to-model mapping is derived from VM0_MODEL_TO_PROVIDER
  * so new models are automatically picked up.
  */
-function buildVm0ApiKeys(): (typeof vm0ApiKeys.$inferInsert)[] {
+export function buildVm0ApiKeys(
+  readEnv: OptionalEnvReader = optionalEnv,
+  logLine: LineWriter = writeLine,
+): (typeof vm0ApiKeys.$inferInsert)[] {
   // Group models by vendor from the canonical mapping
   const vendorModels = new Map<string, string[]>();
   for (const [model, { vendor }] of Object.entries(VM0_MODEL_TO_PROVIDER)) {
@@ -430,15 +438,13 @@ function buildVm0ApiKeys(): (typeof vm0ApiKeys.$inferInsert)[] {
     const envVars = getVendorApiKeyEnvVars(vendor);
     const apiKey = envVars
       .map((name) => {
-        return optionalEnv(name);
+        return readEnv(name);
       })
       .find((value): value is string => {
         return typeof value === "string" && value.length > 0;
       });
     if (!apiKey) {
-      writeLine(
-        `Skipping ${vendor}: ${envVars.join(" or ")} is not configured`,
-      );
+      logLine(`Skipping ${vendor}: ${envVars.join(" or ")} is not configured`);
       continue;
     }
     for (const model of models) {
@@ -559,8 +565,22 @@ async function devSeed() {
   }
 }
 
-const result = await settle(devSeed());
-await closeDbPool();
-if (!result.ok) {
-  throw result.error;
+function isMainModule(): boolean {
+  const entrypoint = process.argv[1];
+  return (
+    entrypoint !== undefined &&
+    import.meta.url === pathToFileURL(entrypoint).href
+  );
+}
+
+async function runDevSeed(): Promise<void> {
+  const result = await settle(devSeed());
+  await closeDbPool();
+  if (!result.ok) {
+    throw result.error;
+  }
+}
+
+if (isMainModule()) {
+  await runDevSeed();
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -795,7 +795,7 @@ describe("Automations API", () => {
                 prompt: "Zombie task",
                 triggerType: "loop" as const,
                 intervalSeconds: 300,
-                enabled: true,
+                enabled: false,
                 nextRunAt: pastDue,
               };
             }),
@@ -816,15 +816,16 @@ describe("Automations API", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const db = store.set(writeDb$);
-    // Flip the first 12 automations off WITHOUT touching their trigger rows:
-    // exactly the historical zombie shape (trigger enabled=true,
-    // next_run_at in the past, automation enabled=false).
+    // Seed zombies disabled, then restore only their trigger state. That avoids
+    // a race window where another test worker's global cron can claim them
+    // before this test has built the historical zombie shape (trigger
+    // enabled=true, next_run_at in the past, automation enabled=false).
     const zombieIds = fixture.automationIds.slice(0, 12);
     const healthyId = fixture.automationIds[12]!;
     await db
-      .update(automations)
-      .set({ enabled: false })
-      .where(inArray(automations.id, [...zombieIds]));
+      .update(automationTriggers)
+      .set({ enabled: true, nextRunAt: pastDue })
+      .where(inArray(automationTriggers.automationId, [...zombieIds]));
 
     const response = await accept(
       cronApi().execute({
@@ -832,8 +833,9 @@ describe("Automations API", () => {
       }),
       [200],
     );
-    // The healthy trigger was claimed and run despite 12 starving zombies.
-    expect(response.body.executed).toBe(1);
+    // The route reports global counts, so assert the local side effect instead:
+    // the healthy trigger was claimed and run despite 12 starving zombies.
+    expect(response.body.success).toBeTruthy();
 
     const [healthyTrigger] = await findTriggerRows(healthyId);
     expect(healthyTrigger?.nextRunAt).toBeNull();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -29,7 +29,6 @@ import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zer
 import {
   cronAggregateInsightsContract,
   cronAggregateUsageContract,
-  cronCleanupSandboxesContract,
   cronExecuteAutomationsContract,
   cronProcessUsageEventsContract,
   cronReconcileBillingEntitlementsContract,
@@ -1586,69 +1585,55 @@ export function createRunsAutomationsApi(context: TestContext) {
       );
     },
 
-    // The email-outbox drain and billing reconciliation crons are deliberately
-    // NOT part of this list: they sweep their work tables globally, so calling
-    // them from other test files would race the email chains
-    // (runs-schedules.bdd.test.ts) and BILL-01 chains (run-lifecycle.bdd.test.ts)
-    // on the shared database, hitting rows whose Resend/Stripe mocks live in
-    // another worker process.
-    async runSafeCronRoutes(validAuth: boolean) {
-      const headers = cronHeaders(validAuth);
-      context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
-        { data: [] },
-      );
+    // Valid cron coverage belongs in the file that owns each global sweep.
+    // This helper only checks auth rejection, so route handlers never scan the
+    // shared test database.
+    async requestSharedCronRoutesWithoutAuth() {
+      const headers = cronHeaders(false);
       const aggregateUsage = await accept(
         setupApp({ context })(cronAggregateUsageContract).aggregate({
           headers,
         }),
-        [200, 401],
+        [401],
       );
       const aggregateInsights = await accept(
         setupApp({ context })(cronAggregateInsightsContract).aggregate({
           headers,
         }),
-        [200, 401],
-      );
-      const cleanupSandboxes = await accept(
-        setupApp({ context })(cronCleanupSandboxesContract).cleanup({
-          headers,
-        }),
-        [200, 401],
+        [401],
       );
       const processUsageEvents = await accept(
         setupApp({ context })(cronProcessUsageEventsContract).process({
           headers,
         }),
-        [200, 401],
+        [401],
       );
       const summarizeMemory = await accept(
         setupApp({ context })(cronSummarizeMemoryContract).summarize({
           headers,
         }),
-        [200, 401],
+        [401],
       );
       const telegramCleanup = await accept(
         setupApp({ context })(cronTelegramCleanupContract).cleanup({
           headers,
         }),
-        [200, 401],
+        [401],
       );
 
       return {
         aggregateUsage,
         aggregateInsights,
-        cleanupSandboxes,
         processUsageEvents,
         summarizeMemory,
         telegramCleanup,
       };
     },
 
-    // Kept out of runSafeCronRoutes for the same shared-database reason as the
-    // email drain: the reconcile sweep retrieves the Stripe subscription of
-    // every org needing reconciliation, and stale orgs created by the BILL-01
-    // chains in run-lifecycle.bdd.test.ts must only be swept by that file's
-    // own Stripe mocks.
+    // Valid reconciliation coverage belongs in its owner file: the sweep
+    // retrieves every org needing reconciliation, and stale orgs created by the
+    // BILL-01 chains in run-lifecycle.bdd.test.ts must only be swept by that
+    // file's own Stripe mocks.
     async reconcileBillingCron(validAuth: boolean) {
       return await accept(
         setupApp({ context })(

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -19,8 +19,8 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
  * plus an unconditional model_usage_observation retention delete), so calling
  * it from any other test file would race this file's far-past observation
  * windows on the shared database — the same single-file-ownership rule as the
- * email drain / billing reconcile / screenshot cleanup crons (see
- * runSafeCronRoutes in helpers/api-bdd-runs-automations.ts).
+ * email drain / billing reconcile / screenshot cleanup crons (see the shared
+ * cron auth helper in helpers/api-bdd-runs-automations.ts).
  *
  * Shared-DB time design: the model-stats chain derives a random far-past UTC
  * day (2003-2009) per run and asserts rankings as baseline+delta, so leftovers

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -50,8 +50,8 @@ import {
  *   which expose the runId. Cron count fields are never asserted strictly
  *   because the cron processes due schedules across all organizations.
  * - SCHED-02 sync-skills valid-path coverage needs a focused external GitHub
- *   tarball/S3 helper; this file keeps cron auth and safe no-work cron routes
- *   route-based without adding that external fixture.
+ *   tarball/S3 helper; this file keeps shared cron auth rejection route-based
+ *   without running valid global sweeps from the wrong owner file.
  */
 
 const context = testContext();
@@ -2004,7 +2004,7 @@ describe("AUTOMATIONS-01: automation lifecycle through the public API", () => {
 });
 
 describe("SCHED-02: cron routes", () => {
-  it("rejects invalid cron auth and accepts safe no-work cron routes with valid auth", async () => {
+  it("rejects invalid cron auth on shared cron routes", async () => {
     const api = createRunsAutomationsApi(context);
 
     const invalidExecute = await api.executeAutomationsCron(false);
@@ -2014,26 +2014,12 @@ describe("SCHED-02: cron routes", () => {
     expectApiError(invalidExecute.body);
     expect(invalidExecute.body.error.code).toBe("UNAUTHORIZED");
 
-    const invalidCronRoutes = await api.runSafeCronRoutes(false);
+    const invalidCronRoutes = await api.requestSharedCronRoutesWithoutAuth();
     expect(
       Object.values(invalidCronRoutes).every((response) => {
         return response.status === 401;
       }),
     ).toBeTruthy();
-
-    context.mocks.axiom.query.mockResolvedValue([]);
-    const validCronRoutes = await api.runSafeCronRoutes(true);
-    expect(
-      Object.values(validCronRoutes).every((response) => {
-        return response.status === 200;
-      }),
-    ).toBeTruthy();
-
-    const execute = await api.executeAutomationsCron(true);
-    if (execute.status !== 200) {
-      throw new Error("Expected execute schedules cron to succeed");
-    }
-    expect(execute.body.success).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary
- add the DeepSeek local dev 1Password key to the API env template
- seed DeepSeek vm0 API keys from `DEV_MODEL_DEEPSEEK_KEY` with `DEEPSEEK_API_KEY` fallback
- keep shared cron auth smoke tests from running valid global sweeps that race API fixtures

## Verification
- `./scripts/sync-env.sh`
- `pnpm -F api db:dev-seed`
- sent `hi` with `deepseek-v4-pro` in the local browser flow and received a completed response
- `pnpm format`
- `pnpm turbo run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm -F api exec vitest src/signals/routes/__tests__/automations.test.ts src/signals/routes/__tests__/runs-schedules.bdd.test.ts`
- `pnpm -F @vm0/db exec vitest src/__tests__/migrations/0418_remove_poor_agent_backend_models.test.ts`
- `pnpm vitest`
- `pnpm knip`
