### PR TITLE
fix: disable org-member automations on removal

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -14,10 +14,11 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createStore } from "ccstate";
-import { asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -866,6 +867,80 @@ describe("Automations API", () => {
       .from(zeroRuns)
       .where(inArray(zeroRuns.automationId, [...zombieIds]));
     expect(zombieRuns).toHaveLength(0);
+  });
+
+  it("suspends due time automations whose owner is no longer an org member", async () => {
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    context.mocks.s3.send.mockResolvedValue({});
+    setSecretKmsClientForTests(fakeKmsClient().client);
+    mockEnv("CRON_SECRET", CRON_SECRET);
+
+    const pastDue = new Date(now() - 60_000);
+    const fixture = await trackAutomations(
+      store.set(
+        seedAutomationsScenario$,
+        {
+          automations: [
+            {
+              name: "orphaned-member",
+              prompt: "Should not run after membership removal",
+              triggerType: "cron",
+              cronExpression: "0 9 * * *",
+              enabled: true,
+              nextRunAt: pastDue,
+            },
+          ],
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const db = store.set(writeDb$);
+    await db
+      .delete(orgMembersCache)
+      .where(
+        and(
+          eq(orgMembersCache.orgId, fixture.orgId),
+          eq(orgMembersCache.userId, fixture.userId),
+        ),
+      );
+
+    const automationId = fixture.automationIds[0]!;
+    const response = await accept(
+      cronApi().execute({
+        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      }),
+      [200],
+    );
+    expect(response.body.skipped).toBeGreaterThanOrEqual(1);
+
+    const [storedAutomation] = await db
+      .select({ enabled: automations.enabled })
+      .from(automations)
+      .where(eq(automations.id, automationId));
+    expect(storedAutomation?.enabled).toBeFalsy();
+
+    const [storedTrigger] = await db
+      .select({
+        enabled: automationTriggers.enabled,
+        nextRunAt: automationTriggers.nextRunAt,
+        lastRunId: automationTriggers.lastRunId,
+      })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.automationId, automationId));
+    expect(storedTrigger).toStrictEqual({
+      enabled: false,
+      nextRunAt: null,
+      lastRunId: null,
+    });
+
+    const runs = await db
+      .select({ id: zeroRuns.id })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.automationId, automationId));
+    expect(runs).toHaveLength(0);
   });
 
   it("enables and disables a single trigger", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
@@ -12,6 +12,7 @@ import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { connectors } from "@vm0/db/schema/connector";
 import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
@@ -210,6 +211,13 @@ export const seedAutomationsScenario$ = command(
     });
     signal.throwIfAborted();
 
