### PR TITLE
perf: serve AVIF/WebP for CDN image previews via format=auto

### DIFF
--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -9,7 +9,7 @@ describe("r2ImageTransformUrl", () => {
         height: 180,
       }),
     ).toBe(
-      "https://cdn.vm0.io/cdn-cgi/image/width=320,height=180,fit=scale-down/artifacts/user/id/image.png",
+      "https://cdn.vm0.io/cdn-cgi/image/width=320,height=180,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/user/id/image.png",
     );
   });
 
@@ -20,7 +20,7 @@ describe("r2ImageTransformUrl", () => {
         height: 96,
       }),
     ).toBe(
-      "https://cdn.vm7.io/cdn-cgi/image/width=96,height=96,fit=scale-down/artifacts/user/id/image.jpg",
+      "https://cdn.vm7.io/cdn-cgi/image/width=96,height=96,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/user/id/image.jpg",
     );
   });
 
@@ -31,7 +31,7 @@ describe("r2ImageTransformUrl", () => {
         { width: 800 },
       ),
     ).toBe(
-      "https://cdn.vm0.io/cdn-cgi/image/width=800,fit=scale-down/artifacts/user/id/image.png?token=abc#preview",
+      "https://cdn.vm0.io/cdn-cgi/image/width=800,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/user/id/image.png?token=abc#preview",
     );
   });
 

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -1,6 +1,10 @@
 const R2_IMAGE_TRANSFORM_HOSTS = new Set(["cdn.vm0.io", "cdn.vm7.io"]);
 const R2_IMAGE_TRANSFORM_PREFIX = "/cdn-cgi/image/";
 
+// Output quality for Cloudflare Image Resizing. Tuned to stay crisp on
+// text-heavy presentation thumbnails while still shrinking payloads.
+const R2_IMAGE_TRANSFORM_QUALITY = 85;
+
 export interface R2ImageTransformOptions {
   readonly width?: number;
   readonly height?: number;
@@ -14,9 +18,7 @@ function normalizedDimension(value: number | undefined): number | null {
   return Math.round(value);
 }
 
-function r2ImageTransformDirectives(
-  options: R2ImageTransformOptions,
-): string | null {
+function r2ImageTransformDirectives(options: R2ImageTransformOptions): string {
   const directives: string[] = [];
   const width = normalizedDimension(options.width);
   const height = normalizedDimension(options.height);
@@ -28,8 +30,13 @@ function r2ImageTransformDirectives(
     directives.push(`height=${String(height)}`);
   }
   directives.push(`fit=${options.fit ?? "scale-down"}`);
+  // Negotiate AVIF/WebP from the request Accept header, cap quality, and drop
+  // metadata so previews download as little as possible.
+  directives.push("format=auto");
+  directives.push(`quality=${String(R2_IMAGE_TRANSFORM_QUALITY)}`);
+  directives.push("metadata=none");
 
-  return directives.length > 1 ? directives.join(",") : null;
+  return directives.join(",");
 }
 
 function parseAbsoluteUrl(url: string): URL | null {
@@ -57,9 +64,5 @@ export function r2ImageTransformUrl(
   }
 
   const directives = r2ImageTransformDirectives(options);
-  if (directives === null) {
-    return url;
-  }
-
   return `${parsed.origin}${R2_IMAGE_TRANSFORM_PREFIX}${directives}${parsed.pathname}${parsed.search}${parsed.hash}`;
 }


### PR DESCRIPTION
## Problem

Opening the chat composer's **Template picker** is slow on first open: the default *slides* tab mounts 82 presentation cards, each requesting a `cdn.vm0.io` preview image. Those images went through Cloudflare Image Resizing with only `width`/`height`/`fit=scale-down` — **no format negotiation and no quality control** — so every thumbnail was delivered as a full-quality JPEG/PNG even when the browser supports AVIF/WebP.

## Change

Extend the shared `r2ImageTransformUrl` helper (`packages/core/src/r2-image-transform.ts`) to always emit, alongside the existing dimension directives:

- `format=auto` — negotiate **AVIF/WebP** from the request `Accept` header, falling back to the source format
- `quality=85` — explicit quality (was Cloudflare's default), tuned to stay crisp on text-heavy slide thumbnails
- `metadata=none` — strip EXIF and other metadata

`fit=scale-down` and the host / already-transformed guards are unchanged. Card request dimensions are intentionally left at 640×360 (≈ retina-correct for the 176px-tall card; shrinking would soften high-DPI displays).

## Verification

Probed `cdn.vm0.io` against a real template thumbnail (`.../01.jpg`) with `Accept: image/avif,image/webp,...`:

| Variant | content-type | bytes |
|---|---|---|
| original | image/jpeg | 54,084 |
| current (width/height/fit) | image/jpeg | 16,075 |
| **this PR** (+format=auto,quality=85,metadata=none) | **image/avif** | **12,223** |

~24% smaller than today's resized JPEG, ~77% smaller than the original. The current URL returns JPEG even when AVIF is accepted, confirming format negotiation was previously off.

## Blast radius

`r2ImageTransformUrl` is shared, so this also improves the chat thread image previews and the web `sprite` / `presentation` / `report` / `illustration` / `web-design` galleries — one central change, site-wide benefit.

## Notes

- **One-time cold re-warm:** changing the directive string changes the Cloudflare cache key, so the first viewer of each variant after deploy regenerates it at the edge. This is a one-time cost; subsequent loads hit warm edge cache.
- `metadata=none` drops the ICC profile; template assets are sRGB, so colors are unaffected.

## Tests

Updated the three exact-string assertions in `r2-image-transform.spec.ts`. The composer test (`chat-composer-models-and-templates.test.tsx`) computes its expected `src` via `r2ImageTransformUrl` itself, so it stays in sync automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)