### PR TITLE
test: refactor chunked write tests with fixture

### DIFF
--- a/crates/vsock-host/src/tests/file/support.rs
+++ b/crates/vsock-host/src/tests/file/support.rs
@@ -218,23 +218,3 @@ pub(super) async fn send_guest_error(guest: &mut UnixStream, seq: u32, message: 
         .await
         .unwrap();
 }
-
-#[derive(Default)]
-pub(super) struct ChunkedWriteTempPath {
-    path: Option<String>,
-}
-
-impl ChunkedWriteTempPath {
-    pub(super) fn assert_next_chunk(&mut self, path: &str, target_path: &str) {
-        if let Some(temp_path) = &self.path {
-            assert_eq!(path, temp_path);
-        } else {
-            assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
-            self.path = Some(path.to_string());
-        }
-    }
-
-    pub(super) fn path(&self) -> &str {
-        self.path.as_deref().expect("temp path")
-    }
-}

--- a/crates/vsock-host/src/tests/file/support.rs
+++ b/crates/vsock-host/src/tests/file/support.rs
@@ -123,6 +123,7 @@ pub(super) struct ExecStartFrame {
     pub(super) msg: RawMessage,
     pub(super) command: String,
     pub(super) label: String,
+    pub(super) sudo: bool,
     pub(super) stdout: ExecOutputPolicy,
     pub(super) expected_exit_codes: Vec<i32>,
 }
