### PR TITLE
fix(guest-download): retry transient http body failures

### DIFF
--- a/crates/guest-download/src/archive.rs
+++ b/crates/guest-download/src/archive.rs
@@ -1,11 +1,16 @@
 use crate::LOG_TAG;
 use crate::error::DownloadError;
+use crate::source::{ArchiveSource, HttpBodyReadFailure};
 use guest_common::log_warn;
-use std::io::Read;
+use std::io;
 use std::path::{Component, Path, PathBuf};
 
 /// Extract a gzip-compressed tar archive into `target_path`.
-pub(crate) fn extract_tar_gz(reader: impl Read, target_path: &str) -> Result<(), DownloadError> {
+pub(crate) fn extract_tar_gz(
+    source: ArchiveSource,
+    target_path: &str,
+) -> Result<(), DownloadError> {
+    let (reader, http_body_read_failure) = source.into_parts();
     let decoder = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(decoder);
 
@@ -18,14 +23,15 @@ pub(crate) fn extract_tar_gz(reader: impl Read, target_path: &str) -> Result<(),
 
     for entry in archive
         .entries()
-        .map_err(|e| DownloadError::fatal(format!("Failed to read archive entries: {e}")))?
+        .map_err(|e| archive_error(&http_body_read_failure, "Failed to read archive entries", e))?
     {
-        let mut entry = entry
-            .map_err(|e| DownloadError::fatal(format!("Failed to read archive entry: {e}")))?;
+        let mut entry = entry.map_err(|e| {
+            archive_error(&http_body_read_failure, "Failed to read archive entry", e)
+        })?;
 
         let entry_path = entry
             .path()
-            .map_err(|e| DownloadError::fatal(format!("Failed to read entry path: {e}")))?
+            .map_err(|e| archive_error(&http_body_read_failure, "Failed to read entry path", e))?
             .into_owned();
 
         let entry_type = entry.header().entry_type();
@@ -46,6 +52,13 @@ pub(crate) fn extract_tar_gz(reader: impl Read, target_path: &str) -> Result<(),
         if entry_type.is_symlink() {
             let link_target = match entry.link_name() {
                 Ok(Some(t)) => t,
+                Err(e) if http_body_read_failure.failed() => {
+                    return Err(archive_error(
+                        &http_body_read_failure,
+                        format!("Failed to read symlink target {}", entry_path.display()),
+                        e,
+                    ));
+                }
                 _ => {
                     log_warn!(
                         LOG_TAG,
@@ -72,6 +85,13 @@ pub(crate) fn extract_tar_gz(reader: impl Read, target_path: &str) -> Result<(),
         if entry_type == tar::EntryType::Link {
             let link_name = match entry.link_name() {
                 Ok(Some(t)) => t,
+                Err(e) if http_body_read_failure.failed() => {
+                    return Err(archive_error(
+                        &http_body_read_failure,
+                        format!("Failed to read hardlink source {}", entry_path.display()),
+                        e,
+                    ));
+                }
                 _ => {
                     log_warn!(
                         LOG_TAG,
@@ -111,14 +131,28 @@ pub(crate) fn extract_tar_gz(reader: impl Read, target_path: &str) -> Result<(),
         // archive stream, so no external actor can modify the filesystem between our checks
         // and the extraction below.
         entry.unpack_in(&target).map_err(|e| {
-            DownloadError::fatal(format!(
-                "Failed to extract entry {}: {e}",
-                entry_path.display()
-            ))
+            archive_error(
+                &http_body_read_failure,
+                format!("Failed to extract entry {}", entry_path.display()),
+                e,
+            )
         })?;
     }
 
     Ok(())
+}
+
+fn archive_error(
+    http_body_read_failure: &HttpBodyReadFailure,
+    message: impl Into<String>,
+    error: io::Error,
+) -> DownloadError {
+    let message = format!("{}: {error}", message.into());
+    if http_body_read_failure.failed() {
+        DownloadError::transport(message, true, None)
+    } else {
+        DownloadError::fatal(message)
+    }
 }
 
 /// Lexically normalize a path by collapsing `.` and `..` components.
@@ -295,7 +329,11 @@ mod tests {
 
     fn extract_archive(tar_gz: Vec<u8>, mount: &Path) -> bool {
         std::fs::create_dir_all(mount).unwrap();
-        extract_tar_gz(Cursor::new(tar_gz), mount.to_str().unwrap()).is_ok()
+        extract_tar_gz(
+            ArchiveSource::local(Cursor::new(tar_gz)),
+            mount.to_str().unwrap(),
+        )
+        .is_ok()
     }
 
     #[test]

--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -1,7 +1,10 @@
 use crate::LOG_TAG;
 use crate::error::DownloadError;
 use guest_common::log_info;
+use std::cell::Cell;
+use std::io;
 use std::io::Read;
+use std::rc::Rc;
 use std::sync::LazyLock;
 use std::time::Duration;
 
@@ -26,12 +29,12 @@ static HTTP_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| {
 /// Open the archive byte stream. HTTP is the production path today; `file://`
 /// is used by the runner-side storage cache to feed host-staged tarballs that
 /// were pushed into the guest over vsock.
-pub(crate) fn open_archive(url: &str) -> Result<Box<dyn Read>, DownloadError> {
+pub(crate) fn open_archive(url: &str) -> Result<ArchiveSource, DownloadError> {
     if let Some(path) = url.strip_prefix("file://") {
         log_info!(LOG_TAG, "Reading local archive");
         let file = std::fs::File::open(path)
             .map_err(|e| DownloadError::fatal(format!("Failed to open local archive: {e}")))?;
-        return Ok(Box::new(file));
+        return Ok(ArchiveSource::local(file));
     }
 
     let response = HTTP_AGENT.get(url).call().map_err(|e| {
@@ -46,5 +49,78 @@ pub(crate) fn open_archive(url: &str) -> Result<Box<dyn Read>, DownloadError> {
         };
         DownloadError::transport(message, retriable, status_code)
     })?;
-    Ok(Box::new(response.into_body().into_reader()))
+    Ok(ArchiveSource::http(response.into_body().into_reader()))
+}
+
+pub(crate) struct ArchiveSource {
+    reader: Box<dyn Read>,
+    http_body_read_failure: HttpBodyReadFailure,
+}
+
+impl ArchiveSource {
+    pub(crate) fn local(reader: impl Read + 'static) -> Self {
+        Self {
+            reader: Box::new(reader),
+            http_body_read_failure: HttpBodyReadFailure::disabled(),
+        }
+    }
+
+    fn http(reader: impl Read + 'static) -> Self {
+        let http_body_read_failure = HttpBodyReadFailure::enabled();
+        Self {
+            reader: Box::new(HttpBodyReader {
+                reader,
+                failure: http_body_read_failure.clone(),
+            }),
+            http_body_read_failure,
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (Box<dyn Read>, HttpBodyReadFailure) {
+        (self.reader, self.http_body_read_failure)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct HttpBodyReadFailure {
+    failed: Option<Rc<Cell<bool>>>,
+}
+
+impl HttpBodyReadFailure {
+    fn enabled() -> Self {
+        Self {
+            failed: Some(Rc::new(Cell::new(false))),
+        }
+    }
+
+    fn disabled() -> Self {
+        Self { failed: None }
+    }
+
+    fn mark_failed(&self) {
+        if let Some(failed) = &self.failed {
+            failed.set(true);
+        }
+    }
+
+    pub(crate) fn failed(&self) -> bool {
+        self.failed.as_ref().is_some_and(|failed| failed.get())
+    }
+}
+
+struct HttpBodyReader<R> {
+    reader: R,
+    failure: HttpBodyReadFailure,
+}
+
+impl<R: Read> Read for HttpBodyReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        match self.reader.read(buffer) {
+            Ok(bytes_read) => Ok(bytes_read),
+            Err(e) => {
+                self.failure.mark_failed();
+                Err(e)
+            }
+        }
+    }
 }

--- a/crates/guest-download/tests/integration/download.rs
+++ b/crates/guest-download/tests/integration/download.rs
@@ -2,6 +2,86 @@ use crate::support::{
     TarEntry, create_tar_gz, create_tar_gz_entries, run_guest_download, write_manifest,
 };
 use httpmock::prelude::*;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+fn start_truncated_then_valid_server(
+    archive: Vec<u8>,
+) -> std::io::Result<(String, thread::JoinHandle<std::io::Result<usize>>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let base_url = format!("http://{}", listener.local_addr()?);
+    let partial_len = (archive.len() / 2).max(1);
+    let partial_archive: Vec<u8> = archive.iter().copied().take(partial_len).collect();
+
+    let handle = thread::spawn(move || -> std::io::Result<usize> {
+        let mut storage_requests = 0;
+        loop {
+            let (mut stream, _) = listener.accept()?;
+            let path = read_request_path(&mut stream)?;
+            if path == "/__unblock" {
+                write_response(&mut stream, &[], 0)?;
+                break;
+            } else if path == "/storage.tar.gz" {
+                if storage_requests == 0 {
+                    write_response(&mut stream, &partial_archive, archive.len())?;
+                } else {
+                    write_response(&mut stream, &archive, archive.len())?;
+                }
+                storage_requests += 1;
+                if storage_requests == 2 {
+                    break;
+                }
+            } else {
+                write_response(&mut stream, &[], 0)?;
+            }
+        }
+        Ok(storage_requests)
+    });
+
+    Ok((base_url, handle))
+}
+
+fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 512];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let bytes_read = stream.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        request.extend(buffer.iter().take(bytes_read).copied());
+    }
+
+    let request = String::from_utf8_lossy(&request);
+    Ok(request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or_default()
+        .to_owned())
+}
+
+fn write_response(
+    stream: &mut TcpStream,
+    body: &[u8],
+    content_length: usize,
+) -> std::io::Result<()> {
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/gzip\r\ncontent-length: {content_length}\r\nconnection: close\r\n\r\n"
+    );
+    stream.write_all(headers.as_bytes())?;
+    stream.write_all(body)?;
+    stream.flush()
+}
+
+fn unblock_server(base_url: &str) -> std::io::Result<()> {
+    let Some(address) = base_url.strip_prefix("http://") else {
+        return Ok(());
+    };
+    let mut stream = TcpStream::connect(address)?;
+    stream.write_all(b"GET /__unblock HTTP/1.1\r\nhost: localhost\r\nconnection: close\r\n\r\n")
+}
 
 // ---------------------------------------------------------------------------
 // Test 1: single storage download succeeds
@@ -351,6 +431,28 @@ fn invalid_tar_gz_non_retriable() {
 
     assert!(!result);
     mock.assert_calls(1);
+}
+
+#[test]
+fn http_body_read_error_retries_then_succeeds() {
+    let tar_gz = create_tar_gz(&[("recovered.txt", b"recovered")]).unwrap();
+    let (base_url, server) = start_truncated_then_valid_server(tar_gz).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = format!("{base_url}/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = run_guest_download(manifest.to_str().unwrap());
+    let _ = unblock_server(&base_url);
+    let storage_requests = server.join().unwrap().unwrap();
+
+    assert!(result);
+    assert_eq!(storage_requests, 2);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("recovered.txt")).unwrap(),
+        "recovered"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Track HTTP response-body read failures while streaming guest-download archives.
- Classify gzip/tar extraction errors as retriable only when an HTTP body read error was observed during that extraction attempt.
- Keep malformed archives and `file://` staged archive failures non-retriable.
- Add an integration test for a truncated HTTP response followed by a successful retry.

Closes #17614

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-download http_body_read_error_retries_then_succeeds`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download invalid_tar_gz_non_retriable`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download --test integration file_scheme`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo fmt --all --check` from `crates/`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets --all-features`
