### PR TITLE
Rename PPT template tab to Presentation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1800,7 +1800,7 @@ function TemplatePickerTabs({
               )}
               stroke={1.8}
             />
-            PPT
+            Presentation
           </TabsTrigger>
         )}
         {hasIllustrationTab && (


### PR DESCRIPTION
Closes vm0-ai/vm0#17674.

## Summary
- Rename the presentation template picker tab from `PPT` to `Presentation`.

## Verification
- `git diff --check`
- `rg -n '>PPT<|PPT|Presentation' turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`

## Note
- `pnpm --dir turbo exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx` could not run in this environment because the project requires pnpm 10.33.4 while the available pnpm is 11.2.2.