@@ -136,7 +137,7 @@ impl ExecStartFrame {
 pub(super) async fn expect_exec_start(guest: &mut UnixStream) -> ExecStartFrame {
     let msg = read_guest_message(guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
-    let (command, label, stdout, expected_exit_codes) = {
+    let (command, label, sudo, stdout, expected_exit_codes) = {
         let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
         exec_start_frame_fields(decoded)
     };
@@ -144,6 +145,7 @@ pub(super) async fn expect_exec_start(guest: &mut UnixStream) -> ExecStartFrame 
         msg,
         command,
         label,
+        sudo,
         stdout,
         expected_exit_codes,
     }
@@ -151,10 +153,11 @@ pub(super) async fn expect_exec_start(guest: &mut UnixStream) -> ExecStartFrame 
 
 fn exec_start_frame_fields(
     decoded: DecodedExecStart<'_>,
-) -> (String, String, ExecOutputPolicy, Vec<i32>) {
+) -> (String, String, bool, ExecOutputPolicy, Vec<i32>) {
     (
         decoded.command.to_string(),
         decoded.label.to_string(),
+        decoded.sudo,
         decoded.stdout,
         decoded.expected_exit_codes,
     )

--- a/crates/vsock-host/src/tests/file/support.rs
+++ b/crates/vsock-host/src/tests/file/support.rs
@@ -125,6 +125,7 @@ pub(super) struct ExecStartFrame {
     pub(super) label: String,
     pub(super) sudo: bool,
     pub(super) stdout: ExecOutputPolicy,
+    pub(super) stderr: ExecOutputPolicy,
     pub(super) expected_exit_codes: Vec<i32>,
 }
 
@@ -137,7 +138,7 @@ impl ExecStartFrame {
 pub(super) async fn expect_exec_start(guest: &mut UnixStream) -> ExecStartFrame {
     let msg = read_guest_message(guest).await;
     assert_eq!(msg.msg_type, MSG_EXEC_START);
-    let (command, label, sudo, stdout, expected_exit_codes) = {
+    let (command, label, sudo, stdout, stderr, expected_exit_codes) = {
         let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
         exec_start_frame_fields(decoded)
     };
@@ -147,18 +148,27 @@ pub(super) async fn expect_exec_start(guest: &mut UnixStream) -> ExecStartFrame 
         label,
         sudo,
         stdout,
+        stderr,
         expected_exit_codes,
     }
 }
 
 fn exec_start_frame_fields(
     decoded: DecodedExecStart<'_>,
-) -> (String, String, bool, ExecOutputPolicy, Vec<i32>) {
+) -> (
+    String,
+    String,
+    bool,
+    ExecOutputPolicy,
+    ExecOutputPolicy,
+    Vec<i32>,
+) {
     (
         decoded.command.to_string(),
         decoded.label.to_string(),
         decoded.sudo,
         decoded.stdout,
+        decoded.stderr,
         decoded.expected_exit_codes,
     )
 }

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -526,6 +526,7 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
         let failed_temp = temp_by_marker
             .get(&failure_marker)
             .expect("failed temp path");
+        assert_ne!(success_temp, failed_temp);
 
         match decoded.label {
             "write-file-rename" => {

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -4,20 +4,93 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use vsock_proto::{ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
 
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
     make_pair, normal_operation_readiness, operation_count, pending_request_count,
-    read_guest_message, send_exec_result, setup_host_and_guest,
+    send_exec_result, setup_host_and_guest,
 };
 use super::support::{
-    ChunkedWriteTempPath, expect_write_file, send_guest_error, send_write_file_failure,
-    send_write_file_success, spawn_write_file,
+    ExecStartFrame, WriteFileFrame, expect_exec_start, expect_write_file, send_guest_error,
+    send_write_file_failure, send_write_file_success, spawn_write_file,
 };
 use crate::file as file_impl;
-use crate::{FrameWriteObserver, operation_tracker::NormalOperationReadiness};
+use crate::{FrameWriteObserver, VsockHost, operation_tracker::NormalOperationReadiness};
+
+struct ChunkedWriteFixture {
+    host: Arc<VsockHost>,
+    guest: UnixStream,
+    target_path: &'static str,
+    temp_path: Option<String>,
+}
+
+impl ChunkedWriteFixture {
+    async fn new(target_path: &'static str) -> Self {
+        let (host, guest) = setup_host_and_guest().await;
+        Self {
+            host: Arc::new(host),
+            guest,
+            target_path,
+            temp_path: None,
+        }
+    }
+
+    fn chunk_limit() -> usize {
+        file_impl::test_support::WRITE_FILE_CHUNK_LIMIT
+    }
+
+    fn two_chunk_content() -> Vec<u8> {
+        vec![0xABu8; Self::chunk_limit() + 100]
+    }
+
+    fn spawn_write(&self, content: Vec<u8>, sudo: bool) -> JoinHandle<io::Result<()>> {
+        spawn_write_file(Arc::clone(&self.host), self.target_path, content, sudo)
+    }
+
+    async fn expect_chunk(&mut self) -> WriteFileFrame {
+        let frame = expect_write_file(&mut self.guest).await;
+        if let Some(temp_path) = &self.temp_path {
+            assert_eq!(frame.path.as_str(), temp_path);
+        } else {
+            assert!(
+                frame
+                    .path
+                    .starts_with(&format!("{}.vm0tmp-", self.target_path))
+            );
+            self.temp_path = Some(frame.path.clone());
+        }
+        frame
+    }
+
+    async fn expect_rename(&mut self) -> ExecStartFrame {
+        let frame = expect_exec_start(&mut self.guest).await;
+        assert_eq!(frame.label, "write-file-rename");
+        assert!(frame.command.contains("mv -f --"));
+        assert!(frame.command.contains(self.temp_path()));
+        assert!(frame.command.contains(self.target_path));
+        frame
+    }
+
+    async fn expect_cleanup(&mut self) -> ExecStartFrame {
+        let frame = expect_exec_start(&mut self.guest).await;
+        assert_eq!(frame.label, "exec-cleanup");
+        assert!(frame.command.contains("rm -f --"));
+        assert!(frame.command.contains(self.temp_path()));
+        frame
+    }
+
+    fn assert_readiness(&self, expected: NormalOperationReadiness) {
+        assert_eq!(normal_operation_readiness(&self.host), expected);
+    }
+
+    fn temp_path(&self) -> &str {
+        self.temp_path.as_deref().expect("temp path")
+    }
+}
 
 #[tokio::test]
 async fn write_file_chunked_cancelled_before_first_frame_write_does_not_cleanup() {
@@ -101,36 +174,24 @@ async fn write_file_chunked_rejects_invalid_path_before_cleanup_or_write() {
 
 #[tokio::test]
 async fn test_write_file_chunked() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-
-    // Content just over the chunk limit: 2 write messages + 1 exec (mv).
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = spawn_write_file(Arc::clone(&host), "/tmp/big.bin", content.clone(), false);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let chunk_limit = ChunkedWriteFixture::chunk_limit();
+    let content = ChunkedWriteFixture::two_chunk_content();
+    let write_task = fixture.spawn_write(content.clone(), false);
 
     let mut chunks_received = Vec::new();
-    let mut temp_path = ChunkedWriteTempPath::default();
 
-    let first = expect_write_file(&mut guest).await;
-    temp_path.assert_next_chunk(&first.path, "/tmp/big.bin");
+    let first = fixture.expect_chunk().await;
     let first_seq = first.seq();
     chunks_received.push((first.append, first.content));
-    send_write_file_success(&mut guest, first_seq).await;
+    send_write_file_success(&mut fixture.guest, first_seq).await;
 
-    let second = expect_write_file(&mut guest).await;
-    temp_path.assert_next_chunk(&second.path, "/tmp/big.bin");
+    let second = fixture.expect_chunk().await;
     let second_seq = second.seq();
     chunks_received.push((second.append, second.content));
-    send_write_file_success(&mut guest, second_seq).await;
+    send_write_file_success(&mut fixture.guest, second_seq).await;
 
-    let rename = read_guest_message(&mut guest).await;
-    assert_eq!(rename.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
-    assert!(decoded.command.contains("mv -f --"));
-    assert!(decoded.command.contains(temp_path.path()));
-    assert!(decoded.command.contains("/tmp/big.bin"));
-    assert_eq!(decoded.label, "write-file-rename");
+    let rename = fixture.expect_rename().await;
 
     assert_eq!(chunks_received.len(), 2);
     assert!(!chunks_received[0].0);
@@ -142,8 +203,8 @@ async fn test_write_file_chunked() {
     assert_eq!(reassembled, content);
 
     send_exec_result(
-        &mut guest,
-        rename.seq,
+        &mut fixture.guest,
+        rename.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -155,44 +216,23 @@ async fn test_write_file_chunked() {
 
 #[tokio::test]
 async fn write_file_chunked_tracks_one_operation_until_rename_result() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Busy
-    );
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Busy
-    );
-    send_write_file_success(&mut guest, second.seq).await;
-
-    let rename = read_guest_message(&mut guest).await;
-    assert_eq!(rename.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
-    assert_eq!(decoded.label, "write-file-rename");
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Busy
-    );
+    let rename = fixture.expect_rename().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
 
     send_exec_result(
-        &mut guest,
-        rename.seq,
+        &mut fixture.guest,
+        rename.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -200,46 +240,32 @@ async fn write_file_chunked_tracks_one_operation_until_rename_result() {
     .await;
 
     write_task.await.unwrap().unwrap();
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Idle
-    );
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
 }
 
 #[tokio::test]
 async fn write_file_chunked_rename_result_before_connection_close_keeps_tracker_closed_not_not_parkable()
  {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, second.seq).await;
-
-    let rename = read_guest_message(&mut guest).await;
-    assert_eq!(rename.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
-    assert_eq!(decoded.label, "write-file-rename");
+    let rename = fixture.expect_rename().await;
     send_exec_result(
-        &mut guest,
-        rename.seq,
+        &mut fixture.guest,
+        rename.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
     )
     .await;
-    drop(guest);
+    let host = Arc::clone(&fixture.host);
+    drop(fixture.guest);
 
     write_task.await.unwrap().unwrap();
     assert_ne!(
@@ -250,36 +276,21 @@ async fn write_file_chunked_rename_result_before_connection_close_keeps_tracker_
 
 #[tokio::test]
 async fn write_file_chunked_failure_remains_busy_until_cleanup_result() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_failure(&mut fixture.guest, second.seq(), "disk full").await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_write_file_failure(&mut guest, second.seq, "disk full").await;
-
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Busy
-    );
+    let cleanup = fixture.expect_cleanup().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
 
     send_exec_result(
-        &mut guest,
-        cleanup.seq,
+        &mut fixture.guest,
+        cleanup.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -288,43 +299,25 @@ async fn write_file_chunked_failure_remains_busy_until_cleanup_result() {
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("disk full"));
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Idle
-    );
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
 }
 
 #[tokio::test]
 async fn write_file_chunked_error_response_cleans_up_and_releases_tracker() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    send_guest_error(&mut fixture.guest, second.seq(), "guest write failed").await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_guest_error(&mut guest, second.seq, "guest write failed").await;
-
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Busy
-    );
+    let cleanup = fixture.expect_cleanup().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
     send_exec_result(
-        &mut guest,
-        cleanup.seq,
+        &mut fixture.guest,
+        cleanup.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -333,53 +326,34 @@ async fn write_file_chunked_error_response_cleans_up_and_releases_tracker() {
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("guest write failed"));
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Idle
-    );
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
 }
 
 #[tokio::test]
 async fn write_file_chunked_unexpected_response_keeps_tracker_fail_closed() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
-
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    guest
-        .write_all(&vsock_proto::encode(MSG_EXEC_START, second.seq, &[]).unwrap())
+    let second = fixture.expect_chunk().await;
+    fixture
+        .guest
+        .write_all(&vsock_proto::encode(MSG_EXEC_START, second.seq(), &[]).unwrap())
         .await
         .unwrap();
 
     let err = write_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::NotParkable
-    );
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
 
-    let cleanup_retry =
-        tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
-            .await
-            .expect("cleanup retry was not sent after unexpected response");
-    assert_eq!(cleanup_retry.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup_retry.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert!(decoded.command.contains("rm -f --"));
+    let cleanup_retry = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
+        .await
+        .expect("cleanup retry was not sent after unexpected response");
     send_exec_result(
-        &mut guest,
-        cleanup_retry.seq,
+        &mut fixture.guest,
+        cleanup_retry.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -389,41 +363,23 @@ async fn write_file_chunked_unexpected_response_keeps_tracker_fail_closed() {
 
 #[tokio::test]
 async fn write_file_chunked_rename_error_response_cleans_up_and_releases_tracker() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, second.seq).await;
+    let rename = fixture.expect_rename().await;
+    send_guest_error(&mut fixture.guest, rename.seq(), "rename unavailable").await;
 
-    let rename = read_guest_message(&mut guest).await;
-    assert_eq!(rename.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
-    assert_eq!(decoded.label, "write-file-rename");
-    send_guest_error(&mut guest, rename.seq, "rename unavailable").await;
-
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Busy
-    );
+    let cleanup = fixture.expect_cleanup().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
     send_exec_result(
-        &mut guest,
-        cleanup.seq,
+        &mut fixture.guest,
+        cleanup.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -432,55 +388,33 @@ async fn write_file_chunked_rename_error_response_cleans_up_and_releases_tracker
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("rename unavailable"));
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::Idle
-    );
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
 }
 
 #[tokio::test]
 async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_failure(&mut fixture.guest, second.seq(), "disk full").await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_write_file_failure(&mut guest, second.seq, "disk full").await;
-
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    send_guest_error(&mut guest, cleanup.seq, "cleanup unavailable").await;
+    let cleanup = fixture.expect_cleanup().await;
+    send_guest_error(&mut fixture.guest, cleanup.seq(), "cleanup unavailable").await;
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("disk full"));
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::NotParkable
-    );
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
 
-    let retry = tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+    let retry = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
         .await
         .expect("cleanup retry was not sent after cleanup error");
-    assert_eq!(retry.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&retry.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert!(decoded.command.contains("rm -f --"));
     send_exec_result(
-        &mut guest,
-        retry.seq,
+        &mut fixture.guest,
+        retry.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -490,14 +424,12 @@ async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
 
 #[tokio::test]
 async fn write_file_chunked_cleanup_retry_does_not_reuse_write_observer() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let write_start_count = Arc::new(AtomicUsize::new(0));
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
+    let content = ChunkedWriteFixture::two_chunk_content();
     let write_task = {
-        let host = Arc::clone(&host);
+        let host = Arc::clone(&fixture.host);
         let write_start_count = Arc::clone(&write_start_count);
         tokio::spawn(async move {
             host.write_file_with_write_observer(
@@ -516,34 +448,25 @@ async fn write_file_chunked_cleanup_retry_does_not_reuse_write_observer() {
         })
     };
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_write_file_failure(&mut guest, second.seq, "disk full").await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_failure(&mut fixture.guest, second.seq(), "disk full").await;
 
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    send_guest_error(&mut guest, cleanup.seq, "cleanup unavailable").await;
+    let cleanup = fixture.expect_cleanup().await;
+    send_guest_error(&mut fixture.guest, cleanup.seq(), "cleanup unavailable").await;
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("disk full"));
     assert_eq!(write_start_count.load(Ordering::SeqCst), 3);
 
-    let retry = tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+    let retry = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
         .await
         .expect("cleanup retry was not sent after observer became inactive");
-    assert_eq!(retry.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&retry.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert!(decoded.command.contains("rm -f --"));
     send_exec_result(
-        &mut guest,
-        retry.seq,
+        &mut fixture.guest,
+        retry.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -554,31 +477,19 @@ async fn write_file_chunked_cleanup_retry_does_not_reuse_write_observer() {
 
 #[tokio::test]
 async fn write_file_chunked_cleanup_nonzero_exit_retries_untracked_on_drop() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move { host.write_file("/tmp/big.bin", &content, false).await })
-    };
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = read_guest_message(&mut guest).await;
-    assert_eq!(first.msg_type, MSG_WRITE_FILE);
-    send_write_file_success(&mut guest, first.seq).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_failure(&mut fixture.guest, second.seq(), "disk full").await;
 
-    let second = read_guest_message(&mut guest).await;
-    assert_eq!(second.msg_type, MSG_WRITE_FILE);
-    send_write_file_failure(&mut guest, second.seq, "disk full").await;
-
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
+    let cleanup = fixture.expect_cleanup().await;
     send_exec_result(
-        &mut guest,
-        cleanup.seq,
+        &mut fixture.guest,
+        cleanup.seq(),
         ExecTermination::Exited { exit_code: 1 },
         &[],
         b"permission denied",
@@ -587,21 +498,14 @@ async fn write_file_chunked_cleanup_nonzero_exit_retries_untracked_on_drop() {
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("disk full"));
-    assert_eq!(
-        normal_operation_readiness(&host),
-        NormalOperationReadiness::NotParkable
-    );
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
 
-    let retry = tokio::time::timeout(Duration::from_secs(2), read_guest_message(&mut guest))
+    let retry = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
         .await
         .expect("cleanup retry was not sent after nonzero cleanup exit");
-    assert_eq!(retry.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&retry.payload).unwrap();
-    assert_eq!(decoded.label, "exec-cleanup");
-    assert!(decoded.command.contains("rm -f --"));
     send_exec_result(
-        &mut guest,
-        retry.seq,
+        &mut fixture.guest,
+        retry.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -635,31 +539,19 @@ async fn test_write_file_at_chunk_limit_uses_single_message() {
 
 #[tokio::test]
 async fn test_write_file_chunked_cleans_up_on_chunk_failure() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = spawn_write_file(Arc::clone(&host), "/tmp/big.bin", content, false);
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = expect_write_file(&mut guest).await;
-    assert!(first.path.starts_with("/tmp/big.bin.vm0tmp-"));
-    let temp_path = first.path.clone();
-    send_write_file_success(&mut guest, first.seq()).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_failure(&mut fixture.guest, second.seq(), "disk full").await;
 
-    let second = expect_write_file(&mut guest).await;
-    assert_eq!(second.path, temp_path);
-    send_write_file_failure(&mut guest, second.seq(), "disk full").await;
-
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert!(decoded.command.contains("rm -f --"));
-    assert!(decoded.command.contains(&temp_path));
-    assert_eq!(decoded.label, "exec-cleanup");
+    let cleanup = fixture.expect_cleanup().await;
     send_exec_result(
-        &mut guest,
-        cleanup.seq,
+        &mut fixture.guest,
+        cleanup.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],
@@ -672,46 +564,29 @@ async fn test_write_file_chunked_cleans_up_on_chunk_failure() {
 
 #[tokio::test]
 async fn test_write_file_chunked_cleans_up_on_mv_failure() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
 
-    let chunk_limit = file_impl::test_support::WRITE_FILE_CHUNK_LIMIT;
-    let content = vec![0xABu8; chunk_limit + 100];
-    let write_task = spawn_write_file(Arc::clone(&host), "/tmp/big.bin", content, false);
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
 
-    let first = expect_write_file(&mut guest).await;
-    assert!(first.path.starts_with("/tmp/big.bin.vm0tmp-"));
-    let temp_path = first.path.clone();
-    send_write_file_success(&mut guest, first.seq()).await;
+    let second = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
 
-    let second = expect_write_file(&mut guest).await;
-    assert_eq!(second.path, temp_path);
-    send_write_file_success(&mut guest, second.seq()).await;
-
-    let rename = read_guest_message(&mut guest).await;
-    assert_eq!(rename.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&rename.payload).unwrap();
-    assert!(decoded.command.contains("mv -f --"));
-    assert!(decoded.command.contains(&temp_path));
-    assert_eq!(decoded.label, "write-file-rename");
+    let rename = fixture.expect_rename().await;
     send_exec_result(
-        &mut guest,
-        rename.seq,
+        &mut fixture.guest,
+        rename.seq(),
         ExecTermination::Exited { exit_code: 1 },
         &[],
         b"permission denied",
     )
     .await;
 
-    let cleanup = read_guest_message(&mut guest).await;
-    assert_eq!(cleanup.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&cleanup.payload).unwrap();
-    assert!(decoded.command.contains("rm -f --"));
-    assert!(decoded.command.contains(&temp_path));
-    assert_eq!(decoded.label, "exec-cleanup");
+    let cleanup = fixture.expect_cleanup().await;
     send_exec_result(
-        &mut guest,
-        cleanup.seq,
+        &mut fixture.guest,
+        cleanup.seq(),
         ExecTermination::Exited { exit_code: 0 },
         &[],
         &[],

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -53,6 +53,10 @@ impl ChunkedWriteFixture {
         vec![0xABu8; Self::chunk_limit() + 100]
     }
 
+    fn three_chunk_content() -> Vec<u8> {
+        vec![0xABu8; Self::chunk_limit() * 2 + 100]
+    }
+
     fn spawn_write(&mut self, content: Vec<u8>, sudo: bool) -> JoinHandle<io::Result<()>> {
         self.sudo = sudo;
         spawn_write_file(Arc::clone(&self.host), self.target_path, content, sudo)
@@ -197,7 +201,7 @@ async fn write_file_chunked_rejects_invalid_path_before_cleanup_or_write() {
 async fn test_write_file_chunked() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let chunk_limit = ChunkedWriteFixture::chunk_limit();
-    let content = ChunkedWriteFixture::two_chunk_content();
+    let content = ChunkedWriteFixture::three_chunk_content();
     let write_task = fixture.spawn_write(content.clone(), false);
 
     let mut chunks_received = Vec::new();
@@ -212,15 +216,23 @@ async fn test_write_file_chunked() {
     chunks_received.push((second.append, second.content));
     send_write_file_success(&mut fixture.guest, second_seq).await;
 
+    let third = fixture.expect_chunk().await;
+    let third_seq = third.seq();
+    chunks_received.push((third.append, third.content));
+    send_write_file_success(&mut fixture.guest, third_seq).await;
+
     let rename = fixture.expect_rename().await;
 
-    assert_eq!(chunks_received.len(), 2);
+    assert_eq!(chunks_received.len(), 3);
     assert!(!chunks_received[0].0);
     assert_eq!(chunks_received[0].1.len(), chunk_limit);
     assert!(chunks_received[1].0);
-    assert_eq!(chunks_received[1].1.len(), 100);
+    assert_eq!(chunks_received[1].1.len(), chunk_limit);
+    assert!(chunks_received[2].0);
+    assert_eq!(chunks_received[2].1.len(), 100);
     let mut reassembled = chunks_received[0].1.clone();
     reassembled.extend_from_slice(&chunks_received[1].1);
+    reassembled.extend_from_slice(&chunks_received[2].1);
     assert_eq!(reassembled, content);
 
     send_exec_result(

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -12,7 +13,7 @@ use vsock_proto::{ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_WRITE_F
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
     make_pair, normal_operation_readiness, operation_count, pending_request_count,
-    send_exec_result, setup_host_and_guest,
+    read_guest_message, send_exec_result, setup_host_and_guest,
 };
 use super::support::{
     ExecStartFrame, WriteFileFrame, expect_exec_start, expect_write_file, send_guest_error,
@@ -337,6 +338,98 @@ async fn write_file_chunked_quotes_target_path_with_single_quote() {
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("permission denied"));
+}
+
+#[tokio::test]
+async fn write_file_chunked_concurrent_writes_to_same_target_use_distinct_temp_paths() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let target_path = "/tmp/shared.bin";
+    let chunk_limit = ChunkedWriteFixture::chunk_limit();
+    let write_a = spawn_write_file(
+        Arc::clone(&host),
+        target_path,
+        vec![0xAA; chunk_limit + 1],
+        false,
+    );
+    let write_b = spawn_write_file(
+        Arc::clone(&host),
+        target_path,
+        vec![0xBB; chunk_limit + 1],
+        false,
+    );
+    let mut chunks_by_temp: BTreeMap<String, (u8, usize)> = BTreeMap::new();
+    let mut temp_by_marker: BTreeMap<u8, String> = BTreeMap::new();
+    let mut renamed_temps = BTreeSet::new();
+
+    while renamed_temps.len() < 2 {
+        let msg = read_guest_message(&mut guest).await;
+        match msg.msg_type {
+            MSG_WRITE_FILE => {
+                let (path, content, sudo, append) =
+                    vsock_proto::decode_write_file(&msg.payload).unwrap();
+                assert!(!sudo);
+                assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
+                let marker = *content.first().expect("chunk content");
+                assert!(matches!(marker, 0xAA | 0xBB));
+                assert!(content.iter().all(|byte| *byte == marker));
+
+                if let Some((known_marker, chunk_count)) = chunks_by_temp.get_mut(path) {
+                    assert_eq!(*known_marker, marker);
+                    assert!(append);
+                    assert_eq!(content.len(), 1);
+                    *chunk_count += 1;
+                } else {
+                    assert!(!append);
+                    assert_eq!(content.len(), chunk_limit);
+                    assert!(temp_by_marker.insert(marker, path.to_string()).is_none());
+                    chunks_by_temp.insert(path.to_string(), (marker, 1));
+                }
+
+                send_write_file_success(&mut guest, msg.seq).await;
+            }
+            MSG_EXEC_START => {
+                let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+                assert_eq!(decoded.label, "write-file-rename");
+                assert!(!decoded.sudo);
+                assert_eq!(decoded.stdout, helper_exec_capture_policy());
+                assert_eq!(decoded.stderr, helper_exec_capture_policy());
+                assert!(decoded.expected_exit_codes.is_empty());
+
+                let renamed_temp = chunks_by_temp
+                    .iter()
+                    .find_map(|(temp_path, (_marker, chunk_count))| {
+                        let expected_command = format!(
+                            "mv -f -- {} {}",
+                            shell_quote_for_test(temp_path),
+                            shell_quote_for_test(target_path)
+                        );
+                        (decoded.command == expected_command && *chunk_count == 2)
+                            .then(|| temp_path.clone())
+                    })
+                    .expect("rename should target a completed temp path");
+                assert!(renamed_temps.insert(renamed_temp));
+
+                send_exec_result(
+                    &mut guest,
+                    msg.seq,
+                    ExecTermination::Exited { exit_code: 0 },
+                    &[],
+                    &[],
+                )
+                .await;
+            }
+            _ => panic!("unexpected guest message type {:#04x}", msg.msg_type),
+        }
+    }
+
+    assert_eq!(chunks_by_temp.len(), 2);
+    assert_eq!(temp_by_marker.len(), 2);
+    assert_ne!(temp_by_marker.get(&0xAA), temp_by_marker.get(&0xBB));
+    assert!(chunks_by_temp.values().all(|(_marker, count)| *count == 2));
+
+    write_a.await.unwrap().unwrap();
+    write_b.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -26,6 +26,7 @@ struct ChunkedWriteFixture {
     guest: UnixStream,
     target_path: &'static str,
     temp_path: Option<String>,
+    sudo: bool,
 }
 
 fn shell_quote_for_test(value: &str) -> String {
@@ -40,6 +41,7 @@ impl ChunkedWriteFixture {
             guest,
             target_path,
             temp_path: None,
+            sudo: false,
         }
     }
 
@@ -51,20 +53,24 @@ impl ChunkedWriteFixture {
         vec![0xABu8; Self::chunk_limit() + 100]
     }
 
-    fn spawn_write(&self, content: Vec<u8>, sudo: bool) -> JoinHandle<io::Result<()>> {
+    fn spawn_write(&mut self, content: Vec<u8>, sudo: bool) -> JoinHandle<io::Result<()>> {
+        self.sudo = sudo;
         spawn_write_file(Arc::clone(&self.host), self.target_path, content, sudo)
     }
 
     async fn expect_chunk(&mut self) -> WriteFileFrame {
         let frame = expect_write_file(&mut self.guest).await;
+        assert_eq!(frame.sudo, self.sudo);
         if let Some(temp_path) = &self.temp_path {
             assert_eq!(frame.path.as_str(), temp_path);
+            assert!(frame.append);
         } else {
             assert!(
                 frame
                     .path
                     .starts_with(&format!("{}.vm0tmp-", self.target_path))
             );
+            assert!(!frame.append);
             self.temp_path = Some(frame.path.clone());
         }
         frame
@@ -73,6 +79,7 @@ impl ChunkedWriteFixture {
     async fn expect_rename(&mut self) -> ExecStartFrame {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "write-file-rename");
+        assert_eq!(frame.sudo, self.sudo);
         assert_eq!(frame.command, self.expected_rename_command());
         frame
     }
@@ -80,6 +87,7 @@ impl ChunkedWriteFixture {
     async fn expect_cleanup(&mut self) -> ExecStartFrame {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "exec-cleanup");
+        assert_eq!(frame.sudo, self.sudo);
         assert_eq!(frame.command, self.expected_cleanup_command());
         frame
     }
@@ -225,6 +233,52 @@ async fn test_write_file_chunked() {
     .await;
 
     write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn write_file_chunked_preserves_sudo_on_chunks_rename_and_cleanup() {
+    let mut rename_fixture = ChunkedWriteFixture::new("/tmp/sudo-big.bin").await;
+    let rename_task = rename_fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), true);
+
+    let first = rename_fixture.expect_chunk().await;
+    send_write_file_success(&mut rename_fixture.guest, first.seq()).await;
+
+    let second = rename_fixture.expect_chunk().await;
+    send_write_file_success(&mut rename_fixture.guest, second.seq()).await;
+
+    let rename = rename_fixture.expect_rename().await;
+    send_exec_result(
+        &mut rename_fixture.guest,
+        rename.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    rename_task.await.unwrap().unwrap();
+
+    let mut cleanup_fixture = ChunkedWriteFixture::new("/tmp/sudo-cleanup.bin").await;
+    let cleanup_task = cleanup_fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), true);
+
+    let first = cleanup_fixture.expect_chunk().await;
+    send_write_file_success(&mut cleanup_fixture.guest, first.seq()).await;
+
+    let second = cleanup_fixture.expect_chunk().await;
+    send_write_file_failure(&mut cleanup_fixture.guest, second.seq(), "disk full").await;
+
+    let cleanup = cleanup_fixture.expect_cleanup().await;
+    send_exec_result(
+        &mut cleanup_fixture.guest,
+        cleanup.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = cleanup_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
 }
 
 #[tokio::test]
@@ -631,14 +685,17 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
             let msg = guest.read_message().await;
             match msg.msg_type {
                 MSG_WRITE_FILE => {
-                    let (path, _chunk, _sudo, _append) =
+                    let (path, _chunk, sudo, append) =
                         vsock_proto::decode_write_file(&msg.payload).unwrap();
+                    assert!(!sudo);
                     if let Some(temp_path) = &temp_path {
                         assert_eq!(path, temp_path);
+                        assert!(append);
                         continue;
                     }
 
                     assert!(path.starts_with("/tmp/big.bin.vm0tmp-"));
+                    assert!(!append);
                     temp_path = Some(path.to_string());
                     send_write_file_success(guest.stream_mut(), msg.seq).await;
                     if let Some(tx) = first_chunk_tx.take() {

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -535,13 +535,11 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
                     shell_quote_for_test(target_path)
                 );
                 assert_eq!(decoded.command, expected_command);
-                assert!(!decoded.command.contains(failed_temp));
                 successful_temp_renamed = true;
             }
             "exec-cleanup" => {
                 let expected_command = format!("rm -f -- {}", shell_quote_for_test(failed_temp));
                 assert_eq!(decoded.command, expected_command);
-                assert!(!decoded.command.contains(success_temp));
                 failed_temp_cleaned = true;
             }
             label => panic!("unexpected exec label {label}"),

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -263,6 +263,48 @@ async fn test_write_file_chunked() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_quotes_target_path_with_single_quote() {
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big'quote.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
+
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
+
+    let second = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
+
+    let rename = fixture.expect_rename().await;
+    assert!(rename.command.contains("'/tmp/big'\\''quote.bin.vm0tmp-"));
+    assert!(rename.command.ends_with(" '/tmp/big'\\''quote.bin'"));
+    send_exec_result(
+        &mut fixture.guest,
+        rename.seq(),
+        ExecTermination::Exited { exit_code: 1 },
+        &[],
+        b"permission denied",
+    )
+    .await;
+
+    let cleanup = fixture.expect_cleanup().await;
+    assert!(
+        cleanup
+            .command
+            .starts_with("rm -f -- '/tmp/big'\\''quote.bin.vm0tmp-")
+    );
+    send_exec_result(
+        &mut fixture.guest,
+        cleanup.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("permission denied"));
+}
+
+#[tokio::test]
 async fn write_file_chunked_preserves_sudo_on_chunks_rename_cleanup_and_retry() {
     let mut rename_fixture = ChunkedWriteFixture::new("/tmp/sudo-big.bin").await;
     let rename_task = rename_fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), true);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -213,6 +213,41 @@ async fn write_file_chunked_rejects_invalid_path_before_cleanup_or_write() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_rejects_temp_path_overflow_before_cleanup_or_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let path = format!("/{}", "a".repeat(u16::MAX as usize - 1));
+    let content = vec![0u8; file_impl::test_support::WRITE_FILE_CHUNK_LIMIT + 1];
+
+    let err = host
+        .write_file_with_write_observer(
+            &path,
+            &content,
+            false,
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(operation_count(&host), 0);
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn test_write_file_chunked() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let chunk_limit = ChunkedWriteFixture::chunk_limit();

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -236,7 +236,7 @@ async fn test_write_file_chunked() {
 }
 
 #[tokio::test]
-async fn write_file_chunked_preserves_sudo_on_chunks_rename_and_cleanup() {
+async fn write_file_chunked_preserves_sudo_on_chunks_rename_cleanup_and_retry() {
     let mut rename_fixture = ChunkedWriteFixture::new("/tmp/sudo-big.bin").await;
     let rename_task = rename_fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), true);
 
@@ -268,17 +268,28 @@ async fn write_file_chunked_preserves_sudo_on_chunks_rename_and_cleanup() {
     send_write_file_failure(&mut cleanup_fixture.guest, second.seq(), "disk full").await;
 
     let cleanup = cleanup_fixture.expect_cleanup().await;
-    send_exec_result(
+    send_guest_error(
         &mut cleanup_fixture.guest,
         cleanup.seq(),
-        ExecTermination::Exited { exit_code: 0 },
-        &[],
-        &[],
+        "cleanup unavailable",
     )
     .await;
 
     let err = cleanup_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("disk full"));
+    cleanup_fixture.assert_readiness(NormalOperationReadiness::NotParkable);
+
+    let retry = tokio::time::timeout(Duration::from_secs(2), cleanup_fixture.expect_cleanup())
+        .await
+        .expect("cleanup retry was not sent after sudo cleanup error");
+    send_exec_result(
+        &mut cleanup_fixture.guest,
+        retry.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -452,89 +452,109 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
         vec![failure_marker; chunk_limit + 1],
         false,
     );
-    let mut chunks_by_temp: BTreeMap<String, (u8, usize)> = BTreeMap::new();
     let mut temp_by_marker: BTreeMap<u8, String> = BTreeMap::new();
+    let mut first_chunks = BTreeMap::new();
+    while first_chunks.len() < 2 {
+        let msg = read_guest_message(&mut guest).await;
+        assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+        let (path, content, sudo, append) = vsock_proto::decode_write_file(&msg.payload).unwrap();
+        assert!(!sudo);
+        assert!(!append);
+        assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
+        assert_eq!(content.len(), chunk_limit);
+        let marker = *content.first().expect("chunk content");
+        assert!(matches!(marker, 0xAA | 0xBB));
+        assert!(content.iter().all(|byte| *byte == marker));
+        assert!(first_chunks.insert(marker, msg.seq).is_none());
+        assert!(temp_by_marker.insert(marker, path.to_string()).is_none());
+    }
+
+    for seq in first_chunks.values() {
+        send_write_file_success(&mut guest, *seq).await;
+    }
+
+    let mut second_chunks = BTreeMap::new();
+    while second_chunks.len() < 2 {
+        let msg = read_guest_message(&mut guest).await;
+        assert_eq!(msg.msg_type, MSG_WRITE_FILE);
+        let (path, content, sudo, append) = vsock_proto::decode_write_file(&msg.payload).unwrap();
+        assert!(!sudo);
+        assert!(append);
+        assert_eq!(content.len(), 1);
+        let marker = *content.first().expect("chunk content");
+        assert!(matches!(marker, 0xAA | 0xBB));
+        assert!(content.iter().all(|byte| *byte == marker));
+        assert_eq!(
+            path,
+            temp_by_marker
+                .get(&marker)
+                .expect("second chunk should use first chunk temp path")
+        );
+        assert!(second_chunks.insert(marker, msg.seq).is_none());
+    }
+
+    send_write_file_failure(
+        &mut guest,
+        *second_chunks
+            .get(&failure_marker)
+            .expect("failure second chunk"),
+        "disk full",
+    )
+    .await;
+    send_write_file_success(
+        &mut guest,
+        *second_chunks
+            .get(&success_marker)
+            .expect("success second chunk"),
+    )
+    .await;
+
     let mut successful_temp_renamed = false;
     let mut failed_temp_cleaned = false;
 
     while !(successful_temp_renamed && failed_temp_cleaned) {
         let msg = read_guest_message(&mut guest).await;
-        match msg.msg_type {
-            MSG_WRITE_FILE => {
-                let (path, content, sudo, append) =
-                    vsock_proto::decode_write_file(&msg.payload).unwrap();
-                assert!(!sudo);
-                assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
-                let marker = *content.first().expect("chunk content");
-                assert!(matches!(marker, 0xAA | 0xBB));
-                assert!(content.iter().all(|byte| *byte == marker));
+        assert_eq!(msg.msg_type, MSG_EXEC_START);
+        let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+        assert!(!decoded.sudo);
+        assert_eq!(decoded.stdout, helper_exec_capture_policy());
+        assert_eq!(decoded.stderr, helper_exec_capture_policy());
+        assert!(decoded.expected_exit_codes.is_empty());
+        let success_temp = temp_by_marker
+            .get(&success_marker)
+            .expect("successful temp path");
+        let failed_temp = temp_by_marker
+            .get(&failure_marker)
+            .expect("failed temp path");
 
-                let chunk_count =
-                    if let Some((known_marker, chunk_count)) = chunks_by_temp.get_mut(path) {
-                        assert_eq!(*known_marker, marker);
-                        assert!(append);
-                        assert_eq!(content.len(), 1);
-                        *chunk_count += 1;
-                        *chunk_count
-                    } else {
-                        assert!(!append);
-                        assert_eq!(content.len(), chunk_limit);
-                        assert!(temp_by_marker.insert(marker, path.to_string()).is_none());
-                        chunks_by_temp.insert(path.to_string(), (marker, 1));
-                        1
-                    };
-
-                if marker == failure_marker && chunk_count == 2 {
-                    send_write_file_failure(&mut guest, msg.seq, "disk full").await;
-                } else {
-                    send_write_file_success(&mut guest, msg.seq).await;
-                }
+        match decoded.label {
+            "write-file-rename" => {
+                let expected_command = format!(
+                    "mv -f -- {} {}",
+                    shell_quote_for_test(success_temp),
+                    shell_quote_for_test(target_path)
+                );
+                assert_eq!(decoded.command, expected_command);
+                assert!(!decoded.command.contains(failed_temp));
+                successful_temp_renamed = true;
             }
-            MSG_EXEC_START => {
-                let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
-                assert!(!decoded.sudo);
-                assert_eq!(decoded.stdout, helper_exec_capture_policy());
-                assert_eq!(decoded.stderr, helper_exec_capture_policy());
-                assert!(decoded.expected_exit_codes.is_empty());
-                let success_temp = temp_by_marker
-                    .get(&success_marker)
-                    .expect("successful temp path");
-                let failed_temp = temp_by_marker
-                    .get(&failure_marker)
-                    .expect("failed temp path");
-
-                match decoded.label {
-                    "write-file-rename" => {
-                        let expected_command = format!(
-                            "mv -f -- {} {}",
-                            shell_quote_for_test(success_temp),
-                            shell_quote_for_test(target_path)
-                        );
-                        assert_eq!(decoded.command, expected_command);
-                        assert!(!decoded.command.contains(failed_temp));
-                        successful_temp_renamed = true;
-                    }
-                    "exec-cleanup" => {
-                        let expected_command =
-                            format!("rm -f -- {}", shell_quote_for_test(failed_temp));
-                        assert_eq!(decoded.command, expected_command);
-                        assert!(!decoded.command.contains(success_temp));
-                        failed_temp_cleaned = true;
-                    }
-                    label => panic!("unexpected exec label {label}"),
-                }
-
-                send_exec_result(
-                    &mut guest,
-                    msg.seq,
-                    ExecTermination::Exited { exit_code: 0 },
-                    &[],
-                    &[],
-                )
-                .await;
+            "exec-cleanup" => {
+                let expected_command = format!("rm -f -- {}", shell_quote_for_test(failed_temp));
+                assert_eq!(decoded.command, expected_command);
+                assert!(!decoded.command.contains(success_temp));
+                failed_temp_cleaned = true;
             }
-            _ => panic!("unexpected guest message type {:#04x}", msg.msg_type),
+            label => panic!("unexpected exec label {label}"),
         }
+
+        send_exec_result(
+            &mut guest,
+            msg.seq,
+            ExecTermination::Exited { exit_code: 0 },
+            &[],
+            &[],
+        )
+        .await;
     }
 
     successful_write.await.unwrap().unwrap();

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -28,6 +28,10 @@ struct ChunkedWriteFixture {
     temp_path: Option<String>,
 }
 
+fn shell_quote_for_test(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 impl ChunkedWriteFixture {
     async fn new(target_path: &'static str) -> Self {
         let (host, guest) = setup_host_and_guest().await;
@@ -70,8 +74,11 @@ impl ChunkedWriteFixture {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "write-file-rename");
         assert!(frame.command.contains("mv -f --"));
-        assert!(frame.command.contains(self.temp_path()));
-        assert!(frame.command.contains(self.target_path));
+        assert!(frame.command.ends_with(&format!(
+            " {} {}",
+            shell_quote_for_test(self.temp_path()),
+            shell_quote_for_test(self.target_path)
+        )));
         frame
     }
 
@@ -79,7 +86,11 @@ impl ChunkedWriteFixture {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "exec-cleanup");
         assert!(frame.command.contains("rm -f --"));
-        assert!(frame.command.contains(self.temp_path()));
+        assert!(
+            frame
+                .command
+                .ends_with(&format!(" {}", shell_quote_for_test(self.temp_path())))
+        );
         frame
     }
 

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -433,6 +433,116 @@ async fn write_file_chunked_concurrent_writes_to_same_target_use_distinct_temp_p
 }
 
 #[tokio::test]
+async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let target_path = "/tmp/shared-failure.bin";
+    let chunk_limit = ChunkedWriteFixture::chunk_limit();
+    let success_marker = 0xAA;
+    let failure_marker = 0xBB;
+    let successful_write = spawn_write_file(
+        Arc::clone(&host),
+        target_path,
+        vec![success_marker; chunk_limit + 1],
+        false,
+    );
+    let failing_write = spawn_write_file(
+        Arc::clone(&host),
+        target_path,
+        vec![failure_marker; chunk_limit + 1],
+        false,
+    );
+    let mut chunks_by_temp: BTreeMap<String, (u8, usize)> = BTreeMap::new();
+    let mut temp_by_marker: BTreeMap<u8, String> = BTreeMap::new();
+    let mut successful_temp_renamed = false;
+    let mut failed_temp_cleaned = false;
+
+    while !(successful_temp_renamed && failed_temp_cleaned) {
+        let msg = read_guest_message(&mut guest).await;
+        match msg.msg_type {
+            MSG_WRITE_FILE => {
+                let (path, content, sudo, append) =
+                    vsock_proto::decode_write_file(&msg.payload).unwrap();
+                assert!(!sudo);
+                assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
+                let marker = *content.first().expect("chunk content");
+                assert!(matches!(marker, 0xAA | 0xBB));
+                assert!(content.iter().all(|byte| *byte == marker));
+
+                let chunk_count =
+                    if let Some((known_marker, chunk_count)) = chunks_by_temp.get_mut(path) {
+                        assert_eq!(*known_marker, marker);
+                        assert!(append);
+                        assert_eq!(content.len(), 1);
+                        *chunk_count += 1;
+                        *chunk_count
+                    } else {
+                        assert!(!append);
+                        assert_eq!(content.len(), chunk_limit);
+                        assert!(temp_by_marker.insert(marker, path.to_string()).is_none());
+                        chunks_by_temp.insert(path.to_string(), (marker, 1));
+                        1
+                    };
+
+                if marker == failure_marker && chunk_count == 2 {
+                    send_write_file_failure(&mut guest, msg.seq, "disk full").await;
+                } else {
+                    send_write_file_success(&mut guest, msg.seq).await;
+                }
+            }
+            MSG_EXEC_START => {
+                let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
+                assert!(!decoded.sudo);
+                assert_eq!(decoded.stdout, helper_exec_capture_policy());
+                assert_eq!(decoded.stderr, helper_exec_capture_policy());
+                assert!(decoded.expected_exit_codes.is_empty());
+                let success_temp = temp_by_marker
+                    .get(&success_marker)
+                    .expect("successful temp path");
+                let failed_temp = temp_by_marker
+                    .get(&failure_marker)
+                    .expect("failed temp path");
+
+                match decoded.label {
+                    "write-file-rename" => {
+                        let expected_command = format!(
+                            "mv -f -- {} {}",
+                            shell_quote_for_test(success_temp),
+                            shell_quote_for_test(target_path)
+                        );
+                        assert_eq!(decoded.command, expected_command);
+                        assert!(!decoded.command.contains(failed_temp));
+                        successful_temp_renamed = true;
+                    }
+                    "exec-cleanup" => {
+                        let expected_command =
+                            format!("rm -f -- {}", shell_quote_for_test(failed_temp));
+                        assert_eq!(decoded.command, expected_command);
+                        assert!(!decoded.command.contains(success_temp));
+                        failed_temp_cleaned = true;
+                    }
+                    label => panic!("unexpected exec label {label}"),
+                }
+
+                send_exec_result(
+                    &mut guest,
+                    msg.seq,
+                    ExecTermination::Exited { exit_code: 0 },
+                    &[],
+                    &[],
+                )
+                .await;
+            }
+            _ => panic!("unexpected guest message type {:#04x}", msg.msg_type),
+        }
+    }
+
+    successful_write.await.unwrap().unwrap();
+    let err = failing_write.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+}
+
+#[tokio::test]
 async fn write_file_chunked_preserves_sudo_on_chunks_rename_cleanup_and_retry() {
     let mut rename_fixture = ChunkedWriteFixture::new("/tmp/sudo-big.bin").await;
     let rename_task = rename_fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), true);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -73,25 +73,27 @@ impl ChunkedWriteFixture {
     async fn expect_rename(&mut self) -> ExecStartFrame {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "write-file-rename");
-        assert!(frame.command.contains("mv -f --"));
-        assert!(frame.command.ends_with(&format!(
-            " {} {}",
-            shell_quote_for_test(self.temp_path()),
-            shell_quote_for_test(self.target_path)
-        )));
+        assert_eq!(frame.command, self.expected_rename_command());
         frame
     }
 
     async fn expect_cleanup(&mut self) -> ExecStartFrame {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "exec-cleanup");
-        assert!(frame.command.contains("rm -f --"));
-        assert!(
-            frame
-                .command
-                .ends_with(&format!(" {}", shell_quote_for_test(self.temp_path())))
-        );
+        assert_eq!(frame.command, self.expected_cleanup_command());
         frame
+    }
+
+    fn expected_rename_command(&self) -> String {
+        format!(
+            "mv -f -- {} {}",
+            shell_quote_for_test(self.temp_path()),
+            shell_quote_for_test(self.target_path)
+        )
+    }
+
+    fn expected_cleanup_command(&self) -> String {
+        format!("rm -f -- {}", shell_quote_for_test(self.temp_path()))
     }
 
     fn assert_readiness(&self, expected: NormalOperationReadiness) {
@@ -646,8 +648,9 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
                 MSG_EXEC_START => {
                     let decoded = vsock_proto::decode_exec_start(&msg.payload).unwrap();
                     let temp_path = temp_path.as_ref().expect("temp path");
-                    assert!(decoded.command.contains("rm -f --"));
-                    assert!(decoded.command.contains(temp_path));
+                    let expected_cleanup_command =
+                        format!("rm -f -- {}", shell_quote_for_test(temp_path));
+                    assert_eq!(decoded.command, expected_cleanup_command.as_str());
                     assert_eq!(decoded.label, "exec-cleanup");
                     if let Some(tx) = cleanup_tx.take() {
                         let _ = tx.send(decoded.command.to_string());

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -7,7 +7,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use vsock_proto::{ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
+use vsock_proto::{ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
 
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
@@ -18,8 +18,8 @@ use super::support::{
     ExecStartFrame, WriteFileFrame, expect_exec_start, expect_write_file, send_guest_error,
     send_write_file_failure, send_write_file_success, spawn_write_file,
 };
-use crate::file as file_impl;
 use crate::{FrameWriteObserver, VsockHost, operation_tracker::NormalOperationReadiness};
+use crate::{exec_operation, file as file_impl};
 
 struct ChunkedWriteFixture {
     host: Arc<VsockHost>,
@@ -84,6 +84,7 @@ impl ChunkedWriteFixture {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "write-file-rename");
         assert_eq!(frame.sudo, self.sudo);
+        assert_helper_exec_capture_policy(&frame);
         assert_eq!(frame.command, self.expected_rename_command());
         frame
     }
@@ -92,6 +93,7 @@ impl ChunkedWriteFixture {
         let frame = expect_exec_start(&mut self.guest).await;
         assert_eq!(frame.label, "exec-cleanup");
         assert_eq!(frame.sudo, self.sudo);
+        assert_helper_exec_capture_policy(&frame);
         assert_eq!(frame.command, self.expected_cleanup_command());
         frame
     }
@@ -114,6 +116,19 @@ impl ChunkedWriteFixture {
 
     fn temp_path(&self) -> &str {
         self.temp_path.as_deref().expect("temp path")
+    }
+}
+
+fn assert_helper_exec_capture_policy(frame: &ExecStartFrame) {
+    let capture_policy = helper_exec_capture_policy();
+    assert_eq!(frame.stdout, capture_policy);
+    assert_eq!(frame.stderr, capture_policy);
+    assert!(frame.expected_exit_codes.is_empty());
+}
+
+fn helper_exec_capture_policy() -> ExecOutputPolicy {
+    ExecOutputPolicy::Capture {
+        limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
     }
 }
 
@@ -732,6 +747,10 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
                         format!("rm -f -- {}", shell_quote_for_test(temp_path));
                     assert_eq!(decoded.command, expected_cleanup_command.as_str());
                     assert_eq!(decoded.label, "exec-cleanup");
+                    assert!(!decoded.sudo);
+                    assert_eq!(decoded.stdout, helper_exec_capture_policy());
+                    assert_eq!(decoded.stderr, helper_exec_capture_policy());
+                    assert!(decoded.expected_exit_codes.is_empty());
                     if let Some(tx) = cleanup_tx.take() {
                         let _ = tx.send(decoded.command.to_string());
                     }


### PR DESCRIPTION
## Summary

- add a local `ChunkedWriteFixture` for chunked write protocol test state and stable frame assertions
- refactor chunked write success, cleanup, rename, and retry tests to use the fixture while keeping scenario-specific responses explicit
- remove the chunked-write-only temp path helper from shared file test support

Closes #17696

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host write_file_chunked`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc
