### PR TITLE
ci: keep staging Stripe webhooks on dashboard endpoint

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -910,16 +910,20 @@ jobs:
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
           DOPPLER_SECRETS_JSON: ${{ toJSON(steps.doppler-oauth.outputs) }}
 
-      - name: Use Stripe CLI webhook secret for API preview
+      - name: Use Stripe CLI webhook secret for PR API preview
+        # Staging uses the standing Stripe Dashboard webhook endpoint at
+        # staging-www.vm6.ai; only PR previews should trust Stripe CLI webhooks.
         if: |
-          needs.prepare.outputs.web-changed == 'true' ||
-          needs.prepare.outputs.api-changed == 'true' ||
-          needs.prepare.outputs.cli-changed == 'true' ||
-          needs.prepare.outputs.platform-changed == 'true' ||
-          needs.prepare.outputs.crates-changed == 'true' ||
-          needs.prepare.outputs.ci-changed == 'true' ||
-          needs.prepare.outputs.e2e-changed == 'true' ||
-          needs.prepare.outputs.api-backend-needed == 'true'
+          needs.prepare.outputs.job-ref != 'staging' && (
+            needs.prepare.outputs.web-changed == 'true' ||
+            needs.prepare.outputs.api-changed == 'true' ||
+            needs.prepare.outputs.cli-changed == 'true' ||
+            needs.prepare.outputs.platform-changed == 'true' ||
+            needs.prepare.outputs.crates-changed == 'true' ||
+            needs.prepare.outputs.ci-changed == 'true' ||
+            needs.prepare.outputs.e2e-changed == 'true' ||
+            needs.prepare.outputs.api-backend-needed == 'true'
+          )
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$PATH"
@@ -1477,7 +1481,9 @@ jobs:
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install --with-deps chromium
       - name: Start Stripe webhook forwarding
-        if: github.event_name == 'push'
+        # Staging receives webhooks from the Dashboard endpoint; PR previews use
+        # the long-running listener from deploy-stripe-listener.
+        if: github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$PATH"
@@ -1521,13 +1527,13 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Print Stripe webhook forwarding log
-        if: always() && github.event_name == 'push'
+        if: always() && github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
         run: |
           if [[ -f /tmp/stripe-listen.log ]]; then
             tail -200 /tmp/stripe-listen.log | sed -E 's/whsec_[[:alnum:]_]+/[masked-stripe-webhook-secret]/g'
           fi
       - name: Stop Stripe webhook forwarding
-        if: always() && github.event_name == 'push'
+        if: always() && github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
         run: |
           if [[ -f /tmp/stripe-listen.pid ]]; then
             kill "$(cat /tmp/stripe-listen.pid)" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- skip replacing `STRIPE_WEBHOOK_SECRET` with a Stripe CLI listener secret when the preview job ref is `staging`
- keep staging push E2E from starting the temporary Stripe CLI webhook forwarder
- leave PR previews on the Stripe CLI listener path

## Verification
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/turbo.yml'); puts 'yaml ok'"`\n\nNote: full vitest/dev server checks were not run for this workflow-only change.