### PR TITLE
perf(runner): move workspace cache hits into sandboxes

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -34,7 +34,7 @@ use super::support::{
     test_device_rate_limits, test_executor_config, test_telemetry,
 };
 use crate::ids::RunId;
-use crate::paths::RunnerPaths;
+use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
 use crate::types::{ResumeSession, SandboxReuseResult};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
@@ -825,7 +825,9 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
         configs[0].workspace_drive,
         Some(sandbox::WorkspaceDriveConfig {
             size_mb: 16,
-            seed_image: Some(expected_seed.clone()),
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
+                expected_seed.clone(),
+            )),
         })
     );
     assert_eq!(
@@ -887,7 +889,7 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
         configs[0].workspace_drive,
         Some(sandbox::WorkspaceDriveConfig {
             size_mb: 16,
-            seed_image: Some(seeded_cache),
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(seeded_cache)),
         })
     );
 }
@@ -1722,10 +1724,24 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
         ..default_params()
     };
     let session_id = "sess-cache-unconfigured-reuse-invalidate-error";
-    let (idle_sandbox, current_image, overrides) =
-        reusable_idle_sandbox_with_workspace_promotion(&cache, &runner_paths, &params, session_id)
-            .await;
-    tokio::fs::remove_file(&current_image).await.unwrap();
+    let (idle_sandbox, overrides) = reusable_idle_sandbox_with_unlocked_workspace_promotion(
+        &cache,
+        &runner_paths,
+        &params,
+        session_id,
+    )
+    .await;
+    let cache_key = scoped_session_workspace_cache_key(
+        "",
+        &params.profile_name,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        u64::from(params.workspace_disk_mb) * 1024 * 1024,
+    );
+    let current_image = runner_paths.session_workspace_cache_current_image(&cache_key);
+    tokio::fs::create_dir_all(current_image.parent().unwrap())
+        .await
+        .unwrap();
     tokio::fs::create_dir(&current_image).await.unwrap();
 
     let mut ctx = minimal_context();

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -4,7 +4,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
 
 use crate::ids::RunId;
-use crate::paths::RunnerPaths;
+use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
     WorkspaceImagePrepareRequest,
@@ -55,22 +55,12 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
     );
     drop(lease);
 
-    let hit = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default",
-            session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
-            workspace_drive_required: true,
-        })
-        .await;
-    assert_eq!(hit.result(), WorkspaceCacheCheckoutResult::Hit);
-    let seed = hit
-        .workspace_drive_config()
-        .and_then(|config| config.seed_image)
-        .expect("seeded workspace cache should produce a seed image");
-    drop(hit);
-    seed
+    let cache_key = scoped_session_workspace_cache_key(
+        "",
+        "vm0/default",
+        session_id,
+        CANONICAL_WORKING_DIR,
+        u64::from(workspace_disk_mb) * 1024 * 1024,
+    );
+    runner_paths.session_workspace_cache_current_image(&cache_key)
 }

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -160,7 +160,6 @@ struct WorkspaceImagePromotionInput<'a> {
     working_dir: &'a str,
     active_image: &'a Path,
     image_size_bytes: u64,
-    consumed_cache_hit: bool,
     terminal_status: WorkspaceCacheTerminalStatus,
     completed_at: &'a str,
     storage_fingerprints: &'a StorageFingerprints,
