### PR TITLE
feat(desktop): add styled macos dmg installer

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -282,8 +282,6 @@ jobs:
           forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$DESKTOP_VERSION.zip"
           zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
           dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
-          dmg_source="$RUNNER_TEMP/zero-desktop-dmg-source"
-          unsigned_dmg="$RUNNER_TEMP/Zero-darwin-arm64-$DESKTOP_VERSION.unsigned.dmg"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge zip artifact found: $forge_zip"
@@ -297,18 +295,10 @@ jobs:
           fi
 
           cp "$forge_zip" "$zip_artifact_path"
-
-          rm -rf "$dmg_source" "$unsigned_dmg" "$dmg_artifact_path"
-          mkdir -p "$dmg_source"
-          ditto "$app_dir" "$dmg_source/Zero Computer Use.app"
-          ln -s /Applications "$dmg_source/Applications"
-          hdiutil create \
-            -volname "Zero Computer Use" \
-            -srcfolder "$dmg_source" \
-            -ov \
-            -format UDZO \
-            "$unsigned_dmg"
-          cp "$unsigned_dmg" "$dmg_artifact_path"
+          node apps/desktop/scripts/create-styled-dmg.mjs \
+            --app "$app_dir" \
+            --out "$dmg_artifact_path" \
+            --volume-name "Zero Computer Use"
           codesign --force --sign "$VM0_DESKTOP_SIGNING_IDENTITY" --timestamp "$dmg_artifact_path"
           xcrun notarytool submit "$dmg_artifact_path" \
             --key "$VM0_DESKTOP_NOTARIZE_API_KEY_PATH" \
@@ -384,6 +374,17 @@ jobs:
             readlink "$dmg_mount/Applications" || true
             exit 1
           fi
+          if [ ! -f "$dmg_mount/.background/background.png" ]; then
+            echo "DMG should contain the Finder background image"
+            find "$dmg_mount" -maxdepth 3 -print || true
+            exit 1
+          fi
+          background_info="$(sips -g pixelWidth -g pixelHeight -g dpiWidth -g dpiHeight "$dmg_mount/.background/background.png")"
+          echo "$background_info"
+          echo "$background_info" | grep -q "pixelWidth: 1320"
+          echo "$background_info" | grep -q "pixelHeight: 800"
+          echo "$background_info" | grep -q "dpiWidth: 144.000"
+          echo "$background_info" | grep -q "dpiHeight: 144.000"
           codesign --verify --deep --strict --verbose=2 "$dmg_mount/Zero Computer Use.app"
           xcrun stapler validate "$dmg_mount/Zero Computer Use.app"
 

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -150,9 +150,10 @@ outside the Mac App Store, validates the stapled ticket, uploads
 `Zero-darwin-arm64-X.Y.Z.zip` and `Zero-darwin-arm64-X.Y.Z.dmg` to the matching
 GitHub Release, and updates the Desktop update manifest.
 
-Use the DMG for manual installation. It opens with `Zero Computer Use.app` and
-an `/Applications` symlink for drag-to-install. The update manifest continues to
-point at the ZIP artifact because the auto-update feed consumes ZIP releases.
+Use the DMG for manual installation. It opens with a styled Finder background,
+`Zero Computer Use.app` on the left, and an `/Applications` symlink on the right
+for drag-to-install. The update manifest continues to point at the ZIP artifact
+because the auto-update feed consumes ZIP releases.
 
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's

--- a/turbo/apps/desktop/assets/dmg-background.svg
+++ b/turbo/apps/desktop/assets/dmg-background.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="400" viewBox="0 0 660 400">
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#f3f6fa"/>
+    </linearGradient>
+    <linearGradient id="arrow" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f28a2f"/>
+      <stop offset="1" stop-color="#2f8fe8"/>
+    </linearGradient>
+    <radialGradient id="blueGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(95 88) rotate(45) scale(210)">
+      <stop offset="0" stop-color="#2f8fe8" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#2f8fe8" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="orangeGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(574 318) rotate(45) scale(220)">
+      <stop offset="0" stop-color="#f28a2f" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#f28a2f" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="softShadow" x="-30%" y="-50%" width="160%" height="200%">
+      <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#2f8fe8" flood-opacity="0.2"/>
+    </filter>
+  </defs>
+
+  <rect width="660" height="400" fill="url(#panel)"/>
+  <rect width="660" height="400" fill="url(#blueGlow)"/>
+  <rect width="660" height="400" fill="url(#orangeGlow)"/>
+
+  <g opacity="0.32">
+    <path d="M0 84H660M0 112H660M0 140H660M0 168H660M0 196H660M0 224H660M0 252H660M0 280H660M0 308H660M0 336H660" stroke="#d7dde6" stroke-width="1"/>
+    <path d="M72 0V400M100 0V400M128 0V400M156 0V400M184 0V400M212 0V400M240 0V400M268 0V400M296 0V400M324 0V400M352 0V400M380 0V400M408 0V400M436 0V400M464 0V400M492 0V400M520 0V400M548 0V400M576 0V400" stroke="#d7dde6" stroke-width="1"/>
+  </g>
+
+  <text x="330" y="52" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="25" font-weight="700" fill="#22252a">Zero Computer Use</text>
+  <text x="330" y="78" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="13" font-weight="500" fill="#6f737a">Drag the app into Applications to install</text>
+
+  <g filter="url(#softShadow)">
+    <line x1="248" y1="214" x2="401" y2="214" stroke="url(#arrow)" stroke-width="5" stroke-linecap="round"/>
+    <path d="M389 196L407 214L389 232" fill="none" stroke="#2f8fe8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <text x="330" y="252" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="13" font-weight="700" fill="#4f555d">Drag to install</text>
+  <text x="330" y="365" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, Helvetica Neue, Arial, sans-serif" font-size="12" fill="#7d828a">Open Zero Computer Use from Applications after copying.</text>
+</svg>

