### PR TITLE
docs: document vsock protocol public api

### DIFF
--- a/crates/vsock-proto/src/error.rs
+++ b/crates/vsock-proto/src/error.rs
@@ -1,9 +1,13 @@
 /// Protocol error.
 #[derive(Debug, Clone)]
 pub enum ProtocolError {
+    /// Encoded message body or payload length exceeded the protocol limit.
     MessageTooLarge(usize),
+    /// Encoded message body length was smaller than the minimum frame body.
     MessageTooSmall(usize),
+    /// Payload contents were structurally invalid.
     InvalidPayload(&'static str),
+    /// Named payload field exceeded its encoded size or count limit.
     PayloadTooLarge(&'static str, usize),
 }
 

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -6,8 +6,14 @@ use std::convert::Infallible;
 /// A raw decoded message.
 #[derive(Debug, Clone)]
 pub struct RawMessage {
+    /// Wire message type byte.
     pub msg_type: u8,
+    /// Wire sequence number from the frame header.
+    ///
+    /// See the crate-level wire-format documentation for request-scoped and
+    /// unsolicited-frame sequence rules.
     pub seq: u32,
+    /// Owned type-specific payload bytes.
     pub payload: Vec<u8>,
 }
 
@@ -25,8 +31,14 @@ impl RawMessage {
 /// A raw decoded message that borrows its payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BorrowedRawMessage<'a> {
+    /// Wire message type byte.
     pub msg_type: u8,
+    /// Wire sequence number from the frame header.
+    ///
+    /// See the crate-level wire-format documentation for request-scoped and
+    /// unsolicited-frame sequence rules.
     pub seq: u32,
+    /// Borrowed type-specific payload bytes.
     pub payload: &'a [u8],
 }
 
@@ -70,6 +82,7 @@ pub struct Decoder {
 }
 
 impl Decoder {
+    /// Create an empty streaming decoder.
     pub fn new() -> Self {
         Self {
             buf: Vec::with_capacity(64 * 1024),

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -63,6 +63,8 @@
 //! read. Host encoders round non-zero sub-millisecond durations up to 1ms and
 //! saturate values that do not fit in `u32`.
 
+#![deny(missing_docs)]
+
 mod error;
 mod frame;
 mod payloads;

--- a/crates/vsock-proto/src/payloads/exec_operation/output.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/output.rs
@@ -11,16 +11,25 @@ const EXEC_OUTPUT_STREAM_STDERR: u8 = 0x01;
 /// Exec output stream selector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecOutputStream {
+    /// Standard output stream.
     Stdout,
+    /// Standard error stream.
     Stderr,
 }
 
 /// Decoded exec_output payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedExecOutput<'a> {
+    /// Output stream that produced this chunk.
     pub stream: ExecOutputStream,
+    /// Per-operation output sequence number.
+    ///
+    /// This starts at `0` for each exec operation and increments across stdout
+    /// and stderr output frames.
     pub output_seq: u32,
+    /// Output bytes borrowed from the decoded payload.
     pub chunk: &'a [u8],
+    /// Whether this emitted output frame was marked as truncated.
     pub truncated: bool,
 }
 

--- a/crates/vsock-proto/src/payloads/exec_operation/result.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/result.rs
@@ -17,30 +17,49 @@ pub(super) const EXEC_CAPTURED_OUTPUT_CAPTURED: u8 = 0x01;
 /// Exec terminal state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecTermination {
-    Exited { exit_code: i32 },
+    /// Process exited with an exit status.
+    Exited {
+        /// Signed process exit code reported by the guest.
+        exit_code: i32,
+    },
+    /// Operation timed out before completion.
     TimedOut,
+    /// Operation was cancelled before completion.
     Cancelled,
+    /// Guest failed to start the process.
     StartFailed,
+    /// Guest failed while waiting for the process to finish.
     WaitFailed,
 }
 
 /// Captured stdout/stderr in an exec result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecCapturedOutput<'a> {
+    /// This stream was not retained in the terminal result.
     Discarded,
-    Captured { bytes: &'a [u8], truncated: bool },
+    /// This stream was retained in the terminal result.
+    Captured {
+        /// Borrowed captured bytes from the decoded payload.
+        bytes: &'a [u8],
+        /// Whether retained bytes were marked as truncated.
+        truncated: bool,
+    },
 }
 
 /// Decoded exec_result payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedExecResult<'a> {
+    /// Terminal state reported by the guest.
     pub termination: ExecTermination,
     /// Exec operation wall-clock duration in milliseconds.
     ///
     /// This is encoded as `u32`, matching exec timeout width.
     pub duration_ms: u32,
+    /// Captured standard output state.
     pub stdout: ExecCapturedOutput<'a>,
+    /// Captured standard error state.
     pub stderr: ExecCapturedOutput<'a>,
+    /// UTF-8 diagnostic text borrowed from the decoded payload.
     pub diagnostic: &'a str,
 }
 

--- a/crates/vsock-proto/src/payloads/exec_operation/start.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/start.rs
@@ -38,13 +38,18 @@ pub enum ExecOutputPolicy {
     /// Retain at most `limit_bytes` bytes in the final exec result.
     ///
     /// A zero limit is valid and means captured output is intentionally empty.
-    Capture { limit_bytes: u32 },
+    Capture {
+        /// Maximum retained bytes for this stream.
+        limit_bytes: u32,
+    },
     /// Emit output chunks to the host up to `limit_bytes` total bytes.
     ///
     /// A zero stream limit is valid and means no chunks should be emitted.
     /// `chunk_limit_bytes` must be non-zero.
     Stream {
+        /// Maximum emitted bytes for this stream.
         limit_bytes: u32,
+        /// Maximum bytes per emitted output chunk.
         chunk_limit_bytes: u32,
     },
     /// Retain output in the final result and also emit output chunks.
@@ -52,8 +57,11 @@ pub enum ExecOutputPolicy {
     /// Zero capture or stream limits are valid. `chunk_limit_bytes` must be
     /// non-zero.
     CaptureAndStream {
+        /// Maximum retained bytes for this stream in the final exec result.
         capture_limit_bytes: u32,
+        /// Maximum emitted bytes for this stream.
         stream_limit_bytes: u32,
+        /// Maximum bytes per emitted output chunk.
         chunk_limit_bytes: u32,
     },
 }
@@ -71,7 +79,10 @@ pub enum ExecLifecyclePolicy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecTimeoutPolicy {
     /// Kill the operation after `timeout_ms`.
-    Duration { timeout_ms: u32 },
+    Duration {
+        /// Positive timeout in milliseconds.
+        timeout_ms: u32,
+    },
     /// Do not apply a protocol-level timeout.
     None,
 }
@@ -83,39 +94,72 @@ pub enum ExecControlPolicy {
     Disabled,
     /// Enable exec control messages using a per-operation nonce.
     Enabled {
+        /// Per-operation nonce registered with the exec operation.
         control_nonce: ExecControlNonce,
+        /// Whether the guest should expose a local sink for exec control.
         sink: bool,
     },
 }
 
 /// Parameters for encoding an exec_start payload with extended metadata.
 pub struct ExecStartEncodeRequest<'a> {
+    /// Process lifecycle policy to encode.
     pub lifecycle: ExecLifecyclePolicy,
+    /// Protocol timeout policy to encode.
     pub timeout: ExecTimeoutPolicy,
+    /// UTF-8 command string to execute.
     pub command: &'a str,
+    /// Environment key/value pairs to encode.
+    ///
+    /// At most 4096 pairs are accepted.
     pub env: &'a [(&'a str, &'a str)],
+    /// Whether the guest should run the command through sudo.
     pub sudo: bool,
+    /// UTF-8 operation label encoded with a `u16` byte length.
     pub label: &'a str,
+    /// Standard output handling policy.
     pub stdout: ExecOutputPolicy,
+    /// Standard error handling policy.
     pub stderr: ExecOutputPolicy,
+    /// Additional exit codes treated as expected by the caller.
+    ///
+    /// At most 64 exit codes are accepted.
     pub expected_exit_codes: &'a [i32],
+    /// Exec control channel policy.
     pub control: ExecControlPolicy,
+    /// Optional bounded stdin bytes.
+    ///
+    /// Present stdin is limited to [`MAX_EXEC_STDIN_BYTES`].
     pub stdin_bytes: Option<&'a [u8]>,
 }
 
 /// Decoded exec_start payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodedExecStart<'a> {
+    /// Decoded process lifecycle policy.
     pub lifecycle: ExecLifecyclePolicy,
+    /// Decoded protocol timeout policy.
     pub timeout: ExecTimeoutPolicy,
+    /// Command string borrowed from the decoded payload.
     pub command: &'a str,
+    /// Decoded environment key/value pairs.
+    ///
+    /// The vector is allocated during decoding; keys and values borrow from the
+    /// decoded payload.
     pub env: Vec<(&'a str, &'a str)>,
+    /// Whether sudo execution was requested.
     pub sudo: bool,
+    /// Operation label borrowed from the decoded payload.
     pub label: &'a str,
+    /// Decoded standard output handling policy.
     pub stdout: ExecOutputPolicy,
+    /// Decoded standard error handling policy.
     pub stderr: ExecOutputPolicy,
+    /// Decoded additional expected exit codes.
     pub expected_exit_codes: Vec<i32>,
+    /// Decoded exec control channel policy.
     pub control: ExecControlPolicy,
+    /// Optional stdin bytes borrowed from the decoded payload.
     pub stdin_bytes: Option<&'a [u8]>,
 }
 

--- a/crates/vsock-proto/src/payloads/exec_operation/started_cancel.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/started_cancel.rs
@@ -4,6 +4,7 @@ use crate::read::{expect_consumed, read_u32};
 /// Decoded exec_started payload.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedExecStarted {
+    /// Non-zero process id reported by the guest.
     pub pid: u32,
 }
 


### PR DESCRIPTION
## Summary

- add crate-local `missing_docs` enforcement for `vsock-proto`
- document the current public protocol rustdoc gaps for raw frames, exec policies, decoded exec payloads, and protocol errors
- keep the change docs-only with no wire-format, validation, or API-shape changes

Closes #17647

## Verification

- `cd crates && cargo fmt --all --check`
- `cd crates && cargo doc -p vsock-proto --no-deps`
- `cd crates && cargo test -p vsock-proto`
- lefthook pre-commit Rust hooks: cargo fmt, workspace cargo doc, workspace cargo clippy
