### PR TITLE
feat: make slash connector commands a two-pane auto-expand menu

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -61,17 +61,31 @@ export const setSelectedSlashSkillIndex$ = command(({ set }, index: number) => {
   set(internalSelectedSlashSkillIndex$, index);
 });
 
-// Which connector drawer is open in the slash menu, or null at the top level.
-// Reset to null whenever the menu's editor content changes so reopening `/`
-// always starts at the top level (replaces a React useEffect/useState pair,
-// which are restricted in this app in favor of ccstate signals).
-const internalOpenSlashConnectorType$ = state<ConnectorType | null>(null);
-export const openSlashConnectorType$ = computed((get) => {
-  return get(internalOpenSlashConnectorType$);
+// Which connector's commands are expanded in the slash menu's right pane, or
+// null until the menu derives the first connected connector. Reset to null
+// whenever the menu's editor content changes so reopening `/` starts fresh
+// (replaces a React useEffect/useState pair, which are restricted in this app in
+// favor of ccstate signals).
+const internalActiveSlashConnectorType$ = state<ConnectorType | null>(null);
+export const activeSlashConnectorType$ = computed((get) => {
+  return get(internalActiveSlashConnectorType$);
 });
-export const setOpenSlashConnectorType$ = command(
+export const setActiveSlashConnectorType$ = command(
   ({ set }, type: ConnectorType | null) => {
-    set(internalOpenSlashConnectorType$, type);
+    set(internalActiveSlashConnectorType$, type);
+  },
+);
+
+// Which column of the slash menu's two-pane Commands block has keyboard focus:
+// the connector rail (left) or the command detail pane (right). Reset to "rail"
+// on content change so reopening `/` starts on the rail.
+const internalSlashMenuColumn$ = state<"rail" | "detail">("rail");
+export const slashMenuColumn$ = computed((get) => {
+  return get(internalSlashMenuColumn$);
+});
+export const setSlashMenuColumn$ = command(
+  ({ set }, column: "rail" | "detail") => {
+    set(internalSlashMenuColumn$, column);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -722,8 +722,12 @@ describe("chat composer models", () => {
     const menu = await screen.findByTestId("slash-skill-menu");
     // The first connector is active by default, so its commands show in the
     // right pane immediately — no drill-in or back step.
-    expect(await within(menu).findByText("GitHub")).toBeInTheDocument();
-    expect(await within(menu).findByText("List PRs")).toBeInTheDocument();
+    await expect(
+      within(menu).findByText("GitHub"),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      within(menu).findByText("List PRs"),
+    ).resolves.toBeInTheDocument();
     expect(within(menu).getByText("Create issue")).toBeInTheDocument();
 
     await user.click(within(menu).getByText("List PRs"));
@@ -856,7 +860,9 @@ describe("chat composer models", () => {
     await user.keyboard("/");
 
     const menu = await screen.findByTestId("slash-skill-menu");
-    expect(await within(menu).findByText("GitHub")).toBeInTheDocument();
+    await expect(
+      within(menu).findByText("GitHub"),
+    ).resolves.toBeInTheDocument();
     expect(within(menu).getByText("/sales-research")).toBeInTheDocument();
 
     // The rail is the connector then the skill; ArrowDown moves to the skill and

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -697,7 +697,7 @@ describe("chat composer models", () => {
     });
   });
 
-  it("opens a connected connector's command drawer and inserts its prompt", async () => {
+  it("auto-expands a connected connector's commands and inserts one", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent({ customSkills: [] });
@@ -720,19 +720,13 @@ describe("chat composer models", () => {
     await user.keyboard("/");
 
     const menu = await screen.findByTestId("slash-skill-menu");
-    await user.click(await within(menu).findByText("GitHub"));
+    // The first connector is active by default, so its commands show in the
+    // right pane immediately — no drill-in or back step.
+    expect(await within(menu).findByText("GitHub")).toBeInTheDocument();
+    expect(await within(menu).findByText("List PRs")).toBeInTheDocument();
+    expect(within(menu).getByText("Create issue")).toBeInTheDocument();
 
-    // Drilling into the connector drawer reveals its curated commands.
-    await expect(
-      within(screen.getByTestId("slash-skill-menu")).findByText("List PRs"),
-    ).resolves.toBeInTheDocument();
-    expect(
-      within(screen.getByTestId("slash-skill-menu")).getByText("Create issue"),
-    ).toBeInTheDocument();
-
-    await user.click(
-      within(screen.getByTestId("slash-skill-menu")).getByText("List PRs"),
-    );
+    await user.click(within(menu).getByText("List PRs"));
 
     // Picking a command drops its natural-language prompt into the composer.
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -795,6 +795,79 @@ describe("chat composer models", () => {
     expect(within(menu).queryByText("GitHub")).not.toBeInTheDocument();
   });
 
+  it("navigates connector commands with the keyboard and inserts one", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent({ customSkills: [] });
+    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatSlashSkillCommands]: true,
+        [FeatureSwitchKey.ChatConnectorCommands]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("/");
+
+    const menu = await screen.findByTestId("slash-skill-menu");
+    await within(menu).findByText("List PRs");
+
+    // ArrowRight moves focus from the connector rail into the command pane,
+    // ArrowDown selects the second command, Enter inserts it.
+    await user.keyboard("{ArrowRight}{ArrowDown}{Enter}");
+
+    await waitFor(() => {
+      expect(editor.textContent).toContain(
+        "Review this pull request and tell me what needs changing",
+      );
+    });
+  });
+
+  it("inserts a skill when arrowing past the connector rail", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent({ customSkills: ["sales-research"] });
+    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+      return respond(200, [
+        { name: "sales-research", displayName: null, description: null },
+      ]);
+    });
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatSlashSkillCommands]: true,
+        [FeatureSwitchKey.ChatConnectorCommands]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("/");
+
+    const menu = await screen.findByTestId("slash-skill-menu");
+    expect(await within(menu).findByText("GitHub")).toBeInTheDocument();
+    expect(within(menu).getByText("/sales-research")).toBeInTheDocument();
+
+    // The rail is the connector then the skill; ArrowDown moves to the skill and
+    // Enter inserts it.
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    await waitFor(() => {
+      expect(editor.textContent).toContain("/sales-research");
+    });
+  });
+
   it("resolves workspace, user, and thread model choices in the visible picker", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();

--- a/turbo/apps/platform/src/views/zero-page/slash-skill.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-skill.tsx
@@ -2,19 +2,16 @@
 // composer. Kept in its own module so the textarea composer and the TipTap
 // skill composer can both reuse them without an import cycle.
 //
-// The menu has two levels. The top level lists connected connectors' command
-// groups (a discoverability scaffold) above the current agent's skills; opening
-// a connector drills into a drawer of that connector's curated commands. Picking
-// any leaf inserts text into the composer.
-import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconFileText,
-} from "@tabler/icons-react";
+// The menu is a two-pane "Commands" block above the agent's skills. The left
+// rail lists connected connectors; highlighting (selecting/hovering) a connector
+// auto-expands its curated commands in the right pane — no drill-in or back step.
+// Picking a command or skill inserts text into the composer.
+import { IconChevronRight, IconFileText } from "@tabler/icons-react";
 import { cn, PopoverContent } from "@vm0/ui";
 import type { ZeroAgentCustomSkill } from "@vm0/api-contracts/contracts/zero-agents";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { ConnectorCommand } from "./connector-commands.ts";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { Link } from "../router/link.tsx";
 
 export interface SlashSkillRange {
@@ -35,16 +32,13 @@ export interface SlashConnectorGroup {
   readonly commands: readonly ConnectorCommand[];
 }
 
-// One navigable row in the menu. The composer builds the ordered list for the
-// current level and the menu renders/keys off it, so indices always agree.
+// One navigable row in the menu's left rail: a connector or a skill. Commands
+// live in the right pane and are navigated separately (see SlashMenuColumn).
 export type SlashMenuItem =
   | { readonly kind: "connector"; readonly group: SlashConnectorGroup }
-  | { readonly kind: "skill"; readonly skill: ComposerSlashSkill }
-  | {
-      readonly kind: "command";
-      readonly command: ConnectorCommand;
-      readonly index: number;
-    };
+  | { readonly kind: "skill"; readonly skill: ComposerSlashSkill };
+
+export type SlashMenuColumn = "rail" | "detail";
 
 export function findActiveSlashSkillRange(
   value: string,
@@ -113,29 +107,21 @@ export function buildComposerSlashSkills({
   });
 }
 
-function slashSkillOptionId(skillName: string): string {
+export function connectorOptionId(connectorType: ConnectorType): string {
+  return `slash-connector-option-${connectorType}`;
+}
+
+export function skillOptionId(skillName: string): string {
   return `slash-skill-option-${skillName}`;
 }
 
-function slashMenuItemId(item: SlashMenuItem): string {
-  if (item.kind === "connector") {
-    return `slash-connector-option-${item.group.connectorType}`;
-  }
-  if (item.kind === "command") {
-    return `slash-command-option-${item.index}`;
-  }
-  return slashSkillOptionId(item.skill.name);
+export function commandOptionId(index: number): string {
+  return `slash-command-option-${index}`;
 }
 
-export function scrollSlashMenuItemIntoView(
-  item: SlashMenuItem | undefined,
-): void {
-  if (!item) {
-    return;
-  }
-
+export function scrollSlashOptionIntoView(elementId: string): void {
   window.requestAnimationFrame(() => {
-    const option = document.getElementById(slashMenuItemId(item));
+    const option = document.getElementById(elementId);
     if (option && typeof option.scrollIntoView === "function") {
       option.scrollIntoView({ block: "nearest" });
     }
@@ -146,187 +132,124 @@ const SECTION_LABEL_CLASS =
   "px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide " +
   "text-muted-foreground";
 
-function SlashMenuRow({
-  item,
-  index,
+const ROW_CLASS =
+  "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors";
+
+// Left rail: one row per connected connector. Highlighting a connector (keyboard
+// rail selection or hover) makes it the active connector whose commands show on
+// the right.
+function SlashConnectorRail({
+  connectorGroups,
+  activeConnectorType,
+  onActivate,
+}: {
+  readonly connectorGroups: readonly SlashConnectorGroup[];
+  readonly activeConnectorType: ConnectorType | null;
+  readonly onActivate: (connectorType: ConnectorType) => void;
+}) {
+  return (
+    <div className="flex w-[112px] shrink-0 flex-col border-r border-border/60 pr-1">
+      {connectorGroups.map((group) => {
+        const active = group.connectorType === activeConnectorType;
+        return (
+          <button
+            id={connectorOptionId(group.connectorType)}
+            key={group.connectorType}
+            type="button"
+            className={cn(
+              ROW_CLASS,
+              active ? "bg-accent" : "hover:bg-accent/60",
+            )}
+            onMouseEnter={() => {
+              onActivate(group.connectorType);
+            }}
+            // preventDefault keeps focus in the editor; the menu is keyboard
+            // driven from the editor's keydown handler.
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onActivate(group.connectorType);
+            }}
+          >
+            <ConnectorIcon type={group.connectorType} size={18} />
+            <span className="truncate text-sm text-popover-foreground">
+              {group.label}
+            </span>
+            <IconChevronRight
+              size={16}
+              stroke={1.8}
+              className="ml-auto shrink-0 text-muted-foreground"
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Right pane: the active connector's curated commands.
+function SlashCommandPane({
+  commands,
+  selected,
   selectedIndex,
   onSelect,
 }: {
-  readonly item: SlashMenuItem;
-  readonly index: number;
+  readonly commands: readonly ConnectorCommand[];
+  readonly selected: boolean;
   readonly selectedIndex: number;
-  readonly onSelect: (item: SlashMenuItem) => void;
+  readonly onSelect: (command: ConnectorCommand) => void;
 }) {
-  const selected = index === selectedIndex;
+  return (
+    <div className="min-w-0 flex-1 pl-1">
+      {commands.map((command, index) => {
+        return (
+          <button
+            id={commandOptionId(index)}
+            key={command.label}
+            type="button"
+            className={cn(
+              ROW_CLASS,
+              selected && index === selectedIndex
+                ? "bg-accent"
+                : "hover:bg-accent/60",
+            )}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              onSelect(command);
+            }}
+          >
+            <span className="truncate text-sm text-popover-foreground">
+              {command.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SlashSkillRow({
+  skill,
+  selected,
+  onSelect,
+}: {
+  readonly skill: ComposerSlashSkill;
+  readonly selected: boolean;
+  readonly onSelect: (skill: ComposerSlashSkill) => void;
+}) {
   return (
     <button
-      id={slashMenuItemId(item)}
+      id={skillOptionId(skill.name)}
       type="button"
-      className={cn(
-        "flex w-full items-center rounded px-2 py-1.5 text-left transition-colors",
-        selected ? "bg-accent" : "hover:bg-accent/60",
-      )}
-      // preventDefault keeps focus in the editor; the menu is keyboard-driven
-      // from the editor's keydown handler.
+      className={cn(ROW_CLASS, selected ? "bg-accent" : "hover:bg-accent/60")}
       onMouseDown={(event) => {
         event.preventDefault();
-        onSelect(item);
+        onSelect(skill);
       }}
     >
-      {item.kind === "skill" ? (
-        <span className="truncate font-mono text-sm text-primary">
-          {item.skill.token}
-        </span>
-      ) : item.kind === "connector" ? (
-        <>
-          <span className="truncate text-sm text-popover-foreground">
-            {item.group.label}
-          </span>
-          <IconChevronRight
-            size={16}
-            stroke={1.8}
-            className="ml-auto shrink-0 text-muted-foreground"
-          />
-        </>
-      ) : (
-        <span className="truncate text-sm text-popover-foreground">
-          {item.command.label}
-        </span>
-      )}
+      <span className="truncate font-mono text-sm text-primary">
+        {skill.token}
+      </span>
     </button>
-  );
-}
-
-// The open connector's drawer: a back row to the top level above that
-// connector's curated commands.
-function SlashDrawerContent({
-  items,
-  drawerLabel,
-  selectedIndex,
-  onSelect,
-  onBack,
-}: {
-  readonly items: readonly SlashMenuItem[];
-  readonly drawerLabel: string | null;
-  readonly selectedIndex: number;
-  readonly onSelect: (item: SlashMenuItem) => void;
-  readonly onBack: () => void;
-}) {
-  return (
-    <>
-      <button
-        type="button"
-        className="flex items-center gap-1.5 px-2 pt-2 pb-1 text-left text-[0.8125rem] font-medium text-popover-foreground"
-        onMouseDown={(event) => {
-          event.preventDefault();
-          onBack();
-        }}
-      >
-        <IconChevronLeft
-          size={16}
-          stroke={1.8}
-          className="shrink-0 text-muted-foreground"
-        />
-        <span className="truncate">{drawerLabel}</span>
-      </button>
-      <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
-        {items.map((item, index) => {
-          return (
-            <SlashMenuRow
-              key={slashMenuItemId(item)}
-              item={item}
-              index={index}
-              selectedIndex={selectedIndex}
-              onSelect={onSelect}
-            />
-          );
-        })}
-      </div>
-    </>
-  );
-}
-
-// The top level: connected connectors' command groups (Commands) above the
-// current agent's skills (Skills).
-function SlashTopLevelContent({
-  items,
-  loading,
-  selectedIndex,
-  onSelect,
-}: {
-  readonly items: readonly SlashMenuItem[];
-  readonly loading: boolean;
-  readonly selectedIndex: number;
-  readonly onSelect: (item: SlashMenuItem) => void;
-}) {
-  const connectorItems = items
-    .map((item, index) => {
-      return { item, index };
-    })
-    .filter((entry) => {
-      return entry.item.kind === "connector";
-    });
-  const skillItems = items
-    .map((item, index) => {
-      return { item, index };
-    })
-    .filter((entry) => {
-      return entry.item.kind === "skill";
-    });
-  // Only show the Skills section header when it has something to say, so a menu
-  // that is all connector commands doesn't render a dangling "Skills" label.
-  const showSkillsSection =
-    loading || skillItems.length > 0 || connectorItems.length === 0;
-
-  return (
-    <>
-      {connectorItems.length > 0 && (
-        <>
-          <div className={SECTION_LABEL_CLASS}>Commands</div>
-          <div className="px-1.5 pb-1">
-            {connectorItems.map((entry) => {
-              return (
-                <SlashMenuRow
-                  key={slashMenuItemId(entry.item)}
-                  item={entry.item}
-                  index={entry.index}
-                  selectedIndex={selectedIndex}
-                  onSelect={onSelect}
-                />
-              );
-            })}
-          </div>
-        </>
-      )}
-      {showSkillsSection && (
-        <>
-          <div className={SECTION_LABEL_CLASS}>Skills</div>
-          {loading ? (
-            <div className="px-2.5 py-2 text-sm text-muted-foreground">
-              Loading skills...
-            </div>
-          ) : skillItems.length > 0 ? (
-            <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
-              {skillItems.map((entry) => {
-                return (
-                  <SlashMenuRow
-                    key={slashMenuItemId(entry.item)}
-                    item={entry.item}
-                    index={entry.index}
-                    selectedIndex={selectedIndex}
-                    onSelect={onSelect}
-                  />
-                );
-              })}
-            </div>
-          ) : (
-            <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
-              No matching skills
-            </div>
-          )}
-        </>
-      )}
-    </>
   );
 }
 
@@ -356,24 +279,39 @@ function SlashSkillsPageLink() {
 }
 
 export function SlashSkillMenu({
-  items,
-  mode,
-  drawerLabel,
-  loading,
+  connectorGroups,
+  activeConnectorType,
+  commands,
+  skills,
+  column,
   selectedIndex,
+  railSkillStartIndex,
+  loading,
   showSkillsPageLink,
-  onSelect,
-  onBack,
+  onActivateConnector,
+  onSelectCommand,
+  onSelectSkill,
 }: {
-  readonly items: readonly SlashMenuItem[];
-  readonly mode: "top" | "drawer";
-  readonly drawerLabel: string | null;
-  readonly loading: boolean;
+  readonly connectorGroups: readonly SlashConnectorGroup[];
+  readonly activeConnectorType: ConnectorType | null;
+  readonly commands: readonly ConnectorCommand[];
+  readonly skills: readonly ComposerSlashSkill[];
+  readonly column: SlashMenuColumn;
   readonly selectedIndex: number;
+  // Rail index where skills begin (after the connectors), so a rail selection
+  // index maps to the right skill row.
+  readonly railSkillStartIndex: number;
+  readonly loading: boolean;
   readonly showSkillsPageLink: boolean;
-  readonly onSelect: (item: SlashMenuItem) => void;
-  readonly onBack: () => void;
+  readonly onActivateConnector: (connectorType: ConnectorType) => void;
+  readonly onSelectCommand: (command: ConnectorCommand) => void;
+  readonly onSelectSkill: (skill: ComposerSlashSkill) => void;
 }) {
+  const hasConnectors = connectorGroups.length > 0;
+  // Show the Skills header only when it has something to say, so a connectors-
+  // only menu doesn't render a dangling "Skills" label.
+  const showSkillsSection = loading || skills.length > 0 || !hasConnectors;
+
   return (
     <PopoverContent
       side="top"
@@ -385,24 +323,56 @@ export function SlashSkillMenu({
       onOpenAutoFocus={(event) => {
         event.preventDefault();
       }}
-      className="flex max-h-80 w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0"
+      className="flex max-h-80 w-[300px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0"
       data-testid="slash-skill-menu"
     >
-      {mode === "drawer" ? (
-        <SlashDrawerContent
-          items={items}
-          drawerLabel={drawerLabel}
-          selectedIndex={selectedIndex}
-          onSelect={onSelect}
-          onBack={onBack}
-        />
-      ) : (
-        <SlashTopLevelContent
-          items={items}
-          loading={loading}
-          selectedIndex={selectedIndex}
-          onSelect={onSelect}
-        />
+      {hasConnectors && (
+        <>
+          <div className={SECTION_LABEL_CLASS}>Commands</div>
+          <div className="flex px-1.5 pb-1">
+            <SlashConnectorRail
+              connectorGroups={connectorGroups}
+              activeConnectorType={activeConnectorType}
+              onActivate={onActivateConnector}
+            />
+            <SlashCommandPane
+              commands={commands}
+              selected={column === "detail"}
+              selectedIndex={selectedIndex}
+              onSelect={onSelectCommand}
+            />
+          </div>
+        </>
+      )}
+      {showSkillsSection && (
+        <>
+          <div className={SECTION_LABEL_CLASS}>Skills</div>
+          {loading ? (
+            <div className="px-2.5 py-2 text-sm text-muted-foreground">
+              Loading skills...
+            </div>
+          ) : skills.length > 0 ? (
+            <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
+              {skills.map((skill, index) => {
+                return (
+                  <SlashSkillRow
+                    key={skill.name}
+                    skill={skill}
+                    selected={
+                      column === "rail" &&
+                      selectedIndex === railSkillStartIndex + index
+                    }
+                    onSelect={onSelectSkill}
+                  />
+                );
+              })}
+            </div>
+          ) : (
+            <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
+              No matching skills
+            </div>
+          )}
+        </>
       )}
       {showSkillsPageLink && <SlashSkillsPageLink />}
     </PopoverContent>

--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -583,6 +583,151 @@ function SlashComposerShell({
   );
 }
 
+// Created once; useEditor refreshes its options via setOptions on every render,
+// so the handlers always close over the latest props/state (no refs needed).
+function useComposerEditor(params: EditorOptionsParams): Editor | null {
+  const editor = useEditor(buildEditorOptions(params));
+  if (editor) {
+    syncEditorState(editor, params.skillNames, params.input);
+  }
+  return editor;
+}
+
+interface SlashMenuHandlers {
+  readonly activateConnector: (connectorType: ConnectorType) => void;
+  readonly insertCommand: (command: ConnectorCommand) => void;
+  readonly insertSkill: (skill: ComposerSlashSkill) => void;
+  readonly handleEditorKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+// The slash-menu interaction handlers are factored out of the component so its
+// body stays small. They capture the current render's derived model + setters,
+// matching the previous inline closures (recreated each render).
+function createSlashMenuHandlers(deps: {
+  readonly editor: Editor | null;
+  readonly slashRange: SlashSkillRange | null;
+  readonly input: string;
+  readonly onDraftChange: (() => void) | undefined;
+  readonly onKeyDown: (event: KeyboardEventLike) => void;
+  readonly filteredConnectorGroups: readonly SlashConnectorGroup[];
+  readonly railItems: readonly SlashMenuItem[];
+  readonly commands: readonly ConnectorCommand[];
+  readonly menuColumn: SlashMenuColumn;
+  readonly activeRailIndex: number;
+  readonly selectedIndex: number;
+  readonly showMenu: boolean;
+  readonly setActiveConnectorType: (value: ConnectorType | null) => void;
+  readonly setColumn: (value: SlashMenuColumn) => void;
+  readonly setSelectedIndex: (value: number) => void;
+  readonly setCaretIndex: (value: number) => void;
+}): SlashMenuHandlers {
+  function activateConnector(connectorType: ConnectorType): void {
+    deps.setActiveConnectorType(connectorType);
+    deps.setColumn("rail");
+    const index = deps.filteredConnectorGroups.findIndex((group) => {
+      return group.connectorType === connectorType;
+    });
+    deps.setSelectedIndex(index !== -1 ? index : 0);
+  }
+
+  function moveSelection(next: number): void {
+    deps.setSelectedIndex(next);
+    if (deps.menuColumn === "detail") {
+      scrollSlashOptionIntoView(commandOptionId(next));
+      return;
+    }
+    const item = deps.railItems[next];
+    if (item?.kind === "connector") {
+      deps.setActiveConnectorType(item.group.connectorType);
+      scrollSlashOptionIntoView(connectorOptionId(item.group.connectorType));
+    } else if (item?.kind === "skill") {
+      scrollSlashOptionIntoView(skillOptionId(item.skill.name));
+    }
+  }
+
+  function enterDetail(): void {
+    if (deps.commands.length === 0) {
+      return;
+    }
+    deps.setColumn("detail");
+    deps.setSelectedIndex(0);
+    scrollSlashOptionIntoView(commandOptionId(0));
+  }
+
+  function exitDetail(): void {
+    deps.setColumn("rail");
+    deps.setSelectedIndex(deps.activeRailIndex);
+  }
+
+  function insertSkill(skill: ComposerSlashSkill): void {
+    if (!deps.editor || !deps.slashRange) {
+      return;
+    }
+    insertSkillToken(deps.editor, deps.slashRange, deps.input, skill);
+    deps.onDraftChange?.();
+  }
+
+  function insertCommand(command: ConnectorCommand): void {
+    if (!deps.editor || !deps.slashRange) {
+      return;
+    }
+    insertPromptText(deps.editor, deps.slashRange, command.prompt);
+    deps.onDraftChange?.();
+  }
+
+  function selectRailAt(index: number): void {
+    const item = deps.railItems[index];
+    if (!item) {
+      return;
+    }
+    if (item.kind === "connector") {
+      activateConnector(item.group.connectorType);
+      enterDetail();
+    } else {
+      insertSkill(item.skill);
+    }
+  }
+
+  function selectCommandAt(index: number): void {
+    const command = deps.commands[index];
+    if (command) {
+      insertCommand(command);
+    }
+  }
+
+  function handleEditorKeyDown(event: KeyboardEvent): boolean {
+    if (
+      deps.showMenu &&
+      handleSlashMenuKey(event, {
+        column: deps.menuColumn,
+        railCount: deps.railItems.length,
+        commandCount: deps.commands.length,
+        selectedIndex: deps.selectedIndex,
+        railItemIsConnector: (index) => {
+          return deps.railItems[index]?.kind === "connector";
+        },
+        moveSelection,
+        enterDetail,
+        exitDetail,
+        selectRailAt,
+        selectCommandAt,
+        close: () => {
+          deps.setCaretIndex(-1);
+        },
+      })
+    ) {
+      return true;
+    }
+    // Defer to the parent for send / global shortcuts. If it consumes the event
+    // (e.g. Enter-to-send) it calls preventDefault; otherwise the editor handles
+    // the keystroke (e.g. Shift+Enter or mobile Enter inserts a newline).
+    deps.onKeyDown(event);
+    return event.defaultPrevented;
+  }
+
+  return { activateConnector, insertCommand, insertSkill, handleEditorKeyDown };
+}
+
 export function TiptapSkillComposer({
   input,
   onInputChange,
@@ -606,7 +751,7 @@ export function TiptapSkillComposer({
   const setCaretIndex = useSet(setSlashSkillCaretIndex$);
   const selectedIndex = useGet(selectedSlashSkillIndex$);
   const setSelectedIndex = useSet(setSelectedSlashSkillIndex$);
-  // Two-pane state lives in signals (React state is restricted here) and resets
+  // Two-pane state lives in signals (React state is restricted here); it resets
   // on content change so reopening `/` always starts fresh on the rail.
   const activeConnectorType = useGet(activeSlashConnectorType$);
   const setActiveConnectorType = useSet(setActiveSlashConnectorType$);
@@ -655,139 +800,46 @@ export function TiptapSkillComposer({
     showSkillsPageLink,
   });
 
-  // Created once; useEditor refreshes its options via setOptions on every render,
-  // so the handlers always close over the latest props/state (no refs needed).
-  const editor = useEditor(
-    buildEditorOptions({
-      input,
-      skillNames,
-      autoFocus,
-      onInputChange,
-      onPaste,
-      setInputRef,
-      setSelectedSkillIndex: setSelectedIndex,
-      setCaretIndex,
-      resetSlashMenuState: () => {
-        if (activeConnectorType !== null) {
-          setActiveConnectorType(null);
-        }
-        if (column !== "rail") {
-          setColumn("rail");
-        }
-      },
-      onEditorKeyDown: (event) => {
-        return handleEditorKeyDown(event);
-      },
-    }),
-  );
+  const editor = useComposerEditor({
+    input,
+    skillNames,
+    autoFocus,
+    onInputChange,
+    onPaste,
+    setInputRef,
+    setSelectedSkillIndex: setSelectedIndex,
+    setCaretIndex,
+    resetSlashMenuState: () => {
+      if (activeConnectorType !== null) {
+        setActiveConnectorType(null);
+      }
+      if (column !== "rail") {
+        setColumn("rail");
+      }
+    },
+    onEditorKeyDown: (event) => {
+      return handlers.handleEditorKeyDown(event);
+    },
+  });
 
-  if (editor) {
-    syncEditorState(editor, skillNames, input);
-  }
-
-  function activateConnector(connectorType: ConnectorType): void {
-    setActiveConnectorType(connectorType);
-    setColumn("rail");
-    const index = filteredConnectorGroups.findIndex((group) => {
-      return group.connectorType === connectorType;
-    });
-    setSelectedIndex(index >= 0 ? index : 0);
-  }
-
-  function moveSelection(next: number): void {
-    setSelectedIndex(next);
-    if (menuColumn === "detail") {
-      scrollSlashOptionIntoView(commandOptionId(next));
-      return;
-    }
-    const item = railItems[next];
-    if (item?.kind === "connector") {
-      setActiveConnectorType(item.group.connectorType);
-      scrollSlashOptionIntoView(connectorOptionId(item.group.connectorType));
-    } else if (item?.kind === "skill") {
-      scrollSlashOptionIntoView(skillOptionId(item.skill.name));
-    }
-  }
-
-  function enterDetail(): void {
-    if (commands.length === 0) {
-      return;
-    }
-    setColumn("detail");
-    setSelectedIndex(0);
-    scrollSlashOptionIntoView(commandOptionId(0));
-  }
-
-  function exitDetail(): void {
-    setColumn("rail");
-    setSelectedIndex(activeRailIndex);
-  }
-
-  function insertSkill(skill: ComposerSlashSkill): void {
-    if (!editor || !slashRange) {
-      return;
-    }
-    insertSkillToken(editor, slashRange, input, skill);
-    onDraftChange?.();
-  }
-
-  function insertCommand(command: ConnectorCommand): void {
-    if (!editor || !slashRange) {
-      return;
-    }
-    insertPromptText(editor, slashRange, command.prompt);
-    onDraftChange?.();
-  }
-
-  function selectRailAt(index: number): void {
-    const item = railItems[index];
-    if (!item) {
-      return;
-    }
-    if (item.kind === "connector") {
-      activateConnector(item.group.connectorType);
-      enterDetail();
-    } else {
-      insertSkill(item.skill);
-    }
-  }
-
-  function selectCommandAt(index: number): void {
-    const command = commands[index];
-    if (command) {
-      insertCommand(command);
-    }
-  }
-
-  function handleEditorKeyDown(event: KeyboardEvent): boolean {
-    if (
-      showMenu &&
-      handleSlashMenuKey(event, {
-        column: menuColumn,
-        railCount: railItems.length,
-        commandCount: commands.length,
-        selectedIndex,
-        railItemIsConnector: (index) => {
-          return railItems[index]?.kind === "connector";
-        },
-        moveSelection,
-        enterDetail,
-        exitDetail,
-        selectRailAt,
-        selectCommandAt,
-        close: () => {
-          setCaretIndex(-1);
-        },
-      })
-    ) {
-      return true;
-    }
-    // Defer to the parent for send / global shortcuts. If it consumes the event
-    // (e.g. Enter-to-send) it calls preventDefault; otherwise the editor handles
-    // the keystroke (e.g. Shift+Enter or mobile Enter inserts a newline).
-    onKeyDown(event);
-    return event.defaultPrevented;
-  }
+  const handlers = createSlashMenuHandlers({
+    editor,
+    slashRange,
+    input,
+    onDraftChange,
+    onKeyDown,
+    filteredConnectorGroups,
+    railItems,
+    commands,
+    menuColumn,
+    activeRailIndex,
+    selectedIndex,
+    showMenu,
+    setActiveConnectorType,
+    setColumn,
+    setSelectedIndex,
+    setCaretIndex,
+  });
 
   return (
     <SlashComposerShell
@@ -804,9 +856,9 @@ export function TiptapSkillComposer({
       railSkillStartIndex={filteredConnectorGroups.length}
       loading={isLoadingOrgSkills}
       showSkillsPageLink={showSkillsPageLink}
-      onActivateConnector={activateConnector}
-      onSelectCommand={insertCommand}
-      onSelectSkill={insertSkill}
+      onActivateConnector={handlers.activateConnector}
+      onSelectCommand={handlers.insertCommand}
+      onSelectSkill={handlers.insertSkill}
     />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -26,22 +26,31 @@ import {
   setSlashSkillCaretIndex$,
   selectedSlashSkillIndex$,
   setSelectedSlashSkillIndex$,
-  openSlashConnectorType$,
-  setOpenSlashConnectorType$,
+  activeSlashConnectorType$,
+  setActiveSlashConnectorType$,
+  slashMenuColumn$,
+  setSlashMenuColumn$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
   buildComposerSlashSkills,
+  commandOptionId,
+  connectorOptionId,
   findActiveSlashSkillRange,
   matchesSkillQuery,
-  scrollSlashMenuItemIntoView,
+  scrollSlashOptionIntoView,
+  skillOptionId,
   skillTokenPattern,
   SlashSkillMenu,
   type ComposerSlashSkill,
   type SlashConnectorGroup,
+  type SlashMenuColumn,
   type SlashMenuItem,
   type SlashSkillRange,
 } from "./slash-skill.tsx";
-import { CONNECTOR_COMMAND_GROUPS } from "./connector-commands.ts";
+import {
+  CONNECTOR_COMMAND_GROUPS,
+  type ConnectorCommand,
+} from "./connector-commands.ts";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 
 // Match the textarea metrics so swapping inputs is visually seamless. The editor
@@ -211,54 +220,80 @@ function insertPromptText(
     .run();
 }
 
+// Two-column keyboard navigation over the slash menu. The "rail" column holds
+// connectors then skills; the "detail" column holds the active connector's
+// commands. Returns true when it consumes the event.
 interface SlashMenuKeyContext {
-  readonly items: readonly SlashMenuItem[];
+  readonly column: SlashMenuColumn;
+  readonly railCount: number;
+  readonly commandCount: number;
   readonly selectedIndex: number;
-  readonly setSelectedIndex: (index: number) => void;
-  readonly setCaretIndex: (index: number) => void;
-  readonly onSelect: (item: SlashMenuItem) => void;
-  // Set while a connector drawer is open; Escape returns to the top level
-  // instead of closing the menu.
-  readonly onBack: (() => void) | null;
+  readonly railItemIsConnector: (index: number) => boolean;
+  readonly moveSelection: (next: number) => void;
+  readonly enterDetail: () => void;
+  readonly exitDetail: () => void;
+  readonly selectRailAt: (index: number) => void;
+  readonly selectCommandAt: (index: number) => void;
+  readonly close: () => void;
 }
 
-// Drives the suggestion menu from the keyboard. Returns true when it consumes the
-// event so the editor can stop handling that keystroke.
 function handleSlashMenuKey(
   event: KeyboardEvent,
   ctx: SlashMenuKeyContext,
 ): boolean {
+  const length = ctx.column === "detail" ? ctx.commandCount : ctx.railCount;
   if (event.key === "ArrowDown") {
     event.preventDefault();
-    const next = Math.min(
-      ctx.selectedIndex + 1,
-      Math.max(ctx.items.length - 1, 0),
-    );
-    ctx.setSelectedIndex(next);
-    scrollSlashMenuItemIntoView(ctx.items[next]);
+    ctx.moveSelection(Math.min(ctx.selectedIndex + 1, Math.max(length - 1, 0)));
     return true;
   }
   if (event.key === "ArrowUp") {
     event.preventDefault();
-    const next = Math.max(ctx.selectedIndex - 1, 0);
-    ctx.setSelectedIndex(next);
-    scrollSlashMenuItemIntoView(ctx.items[next]);
+    ctx.moveSelection(Math.max(ctx.selectedIndex - 1, 0));
     return true;
   }
-  if ((event.key === "Enter" || event.key === "Tab") && ctx.items[0]) {
-    event.preventDefault();
-    const item = ctx.items[Math.min(ctx.selectedIndex, ctx.items.length - 1)];
-    if (item) {
-      ctx.onSelect(item);
+  if (event.key === "ArrowRight") {
+    if (
+      ctx.column === "rail" &&
+      ctx.railItemIsConnector(ctx.selectedIndex) &&
+      ctx.commandCount > 0
+    ) {
+      event.preventDefault();
+      ctx.enterDetail();
+      return true;
     }
+    return false;
+  }
+  if (event.key === "ArrowLeft") {
+    if (ctx.column === "detail") {
+      event.preventDefault();
+      ctx.exitDetail();
+      return true;
+    }
+    return false;
+  }
+  if (event.key === "Enter" || event.key === "Tab") {
+    if (ctx.column === "detail") {
+      if (ctx.commandCount === 0) {
+        return false;
+      }
+      event.preventDefault();
+      ctx.selectCommandAt(Math.min(ctx.selectedIndex, ctx.commandCount - 1));
+      return true;
+    }
+    if (ctx.railCount === 0) {
+      return false;
+    }
+    event.preventDefault();
+    ctx.selectRailAt(Math.min(ctx.selectedIndex, ctx.railCount - 1));
     return true;
   }
   if (event.key === "Escape") {
     event.preventDefault();
-    if (ctx.onBack) {
-      ctx.onBack();
+    if (ctx.column === "detail") {
+      ctx.exitDetail();
     } else {
-      ctx.setCaretIndex(-1);
+      ctx.close();
     }
     return true;
   }
@@ -274,9 +309,9 @@ interface EditorOptionsParams {
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
   readonly setSelectedSkillIndex: (index: number) => void;
   readonly setCaretIndex: (index: number) => void;
-  // Drop back to the menu's top level when the content changes, so a connector
-  // drawer never silently reopens on the next `/`.
-  readonly resetConnectorDrawer: () => void;
+  // Reset the menu's two-pane state (active connector + focused column) when the
+  // content changes, so reopening `/` always starts fresh on the rail.
+  readonly resetSlashMenuState: () => void;
   readonly onEditorKeyDown: (event: KeyboardEvent) => boolean;
 }
 
@@ -315,7 +350,7 @@ function buildEditorOptions(
         params.onInputChange(value);
       }
       params.setSelectedSkillIndex(0);
-      params.resetConnectorDrawer();
+      params.resetSlashMenuState();
       params.setCaretIndex(caretStringIndex(editor));
     },
     onSelectionUpdate: ({ editor }) => {
@@ -386,28 +421,35 @@ function buildConnectorGroups(
 }
 
 interface SlashMenuModel {
-  readonly menuItems: readonly SlashMenuItem[];
-  readonly menuMode: "top" | "drawer";
-  readonly openGroup: SlashConnectorGroup | null;
+  readonly filteredConnectorGroups: readonly SlashConnectorGroup[];
+  readonly suggestions: readonly ComposerSlashSkill[];
+  readonly railItems: readonly SlashMenuItem[];
+  readonly activeGroup: SlashConnectorGroup | null;
+  readonly activeRailIndex: number;
+  readonly commands: readonly ConnectorCommand[];
+  readonly column: SlashMenuColumn;
   readonly showMenu: boolean;
 }
 
-// Builds the ordered rows for the current menu level plus whether the menu is
-// shown, from the active slash query, the agent's skills, and the connected
-// connector groups. Kept pure so the component stays small. The menu renders and
-// keys off the same array, so the keyboard selection index always agrees.
+// Builds the two-pane menu model from the active slash query, the agent's
+// skills, the connected connector groups, and the current active connector /
+// focused column. Kept pure so the component stays small. The menu renders and
+// keys off the same derived arrays, so the keyboard selection index always
+// agrees with what is shown.
 function buildSlashMenuModel({
   slashRange,
   composerSkills,
   connectorGroups,
-  openConnectorType,
+  activeConnectorType,
+  column,
   isLoadingOrgSkills,
   showSkillsPageLink,
 }: {
   readonly slashRange: SlashSkillRange | null;
   readonly composerSkills: readonly ComposerSlashSkill[];
   readonly connectorGroups: readonly SlashConnectorGroup[];
-  readonly openConnectorType: ConnectorType | null;
+  readonly activeConnectorType: ConnectorType | null;
+  readonly column: SlashMenuColumn;
   readonly isLoadingOrgSkills: boolean;
   readonly showSkillsPageLink: boolean;
 }): SlashMenuModel {
@@ -424,101 +466,45 @@ function buildSlashMenuModel({
       : connectorGroups.filter((group) => {
           return group.label.toLowerCase().includes(query.toLowerCase());
         });
-  const openGroup =
-    connectorGroups.find((group) => {
-      return group.connectorType === openConnectorType;
-    }) ?? null;
-  const menuItems: readonly SlashMenuItem[] = openGroup
-    ? openGroup.commands.map((command, index) => {
-        return { kind: "command", command, index } as const;
+  // The active connector (whose commands fill the right pane) follows the user's
+  // choice, defaulting to the first connector so the pane is never empty.
+  const activeGroup =
+    filteredConnectorGroups.find((group) => {
+      return group.connectorType === activeConnectorType;
+    }) ??
+    filteredConnectorGroups[0] ??
+    null;
+  const activeRailIndex = activeGroup
+    ? filteredConnectorGroups.findIndex((group) => {
+        return group.connectorType === activeGroup.connectorType;
       })
-    : [
-        ...filteredConnectorGroups.map((group) => {
-          return { kind: "connector", group } as const;
-        }),
-        ...suggestions.map((skill) => {
-          return { kind: "skill", skill } as const;
-        }),
-      ];
+    : 0;
+  const commands = activeGroup?.commands ?? [];
+  const railItems: readonly SlashMenuItem[] = [
+    ...filteredConnectorGroups.map((group) => {
+      return { kind: "connector", group } as const;
+    }),
+    ...suggestions.map((skill) => {
+      return { kind: "skill", skill } as const;
+    }),
+  ];
   const showMenu =
     slashRange !== null &&
     (isLoadingOrgSkills ||
       composerSkills.length > 0 ||
       showSkillsPageLink ||
-      filteredConnectorGroups.length > 0 ||
-      openGroup !== null);
+      filteredConnectorGroups.length > 0);
   return {
-    menuItems,
-    menuMode: openGroup ? "drawer" : "top",
-    openGroup,
+    filteredConnectorGroups,
+    suggestions,
+    railItems,
+    activeGroup,
+    activeRailIndex,
+    commands,
+    // The detail column only makes sense when the active connector has commands.
+    column: commands.length > 0 ? column : "rail",
     showMenu,
   };
-}
-
-interface SlashSelectContext {
-  readonly editor: Editor | null;
-  readonly slashRange: SlashSkillRange | null;
-  readonly input: string;
-  readonly onDraftChange: (() => void) | undefined;
-  readonly openDrawer: (connectorType: ConnectorType) => void;
-}
-
-// Applies a chosen menu row: connectors open their command drawer; skills and
-// commands insert their text via the shared insertion path.
-function selectSlashMenuItem(
-  item: SlashMenuItem,
-  ctx: SlashSelectContext,
-): void {
-  if (item.kind === "connector") {
-    ctx.openDrawer(item.group.connectorType);
-    return;
-  }
-  if (!ctx.editor || !ctx.slashRange) {
-    return;
-  }
-  if (item.kind === "skill") {
-    insertSkillToken(ctx.editor, ctx.slashRange, ctx.input, item.skill);
-  } else {
-    insertPromptText(ctx.editor, ctx.slashRange, item.command.prompt);
-  }
-  ctx.onDraftChange?.();
-}
-
-interface ComposerKeyContext {
-  readonly showMenu: boolean;
-  readonly menuItems: readonly SlashMenuItem[];
-  readonly selectedIndex: number;
-  readonly setSelectedIndex: (index: number) => void;
-  readonly setCaretIndex: (index: number) => void;
-  readonly onSelect: (item: SlashMenuItem) => void;
-  readonly onBack: (() => void) | null;
-  readonly onKeyDown: (event: KeyboardEventLike) => void;
-}
-
-// Lets the open suggestion menu consume navigation/selection keys first, then
-// defers to the parent for send / global shortcuts.
-function handleComposerKeyDown(
-  event: KeyboardEvent,
-  ctx: ComposerKeyContext,
-): boolean {
-  if (
-    ctx.showMenu &&
-    handleSlashMenuKey(event, {
-      items: ctx.menuItems,
-      selectedIndex: ctx.selectedIndex,
-      setSelectedIndex: ctx.setSelectedIndex,
-      setCaretIndex: ctx.setCaretIndex,
-      onSelect: ctx.onSelect,
-      onBack: ctx.onBack,
-    })
-  ) {
-    return true;
-  }
-  // Defer to the parent for send / global shortcuts. If it consumes the event
-  // (e.g. Enter-to-send) it calls preventDefault; otherwise the editor handles
-  // the keystroke (e.g. Shift+Enter or mobile Enter inserts a newline).
-  ctx.onKeyDown(event);
-  return event.defaultPrevented;
 }
 
 // Presentational shell: the TipTap editor with its placeholder, anchored to the
@@ -530,27 +516,35 @@ function SlashComposerShell({
   input,
   sending,
   showMenu,
-  menuItems,
-  menuMode,
-  drawerLabel,
-  loading,
+  connectorGroups,
+  activeConnectorType,
+  commands,
+  skills,
+  column,
   selectedIndex,
+  railSkillStartIndex,
+  loading,
   showSkillsPageLink,
-  onSelect,
-  onBack,
+  onActivateConnector,
+  onSelectCommand,
+  onSelectSkill,
 }: {
   readonly editor: Editor | null;
   readonly input: string;
   readonly sending: boolean | undefined;
   readonly showMenu: boolean;
-  readonly menuItems: readonly SlashMenuItem[];
-  readonly menuMode: "top" | "drawer";
-  readonly drawerLabel: string | null;
-  readonly loading: boolean;
+  readonly connectorGroups: readonly SlashConnectorGroup[];
+  readonly activeConnectorType: ConnectorType | null;
+  readonly commands: readonly ConnectorCommand[];
+  readonly skills: readonly ComposerSlashSkill[];
+  readonly column: SlashMenuColumn;
   readonly selectedIndex: number;
+  readonly railSkillStartIndex: number;
+  readonly loading: boolean;
   readonly showSkillsPageLink: boolean;
-  readonly onSelect: (item: SlashMenuItem) => void;
-  readonly onBack: () => void;
+  readonly onActivateConnector: (connectorType: ConnectorType) => void;
+  readonly onSelectCommand: (command: ConnectorCommand) => void;
+  readonly onSelectSkill: (skill: ComposerSlashSkill) => void;
 }) {
   return (
     <Popover open={showMenu}>
@@ -571,14 +565,18 @@ function SlashComposerShell({
       </PopoverAnchor>
       {showMenu && (
         <SlashSkillMenu
-          items={menuItems}
-          mode={menuMode}
-          drawerLabel={drawerLabel}
-          loading={loading}
+          connectorGroups={connectorGroups}
+          activeConnectorType={activeConnectorType}
+          commands={commands}
+          skills={skills}
+          column={column}
           selectedIndex={selectedIndex}
+          railSkillStartIndex={railSkillStartIndex}
+          loading={loading}
           showSkillsPageLink={showSkillsPageLink}
-          onSelect={onSelect}
-          onBack={onBack}
+          onActivateConnector={onActivateConnector}
+          onSelectCommand={onSelectCommand}
+          onSelectSkill={onSelectSkill}
         />
       )}
     </Popover>
@@ -606,13 +604,14 @@ export function TiptapSkillComposer({
 }) {
   const caretIndex = useGet(slashSkillCaretIndex$);
   const setCaretIndex = useSet(setSlashSkillCaretIndex$);
-  const selectedSkillIndex = useGet(selectedSlashSkillIndex$);
-  const setSelectedSkillIndex = useSet(setSelectedSlashSkillIndex$);
-  // Which connector drawer is open, or null at the top level. Lives in a signal
-  // (React state is restricted here) and resets on content change so reopening
-  // `/` always starts at the top level.
-  const openConnectorType = useGet(openSlashConnectorType$);
-  const setOpenConnectorType = useSet(setOpenSlashConnectorType$);
+  const selectedIndex = useGet(selectedSlashSkillIndex$);
+  const setSelectedIndex = useSet(setSelectedSlashSkillIndex$);
+  // Two-pane state lives in signals (React state is restricted here) and resets
+  // on content change so reopening `/` always starts fresh on the rail.
+  const activeConnectorType = useGet(activeSlashConnectorType$);
+  const setActiveConnectorType = useSet(setActiveSlashConnectorType$);
+  const column = useGet(slashMenuColumn$);
+  const setColumn = useSet(setSlashMenuColumn$);
   const currentAgent = useLastResolved(currentChatAgent$);
   const features = useLastResolved(featureSwitch$);
   const orgSkillsLoadable = useLastLoadable(orgSkills$);
@@ -637,11 +636,21 @@ export function TiptapSkillComposer({
     features?.[FeatureSwitchKey.ChatConnectorCommands] ?? false,
     connectorStatuses,
   );
-  const { menuItems, menuMode, openGroup, showMenu } = buildSlashMenuModel({
+  const {
+    filteredConnectorGroups,
+    suggestions,
+    railItems,
+    activeGroup,
+    activeRailIndex,
+    commands,
+    column: menuColumn,
+    showMenu,
+  } = buildSlashMenuModel({
     slashRange,
     composerSkills,
     connectorGroups,
-    openConnectorType,
+    activeConnectorType,
+    column,
     isLoadingOrgSkills,
     showSkillsPageLink,
   });
@@ -656,24 +665,18 @@ export function TiptapSkillComposer({
       onInputChange,
       onPaste,
       setInputRef,
-      setSelectedSkillIndex,
+      setSelectedSkillIndex: setSelectedIndex,
       setCaretIndex,
-      resetConnectorDrawer: () => {
-        if (openConnectorType !== null) {
-          setOpenConnectorType(null);
+      resetSlashMenuState: () => {
+        if (activeConnectorType !== null) {
+          setActiveConnectorType(null);
+        }
+        if (column !== "rail") {
+          setColumn("rail");
         }
       },
       onEditorKeyDown: (event) => {
-        return handleComposerKeyDown(event, {
-          showMenu,
-          menuItems,
-          selectedIndex: selectedSkillIndex,
-          setSelectedIndex: setSelectedSkillIndex,
-          setCaretIndex,
-          onSelect: selectItem,
-          onBack: openGroup ? closeConnectorDrawer : null,
-          onKeyDown,
-        });
+        return handleEditorKeyDown(event);
       },
     }),
   );
@@ -682,24 +685,108 @@ export function TiptapSkillComposer({
     syncEditorState(editor, skillNames, input);
   }
 
-  function openConnectorDrawer(connectorType: ConnectorType): void {
-    setOpenConnectorType(connectorType);
-    setSelectedSkillIndex(0);
-  }
-
-  function closeConnectorDrawer(): void {
-    setOpenConnectorType(null);
-    setSelectedSkillIndex(0);
-  }
-
-  function selectItem(item: SlashMenuItem): void {
-    selectSlashMenuItem(item, {
-      editor,
-      slashRange,
-      input,
-      onDraftChange,
-      openDrawer: openConnectorDrawer,
+  function activateConnector(connectorType: ConnectorType): void {
+    setActiveConnectorType(connectorType);
+    setColumn("rail");
+    const index = filteredConnectorGroups.findIndex((group) => {
+      return group.connectorType === connectorType;
     });
+    setSelectedIndex(index >= 0 ? index : 0);
+  }
+
+  function moveSelection(next: number): void {
+    setSelectedIndex(next);
+    if (menuColumn === "detail") {
+      scrollSlashOptionIntoView(commandOptionId(next));
+      return;
+    }
+    const item = railItems[next];
+    if (item?.kind === "connector") {
+      setActiveConnectorType(item.group.connectorType);
+      scrollSlashOptionIntoView(connectorOptionId(item.group.connectorType));
+    } else if (item?.kind === "skill") {
+      scrollSlashOptionIntoView(skillOptionId(item.skill.name));
+    }
+  }
+
+  function enterDetail(): void {
+    if (commands.length === 0) {
+      return;
+    }
+    setColumn("detail");
+    setSelectedIndex(0);
+    scrollSlashOptionIntoView(commandOptionId(0));
+  }
+
+  function exitDetail(): void {
+    setColumn("rail");
+    setSelectedIndex(activeRailIndex);
+  }
+
+  function insertSkill(skill: ComposerSlashSkill): void {
+    if (!editor || !slashRange) {
+      return;
+    }
+    insertSkillToken(editor, slashRange, input, skill);
+    onDraftChange?.();
+  }
+
+  function insertCommand(command: ConnectorCommand): void {
+    if (!editor || !slashRange) {
+      return;
+    }
+    insertPromptText(editor, slashRange, command.prompt);
+    onDraftChange?.();
+  }
+
+  function selectRailAt(index: number): void {
+    const item = railItems[index];
+    if (!item) {
+      return;
+    }
+    if (item.kind === "connector") {
+      activateConnector(item.group.connectorType);
+      enterDetail();
+    } else {
+      insertSkill(item.skill);
+    }
+  }
+
+  function selectCommandAt(index: number): void {
+    const command = commands[index];
+    if (command) {
+      insertCommand(command);
+    }
+  }
+
+  function handleEditorKeyDown(event: KeyboardEvent): boolean {
+    if (
+      showMenu &&
+      handleSlashMenuKey(event, {
+        column: menuColumn,
+        railCount: railItems.length,
+        commandCount: commands.length,
+        selectedIndex,
+        railItemIsConnector: (index) => {
+          return railItems[index]?.kind === "connector";
+        },
+        moveSelection,
+        enterDetail,
+        exitDetail,
+        selectRailAt,
+        selectCommandAt,
+        close: () => {
+          setCaretIndex(-1);
+        },
+      })
+    ) {
+      return true;
+    }
+    // Defer to the parent for send / global shortcuts. If it consumes the event
+    // (e.g. Enter-to-send) it calls preventDefault; otherwise the editor handles
+    // the keystroke (e.g. Shift+Enter or mobile Enter inserts a newline).
+    onKeyDown(event);
+    return event.defaultPrevented;
   }
 
   return (
@@ -708,14 +795,18 @@ export function TiptapSkillComposer({
       input={input}
       sending={sending}
       showMenu={showMenu}
-      menuItems={menuItems}
-      menuMode={menuMode}
-      drawerLabel={openGroup ? openGroup.label : null}
+      connectorGroups={filteredConnectorGroups}
+      activeConnectorType={activeGroup ? activeGroup.connectorType : null}
+      commands={commands}
+      skills={suggestions}
+      column={menuColumn}
+      selectedIndex={selectedIndex}
+      railSkillStartIndex={filteredConnectorGroups.length}
       loading={isLoadingOrgSkills}
-      selectedIndex={selectedSkillIndex}
       showSkillsPageLink={showSkillsPageLink}
-      onSelect={selectItem}
-      onBack={closeConnectorDrawer}
+      onActivateConnector={activateConnector}
+      onSelectCommand={insertCommand}
+      onSelectSkill={insertSkill}
     />
   );
 }


### PR DESCRIPTION
## What

Change the connector slash menu from a **drill-in drawer** (click a connector → see its commands → press back) to a **two-pane auto-expand** master-detail, per design feedback ("选中时自动展开"):

- **Left rail** lists connected connectors (now with their `ConnectorIcon`).
- **Right pane** auto-expands the **highlighted** connector's commands — no drill-in, no back step. The first connector is active by default so the pane is never empty.
- **Skills** stay as a list below the Commands block; the bottom "View all skills" footer is unchanged.

## Interaction

- **Mouse**: hovering a connector reveals its commands on the right; click a command to insert it.
- **Keyboard**: ↑/↓ move within the focused column; →/Enter on a connector enters the command pane; ←/Esc returns to the rail; Esc on the rail closes; Enter on a skill or command inserts.

## How

- Replace the `openSlashConnectorType` drawer signal with `activeSlashConnectorType` + a new `slashMenuColumn` (`"rail" | "detail"`) signal (this app uses ccstate signals instead of React state for composer UI).
- `slash-skill.tsx`: the menu is now `SlashConnectorRail` + `SlashCommandPane` (two-pane) above the skills list; selecting/hovering a connector marks it active.
- `tiptap-skill-composer.tsx`: `buildSlashMenuModel` derives the rail items, active group, and effective column; two-column keyboard navigation in `handleSlashMenuKey`.
- Insertion is unchanged (natural-language prompt via the shared `insertContentAt` path; no `setTextSelection`, no `#[number]`).

## Tests

Updated the connector integration test to assert commands auto-expand without a drill-in click; the "not connected" and "switch off" hide tests are unchanged. Skill-only menu tests are unaffected.

Follow-up to #17588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)