### PR TITLE
fix: avoid keyboard safe area gap

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -343,7 +343,7 @@
     />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <script>
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import indexHtml from "../../../../index.html?raw";
+
+function getViewportDirectives(): string[] {
+  const match = /<meta\s+name="viewport"\s+content="([^"]+)"/.exec(indexHtml);
+  return (
+    match?.[1].split(",").map((directive) => {
+      return directive.trim();
+    }) ?? []
+  );
+}
+
+function readGlobalCss(): string {
+  return readFileSync(
+    join(process.cwd(), "apps/platform/src/views/css/index.css"),
+    "utf8",
+  );
+}
+
+describe("platform entrypoint safe area behavior", () => {
+  it("keeps the viewport hints needed for iOS keyboard resizing", () => {
+    expect(getViewportDirectives()).toStrictEqual(
+      expect.arrayContaining([
+        "viewport-fit=cover",
+        "interactive-widget=resizes-content",
+      ]),
+    );
+  });
+
+  it("suppresses the bottom safe-area inset while text entry is focused", () => {
+    const globalCss = readGlobalCss();
+
+    expect(globalCss).toMatch(
+      /--sab-raw:\s*env\(safe-area-inset-bottom,\s*0px\);/,
+    );
+    expect(globalCss).toMatch(/--sab:\s*var\(--sab-raw\);/);
+    expect(globalCss).toMatch(
+      /:root:has\([\s\S]*:focus-visible[\s\S]*\)\s*{\s*--sab:\s*0px;\s*}/,
+    );
+    expect(globalCss).toMatch(/bottom:\s*calc\(-1\s*\*\s*var\(--sab\)\);/);
+  });
+});

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -50,8 +50,20 @@
    Use var(--sat) / var(--sab) in components instead of env() directly. */
 :root {
   --sat: env(safe-area-inset-top, 0px);
-  --sab: env(safe-area-inset-bottom, 0px);
+  --sab-raw: env(safe-area-inset-bottom, 0px);
+  --sab: var(--sab-raw);
   --zero-desktop-titlebar-height: 48px;
+}
+
+:root:has(
+  :is(
+    input,
+    textarea,
+    select,
+    [contenteditable]:not([contenteditable="false"])
+  ):focus-visible
+) {
+  --sab: 0px;
 }
 
 .zero-viewport-shell {


### PR DESCRIPTION
## Summary
- add the standard `interactive-widget=resizes-content` viewport hint for supported mobile browsers
- keep the raw bottom safe-area value while routing `--sab` through a focus-aware CSS variable
- suppress bottom safe-area padding while text inputs or contenteditable composer fields are focus-visible to avoid the iOS PWA keyboard gap

## Validation
- `pnpm exec prettier --check apps/platform/index.html apps/platform/src/views/css/index.css`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app build`

Full local vitest was not run per vm0 PR verification preference; CI should cover the broader suite.