### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -984,9 +984,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "diff"
@@ -3298,12 +3295,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3313,15 +3309,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary

- Ran `cargo update --verbose` in the Rust workspace at `crates/`.
- Updated 3 lockfile packages:
  - `time` `0.3.47` -> `0.3.49`
  - `time-core` `0.1.8` -> `0.1.9`
  - `time-macros` `0.2.27` -> `0.2.29`
- Verified direct `[workspace.dependencies]` entries against registry metadata; all direct workspace dependencies are already at their latest published versions within their declared constraints.

## Dependencies not updated

- `generic-array` remains at `0.14.7` even though `0.14.9` is available.
  - Reason: it is pinned by transitive dependency `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"`.
  - Dependency path: `crypto-common` -> `digest` -> `crc-fast` -> `aws-smithy-checksums` -> `aws-sdk-s3` -> `runner`.
  - This is not pinned directly in vm0's `Cargo.toml` files.

## Manual version bumps

- None. No safe minor/patch direct `Cargo.toml` version specifier bumps were available.

## Test status

- `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target cargo test --workspace --jobs 1`
  - Local automation run failed before a clean full-workspace result because of environment constraints:
    - default parallel link initially hit `ld terminated with signal 9 [Killed]` for the large `runner` test binary;
    - after `--jobs 1`, the `runner` suite failed under this shell's default tempdir permissions, e.g. temp dirs under `/tmp/.tmp...` were `group/other writable without the sticky bit`.
- Follow-up validation passed with local resource/security workarounds:
  - `runner` test executable rerun under `umask 077 --test-threads=1`: `1826 passed; 0 failed; 1 ignored`.
  - `(umask 077 && CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target-small CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test --workspace --exclude runner --jobs 1)`: passed for all non-`runner` workspace tests and doctests.
