### PR TITLE
test(mitm-addon): clarify invalid gzip capture fallback

### DIFF
--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -144,17 +144,26 @@ class TestDecompression:
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "hello world"}'
 
-    def test_invalid_gzip_marks_binary(self, real_flow):
-        """Invalid gzip data should fall back to original bytes and be marked binary."""
+    def test_invalid_gzip_text_fallback_captures_original_utf8_body(self, real_flow):
+        """Invalid gzip falls back to original bytes, then normal text capture rules apply."""
         flow = self._make_flow_with_compressed_buffer(
             real_flow, b"not gzip at all", "gzip", content_type="text/plain"
         )
         entry = {}
         add_capture_fields(flow, entry)
-        # Original compressed bytes are not valid UTF-8 text, but this happens
-        # to be valid UTF-8 so it gets captured as-is
         assert "response_body" in entry
         assert entry["response_body"] == "not gzip at all"
+        assert entry["response_body_encoding"] == "utf-8"
+
+    def test_invalid_gzip_non_text_fallback_marks_binary(self, real_flow):
+        """Binary marking comes from normal capture rules after invalid gzip fallback."""
+        flow = self._make_flow_with_compressed_buffer(
+            real_flow, b"not gzip at all", "gzip", content_type="application/octet-stream"
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
 
     def test_unknown_encoding_passes_through(self, real_flow):
         flow = self._make_flow_with_compressed_buffer(real_flow, b'{"ok": true}', "x-custom")


### PR DESCRIPTION
## Summary

- Rename the misleading invalid gzip capture test to describe UTF-8 fallback behavior.
- Assert `response_body_encoding == "utf-8"` for the ASCII `text/plain` fallback case.
- Add a non-text invalid gzip fallback test that documents when capture marks the body as binary.

Runtime behavior is unchanged; this PR only clarifies test documentation and coverage.

Fixes #17643

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_body_capture_decompression.py -k "invalid_gzip"`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_body_capture_decompression.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check tests/test_body_capture_decompression.py`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright tests/test_body_capture_decompression.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_body_capture_decompression.py tests/test_body_capture_stream_buffer.py tests/test_body_capture_fields.py tests/test_body_decoding.py`
