### PR TITLE
test(mitm-addon): cover browser firewall bypass

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -27,9 +27,10 @@ Request context
   handling. Read by body capture to mark oversized request bodies truncated.
 - ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
   ``"claude-code"``. Read by model-provider usage protocol selection.
-- ``BROWSER_USER_AGENT``: ``bool`` written by ``request()`` for browser-looking
-  user agents. Read by request dispatch to skip the firewall credential flow for
-  that request and by network-log entry construction.
+- ``BROWSER_USER_AGENT``: ``bool`` written during request classification for
+  browser-looking user agents. Read by request dispatch to skip credential
+  mutation after a firewall allow decision and by network-log entry
+  construction.
 
 Timing context
 --------------

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -28,9 +28,8 @@ Request context
 - ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
   ``"claude-code"``. Read by model-provider usage protocol selection.
 - ``BROWSER_USER_AGENT``: ``bool`` written during request classification for
-  browser-looking user agents. Read by request dispatch to skip credential
-  mutation after a firewall allow decision and by network-log entry
-  construction.
+  browser-looking user agents. Read by request dispatch to skip firewall
+  matching and credential mutation, and by network-log entry construction.
 
 Timing context
 --------------

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -150,7 +150,6 @@ _RequestClassificationKind = Literal[
     "invalid_registry_vm",
     "authority_denied",
     "api_allow",
-    "browser_allow",
     "firewall_block",
     "firewall_allow",
     "allow",
@@ -593,9 +592,6 @@ def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
         ):
             return _RequestClassification(kind="api_allow", vm_info=vm_info)
 
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-        return _RequestClassification(kind="browser_allow", vm_info=vm_info)
-
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
     compiled_network_policies = registry_state.compiled_network_policies[client_ip]
     if compiled_firewalls:
@@ -625,7 +621,6 @@ def _classification_needs_request_timing(classification: _RequestClassification)
     return classification.kind in (
         "authority_denied",
         "api_allow",
-        "browser_allow",
         "firewall_block",
         "firewall_allow",
         "allow",
@@ -1199,6 +1194,8 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     classification = _classify_request(flow)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+        return
     if classification.kind != "firewall_allow" or allow is None or vm_info is None:
         return
     if not _firewall_allow_auth_base(allow):
@@ -1267,6 +1264,21 @@ def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallB
     )
 
 
+def _record_browser_firewall_passthrough(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+) -> None:
+    """Record an allowed browser-looking firewall match without applying auth."""
+    api_entry = allow.api_entry
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.FIREWALL_BASE] = api_entry["base"]
+    flow.metadata[metadata_keys.FIREWALL_NAME] = allow.name
+    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = allow.permission or ""
+    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = allow.rule or ""
+    flow.metadata[metadata_keys.FIREWALL_PARAMS] = allow.params
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+
+
 async def request(flow: http.HTTPFlow) -> None:
     """
     Intercept request: inject firewall auth headers for configured firewall rules.
@@ -1311,15 +1323,6 @@ async def request(flow: http.HTTPFlow) -> None:
         if classification.kind == "api_allow":
             flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
             return
-        if classification.kind == "browser_allow":
-            # User-Agent is client-controlled. This is a credential-flow skip
-            # for browser-looking traffic, not proof that the request came from
-            # a trusted browser integration. Registry and authority validation
-            # have already run, but connector/model-provider auth is not fetched
-            # or injected on this path.
-            flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
-            return
         if classification.kind == "firewall_block":
             firewall_block = classification.firewall_block
             if firewall_block is not None:
@@ -1329,6 +1332,9 @@ async def request(flow: http.HTTPFlow) -> None:
             allow = classification.firewall_allow
             vm_info = classification.vm_info
             if allow is None or vm_info is None:
+                return
+            if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+                _record_browser_firewall_passthrough(flow, allow)
                 return
             _maybe_track_usage_flow(
                 flow,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -150,6 +150,7 @@ _RequestClassificationKind = Literal[
     "invalid_registry_vm",
     "authority_denied",
     "api_allow",
+    "browser_allow",
     "firewall_block",
     "firewall_allow",
     "allow",
@@ -592,6 +593,9 @@ def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
         ):
             return _RequestClassification(kind="api_allow", vm_info=vm_info)
 
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+        return _RequestClassification(kind="browser_allow", vm_info=vm_info)
+
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
     compiled_network_policies = registry_state.compiled_network_policies[client_ip]
     if compiled_firewalls:
@@ -621,6 +625,7 @@ def _classification_needs_request_timing(classification: _RequestClassification)
     return classification.kind in (
         "authority_denied",
         "api_allow",
+        "browser_allow",
         "firewall_block",
         "firewall_allow",
         "allow",
@@ -1264,21 +1269,6 @@ def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallB
     )
 
 
-def _record_browser_firewall_passthrough(
-    flow: http.HTTPFlow,
-    allow: matching.FirewallAllow,
-) -> None:
-    """Record an allowed browser-looking firewall match without applying auth."""
-    api_entry = allow.api_entry
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-    flow.metadata[metadata_keys.FIREWALL_BASE] = api_entry["base"]
-    flow.metadata[metadata_keys.FIREWALL_NAME] = allow.name
-    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = allow.permission or ""
-    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = allow.rule or ""
-    flow.metadata[metadata_keys.FIREWALL_PARAMS] = allow.params
-    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
-
-
 async def request(flow: http.HTTPFlow) -> None:
     """
     Intercept request: inject firewall auth headers for configured firewall rules.
