### PR TITLE
fix: remove VM0 template section headers from template picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1554,7 +1554,6 @@ describe("chat composer templates", () => {
     click(tabByText("Illustration"));
 
     await waitFor(() => {
-      expect(screen.getByText("VM0 illustration styles")).toBeInTheDocument();
       expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
       expect(
         screen.getByTitle(`${illustrationTemplate.title} illustration preview`),
@@ -1590,7 +1589,7 @@ describe("chat composer templates", () => {
     });
     click(buttonByText("Templates"));
     await waitFor(() => {
-      expect(screen.getByText("VM0 illustration styles")).toBeInTheDocument();
+      expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
     });
 
     await fill(screen.getByLabelText("Search templates"), "no matching style");
@@ -1688,7 +1687,6 @@ describe("chat composer templates", () => {
 
     await waitFor(() => {
       expect(tabByText("Video")).toBeInTheDocument();
-      expect(screen.getByText("VM0 video styles")).toBeInTheDocument();
       expect(
         screen.getByLabelText(`Select video style ${videoStyle.nameEn}`),
       ).toBeInTheDocument();
@@ -1807,7 +1805,7 @@ describe("chat composer templates", () => {
     click(tabByText("Video"));
 
     await waitFor(() => {
-      expect(screen.getByText("VM0 video styles")).toBeInTheDocument();
+      expect(buttonByText("Brand & Commercial")).toBeInTheDocument();
     });
 
     click(buttonByText("Brand & Commercial"));

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -910,25 +910,6 @@ function VideoTemplateGrid({
   );
 }
 
-function TemplateSectionHeader({
-  label,
-  count,
-}: {
-  label: string;
-  count: number;
-}) {
-  return (
-    <div className="mb-4 flex items-center gap-3">
-      <h3 className="rounded-md bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground">
-        {label}
-      </h3>
-      <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-semibold text-muted-foreground">
-        {count}
-      </span>
-    </div>
-  );
-}
-
 function TemplateEmptyPanel({
   title,
   description,
@@ -2071,10 +2052,6 @@ function TemplatePickerDialog({
             </div>
             {selectedCategory === "slides" && hasPptTab && (
               <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4">
-                <TemplateSectionHeader
-                  label="VM0 templates"
-                  count={filteredPptItems.length}
-                />
                 {filteredPptItems.length > 0 ? (
                   <PptTemplateGrid
                     items={filteredPptItems}
@@ -2095,10 +2072,6 @@ function TemplatePickerDialog({
                 data-illustration-template-grid-scroll=""
                 className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4"
               >
-                <TemplateSectionHeader
-                  label="VM0 illustration styles"
-                  count={filteredIllustrationItems.length}
-                />
                 {filteredIllustrationItems.length > 0 ? (
                   <IllustrationTemplateGrid
                     items={filteredIllustrationItems}
@@ -2119,10 +2092,6 @@ function TemplatePickerDialog({
                 data-video-template-grid-scroll=""
                 className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4"
               >
-                <TemplateSectionHeader
-                  label="VM0 video styles"
-                  count={filteredVideoItems.length}
-                />
                 <div className="mb-4 flex flex-wrap gap-2">
                   {videoGroupFilters.map((group) => {
                     const selected = videoGroup === group.tag;


### PR DESCRIPTION
## What

Removes the standalone section headers from the template picker dialog:
- **Slides** tab: `VM0 templates` + count badge
- **Illustration** tab: `VM0 illustration styles` + count badge
- **Video** tab: `VM0 video styles` + count badge

Also deletes the now-unused `TemplateSectionHeader` component.

## Why

The picker was originally designed to split into a **VM0 templates** section and a planned **My templates** section. The "My templates" half was never built, so the remaining section header (with its count badge, e.g. `VM0 templates  81`) is meaningless and confusing to users — flagged in #17676.

With only one section, the header carries no information, so it's removed across all three tabs. The grids, search, video group filters, and empty states are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)