### PR TITLE
test(guest-init): cover pid1 wait and reap paths

### DIFF
--- a/crates/guest-init/src/pid1.rs
+++ b/crates/guest-init/src/pid1.rs
@@ -238,8 +238,9 @@ mod tests {
         }
         // SAFETY: parent still owns the read fd and transfers it to OwnedFd.
         let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        let child = ChildGuard::new(pid);
         wait_for_child_ready(&read_fd);
-        ChildGuard::new(pid)
+        child
     }
 
     fn wait_for_child_ready(read_fd: &OwnedFd) {

--- a/crates/guest-init/src/pid1.rs
+++ b/crates/guest-init/src/pid1.rs
@@ -71,25 +71,40 @@ fn decode_wait_status(status: libc::c_int) -> i32 {
     }
 }
 
+fn last_errno() -> libc::c_int {
+    // SAFETY: __errno_location() is valid after a failed libc call.
+    unsafe { *libc::__errno_location() }
+}
+
+fn wait_blocking_with<F>(pid: libc::pid_t, mut wait: F) -> i32
+where
+    F: FnMut(&mut libc::c_int) -> Result<libc::pid_t, libc::c_int>,
+{
+    loop {
+        let mut status: libc::c_int = 0;
+        match wait(&mut status) {
+            Ok(result) if result == pid => return decode_wait_status(status),
+            Ok(_) => return 1,
+            Err(errno) if errno == libc::EINTR => {}
+            Err(_) => return 1,
+        }
+    }
+}
+
 /// Block until a specific child exits and return its exit code.
 ///
 /// Uses `waitpid(pid, 0)` (blocking) which only returns `pid` on success
 /// or `-1` on error. Retries on `EINTR`; returns 1 on unexpected errors.
 pub fn wait_blocking(pid: i32) -> i32 {
-    loop {
-        let mut status: libc::c_int = 0;
+    wait_blocking_with(pid, |status| {
         // SAFETY: pid is a valid child PID; status is written on success.
-        let result = unsafe { libc::waitpid(pid, &mut status, 0) };
-        if result == pid {
-            return decode_wait_status(status);
+        let result = unsafe { libc::waitpid(pid, status, 0) };
+        if result == -1 {
+            Err(last_errno())
+        } else {
+            Ok(result)
         }
-        // result == -1: EINTR → retry, anything else (ECHILD) → give up
-        // SAFETY: __errno_location() is valid after a failed libc call.
-        let errno = unsafe { *libc::__errno_location() };
-        if errno != libc::EINTR {
-            return 1;
-        }
-    }
+    })
 }
 
 /// Reap zombie child processes (non-blocking) and detect watched child exit.
@@ -116,4 +131,241 @@ pub fn reap_zombies(watched_pid: i32) -> Option<i32> {
         // Orphaned zombie — reaped and discarded
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::sync::Mutex;
+
+    static PID1_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ChildGuard {
+        pid: libc::pid_t,
+        reaped: bool,
+    }
+
+    impl ChildGuard {
+        fn new(pid: libc::pid_t) -> Self {
+            Self { pid, reaped: false }
+        }
+
+        fn pid(&self) -> libc::pid_t {
+            self.pid
+        }
+
+        fn disarm(&mut self) {
+            self.reaped = true;
+        }
+    }
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            if self.reaped {
+                return;
+            }
+            // SAFETY: pid belongs to a child created by this test helper. Cleanup
+            // is best-effort and handles already-exited or already-reaped children.
+            unsafe {
+                let _ = libc::kill(self.pid, libc::SIGKILL);
+                let mut status: libc::c_int = 0;
+                loop {
+                    let result = libc::waitpid(self.pid, &mut status, 0);
+                    if result == self.pid {
+                        break;
+                    }
+                    if result == -1 && last_errno() == libc::EINTR {
+                        continue;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    fn fork_exiting_child(exit_code: libc::c_int) -> ChildGuard {
+        // SAFETY: the child calls only _exit after fork.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed with errno {}", last_errno());
+        if pid == 0 {
+            // SAFETY: _exit is async-signal-safe and avoids running Rust destructors
+            // in the forked child.
+            unsafe {
+                libc::_exit(exit_code);
+            }
+        }
+        ChildGuard::new(pid)
+    }
+
+    fn fork_paused_child() -> ChildGuard {
+        let mut fds = [0; 2];
+        // SAFETY: fds points to two valid integers for pipe to initialize.
+        let pipe_result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(pipe_result, 0, "pipe failed with errno {}", last_errno());
+
+        // SAFETY: the child uses only async-signal-safe libc calls before _exit.
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            // SAFETY: both fds were initialized by pipe above.
+            unsafe {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+            }
+            panic!("fork failed with errno {}", last_errno());
+        }
+
+        if pid == 0 {
+            // SAFETY: this is the forked child path. It uses raw libc calls and
+            // exits through _exit to avoid running Rust destructors.
+            unsafe {
+                libc::close(fds[0]);
+                let ready = [1_u8];
+                let written = libc::write(fds[1], ready.as_ptr().cast(), ready.len());
+                libc::close(fds[1]);
+                if written != 1 {
+                    libc::_exit(125);
+                }
+                loop {
+                    libc::pause();
+                }
+            }
+        }
+
+        // SAFETY: parent owns both raw fds after fork; close the unused write end.
+        unsafe {
+            libc::close(fds[1]);
+        }
+        // SAFETY: parent still owns the read fd and transfers it to OwnedFd.
+        let read_fd = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+        wait_for_child_ready(&read_fd);
+        ChildGuard::new(pid)
+    }
+
+    fn wait_for_child_ready(read_fd: &OwnedFd) {
+        let mut ready = [0_u8];
+        // SAFETY: read_fd is a valid pipe read end and ready points to writable memory.
+        let result =
+            unsafe { libc::read(read_fd.as_raw_fd(), ready.as_mut_ptr().cast(), ready.len()) };
+        assert_eq!(result, 1, "read failed with errno {}", last_errno());
+    }
+
+    fn wait_until_waitable(pid: libc::pid_t) {
+        // SAFETY: zeroed siginfo_t is valid for waitid to fill.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        // SAFETY: pid is a child created by this test. WNOWAIT observes its
+        // waitable status without reaping it.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        assert_eq!(result, 0, "waitid failed with errno {}", last_errno());
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum ReapCheck {
+        AlreadyReaped,
+        ReapedDuringCheck,
+        StillPresent,
+    }
+
+    fn check_child_reaped(pid: libc::pid_t) -> ReapCheck {
+        let mut status: libc::c_int = 0;
+        // SAFETY: pid was created by this test. WNOHANG prevents blocking if a
+        // regression leaves the child unreaped.
+        let result = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if result == -1 && last_errno() == libc::ECHILD {
+            ReapCheck::AlreadyReaped
+        } else if result == pid {
+            ReapCheck::ReapedDuringCheck
+        } else {
+            ReapCheck::StillPresent
+        }
+    }
+
+    #[test]
+    fn wait_loop_retries_after_eintr() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+        let mut calls = 0;
+
+        let exit_code = wait_blocking_with(123, |status| {
+            calls += 1;
+            if calls == 1 {
+                Err(libc::EINTR)
+            } else {
+                *status = 0;
+                Ok(123)
+            }
+        });
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn wait_loop_returns_one_for_non_eintr_error() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+
+        let exit_code = wait_blocking_with(123, |_status| Err(libc::ECHILD));
+
+        assert_eq!(exit_code, 1);
+    }
+
+    #[test]
+    fn wait_blocking_returns_normal_child_exit_code() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+        let mut child = fork_exiting_child(42);
+
+        let exit_code = wait_blocking(child.pid());
+        child.disarm();
+
+        assert_eq!(exit_code, 42);
+    }
+
+    #[test]
+    fn wait_blocking_maps_signal_exit_code() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+        let mut child = fork_paused_child();
+        // SAFETY: pid belongs to the paused child created by this test.
+        let kill_result = unsafe { libc::kill(child.pid(), libc::SIGKILL) };
+        assert_eq!(kill_result, 0, "kill failed with errno {}", last_errno());
+
+        let exit_code = wait_blocking(child.pid());
+        child.disarm();
+
+        assert_eq!(exit_code, 128 + libc::SIGKILL);
+    }
+
+    #[test]
+    fn reap_zombies_reaps_unrelated_child_without_watched_result() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+        let watched = fork_paused_child();
+        let mut unrelated = fork_exiting_child(17);
+        wait_until_waitable(unrelated.pid());
+
+        let result = reap_zombies(watched.pid());
+        let unrelated_state = check_child_reaped(unrelated.pid());
+        if unrelated_state != ReapCheck::StillPresent {
+            unrelated.disarm();
+        }
+
+        assert_eq!(result, None);
+        assert_eq!(unrelated_state, ReapCheck::AlreadyReaped);
+    }
+
+    #[test]
+    fn reap_zombies_returns_watched_child_exit_code() {
+        let _guard = PID1_TEST_LOCK.lock().unwrap();
+        let mut watched = fork_exiting_child(23);
+        wait_until_waitable(watched.pid());
+
+        let result = reap_zombies(watched.pid());
+        watched.disarm();
+
+        assert_eq!(result, Some(23));
+    }
 }


### PR DESCRIPTION
## Summary
- add focused inline coverage for guest-init PID 1 wait/reap behavior
- preserve the production waitpid path while making EINTR and error fallback deterministic to test
- cover normal exits, signal exits, unrelated zombie reaping, and watched-child detection without signal handler mutation or sleeps

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-init
- cargo fmt --manifest-path crates/guest-init/Cargo.toml --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-init --all-targets -- -D warnings
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc, commitlint

Closes #17645