### PR TITLE
[codex] use haiku for real claude e2e

### DIFF
--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -28,6 +28,8 @@ setup_file() {
     export TEST_DIR="$(mktemp -d)"
     export AGENT_NAME="e2e-real-claude-${UNIQUE_ID}"
     export VOLUME_NAME="e2e-real-claude-vol-${UNIQUE_ID}"
+    # Org provider setup supplies the API key; compose env pins the model.
+    export REAL_CLAUDE_MODEL="claude-haiku-4-5"
 
     # Create volume for claude-files (needed by these tests)
     mkdir -p "$TEST_DIR/$VOLUME_NAME"
@@ -48,6 +50,8 @@ agents:
   ${AGENT_NAME}:
     description: "Real Claude smoke test"
     framework: claude-code
+    environment:
+      ANTHROPIC_MODEL: "$REAL_CLAUDE_MODEL"
     volumes:
       - claude-files:/home/user/.claude
 volumes:
@@ -62,6 +66,8 @@ agents:
   ${AGENT_NAME}-flags:
     description: "Real Claude flags test"
     framework: claude-code
+    environment:
+      ANTHROPIC_MODEL: "$REAL_CLAUDE_MODEL"
     volumes:
       - claude-files:/home/user/.claude
 volumes:
@@ -76,6 +82,8 @@ agents:
   ${AGENT_NAME}-settings:
     description: "Real Claude settings test"
     framework: claude-code
+    environment:
+      ANTHROPIC_MODEL: "$REAL_CLAUDE_MODEL"
     volumes:
       - claude-files:/home/user/.claude
 volumes:
@@ -90,6 +98,8 @@ agents:
   ${AGENT_NAME}-slash:
     description: "Real Claude slash-command no-history test"
     framework: claude-code
+    environment:
+      ANTHROPIC_MODEL: "$REAL_CLAUDE_MODEL"
     volumes:
       - claude-files:/home/user/.claude
 volumes:


### PR DESCRIPTION
## Summary
- Pin the real Claude smoke e2e compose files to `claude-haiku-4-5` via `ANTHROPIC_MODEL`.
- Keep `anthropic-api-key` provider setup for the API key while overriding the runtime model at the compose environment layer.

## Validation
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t27-real-claude-smoke.bats` -> `5`
- `git diff --check`
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types` after `pnpm install` refreshed local generated firewalls and missing dependencies
- `cd turbo && pnpm knip`
- `cd turbo && pnpm vitest` was attempted; local full-suite run failed in unrelated tests: `0418_remove_poor_agent_backend_models.test.ts`, `runs-schedules.bdd.test.ts`, `team-navigation.test.tsx`, `zero-automation-detail-page.test.tsx`, and `zero-connectors-page.test.tsx`. This PR only changes the CLI e2e Bats file; PR CI should provide clean-environment signal.