### PR TITLE
fix: bound websocket model usage sources

### DIFF
--- a/crates/.gitignore
+++ b/crates/.gitignore
@@ -1,1 +1,2 @@
 /target
+.venv

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -106,8 +106,8 @@ Model-provider usage
 - ``MODEL_PROVIDER_USAGE_SOURCES``: ``dict`` keyed by WebSocket response id,
   with normalized token usage dict values. Written by WebSocket model-provider
   usage extraction and read by model usage-event and observation reporters.
-  Retained after terminal reporting for diagnostics, like
-  ``MODEL_PROVIDER_USAGE``.
+  Entries may be removed before ``websocket_end()`` once a terminal WebSocket
+  usage frame is accepted into the source-preserving usage buffer.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` model id from registry VM info.
   Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1526,6 +1526,8 @@ def _single_content_length_response_size(content_length: str, start: int, end: i
 def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:
     if release_tracking:
         _clear_model_websocket_messages(flow)
+        if response_streaming.is_model_websocket_usage_enabled(flow):
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
     response_streaming.release_response_stream_state(flow)
     if release_tracking:
         _release_tracked_usage_flow(flow)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -5,7 +5,7 @@ Lifecycle:
   install the streaming callback, capped forensic buffer, and incremental
   usage parsers.
 - ``mitm_addon.websocket_message()`` calls ``feed_model_websocket_usage()`` for
-  server-side frames on model-provider WebSocket upgrades.
+  terminal server-side usage frames on model-provider WebSocket upgrades.
 - ``mitm_addon.response()`` finalizes HTTP model and connector usage before
   reporting it.
 - ``mitm_addon.error()`` may finalize partial SSE usage before terminal cleanup.
@@ -310,10 +310,11 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
 
     Called from ``websocket_message()`` only for server-originated frames. Reads
     ``_MODEL_WEBSOCKET_USAGE_ENABLED`` via ``is_model_websocket_usage_enabled()``
-    and writes per-response sources to
-    ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES``. Frames without a response id
-    fall back to ``metadata_keys.MODEL_PROVIDER_USAGE``. This helper is not
-    idempotent for the same frame; callers must feed each server frame once.
+    and temporarily writes per-response sources to
+    ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES`` until they are accepted into
+    the source-preserving usage buffer. Frames without a response id fall back
+    to ``metadata_keys.MODEL_PROVIDER_USAGE``. This helper is not idempotent for
+    the same frame; callers must feed each server frame once.
     """
     if not is_model_websocket_usage_enabled(flow):
         return
@@ -332,6 +333,18 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
             usage_target = {}
             usage_sources[message_id] = usage_target
         usage.merge_openai_responses_usage_result(usage_target, usage_result)
+        run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+        release_source = usage.report_model_provider_usage_source(
+            flow,
+            run_id,
+            message_id,
+            usage_target,
+        )
+        # OpenAI Responses WebSocket usage extraction only returns terminal
+        # usage frames. Once the source is accepted into the source-preserving
+        # buffer, terminal end/error hooks do not need to retain it on the flow.
+        if release_source:
+            usage_sources.pop(message_id, None)
         return
 
     usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -340,9 +340,10 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
             message_id,
             usage_target,
         )
-        # OpenAI Responses WebSocket usage extraction only returns terminal
-        # usage frames. Once the source is accepted into the source-preserving
-        # buffer, terminal end/error hooks do not need to retain it on the flow.
+        # The accepted OpenAI Responses WebSocket events are final for a logical
+        # response id. Once that source reaches the source-preserving buffer,
+        # later same-id frames are duplicates under source/category idempotency
+        # and terminal end/error hooks do not need to retain it on the flow.
         if release_source:
             usage_sources.pop(message_id, None)
         return

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -28,6 +28,8 @@ from .anthropic_messages import (
 from .buffer import (
     DEFAULT_FLUSH_INTERVAL_SECONDS,
     buffer_model_usage_observations,
+    buffer_source_model_usage_observations,
+    buffer_source_usage_events,
     buffer_usage_events,
     configure_usage_buffer,
     flush_usage_events,
@@ -54,11 +56,14 @@ from .providers.model_provider import (
     is_model_provider_usage_observable,
     report_model_provider_usage,
     report_model_provider_usage_observation,
+    report_model_provider_usage_source,
 )
 
 __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
     "buffer_model_usage_observations",
+    "buffer_source_model_usage_observations",
+    "buffer_source_usage_events",
     "buffer_usage_events",
     "configure_usage_buffer",
     "create_anthropic_messages_json_usage_extractor",
@@ -81,6 +86,7 @@ __all__ = [
     "report_connector_usage",
     "report_model_provider_usage",
     "report_model_provider_usage_observation",
+    "report_model_provider_usage_source",
     "reset_usage_buffer_for_tests",
     "set_pending_path",
     "webhook",

--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -9,9 +9,11 @@ bucketing. The seen-key set survives flushes and is bounded by
 ``MAX_SOURCE_IDEMPOTENCY_KEYS``, evicting oldest keys first, so duplicate
 response/error observations do not become separate aggregate rows.
 
-Accepted events are separated by webhook destination and output shape, then
-aggregated by ``run_id``, ``kind``, provider/model resource id, and
+By default, accepted events are separated by webhook destination and output
+shape, then aggregated by ``run_id``, ``kind``, provider/model resource id, and
 ``category``. Matching aggregate buckets sum ``quantity`` before delivery.
+Source-preserving wrappers skip aggregation and keep the original event
+idempotency keys in the webhook payload for finalized source-level reports.
 
 Flushes are triggered by buffer bounds, the lazy timer, or explicit lifecycle
 calls. The trigger label is emitted in ``usage_event_buffer_flush`` proxy-log
@@ -52,6 +54,8 @@ __all__ = [
     "UsageEventBuffer",
     "UsageFlushTrigger",
     "buffer_model_usage_observations",
+    "buffer_source_model_usage_observations",
+    "buffer_source_usage_events",
     "buffer_usage_events",
     "configure_usage_buffer",
     "flush_usage_events",
@@ -108,6 +112,45 @@ def buffer_model_usage_observations(
         resource_field_name="model",
         include_kind=False,
         log_type="model_usage_observation",
+    )
+
+
+def buffer_source_usage_events(
+    url: str,
+    sandbox_token: str,
+    run_id: str,
+    events: Iterable[UsageEvent],
+    proxy_log_path: str,
+) -> int:
+    """Buffer source events without replacing their idempotency keys."""
+    return _usage_event_buffer.buffer_usage_events(
+        url,
+        sandbox_token,
+        run_id,
+        events,
+        proxy_log_path,
+        preserve_source_idempotency=True,
+    )
+
+
+def buffer_source_model_usage_observations(
+    url: str,
+    sandbox_token: str,
+    run_id: str,
+    events: Iterable[UsageEvent],
+    proxy_log_path: str,
+) -> int:
+    """Buffer model usage observations without replacing their source keys."""
+    return _usage_event_buffer.buffer_usage_events(
+        url,
+        sandbox_token,
+        run_id,
+        events,
+        proxy_log_path,
+        resource_field_name="model",
+        include_kind=False,
+        log_type="model_usage_observation",
+        preserve_source_idempotency=True,
     )
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/models.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/models.py
@@ -52,6 +52,12 @@ class _AggregateBucket:
 
 
 @dataclass(frozen=True)
+class _BufferedSourceEvent:
+    run_id: str
+    event: UsageEvent
+
+
+@dataclass(frozen=True)
 class _FlushEvent:
     payload: dict
     source_event_count: int

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -99,6 +99,7 @@ class UsageEventBuffer:
         resource_field_name: ResourceFieldName = "provider",
         include_kind: bool = True,
         log_type: str = "usage_event",
+        preserve_source_idempotency: bool = False,
     ) -> int:
         """Add source usage events and flush if the buffer exceeds a bound."""
         flush_now = False
@@ -113,6 +114,7 @@ class UsageEventBuffer:
                 resource_field_name=resource_field_name,
                 include_kind=include_kind,
                 log_type=log_type,
+                preserve_source_idempotency=preserve_source_idempotency,
             )
             if accepted_count == 0:
                 return 0

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -20,7 +20,9 @@ from .models import (
     UsageFlushTrigger,
     _AggregateBucket,
     _AggregateKey,
+    _batch_priority,
     _BatchAdmissionResult,
+    _BufferedSourceEvent,
     _DeliveringFlush,
     _DeliveryCompletion,
     _destination_priority,
@@ -45,6 +47,7 @@ class _UsageBufferState:
         self._buffer_id = str(uuid.uuid4())
         self._flush_sequence = 0
         self._buckets: dict[_DestinationKey, dict[_AggregateKey, _AggregateBucket]] = {}
+        self._source_events: dict[_DestinationKey, list[_BufferedSourceEvent]] = {}
         # Keep source keys across flushes so aggregate idempotency does not
         # turn response/error duplicates into distinct server-side rows.
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
@@ -55,6 +58,7 @@ class _UsageBufferState:
 
     def clear(self) -> None:
         self._buckets = {}
+        self._source_events = {}
         self._seen_source_keys.clear()
         self._source_event_count = 0
         self._active_enqueue_count = 0
@@ -72,8 +76,10 @@ class _UsageBufferState:
         resource_field_name: ResourceFieldName,
         include_kind: bool,
         log_type: str,
+        preserve_source_idempotency: bool,
     ) -> int:
         buckets: dict[_AggregateKey, _AggregateBucket] | None = None
+        source_events: list[_BufferedSourceEvent] | None = None
         destination = _DestinationKey(
             url,
             sandbox_token,
@@ -87,18 +93,23 @@ class _UsageBufferState:
             source_key = event["idempotencyKey"]
             if source_key in self._seen_source_keys:
                 continue
-            if buckets is None:
-                buckets = self._buckets.setdefault(destination, {})
             self._seen_source_keys[source_key] = None
-            aggregate_key = _AggregateKey(
-                run_id=run_id,
-                kind=event["kind"],
-                provider=event["provider"],
-                category=event["category"],
-            )
-            bucket = buckets.setdefault(aggregate_key, _AggregateBucket())
-            bucket.quantity += event["quantity"]
-            bucket.source_event_count += 1
+            if preserve_source_idempotency:
+                if source_events is None:
+                    source_events = self._source_events.setdefault(destination, [])
+                source_events.append(_BufferedSourceEvent(run_id=run_id, event=_copy_event(event)))
+            else:
+                if buckets is None:
+                    buckets = self._buckets.setdefault(destination, {})
+                aggregate_key = _AggregateKey(
+                    run_id=run_id,
+                    kind=event["kind"],
+                    provider=event["provider"],
+                    category=event["category"],
+                )
+                bucket = buckets.setdefault(aggregate_key, _AggregateBucket())
+                bucket.quantity += event["quantity"]
+                bucket.source_event_count += 1
             self._source_event_count += 1
             accepted_count += 1
         self._evict_source_keys()
@@ -121,6 +132,14 @@ class _UsageBufferState:
             events_by_run: dict[str, int] = {}
             for aggregate_key in buckets:
                 events_by_run[aggregate_key.run_id] = events_by_run.get(aggregate_key.run_id, 0) + 1
+            count += sum(
+                (event_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
+                for event_count in events_by_run.values()
+            )
+        for source_events in self._source_events.values():
+            events_by_run: dict[str, int] = {}
+            for source_event in source_events:
+                events_by_run[source_event.run_id] = events_by_run.get(source_event.run_id, 0) + 1
             count += sum(
                 (event_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
                 for event_count in events_by_run.values()
@@ -166,21 +185,28 @@ class _UsageBufferState:
         return pending_flush
 
     def live_priority(self) -> int | None:
-        if not self._buckets:
+        destinations = (*self._buckets, *self._source_events)
+        if not destinations:
             return None
-        return min(_destination_priority(destination) for destination in self._buckets)
+        return min(_destination_priority(destination) for destination in destinations)
 
     def snapshot_live_flush(self) -> _PendingFlush | None:
-        if not self._buckets:
+        if not self._buckets and not self._source_events:
             self._source_event_count = 0
             return None
 
         self._flush_sequence += 1
         flush_sequence = self._flush_sequence
         buckets = self._buckets
+        source_events = self._source_events
         self._buckets = {}
+        self._source_events = {}
         self._source_event_count = 0
-        batches = self._build_flush_batches(buckets, flush_sequence)
+        batches = [
+            *self._build_flush_batches(buckets, flush_sequence),
+            *self._build_source_event_flush_batches(source_events),
+        ]
+        batches.sort(key=_flush_batch_sort_key)
         return _pending_flush_from_batches(flush_sequence, batches)
 
     def begin_delivery(
@@ -372,6 +398,52 @@ class _UsageBufferState:
                     )
         return batches
 
+    def _build_source_event_flush_batches(
+        self,
+        source_events_by_destination: dict[_DestinationKey, list[_BufferedSourceEvent]],
+    ) -> list[_FlushBatch]:
+        batches: list[_FlushBatch] = []
+        for destination in sorted(
+            source_events_by_destination,
+            key=lambda item: (
+                _destination_priority(item),
+                item.url,
+                item.sandbox_token,
+                item.proxy_log_path,
+                item.resource_field_name,
+                item.include_kind,
+                item.log_type,
+            ),
+        ):
+            events_by_run: dict[str, list[_FlushEvent]] = {}
+            for source_event in source_events_by_destination[destination]:
+                events_by_run.setdefault(source_event.run_id, []).append(
+                    _FlushEvent(
+                        payload=_source_event_payload(destination, source_event.event),
+                        source_event_count=1,
+                    )
+                )
+            for run_id in sorted(events_by_run):
+                events = events_by_run[run_id]
+                for start in range(0, len(events), USAGE_EVENT_BATCH_SIZE):
+                    batch_events = events[start : start + USAGE_EVENT_BATCH_SIZE]
+                    batches.append(
+                        _FlushBatch(
+                            url=destination.url,
+                            sandbox_token=destination.sandbox_token,
+                            payload={
+                                "runId": run_id,
+                                "events": [event.payload for event in batch_events],
+                            },
+                            proxy_log_path=destination.proxy_log_path,
+                            log_type=destination.log_type,
+                            source_event_count=sum(
+                                event.source_event_count for event in batch_events
+                            ),
+                        )
+                    )
+        return batches
+
     def _events_by_run(
         self,
         destination: _DestinationKey,
@@ -420,3 +492,37 @@ class _UsageBufferState:
                 aggregate_key.category,
             ),
         )
+
+
+def _copy_event(event: UsageEvent) -> UsageEvent:
+    return {
+        "idempotencyKey": event["idempotencyKey"],
+        "kind": event["kind"],
+        "provider": event["provider"],
+        "category": event["category"],
+        "quantity": event["quantity"],
+    }
+
+
+def _source_event_payload(destination: _DestinationKey, event: UsageEvent) -> dict:
+    payload = {
+        "idempotencyKey": event["idempotencyKey"],
+        destination.resource_field_name: event["provider"],
+        "category": event["category"],
+        "quantity": event["quantity"],
+    }
+    if destination.include_kind:
+        payload["kind"] = event["kind"]
+    return payload
+
+
+def _flush_batch_sort_key(batch: _FlushBatch) -> tuple[object, ...]:
+    run_id = batch.payload.get("runId")
+    return (
+        _batch_priority(batch),
+        batch.url,
+        batch.sandbox_token,
+        batch.proxy_log_path,
+        batch.log_type,
+        run_id if isinstance(run_id, str) else "",
+    )

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -137,12 +137,14 @@ class _UsageBufferState:
                 for event_count in events_by_run.values()
             )
         for source_events in self._source_events.values():
-            events_by_run: dict[str, int] = {}
+            source_events_by_run: dict[str, int] = {}
             for source_event in source_events:
-                events_by_run[source_event.run_id] = events_by_run.get(source_event.run_id, 0) + 1
+                source_events_by_run[source_event.run_id] = (
+                    source_events_by_run.get(source_event.run_id, 0) + 1
+                )
             count += sum(
                 (event_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
-                for event_count in events_by_run.values()
+                for event_count in source_events_by_run.values()
             )
         return count
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -35,8 +35,10 @@ from .model_tokens import (
 )
 from .sse import SseUsageScanner
 
-# Terminal Responses events whose Response object may carry usage. Keep this
-# narrow so high-volume delta events stay on the SSE discard path.
+# Terminal Responses events whose Response object may carry usage. WebSocket
+# source eviction relies on these events being final for the logical response id;
+# protocols with mutable post-terminal usage snapshots need a source-upsert
+# contract instead of source-preserving append-only events.
 _RESPONSES_TERMINAL_USAGE_EVENTS = frozenset(
     ("response.completed", "response.done", "response.incomplete", "response.failed")
 )

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -1,9 +1,11 @@
 """Model-provider usage reporting entry point.
 
-Buffers token counts already normalized by an addon-side provider extractor
-(stored in ``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]`` or
-``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES]``) for aggregate
-upload to the platform usage webhook endpoints.
+Buffers token counts already normalized by an addon-side provider extractor.
+Flow-terminal reporters aggregate usage stored in
+``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]`` or
+``flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES]``. WebSocket
+response-id sources can also be buffered incrementally with their source
+idempotency keys preserved.
 
 Model-provider usage reporting is separate from platform billing. New run
 contexts set ``flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER]`` to the
@@ -25,7 +27,13 @@ import flow_metadata_keys as metadata_keys
 from auth import get_api_url
 from logging_utils import log_proxy_entry
 
-from ..buffer import UsageEvent, buffer_model_usage_observations, buffer_usage_events
+from ..buffer import (
+    UsageEvent,
+    buffer_model_usage_observations,
+    buffer_source_model_usage_observations,
+    buffer_source_usage_events,
+    buffer_usage_events,
+)
 from ..idempotency import (
     USAGE_EVENT_NAMESPACE_MODEL,
     USAGE_OBSERVATION_NAMESPACE_MODEL,
@@ -84,7 +92,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     if not events:
         return False
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
-    api_url = get_api_url()
+    api_url = get_api_url() if sandbox_token else ""
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if not sandbox_token or not api_url:
         log_proxy_entry(
@@ -136,7 +144,7 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
     if not events:
         return False
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
-    api_url = get_api_url()
+    api_url = get_api_url() if sandbox_token else ""
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if not sandbox_token or not api_url:
         log_proxy_entry(
@@ -154,6 +162,82 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
         events,
         proxy_log_path,
     )
+    return True
+
+
+def report_model_provider_usage_source(
+    flow: http.HTTPFlow,
+    run_id: str,
+    message_id: str,
+    source_usage: dict,
+) -> bool:
+    """Buffer one finalized WebSocket response usage source.
+
+    Unlike flow-terminal reporting, this preserves the source idempotency keys
+    in the webhook payload so the platform can dedupe one response source even
+    when a later lifecycle hook sees the same source again. Returns whether the
+    source can be released from flow metadata.
+    """
+    usage_events: list[UsageEvent] = []
+    observation_events: list[UsageEvent] = []
+    source_id = f"{flow.id}:{message_id}"
+    provider = _reported_model(flow, source_usage)
+    if _is_billable_model_provider(flow, run_id):
+        usage_events = _build_usage_events(
+            run_id,
+            source_id,
+            provider,
+            source_usage,
+            USAGE_EVENT_NAMESPACE_MODEL,
+        )
+    if run_id and is_model_provider_usage_observable(flow):
+        observation_events = _build_usage_events(
+            run_id,
+            source_id,
+            provider,
+            source_usage,
+            USAGE_OBSERVATION_NAMESPACE_MODEL,
+        )
+
+    if not usage_events and not observation_events:
+        return True
+
+    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
+    api_url = get_api_url() if sandbox_token else ""
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    if not sandbox_token or not api_url:
+        if usage_events:
+            log_proxy_entry(
+                proxy_log_path,
+                "warn",
+                "Cannot report usage event: missing sandbox_token or api_url",
+                type="usage_event",
+            )
+        if observation_events:
+            log_proxy_entry(
+                proxy_log_path,
+                "warn",
+                "Cannot report model usage observation: missing sandbox_token or api_url",
+                type="model_usage_observation",
+            )
+        return False
+
+    if usage_events:
+        buffer_source_usage_events(
+            f"{api_url}/api/webhooks/agent/usage-event",
+            sandbox_token,
+            run_id,
+            usage_events,
+            proxy_log_path,
+        )
+    if observation_events:
+        buffer_source_model_usage_observations(
+            f"{api_url}/api/webhooks/agent/model-usage-observation",
+            sandbox_token,
+            run_id,
+            observation_events,
+            proxy_log_path,
+        )
     return True
 
 
@@ -175,7 +259,7 @@ def _iter_model_provider_usage_sources(flow: http.HTTPFlow) -> Iterator[tuple[st
             for message_id, source_usage in usage_sources.items()
             if isinstance(message_id, str) and message_id and isinstance(source_usage, dict)
         )
-        for message_id, source_usage in sorted(valid_sources):
+        for message_id, source_usage in valid_sources:
             yield f"{flow.id}:{message_id}", source_usage
 
     usage = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
@@ -222,3 +306,12 @@ def _string_or_none(value: object) -> str | None:
     if not isinstance(value, str) or not value:
         return None
     return value
+
+
+def _is_billable_model_provider(flow: http.HTTPFlow, run_id: str) -> bool:
+    if not run_id:
+        return False
+    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+    if not firewall_name.startswith("model-provider:"):
+        return False
+    return bool(flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False))

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -182,7 +182,9 @@ def report_model_provider_usage_source(
     observation_events: list[UsageEvent] = []
     source_id = f"{flow.id}:{message_id}"
     provider = _reported_model(flow, source_usage)
-    if _is_billable_model_provider(flow, run_id):
+    can_report_usage = _is_billable_model_provider(flow, run_id)
+    can_report_observation = bool(run_id and is_model_provider_usage_observable(flow))
+    if can_report_usage:
         usage_events = _build_usage_events(
             run_id,
             source_id,
@@ -190,7 +192,7 @@ def report_model_provider_usage_source(
             source_usage,
             USAGE_EVENT_NAMESPACE_MODEL,
         )
-    if run_id and is_model_provider_usage_observable(flow):
+    if can_report_observation:
         observation_events = _build_usage_events(
             run_id,
             source_id,
@@ -200,7 +202,7 @@ def report_model_provider_usage_source(
         )
 
     if not usage_events and not observation_events:
-        return True
+        return not (can_report_usage or can_report_observation)
 
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
     api_url = get_api_url() if sandbox_token else ""

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
@@ -1,8 +1,11 @@
 """Tests for model-provider WebSocket usage metadata."""
 
 import json
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
+from mitmproxy import http
 
 from tests.model_provider_websocket_helpers import (
     _capture_deferred_websocket_trims,
@@ -21,11 +24,19 @@ def deferred_websocket_trim_scheduler(
     return _capture_deferred_websocket_trims(monkeypatch)
 
 
+def _openai_model_websocket_metadata_flow(
+    tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
+) -> http.HTTPFlow:
+    flow = _openai_model_websocket_flow(tmp_path, real_flow)
+    flow.metadata["vm_sandbox_token"] = ""
+    return flow
+
+
 class TestModelProviderWebSocketUsageMetadata:
     """Tests for WebSocket usage metadata parsing without webhook reporting."""
 
     def test_model_websocket_zero_frame_preserves_prior_positive_usage(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
 
         _feed_websocket_server_message(
             flow,
@@ -71,7 +82,7 @@ class TestModelProviderWebSocketUsageMetadata:
         }
 
     def test_model_websocket_positive_frame_updates_prior_zero_usage(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
 
         _feed_websocket_server_message(
             flow,
@@ -108,7 +119,7 @@ class TestModelProviderWebSocketUsageMetadata:
         }
 
     def test_model_websocket_partial_frame_preserves_existing_categories(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
 
         _feed_websocket_server_message(
             flow,
@@ -150,7 +161,7 @@ class TestModelProviderWebSocketUsageMetadata:
         }
 
     def test_model_websocket_accepts_text_frame_content(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
 
         _feed_websocket_server_text_message(
             flow,
@@ -174,7 +185,7 @@ class TestModelProviderWebSocketUsageMetadata:
         }
 
     def test_model_websocket_malformed_frame_preserves_prior_usage(self, tmp_path, real_flow):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
         flow.metadata["model_provider_usage"] = {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
@@ -194,7 +205,7 @@ class TestModelProviderWebSocketUsageMetadata:
     def test_model_websocket_valid_id_usage_replaces_non_dict_usage_sources_metadata(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
         flow.metadata["model_provider_usage_sources"] = "invalid"
 
         _feed_websocket_server_message(
@@ -224,7 +235,7 @@ class TestModelProviderWebSocketUsageMetadata:
     def test_model_websocket_ignores_invalid_frames_with_non_dict_usage_metadata(
         self, tmp_path, real_flow
     ):
-        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
         flow.metadata["model_provider_usage"] = "invalid"
         flow.metadata["model_provider_usage_sources"] = "invalid"
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -72,6 +72,14 @@ def _openai_model_websocket_request_flow(
     )
 
 
+def _sum_quantities_by_category(events: list[dict]) -> dict[str, int]:
+    quantities: dict[str, int] = {}
+    for event in events:
+        category = event["category"]
+        quantities[category] = quantities.get(category, 0) + event["quantity"]
+    return quantities
+
+
 class TestModelProviderWebSocketUsage:
     """Tests for model-provider WebSocket usage reporting."""
 
@@ -93,6 +101,14 @@ class TestModelProviderWebSocketUsage:
 
     def _run_websocket_end(self, flow: http.HTTPFlow):
         with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+        return webhook
+
+    def _run_websocket_messages_and_end(self, flow: http.HTTPFlow, *messages: bytes):
+        with self._usage_webhook_api() as webhook:
+            for message in messages:
+                _feed_websocket_server_message(flow, message)
             mitm_addon.websocket_end(flow)
             usage.flush_usage_events(trigger="test")
         return webhook
@@ -133,15 +149,9 @@ class TestModelProviderWebSocketUsage:
         webhook = self._run_websocket_message_and_end(flow)
 
         events = webhook.usage_events()
-        by_category = {event["category"]: event["quantity"] for event in events}
+        by_category = _sum_quantities_by_category(events)
         assert flow.metadata["model_provider_usage"] == {}
-        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
-            "message_id": "resp_ws_1",
-            "model": "gpt-5.5",
-            "tokens.input": 40,
-            "tokens.output": 20,
-            "tokens.cache_read": 10,
-        }
+        assert _model_websocket_usage_sources(flow) == {}
         assert by_category == {
             "tokens.input": 40,
             "tokens.output": 20,
@@ -151,16 +161,13 @@ class TestModelProviderWebSocketUsage:
     def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
-        _feed_websocket_server_message(
+        webhook = self._run_websocket_messages_and_end(
             flow,
             _openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=10,
                 output_tokens=4,
             ),
-        )
-        _feed_websocket_server_message(
-            flow,
             _openai_websocket_usage_frame(
                 "resp_ws_2",
                 input_tokens=3,
@@ -168,16 +175,12 @@ class TestModelProviderWebSocketUsage:
             ),
         )
 
-        webhook = self._run_websocket_end(flow)
-
-        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+        assert _model_websocket_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 13,
             "tokens.output": 6,
         }
-        assert {
-            event["category"]: event["quantity"]
-            for event in webhook.model_usage_observation_events()
-        } == {
+        assert _sum_quantities_by_category(webhook.model_usage_observation_events()) == {
             "tokens.input": 13,
             "tokens.output": 6,
         }
@@ -185,7 +188,7 @@ class TestModelProviderWebSocketUsage:
     def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
-        _feed_websocket_server_message(
+        webhook = self._run_websocket_messages_and_end(
             flow,
             _openai_websocket_usage_frame(
                 "resp_ws_1",
@@ -193,9 +196,6 @@ class TestModelProviderWebSocketUsage:
                 output_tokens=4,
                 model="gpt-5.5",
             ),
-        )
-        _feed_websocket_server_message(
-            flow,
             _openai_websocket_usage_frame(
                 "resp_ws_2",
                 input_tokens=3,
@@ -204,8 +204,7 @@ class TestModelProviderWebSocketUsage:
             ),
         )
 
-        webhook = self._run_websocket_end(flow)
-
+        assert _model_websocket_usage_sources(flow) == {}
         assert {
             (event["provider"], event["category"]): event["quantity"]
             for event in webhook.usage_events()
@@ -230,7 +229,7 @@ class TestModelProviderWebSocketUsage:
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
-        _feed_websocket_server_message(
+        webhook = self._run_websocket_messages_and_end(
             flow,
             json.dumps(
                 {
@@ -241,9 +240,6 @@ class TestModelProviderWebSocketUsage:
                     },
                 }
             ).encode(),
-        )
-        _feed_websocket_server_message(
-            flow,
             _openai_websocket_usage_frame(
                 "resp_ws_1",
                 input_tokens=10,
@@ -252,27 +248,17 @@ class TestModelProviderWebSocketUsage:
             ),
         )
 
-        webhook = self._run_websocket_end(flow)
-
         assert flow.metadata["model_provider_usage"] == {
             "model": "gpt-5.5",
             "tokens.input": 7,
             "tokens.output": 1,
         }
-        assert _model_websocket_usage_sources(flow)["resp_ws_1"] == {
-            "message_id": "resp_ws_1",
-            "model": "gpt-5.5",
-            "tokens.input": 10,
-            "tokens.output": 4,
-        }
-        assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
+        assert _model_websocket_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
             "tokens.input": 17,
             "tokens.output": 5,
         }
-        assert {
-            event["category"]: event["quantity"]
-            for event in webhook.model_usage_observation_events()
-        } == {
+        assert _sum_quantities_by_category(webhook.model_usage_observation_events()) == {
             "tokens.input": 17,
             "tokens.output": 5,
         }
@@ -442,7 +428,7 @@ class TestModelProviderWebSocketUsage:
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 
-        _feed_websocket_server_message(
+        webhook = self._run_websocket_messages_and_end(
             flow,
             json.dumps(
                 {
@@ -457,9 +443,6 @@ class TestModelProviderWebSocketUsage:
                     },
                 }
             ).encode(),
-        )
-        _feed_websocket_server_message(
-            flow,
             json.dumps(
                 {
                     "type": "response.done",
@@ -476,11 +459,10 @@ class TestModelProviderWebSocketUsage:
             ).encode(),
         )
 
-        webhook = self._run_websocket_end(flow)
-
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         idempotency_by_category = {event["category"]: event["idempotencyKey"] for event in events}
+        assert _model_websocket_usage_sources(flow) == {}
         assert by_category == {
             "tokens.input": 100,
             "tokens.output": 40,
@@ -530,16 +512,15 @@ class TestModelProviderWebSocketUsage:
         assert flow.websocket is not None
         messages = flow.websocket.messages
 
-        mitm_addon.websocket_message(flow)
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            usage.flush_usage_events(trigger="test")
 
         assert messages == [old_client, old_server, latest_server]
-        assert _model_websocket_usage_sources(flow) == {
-            "resp_ws_latest": {
-                "message_id": "resp_ws_latest",
-                "model": "gpt-5.5",
-                "tokens.input": 10,
-                "tokens.output": 4,
-            }
+        assert _model_websocket_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
+            "tokens.input": 10,
+            "tokens.output": 4,
         }
         assert flow.metadata["model_provider_usage"] == {}
         assert len(deferred_websocket_trim_scheduler) == 1
@@ -591,15 +572,17 @@ class TestModelProviderWebSocketUsage:
                 output_tokens=1,
             ),
         )
-        mitm_addon.websocket_message(flow)
-        assert len(deferred_websocket_trim_scheduler) == 1
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            assert len(deferred_websocket_trim_scheduler) == 1
 
-        latest_server = _append_websocket_message(
-            flow,
-            from_client=False,
-            content=_openai_websocket_usage_frame("resp_ws_latest"),
-        )
-        mitm_addon.websocket_message(flow)
+            latest_server = _append_websocket_message(
+                flow,
+                from_client=False,
+                content=_openai_websocket_usage_frame("resp_ws_latest"),
+            )
+            mitm_addon.websocket_message(flow)
+            usage.flush_usage_events(trigger="test")
 
         assert len(deferred_websocket_trim_scheduler) == 1
         assert flow.websocket is not None
@@ -608,19 +591,10 @@ class TestModelProviderWebSocketUsage:
         _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
 
         assert flow.websocket.messages == [latest_server]
-        assert _model_websocket_usage_sources(flow) == {
-            "resp_ws_first": {
-                "message_id": "resp_ws_first",
-                "model": "gpt-5.5",
-                "tokens.input": 1,
-                "tokens.output": 1,
-            },
-            "resp_ws_latest": {
-                "message_id": "resp_ws_latest",
-                "model": "gpt-5.5",
-                "tokens.input": 10,
-                "tokens.output": 4,
-            },
+        assert _model_websocket_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
+            "tokens.input": 11,
+            "tokens.output": 5,
         }
         assert flow.metadata["model_provider_usage"] == {}
 
@@ -652,10 +626,11 @@ class TestModelProviderWebSocketUsage:
             from_client=False,
             content=_openai_websocket_usage_frame("resp_ws_1"),
         )
-        mitm_addon.websocket_message(flow)
-        assert len(deferred_websocket_trim_scheduler) == 1
-
-        webhook = self._run_websocket_end(flow)
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            assert len(deferred_websocket_trim_scheduler) == 1
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
 
         assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
             "tokens.input": 10,
@@ -680,10 +655,11 @@ class TestModelProviderWebSocketUsage:
             from_client=False,
             content=_openai_websocket_usage_frame("resp_ws_1"),
         )
-        mitm_addon.websocket_message(flow)
-        assert len(deferred_websocket_trim_scheduler) == 1
-
-        webhook = self._run_error(flow)
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.websocket_message(flow)
+            assert len(deferred_websocket_trim_scheduler) == 1
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
 
         assert {event["category"]: event["quantity"] for event in webhook.usage_events()} == {
             "tokens.input": 10,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -185,6 +185,35 @@ class TestModelProviderWebSocketUsage:
             "tokens.output": 6,
         }
 
+    def test_model_websocket_late_same_id_frame_after_release_is_duplicate(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_1",
+                input_tokens=20,
+                output_tokens=12,
+            ),
+            _openai_websocket_usage_frame(
+                "resp_ws_1",
+                input_tokens=10,
+                output_tokens=7,
+            ),
+        )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
+            "tokens.input": 20,
+            "tokens.output": 12,
+        }
+        assert _sum_quantities_by_category(webhook.model_usage_observation_events()) == {
+            "tokens.input": 20,
+            "tokens.output": 12,
+        }
+
     def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -214,6 +214,45 @@ class TestModelProviderWebSocketUsage:
             "tokens.output": 12,
         }
 
+    def test_model_websocket_late_same_id_frame_can_add_new_category_after_release(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 20},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"output_tokens": 12},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        assert _sum_quantities_by_category(webhook.usage_events()) == {
+            "tokens.input": 20,
+            "tokens.output": 12,
+        }
+        assert _sum_quantities_by_category(webhook.model_usage_observation_events()) == {
+            "tokens.input": 20,
+            "tokens.output": 12,
+        }
+
     def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -253,6 +253,50 @@ class TestModelProviderWebSocketUsage:
             "tokens.output": 12,
         }
 
+    def test_model_websocket_zero_frame_model_is_used_by_later_positive_frame(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_1",
+                        "usage": {"input_tokens": 20, "output_tokens": 12},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        assert {
+            (event["provider"], event["category"]): event["quantity"]
+            for event in webhook.usage_events()
+        } == {
+            ("gpt-5.5", "tokens.input"): 20,
+            ("gpt-5.5", "tokens.output"): 12,
+        }
+        assert {
+            (event["model"], event["category"]): event["quantity"]
+            for event in webhook.model_usage_observation_events()
+        } == {
+            ("gpt-5.5", "tokens.input"): 20,
+            ("gpt-5.5", "tokens.output"): 12,
+        }
+
     def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -72,6 +72,73 @@ def test_model_usage_observation_buffer_uses_model_event_shape(tmp_path):
     assert enqueue.last_call.log_type == "model_usage_observation"
 
 
+def test_source_preserving_usage_buffer_keeps_source_idempotency_keys(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_source_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [
+            event(source_key="source-1", quantity=10),
+            event(source_key="source-2", quantity=5),
+            event(source_key="source-1", quantity=100),
+        ],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload == {
+        "runId": "run-1",
+        "events": [
+            {
+                "idempotencyKey": "source-1",
+                "kind": "model",
+                "provider": "claude-sonnet-4-6",
+                "category": "tokens.input",
+                "quantity": 10,
+            },
+            {
+                "idempotencyKey": "source-2",
+                "kind": "model",
+                "provider": "claude-sonnet-4-6",
+                "category": "tokens.input",
+                "quantity": 5,
+            },
+        ],
+    }
+
+
+def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_source_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [event(source_key="source-1", quantity=10)],
+        str(tmp_path / "proxy.jsonl"),
+    )
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload == {
+        "runId": "run-1",
+        "events": [
+            {
+                "idempotencyKey": "source-1",
+                "model": "claude-sonnet-4-6",
+                "category": "tokens.input",
+                "quantity": 10,
+            }
+        ],
+    }
+    assert enqueue.last_call.log_type == "model_usage_observation"
+
+
 def test_flush_keeps_runs_categories_providers_and_destinations_separate(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)


### PR DESCRIPTION
## Summary
- add source-preserving usage buffer wrappers so finalized WebSocket response sources keep their source idempotency keys
- report and release OpenAI Responses WebSocket per-response usage as terminal frames arrive, leaving websocket_end/error as fallback for unreported sources
- document the finality contract: once a WebSocket response source is accepted into the source-preserving buffer, later same-id frames are treated as source/category idempotency duplicates rather than corrections
- update WebSocket usage tests for incremental release and add buffer coverage for source-preserving payloads

Closes #17620

## Tests
- cd crates/runner/mitm-addon && .venv/bin/python -m ruff check . && .venv/bin/python -m ruff format --check . && .venv/bin/basedpyright -p .
- cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_model_provider_websocket_usage.py tests/test_model_provider_websocket_metadata.py tests/test_usage_buffer_aggregation.py
- cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_openai_responses_event_json.py tests/test_model_provider_usage.py tests/test_usage_buffer_idempotency.py tests/test_usage_buffer_flush_failures.py tests/test_usage_buffer_timer_shutdown.py tests/test_usage_buffer_logging.py tests/test_counters.py
- cd crates/runner/mitm-addon && .venv/bin/python -m pytest