### PR TITLE
refactor: remove chat recommended followups switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -312,7 +312,6 @@ describe("CHAT-02: completed chat callback", () => {
   it("persists assistant output, reorders threads, titles the thread, recommends follow-ups, notifies, and auto-sends the queued template message", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.proxyChatCallbackToApp();
-    await chatCallbacks.enableChatRecommendedFollowups(actor);
 
     const titlePrompts: string[] = [];
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1499,7 +1499,6 @@ describe("CHAT-02: prior rounds and thread titles", () => {
   it("carries prior completed rounds, generates the thread title, and rejects lifecycle follow-up revokes", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.proxyChatCallbackToApp();
-    await chatCallbacks.enableChatRecommendedFollowups(actor);
     mockOptionalEnv("OPENROUTER_API_KEY", "title-key");
     let upstreamAuthorization: string | null = null;
     let titleRequests = 0;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -2,9 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
 import { pushSubscriptionsContract } from "@vm0/api-contracts/contracts/push-subscriptions";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { z } from "zod";
 
 import { createApp } from "../../../../app-factory";
@@ -107,10 +105,6 @@ function capturedRunContextSnapshot(
 }
 
 export function createChatCallbacksApi(context: TestContext) {
-  function featureSwitchesClient() {
-    return setupApp({ context })(zeroFeatureSwitchesContract);
-  }
-
   function pushSubscriptionsClient() {
     return setupApp({ context })(pushSubscriptionsContract);
   }
@@ -218,18 +212,6 @@ export function createChatCallbacksApi(context: TestContext) {
     disableVapid(): void {
       mockOptionalEnv("VAPID_PUBLIC_KEY", undefined);
       mockOptionalEnv("VAPID_PRIVATE_KEY", undefined);
-    },
-
-    async enableChatRecommendedFollowups(actor: ApiTestUser): Promise<void> {
-      await accept(
-        featureSwitchesClient().update({
-          headers: authenticate(context, actor),
-          body: {
-            switches: { [FeatureSwitchKey.ChatRecommendedFollowups]: true },
-          },
-        }),
-        [200],
-      );
     },
 
     /** Replaces the org model-first policy set through the public route. */

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-chat.ts
@@ -13,8 +13,6 @@ import {
   type ChatMessageGenerationTemplate,
   type ChatMessageRecommendedFollowups,
 } from "@vm0/db/schema/chat-message";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -64,7 +62,6 @@ import {
   generateChatNotificationSummary,
 } from "../services/zero-chat-title.service";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
-import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { settle, tapError } from "../utils";
 import { buildGenerationTemplatePrompt } from "./generation-template-prompt";
 
@@ -536,25 +533,9 @@ async function insertRunLifecycleMarker(args: {
 async function generateRecommendedFollowupsForCompletedRun(args: {
   readonly db: Db;
   readonly threadId: string;
-  readonly orgId: string;
-  readonly userId: string;
   readonly signal: AbortSignal;
 }): Promise<ChatMessageRecommendedFollowups | undefined> {
-  const featureSwitchContext = await loadUserFeatureSwitchContext(
-    args.db,
-    args.orgId,
-    args.userId,
-  );
   args.signal.throwIfAborted();
-  if (
-    !isFeatureEnabled(
-      FeatureSwitchKey.ChatRecommendedFollowups,
-      featureSwitchContext,
-    )
-  ) {
-    return undefined;
-  }
-
   const suggestions = await generateChatThreadRecommendedFollowups({
     db: args.db,
     threadId: args.threadId,
@@ -636,8 +617,6 @@ async function handleCompletedChatCallback(args: {
       await generateRecommendedFollowupsForCompletedRun({
         db: args.db,
         threadId: args.chatThread.chatThreadId,
-        orgId: args.chatThread.orgId,
-        userId: args.chatThread.userId,
         signal: args.signal,
       });
     await insertRunLifecycleMarker({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4098,7 +4098,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${FOLLOWUP_THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatRecommendedFollowups]: true },
     });
 
     await waitFor(() => {
@@ -4190,7 +4189,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${FOLLOWUP_THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatRecommendedFollowups]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3872,12 +3872,7 @@ function ThinkingIndicator({
   const donePhrase = useGet(thread.donePhrase$);
   const latestRunStatus = useLastResolved(thread.latestRunStatus$);
   const isQueued = latestRunStatus === "queued";
-  const features = useLastResolved(featureSwitch$);
-  const recommendedFollowupsEnabled =
-    features?.[FeatureSwitchKey.ChatRecommendedFollowups] ?? false;
-  const recommendedFollowupSource = recommendedFollowupsEnabled
-    ? latestRecommendedFollowups(groups)
-    : null;
+  const recommendedFollowupSource = latestRecommendedFollowups(groups);
   const doneLabel = recommendedFollowupSource ? "Keep going" : donePhrase;
 
   if (

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,7 +54,6 @@ export enum FeatureSwitchKey {
   VideoTemplatePicker = "videoTemplatePicker",
   MemoryViewer = "memoryViewer",
   MemoryDevRefresh = "memoryDevRefresh",
-  ChatRecommendedFollowups = "chatRecommendedFollowups",
   ChatRunUsage = "chatRunUsage",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -103,9 +103,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
-      true,
-    );
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -114,9 +111,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatRecommendedFollowups]).toBe(
-      true,
-    );
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -302,12 +302,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatRecommendedFollowups]: {
-    maintainer: "linghan@vm0.ai",
-    description:
-      "Generate and show recommended follow-up prompts after completed chat runs.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ChatRunUsage]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the `ChatRecommendedFollowups` feature switch key and registry entry
- make recommended follow-up generation/display unconditional now that it is GA
- remove test-only feature switch overrides for recommended followups

## Verification
- `pnpm prettier --write ...`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx`

## Notes
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` was attempted after starting and migrating a local Postgres test DB. It fails before callback handling with `Job not found in queue` at runner job claim, which is outside this switch-removal path.