### PR TITLE
fix: lock pwa root viewport

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -446,12 +446,37 @@
     </script>
     <div id="root">
       <style>
+        :root {
+          --zero-viewport-height: 100dvh;
+        }
+        @supports (height: 100lvh) {
+          @media (display-mode: standalone) {
+            :root {
+              --zero-viewport-height: 100lvh;
+            }
+          }
+        }
+        html,
         body {
           margin: 0;
         }
+        html,
+        body,
+        #root {
+          width: 100%;
+          height: var(--zero-viewport-height);
+          min-height: var(--zero-viewport-height);
+          overflow: hidden;
+        }
+        #root {
+          position: fixed;
+          top: 0;
+          right: 0;
+          left: 0;
+        }
         .sk {
-          height: 100dvh;
-          min-height: 100dvh;
+          height: var(--zero-viewport-height);
+          min-height: var(--zero-viewport-height);
           background: #fdfdfe;
         }
         [data-theme="dark"] .sk {

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -15,10 +15,17 @@ function getViewportDirectives(): string[] {
 }
 
 function readGlobalCss(): string {
-  return readFileSync(
+  const candidates = [
+    join(process.cwd(), "src/views/css/index.css"),
     join(process.cwd(), "apps/platform/src/views/css/index.css"),
-    "utf8",
-  );
+  ];
+  const path = candidates.find((candidate) => {
+    return existsSync(candidate);
+  });
+  if (path === undefined) {
+    throw new Error("Unable to locate platform global CSS");
+  }
+  return readFileSync(path, "utf8");
 }
 
 describe("platform entrypoint safe area behavior", () => {
@@ -28,6 +35,12 @@ describe("platform entrypoint safe area behavior", () => {
         "viewport-fit=cover",
         "interactive-widget=resizes-content",
       ]),
+    );
+
+    expect(indexHtml).toMatch(/--zero-viewport-height:\s*100dvh;/);
+    expect(indexHtml).toMatch(/--zero-viewport-height:\s*100lvh;/);
+    expect(indexHtml).toMatch(
+      /\.sk\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);/,
     );
   });
 
@@ -42,5 +55,24 @@ describe("platform entrypoint safe area behavior", () => {
       /:root:has\([\s\S]*:focus-visible[\s\S]*\)\s*{\s*--sab:\s*0px;\s*}/,
     );
     expect(globalCss).toMatch(/bottom:\s*calc\(-1\s*\*\s*var\(--sab\)\);/);
+  });
+
+  it("keeps the app shell out of page-level scrolling in standalone PWA mode", () => {
+    const globalCss = readGlobalCss();
+
+    expect(globalCss).toMatch(/--zero-viewport-height:\s*100dvh;/);
+    expect(globalCss).toMatch(/--zero-viewport-height:\s*100lvh;/);
+    expect(globalCss).toMatch(
+      /:root:has\([\s\S]*:focus-visible[\s\S]*\)\s*{\s*--zero-viewport-height:\s*100dvh;\s*}/,
+    );
+    expect(globalCss).toMatch(
+      /html,\s*body,\s*#root\s*{[\s\S]*overflow:\s*hidden;[\s\S]*overscroll-behavior:\s*none;/,
+    );
+    expect(globalCss).toMatch(
+      /#root\s*{[\s\S]*position:\s*fixed;[\s\S]*top:\s*0;[\s\S]*right:\s*0;[\s\S]*left:\s*0;/,
+    );
+    expect(globalCss).toMatch(
+      /\.zero-viewport-shell\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);[\s\S]*max-height:\s*var\(--zero-viewport-height\);[\s\S]*overflow:\s*hidden;/,
+    );
   });
 });

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -52,7 +52,16 @@
   --sat: env(safe-area-inset-top, 0px);
   --sab-raw: env(safe-area-inset-bottom, 0px);
   --sab: var(--sab-raw);
+  --zero-viewport-height: 100dvh;
   --zero-desktop-titlebar-height: 48px;
+}
+
+@supports (height: 100lvh) {
+  @media (display-mode: standalone) {
+    :root {
+      --zero-viewport-height: 100lvh;
+    }
+  }
 }
 
 :root:has(
@@ -66,9 +75,47 @@
   --sab: 0px;
 }
 
+@supports (height: 100lvh) {
+  @media (display-mode: standalone) {
+    :root:has(
+      :is(
+        input,
+        textarea,
+        select,
+        [contenteditable]:not([contenteditable="false"])
+      ):focus-visible
+    ) {
+      --zero-viewport-height: 100dvh;
+    }
+  }
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: var(--zero-viewport-height);
+  min-height: var(--zero-viewport-height);
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+body {
+  margin: 0;
+}
+
+#root {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+}
+
 .zero-viewport-shell {
-  height: 100dvh;
-  min-height: 100dvh;
+  height: var(--zero-viewport-height);
+  min-height: var(--zero-viewport-height);
+  max-height: var(--zero-viewport-height);
+  overflow: hidden;
 }
 
 @media (display-mode: standalone) {


### PR DESCRIPTION
## Summary
- follow up #17618 by moving the mobile PWA viewport fix to the root shell contract
- use stable `100lvh` for standalone PWA layout when text entry is not focused, then switch back to `100dvh` while text inputs/contenteditable fields are focus-visible
- lock `html`, `body`, and `#root` out of page-level scrolling so iOS keyboard focus does not leave the app offset after the keyboard closes
- update the entrypoint safe-area test to cover the root viewport contract and make the CSS fixture lookup work from either workspace or package cwd

## Validation
- `pnpm exec prettier --check apps/platform/index.html apps/platform/src/views/css/index.css apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app build`

I could not reproduce the exact iOS standalone PWA keyboard sequence locally in this runtime; this PR is based on the screenshot sequence showing body/viewport offset retention after keyboard dismissal.