--- a/turbo/apps/desktop/scripts/create-styled-dmg.mjs
+++ b/turbo/apps/desktop/scripts/create-styled-dmg.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, rm, stat, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const desktopDir = path.resolve(scriptDir, "..");
+const defaultBackgroundSvg = path.join(
+  desktopDir,
+  "assets",
+  "dmg-background.svg",
+);
+
+const windowBounds = {
+  left: 120,
+  top: 90,
+  right: 780,
+  bottom: 490,
+};
+const backgroundWidth = windowBounds.right - windowBounds.left;
+const backgroundHeight = windowBounds.bottom - windowBounds.top;
+const backgroundScale = 2;
+const backgroundDpi = 72 * backgroundScale;
+const appIconPosition = { x: 170, y: 224 };
+const applicationsIconPosition = { x: 490, y: 224 };
+
+function usage() {
+  return [
+    "Usage:",
+    "  node apps/desktop/scripts/create-styled-dmg.mjs --app <app-path> --out <dmg-path> [--volume-name <name>] [--background-svg <svg-path>]",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const options = {
+    volumeName: "Zero Computer Use",
+    backgroundSvg: defaultBackgroundSvg,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+
+    if (!value) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--app") {
+      options.appPath = path.resolve(value);
+      index += 1;
+      continue;
+    }
+    if (arg === "--out") {
+      options.outPath = path.resolve(value);
+      index += 1;
+      continue;
+    }
+    if (arg === "--volume-name") {
+      options.volumeName = value;
+      index += 1;
+      continue;
+    }
+    if (arg === "--background-svg") {
+      options.backgroundSvg = path.resolve(value);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.appPath || !options.outPath) {
+    throw new Error(usage());
+  }
+
+  return options;
+}
+
+function escapeAppleScriptString(value) {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+async function run(command, args, options = {}) {
+  const { silent, ...execOptions } = options;
+  const { stdout, stderr } = await execFileAsync(command, args, {
+    maxBuffer: 20 * 1024 * 1024,
+    ...execOptions,
+  });
+
+  if (stdout && !silent) {
+    process.stdout.write(stdout);
+  }
+  if (stderr && !silent) {
+    process.stderr.write(stderr);
+  }
+
+  return stdout;
+}
+
+async function pathExists(targetPath) {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function appSizeMegabytes(appPath) {
+  const stdout = await run("du", ["-sm", appPath], { silent: true });
+  const [size] = stdout.trim().split(/\s+/);
+  return Number.parseInt(size, 10);
+}
+
+function finderLayoutScript({ appName, backgroundPng, mountPath }) {
+  const escapedAppName = escapeAppleScriptString(appName);
+  const escapedBackgroundPng = escapeAppleScriptString(backgroundPng);
+  const escapedMountPath = escapeAppleScriptString(mountPath);
+
+  return `
+set mountedFolder to POSIX file "${escapedMountPath}" as alias
+set backgroundPicture to POSIX file "${escapedBackgroundPng}" as alias
+tell application "Finder"
+  open mountedFolder
+  set targetWindow to container window of mountedFolder
+  set current view of targetWindow to icon view
+  set toolbar visible of targetWindow to false
+  set statusbar visible of targetWindow to false
+  set bounds of targetWindow to {${windowBounds.left}, ${windowBounds.top}, ${windowBounds.right}, ${windowBounds.bottom}}
+  set viewOptions to icon view options of targetWindow
+  set arrangement of viewOptions to not arranged
+  set icon size of viewOptions to 104
+  set text size of viewOptions to 13
+  set background picture of viewOptions to backgroundPicture
+  set position of item "${escapedAppName}" of mountedFolder to {${appIconPosition.x}, ${appIconPosition.y}}
+  set position of item "Applications" of mountedFolder to {${applicationsIconPosition.x}, ${applicationsIconPosition.y}}
+  update mountedFolder without registering applications
+  delay 1
+  close targetWindow
+end tell
+`;
+}
+
+async function createStyledDmg({
+  appPath,
+  backgroundSvg,
+  outPath,
+  volumeName,
+}) {
+  if (process.platform !== "darwin") {
+    throw new Error("Styled DMG creation requires macOS.");
+  }
+
+  const appStats = await stat(appPath);
+  if (!appStats.isDirectory() || path.extname(appPath) !== ".app") {
+    throw new Error(`Expected --app to point at a .app bundle: ${appPath}`);
+  }
+  if (!(await pathExists(backgroundSvg))) {
+    throw new Error(`No DMG background SVG found: ${backgroundSvg}`);
+  }
+
+  const appName = path.basename(appPath);
+  const tempDir = await mkdtemp(path.join(tmpdir(), "zero-desktop-dmg-"));
+  const rwDmgPath = path.join(tempDir, "Zero Computer Use.rw.dmg");
+  const mountPath = path.join(tempDir, "mount");
+  const backgroundDir = path.join(mountPath, ".background");
+  const backgroundPng = path.join(backgroundDir, "background.png");
+  const dsStore = path.join(mountPath, ".DS_Store");
+  let mounted = false;
+
+  try {
+    const sourceSizeMb = await appSizeMegabytes(appPath);
+    const imageSizeMb = Math.max(sourceSizeMb + 96, 360);
+
+    await rm(outPath, { force: true });
+    await mkdir(mountPath);
+    await run("hdiutil", [
+      "create",
+      "-volname",
+      volumeName,
+      "-size",
+      `${imageSizeMb}m`,
+      "-fs",
+      "HFS+",
+      "-ov",
+      rwDmgPath,
+    ]);
+    await run("hdiutil", [
+      "attach",
+      rwDmgPath,
+      "-nobrowse",
+      "-mountpoint",
+      mountPath,
+    ]);
+    mounted = true;
+
+    await run("ditto", [appPath, path.join(mountPath, appName)]);
+    await symlink("/Applications", path.join(mountPath, "Applications"));
+    await mkdir(backgroundDir);
+    await run("sips", [
+      "-s",
+      "format",
+      "png",
+      "-z",
+      String(backgroundHeight * backgroundScale),
+      String(backgroundWidth * backgroundScale),
+      "-s",
+      "dpiWidth",
+      String(backgroundDpi),
+      "-s",
+      "dpiHeight",
+      String(backgroundDpi),
+      backgroundSvg,
+      "--out",
+      backgroundPng,
+    ]);
+    await run("chflags", ["hidden", backgroundDir]);
+    await run("osascript", [
+      "-e",
+      finderLayoutScript({
+        appName,
+        backgroundPng,
+        mountPath,
+      }),
+    ]);
+    if (!(await pathExists(dsStore))) {
+      throw new Error("Finder did not write the DMG layout metadata.");
+    }
+    await run("sync", []);
+
+    await run("hdiutil", ["detach", mountPath]);
+    mounted = false;
+
+    await run("hdiutil", [
+      "convert",
+      rwDmgPath,
+      "-format",
+      "UDZO",
+      "-imagekey",
+      "zlib-level=9",
+      "-o",
+      outPath,
+    ]);
+    await run("hdiutil", ["verify", outPath]);
+  } finally {
+    if (mounted) {
+      await run("hdiutil", ["detach", mountPath]).catch(() => {});
+    }
+    if (process.env.ZERO_DESKTOP_KEEP_DMG_TEMP !== "true") {
+      await rm(tempDir, { force: true, recursive: true });
+    } else {
+      console.log(`Kept temporary DMG directory: ${tempDir}`);
+    }
+  }
+}
+
+const options = parseArgs(process.argv.slice(2));
+await createStyledDmg(options);
+console.log(`Created styled DMG: ${options.outPath}`);


### PR DESCRIPTION
## Summary
- replace the release DMG `hdiutil -srcfolder` path with `apps/desktop/scripts/create-styled-dmg.mjs`
- add a styled Retina Finder background for drag-to-install DMGs
- verify release DMGs include the background image at 1320x800 / 144 DPI before upload

## Release behavior
When release-please creates a `desktop-vX.Y.Z` release, the `build-desktop-release` job now calls `node apps/desktop/scripts/create-styled-dmg.mjs` to build `Zero-darwin-arm64-$DESKTOP_VERSION.dmg`, then signs, notarizes, staples, verifies, and uploads that DMG alongside the ZIP. The web/api/app-runner promote jobs are not changed.

## Testing
- `pnpm format`
- `node --check turbo/apps/desktop/scripts/create-styled-dmg.mjs`
- `git diff --check`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip --workspace @vm0/desktop`
- local styled DMG generation from a packaged `Zero Computer Use.app`
- `hdiutil verify` and mounted-content checks for `.DS_Store`, `.background/background.png`, app bundle, and `/Applications` symlink

Known local baseline/env limitations:
- `pnpm knip` fails on existing repository-wide unused files/exports; `pnpm knip --workspace @vm0/desktop` passes.
- `pnpm vitest` fails outside Desktop after surfacing local API DB/env issues, including missing `chat_messages.usage_payload`. `pnpm -F @vm0/db db:migrate` is currently blocked locally by `invalid DATABASE_URL`. Desktop tests pass.