### PR TITLE
feat: add desktop dmg download dialog

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -75,6 +75,27 @@ describe("desktop update routes", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
+  it("redirects the dmg route to the current stable desktop dmg asset", async () => {
+    mockDesktopUpdateManifestForTest(
+      stableManifest("0.12.0", {
+        "0.12.0": darwinArm64Release(
+          "0.12.0",
+          "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-arm64-0.12.0.zip",
+        ),
+      }),
+    );
+
+    const response = await appRequest(
+      "http://api.test/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-arm64-0.12.0.dmg",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
   it("serves the current stable macOS arm64 update from the manifest", async () => {
     const zipUrl =
       "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
@@ -161,5 +182,21 @@ describe("desktop update routes", () => {
     );
 
     expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns not found when no dmg release is available", async () => {
+    const zipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.11.2/Zero-darwin-arm64-0.11.2.zip";
+    mockDesktopUpdateManifestForTest(
+      stableManifest("0.11.2", {
+        "0.11.2": darwinArm64Release("0.11.2", zipUrl),
+      }),
+    );
+
+    const response = await appRequest(
+      "http://api.test/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+    );
+
+    expect(response.status).toBe(404);
   });
 });

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -5,12 +5,14 @@ import { notFound } from "../../lib/error";
 import { pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route";
 import {
+  loadDesktopDmgDownloadUrl,
   loadDesktopReleasePageUrl,
   loadDesktopUpdateFeed,
 } from "../services/desktop-updates.service";
 
 const feedParams$ = pathParamsOf(desktopUpdatesContract.feed);
 const releasePageParams$ = pathParamsOf(desktopUpdatesContract.releasePage);
+const dmgDownloadParams$ = pathParamsOf(desktopUpdatesContract.dmgDownload);
 
 const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
   const url = await loadDesktopReleasePageUrl(get(releasePageParams$), signal);
@@ -43,10 +45,31 @@ const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
+const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
+  const url = await loadDesktopDmgDownloadUrl(get(dmgDownloadParams$), signal);
+  signal.throwIfAborted();
+
+  if (!url) {
+    return notFound("No desktop DMG is available for this feed.");
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: url,
+      "Cache-Control": "no-store",
+    },
+  });
+});
+
 export const desktopUpdateRoutes: readonly RouteEntry[] = [
   {
     route: desktopUpdatesContract.releasePage,
     handler: getDesktopReleasePage$,
+  },
+  {
+    route: desktopUpdatesContract.dmgDownload,
+    handler: getDesktopDmgDownload$,
   },
   {
     route: desktopUpdatesContract.feed,

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -13,6 +13,9 @@ const DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
 const DESKTOP_RELEASE_PAGE_URL_PREFIX =
   "https://github.com/vm0-ai/vm0/releases/tag/desktop-v";
+const DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX =
+  "https://github.com/vm0-ai/vm0/releases/download";
+const MIN_DESKTOP_DMG_VERSION = "0.12.0";
 
 const DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS = 60_000;
 
@@ -127,6 +130,17 @@ function desktopReleasePageUrl(
   )}`;
 }
 
+function desktopDmgDownloadUrl(
+  release: DesktopUpdateManifest["releases"][string],
+  request: DesktopUpdateFeedRequest,
+): string {
+  const tagName = `desktop-v${release.version}`;
+  const assetName = `Zero-${request.platform}-${request.arch}-${release.version}.dmg`;
+  return `${DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX}/${encodeURIComponent(
+    tagName,
+  )}/${encodeURIComponent(assetName)}`;
+}
+
 function selectDesktopRelease(
   manifest: DesktopUpdateManifest,
   request: DesktopUpdateFeedRequest,
@@ -236,4 +250,20 @@ export async function loadDesktopReleasePageUrl(
   const manifest = await loadDesktopUpdateManifest(signal);
   const selected = selectDesktopRelease(manifest, request);
   return selected ? desktopReleasePageUrl(selected.release) : null;
+}
+
+export async function loadDesktopDmgDownloadUrl(
+  request: DesktopUpdateFeedRequest,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const manifest = await loadDesktopUpdateManifest(signal);
+  const selected = selectDesktopRelease(manifest, request);
+  if (
+    !selected ||
+    compareDesktopVersions(selected.release.version, MIN_DESKTOP_DMG_VERSION) <
+      0
+  ) {
+    return null;
+  }
+  return desktopDmgDownloadUrl(selected.release, request);
 }

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -9,11 +9,11 @@ import { resolveApiBaseForNavigation } from "../api-base.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 
-const ZERO_DESKTOP_RELEASE_PATH =
-  "/api/zero/desktop/updates/stable/darwin/arm64/release";
+const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
+  "/api/zero/desktop/updates/stable/darwin/arm64/dmg";
 
 export const ZERO_DESKTOP_DOWNLOAD_URL = new URL(
-  ZERO_DESKTOP_RELEASE_PATH,
+  ZERO_DESKTOP_DMG_DOWNLOAD_PATH,
   resolveApiBaseForNavigation("api"),
 ).toString();
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -135,6 +135,16 @@ export const clearComputerUsePopoverCloseSuppression$ = command(({ set }) => {
   set(internalComputerUsePopoverIgnoreClose$, false);
 });
 
+const internalComputerUseDownloadDialogOpen$ = state(false);
+export const computerUseDownloadDialogOpen$ = computed((get) => {
+  return get(internalComputerUseDownloadDialogOpen$);
+});
+export const setComputerUseDownloadDialogOpen$ = command(
+  ({ set }, open: boolean) => {
+    set(internalComputerUseDownloadDialogOpen$, open);
+  },
+);
+
 // -- Model picker open state ------------------------------------------------
 
 const internalModelPickerOpen$ = state(false);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -720,6 +720,16 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+function linkByText(text: string): HTMLElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!link) {
+    throw new Error(`${text} link not found`);
+  }
+  return link;
+}
+
 function presentationTemplateLabel(
   item: (typeof PRESENTATION_TEMPLATE_ITEMS)[number],
 ): string {
@@ -4270,6 +4280,38 @@ describe("chat lifecycle", () => {
         "false",
       );
     });
+  });
+
+  it("opens the Computer Use download dialog from the chat composer", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "computer-use-download";
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+      return respond(200, { hosts: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
+    });
+
+    await user.click(await screen.findByLabelText("Computer Use"));
+    await user.click(await screen.findByText("Connect my computer"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Connect your computer")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Download Zero Computer Use for macOS, then open it to let Zero use your desktop.",
+      ),
+    ).toBeInTheDocument();
+    expect(linkByText("Download for macOS")).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+      ),
+    );
   });
 
   it("does not auto-select the only online Computer Use host", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -21,6 +21,7 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconDeviceDesktop,
+  IconDownload,
   IconPresentation,
   IconEye,
   IconLoader2,
@@ -39,6 +40,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
@@ -144,6 +146,7 @@ import {
   composerSavingType$,
   setComposerSavingType$,
   clearComputerUsePopoverCloseSuppression$,
+  computerUseDownloadDialogOpen$,
   computerUsePopoverOpen$,
   addDialogSearch$,
   setAddDialogSearch$,
@@ -164,6 +167,7 @@ import {
   templatePickerPreviewSlug$,
   setTemplatePickerPreviewSlug$,
   templatePickerPreviewSlideIndex$,
+  setComputerUseDownloadDialogOpen$,
   setTemplatePickerPreviewSlideIndex$,
   setComputerUsePopoverOpen$,
   templateCardHover$,
@@ -2720,6 +2724,8 @@ function ComputerUsePopoverButton({
   const active = computerUse.selectedHostId !== null;
   const open = useGet(computerUsePopoverOpen$);
   const setOpen = useSet(setComputerUsePopoverOpen$);
+  const downloadDialogOpen = useGet(computerUseDownloadDialogOpen$);
+  const setDownloadDialogOpen = useSet(setComputerUseDownloadDialogOpen$);
   const clearCloseSuppression = useSet(
     clearComputerUsePopoverCloseSuppression$,
   );
@@ -2738,108 +2744,165 @@ function ComputerUsePopoverButton({
   };
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <PopoverTrigger asChild>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  "inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5",
-                  active && "text-primary",
-                )}
-                aria-label="Computer Use"
+    <>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <PopoverTrigger asChild>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5",
+                    active && "text-primary",
+                  )}
+                  aria-label="Computer Use"
+                >
+                  <IconDeviceDesktop size={18} stroke={1.5} />
+                </button>
+              </TooltipTrigger>
+            </PopoverTrigger>
+            <TooltipContent side="top" className="text-xs">
+              Computer
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <PopoverContent
+          side="top"
+          align="start"
+          className="w-72 p-0 rounded-lg"
+        >
+          <div className="py-1">
+            {computerUse.loading ? (
+              <div className="flex flex-col animate-pulse">
+                {Array.from({ length: 2 }, (_, i) => {
+                  return (
+                    <div key={i} className="flex items-center gap-2 px-3 py-2">
+                      <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
+                      <span className="h-3.5 w-24 rounded bg-muted/50 flex-1" />
+                      <span className="h-3 w-6 rounded-full bg-muted/50" />
+                    </div>
+                  );
+                })}
+              </div>
+            ) : computerUse.hosts.length > 0 ? (
+              <div
+                className="flex max-h-72 flex-col overflow-y-auto"
+                role="radiogroup"
+                aria-label="Computer Use host"
               >
-                <IconDeviceDesktop size={18} stroke={1.5} />
-              </button>
-            </TooltipTrigger>
-          </PopoverTrigger>
-          <TooltipContent side="top" className="text-xs">
-            Computer
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <PopoverContent side="top" align="start" className="w-72 p-0 rounded-lg">
-        <div className="py-1">
-          {computerUse.loading ? (
-            <div className="flex flex-col animate-pulse">
-              {Array.from({ length: 2 }, (_, i) => {
-                return (
-                  <div key={i} className="flex items-center gap-2 px-3 py-2">
-                    <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
-                    <span className="h-3.5 w-24 rounded bg-muted/50 flex-1" />
-                    <span className="h-3 w-6 rounded-full bg-muted/50" />
-                  </div>
-                );
-              })}
-            </div>
-          ) : computerUse.hosts.length > 0 ? (
-            <div
-              className="flex max-h-72 flex-col overflow-y-auto"
-              role="radiogroup"
-              aria-label="Computer Use host"
-            >
-              {computerUse.hosts.map((host) => {
-                const checked = computerUse.selectedHostId === host.id;
-                return (
-                  <button
-                    key={host.id}
-                    type="button"
-                    role="radio"
-                    aria-checked={checked}
-                    onClick={() => {
-                      computerUse.onChange(checked ? null : host.id);
-                    }}
-                    className={cn(
-                      "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
-                      checked ? "bg-primary/5" : "hover:bg-muted/50",
-                    )}
-                  >
-                    <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-                      <IconDeviceDesktop size={16} stroke={1.5} />
-                    </span>
-                    <span className="text-sm flex-1 truncate text-foreground">
-                      {host.hostName}
-                    </span>
-                    <span
+                {computerUse.hosts.map((host) => {
+                  const checked = computerUse.selectedHostId === host.id;
+                  return (
+                    <button
+                      key={host.id}
+                      type="button"
+                      role="radio"
+                      aria-checked={checked}
+                      onClick={() => {
+                        computerUse.onChange(checked ? null : host.id);
+                      }}
                       className={cn(
-                        "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors",
-                        checked
-                          ? "border-primary bg-primary text-primary-foreground"
-                          : "border-border text-transparent",
+                        "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
+                        checked ? "bg-primary/5" : "hover:bg-muted/50",
                       )}
-                      aria-hidden="true"
                     >
-                      {checked && <IconCheck size={11} stroke={3} />}
-                    </span>
-                  </button>
-                );
-              })}
+                      <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
+                        <IconDeviceDesktop size={16} stroke={1.5} />
+                      </span>
+                      <span className="text-sm flex-1 truncate text-foreground">
+                        {host.hostName}
+                      </span>
+                      <span
+                        className={cn(
+                          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors",
+                          checked
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-border text-transparent",
+                        )}
+                        aria-hidden="true"
+                      >
+                        {checked && <IconCheck size={11} stroke={3} />}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="px-3 py-2 text-sm text-muted-foreground">
+                No online computers
+              </div>
+            )}
+          </div>
+          <div className="border-t border-border/50 p-1">
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
+              onClick={() => {
+                setOpen(false);
+                setDownloadDialogOpen(true);
+              }}
+            >
+              <IconPlug
+                size={18}
+                stroke={1.5}
+                className="shrink-0 text-muted-foreground"
+              />
+              Connect my computer
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
+      <ComputerUseDownloadDialog
+        open={downloadDialogOpen}
+        onOpenChange={setDownloadDialogOpen}
+        downloadUrl={computerUse.downloadUrl}
+      />
+    </>
+  );
+}
+
+function ComputerUseDownloadDialog({
+  open,
+  onOpenChange,
+  downloadUrl,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  downloadUrl: string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-gray-50 text-muted-foreground">
+              <IconDeviceDesktop size={18} stroke={1.5} />
             </div>
-          ) : (
-            <div className="px-3 py-2 text-sm text-muted-foreground">
-              No online computers
+            <div className="min-w-0 space-y-1 text-left">
+              <DialogTitle>Connect your computer</DialogTitle>
+              <DialogDescription>
+                Download Zero Computer Use for macOS, then open it to let Zero
+                use your desktop.
+              </DialogDescription>
             </div>
-          )}
-        </div>
-        <div className="border-t border-border/50 p-1">
+          </div>
+        </DialogHeader>
+        <Button asChild className="mt-2 w-full">
           <a
-            href={computerUse.downloadUrl}
+            href={downloadUrl}
             target="_blank"
             rel="noreferrer"
-            className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
+            onClick={() => {
+              onOpenChange(false);
+            }}
           >
-            <IconPlug
-              size={18}
-              stroke={1.5}
-              className="shrink-0 text-muted-foreground"
-            />
-            Connect my computer
+            <IconDownload size={16} stroke={1.5} />
+            Download for macOS
           </a>
-        </div>
-      </PopoverContent>
-    </Popover>
+        </Button>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2280,7 +2280,7 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
-  it("matches the zero desktop update release rewrite path exactly", () => {
+  it("matches the zero desktop update release and DMG rewrite paths exactly", () => {
     expect(
       matchesApiBackendRewritePath(
         "/api/zero/desktop/updates/stable/darwin/arm64/release",
@@ -2288,7 +2288,17 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(true);
     expect(
       matchesApiBackendRewritePath(
+        "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+      ),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath(
         "/api/zero/desktop/updates/stable/darwin/arm64/release/extra",
+      ),
+    ).toBe(false);
+    expect(
+      matchesApiBackendRewritePath(
+        "/api/zero/desktop/updates/stable/darwin/arm64/dmg/extra",
       ),
     ).toBe(false);
     expect(

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -21,6 +21,10 @@ const ZERO_DESKTOP_UPDATE_RELEASE_REWRITE_SOURCE =
   "/api/zero/desktop/updates/:channel/:platform/:arch/release";
 const ZERO_DESKTOP_UPDATE_RELEASE_PATH_RE =
   /^\/api\/zero\/desktop\/updates\/[^/]+\/[^/]+\/[^/]+\/release$/;
+const ZERO_DESKTOP_UPDATE_DMG_REWRITE_SOURCE =
+  "/api/zero/desktop/updates/:channel/:platform/:arch/dmg";
+const ZERO_DESKTOP_UPDATE_DMG_PATH_RE =
+  /^\/api\/zero\/desktop\/updates\/[^/]+\/[^/]+\/[^/]+\/dmg$/;
 const ZERO_SECRETS_BY_NAME_REWRITE_SOURCE = "/api/zero/secrets/:name";
 const ZERO_SECRETS_BY_NAME_PATH_RE = /^\/api\/zero\/secrets\/[^/]+$/;
 const ZERO_RUNS_REWRITE_SOURCE = "/api/zero/runs";
@@ -455,6 +459,11 @@ export const API_BACKEND_REWRITES = [
     ZERO_DESKTOP_UPDATE_RELEASE_REWRITE_SOURCE,
     "/api/zero/desktop/updates/:channel/:platform/:arch/release",
     ZERO_DESKTOP_UPDATE_RELEASE_PATH_RE,
+  ],
+  [
+    ZERO_DESKTOP_UPDATE_DMG_REWRITE_SOURCE,
+    "/api/zero/desktop/updates/:channel/:platform/:arch/dmg",
+    ZERO_DESKTOP_UPDATE_DMG_PATH_RE,
   ],
   [
     AGENT_RUN_CANCEL_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -47,6 +47,20 @@ export const desktopUpdatesContract = c.router({
     },
     summary: "Redirect to the current desktop release page",
   },
+  dmgDownload: {
+    method: "GET",
+    path: "/api/zero/desktop/updates/:channel/:platform/:arch/dmg",
+    pathParams: z.object({
+      channel: desktopUpdateChannelSchema,
+      platform: desktopUpdatePlatformSchema,
+      arch: desktopUpdateArchitectureSchema,
+    }),
+    responses: {
+      302: c.noBody(),
+      404: apiErrorSchema,
+    },
+    summary: "Redirect to the current desktop DMG download",
+  },
   feed: {
     method: "GET",
     path: "/api/desktop/updates/:channel/:platform/:arch/RELEASES.json",


### PR DESCRIPTION
## Summary
- add a stable desktop DMG download endpoint that redirects to the current DMG asset
- route the Computer Use download CTA through the DMG endpoint instead of the GitHub release page
- show a minimal download dialog from the composer before downloading macOS desktop app

## Testing
- pnpm exec vitest --run src/signals/routes/__tests__/desktop-updates.test.ts (apps/api)
- pnpm exec vitest --run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "Computer Use" (apps/platform)
- pnpm exec vitest --run src/contracts/__tests__/desktop-updates.test.ts src/rust-bindings/__tests__/routes.test.ts (packages/api-contracts)
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/app check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- git diff --check