### PR TITLE
refactor: consolidate exec cancel handling

### DIFF
--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -9,6 +9,7 @@ use vsock_proto::{ExecControlStatus, MSG_EXEC_CANCEL, MSG_EXEC_START};
 use crate::{ConnectionState, FrameWriteObserver, Shared, normal_operation_transition_error};
 
 use super::diagnostics::{ExecOperationDiagnostic, ExecOperationFrameDiagnostic};
+use super::handle::ExecWaitLifecycle;
 use super::types::exec_control_status_error;
 use super::{
     EXEC_OPERATION_FRAME_WRITE_COMPLETED, EXEC_OPERATION_FRAME_WRITE_NOT_STARTED,
@@ -52,10 +53,11 @@ fn mark_exec_operation_host_cancel_requested(shared: &Arc<Shared>, seq: u32) {
     }
 }
 
-pub(in crate::exec_operation) async fn send_supervised_exec_cancel_frame(
+pub(in crate::exec_operation) async fn send_exec_cancel_frame(
     shared: &Arc<Shared>,
     seq: u32,
     diagnostic: &ExecOperationDiagnostic,
+    lifecycle: ExecWaitLifecycle,
 ) -> io::Result<()> {
     let payload = vsock_proto::encode_exec_cancel();
     write_frame(
@@ -68,12 +70,7 @@ pub(in crate::exec_operation) async fn send_supervised_exec_cancel_frame(
         exec_cancel_write_observer(shared, seq),
     )
     .await?;
-    tracing::info!(
-        seq = seq,
-        label = %diagnostic.label_log,
-        elapsed_ms = diagnostic.elapsed_ms(),
-        "supervised exec operation cancel sent"
-    );
+    lifecycle.log_cancel_sent(seq, diagnostic);
     Ok(())
 }
 

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -4,12 +4,11 @@ use std::sync::atomic::{AtomicU8, Ordering};
 
 use tokio::io::AsyncWriteExt;
 use tokio::time::Instant;
-use vsock_proto::{ExecControlStatus, MSG_EXEC_CANCEL, MSG_EXEC_START};
+use vsock_proto::{ExecControlStatus, MSG_EXEC_START};
 
 use crate::{ConnectionState, FrameWriteObserver, Shared, normal_operation_transition_error};
 
 use super::diagnostics::{ExecOperationDiagnostic, ExecOperationFrameDiagnostic};
-use super::handle::ExecWaitLifecycle;
 use super::types::exec_control_status_error;
 use super::{
     EXEC_OPERATION_FRAME_WRITE_COMPLETED, EXEC_OPERATION_FRAME_WRITE_NOT_STARTED,
@@ -51,27 +50,6 @@ fn mark_exec_operation_host_cancel_requested(shared: &Arc<Shared>, seq: u32) {
     if let ConnectionState::Connected { operations, .. } = &mut *guard {
         operations.mark_host_cancel_requested(seq);
     }
-}
-
-pub(in crate::exec_operation) async fn send_exec_cancel_frame(
-    shared: &Arc<Shared>,
-    seq: u32,
-    diagnostic: &ExecOperationDiagnostic,
-    lifecycle: ExecWaitLifecycle,
-) -> io::Result<()> {
-    let payload = vsock_proto::encode_exec_cancel();
-    write_frame(
-        shared,
-        MSG_EXEC_CANCEL,
-        seq,
-        &payload,
-        Some(diagnostic.frame("cancel")),
-        None,
-        exec_cancel_write_observer(shared, seq),
-    )
-    .await?;
-    lifecycle.log_cancel_sent(seq, diagnostic);
-    Ok(())
 }
 
 fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> io::Result<()> {

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
 use vsock_proto::{
     ExecControlNonce, ExecControlStatus, ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
 };
@@ -13,7 +14,7 @@ use super::EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT;
 use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
     clear_exec_operation_stream_sender, exec_cancel_write_observer,
-    mark_pending_exec_control_possible_guest_write, send_supervised_exec_cancel_frame, write_frame,
+    mark_pending_exec_control_possible_guest_write, send_exec_cancel_frame, write_frame,
     write_frame_with_pre_write,
 };
 use super::state::{PendingExecControl, PendingExecControlGuard};
@@ -53,21 +54,101 @@ pub(in crate::exec_operation) struct ExecCancelWaitResult {
     pub(in crate::exec_operation) cancel_seq: Option<u32>,
 }
 
-impl ExecWaitCore {
-    fn operation_closed_message(lifecycle: ExecWaitLifecycle) -> &'static str {
-        match lifecycle {
+impl ExecWaitLifecycle {
+    fn operation_closed_message(self) -> &'static str {
+        match self {
             ExecWaitLifecycle::OneShot => "exec operation closed",
             ExecWaitLifecycle::Supervised => "supervised exec operation closed",
         }
     }
 
-    fn timeout_error_message(lifecycle: ExecWaitLifecycle) -> &'static str {
-        match lifecycle {
+    fn timeout_error_message(self) -> &'static str {
+        match self {
             ExecWaitLifecycle::OneShot => "exec operation timeout",
             ExecWaitLifecycle::Supervised => "supervised exec operation timeout",
         }
     }
 
+    pub(in crate::exec_operation) fn log_cancel_sent(
+        self,
+        seq: u32,
+        diagnostic: &ExecOperationDiagnostic,
+    ) {
+        match self {
+            ExecWaitLifecycle::OneShot => {
+                tracing::info!(
+                    seq = seq,
+                    label = %diagnostic.label_log,
+                    elapsed_ms = diagnostic.elapsed_ms(),
+                    "exec operation cancel sent"
+                );
+            }
+            ExecWaitLifecycle::Supervised => {
+                tracing::info!(
+                    seq = seq,
+                    label = %diagnostic.label_log,
+                    elapsed_ms = diagnostic.elapsed_ms(),
+                    "supervised exec operation cancel sent"
+                );
+            }
+        }
+    }
+
+    fn log_cancel_completed(self, seq: u32, label: &str, registered_at: Instant) {
+        match self {
+            ExecWaitLifecycle::OneShot => {
+                tracing::info!(
+                    seq = seq,
+                    label = %label,
+                    elapsed_ms = registered_at.elapsed().as_millis(),
+                    "exec operation cancel completed"
+                );
+            }
+            ExecWaitLifecycle::Supervised => {
+                tracing::info!(
+                    seq = seq,
+                    label = %label,
+                    elapsed_ms = registered_at.elapsed().as_millis(),
+                    "supervised exec operation cancel completed"
+                );
+            }
+        }
+    }
+
+    fn unexpected_cancel_terminal_state_message(self, termination: ExecTermination) -> String {
+        match self {
+            ExecWaitLifecycle::OneShot => {
+                format!("exec cancel returned terminal state: {termination:?}")
+            }
+            ExecWaitLifecycle::Supervised => {
+                format!("supervised exec cancel returned terminal state: {termination:?}")
+            }
+        }
+    }
+}
+
+impl ExecCancelWaitResult {
+    fn into_expected_cancel_result(
+        self,
+        lifecycle: ExecWaitLifecycle,
+        cancel_label_log: &str,
+        registered_at: Instant,
+    ) -> io::Result<ExecOperationResult> {
+        let Some(seq) = self.cancel_seq else {
+            return Ok(self.result);
+        };
+        if self.result.termination == ExecTermination::Cancelled {
+            lifecycle.log_cancel_completed(seq, cancel_label_log, registered_at);
+            return Ok(self.result);
+        }
+
+        Err(io::Error::other(
+            lifecycle.unexpected_cancel_terminal_state_message(self.result.termination),
+        ))
+    }
+}
+
+impl ExecWaitCore {
     fn log_timeout(&self, seq: u32, poison_on_timeout: bool, lifecycle: ExecWaitLifecycle) {
         match lifecycle {
             ExecWaitLifecycle::OneShot => {
@@ -162,11 +243,11 @@ impl ExecWaitCore {
         poison_on_timeout: bool,
         lifecycle: ExecWaitLifecycle,
     ) -> io::Result<ExecOperationResult> {
-        let seq = self.active_seq_or_closed(Self::operation_closed_message(lifecycle))?;
+        let seq = self.active_seq_or_closed(lifecycle.operation_closed_message())?;
         let rx = self.result_rx.as_mut().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::ConnectionReset,
-                Self::operation_closed_message(lifecycle),
+                lifecycle.operation_closed_message(),
             )
         })?;
 
@@ -190,7 +271,7 @@ impl ExecWaitCore {
                 }
                 Err(io::Error::new(
                     io::ErrorKind::TimedOut,
-                    Self::timeout_error_message(lifecycle),
+                    lifecycle.timeout_error_message(),
                 ))
             }
         }
@@ -224,25 +305,13 @@ impl ExecOperationHandle {
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
         let registered_at = self.wait_core.diagnostic().registered_at;
-        let wait_result = self.cancel_and_wait_for_terminal_status(timeout).await?;
-        if wait_result.cancel_seq.is_none()
-            || wait_result.result.termination == ExecTermination::Cancelled
-        {
-            if let Some(seq) = wait_result.cancel_seq {
-                tracing::info!(
-                    seq = seq,
-                    label = %cancel_label_log,
-                    elapsed_ms = registered_at.elapsed().as_millis(),
-                    "exec operation cancel completed"
-                );
-            }
-            return Ok(wait_result.result);
-        }
-
-        Err(io::Error::other(format!(
-            "exec cancel returned terminal state: {:?}",
-            wait_result.result.termination
-        )))
+        self.cancel_and_wait_for_terminal_status(timeout)
+            .await?
+            .into_expected_cancel_result(
+                ExecWaitLifecycle::OneShot,
+                &cancel_label_log,
+                registered_at,
+            )
     }
 
     pub(crate) async fn cancel_and_wait_for_terminal(
@@ -267,26 +336,14 @@ impl ExecOperationHandle {
 
         let seq = self
             .wait_core
-            .active_seq_or_closed(ExecWaitCore::operation_closed_message(
-                ExecWaitLifecycle::OneShot,
-            ))?;
-        let payload = vsock_proto::encode_exec_cancel();
-        write_frame(
+            .active_seq_or_closed(ExecWaitLifecycle::OneShot.operation_closed_message())?;
+        send_exec_cancel_frame(
             self.wait_core.shared(),
-            MSG_EXEC_CANCEL,
             seq,
-            &payload,
-            Some(self.wait_core.diagnostic().frame("cancel")),
-            None,
-            exec_cancel_write_observer(self.wait_core.shared(), seq),
+            self.wait_core.diagnostic(),
+            ExecWaitLifecycle::OneShot,
         )
         .await?;
-        tracing::info!(
-            seq = seq,
-            label = %self.wait_core.diagnostic().label_log,
-            elapsed_ms = self.wait_core.diagnostic().elapsed_ms(),
-            "exec operation cancel sent"
-        );
 
         let result = self
             .wait_core
@@ -344,7 +401,12 @@ impl SupervisedExecCancelHandle {
     pub async fn cancel(self, timeout: Duration) -> io::Result<()> {
         tokio::time::timeout(
             timeout,
-            send_supervised_exec_cancel_frame(&self.shared, self.seq, &self.diagnostic),
+            send_exec_cancel_frame(
+                &self.shared,
+                self.seq,
+                &self.diagnostic,
+                ExecWaitLifecycle::Supervised,
+            ),
         )
         .await
         .unwrap_or_else(|_| {
@@ -443,25 +505,13 @@ impl SupervisedExecHandle {
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
         let registered_at = self.wait_core.diagnostic().registered_at;
-        let wait_result = self.cancel_and_wait_for_terminal_status(timeout).await?;
-        if wait_result.cancel_seq.is_none()
-            || wait_result.result.termination == ExecTermination::Cancelled
-        {
-            if let Some(seq) = wait_result.cancel_seq {
-                tracing::info!(
-                    seq = seq,
-                    label = %cancel_label_log,
-                    elapsed_ms = registered_at.elapsed().as_millis(),
-                    "supervised exec operation cancel completed"
-                );
-            }
-            return Ok(wait_result.result);
-        }
-
-        Err(io::Error::other(format!(
-            "supervised exec cancel returned terminal state: {:?}",
-            wait_result.result.termination
-        )))
+        self.cancel_and_wait_for_terminal_status(timeout)
+            .await?
+            .into_expected_cancel_result(
+                ExecWaitLifecycle::Supervised,
+                &cancel_label_log,
+                registered_at,
+            )
     }
 
     pub(in crate::exec_operation) async fn cancel_and_wait_for_terminal_status(
@@ -477,13 +527,12 @@ impl SupervisedExecHandle {
 
         let seq = self
             .wait_core
-            .active_seq_or_closed(ExecWaitCore::operation_closed_message(
-                ExecWaitLifecycle::Supervised,
-            ))?;
-        send_supervised_exec_cancel_frame(
+            .active_seq_or_closed(ExecWaitLifecycle::Supervised.operation_closed_message())?;
+        send_exec_cancel_frame(
             self.wait_core.shared(),
             seq,
             self.wait_core.diagnostic(),
+            ExecWaitLifecycle::Supervised,
         )
         .await?;
 

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -14,8 +14,7 @@ use super::EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT;
 use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
     clear_exec_operation_stream_sender, exec_cancel_write_observer,
-    mark_pending_exec_control_possible_guest_write, send_exec_cancel_frame, write_frame,
-    write_frame_with_pre_write,
+    mark_pending_exec_control_possible_guest_write, write_frame, write_frame_with_pre_write,
 };
 use super::state::{PendingExecControl, PendingExecControlGuard};
 use super::types::{
@@ -69,11 +68,7 @@ impl ExecWaitLifecycle {
         }
     }
 
-    pub(in crate::exec_operation) fn log_cancel_sent(
-        self,
-        seq: u32,
-        diagnostic: &ExecOperationDiagnostic,
-    ) {
+    fn log_cancel_sent(self, seq: u32, diagnostic: &ExecOperationDiagnostic) {
         match self {
             ExecWaitLifecycle::OneShot => {
                 tracing::info!(
@@ -146,6 +141,27 @@ impl ExecCancelWaitResult {
             lifecycle.unexpected_cancel_terminal_state_message(self.result.termination),
         ))
     }
+}
+
+pub(in crate::exec_operation) async fn send_exec_cancel_frame(
+    shared: &Arc<Shared>,
+    seq: u32,
+    diagnostic: &ExecOperationDiagnostic,
+    lifecycle: ExecWaitLifecycle,
+) -> io::Result<()> {
+    let payload = vsock_proto::encode_exec_cancel();
+    write_frame(
+        shared,
+        MSG_EXEC_CANCEL,
+        seq,
+        &payload,
+        Some(diagnostic.frame("cancel")),
+        None,
+        exec_cancel_write_observer(shared, seq),
+    )
+    .await?;
+    lifecycle.log_cancel_sent(seq, diagnostic);
+    Ok(())
 }
 
 impl ExecWaitCore {

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -19,8 +19,7 @@ use crate::{ConnectionState, Shared};
 
 use super::diagnostics::*;
 use super::dispatch::dispatch_result;
-use super::frame::send_exec_cancel_frame;
-use super::handle::{ExecOperationHandle, ExecWaitCore, ExecWaitLifecycle};
+use super::handle::{ExecOperationHandle, ExecWaitCore, ExecWaitLifecycle, send_exec_cancel_frame};
 use super::state::*;
 use super::types::ExecOperationResult;
 use super::{

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -19,8 +19,8 @@ use crate::{ConnectionState, Shared};
 
 use super::diagnostics::*;
 use super::dispatch::dispatch_result;
-use super::frame::send_supervised_exec_cancel_frame;
-use super::handle::{ExecOperationHandle, ExecWaitCore};
+use super::frame::send_exec_cancel_frame;
+use super::handle::{ExecOperationHandle, ExecWaitCore, ExecWaitLifecycle};
 use super::state::*;
 use super::types::ExecOperationResult;
 use super::{
@@ -544,7 +544,7 @@ async fn supervised_cancel_frame_marks_terminal_result_as_host_requested_cancel(
         false,
     );
 
-    send_supervised_exec_cancel_frame(&shared, 7, &diagnostic)
+    send_exec_cancel_frame(&shared, 7, &diagnostic, ExecWaitLifecycle::Supervised)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

- Replace the supervised-only exec cancel frame helper with a lifecycle-aware cancel frame writer shared by one-shot and supervised cancellation.
- Centralize cancel terminal outcome validation so both handle types use the same already-ready, cancelled, and unexpected-terminal-state rules.
- Keep one-shot and supervised cancel-and-wait flows explicit, including supervised stream sender cleanup ordering and drop-time cancel behavior.

Closes #17694

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation::cancel
- cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation::supervised::cancel
- cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation::tests::one_shot_cancel_handle_marks_terminal_result_as_host_requested_cancel
- cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation::tests::supervised_cancel_frame_marks_terminal_result_as_host_requested_cancel
- cargo test --manifest-path crates/Cargo.toml -p vsock-host copy_file_stream_error_releases_tracker_when_cancel_sees_terminal_result
- cargo test --manifest-path crates/Cargo.toml -p vsock-host copy_file_cancellation_cancels_guest_exec_operation_and_removes_temp
- cargo test --manifest-path crates/Cargo.toml -p vsock-host host_cancel
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- git diff --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings
- lefthook pre-commit: cargo-doc, cargo-clippy
- lefthook commit-msg: commitlint