### PR TITLE
test: make mitm jsonl log flushing explicit

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -18,7 +18,6 @@ import json
 import uuid
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
-from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -39,7 +38,7 @@ from usage.providers import connectors as _usage_connectors
 
 
 @pytest.fixture(autouse=True)
-def _reset_module_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+def _reset_module_state() -> Iterator[None]:
     """Clear cached singletons between tests.
 
     ``registry`` and ``auth`` cache registry data and firewall header
@@ -59,26 +58,6 @@ def _reset_module_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.reset_usage_buffer_for_tests()
     logging_utils.reset_log_writer_for_tests()
-
-    original_read_text = Path.read_text
-    original_exists = Path.exists
-
-    def read_text_after_jsonl_flush(
-        path: Path,
-        *args: Any,
-        **kwargs: Any,
-    ) -> str:
-        if path.suffix == ".jsonl":
-            logging_utils.flush_all_logs()
-        return original_read_text(path, *args, **kwargs)
-
-    def exists_after_jsonl_flush(path: Path) -> bool:
-        if path.suffix == ".jsonl":
-            logging_utils.flush_all_logs()
-        return original_exists(path)
-
-    monkeypatch.setattr(Path, "read_text", read_text_after_jsonl_flush)
-    monkeypatch.setattr(Path, "exists", exists_after_jsonl_flush)
     yield
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()

--- a/crates/runner/mitm-addon/tests/jsonl_log_helpers.py
+++ b/crates/runner/mitm-addon/tests/jsonl_log_helpers.py
@@ -1,0 +1,21 @@
+"""Helpers for observing async JSONL test logs."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import logging_utils
+
+
+def read_jsonl_text_after_flush(path: Path) -> str:
+    logging_utils.flush_log_path(str(path))
+    return path.read_text()
+
+
+def read_jsonl_entries_after_flush(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in read_jsonl_text_after_flush(path).splitlines()]
+
+
+def jsonl_exists_after_flush(path: Path) -> bool:
+    logging_utils.flush_log_path(str(path))
+    return path.exists()

--- a/crates/runner/mitm-addon/tests/test_connection_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_connection_hooks.py
@@ -16,6 +16,7 @@ import logging_utils
 import mitm_addon
 import registry
 import usage
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 from tests.usage_buffer_helpers import RecordingEnqueue, event
@@ -993,9 +994,9 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 1
-        entry = json.loads(lines[0])
+        entries = read_jsonl_entries_after_flush(Path(log_path))
+        assert len(entries) == 1
+        entry = entries[0]
         assert entry["type"] == "tcp"
         assert entry["host"] == "140.82.116.3"
         assert entry["port"] == 22
