### PR TITLE
fix: classify provider credit limit failures

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -342,7 +342,7 @@ fn classify_cli_failure_reason(
     failure_message: &str,
 ) -> Option<FailureReason> {
     let normalized = failure_message.to_ascii_lowercase();
-    if normalized.contains("402 insufficient credits") {
+    if is_insufficient_credits_error(&normalized) {
         return Some(FailureReason::InsufficientCredits);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
@@ -376,6 +376,13 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::UsageLimit);
     }
     None
+}
+
+fn is_insufficient_credits_error(normalized: &str) -> bool {
+    normalized.contains("402 insufficient credits")
+        || (normalized.contains("api error: 402")
+            && normalized.contains("requires more credits")
+            && normalized.contains("can only afford"))
 }
 
 fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
@@ -1119,6 +1126,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "API Error: 402 Insufficient credits. Add credits or configure your own API key to continue.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::InsufficientCredits));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_provider_credit_affordability_error() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 402 This request requires more credits, or fewer max_tokens. You requested up to 64000 tokens, but can only afford 1600. To increase, visit https://openrouter.ai/settings/credits and upgrade to a paid account",
         );
 
         assert_eq!(reason, Some(FailureReason::InsufficientCredits));

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1142,6 +1142,35 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_classifies_claude_result_credit_affordability_diagnostic() {
+        let message = "API Error: 402 This request requires more credits, or fewer max_tokens. You requested up to 64000 tokens, but can only afford 1600. To increase, visit https://openrouter.ai/settings/credits and upgrade to a paid account";
+        let msg = cli_failure_message(
+            1,
+            &["background stderr noise".to_string()],
+            Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
+        );
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic =
+            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::InsufficientCredits)
+        );
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult)
+        );
+    }
+
+    #[test]
     fn cli_failure_reason_ignores_generic_402_error() {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1142,6 +1142,16 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_ignores_generic_402_error() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 402 Payment Required",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
     fn cli_failure_reason_classifies_claude_invalid_credentials() {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,


### PR DESCRIPTION
## Summary

- classify provider 402 credit affordability messages as `insufficient_credits`
- keep generic 401/402 failures out of this downgrade path unless they match the credit-limit wording
- add regression coverage for the OpenRouter-style `requires more credits ... can only afford` message, the generic 402 negative case, and the `claude_result` diagnostic path from #17650

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason_`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`

Closes #17650