### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -366,16 +366,24 @@ install_packages() {
   rm -rf /var/lib/apt/lists/* /var/cache/apt/*
   '
 
-  # Chromium from Debian Bookworm (Ubuntu 24.04 snap stub does not work).
+  # Chromium from Debian Bookworm security (Ubuntu 24.04 snap stub does not work).
   # Installed separately to avoid cross-distro dependency conflicts.
   sudo chroot "$ROOTFS_DIR" bash -c 'set -e
     export DEBIAN_FRONTEND=noninteractive
-    curl -fsSL https://ftp-master.debian.org/keys/archive-key-12.asc \
+    {
+      curl -fsSL https://ftp-master.debian.org/keys/archive-key-12.asc
+      curl -fsSL https://ftp-master.debian.org/keys/archive-key-12-security.asc
+    } \
       | gpg --dearmor -o /usr/share/keyrings/debian-bookworm.gpg
-    echo "deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main" \
-      > /etc/apt/sources.list.d/debian-bookworm.list
+    cat > /etc/apt/sources.list.d/debian-bookworm.list <<EOF
+deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main
+deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://security.debian.org/debian-security bookworm-security main
+EOF
     apt-get update
-    apt-get install -y -t bookworm chromium
+    apt-get install -y -t bookworm \
+      chromium/bookworm-security \
+      chromium-common/bookworm-security \
+      chromium-sandbox/bookworm-security
     rm -f /etc/apt/sources.list.d/debian-bookworm.list \
          /usr/share/keyrings/debian-bookworm.gpg
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*


### PR DESCRIPTION
## Summary
- Updated Chromium to use Debian Bookworm security packages.
- Old: `chromium`, `chromium-common`, and `chromium-sandbox` resolved from Debian `bookworm` main at `147.0.7727.137-1~deb12u1`.
- New: `chromium`, `chromium-common`, and `chromium-sandbox` resolve from Debian `bookworm-security` at `149.0.7827.114-1~deb12u1`.

## Checked and unchanged
- Go: `1.26.4` is the latest stable release.
- Claude Code: `2.1.177` is the latest release.
- Codex CLI: `0.139.0` is the latest release.
- Google Workspace CLI: `0.22.5` is the latest release.
- xurl: `1.0.3` is the latest release.
- agent-browser: `0.27.3` is the latest release.
- pnpm: `11.6.0` is the latest release.
- NodeSource Node.js: `24.x` remains the latest LTS line; newer `25.x` exists but is not LTS.
- PostgreSQL: `18` remains the newest stable PGDG package line for Ubuntu Noble.

## Validation
- `bash -n crates/runner/scripts/build-template.sh`
- APT metadata simulation confirmed `chromium`, `chromium-common`, and `chromium-sandbox` select `149.0.7827.114-1~deb12u1` from `bookworm-security`.