@@ -1016,8 +1017,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_error(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["type"] == "tcp"
         assert entry["error"] == "connection reset by peer"
 
@@ -1029,6 +1029,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
+        logging_utils.flush_log_path(log_path)
         assert not Path(log_path).exists()
 
     def test_handles_missing_server_addr(self, tmp_path, mitm_ctx, real_tcp_flow):
@@ -1042,7 +1043,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["host"] == "unknown"
         assert entry["port"] == 0
 
@@ -1055,7 +1056,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["latency_ms"] == 0
 
     def test_tcp_message_defers_registered_flow_drain(
@@ -1086,7 +1087,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["request_size"] == len(b"client-one") + len(b"client-two")
         assert entry["response_size"] == len(b"server-one")
 
@@ -1107,7 +1108,7 @@ class TestTcpLog:
             mitm_addon.tcp_message(flow)
             mitm_addon.tcp_end(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["request_size"] == len(b"client")
         assert entry["response_size"] == len(b"server-response")
         assert flow.messages == []
@@ -1146,7 +1147,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["request_size"] == len(first_client.content) + len(second_client.content)
         assert entry["response_size"] == len(first_server.content) + len(second_server.content)
         assert flow.messages == []
@@ -1174,7 +1175,7 @@ class TestTcpLog:
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["request_size"] == mitm_addon._MAX_SAFE_NETWORK_LOG_SIZE
         assert entry["response_size"] == 0
         assert flow.messages == []

--- a/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
@@ -5,6 +5,11 @@ import json
 import pytest
 
 import usage
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+    read_jsonl_text_after_flush,
+)
 from tests.x_flow_helpers import make_x_usage_flow
 
 
@@ -48,8 +53,8 @@ class TestConnectorUsageDispatcher:
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         assert self._call_and_get_billing(flow) == []
         proxy_log = tmp_path / "proxy.jsonl"
-        if proxy_log.exists():
-            assert "no registered handler" not in proxy_log.read_text()
+        if jsonl_exists_after_flush(proxy_log):
+            assert "no registered handler" not in read_jsonl_text_after_flush(proxy_log)
 
     @pytest.mark.parametrize("firewall_name", [None, 42])
     def test_skips_malformed_firewall_name_without_warning(
@@ -64,8 +69,8 @@ class TestConnectorUsageDispatcher:
         assert self._call_and_get_billing(flow) == []
 
         proxy_log = tmp_path / "proxy.jsonl"
-        if proxy_log.exists():
-            assert "no registered handler" not in proxy_log.read_text()
+        if jsonl_exists_after_flush(proxy_log):
+            assert "no registered handler" not in read_jsonl_text_after_flush(proxy_log)
 
     def test_skips_for_non_x_billable_firewall(self, tmp_path, real_flow):
         """Billable non-x connectors (hypothetical future additions to
@@ -94,9 +99,9 @@ class TestConnectorUsageDispatcher:
             assert self._call_and_get_billing(flow) == []
 
         lines = [
-            json.loads(line)
-            for line in proxy_log.read_text().splitlines()
-            if "no registered handler" in line
+            entry
+            for entry in read_jsonl_entries_after_flush(proxy_log)
+            if "no registered handler" in entry["message"]
         ]
         assert len(lines) == 1
         assert lines[0]["level"] == "warn"
@@ -113,9 +118,9 @@ class TestConnectorUsageDispatcher:
             assert self._call_and_get_billing(flow) == []
 
         warned_names = [
-            json.loads(line)["firewall_name"]
-            for line in proxy_log.read_text().splitlines()
-            if "no registered handler" in line
+            entry["firewall_name"]
+            for entry in read_jsonl_entries_after_flush(proxy_log)
+            if "no registered handler" in entry["message"]
         ]
         assert warned_names == ["github", "slack"]
 
@@ -127,8 +132,8 @@ class TestConnectorUsageDispatcher:
         flow.metadata["firewall_name"] = ""
         assert self._call_and_get_billing(flow) == []
 
-        if proxy_log.exists():
-            assert "no registered handler" not in proxy_log.read_text()
+        if jsonl_exists_after_flush(proxy_log):
+            assert "no registered handler" not in read_jsonl_text_after_flush(proxy_log)
 
     def test_registered_x_usage_requires_original_url(self, tmp_path, real_flow, mitm_ctx):
         flow = self._make_x_flow(real_flow, tmp_path)

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import usage
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 
@@ -156,7 +157,7 @@ class TestUsagePendingCounter:
         finally:
             usage.counters.decrement_pending_reports()
 
-        entry = json.loads(proxy_log.read_text())
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["url"] == "https://api.vm0.ai/api/webhooks/agent/usage-event"
         assert entry["type"] == "usage_event"
         assert entry["payload_run_id"] == "run-1"

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -12,6 +12,10 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
@@ -45,7 +49,7 @@ class TestErrorHandler:
         assert body["base"] == "https://fal.run"
         assert body["upstreamStatus"] == 0
 
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
@@ -53,9 +57,7 @@ class TestErrorHandler:
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert entry["connector_diagnostic_base"] == "https://fal.run"
 
-        proxy_entries = [
-            json.loads(line) for line in (tmp_path / "proxy.jsonl").read_text().splitlines()
-        ]
+        proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert proxy_entries[0]["type"] == "connector_diagnostic"
         assert proxy_entries[0]["upstream_status"] == 0
         assert proxy_entries[1]["type"] == "connection_error"
@@ -85,7 +87,7 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert flow.response is None
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
         assert entry["browser_user_agent"] is True
         assert entry["error"] == "connection reset by peer"
@@ -114,7 +116,7 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert flow.response is None
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
         assert entry["error"] == "connection reset by peer"
         assert "connector_diagnostic_type" not in entry
@@ -241,9 +243,9 @@ class TestErrorHandler:
         with mitm_ctx():
             mitm_addon.error(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 1
-        entry = json.loads(lines[0])
+        entries = read_jsonl_entries_after_flush(Path(log_path))
+        assert len(entries) == 1
+        entry = entries[0]
         assert entry["type"] == "http"
         assert entry["action"] == "ALLOW"
         assert entry["host"] == "slack.com"
@@ -274,7 +276,7 @@ class TestErrorHandler:
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
 
-        entry = json.loads((registry_file.parent / "network.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(registry_file.parent / "network.jsonl")
         assert entry["type"] == "http"
         assert entry["action"] == "ALLOW"
         assert entry["host"] == "api.anthropic.com"
@@ -298,7 +300,7 @@ class TestErrorHandler:
         with mitm_ctx():
             mitm_addon.error(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["host"] == "fallback.example.com"
         assert entry["port"] == 9443
         assert entry["url"] == "https://invalid.example.com:bad/path"
@@ -320,7 +322,7 @@ class TestErrorHandler:
         with mitm_ctx():
             mitm_addon.error(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["firewall_base"] == "https://slack.com/api"
         assert entry["firewall_name"] == "slack"
         assert "firewall_ref" not in entry
@@ -340,8 +342,8 @@ class TestErrorHandler:
 
         mitm_addon.error(flow)
 
-        assert proxy_log.exists()
-        entry = json.loads(proxy_log.read_text().strip())
+        assert jsonl_exists_after_flush(proxy_log)
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["message"] == "Error: connection reset by peer: https://slack.com/api/test"
         assert "api_key=secret" not in entry["message"]
         assert "#frag" not in entry["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -24,6 +24,7 @@ from tests.auth_state_helpers import (
     set_cached_headers,
 )
 from tests.firewall_helpers import cancel_pending_task
+from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from url_utils import get_original_url
 
 _MALFORMED_SUCCESS_PREFIX = "Firewall auth endpoint returned malformed success response"
@@ -744,9 +745,7 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_permission"] == "repo-read"
         assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
         assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
-        log_text = await asyncio.to_thread(
-            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
-        )
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "Firewall https://api.github.com: api.github.com" in log_text
 
     async def test_standard_auth_filters_unsafe_resolved_headers(
@@ -1262,9 +1261,7 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
-        log_text = await asyncio.to_thread(
-            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
-        )
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "invalid expiresAt" in log_text
 
     async def test_no_response_set_on_success(self, real_flow, headers, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -10,6 +10,7 @@ import auth_base_forwarder as forwarder
 from aws_sigv4 import AwsSigV4Credentials
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
+from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
 
 def _templated_builtin_auth_header_names() -> list[str]:
@@ -721,9 +722,7 @@ class TestAuthBaseUrlRewriteForwarding:
         assert "api_key" not in flow.request.query
         assert flow.request.query["client"] == "visible"
         # Success-path log line must not be written.
-        log_text = await asyncio.to_thread(
-            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
-        )
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "URL rewrite forward failed" in log_text
         assert "Firewall URL rewrite:" not in log_text
         assert f"Firewall {allow.api_entry['base']}:" not in log_text

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
@@ -7,6 +7,7 @@ from mitmproxy import http
 
 import auth
 from tests.firewall_rewrite_helpers import make_allow, make_success_rewrite_inputs
+from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
 
 class TestAuthBaseUrlRewriteSuccess:
@@ -267,9 +268,7 @@ class TestAuthBaseUrlRewriteSuccess:
         # forward_request called with the rewritten URL
         call_args = mock_forward.call_args
         assert call_args[0][0] == "https://discord.com/api/webhooks/123/abc"
-        log_text = await asyncio.to_thread(
-            lambda: proxy_log_path.read_text() if proxy_log_path.exists() else ""
-        )
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "Firewall URL rewrite:" in log_text
         assert f"Firewall {allow.api_entry['base']}:" in log_text
 

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -1,11 +1,10 @@
 """Tests for mitm addon logging utilities."""
 
-import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import flow_metadata_keys as metadata_keys
 import logging_utils
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
@@ -17,9 +16,9 @@ class TestLogNetworkEntry:
         with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
             logging_utils.log_network_entry(log_path, entry)
 
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 1
-        parsed = json.loads(lines[0])
+        entries = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert len(entries) == 1
+        parsed = entries[0]
         assert parsed["action"] == "ALLOW"
         assert parsed["host"] == "example.com"
         assert_utc_millisecond_timestamp(parsed["timestamp"])
@@ -32,7 +31,7 @@ class TestLogNetworkEntry:
         with patch.object(logging_utils.ctx, "log", MagicMock(), create=True):
             logging_utils.log_network_entry(log_path, entry)
 
-        parsed = json.loads(Path(log_path).read_text().strip())
+        [parsed] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert_utc_millisecond_timestamp(parsed["timestamp"])
         assert parsed["timestamp"] != "caller-timestamp"
         assert entry["timestamp"] == "caller-timestamp"
@@ -44,8 +43,8 @@ class TestLogNetworkEntry:
             logging_utils.log_network_entry(log_path, {"n": 1})
             logging_utils.log_network_entry(log_path, {"n": 2})
 
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 2
+        entries = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert len(entries) == 2
 
     def test_no_path_is_noop(self):
         log = MagicMock()
@@ -78,6 +77,7 @@ class TestLogNetworkEntry:
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
         assert "Failed to encode network log: TypeError:" in warning
+        logging_utils.flush_log_path(str(log_path))
         assert not log_path.exists()
 
     def test_full_backlog_warns_without_creating_file(self, tmp_path):
@@ -93,6 +93,7 @@ class TestLogNetworkEntry:
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
         assert warning == "Dropping network log because the JSONL writer backlog is full"
+        logging_utils.flush_log_path(str(log_path))
         assert not log_path.exists()
 
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -12,10 +12,16 @@ import pytest
 import zstandard
 from mitmproxy.test import tutils
 
+import logging_utils
 import mitm_addon
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+    read_jsonl_text_after_flush,
+)
 from tests.usage_helpers import set_stream_buffer
 
 
@@ -412,7 +418,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
-        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
@@ -446,13 +452,13 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
-        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
         assert entries[0]["type"] == "usage_event"
         assert entries[0]["error"] == "string limit exceeded"
-        assert oversized_model not in proxy_log_path.read_text()
+        assert oversized_model not in read_jsonl_text_after_flush(proxy_log_path)
 
     def test_openai_json_fallback_parse_error_logs_proxy_warning(self, tmp_path, real_flow):
         """OpenAI fallback parse failures should use the same proxy warning."""
@@ -474,7 +480,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
-        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
@@ -524,7 +530,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
-        entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
         assert entries[0]["message"] == "Model provider JSON usage extraction failed"
@@ -577,8 +583,8 @@ class TestModelProviderResponseUsage:
         assert extracted["tokens.output"] == expected["tokens.output"]
         if provider_case.uses_openai_responses:
             assert extracted["tokens.cache_read"] == expected["tokens.cache_read"]
-        if proxy_log_path.exists():
-            entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        if jsonl_exists_after_flush(proxy_log_path):
+            entries = read_jsonl_entries_after_flush(proxy_log_path)
             assert not any(
                 entry.get("message") == "Model provider JSON usage extraction failed"
                 for entry in entries
@@ -635,8 +641,8 @@ class TestModelProviderResponseUsage:
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == _expected_event_quantities(provider_case)
-        if proxy_log_path.exists():
-            entries = [json.loads(line) for line in proxy_log_path.read_text().splitlines()]
+        if jsonl_exists_after_flush(proxy_log_path):
+            entries = read_jsonl_entries_after_flush(proxy_log_path)
             assert not any(
                 entry.get("message") == "Model provider JSON usage extraction failed"
                 for entry in entries
@@ -662,6 +668,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     def test_openai_json_fallback_valid_body_without_usage_stays_quiet(self, tmp_path, real_flow):
@@ -684,6 +691,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     @pytest.mark.parametrize(
@@ -736,6 +744,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     def test_anthropic_json_fallback_metadata_only_usage_stays_quiet(self, tmp_path, real_flow):
@@ -761,6 +770,7 @@ class TestModelProviderResponseUsage:
             "message_id": "msg_1",
             "model": "claude-sonnet-4-6",
         }
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     @pytest.mark.parametrize(
@@ -800,6 +810,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert flow.metadata["model_provider_usage"] == expected_usage
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     def test_codex_oauth_non_streaming_json_fallback(self, tmp_path, real_flow):
@@ -868,6 +879,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     def test_full_pipeline_large_model_json_uses_bounded_buffer(self, tmp_path, real_flow):
@@ -1038,7 +1050,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         usage_warnings = [
             entry
             for entry in entries
@@ -1125,6 +1137,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert "model_provider_usage" not in flow.metadata
+        logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
     @pytest.mark.parametrize("firewall_name", [None, 42])

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -1,6 +1,5 @@
 """Tests for model-provider SSE usage reporting paths."""
 
-import json
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -13,6 +12,10 @@ from mitmproxy.test import tutils
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 
 
 def _model_provider_sse_flow(
@@ -59,11 +62,11 @@ def _openai_responses_sse_flow(
 
 def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
     proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-    if not proxy_log.exists():
+    if not jsonl_exists_after_flush(proxy_log):
         return []
     return [
         entry
-        for entry in (json.loads(line) for line in proxy_log.read_text().splitlines())
+        for entry in read_jsonl_entries_after_flush(proxy_log)
         if entry.get("message") == "Model provider SSE usage extraction failed"
     ]
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -1,11 +1,14 @@
 """Tests for model provider usage reporting."""
 
-import json
 import uuid
 
 import pytest
 
 import usage
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 
 
 class TestReportModelProviderUsage:
@@ -300,8 +303,8 @@ class TestReportModelProviderUsage:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
-        assert proxy_log.exists()
-        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert jsonl_exists_after_flush(proxy_log)
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["level"] == "warn"
         assert entry["message"] == "Cannot report usage event: missing sandbox_token or api_url"
         assert entry["type"] == "usage_event"
@@ -321,8 +324,8 @@ class TestReportModelProviderUsage:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert proxy_log.exists()
-        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert jsonl_exists_after_flush(proxy_log)
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["level"] == "warn"
         assert entry["message"] == "Cannot report usage event: missing sandbox_token or api_url"
         assert entry["type"] == "usage_event"

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _write_github_firewall_registry
 
 _BROWSER_USER_AGENT = (
@@ -93,7 +94,7 @@ async def test_authority_validation_deny_response_logs_network_target(
     with mitm_ctx():
         mitm_addon.response(flow)
 
-    entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["type"] == "http"
     assert entry["action"] == "DENY"
     assert entry["host"] == "attacker.example.com"
@@ -135,7 +136,7 @@ async def test_browser_user_agent_marker_survives_authority_validation_block(
     with mitm_ctx():
         mitm_addon.response(flow)
 
-    entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["action"] == "DENY"
     assert entry["browser_user_agent"] is True
 
@@ -1132,7 +1133,7 @@ async def test_rejects_invalid_https_sni_before_firewall_auth(
     assert flow.metadata["firewall_action"] == "DENY"
     assert flow.metadata["firewall_error"] == "invalid_sni"
     assert flow.metadata["original_url"] == expected_original_url
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "authority_validation"
     assert proxy_log_entry["reason"] == "invalid_sni"
     assert proxy_log_entry["sni"] == expected_sni

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -10,6 +10,10 @@ import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
+from tests.jsonl_log_helpers import (
+    read_jsonl_entries_after_flush,
+    read_jsonl_text_after_flush,
+)
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import (
     _single_firewall_vm,
@@ -202,7 +206,7 @@ async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ct
     assert body["permissions"] == []
     assert body["reason"] == "unknown_endpoint"
     assert body["base"] == "https://api.github.com"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["name"] == "github"
     assert proxy_log_entry["reason"] == "unknown_endpoint"
@@ -251,7 +255,7 @@ async def test_firewall_malformed_config_block_reports_reason(
     assert body["error"] == "permission_denied"
     assert body["permissions"] == []
     assert body["reason"] == "malformed_firewall_config"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["reason"] == "malformed_firewall_config"
 
@@ -299,7 +303,7 @@ async def test_firewall_malformed_auth_config_block_reports_reason(
     assert body["error"] == "permission_denied"
     assert body["permissions"] == []
     assert body["reason"] == "malformed_firewall_config"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["reason"] == "malformed_firewall_config"
 
@@ -347,7 +351,7 @@ async def test_firewall_malformed_network_policy_block_reports_reason(
     assert body["permissions"] == []
     assert body["message"] == "Request blocked: malformed network policy"
     assert body["reason"] == "malformed_network_policy"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["reason"] == "malformed_network_policy"
     assert "networkPolicies" not in proxy_log_entry
@@ -396,7 +400,7 @@ async def test_firewall_top_level_malformed_network_policy_block_reports_reason(
     assert body["permissions"] == []
     assert body["message"] == "Request blocked: malformed network policy"
     assert body["reason"] == "malformed_network_policy"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["reason"] == "malformed_network_policy"
     assert "networkPolicies" not in proxy_log_entry
@@ -444,7 +448,7 @@ async def test_firewall_permission_denied_block_reports_reason(
     body = json.loads(flow.response.content)
     assert body["permissions"] == ["read-repos"]
     assert body["reason"] == "permission_denied"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["reason"] == "permission_denied"
 
@@ -549,14 +553,14 @@ async def test_oversized_auth_base_request_does_not_capture_request_body(
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
     assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
 
-    network_log_text = (tmp_path / "net.jsonl").read_text()
+    network_log_text = read_jsonl_text_after_flush(tmp_path / "net.jsonl")
     assert "super-secret-body" not in network_log_text
     network_log_entry = json.loads(network_log_text)
     assert "request_body" not in network_log_entry
     assert network_log_entry["request_body_truncated"] is True
     assert network_log_entry["firewall_error"] == "auth_base_request_body_too_large"
 
-    proxy_log_text = (tmp_path / "proxy.jsonl").read_text()
+    proxy_log_text = read_jsonl_text_after_flush(tmp_path / "proxy.jsonl")
     assert "super-secret-body" not in proxy_log_text
 
 
@@ -596,14 +600,14 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
     assert flow.live is False
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
 
-    network_log_text = (tmp_path / "net.jsonl").read_text()
+    network_log_text = read_jsonl_text_after_flush(tmp_path / "net.jsonl")
     network_log_entry = json.loads(network_log_text)
     assert network_log_entry["error"] == Error.KILLED_MESSAGE
     assert network_log_entry["request_size"] == 0
     assert "request_body" not in network_log_entry
     assert network_log_entry["firewall_error"] == "auth_base_request_body_too_large"
 
-    proxy_log_text = (tmp_path / "proxy.jsonl").read_text()
+    proxy_log_text = read_jsonl_text_after_flush(tmp_path / "proxy.jsonl")
     assert "auth.base request body too large" in proxy_log_text
 
 
@@ -941,7 +945,7 @@ async def test_browser_firewall_match_skips_auth_injection(
 
     flow.response = mitm_addon.http.Response.make(200)
     mitm_addon.response(flow)
-    network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
+    network_log_entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
     assert network_log_entry["browser_user_agent"] is True
     assert "firewall_base" not in network_log_entry
 
@@ -1105,7 +1109,7 @@ async def test_browser_firewall_match_bypasses_explicit_denied_permission(
 
     flow.response = mitm_addon.http.Response.make(200)
     mitm_addon.response(flow)
-    network_log_entry = json.loads((tmp_path / "net.jsonl").read_text().splitlines()[0])
+    network_log_entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
     assert network_log_entry["browser_user_agent"] is True
     assert "firewall_base" not in network_log_entry
 
@@ -1192,7 +1196,7 @@ async def test_firewall_unsafe_path_blocks_before_auth_injection(
     assert body["permissions"] == []
     assert body["reason"] == "unsafe_path"
     assert body["base"] == "https://api.github.com"
-    proxy_log_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["name"] == "github"
     assert proxy_log_entry["reason"] == "unsafe_path"

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -20,6 +20,10 @@ from tests.auth_state_helpers import (
     set_last_force_refresh_at,
 )
 from tests.flow_helpers import header_map, response_stream
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
@@ -61,7 +65,7 @@ class TestResponseHandler:
             "base": "https://fal.run",
             "upstreamStatus": 401,
         }
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["action"] == "ALLOW"
         assert entry["status"] == 401
         assert entry["firewall_error"] == "connector_not_configured_for_run"
@@ -69,7 +73,7 @@ class TestResponseHandler:
         assert entry["connector_diagnostic_reason"] == "not_configured_for_run"
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert entry["connector_diagnostic_base"] == "https://fal.run"
-        proxy_entry = json.loads((tmp_path / "proxy.jsonl").read_text().splitlines()[0])
+        proxy_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
         assert proxy_entry["type"] == "connector_diagnostic"
         assert proxy_entry["connector"] == "fal"
         assert proxy_entry["upstream_status"] == 401
@@ -161,7 +165,7 @@ class TestResponseHandler:
         assert content is not None
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["firewall_error"] == "connector_not_configured_for_run"
 
     async def test_replaces_connector_401_body_when_only_proxy_authorization_is_present(
@@ -195,7 +199,7 @@ class TestResponseHandler:
         assert content is not None
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["firewall_error"] == "connector_not_configured_for_run"
 
     async def test_replaces_connector_401_body_when_auth_header_has_empty_key_token(
@@ -229,7 +233,7 @@ class TestResponseHandler:
         assert content is not None
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["firewall_error"] == "connector_not_configured_for_run"
 
     async def test_replaces_connector_401_body_when_auth_query_param_is_empty(
@@ -259,7 +263,7 @@ class TestResponseHandler:
         assert content is not None
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["firewall_error"] == "connector_not_configured_for_run"
 
     async def test_preserves_connector_401_body_when_user_auth_is_present(
@@ -289,7 +293,7 @@ class TestResponseHandler:
 
         assert flow.response.status_code == 401
         assert flow.response.content == b"upstream auth error"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
 
@@ -317,7 +321,7 @@ class TestResponseHandler:
 
         assert flow.response.status_code == 401
         assert flow.response.content == b'{"error":"provider auth error"}'
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 401
         assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
@@ -345,7 +349,7 @@ class TestResponseHandler:
 
         assert flow.response.status_code == 401
         assert flow.response.content == b"upstream query auth error"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
 
@@ -371,7 +375,7 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         assert flow.response.content == b'{"ok":true}'
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 200
         assert "connector_diagnostic_type" not in entry
 
@@ -404,7 +408,7 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         assert flow.response.content == b"browser upstream body"
-        entry = json.loads((tmp_path / "net.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["browser_user_agent"] is True
         assert "connector_diagnostic_type" not in entry
 
@@ -444,9 +448,9 @@ class TestResponseHandler:
         assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
         # Network log should be written
-        lines = Path(log_path).read_text().splitlines()
-        assert len(lines) == 1
-        entry = json.loads(lines[0])
+        entries = read_jsonl_entries_after_flush(Path(log_path))
+        assert len(entries) == 1
+        entry = entries[0]
         assert entry["action"] == "ALLOW"
         assert entry["host"] == "api.anthropic.com"
         assert entry["latency_ms"] > 0
@@ -471,7 +475,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["host"] == "target.example.com"
         assert entry["port"] == 9443
         assert entry["url"] == "https://target.example.com:9443/path"
@@ -503,7 +507,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["firewall_base"] == "https://api.example.com"
         assert entry["firewall_name"] == "model-provider:example"
         assert entry["firewall_permission"] == "read"
@@ -557,7 +561,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["host"] == "target.example.com"
         assert entry["port"] == 9443
         assert entry["url"] == expected_url
@@ -579,7 +583,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        entry = json.loads(Path(log_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
         assert entry["host"] == "fallback.example.com"
         assert entry["port"] == 9443
         assert entry["url"] == "https://invalid.example.com:bad/path"
@@ -605,8 +609,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 100
 
     def test_response_size_tracks_streamed_bytes_when_buffer_truncated(
@@ -635,8 +638,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == len(body)
 
     @pytest.mark.parametrize(
@@ -667,8 +669,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == expected_size
 
     def test_response_size_accepts_max_safe_content_length(self, tmp_path, real_flow, mitm_ctx):
@@ -687,8 +688,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 9007199254740991
 
     def test_response_size_is_zero_without_stream_state_or_content_length(
@@ -709,8 +709,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 0
 
     @pytest.mark.parametrize(
@@ -754,8 +753,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 0
 
     def test_response_size_accepts_matching_repeated_content_length(
@@ -777,8 +775,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 50000
 
     def test_response_size_rejects_conflicting_repeated_content_length(
@@ -800,8 +797,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 0
 
     def test_response_size_keeps_zero_streamed_bytes(self, tmp_path, real_flow, mitm_ctx):
@@ -823,8 +819,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 0
 
     def test_response_size_tracks_streamed_bytes_when_buffer_truncated_without_length(
@@ -851,8 +846,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == len(body)
 
     def test_401_firewall_cache_invalidation(self, real_flow, mitm_ctx, headers):
@@ -933,8 +927,7 @@ class TestResponseHandler:
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        lines = Path(log_path).read_text().splitlines()
-        entry = json.loads(lines[0])
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 0
         assert cached_headers(cache_key) is None
         assert force_refresh_pending(cache_key)
@@ -1029,8 +1022,8 @@ class TestResponseHandler:
 
         mitm_addon.response(flow)
 
-        assert proxy_log.exists()
-        entry = json.loads(proxy_log.read_text().strip())
+        assert jsonl_exists_after_flush(proxy_log)
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["message"] == "Response 500: https://api.example.com/fail"
         assert "api_key=secret" not in entry["message"]
         assert "#frag" not in entry["message"]

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -6,6 +6,7 @@ import pytest
 
 import usage
 import usage.buffer as usage_buffer
+from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from tests.pending_helpers import assert_pending
 from tests.usage_buffer_helpers import DeliveryOutcomeCallback, RecordingEnqueue, event
 
@@ -860,7 +861,7 @@ def test_permanent_sync_fallback_failure_does_not_requeue(tmp_path, fresh_usage_
         reports=0,
         flush_request_id="permanent-failure",
     )
-    assert "non-retryable" in proxy_log_path.read_text()
+    assert "non-retryable" in read_jsonl_text_after_flush(proxy_log_path)
     assert usage.flush_usage_events(trigger="test") == 0
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -1,6 +1,5 @@
 """Tests for usage reporting idempotency across mitmproxy hooks."""
 
-import json
 import time
 import uuid
 from pathlib import Path
@@ -12,6 +11,10 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.flow_helpers import header_map
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 from tests.usage_helpers import set_stream_buffer
 
 
@@ -55,8 +58,8 @@ class TestUsageReportingIdempotency:
         events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-        if proxy_log.exists():
-            entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        if jsonl_exists_after_flush(proxy_log):
+            entries = read_jsonl_entries_after_flush(proxy_log)
             assert not any(
                 entry.get("message") == "Model provider JSON usage extraction failed"
                 for entry in entries

--- a/crates/runner/mitm-addon/tests/test_utils.py
+++ b/crates/runner/mitm-addon/tests/test_utils.py
@@ -1,12 +1,11 @@
 """Tests for URL and logging utility functions."""
 
-import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import logging_utils
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 from url_utils import AuthorityValidationError, get_original_url
 
@@ -108,7 +107,7 @@ class TestLogProxyEntry:
     def test_writes_jsonl(self, tmp_path):
         proxy_path = str(tmp_path / "proxy-test.jsonl")
         logging_utils.log_proxy_entry(proxy_path, "warn", "test message", extra_field="value")
-        entry = json.loads((tmp_path / "proxy-test.jsonl").read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy-test.jsonl")
         assert entry["level"] == "warn"
         assert entry["message"] == "test message"
         assert entry["extra_field"] == "value"
@@ -126,7 +125,7 @@ class TestLogProxyEntry:
             raw_url_copy=raw_url,
         )
 
-        entry = json.loads(proxy_path.read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(proxy_path)
         assert entry["message"] == "url diagnostic"
         assert entry["url"] == "https://example.com/v1/search"
         assert entry["raw_url_copy"] == raw_url
@@ -135,10 +134,10 @@ class TestLogProxyEntry:
         proxy_path = str(tmp_path / "proxy-test.jsonl")
         logging_utils.log_proxy_entry(proxy_path, "info", "first")
         logging_utils.log_proxy_entry(proxy_path, "warn", "second")
-        lines = (tmp_path / "proxy-test.jsonl").read_text().strip().split("\n")
-        assert len(lines) == 2
-        assert json.loads(lines[0])["message"] == "first"
-        assert json.loads(lines[1])["message"] == "second"
+        entries = read_jsonl_entries_after_flush(tmp_path / "proxy-test.jsonl")
+        assert len(entries) == 2
+        assert entries[0]["message"] == "first"
+        assert entries[1]["message"] == "second"
 
     def test_empty_path_no_op(self, tmp_path):
         log = MagicMock()
@@ -189,6 +188,7 @@ class TestLogProxyEntry:
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
         assert "Failed to encode proxy log: TypeError:" in warning
+        logging_utils.flush_log_path(str(proxy_path))
         assert not proxy_path.exists()
 
     def test_extra_cannot_override_reserved_fields(self, tmp_path):
@@ -205,7 +205,7 @@ class TestLogProxyEntry:
 
         logging_utils.log_proxy_entry(str(proxy_path), "warn", "logger-message", **extra)
 
-        entry = json.loads(Path(proxy_path).read_text().strip())
+        [entry] = read_jsonl_entries_after_flush(proxy_path)
         assert_utc_millisecond_timestamp(entry["timestamp"])
         assert entry["timestamp"] != "caller-timestamp"
         assert entry["level"] == "warn"

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -11,6 +11,11 @@ import pytest
 
 import auth
 import usage
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+    read_jsonl_text_after_flush,
+)
 
 
 class _QueuedUsageExecutor:
@@ -117,10 +122,7 @@ class TestUsageWebhookDelivery:
         ]
         uuid.UUID(body["events"][0]["idempotencyKey"])
         payload_bytes = len(json.dumps(body).encode())
-        log_entries = [
-            json.loads(line)
-            for line in Path(flow.metadata["vm_proxy_log_path"]).read_text().splitlines()
-        ]
+        log_entries = read_jsonl_entries_after_flush(Path(flow.metadata["vm_proxy_log_path"]))
         webhook_entries = [entry for entry in log_entries if entry["type"] == "usage_event"]
         assert len(webhook_entries) == 2
         assert {entry["level"] for entry in webhook_entries} == {"info"}
@@ -202,7 +204,7 @@ class TestUsageWebhookDelivery:
 
         assert usage_webhook_server.request_count == 2
         mock_sleep.assert_called_once_with(0.5)
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         assert [entry["level"] for entry in entries] == ["info", "info"]
         assert [entry["attempt"] for entry in entries] == [1, 2]
         assert all(entry["url"] == usage_webhook_server.url("/x") for entry in entries)
@@ -233,9 +235,9 @@ class TestUsageWebhookDelivery:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 2
-        assert proxy_log.exists()
-        assert "2 attempts" in proxy_log.read_text()
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        assert jsonl_exists_after_flush(proxy_log)
+        assert "2 attempts" in read_jsonl_text_after_flush(proxy_log)
+        entries = read_jsonl_entries_after_flush(proxy_log)
         assert all(entry["level"] != "error" for entry in entries)
 
     def test_give_up_with_payload_collision_logs_body_free_summary(
@@ -256,7 +258,7 @@ class TestUsageWebhookDelivery:
         )
 
         assert outcome == "retryable_failure"
-        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["level"] == "info"
         assert entry["delivery_outcome"] == "retryable_failure"
         assert entry["attempt"] == 1
@@ -286,7 +288,7 @@ class TestUsageWebhookDelivery:
         assert outcome == "retryable_failure"
         assert usage_webhook_server.request_count == 2
         mock_sleep.assert_called_once_with(0.5)
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         assert [entry["level"] for entry in entries] == ["info", "info"]
         assert entries[-1]["delivery_outcome"] == "retryable_failure"
 
@@ -305,7 +307,7 @@ class TestUsageWebhookDelivery:
 
         assert outcome == "permanent_failure"
         assert usage_webhook_server.request_count == 1
-        [entry] = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["level"] == "error"
         assert entry["attempt"] == 1
         assert "permanent HTTP error" in entry["message"]
@@ -328,7 +330,7 @@ class TestUsageWebhookDelivery:
 
         assert usage.counters._pending_reports == 1
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert "non-retryable" in proxy_log.read_text()
+        assert "non-retryable" in read_jsonl_text_after_flush(proxy_log)
         with pytest.raises(ValueError, match="absolute http"):
             sync_usage_executor.shutdown(wait=True)
 
@@ -362,7 +364,7 @@ class TestUsageWebhookDelivery:
                 max_retries=1,
             )
 
-        log_text = proxy_log.read_text()
+        log_text = read_jsonl_text_after_flush(proxy_log)
         assert "giving up" not in log_text
         assert "non-retryable" in log_text
 
@@ -380,7 +382,7 @@ class TestUsageWebhookDelivery:
                 max_retries=1,
             )
 
-        entry = json.loads(proxy_log.read_text())
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["url"] == "not-a-url"
         _assert_body_free_webhook_entry(
             entry,
@@ -403,7 +405,7 @@ class TestUsageWebhookDelivery:
                 max_retries=1,
             )
 
-        entry = json.loads(proxy_log.read_text())
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
         assert entry["level"] == "error"
         assert entry["attempt"] == 1
         assert "non-retryable" in entry["message"]
@@ -462,7 +464,7 @@ class TestUsageWebhookDelivery:
         assert len(executor.submissions) == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
         assert usage.counters._pending_reports == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
 
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         saturated_entry = entries[-1]
         assert saturated_entry["level"] == "info"
         assert saturated_entry["reason"] == "delivery_saturated"

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -11,6 +11,7 @@ import mitm_addon
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import response_stream
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.x_flow_helpers import (
     json_body_that_exceeds_decoder_recursion,
     json_body_that_exceeds_integer_digit_limit,
@@ -339,7 +340,7 @@ class TestXConnectorResponsePipeline:
 
         assert webhook.request_count == 0
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         lost_visibility_entries = [
             entry for entry in entries if "unparseable" in entry["message"].lower()
         ]
@@ -373,7 +374,7 @@ class TestXConnectorResponsePipeline:
 
         assert webhook.request_count == 0
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         lost_visibility_entries = [
             entry for entry in entries if "unparseable" in entry["message"].lower()
         ]
@@ -408,7 +409,7 @@ class TestXConnectorResponsePipeline:
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3
         proxy_log = Path(flow.metadata["vm_proxy_log_path"])
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+        entries = read_jsonl_entries_after_flush(proxy_log)
         assert all(entry["level"] != "error" for entry in entries)
         assert all("unparseable" not in entry["message"].lower() for entry in entries)
         assert all("parse_error" not in entry for entry in entries)

--- a/crates/runner/mitm-addon/tests/usage_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_buffer_helpers.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import inspect
-import json
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 import usage.buffer as usage_buffer
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from usage.webhook import WebhookDeliveryOutcome
 
 
@@ -129,7 +129,7 @@ def payloads_from_enqueue_calls(calls: Sequence[RecordedEnqueueCall]) -> list[di
 
 def flush_log_entries(proxy_log_path: Path) -> list[dict]:
     return [
-        json.loads(line)
-        for line in proxy_log_path.read_text().splitlines()
-        if '"usage_event_buffer_flush"' in line
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log_path)
+        if entry.get("type") == "usage_event_buffer_flush"
     ]

--- a/crates/runner/mitm-addon/tests/x_connector_usage/helpers.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/helpers.py
@@ -1,6 +1,5 @@
 """Local harness for direct X connector usage reporting tests."""
 
-import json
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
@@ -9,6 +8,10 @@ from typing import Any
 from mitmproxy import http
 
 import usage
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 from tests.usage_helpers import UsageWebhookServer
 from tests.x_flow_helpers import RealFlowFactory, make_x_usage_flow
 
@@ -78,8 +81,8 @@ class XUsageHarness:
 
 
 def assert_lost_visibility_error(proxy_log: Path) -> dict[str, Any]:
-    assert proxy_log.exists()
-    entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+    assert jsonl_exists_after_flush(proxy_log)
+    entries = read_jsonl_entries_after_flush(proxy_log)
     matching_entries = [
         entry
         for entry in entries

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
@@ -6,6 +6,11 @@ import json
 import pytest
 
 import usage
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+    read_jsonl_text_after_flush,
+)
 
 
 def test_logs_single_resource_get(x_usage, tmp_path, real_flow):
@@ -285,8 +290,8 @@ def test_handles_unknown_includes_key(x_usage, tmp_path, real_flow):
         "includes.future_widget": 3,
     }
     proxy_log = tmp_path / "proxy.jsonl"
-    assert proxy_log.exists()
-    content = proxy_log.read_text()
+    assert jsonl_exists_after_flush(proxy_log)
+    content = read_jsonl_text_after_flush(proxy_log)
     assert "future_widget" in content
     assert "unrecognised" in content.lower()
     assert '"level":"warn"' in content or '"level": "warn"' in content
@@ -463,7 +468,7 @@ def test_tweet_counts_missing_total_skips_billing_and_logs_warning(x_usage, tmp_
     assert x_usage.call_and_get_billing(flow) == []
 
     proxy_log = tmp_path / "proxy.jsonl"
-    entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+    entries = read_jsonl_entries_after_flush(proxy_log)
     assert any(
         entry["level"] == "warn" and "total_tweet_count" in entry["message"] for entry in entries
     )
@@ -485,7 +490,7 @@ def test_tweet_counts_unparseable_ignores_request_hints_and_logs_error(
     assert x_usage.call_and_get_billing(flow) == []
 
     proxy_log = tmp_path / "proxy.jsonl"
-    entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+    entries = read_jsonl_entries_after_flush(proxy_log)
     assert any(
         entry["level"] == "error" and "count endpoint" in entry["message"] for entry in entries
     )

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -4,6 +4,11 @@ import json
 
 import pytest
 
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+    read_jsonl_text_after_flush,
+)
 from tests.x_connector_usage.helpers import assert_lost_visibility_error
 
 
@@ -79,8 +84,8 @@ def test_legacy_x_json_fallback_ignores_boolean_result_count(x_usage, tmp_path, 
     payloads = x_usage.call_and_get_billing(flow)
 
     assert payloads == []
-    if proxy_log.exists():
-        entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+    if jsonl_exists_after_flush(proxy_log):
+        entries = read_jsonl_entries_after_flush(proxy_log)
         assert all(entry["level"] != "error" for entry in entries)
         assert all("unparseable" not in entry["message"].lower() for entry in entries)
 
@@ -95,7 +100,7 @@ def test_truncated_buffer_with_no_hints_skips_billing(x_usage, tmp_path, real_fl
 
     assert x_usage.call_and_get_billing(flow) == []
 
-    entry = json.loads(proxy_log.read_text().splitlines()[0])
+    entry = read_jsonl_entries_after_flush(proxy_log)[0]
     assert entry["level"] == "error"
     assert "unparseable" in entry["message"].lower()
     assert entry["body_truncated"] is True
@@ -143,8 +148,8 @@ def test_unparseable_no_hints_writes_error_to_proxy_log(x_usage, tmp_path, real_
     )
     proxy_log = tmp_path / "proxy.jsonl"
     assert x_usage.call_and_get_billing(flow) == []
-    assert proxy_log.exists()
-    content = proxy_log.read_text()
+    assert jsonl_exists_after_flush(proxy_log)
+    content = read_jsonl_text_after_flush(proxy_log)
     assert sensitive_query not in content
     entries = [json.loads(line) for line in content.splitlines()]
     matching_entries = [
@@ -178,7 +183,7 @@ def test_unparseable_x_json_state_logs_parse_error(x_usage, tmp_path, real_flow)
 
     assert x_usage.call_and_get_billing(flow) == []
 
-    entry = json.loads(proxy_log.read_text().splitlines()[0])
+    entry = read_jsonl_entries_after_flush(proxy_log)[0]
     assert entry["level"] == "error"
     assert "unparseable" in entry["message"].lower()
     assert entry["parse_error"] == "incomplete json"
@@ -207,7 +212,7 @@ def test_unparseable_x_json_state_omits_invalid_parse_error(
 
     assert x_usage.call_and_get_billing(flow) == []
 
-    entry = json.loads(proxy_log.read_text().splitlines()[0])
+    entry = read_jsonl_entries_after_flush(proxy_log)[0]
     assert entry["level"] == "error"
     assert "unparseable" in entry["message"].lower()
     assert "parse_error" not in entry
@@ -299,8 +304,8 @@ def test_oversized_fallback_query_suppresses_request_hints(x_usage, tmp_path, re
 
     assert x_usage.call_and_get_billing(flow) == []
 
-    assert proxy_log.exists()
-    content = proxy_log.read_text()
+    assert jsonl_exists_after_flush(proxy_log)
+    content = read_jsonl_text_after_flush(proxy_log)
     assert "unparseable" in content.lower()
     assert '"level":"error"' in content or '"level": "error"' in content
 
@@ -507,8 +512,8 @@ def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
 
     assert p["category"] == expected_category
     assert p["quantity"] == expected_quantity
-    assert proxy_log.exists()
-    entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+    assert jsonl_exists_after_flush(proxy_log)
+    entries = read_jsonl_entries_after_flush(proxy_log)
     assert all(entry["level"] != "error" for entry in entries)
     assert all("unparseable" not in entry["message"].lower() for entry in entries)
     assert all("parse_error" not in entry for entry in entries)
@@ -719,8 +724,8 @@ def test_billable_counts_fallback_empty_id_segments_are_no_hint(x_usage, tmp_pat
     flow = x_usage.make_flow(real_flow, tmp_path, query="ids=,,", body=b"not json")
     proxy_log = tmp_path / "proxy.jsonl"
     assert x_usage.call_and_get_billing(flow) == []
-    assert proxy_log.exists()
-    content = proxy_log.read_text()
+    assert jsonl_exists_after_flush(proxy_log)
+    content = read_jsonl_text_after_flush(proxy_log)
     assert "unparseable" in content.lower()
     assert '"level":"error"' in content or '"level": "error"' in content
 

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -8,6 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.jsonl_log_helpers import (
+    jsonl_exists_after_flush,
+    read_jsonl_entries_after_flush,
+)
 from tests.x_flow_helpers import (
     json_body_that_exceeds_decoder_recursion,
     json_body_that_exceeds_integer_digit_limit,
@@ -62,8 +66,8 @@ def test_x_json_parse_error_on_write_does_not_emit_lost_visibility_log(
 
     assert p["category"] == "content.create_with_url"
     assert p["quantity"] == 1
-    assert proxy_log.exists()
-    entries = [json.loads(line) for line in proxy_log.read_text().splitlines()]
+    assert jsonl_exists_after_flush(proxy_log)
+    entries = read_jsonl_entries_after_flush(proxy_log)
     assert all(entry["level"] != "error" for entry in entries)
     assert all("unparseable" not in entry["message"].lower() for entry in entries)
     assert all("parse_error" not in entry for entry in entries)


### PR DESCRIPTION
## Summary

- Remove the autouse `Path.read_text` / `Path.exists` monkeypatch from mitm-addon tests.
- Add explicit JSONL log observation helpers that flush only the requested path.
- Migrate network/proxy JSONL assertions to explicit path-level flushing, with missing-file checks flushing before `exists()`.

Closes #17619.

## Tests

```bash
cd crates/runner/mitm-addon
pytest tests/
ruff check tests/jsonl_log_helpers.py tests/conftest.py tests/test_logging_utils.py tests/test_response_handler.py tests/test_error_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_authority_validation.py tests/test_connection_hooks.py tests/test_firewall_auth.py tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_forwarding.py tests/test_model_provider_response_usage.py tests/test_model_provider_sse_usage.py tests/test_model_provider_usage.py tests/test_connector_usage_dispatcher.py tests/test_counters.py tests/test_usage_buffer_flush_failures.py tests/test_usage_reporting_idempotency.py tests/test_utils.py tests/test_webhook.py tests/test_x_connector_pipeline.py tests/usage_buffer_helpers.py tests/x_connector_usage/helpers.py tests/x_connector_usage/test_reads.py tests/x_connector_usage/test_unparseable.py tests/x_connector_usage/test_writes.py
python3 -m compileall -q tests/jsonl_log_helpers.py tests/conftest.py tests/test_logging_utils.py tests/test_response_handler.py tests/test_error_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_authority_validation.py tests/test_connection_hooks.py tests/test_firewall_auth.py tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_forwarding.py tests/test_model_provider_response_usage.py tests/test_webhook.py tests/x_connector_usage tests/test_utils.py
```