@@ -1323,6 +1313,14 @@ async def request(flow: http.HTTPFlow) -> None:
         if classification.kind == "api_allow":
             flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
             return
+        if classification.kind == "browser_allow":
+            # User-Agent is client-controlled. This is a business passthrough
+            # for browser-looking traffic, not proof of trusted browser
+            # provenance. Registry and authority validation have already run,
+            # but firewall matching, credential fetch, and auth injection do not.
+            flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+            return
         if classification.kind == "firewall_block":
             firewall_block = classification.firewall_block
             if firewall_block is not None:
@@ -1332,9 +1330,6 @@ async def request(flow: http.HTTPFlow) -> None:
             allow = classification.firewall_allow
             vm_info = classification.vm_info
             if allow is None or vm_info is None:
-                return
-            if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-                _record_browser_firewall_passthrough(flow, allow)
                 return
             _maybe_track_usage_flow(
                 flow,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1199,8 +1199,6 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     classification = _classify_request(flow)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-        return
     if classification.kind != "firewall_allow" or allow is None or vm_info is None:
         return
     if not _firewall_allow_auth_base(allow):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -653,6 +653,46 @@ async def test_auth_base_requestheaders_rejects_unbounded_body_framing(
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == ("auth_base_request_body_length_required")
 
 
+async def test_browser_auth_base_requestheaders_skips_body_framing_rejection(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("User-Agent", _BROWSER_USER_AGENT),
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is None
+    assert flow.error is None
+    assert flow.live is True
+    assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://placeholder.example.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "webhook"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "send"
+    assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == "ANY /"
+    assert flow.metadata[metadata_keys.FIREWALL_PARAMS] == {}
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert metadata_keys.FIREWALL_API_ID not in flow.metadata
+    assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
+
+
 async def test_auth_base_requestheaders_rejects_extreme_content_length_before_auth(
     tmp_path, real_flow, mitm_ctx, headers
 ):
@@ -925,9 +965,13 @@ async def test_browser_firewall_match_skips_auth_injection(
     assert flow.metadata["firewall_action"] == "ALLOW"
     assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["browser_user_agent"] is True
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
+    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
+    assert flow.metadata["firewall_name"] == "stripe"
+    assert flow.metadata["firewall_permission"] == ""
+    assert flow.metadata["firewall_rule_match"] == ""
+    assert flow.metadata["firewall_params"] == {}
     assert "firewall_api_id" not in flow.metadata
+    assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
     assert "auth_resolved_secrets" not in flow.metadata
     assert "auth_url_rewrite" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="browser-passthrough")
@@ -943,7 +987,12 @@ async def test_browser_firewall_match_skips_auth_injection(
     mitm_addon.response(flow)
     network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
     assert network_log_entry["browser_user_agent"] is True
-    assert "firewall_base" not in network_log_entry
+    assert network_log_entry["firewall_base"] == "https://api.stripe.com"
+    assert network_log_entry["firewall_name"] == "stripe"
+    assert network_log_entry["firewall_permission"] == ""
+    assert network_log_entry["firewall_rule_match"] == ""
+    assert network_log_entry["firewall_params"] == {}
+    assert network_log_entry["firewall_billable"] is False
 
 
 async def test_non_browser_firewall_match_still_injects_auth(
@@ -995,10 +1044,10 @@ async def test_non_browser_firewall_match_still_injects_auth(
     assert flow.metadata["firewall_name"] == "stripe"
 
 
-async def test_browser_firewall_match_bypasses_denied_unknown_policy(
+async def test_browser_firewall_match_denies_unknown_policy(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs skip the firewall matcher for unknown endpoints."""
+    """Browser-looking UAs still enforce unknownPolicy blocks."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1037,19 +1086,22 @@ async def test_browser_firewall_match_bypasses_denied_unknown_policy(
         await mitm_addon.request(flow)
 
     mock_headers.assert_not_called()
-    assert flow.response is None
+    assert flow.response is not None
+    assert flow.response.status_code == 403
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_billable"] is False
+    assert flow.metadata["firewall_action"] == "DENY"
     assert flow.metadata["browser_user_agent"] is True
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
+    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
+    assert flow.metadata["firewall_name"] == "stripe"
+    body = json.loads(flow.response.content)
+    assert body["error"] == "permission_denied"
+    assert body["reason"] == "unknown_endpoint"
 
 
-async def test_browser_firewall_match_bypasses_explicit_denied_permission(
+async def test_browser_firewall_match_denies_explicit_denied_permission(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs pass through even when a matched permission is denied."""
+    """Browser-looking UAs still enforce explicit denied permissions."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1094,20 +1146,17 @@ async def test_browser_firewall_match_bypasses_explicit_denied_permission(
         await mitm_addon.request(flow)
 
     mock_headers.assert_not_called()
-    assert flow.response is None
+    assert flow.response is not None
+    assert flow.response.status_code == 403
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_billable"] is False
+    assert flow.metadata["firewall_action"] == "DENY"
     assert flow.metadata["browser_user_agent"] is True
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
+    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
+    assert flow.metadata["firewall_name"] == "stripe"
     assert "firewall_api_id" not in flow.metadata
-
-    flow.response = mitm_addon.http.Response.make(200)
-    mitm_addon.response(flow)
-    network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
-    assert network_log_entry["browser_user_agent"] is True
-    assert "firewall_base" not in network_log_entry
+    body = json.loads(flow.response.content)
+    assert body["error"] == "permission_denied"
+    assert body["reason"] == "permission_denied"
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -683,12 +683,12 @@ async def test_browser_auth_base_requestheaders_skips_body_framing_rejection(
     assert flow.live is True
     assert metadata_keys.FIREWALL_ERROR not in flow.metadata
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
-    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://placeholder.example.com"
-    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "webhook"
-    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "send"
-    assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == "ANY /"
-    assert flow.metadata[metadata_keys.FIREWALL_PARAMS] == {}
     assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_NAME not in flow.metadata
+    assert metadata_keys.FIREWALL_PERMISSION not in flow.metadata
+    assert metadata_keys.FIREWALL_RULE_MATCH not in flow.metadata
+    assert metadata_keys.FIREWALL_PARAMS not in flow.metadata
     assert metadata_keys.FIREWALL_API_ID not in flow.metadata
     assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
 
@@ -965,11 +965,11 @@ async def test_browser_firewall_match_skips_auth_injection(
     assert flow.metadata["firewall_action"] == "ALLOW"
     assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["browser_user_agent"] is True
-    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
-    assert flow.metadata["firewall_name"] == "stripe"
-    assert flow.metadata["firewall_permission"] == ""
-    assert flow.metadata["firewall_rule_match"] == ""
-    assert flow.metadata["firewall_params"] == {}
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
+    assert "firewall_permission" not in flow.metadata
+    assert "firewall_rule_match" not in flow.metadata
+    assert "firewall_params" not in flow.metadata
     assert "firewall_api_id" not in flow.metadata
     assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
     assert "auth_resolved_secrets" not in flow.metadata
@@ -987,12 +987,7 @@ async def test_browser_firewall_match_skips_auth_injection(
     mitm_addon.response(flow)
     network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
     assert network_log_entry["browser_user_agent"] is True
-    assert network_log_entry["firewall_base"] == "https://api.stripe.com"
-    assert network_log_entry["firewall_name"] == "stripe"
-    assert network_log_entry["firewall_permission"] == ""
-    assert network_log_entry["firewall_rule_match"] == ""
-    assert network_log_entry["firewall_params"] == {}
-    assert network_log_entry["firewall_billable"] is False
+    assert "firewall_base" not in network_log_entry
 
 
 async def test_non_browser_firewall_match_still_injects_auth(
@@ -1044,10 +1039,10 @@ async def test_non_browser_firewall_match_still_injects_auth(
     assert flow.metadata["firewall_name"] == "stripe"
 
 
-async def test_browser_firewall_match_denies_unknown_policy(
+async def test_browser_firewall_match_bypasses_denied_unknown_policy(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs still enforce unknownPolicy blocks."""
+    """Browser-looking UAs skip the firewall matcher for unknown endpoints."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1086,22 +1081,19 @@ async def test_browser_firewall_match_denies_unknown_policy(
         await mitm_addon.request(flow)
 
     mock_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 403
+    assert flow.response is None
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["browser_user_agent"] is True
-    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
-    assert flow.metadata["firewall_name"] == "stripe"
-    body = json.loads(flow.response.content)
-    assert body["error"] == "permission_denied"
-    assert body["reason"] == "unknown_endpoint"
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
 
 
-async def test_browser_firewall_match_denies_explicit_denied_permission(
+async def test_browser_firewall_match_bypasses_explicit_denied_permission(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs still enforce explicit denied permissions."""
+    """Browser-looking UAs pass through even when a matched permission is denied."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1146,17 +1138,20 @@ async def test_browser_firewall_match_denies_explicit_denied_permission(
         await mitm_addon.request(flow)
 
     mock_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 403
+    assert flow.response is None
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata["firewall_billable"] is False
     assert flow.metadata["browser_user_agent"] is True
-    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
-    assert flow.metadata["firewall_name"] == "stripe"
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
     assert "firewall_api_id" not in flow.metadata
-    body = json.loads(flow.response.content)
-    assert body["error"] == "permission_denied"
-    assert body["reason"] == "permission_denied"
+
+    flow.response = mitm_addon.http.Response.make(200)
+    mitm_addon.response(flow)
+    network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
+    assert network_log_entry["browser_user_agent"] is True
+    assert "firewall_base" not in network_log_entry
 
 
 @pytest.mark.parametrize(
@@ -1247,10 +1242,10 @@ async def test_firewall_unsafe_path_blocks_before_auth_injection(
     assert proxy_log_entry["reason"] == "unsafe_path"
 
 
-async def test_browser_firewall_unsafe_path_blocks_before_auth_injection(
+async def test_browser_firewall_unsafe_path_bypasses_firewall_match(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs still enforce unsafe-path blocks."""
+    """Browser-looking UAs skip firewall matching, including unsafe-path blocks."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1292,13 +1287,10 @@ async def test_browser_firewall_unsafe_path_blocks_before_auth_injection(
         await mitm_addon.request(flow)
 
     mock_headers.assert_not_called()
-    assert flow.response is not None
-    assert flow.response.status_code == 403
+    assert flow.response is None
     assert flow.metadata["browser_user_agent"] is True
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
-    assert flow.metadata["firewall_name"] == "github"
+    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata["firewall_billable"] is False
+    assert "firewall_base" not in flow.metadata
+    assert "firewall_name" not in flow.metadata
     assert "Authorization" not in flow.request.headers
-    body = json.loads(flow.response.content)
-    assert body["error"] == "permission_denied"
-    assert body["reason"] == "unsafe_path"

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1245,3 +1245,60 @@ async def test_firewall_unsafe_path_blocks_before_auth_injection(
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["name"] == "github"
     assert proxy_log_entry["reason"] == "unsafe_path"
+
+
+async def test_browser_firewall_unsafe_path_blocks_before_auth_injection(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    """Browser-looking UAs still enforce unsafe-path blocks."""
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "full-access",
+                        "rules": ["ANY /{path+}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/%2e%2e/admin",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("User-Agent", _BROWSER_USER_AGENT),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as mock_headers,
+    ):
+        await mitm_addon.request(flow)
+
+    mock_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata["browser_user_agent"] is True
+    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata["firewall_base"] == "https://api.github.com"
+    assert flow.metadata["firewall_name"] == "github"
+    assert "Authorization" not in flow.request.headers
+    body = json.loads(flow.response.content)
+    assert body["error"] == "permission_denied"
+    assert body["reason"] == "unsafe_path"


### PR DESCRIPTION
## Summary

- keep browser-looking `User-Agent` traffic as a business passthrough after registry and authority validation
- clarify that browser passthrough skips firewall matching and credential mutation
- add regression coverage for auth.base request-header preflight and unsafe-path firewall rules so browser UA traffic stays out of firewall/auth paths

Refs #17622.

## Tests

- `.venv/bin/pytest tests/test_request_handler_firewall_dispatch.py tests/test_response_handler.py tests/test_error_handler.py tests/test_request_handler_usage_tracking.py`
- `.venv/bin/ruff check src tests/test_request_handler_firewall_dispatch.py`
- `.venv/bin/basedpyright src/mitm_addon.py src/flow_metadata_keys.py tests/test_request_handler_firewall_dispatch.py`
