### PR TITLE
fix: align feedback composer chip spacing with attachment chips

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -538,8 +538,13 @@ function ComposerFeedbackRow({
   return (
     <div
       className={cn(
-        "flex flex-col gap-1.5 py-1.5",
-        showDivider && "border-t border-dashed border-border/60",
+        // Bottom padding on every row; top padding only when a dashed divider
+        // separates stacked fragments. The first row gets no top inset so the
+        // quote chip sits as high as the attachment chips do (matching the
+        // composer's pt-3), letting the card extend upward instead of leaving a
+        // gap above the chip.
+        "flex flex-col gap-1.5 pb-1.5",
+        showDivider && "border-t border-dashed border-border/60 pt-1.5",
       )}
     >
       {/* Quote reference reuses the selected-template chip treatment (bordered
@@ -602,7 +607,9 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
 
   return (
     // min-h keeps the card from shrinking below the textarea's resting height.
-    <div className="flex min-h-[96px] flex-col px-3 pb-2 pt-3">
+    // px-4 / pt-3 mirror the attachment-chips inset so the feedback chip lines
+    // up with attachments on both the left and top edges.
+    <div className="flex min-h-[96px] flex-col px-4 pb-2 pt-3">
       {feedback.items.map((item, index) => {
         return (
           <ComposerFeedbackRow


### PR DESCRIPTION
## Problem

The inline "provide feedback" composer's quote chip spacing didn't match the regular composer's "add attachment" spacing:

- **Left edge:** feedback rows used `px-3` (12px) while attachment chips use `px-4` (16px).
- **Top edge:** each feedback row added `py-1.5`, pushing the first quote chip to 18px from the card top vs the attachment chips' 12px — leaving a visible gap above the chip.

## Fix

- `ComposerFeedbackRows` wrapper: `px-3` → `px-4` to mirror the attachment-chips left/top inset.
- `ComposerFeedbackRow`: replace the per-row `py-1.5` with `pb-1.5`, and apply `pt-1.5` only when a dashed divider separates stacked fragments. The first row gets no top inset, so the card extends upward to the chip (matching `pt-3`) instead of leaving a gap.

Multi-fragment spacing and the dashed divider between stacked feedback items are preserved (symmetric 6px above/below the divider).

## Verification

- Prettier (`3.8.1`) clean on the changed file.
- oxlint (`1.57.0`) — 0 warnings, 0 errors.
- Pure Tailwind className change; no logic or test-string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)