@@ -1704,7 +1703,7 @@ impl SessionWorkspaceCache {
 
         let mut stats = self.fs_stats().await?;
         let mut budget = CacheBudget::from_fs_stats(stats);
-        if !input.consumed_cache_hit && stats.available_bytes < budget.min_free_bytes {
+        if stats.available_bytes < budget.min_free_bytes {
             match self.gc_locked(false).await {
                 Ok(freed) if freed > 0 => {
                     stats = self.fs_stats().await?;
@@ -1719,7 +1718,7 @@ impl SessionWorkspaceCache {
                 ),
             }
         }
-        if !input.consumed_cache_hit && stats.available_bytes < budget.min_free_bytes {
+        if stats.available_bytes < budget.min_free_bytes {
             info!(
                 run_id = %input.run_id,
                 cache_key = input.cache_key,
@@ -1739,16 +1738,6 @@ impl SessionWorkspaceCache {
             );
             return Ok(false);
         }
-        if input.consumed_cache_hit && image_metadata.len() != input.image_size_bytes {
-            info!(
-                run_id = %input.run_id,
-                cache_key = input.cache_key,
-                actual_image_size_bytes = image_metadata.len(),
-                expected_image_size_bytes = input.image_size_bytes,
-                "workspace image cache promotion skipped because active image size does not match cache key"
-            );
-            return Ok(false);
-        }
         let active_allocated = allocated_bytes(&image_metadata);
         if active_allocated > budget.max_entry_bytes {
             info!(
@@ -1759,95 +1748,6 @@ impl SessionWorkspaceCache {
                 "workspace image cache promotion skipped because image is too large"
             );
             return Ok(false);
-        }
-        if input.consumed_cache_hit {
-            ensure_workspace_cache_entry_dir(&cache_dir).await?;
-            let current = self.session_workspace_cache_current_image(input.cache_key);
-            remove_workspace_cache_path_if_exists(&current).await?;
-            if let Err(e) = std::fs::rename(input.active_image, &current) {
-                return Err(e.into());
-            }
-            let current_metadata = match fs::symlink_metadata(&current).await {
-                Ok(metadata) => metadata,
-                Err(e) => {
-                    let _ = remove_workspace_cache_path_if_exists(&current).await;
-                    return Err(e.into());
-                }
-            };
-            if !current_metadata.is_file() {
-                let _ = remove_workspace_cache_path_if_exists(&current).await;
-                return Err(RunnerError::Internal(format!(
-                    "workspace image cache current image is not a file: {}",
-                    current.display()
-                )));
-            }
-            let logical_image_size_bytes = current_metadata.len();
-            if logical_image_size_bytes != input.image_size_bytes {
-                let _ = remove_workspace_cache_path_if_exists(&current).await;
-                info!(
-                    run_id = %input.run_id,
-                    cache_key = input.cache_key,
-                    actual_image_size_bytes = logical_image_size_bytes,
-                    expected_image_size_bytes = input.image_size_bytes,
-                    "workspace image cache promotion skipped because moved image size does not match cache key"
-                );
-                return Ok(false);
-            }
-            let allocated = allocated_bytes(&current_metadata);
-            if allocated > budget.max_entry_bytes {
-                let _ = remove_workspace_cache_path_if_exists(&current).await;
-                info!(
-                    run_id = %input.run_id,
-                    cache_key = input.cache_key,
-                    allocated_bytes = allocated,
-                    max_entry_bytes = budget.max_entry_bytes,
-                    "workspace image cache promotion skipped because moved image is too large"
-                );
-                return Ok(false);
-            }
-            let metadata = WorkspaceCacheMetadata {
-                format_version: CACHE_FORMAT_VERSION,
-                key_version: CACHE_KEY_VERSION,
-                cache_scope: self.inner.cache_scope.clone(),
-                profile_name: input.profile_name.to_owned(),
-                session_id: input.session_id.to_owned(),
-                working_dir: input.working_dir.to_owned(),
-                last_completed_at: input.completed_at.to_owned(),
-                last_used_at: local_timestamp(),
-                last_terminal_status: input.terminal_status,
-                workspace_trust: WorkspaceTrust::Clean,
-                logical_image_size_bytes,
-                allocated_bytes: allocated,
-                current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
-                drive_layout: WORKSPACE_DRIVE_LAYOUT.to_owned(),
-                storage_fingerprints: filter_storage_fingerprints_for_working_dir(
-                    input.storage_fingerprints,
-                    input.working_dir,
-                ),
-                state: WorkspaceCacheState::Current,
-            };
-            if let Err(e) = self
-                .write_metadata(input.cache_key, input.run_id, metadata)
-                .await
-            {
-                let _ = remove_workspace_cache_path_if_exists(&current).await;
-                return Err(e);
-            }
-            info!(
-                run_id = %input.run_id,
-                cache_key = input.cache_key,
-                allocated_bytes = allocated,
-                "workspace image cache promoted by moving active image"
-            );
-            if let Err(e) = self.gc_locked(false).await {
-                warn!(
-                    run_id = %input.run_id,
-                    cache_key = input.cache_key,
-                    error = %e,
-                    "workspace image cache GC failed after promotion"
-                );
-            }
-            return Ok(true);
         }
         if !has_copy_headroom(stats, budget, active_allocated) {
             match self.gc_locked(false).await {
@@ -2240,7 +2140,6 @@ impl WorkspaceImageLease {
                 working_dir: &self.working_dir,
                 active_image: &self.active_image,
                 image_size_bytes: self.image_size_bytes,
-                consumed_cache_hit: self.consumed_cache_hit,
                 terminal_status,
                 completed_at: &completed_at,
                 storage_fingerprints,
@@ -2359,7 +2258,6 @@ impl WorkspaceImagePromotionContext {
                 working_dir: &self.working_dir,
                 active_image: &self.active_image,
                 image_size_bytes: self.image_size_bytes,
-                consumed_cache_hit: self.consumed_cache_hit,
                 terminal_status: self.terminal_status,
                 completed_at: &self.completed_at,
                 storage_fingerprints: promotion_storage_fingerprints,
@@ -4271,7 +4169,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
+    async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -4323,8 +4221,15 @@ mod tests {
                 .unwrap()
         );
 
-        assert!(!active_image.exists());
+        assert_eq!(fs::read(&active_image).await.unwrap(), updated);
         assert_eq!(fs::read(&current).await.unwrap(), updated);
+        let active_metadata = fs::metadata(&active_image).await.unwrap();
+        let current_metadata = fs::metadata(&current).await.unwrap();
+        assert_ne!(
+            (active_metadata.dev(), active_metadata.ino()),
+            (current_metadata.dev(), current_metadata.ino()),
+            "published cache image must not share an inode with a sandbox that has not been destroyed yet"
+        );
         let metadata = cache
             .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
             .await
@@ -5405,7 +5310,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            lease
+            !lease
                 .promote(
                     run_id,
                     None,
@@ -5415,9 +5320,12 @@ mod tests {
                 )
                 .await
                 .unwrap(),
-            "consumed cache hit promotion should move the active image back without copy headroom"
+            "checkout does not need copy headroom, but publishing an independent cache copy still does"
         );
-        assert!(tokio::fs::try_exists(&current).await.unwrap());
+        assert!(
+            !tokio::fs::try_exists(&current).await.unwrap(),
+            "failed copy promotion must not publish reusable metadata for the consumed cache hit"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -704,71 +704,6 @@ impl SessionWorkspaceCache {
             .await
         {
             Ok(Some(metadata)) => {
-                if !has_copy_headroom(stats, budget, metadata.allocated_bytes) {
-                    match self.gc(false).await {
-                        Ok(freed) if freed > 0 => match self.fs_stats().await {
-                            Ok(updated) => {
-                                stats = updated;
-                                budget = CacheBudget::from_fs_stats(stats);
-                            }
-                            Err(e) => warn!(
-                                run_id = %request.run_id,
-                                cache_key,
-                                error = %e,
-                                "workspace image cache stats refresh failed after cache-hit GC"
-                            ),
-                        },
-                        Ok(_) => {}
-                        Err(e) => warn!(
-                            run_id = %request.run_id,
-                            cache_key,
-                            error = %e,
-                            "workspace image cache GC failed before cache hit checkout"
-                        ),
-                    }
-                }
-                if !has_copy_headroom(stats, budget, metadata.allocated_bytes) {
-                    info!(
-                        run_id = %request.run_id,
-                        cache_key,
-                        allocated_bytes = metadata.allocated_bytes,
-                        available_bytes = stats.available_bytes,
-                        min_free_bytes = budget.min_free_bytes,
-                        "workspace image cache hit skipped due to free-space pressure"
-                    );
-                    if let Err(e) = self
-                        .invalidate_current_image(
-                            request.run_id,
-                            &cache_key,
-                            &current_path,
-                            "cache hit checkout skipped due to free-space pressure",
-                        )
-                        .await
-                    {
-                        warn!(
-                            run_id = %request.run_id,
-                            cache_key,
-                            error = %e,
-                            "failed to invalidate workspace image cache baseline after checkout was skipped"
-                        );
-                        return workspace_drive(
-                            WorkspaceCacheCheckoutResult::DiskPressure,
-                            None,
-                            None,
-                            Some(lock),
-                            None,
-                            true,
-                        );
-                    }
-                    return workspace_drive(
-                        WorkspaceCacheCheckoutResult::DiskPressure,
-                        None,
-                        None,
-                        Some(lock),
-                        Some(cache_key),
-                        true,
-                    );
-                }
                 let previous = metadata.storage_fingerprints.clone();
                 match fs::remove_file(&metadata_path).await {
                     Ok(()) => {
@@ -5369,7 +5304,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checkout_uses_current_allocated_bytes_when_cache_hit_copy_lacks_headroom() {
+    async fn cache_hit_checkout_does_not_require_copy_headroom() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -5444,21 +5379,33 @@ mod tests {
             })
             .await;
 
-        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::DiskPressure);
-        assert!(!lease.can_attempt_promotion(Some("sess-1")));
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+        assert!(lease.can_attempt_promotion(Some("sess-1")));
+        assert_eq!(
+            lease
+                .workspace_drive_config()
+                .and_then(|config| config.seed_image),
+            Some(sandbox::WorkspaceDriveSeedImage::Move(current.clone()))
+        );
         assert!(
-            !tokio::fs::try_exists(&current).await.unwrap(),
-            "current image must not remain reusable after real allocated bytes make a cache hit unsafe"
+            tokio::fs::try_exists(&current).await.unwrap(),
+            "move checkout keeps the source in place until sandbox preparation consumes it"
+        );
+        assert!(
+            !tokio::fs::try_exists(paths.session_workspace_cache_metadata(&cache_key))
+                .await
+                .unwrap(),
+            "move checkout removes metadata before handing the current image to sandbox preparation"
         );
         tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
             .await
             .unwrap();
-        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"new image")
+        tokio::fs::rename(&current, paths.active_workspace_image(&sandbox_id))
             .await
             .unwrap();
 
         assert!(
-            !lease
+            lease
                 .promote(
                     run_id,
                     None,
@@ -5468,9 +5415,9 @@ mod tests {
                 )
                 .await
                 .unwrap(),
-            "disk-pressure checkout should not promote a fresh image into the cache"
+            "consumed cache hit promotion should move the active image back without copy headroom"
         );
-        assert!(cache.held_session_states().await.is_empty());
+        assert!(tokio::fs::try_exists(&current).await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/runner/src/workspace_image_cache.rs
+++ b/crates/runner/src/workspace_image_cache.rs
@@ -117,6 +117,7 @@ pub(crate) struct WorkspaceImageLease {
     working_dir: String,
     active_image: PathBuf,
     source_image: Option<PathBuf>,
+    consumed_cache_hit: bool,
     image_size_bytes: u64,
     workspace_drive_enabled: bool,
     result: WorkspaceCacheCheckoutResult,
@@ -135,6 +136,7 @@ pub(crate) struct WorkspaceImagePromotionContext {
     working_dir: String,
     active_image: PathBuf,
     image_size_bytes: u64,
+    consumed_cache_hit: bool,
     terminal_status: WorkspaceCacheTerminalStatus,
     completed_at: String,
     storage_fingerprints: StorageFingerprints,
@@ -158,6 +160,7 @@ struct WorkspaceImagePromotionInput<'a> {
     working_dir: &'a str,
     active_image: &'a Path,
     image_size_bytes: u64,
+    consumed_cache_hit: bool,
     terminal_status: WorkspaceCacheTerminalStatus,
     completed_at: &'a str,
     storage_fingerprints: &'a StorageFingerprints,
@@ -467,6 +470,7 @@ impl SessionWorkspaceCache {
             working_dir: lease_working_dir.to_owned(),
             active_image: active_image.clone(),
             source_image: None,
+            consumed_cache_hit: false,
             image_size_bytes: request.image_size_bytes,
             workspace_drive_enabled: request.workspace_drive_available,
             result,
@@ -519,23 +523,30 @@ impl SessionWorkspaceCache {
         let lease_working_dir = normalized_working_dir
             .as_deref()
             .unwrap_or(request.working_dir);
-        let workspace_drive =
-            |result, source_image, previous_storage, lock, cache_key, workspace_drive_enabled| {
-                WorkspaceImageLease {
-                    cache: self.clone(),
-                    cache_key,
-                    profile_name: request.profile_name.to_owned(),
-                    session_id: request.session_id.map(str::to_owned),
-                    working_dir: lease_working_dir.to_owned(),
-                    active_image: active_image.clone(),
-                    source_image,
-                    image_size_bytes: request.image_size_bytes,
-                    workspace_drive_enabled,
-                    result,
-                    previous_storage,
-                    entry_lock: lock,
-                }
-            };
+        let workspace_drive = |result,
+                               source_image: Option<PathBuf>,
+                               previous_storage,
+                               lock,
+                               cache_key,
+                               workspace_drive_enabled| {
+            let consumed_cache_hit =
+                result == WorkspaceCacheCheckoutResult::Hit && source_image.is_some();
+            WorkspaceImageLease {
+                cache: self.clone(),
+                cache_key,
+                profile_name: request.profile_name.to_owned(),
+                session_id: request.session_id.map(str::to_owned),
+                working_dir: lease_working_dir.to_owned(),
+                active_image: active_image.clone(),
+                source_image,
+                consumed_cache_hit,
+                image_size_bytes: request.image_size_bytes,
+                workspace_drive_enabled,
+                result,
+                previous_storage,
+                entry_lock: lock,
+            }
+        };
 
         let Some(working_dir) = normalized_working_dir.as_deref() else {
             warn!(
@@ -759,23 +770,30 @@ impl SessionWorkspaceCache {
                     );
                 }
                 let previous = metadata.storage_fingerprints.clone();
-                if let Err(e) = self
-                    .write_metadata(
-                        &cache_key,
-                        request.run_id,
-                        WorkspaceCacheMetadata {
-                            last_used_at: local_timestamp(),
-                            ..metadata
-                        },
-                    )
-                    .await
-                {
-                    warn!(
-                        run_id = %request.run_id,
-                        cache_key,
-                        error = %e,
-                        "failed to update workspace image cache lastUsedAt"
-                    );
+                match fs::remove_file(&metadata_path).await {
+                    Ok(()) => {
+                        info!(
+                            run_id = %request.run_id,
+                            cache_key,
+                            "workspace image cache hit checked out with move seed"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            run_id = %request.run_id,
+                            cache_key,
+                            error = %e,
+                            "failed to remove workspace image cache metadata before move checkout; using fresh workspace image"
+                        );
+                        return workspace_drive(
+                            WorkspaceCacheCheckoutResult::Miss,
+                            None,
+                            None,
+                            Some(lock),
+                            Some(cache_key),
+                            true,
+                        );
+                    }
                 }
                 Some((current_path, previous))
             }
@@ -1664,6 +1682,29 @@ impl SessionWorkspaceCache {
         }
     }
 
+    async fn invalidate_cache_entry(
+        &self,
+        run_id: RunId,
+        cache_key: &str,
+        reason: &str,
+    ) -> RunnerResult<bool> {
+        let entry_dir = self.session_workspace_cache_entry_dir(cache_key);
+        match remove_workspace_cache_path_if_exists(&entry_dir).await {
+            Ok(removed) => {
+                if removed {
+                    info!(
+                        run_id = %run_id,
+                        cache_key,
+                        reason,
+                        "workspace image cache entry invalidated"
+                    );
+                }
+                Ok(removed)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
     async fn promote_locked(&self, input: WorkspaceImagePromotionInput<'_>) -> RunnerResult<bool> {
         let cache_dir = self.session_workspace_cache_entry_dir(input.cache_key);
         if remove_non_directory_workspace_cache_entry(&cache_dir).await? {
@@ -1728,7 +1769,7 @@ impl SessionWorkspaceCache {
 
         let mut stats = self.fs_stats().await?;
         let mut budget = CacheBudget::from_fs_stats(stats);
-        if stats.available_bytes < budget.min_free_bytes {
+        if !input.consumed_cache_hit && stats.available_bytes < budget.min_free_bytes {
             match self.gc_locked(false).await {
                 Ok(freed) if freed > 0 => {
                     stats = self.fs_stats().await?;
@@ -1743,7 +1784,7 @@ impl SessionWorkspaceCache {
                 ),
             }
         }
-        if stats.available_bytes < budget.min_free_bytes {
+        if !input.consumed_cache_hit && stats.available_bytes < budget.min_free_bytes {
             info!(
                 run_id = %input.run_id,
                 cache_key = input.cache_key,
@@ -1763,6 +1804,16 @@ impl SessionWorkspaceCache {
             );
             return Ok(false);
         }
+        if input.consumed_cache_hit && image_metadata.len() != input.image_size_bytes {
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                actual_image_size_bytes = image_metadata.len(),
+                expected_image_size_bytes = input.image_size_bytes,
+                "workspace image cache promotion skipped because active image size does not match cache key"
+            );
+            return Ok(false);
+        }
         let active_allocated = allocated_bytes(&image_metadata);
         if active_allocated > budget.max_entry_bytes {
             info!(
@@ -1773,6 +1824,95 @@ impl SessionWorkspaceCache {
                 "workspace image cache promotion skipped because image is too large"
             );
             return Ok(false);
+        }
+        if input.consumed_cache_hit {
+            ensure_workspace_cache_entry_dir(&cache_dir).await?;
+            let current = self.session_workspace_cache_current_image(input.cache_key);
+            remove_workspace_cache_path_if_exists(&current).await?;
+            if let Err(e) = std::fs::rename(input.active_image, &current) {
+                return Err(e.into());
+            }
+            let current_metadata = match fs::symlink_metadata(&current).await {
+                Ok(metadata) => metadata,
+                Err(e) => {
+                    let _ = remove_workspace_cache_path_if_exists(&current).await;
+                    return Err(e.into());
+                }
+            };
+            if !current_metadata.is_file() {
+                let _ = remove_workspace_cache_path_if_exists(&current).await;
+                return Err(RunnerError::Internal(format!(
+                    "workspace image cache current image is not a file: {}",
+                    current.display()
+                )));
+            }
+            let logical_image_size_bytes = current_metadata.len();
+            if logical_image_size_bytes != input.image_size_bytes {
+                let _ = remove_workspace_cache_path_if_exists(&current).await;
+                info!(
+                    run_id = %input.run_id,
+                    cache_key = input.cache_key,
+                    actual_image_size_bytes = logical_image_size_bytes,
+                    expected_image_size_bytes = input.image_size_bytes,
+                    "workspace image cache promotion skipped because moved image size does not match cache key"
+                );
+                return Ok(false);
+            }
+            let allocated = allocated_bytes(&current_metadata);
+            if allocated > budget.max_entry_bytes {
+                let _ = remove_workspace_cache_path_if_exists(&current).await;
+                info!(
+                    run_id = %input.run_id,
+                    cache_key = input.cache_key,
+                    allocated_bytes = allocated,
+                    max_entry_bytes = budget.max_entry_bytes,
+                    "workspace image cache promotion skipped because moved image is too large"
+                );
+                return Ok(false);
+            }
+            let metadata = WorkspaceCacheMetadata {
+                format_version: CACHE_FORMAT_VERSION,
+                key_version: CACHE_KEY_VERSION,
+                cache_scope: self.inner.cache_scope.clone(),
+                profile_name: input.profile_name.to_owned(),
+                session_id: input.session_id.to_owned(),
+                working_dir: input.working_dir.to_owned(),
+                last_completed_at: input.completed_at.to_owned(),
+                last_used_at: local_timestamp(),
+                last_terminal_status: input.terminal_status,
+                workspace_trust: WorkspaceTrust::Clean,
+                logical_image_size_bytes,
+                allocated_bytes: allocated,
+                current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
+                drive_layout: WORKSPACE_DRIVE_LAYOUT.to_owned(),
+                storage_fingerprints: filter_storage_fingerprints_for_working_dir(
+                    input.storage_fingerprints,
+                    input.working_dir,
+                ),
+                state: WorkspaceCacheState::Current,
+            };
+            if let Err(e) = self
+                .write_metadata(input.cache_key, input.run_id, metadata)
+                .await
+            {
+                let _ = remove_workspace_cache_path_if_exists(&current).await;
+                return Err(e);
+            }
+            info!(
+                run_id = %input.run_id,
+                cache_key = input.cache_key,
+                allocated_bytes = allocated,
+                "workspace image cache promoted by moving active image"
+            );
+            if let Err(e) = self.gc_locked(false).await {
+                warn!(
+                    run_id = %input.run_id,
+                    cache_key = input.cache_key,
+                    error = %e,
+                    "workspace image cache GC failed after promotion"
+                );
+            }
+            return Ok(true);
         }
         if !has_copy_headroom(stats, budget, active_allocated) {
             match self.gc_locked(false).await {
@@ -2031,7 +2171,13 @@ impl WorkspaceImageLease {
         self.workspace_drive_enabled
             .then(|| sandbox::WorkspaceDriveConfig {
                 size_mb: workspace_image_size_mb(self.image_size_bytes),
-                seed_image: self.source_image.clone(),
+                seed_image: self.source_image.as_ref().map(|source_image| {
+                    if self.consumed_cache_hit {
+                        sandbox::WorkspaceDriveSeedImage::Move(source_image.clone())
+                    } else {
+                        sandbox::WorkspaceDriveSeedImage::Copy(source_image.clone())
+                    }
+                }),
             })
     }
 
@@ -2058,6 +2204,12 @@ impl WorkspaceImageLease {
         let Some(cache_key) = self.cache_key.as_deref() else {
             return Ok(false);
         };
+        if self.consumed_cache_hit {
+            return self
+                .cache
+                .invalidate_cache_entry(run_id, cache_key, reason)
+                .await;
+        }
         let current = self.cache.session_workspace_cache_current_image(cache_key);
         self.cache
             .invalidate_current_image(run_id, cache_key, &current, reason)
@@ -2153,6 +2305,7 @@ impl WorkspaceImageLease {
                 working_dir: &self.working_dir,
                 active_image: &self.active_image,
                 image_size_bytes: self.image_size_bytes,
+                consumed_cache_hit: self.consumed_cache_hit,
                 terminal_status,
                 completed_at: &completed_at,
                 storage_fingerprints,
@@ -2209,6 +2362,7 @@ impl WorkspaceImageLease {
             working_dir: self.working_dir.clone(),
             active_image: self.active_image.clone(),
             image_size_bytes: self.image_size_bytes,
+            consumed_cache_hit: self.consumed_cache_hit,
             terminal_status: request.terminal_status,
             completed_at: request.completed_at,
             storage_fingerprints: request.storage_fingerprints,
@@ -2270,6 +2424,7 @@ impl WorkspaceImagePromotionContext {
                 working_dir: &self.working_dir,
                 active_image: &self.active_image,
                 image_size_bytes: self.image_size_bytes,
+                consumed_cache_hit: self.consumed_cache_hit,
                 terminal_status: self.terminal_status,
                 completed_at: &self.completed_at,
                 storage_fingerprints: promotion_storage_fingerprints,
@@ -2283,6 +2438,7 @@ impl WorkspaceImagePromotionContext {
             cache_key,
             entry_lock,
             run_id,
+            consumed_cache_hit,
             ..
         } = self;
         let _late_entry_lock_guard = match entry_lock.as_ref() {
@@ -2303,6 +2459,11 @@ impl WorkspaceImagePromotionContext {
                 }
             },
         };
+        if consumed_cache_hit {
+            return cache
+                .invalidate_cache_entry(run_id, &cache_key, reason)
+                .await;
+        }
         let current = cache.session_workspace_cache_current_image(&cache_key);
         cache
             .invalidate_current_image(run_id, &cache_key, &current, reason)
@@ -2324,6 +2485,7 @@ impl WorkspaceImagePromotionContext {
             working_dir,
             active_image,
             image_size_bytes,
+            consumed_cache_hit,
             terminal_status: _,
             completed_at: _,
             storage_fingerprints: _,
@@ -2341,6 +2503,7 @@ impl WorkspaceImagePromotionContext {
             working_dir,
             active_image,
             source_image: None,
+            consumed_cache_hit,
             image_size_bytes,
             workspace_drive_enabled: request.workspace_drive_available,
             result: WorkspaceCacheCheckoutResult::Miss,
@@ -2942,15 +3105,8 @@ mod tests {
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
         let cache = SessionWorkspaceCache::new(paths.clone());
         let session_id = "sess-race";
-        let image_size = b"new image".len() as u64;
-        let key = promote_current_cache_entry(
-            &cache,
-            &paths,
-            session_id,
-            b"new image",
-            "2026-06-02T00:00:00.000Z",
-        )
-        .await;
+        let existing_image = format!("image-{session_id}").into_bytes();
+        let image_size = existing_image.len() as u64;
         let stale_run_id = RunId::new_v4();
         let stale_sandbox_id = sandbox::SandboxId::new_v4();
         let stale_lease = cache
@@ -2964,14 +3120,23 @@ mod tests {
                 workspace_drive_required: false,
             })
             .await;
-        assert!(stale_lease.is_cache_hit());
+        assert_eq!(stale_lease.result(), WorkspaceCacheCheckoutResult::Miss);
         let stale_active_image = paths.active_workspace_image(&stale_sandbox_id);
         tokio::fs::create_dir_all(stale_active_image.parent().unwrap())
             .await
             .unwrap();
-        tokio::fs::write(&stale_active_image, b"old image")
+        tokio::fs::write(&stale_active_image, vec![b'o'; image_size as usize])
             .await
             .unwrap();
+        let key = write_current_cache_entry(
+            &cache,
+            stale_run_id,
+            session_id,
+            "/workspace",
+            "2026-06-02T00:00:00.000Z",
+            "2026-06-02T00:00:00.000Z",
+        )
+        .await;
 
         let promoted = stale_lease
             .promote(
@@ -2994,7 +3159,7 @@ mod tests {
         let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
             .await
             .unwrap();
-        assert_eq!(current, b"new image");
+        assert_eq!(current, existing_image);
     }
 
     #[tokio::test]
@@ -3005,10 +3170,8 @@ mod tests {
         let cache = SessionWorkspaceCache::new(paths.clone());
         let session_id = "sess-same-completed-at";
         let completed_at = "2026-06-02T00:00:00.000Z";
-        let image_size = b"old image".len() as u64;
-        let key =
-            promote_current_cache_entry(&cache, &paths, session_id, b"old image", completed_at)
-                .await;
+        let existing_image = format!("image-{session_id}").into_bytes();
+        let image_size = existing_image.len() as u64;
         let competing_run_id = RunId::new_v4();
         let competing_sandbox_id = sandbox::SandboxId::new_v4();
         let competing_lease = cache
@@ -3022,14 +3185,23 @@ mod tests {
                 workspace_drive_required: false,
             })
             .await;
-        assert!(competing_lease.is_cache_hit());
+        assert_eq!(competing_lease.result(), WorkspaceCacheCheckoutResult::Miss);
         let competing_active_image = paths.active_workspace_image(&competing_sandbox_id);
         tokio::fs::create_dir_all(competing_active_image.parent().unwrap())
             .await
             .unwrap();
-        tokio::fs::write(&competing_active_image, b"new image")
+        tokio::fs::write(&competing_active_image, vec![b'n'; image_size as usize])
             .await
             .unwrap();
+        let key = write_current_cache_entry(
+            &cache,
+            competing_run_id,
+            session_id,
+            "/workspace",
+            completed_at,
+            completed_at,
+        )
+        .await;
 
         let promoted = competing_lease
             .promote(
@@ -3052,7 +3224,7 @@ mod tests {
         let current = tokio::fs::read(paths.session_workspace_cache_current_image(&key))
             .await
             .unwrap();
-        assert_eq!(current, b"old image");
+        assert_eq!(current, existing_image);
     }
 
     #[tokio::test]
@@ -4059,13 +4231,213 @@ mod tests {
             .await;
 
         assert_eq!(checkout.result(), WorkspaceCacheCheckoutResult::Hit);
+        let seed = checkout
+            .workspace_drive_config()
+            .and_then(|config| config.seed_image)
+            .expect("shared checkout should seed from the host-level workspace image cache");
+        match seed {
+            sandbox::WorkspaceDriveSeedImage::Move(path) => assert!(
+                path.starts_with(home.workspace_image_cache_dir()),
+                "shared checkout must move from the host-level workspace image cache"
+            ),
+            other => panic!("shared checkout should use a move seed, got {other:?}"),
+        }
+        let key = cache_b.scoped_cache_key(TEST_PROFILE_NAME, "sess-1", "/workspace", 5);
         assert!(
-            checkout
-                .source_image
-                .as_ref()
-                .is_some_and(|path| path.starts_with(home.workspace_image_cache_dir())),
-            "shared checkout must source the host-level workspace image cache",
+            !home
+                .workspace_image_cache_dir()
+                .join(key)
+                .join("metadata.json")
+                .exists(),
+            "move checkout must remove reusable cache metadata"
         );
+    }
+
+    #[tokio::test]
+    async fn cache_hit_removes_metadata_and_returns_move_seed() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let key = write_current_cache_entry(
+            &cache,
+            run_id,
+            "sess-move-hit",
+            "/workspace",
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-01T00:00:00.000Z",
+        )
+        .await;
+        let current = paths.session_workspace_cache_current_image(&key);
+        let image_size = fs::metadata(&current).await.unwrap().len();
+
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some("sess-move-hit"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+                workspace_drive_required: true,
+            })
+            .await;
+
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+        assert!(lease.consumed_cache_hit);
+        assert_eq!(
+            lease
+                .workspace_drive_config()
+                .and_then(|config| config.seed_image),
+            Some(sandbox::WorkspaceDriveSeedImage::Move(current.clone()))
+        );
+        assert!(current.exists());
+        assert!(matches!(
+            fs::metadata(paths.session_workspace_cache_metadata(&key)).await,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound
+        ));
+    }
+
+    #[tokio::test]
+    async fn metadata_missing_current_present_is_not_a_cache_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let key = cache.scoped_cache_key(TEST_PROFILE_NAME, "sess-no-metadata", "/workspace", 5);
+        fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+            .await
+            .unwrap();
+        fs::write(paths.session_workspace_cache_current_image(&key), b"image")
+            .await
+            .unwrap();
+
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some("sess-no-metadata"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+                workspace_drive_required: true,
+            })
+            .await;
+
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
+        assert_eq!(
+            lease
+                .workspace_drive_config()
+                .and_then(|config| config.seed_image),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn consumed_cache_hit_promotion_moves_active_image_back_to_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = sandbox::SandboxId::new_v4();
+        let key = write_current_cache_entry(
+            &cache,
+            run_id,
+            "sess-move-promote",
+            "/workspace",
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-01T00:00:00.000Z",
+        )
+        .await;
+        let current = paths.session_workspace_cache_current_image(&key);
+        let image_size = fs::metadata(&current).await.unwrap().len();
+        let active_image = paths.active_workspace_image(&sandbox_id);
+
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some("sess-move-promote"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+        fs::create_dir_all(active_image.parent().unwrap())
+            .await
+            .unwrap();
+        fs::rename(&current, &active_image).await.unwrap();
+        let updated = vec![b'x'; image_size as usize];
+        fs::write(&active_image, &updated).await.unwrap();
+
+        assert!(
+            lease
+                .promote(
+                    run_id,
+                    None,
+                    WorkspaceCacheTerminalStatus::Success,
+                    "2026-05-02T00:00:00.000Z".into(),
+                    &StorageFingerprints::default(),
+                )
+                .await
+                .unwrap()
+        );
+
+        assert!(!active_image.exists());
+        assert_eq!(fs::read(&current).await.unwrap(), updated);
+        let metadata = cache
+            .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
+            .await
+            .unwrap();
+        assert_eq!(metadata.logical_image_size_bytes, image_size);
+        assert_eq!(metadata.last_completed_at, "2026-05-02T00:00:00.000Z");
+    }
+
+    #[tokio::test]
+    async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let key = write_current_cache_entry(
+            &cache,
+            run_id,
+            "sess-move-invalidate",
+            "/workspace",
+            "2026-05-01T00:00:00.000Z",
+            "2026-05-01T00:00:00.000Z",
+        )
+        .await;
+        let current = paths.session_workspace_cache_current_image(&key);
+        let image_size = fs::metadata(&current).await.unwrap().len();
+
+        let lease = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                run_id,
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                session_id: Some("sess-move-invalidate"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+        fs::remove_file(&current).await.unwrap();
+
+        assert!(
+            lease
+                .invalidate(run_id, "test consumed cache hit failure")
+                .await
+                .unwrap()
+        );
+        assert!(!paths.session_workspace_cache_entry_dir(&key).exists());
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxError, SandboxFactory, SandboxInitializationPhase,
-    SandboxInvalidStateContext,
+    SandboxInvalidStateContext, WorkspaceDriveSeedImage,
 };
 use tracing::{info, warn};
 
@@ -486,17 +486,31 @@ pub(crate) async fn prepare_workspace_drive_image(
             })?;
     }
 
-    if let Some(source_image) = config.seed_image.as_ref() {
-        if let Some(timing) = timing.as_deref_mut() {
-            timing.mark_workspace_seed_image_used();
+    match config.seed_image.as_ref() {
+        Some(WorkspaceDriveSeedImage::Copy(source_image)) => {
+            if let Some(timing) = timing.as_deref_mut() {
+                timing.mark_workspace_seed_image_used();
+            }
+            return copy_workspace_drive_seed_image(
+                path,
+                source_image,
+                workspace_drive_size_bytes(config.size_mb),
+                timing,
+            )
+            .await;
         }
-        return copy_workspace_drive_seed_image(
-            path,
-            source_image,
-            workspace_drive_size_bytes(config.size_mb),
-            timing,
-        )
-        .await;
+        Some(WorkspaceDriveSeedImage::Move(source_image)) => {
+            if let Some(timing) = timing.as_deref_mut() {
+                timing.mark_workspace_seed_image_used();
+            }
+            return move_workspace_drive_seed_image(
+                path,
+                source_image,
+                workspace_drive_size_bytes(config.size_mb),
+            )
+            .await;
+        }
+        None => {}
     }
 
     let file = tokio::fs::File::create(path)
@@ -546,33 +560,7 @@ async fn copy_workspace_drive_seed_image(
     expected_size_bytes: u64,
     timing: Option<&mut SandboxCreateTiming>,
 ) -> sandbox::Result<()> {
-    let source_metadata =
-        tokio::fs::metadata(source)
-            .await
-            .map_err(|e| SandboxError::Initialization {
-                phase: SandboxInitializationPhase::SandboxAllocation,
-                message: format!("read workspace seed image {}: {e}", source.display()),
-            })?;
-    if !source_metadata.is_file() {
-        return Err(SandboxError::Initialization {
-            phase: SandboxInitializationPhase::SandboxAllocation,
-            message: format!(
-                "workspace seed image is not a regular file: {}",
-                source.display()
-            ),
-        });
-    }
-    if source_metadata.len() != expected_size_bytes {
-        return Err(SandboxError::Initialization {
-            phase: SandboxInitializationPhase::SandboxAllocation,
-            message: format!(
-                "workspace seed image size mismatch for {}: expected {} bytes, got {} bytes",
-                source.display(),
-                expected_size_bytes,
-                source_metadata.len()
-            ),
-        });
-    }
+    validate_workspace_seed_source(source, expected_size_bytes).await?;
 
     let source_str = source
         .to_str()
@@ -611,18 +599,88 @@ async fn copy_workspace_drive_seed_image(
         result
     }?;
 
-    let target_metadata =
-        tokio::fs::metadata(target)
+    validate_workspace_seed_target(target, expected_size_bytes, "copied").await
+}
+
+async fn move_workspace_drive_seed_image(
+    target: &Path,
+    source: &Path,
+    expected_size_bytes: u64,
+) -> sandbox::Result<()> {
+    validate_workspace_seed_source(source, expected_size_bytes).await?;
+    if let Err(e) = std::fs::rename(source, target) {
+        return Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: format!(
+                "move workspace seed image {} to {}: {e}",
+                source.display(),
+                target.display()
+            ),
+        });
+    }
+    validate_workspace_seed_target(target, expected_size_bytes, "moved").await
+}
+
+async fn validate_workspace_seed_source(
+    source: &Path,
+    expected_size_bytes: u64,
+) -> sandbox::Result<()> {
+    let source_metadata =
+        tokio::fs::symlink_metadata(source)
             .await
             .map_err(|e| SandboxError::Initialization {
                 phase: SandboxInitializationPhase::SandboxAllocation,
-                message: format!("read copied workspace image {}: {e}", target.display()),
+                message: format!("read workspace seed image {}: {e}", source.display()),
             })?;
+    if !source_metadata.is_file() {
+        return Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: format!(
+                "workspace seed image is not a regular file: {}",
+                source.display()
+            ),
+        });
+    }
+    if source_metadata.len() != expected_size_bytes {
+        return Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: format!(
+                "workspace seed image size mismatch for {}: expected {} bytes, got {} bytes",
+                source.display(),
+                expected_size_bytes,
+                source_metadata.len()
+            ),
+        });
+    }
+    Ok(())
+}
+
+async fn validate_workspace_seed_target(
+    target: &Path,
+    expected_size_bytes: u64,
+    action: &str,
+) -> sandbox::Result<()> {
+    let target_metadata =
+        tokio::fs::symlink_metadata(target)
+            .await
+            .map_err(|e| SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: format!("read {action} workspace image {}: {e}", target.display()),
+            })?;
+    if !target_metadata.is_file() {
+        return Err(SandboxError::Initialization {
+            phase: SandboxInitializationPhase::SandboxAllocation,
+            message: format!(
+                "{action} workspace image is not a regular file: {}",
+                target.display()
+            ),
+        });
+    }
     if target_metadata.len() != expected_size_bytes {
         return Err(SandboxError::Initialization {
             phase: SandboxInitializationPhase::SandboxAllocation,
             message: format!(
-                "copied workspace image size mismatch for {}: expected {} bytes, got {} bytes",
+                "{action} workspace image size mismatch for {}: expected {} bytes, got {} bytes",
                 target.display(),
                 expected_size_bytes,
                 target_metadata.len()
@@ -801,7 +859,7 @@ mod tests {
             &target,
             &sandbox::WorkspaceDriveConfig {
                 size_mb: 1,
-                seed_image: Some(source.clone()),
+                seed_image: Some(WorkspaceDriveSeedImage::Copy(source.clone())),
             },
             Some(&mut timing),
         )
@@ -848,7 +906,7 @@ mod tests {
             &target,
             &sandbox::WorkspaceDriveConfig {
                 size_mb: 1,
-                seed_image: Some(source),
+                seed_image: Some(WorkspaceDriveSeedImage::Copy(source)),
             },
             None,
         )
@@ -862,6 +920,136 @@ mod tests {
             }
             other => panic!("expected workspace seed initialization error, got {other:?}"),
         }
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    async fn prepare_workspace_drive_image_moves_seed_image() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("seed.ext4");
+        let target = tmp.path().join("nested").join("workspace.ext4");
+        let marker_offset = 4096;
+        let marker = b"vm0";
+        let mut timing = SandboxCreateTiming::new("sandbox".into(), "vm0/default".into());
+
+        let mut source_file = tokio::fs::File::create(&source).await.unwrap();
+        source_file
+            .set_len(workspace_drive_size_bytes(1))
+            .await
+            .unwrap();
+        source_file
+            .seek(SeekFrom::Start(marker_offset))
+            .await
+            .unwrap();
+        source_file.write_all(marker).await.unwrap();
+        source_file.flush().await.unwrap();
+        drop(source_file);
+
+        prepare_workspace_drive_image(
+            &target,
+            &sandbox::WorkspaceDriveConfig {
+                size_mb: 1,
+                seed_image: Some(WorkspaceDriveSeedImage::Move(source.clone())),
+            },
+            Some(&mut timing),
+        )
+        .await
+        .unwrap();
+
+        assert!(!source.exists());
+        let metadata = tokio::fs::metadata(&target).await.unwrap();
+        assert_eq!(metadata.len(), workspace_drive_size_bytes(1));
+        assert!(
+            timing
+                .stage_duration_for_test(SandboxCreateStage::WorkspaceSeedSparseCopy)
+                .is_none()
+        );
+        assert!(
+            timing
+                .stage_duration_for_test(SandboxCreateStage::WorkspaceFreshFormat)
+                .is_none()
+        );
+
+        let mut target_file = tokio::fs::File::open(&target).await.unwrap();
+        target_file
+            .seek(SeekFrom::Start(marker_offset))
+            .await
+            .unwrap();
+        let mut moved_marker = [0; 3];
+        target_file.read_exact(&mut moved_marker).await.unwrap();
+        assert_eq!(&moved_marker, marker);
+    }
+
+    #[tokio::test]
+    async fn prepare_workspace_drive_image_rejects_move_seed_image_size_mismatch_without_moving() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("seed.ext4");
+        let target = tmp.path().join("workspace.ext4");
+
+        let source_file = tokio::fs::File::create(&source).await.unwrap();
+        source_file
+            .set_len(workspace_drive_size_bytes(1) - 1)
+            .await
+            .unwrap();
+        drop(source_file);
+
+        let err = prepare_workspace_drive_image(
+            &target,
+            &sandbox::WorkspaceDriveConfig {
+                size_mb: 1,
+                seed_image: Some(WorkspaceDriveSeedImage::Move(source.clone())),
+            },
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        match err {
+            SandboxError::Initialization { phase, message } => {
+                assert_eq!(phase, SandboxInitializationPhase::SandboxAllocation);
+                assert!(message.contains("workspace seed image size mismatch"));
+            }
+            other => panic!("expected workspace seed initialization error, got {other:?}"),
+        }
+        assert!(source.exists());
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
+    async fn prepare_workspace_drive_image_rejects_move_seed_symlink_without_moving() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real_source = tmp.path().join("real-seed.ext4");
+        let source_link = tmp.path().join("seed-link.ext4");
+        let target = tmp.path().join("workspace.ext4");
+
+        let source_file = tokio::fs::File::create(&real_source).await.unwrap();
+        source_file
+            .set_len(workspace_drive_size_bytes(1))
+            .await
+            .unwrap();
+        drop(source_file);
+        std::os::unix::fs::symlink(&real_source, &source_link).unwrap();
+
+        let err = prepare_workspace_drive_image(
+            &target,
+            &sandbox::WorkspaceDriveConfig {
+                size_mb: 1,
+                seed_image: Some(WorkspaceDriveSeedImage::Move(source_link.clone())),
+            },
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        match err {
+            SandboxError::Initialization { phase, message } => {
+                assert_eq!(phase, SandboxInitializationPhase::SandboxAllocation);
+                assert!(message.contains("workspace seed image is not a regular file"));
+            }
+            other => panic!("expected workspace seed initialization error, got {other:?}"),
+        }
+        assert!(real_source.exists());
+        assert!(source_link.exists());
         assert!(!target.exists());
     }
 

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -107,14 +107,6 @@ pub enum WorkspaceDriveSeedImage {
     /// Move the host-local ext4 image into this sandbox's active workspace
     /// image. The source is consumed when sandbox preparation succeeds.
     Move(PathBuf),
-}
-
-impl WorkspaceDriveSeedImage {
-    pub fn path(&self) -> &Path {
-        match self {
-            Self::Copy(path) | Self::Move(path) => path,
-        }
-    }
 }
 
 /// Provider-neutral workspace block image configuration for one sandbox.

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -97,6 +97,26 @@ pub struct DeviceRateLimits {
     pub network: NetworkRateLimits,
 }
 
+/// Host-local ext4 image seeding behavior for one sandbox workspace image.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkspaceDriveSeedImage {
+    /// Copy the host-local ext4 image into this sandbox's active workspace
+    /// image. The source must remain intact and must never be mounted
+    /// read-write by the provider.
+    Copy(PathBuf),
+    /// Move the host-local ext4 image into this sandbox's active workspace
+    /// image. The source is consumed when sandbox preparation succeeds.
+    Move(PathBuf),
+}
+
+impl WorkspaceDriveSeedImage {
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Copy(path) | Self::Move(path) => path,
+        }
+    }
+}
+
 /// Provider-neutral workspace block image configuration for one sandbox.
 ///
 /// The image is mounted by runner-controlled guest setup at the canonical
@@ -107,9 +127,9 @@ pub struct WorkspaceDriveConfig {
     /// Logical size in MiB for newly initialized workspace images.
     pub size_mb: u32,
     /// Optional host-local ext4 image used to seed this sandbox's active
-    /// workspace image. Providers must copy this image into the active image;
-    /// they must never mount the source image read-write.
-    pub seed_image: Option<PathBuf>,
+    /// workspace image. The seed variant determines whether providers must
+    /// preserve the source image or consume it with a move.
+    pub seed_image: Option<WorkspaceDriveSeedImage>,
 }
 
 /// Per-sandbox creation configuration passed to [`crate::SandboxFactory::create`].

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -29,6 +29,7 @@ mod types;
 pub use config::{
     BlockRateLimits, DeviceRateLimits, FactoryConfig, NetworkRateLimits, ResourceLimits,
     RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef, WorkspaceDriveConfig,
+    WorkspaceDriveSeedImage,
 };
 pub use control::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
 pub use error::{


### PR DESCRIPTION
## Summary

- Add explicit workspace seed semantics with `WorkspaceDriveSeedImage::Copy` and `Move`.
- Change workspace cache hits into destructive move checkouts: runner removes reusable metadata and hands `cache/current` to sandbox-fc as a move seed.
- Teach sandbox-fc to validate and rename move seeds into the active sandbox workspace image without running sparse copy during sandbox create.
- Keep promotion publishing safe by sparse-copying the active image back to `cache/current`, so the reusable cache never shares an inode with a sandbox that has not been destroyed yet.
- Invalidate consumed entries cleanly on create/reuse failures.

Closes #17623

## Test plan

- `cargo check --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo test --manifest-path crates/Cargo.toml -p runner`