+    await writeDb.insert(orgMembersCache).values({
+      userId,
+      orgId,
+      role: "member",
+    });
+    signal.throwIfAborted();
+
     const automationIds: string[] = [];
     for (const seed of values.automations) {
       const automationId = await seedAutomation(writeDb, {
@@ -342,6 +350,15 @@ export const deleteAutomationsScenario$ = command(
         and(
           eq(orgMembersMetadata.orgId, fixture.orgId),
           eq(orgMembersMetadata.userId, fixture.userId),
+        ),
+      );
+    signal.throwIfAborted();
+    await writeDb
+      .delete(orgMembersCache)
+      .where(
+        and(
+          eq(orgMembersCache.orgId, fixture.orgId),
+          eq(orgMembersCache.userId, fixture.userId),
         ),
       );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -1,14 +1,21 @@
 import { randomUUID } from "node:crypto";
 
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import {
   createAuthOrgAgentsBddApi,
   type ApiTestUser,
 } from "./helpers/api-bdd-auth-org";
 import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
-import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
+import {
+  createRunsAutomationsApi,
+  uniqueAutomationName,
+} from "./helpers/api-bdd-runs-automations";
 import { expectApiError } from "./helpers/api-bdd";
 
 /*
@@ -32,6 +39,7 @@ zero-team, zero-default-agent, and zero-onboarding-setup route tests:
 
 const context = testContext();
 const api = createAuthOrgAgentsBddApi(context);
+const store = createStore();
 
 function shortId(): string {
   return randomUUID().replace(/-/g, "").slice(0, 10);
@@ -738,6 +746,101 @@ describe("ORG-02: membership admin matrix", () => {
 });
 
 describe("ORG-02: member cleanup detaches Slack connections", () => {
+  async function expectAutomationSuspended(
+    automationId: string,
+  ): Promise<void> {
+    const db = store.set(writeDb$);
+    const [storedAutomation] = await db
+      .select({ enabled: automations.enabled })
+      .from(automations)
+      .where(eq(automations.id, automationId));
+    expect(storedAutomation?.enabled).toBeFalsy();
+
+    const [storedTrigger] = await db
+      .select({
+        enabled: automationTriggers.enabled,
+        nextRunAt: automationTriggers.nextRunAt,
+      })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.automationId, automationId));
+    expect(storedTrigger).toStrictEqual({
+      enabled: false,
+      nextRunAt: null,
+    });
+  }
+
+  it("suspends member-owned org automations on leave and removal", async () => {
+    const runs = createRunsAutomationsApi(context);
+    const admin = api.user();
+    const leavingMember = api.user({
+      orgId: admin.orgId,
+      orgRole: "org:member",
+      email: `leaving-${shortId()}@example.test`,
+    });
+    const removedMember = api.user({
+      orgId: admin.orgId,
+      orgRole: "org:member",
+      email: `removed-${shortId()}@example.test`,
+    });
+
+    api.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    await onboardAdmin(admin, { slug: slug("bdd-r5-auto-cleanup") });
+
+    await runs.enableAutomations(leavingMember);
+    const leavingAgent = await api.createAgent(leavingMember, {
+      displayName: "BDD Leaving Member Automation Agent",
+      visibility: "private",
+    });
+    const leavingAutomation = await runs.createAutomation(leavingMember, {
+      name: uniqueAutomationName("bdd-leave-cleanup"),
+      agentId: leavingAgent.agentId,
+      cronExpression: "0 9 * * *",
+      prompt: "leaving member scheduled automation",
+      timezone: "UTC",
+      enabled: true,
+    });
+
+    api.mockClerkOrg(leavingMember, {
+      members: [
+        { actor: admin, role: "org:admin" },
+        { actor: leavingMember, role: "org:member" },
+      ],
+    });
+    await expect(api.leaveOrg(leavingMember)).resolves.toStrictEqual({
+      message: "Left org",
+    });
+    await expectAutomationSuspended(leavingAutomation.automation.id);
+
+    await runs.enableAutomations(removedMember);
+    const removedAgent = await api.createAgent(removedMember, {
+      displayName: "BDD Removed Member Automation Agent",
+      visibility: "private",
+    });
+    const removedAutomation = await runs.createAutomation(removedMember, {
+      name: uniqueAutomationName("bdd-remove-cleanup"),
+      agentId: removedAgent.agentId,
+      cronExpression: "0 10 * * *",
+      prompt: "removed member scheduled automation",
+      timezone: "UTC",
+      enabled: true,
+    });
+
+    api.mockClerkOrg(admin, {
+      members: [
+        { actor: admin, role: "org:admin" },
+        { actor: removedMember, role: "org:member" },
+      ],
+    });
+    await expect(
+      api.removeMember(admin, { email: removedMember.email }),
+    ).resolves.toStrictEqual({
+      message: `Removed ${removedMember.email} from org`,
+    });
+    await expectAutomationSuspended(removedAutomation.automation.id);
+  });
+
   it("disconnects slack-linked members on leave, removal, and org deletion [ORG-SLACK-D]", async () => {
     const integrations = createBddIntegrationApi(context);
     const admin = api.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -426,6 +426,73 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
     expect(membershipDeleted.body).toBe("OK");
   });
 
+  it("suspends org-member automations after a verified organizationMembership.deleted event", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsAutomationsApi(context);
+    api.configureClerkWebhookSecret();
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+
+    const member = bdd.user();
+    await runs.grantProEntitlement(member);
+    await runs.ensureOrgModelProvider(member);
+    await runs.enableAutomations(member);
+    const agent = await bdd.createAgent(member, {
+      displayName: "BDD Membership Deleted Agent",
+      visibility: "private",
+    });
+    const created = await runs.createAutomation(member, {
+      name: uniqueAutomationName("bdd-membership-deleted"),
+      agentId: agent.agentId,
+      cronExpression: "0 9 * * *",
+      prompt: "membership deleted scheduled automation",
+      timezone: "UTC",
+      enabled: true,
+    });
+
+    const db = store.set(writeDb$);
+    const [initialTrigger] = await db
+      .select({
+        enabled: automationTriggers.enabled,
+        nextRunAt: automationTriggers.nextRunAt,
+      })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.automationId, created.automation.id));
+    expect(initialTrigger?.enabled).toBeTruthy();
+    expect(initialTrigger?.nextRunAt).not.toBeNull();
+
+    api.verifyNextClerkWebhook({
+      type: "organizationMembership.deleted",
+      data: {
+        id: "mem_bdd_deleted",
+        organization: { id: orgOf(member) },
+        publicUserData: { userId: member.userId },
+      },
+    });
+    const response = await api.requestClerkWebhook("{}", {}, [200]);
+    expect(response.body).toBe("OK");
+    await flushWaitUntilForTest();
+
+    const [storedAutomation] = await db
+      .select({ enabled: automations.enabled })
+      .from(automations)
+      .where(eq(automations.id, created.automation.id));
+    expect(storedAutomation?.enabled).toBeFalsy();
+
+    const [storedTrigger] = await db
+      .select({
+        enabled: automationTriggers.enabled,
+        nextRunAt: automationTriggers.nextRunAt,
+      })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.automationId, created.automation.id));
+    expect(storedTrigger).toStrictEqual({
+      enabled: false,
+      nextRunAt: null,
+    });
+  });
+
   it("rejects GitHub requests with missing headers or invalid signatures", async () => {
     api.configureGithubWebhookSecret();
 

--- a/turbo/apps/api/src/signals/routes/automations.ts
+++ b/turbo/apps/api/src/signals/routes/automations.ts
@@ -12,6 +12,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { now } from "../external/time";
+import { upsertMemberRoleCache$ } from "../services/auth.service";
 import {
   addTrigger$,
   createAutomation$,
@@ -143,6 +144,17 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   signal.throwIfAborted();
 
+  if (auth.orgRole !== undefined) {
+    await set(
+      upsertMemberRoleCache$,
+      auth.orgId,
+      auth.userId,
+      auth.orgRole,
+      signal,
+    );
+    signal.throwIfAborted();
+  }
+
   const result = await set(
     createAutomation$,
     { userId: auth.userId, orgId: auth.orgId, body: bodyResult.data },
@@ -262,6 +274,17 @@ function makeSetEnabledInner(enabled: boolean) {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationsByRefContract.enable));
 
+    if (enabled && auth.orgRole !== undefined) {
+      await set(
+        upsertMemberRoleCache$,
+        auth.orgId,
+        auth.userId,
+        auth.orgRole,
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+
     const result = await set(
       setAutomationEnabled$,
       { userId: auth.userId, orgId: auth.orgId, ref: params.ref, enabled },
@@ -333,6 +356,17 @@ const addTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return badRequestMessage(WEBHOOK_TRIGGERS_DISABLED_MESSAGE);
   }
   signal.throwIfAborted();
+
+  if (auth.orgRole !== undefined) {
+    await set(
+      upsertMemberRoleCache$,
+      auth.orgId,
+      auth.userId,
+      auth.orgRole,
+      signal,
+    );
+    signal.throwIfAborted();
+  }
 
   const result = await set(
     addTrigger$,

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -10,6 +10,7 @@ import type { RouteEntry } from "../route";
 import { settle, tapError } from "../utils";
 import {
   cleanupClerkBannedUser$,
+  cleanupClerkDeletedOrgMembership$,
   cleanupClerkDeletedOrg$,
   cleanupClerkDeletedUser$,
 } from "../services/webhooks-clerk-cleanup.service";
@@ -30,6 +31,38 @@ function eventDataId(data: unknown): string | undefined {
     return data.id;
   }
   return undefined;
+}
+
+function propertyOf(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return Reflect.get(value, key);
+}
+
+function stringPropertyOf(value: unknown, key: string): string | undefined {
+  const property = propertyOf(value, key);
+  return typeof property === "string" ? property : undefined;
+}
+
+function organizationMembershipIdentity(data: unknown):
+  | {
+      readonly orgId: string;
+      readonly userId: string;
+    }
+  | undefined {
+  const organization = propertyOf(data, "organization");
+  const orgId =
+    stringPropertyOf(organization, "id") ??
+    stringPropertyOf(data, "organization_id");
+  const publicUserData =
+    propertyOf(data, "publicUserData") ?? propertyOf(data, "public_user_data");
+  const userId =
+    stringPropertyOf(publicUserData, "userId") ??
+    stringPropertyOf(publicUserData, "user_id") ??
+    stringPropertyOf(data, "user_id");
+
+  return orgId && userId ? { orgId, userId } : undefined;
 }
 
 const postClerkWebhook$ = command(
@@ -98,7 +131,25 @@ const postClerkWebhook$ = command(
     }
 
     if (event.type === "organizationMembership.deleted") {
-      L.debug("organizationMembership.deleted received");
+      const identity = organizationMembershipIdentity(event.data);
+      if (!identity) {
+        L.error("organizationMembership.deleted event missing org/user ID", {
+          data: event.data,
+        });
+        return new Response("OK", { status: 200 });
+      }
+
+      waitUntil(
+        tapError(
+          set(cleanupClerkDeletedOrgMembership$, identity, signal),
+          (error) => {
+            L.error("organizationMembership.deleted cleanup failed", {
+              ...identity,
+              error,
+            });
+          },
+        ),
+      );
       return new Response("OK", { status: 200 });
     }
 

--- a/turbo/apps/api/src/signals/services/auth.service.ts
+++ b/turbo/apps/api/src/signals/services/auth.service.ts
@@ -24,7 +24,7 @@ export const updateCliTokenLastUsedAt$ = command(
   },
 );
 
-const upsertMemberRoleCache$ = command(
+export const upsertMemberRoleCache$ = command(
   async (
     { set },
     orgId: string,

--- a/turbo/apps/api/src/signals/services/automations/suspend.ts
+++ b/turbo/apps/api/src/signals/services/automations/suspend.ts
@@ -1,0 +1,46 @@
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { and, eq, inArray } from "drizzle-orm";
+
+import type { Db } from "../../external/db";
+import { nowDate } from "../../external/time";
+
+const TIME_TRIGGER_KINDS = ["cron", "once", "loop"] as const;
+
+export async function suspendOrgMemberAutomations(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<void> {
+  const suspendedAt = nowDate();
+  const automationIds = db
+    .select({ id: automations.id })
+    .from(automations)
+    .where(
+      and(
+        eq(automations.orgId, args.orgId),
+        eq(automations.userId, args.userId),
+      ),
+    );
+
+  await db
+    .update(automations)
+    .set({ enabled: false, updatedAt: suspendedAt })
+    .where(
+      and(
+        eq(automations.orgId, args.orgId),
+        eq(automations.userId, args.userId),
+      ),
+    );
+
+  await db
+    .update(automationTriggers)
+    .set({ enabled: false, nextRunAt: null, updatedAt: suspendedAt })
+    .where(
+      and(
+        inArray(automationTriggers.automationId, automationIds),
+        inArray(automationTriggers.kind, [...TIME_TRIGGER_KINDS]),
+      ),
+    );
+}

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -1,5 +1,6 @@
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
 import { and, eq, inArray, lte } from "drizzle-orm";
@@ -21,6 +22,7 @@ import {
   automationRowToTimeAutomation,
   DefaultInterpreter,
 } from "./default-interpreter";
+import { suspendOrgMemberAutomations } from "./suspend";
 import { TimeTrigger } from "./time-trigger";
 
 const log = logger("api:automations:trigger-poller");
@@ -58,6 +60,19 @@ interface DueTrigger {
   };
 }
 
+interface DueTriggerRow {
+  readonly trigger: TriggerRow;
+  readonly automationId: string;
+  readonly agentId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly chatThreadId: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly instruction: string;
+  readonly appendSystemPrompt: string | null;
+}
+
 interface ExecuteDueTriggersResult {
   readonly executed: number;
   readonly skipped: number;
@@ -91,6 +106,72 @@ type TriggerRunModelContext =
 
 function isActivePreviousRunStatus(status: string): boolean {
   return status === "pending" || status === "running";
+}
+
+function dueTriggerFromRow(row: DueTriggerRow): DueTrigger {
+  return {
+    trigger: row.trigger,
+    automation: {
+      id: row.automationId,
+      agentId: row.agentId,
+      orgId: row.orgId,
+      userId: row.userId,
+      chatThreadId: row.chatThreadId,
+      name: row.name,
+      description: row.description,
+      instruction: row.instruction,
+      appendSystemPrompt: row.appendSystemPrompt,
+    },
+  };
+}
+
+async function hasOrgMembership(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<boolean> {
+  const [membership] = await db
+    .select({ userId: orgMembersCache.userId })
+    .from(orgMembersCache)
+    .where(
+      and(
+        eq(orgMembersCache.orgId, args.orgId),
+        eq(orgMembersCache.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  return membership !== undefined;
+}
+
+async function suspendIfOwnerMissingMembership(
+  db: Db,
+  due: DueTrigger,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const ownerIsMember = await hasOrgMembership(db, {
+    orgId: due.automation.orgId,
+    userId: due.automation.userId,
+  });
+  signal.throwIfAborted();
+
+  if (ownerIsMember) {
+    return false;
+  }
+
+  log.warn("Suspending trigger: automation owner is no longer an org member", {
+    triggerId: due.trigger.id,
+    automationId: due.automation.id,
+    orgId: due.automation.orgId,
+    userId: due.automation.userId,
+  });
+  await suspendOrgMemberAutomations(db, {
+    orgId: due.automation.orgId,
+    userId: due.automation.userId,
+  });
+  signal.throwIfAborted();
+  return true;
 }
 
 function isRunTriggerFailure(error: unknown): error is RunTriggerFailure {
@@ -418,24 +499,17 @@ export const executeDueTriggers$ = command(
     let executed = 0;
     let skippedActiveRun = 0;
     let skippedClaimRace = 0;
+    let skippedMissingMembership = 0;
     let preRunFailures = 0;
     const timeTrigger = new TimeTrigger();
 
     for (const row of rows) {
-      const due: DueTrigger = {
-        trigger: row.trigger,
-        automation: {
-          id: row.automationId,
-          agentId: row.agentId,
-          orgId: row.orgId,
-          userId: row.userId,
-          chatThreadId: row.chatThreadId,
-          name: row.name,
-          description: row.description,
-          instruction: row.instruction,
-          appendSystemPrompt: row.appendSystemPrompt,
-        },
-      };
+      const due = dueTriggerFromRow(row);
+
+      if (await suspendIfOwnerMissingMembership(db, due, signal)) {
+        skippedMissingMembership++;
+        continue;
+      }
 
       if (row.trigger.lastRunId) {
         const [lastRun] = await db
@@ -489,7 +563,11 @@ export const executeDueTriggers$ = command(
       executed++;
     }
 
-    const skipped = skippedActiveRun + skippedClaimRace + preRunFailures;
+    const skipped =
+      skippedActiveRun +
+      skippedClaimRace +
+      skippedMissingMembership +
+      preRunFailures;
     // Per-tick metrics with the skip reason broken out (#17546): the previous
     // single "skipped" total hid whether the batch was draining real work or
     // just churning on active-run/claim-race rows. Routine diagnostic, so debug
@@ -499,6 +577,7 @@ export const executeDueTriggers$ = command(
       executed,
       skippedActiveRun,
       skippedClaimRace,
+      skippedMissingMembership,
       preRunFailures,
     });
     if (rows.length >= DUE_BATCH_LIMIT && executed === 0) {
@@ -513,6 +592,7 @@ export const executeDueTriggers$ = command(
           dueCount: rows.length,
           skippedActiveRun,
           skippedClaimRace,
+          skippedMissingMembership,
           preRunFailures,
         },
       );

--- a/turbo/apps/api/src/signals/services/org-member-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/org-member-cleanup.service.ts
@@ -1,0 +1,75 @@
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { and, eq, inArray } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+import { suspendOrgMemberAutomations } from "./automations/suspend";
+
+export async function cleanupOrgMemberResources(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+  },
+  signal: AbortSignal,
+): Promise<void> {
+  await suspendOrgMemberAutomations(db, args);
+  signal.throwIfAborted();
+
+  const [installation] = await db
+    .select({ slackWorkspaceId: slackOrgInstallations.slackWorkspaceId })
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, args.orgId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (installation) {
+    const connections = await db
+      .select({ id: slackOrgConnections.id })
+      .from(slackOrgConnections)
+      .where(
+        and(
+          eq(slackOrgConnections.vm0UserId, args.userId),
+          eq(
+            slackOrgConnections.slackWorkspaceId,
+            installation.slackWorkspaceId,
+          ),
+        ),
+      );
+    signal.throwIfAborted();
+
+    if (connections.length > 0) {
+      await db.delete(slackOrgConnections).where(
+        inArray(
+          slackOrgConnections.id,
+          connections.map((connection) => {
+            return connection.id;
+          }),
+        ),
+      );
+      signal.throwIfAborted();
+    }
+  }
+
+  await db
+    .delete(orgMembersCache)
+    .where(
+      and(
+        eq(orgMembersCache.userId, args.userId),
+        eq(orgMembersCache.orgId, args.orgId),
+      ),
+    );
+  signal.throwIfAborted();
+
+  await db
+    .delete(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.userId, args.userId),
+        eq(orgMembersMetadata.orgId, args.orgId),
+      ),
+    );
+  signal.throwIfAborted();
+}

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -46,6 +46,7 @@ import { getStripeClient } from "../external/stripe-client";
 import { settle, tapError } from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import { cleanupOrgMemberResources } from "./org-member-cleanup.service";
 import { deleteZeroConnectorLocalState$ } from "./zero-connector-data.service";
 
 const L = logger("WebhookClerkCleanup");
@@ -638,6 +639,19 @@ export const cleanupClerkDeletedUser$ = command(
     await get(deleteUserS3Data(db, userId));
     signal.throwIfAborted();
     await deleteUserData(db, userId);
+  },
+);
+
+export const cleanupClerkDeletedOrgMembership$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await cleanupOrgMemberResources(set(writeDb$), args, signal);
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-org-data.service.ts
@@ -1,5 +1,5 @@
 import { command, computed, type Computed } from "ccstate";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -23,6 +23,7 @@ import { fetchClerkMembershipRequests } from "../external/clerk-membership-reque
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import { settle } from "../utils";
+import { cleanupOrgMemberResources } from "./org-member-cleanup.service";
 
 const clerkOrgIdentitySchema = z.object({
   slug: z.string().nullable().optional(),
@@ -138,67 +139,6 @@ function isReservedSlug(slug: string): boolean {
     slug === "app" ||
     slug === "www"
   );
-}
-
-async function cleanupOrgMember(
-  writeDb: Db,
-  args: Pick<LeaveZeroOrgArgs, "orgId" | "userId">,
-  signal: AbortSignal,
-): Promise<void> {
-  const [installation] = await writeDb
-    .select({ slackWorkspaceId: slackOrgInstallations.slackWorkspaceId })
-    .from(slackOrgInstallations)
-    .where(eq(slackOrgInstallations.orgId, args.orgId))
-    .limit(1);
-  signal.throwIfAborted();
-
-  if (installation) {
-    const connections = await writeDb
-      .select({ id: slackOrgConnections.id })
-      .from(slackOrgConnections)
-      .where(
-        and(
-          eq(slackOrgConnections.vm0UserId, args.userId),
-          eq(
-            slackOrgConnections.slackWorkspaceId,
-            installation.slackWorkspaceId,
-          ),
-        ),
-      );
-    signal.throwIfAborted();
-
-    if (connections.length > 0) {
-      await writeDb.delete(slackOrgConnections).where(
-        inArray(
-          slackOrgConnections.id,
-          connections.map((connection) => {
-            return connection.id;
-          }),
-        ),
-      );
-      signal.throwIfAborted();
-    }
-  }
-
-  await writeDb
-    .delete(orgMembersCache)
-    .where(
-      and(
-        eq(orgMembersCache.userId, args.userId),
-        eq(orgMembersCache.orgId, args.orgId),
-      ),
-    );
-  signal.throwIfAborted();
-
-  await writeDb
-    .delete(orgMembersMetadata)
-    .where(
-      and(
-        eq(orgMembersMetadata.userId, args.userId),
-        eq(orgMembersMetadata.orgId, args.orgId),
-      ),
-    );
-  signal.throwIfAborted();
 }
 
 function isClerkNotFound(error: unknown): boolean {
@@ -402,7 +342,7 @@ export const leaveZeroOrg$ = command(
     });
     signal.throwIfAborted();
 
-    await cleanupOrgMember(set(writeDb$), args, signal);
+    await cleanupOrgMemberResources(set(writeDb$), args, signal);
     signal.throwIfAborted();
 
     return { message: "Left org" };
@@ -453,7 +393,7 @@ export const removeZeroOrgMember$ = command(
     });
     signal.throwIfAborted();
 
-    await cleanupOrgMember(
+    await cleanupOrgMemberResources(
       set(writeDb$),
       { orgId: args.orgId, userId: target.id },
       signal,


### PR DESCRIPTION
Closes #17346.

## Summary
- suspend org-member owned automations and time triggers during org leave, admin removal, and Clerk `organizationMembership.deleted` cleanup
- add scheduler guard that suspends due automations when the owner is no longer in `org_members_cache` before creating runs
- keep automation/run history readable by disabling rows instead of deleting them, and refresh member-role cache on automation writes from session auth

## Tests
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/automations.test.ts src/signals/routes/__tests__/org-team.bdd.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runs-schedules.bdd.test.ts -t "lets cron execution process a due loop schedule|advances loop and cron schedules"`
- pre-commit `pnpm check-types` passed after regenerating the local ignored Google Cloud firewall artifact