### PR TITLE
feat: send Claude prompt over stream-json stdin

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -48,13 +48,14 @@ struct ClaudeArgsConfig<'a> {
     tools: &'a str,
     settings: &'a str,
     include_partial_messages: bool,
-    prompt: &'a str,
 }
 
 fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
         "--verbose".to_string(),
+        "--input-format".to_string(),
+        "stream-json".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
         "--dangerously-skip-permissions".to_string(),
@@ -85,10 +86,6 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
         args.push("--include-partial-messages".to_string());
     }
 
-    // "--" terminates option parsing so Commander.js variadic options
-    // (--disallowed-tools, --tools) do not consume the prompt.
-    args.push("--".to_string());
-    args.push(config.prompt.to_string());
     args
 }
 
@@ -100,7 +97,6 @@ fn build_claude_command(use_mock: bool) -> Vec<String> {
         tools: env::tools(),
         settings: env::settings(),
         include_partial_messages: env::chat_stream_config().is_some(),
-        prompt: env::prompt(),
     });
 
     let bin = if use_mock {
@@ -248,7 +244,6 @@ mod tests {
         disallowed_tools: &str,
         tools: &str,
         settings: &str,
-        prompt: &str,
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
@@ -259,13 +254,11 @@ mod tests {
             tools,
             settings,
             include_partial_messages: false,
-            prompt,
         })
     }
 
     fn build_claude_args_with_partial_messages_for_test(
         include_partial_messages: bool,
-        prompt: &str,
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
@@ -276,7 +269,6 @@ mod tests {
             tools: "",
             settings: "",
             include_partial_messages,
-            prompt,
         })
     }
 
@@ -286,67 +278,60 @@ mod tests {
         build_claude_command(use_mock)
     }
 
-    /// Assert prompt is last and preceded by "--" separator.
-    fn assert_prompt_with_separator(args: &[String], expected_prompt: &str) {
-        let len = args.len();
-        assert!(len >= 2, "args too short: {args:?}");
-        assert_eq!(
-            args[len - 2],
-            "--",
-            "second-to-last arg must be '--': {args:?}"
+    fn assert_claude_prompt_is_not_positional(args: &[String], prompt: &str) {
+        assert!(!args.contains(&"--".to_string()), "unexpected --: {args:?}");
+        assert!(
+            !args.iter().any(|arg| arg == prompt),
+            "prompt must be written to stdin, not argv: {args:?}"
         );
-        assert_eq!(args[len - 1], expected_prompt);
     }
 
     #[test]
     fn build_claude_args_basic() {
-        let args = build_claude_args_for_test("", "", "", "", "", "hello world");
+        let args = build_claude_args_for_test("", "", "", "", "");
         assert!(args.contains(&"--print".to_string()));
+        let input_idx = args
+            .iter()
+            .position(|arg| arg == "--input-format")
+            .expect("input format flag should be present");
+        assert_eq!(args[input_idx + 1], "stream-json");
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
-        assert_prompt_with_separator(&args, "hello world");
+        assert_claude_prompt_is_not_positional(&args, "hello world");
+        assert!(!args.contains(&"--replay-user-messages".to_string()));
         assert!(!args.contains(&"--append-system-prompt".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_append_system_prompt() {
-        let args = build_claude_args_for_test("", "Your name is Aria.", "", "", "", "analyze this");
+        let args = build_claude_args_for_test("", "Your name is Aria.", "", "", "");
         let asp_idx = args
             .iter()
             .position(|a| a == "--append-system-prompt")
             .unwrap();
         assert_eq!(args[asp_idx + 1], "Your name is Aria.");
-        assert_prompt_with_separator(&args, "analyze this");
+        assert_claude_prompt_is_not_positional(&args, "analyze this");
     }
 
     #[test]
     fn build_claude_args_empty_append_system_prompt_omitted() {
-        let args = build_claude_args_for_test("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "");
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
     #[test]
-    fn build_claude_args_include_partial_messages_before_prompt_separator() {
-        let args = build_claude_args_with_partial_messages_for_test(true, "test");
-        let flag_idx = args
-            .iter()
-            .position(|arg| arg == "--include-partial-messages")
-            .expect("flag should be present");
-        let separator_idx = args
-            .iter()
-            .position(|arg| arg == "--")
-            .expect("separator should be present");
-
-        assert!(flag_idx < separator_idx);
-        assert_prompt_with_separator(&args, "test");
+    fn build_claude_args_includes_partial_messages_when_enabled() {
+        let args = build_claude_args_with_partial_messages_for_test(true);
+        assert!(args.contains(&"--include-partial-messages".to_string()));
+        assert_claude_prompt_is_not_positional(&args, "test");
     }
 
     #[test]
     fn build_claude_args_omits_partial_messages_when_disabled() {
-        let args = build_claude_args_with_partial_messages_for_test(false, "test");
+        let args = build_claude_args_with_partial_messages_for_test(false);
 
         assert!(!args.contains(&"--include-partial-messages".to_string()));
-        assert_prompt_with_separator(&args, "test");
+        assert_claude_prompt_is_not_positional(&args, "test");
     }
 
     #[test]
@@ -363,7 +348,6 @@ mod tests {
             tools: "",
             settings: "",
             include_partial_messages: false,
-            prompt: "prompt",
         });
         guest_common::log::clear_system_log_file();
         let system_log = std::fs::read_to_string(system_log_path).unwrap();
@@ -376,10 +360,10 @@ mod tests {
 
     #[test]
     fn build_claude_args_with_resume_and_append() {
-        let args = build_claude_args_for_test("sess-123", "Be helpful.", "", "", "", "prompt");
+        let args = build_claude_args_for_test("sess-123", "Be helpful.", "", "", "");
         assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&"--append-system-prompt".to_string()));
-        assert_prompt_with_separator(&args, "prompt");
+        assert_claude_prompt_is_not_positional(&args, "prompt");
     }
 
     #[test]
@@ -625,56 +609,53 @@ mod tests {
 
     #[test]
     fn build_claude_args_with_disallowed_tools() {
-        let args =
-            build_claude_args_for_test("", "", "CronCreate,CronDelete,CronList", "", "", "hello");
+        let args = build_claude_args_for_test("", "", "CronCreate,CronDelete,CronList", "", "");
         let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
         assert_eq!(args[dt_idx + 1], "CronCreate");
         assert_eq!(args[dt_idx + 2], "CronDelete");
         assert_eq!(args[dt_idx + 3], "CronList");
-        // "--" must separate variadic tools from the prompt
-        assert_prompt_with_separator(&args, "hello");
+        assert_claude_prompt_is_not_positional(&args, "hello");
     }
 
     #[test]
     fn build_claude_args_empty_disallowed_tools_omitted() {
-        let args = build_claude_args_for_test("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "");
         assert!(!args.contains(&"--disallowed-tools".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_tools() {
-        let args = build_claude_args_for_test("", "", "", "Bash,Edit,Read", "", "hello");
+        let args = build_claude_args_for_test("", "", "", "Bash,Edit,Read", "");
         let t_idx = args.iter().position(|a| a == "--tools").unwrap();
         assert_eq!(args[t_idx + 1], "Bash");
         assert_eq!(args[t_idx + 2], "Edit");
         assert_eq!(args[t_idx + 3], "Read");
-        // "--" must separate variadic tools from the prompt
-        assert_prompt_with_separator(&args, "hello");
+        assert_claude_prompt_is_not_positional(&args, "hello");
     }
 
     #[test]
     fn build_claude_args_empty_tools_omitted() {
-        let args = build_claude_args_for_test("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "");
         assert!(!args.contains(&"--tools".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_settings() {
-        let args = build_claude_args_for_test("", "", "", "", r#"{"hooks":{}}"#, "hello");
+        let args = build_claude_args_for_test("", "", "", "", r#"{"hooks":{}}"#);
         let s_idx = args.iter().position(|a| a == "--settings").unwrap();
         assert_eq!(args[s_idx + 1], r#"{"hooks":{}}"#);
-        assert_prompt_with_separator(&args, "hello");
+        assert_claude_prompt_is_not_positional(&args, "hello");
     }
 
     #[test]
     fn build_claude_args_empty_settings_omitted() {
-        let args = build_claude_args_for_test("", "", "", "", "", "test");
+        let args = build_claude_args_for_test("", "", "", "", "");
         assert!(!args.contains(&"--settings".to_string()));
     }
 
     #[test]
     fn build_claude_args_omits_effort() {
-        let args = build_claude_args_for_test("", "", "", "", "", "p");
+        let args = build_claude_args_for_test("", "", "", "", "");
         assert!(
             !args.iter().any(|arg| arg == "--effort"),
             "unexpected effort default: {args:?}"
@@ -689,7 +670,6 @@ mod tests {
             "CronCreate,CronDelete",
             "Bash,Read",
             r#"{"hooks":{}}"#,
-            "do something",
         );
         for expected in [
             "--resume",
@@ -707,12 +687,12 @@ mod tests {
         ] {
             assert!(args.iter().any(|a| a == expected), "missing: {expected}");
         }
-        assert_prompt_with_separator(&args, "do something");
+        assert_claude_prompt_is_not_positional(&args, "do something");
     }
 
     #[test]
     fn build_claude_args_disallowed_tools_whitespace_trimmed() {
-        let args = build_claude_args_for_test("", "", " CronCreate , CronDelete ", "", "", "test");
+        let args = build_claude_args_for_test("", "", " CronCreate , CronDelete ", "", "");
         let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
         assert_eq!(args[dt_idx + 1], "CronCreate");
         assert_eq!(args[dt_idx + 2], "CronDelete");
@@ -720,7 +700,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_tools_whitespace_trimmed() {
-        let args = build_claude_args_for_test("", "", "", " Bash , Read ", "", "test");
+        let args = build_claude_args_for_test("", "", "", " Bash , Read ", "");
         let t_idx = args.iter().position(|a| a == "--tools").unwrap();
         assert_eq!(args[t_idx + 1], "Bash");
         assert_eq!(args[t_idx + 2], "Read");
@@ -729,7 +709,7 @@ mod tests {
     #[test]
     fn build_claude_args_disallowed_tools_empty_items_skipped() {
         // Trailing comma produces an empty token that should be skipped
-        let args = build_claude_args_for_test("", "", "CronCreate,,CronDelete,", "", "", "test");
+        let args = build_claude_args_for_test("", "", "CronCreate,,CronDelete,", "", "");
         let dt_idx = args.iter().position(|a| a == "--disallowed-tools").unwrap();
         // Only non-empty tools should be present
         let tool_args: Vec<&str> = args[dt_idx + 1..]
@@ -742,7 +722,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_tools_empty_items_skipped() {
-        let args = build_claude_args_for_test("", "", "", "Bash,,Read,", "", "test");
+        let args = build_claude_args_for_test("", "", "", "Bash,,Read,", "");
         let t_idx = args.iter().position(|a| a == "--tools").unwrap();
         let tool_args: Vec<&str> = args[t_idx + 1..]
             .iter()
@@ -754,15 +734,15 @@ mod tests {
 
     #[test]
     fn build_claude_args_comma_only_tool_values_omitted() {
-        let args = build_claude_args_for_test("", "", " , ,, ", ",,,", "", "test");
+        let args = build_claude_args_for_test("", "", " , ,, ", ",,,", "");
         assert!(!args.contains(&"--disallowed-tools".to_string()));
         assert!(!args.contains(&"--tools".to_string()));
-        assert_prompt_with_separator(&args, "test");
+        assert_claude_prompt_is_not_positional(&args, "test");
     }
 
     #[test]
-    fn build_claude_args_prompt_always_last() {
-        let args = build_claude_args_for_test("", "", "", "", "", "my prompt");
-        assert_eq!(args.last().unwrap(), "my prompt");
+    fn build_claude_args_prompt_never_appears_in_argv() {
+        let args = build_claude_args_for_test("", "", "", "", "");
+        assert_claude_prompt_is_not_positional(&args, "my prompt");
     }
 }

--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -46,6 +46,10 @@ impl CliFrameworkBehavior {
         matches!(self.framework, env::Framework::ClaudeCode)
     }
 
+    pub(super) fn uses_stream_json_stdin(self) -> bool {
+        matches!(self.framework, env::Framework::ClaudeCode)
+    }
+
     pub(super) fn track_claude_tool_events(
         self,
         event: &serde_json::Value,
@@ -111,6 +115,12 @@ mod tests {
             !CliFrameworkBehavior::new(env::Framework::ClaudeCode)
                 .handles_claude_result_event(&codex_terminal_event)
         );
+    }
+
+    #[test]
+    fn framework_behavior_stream_json_stdin_only_for_claude_code() {
+        assert!(CliFrameworkBehavior::new(env::Framework::ClaudeCode).uses_stream_json_stdin());
+        assert!(!CliFrameworkBehavior::new(env::Framework::Codex).uses_stream_json_stdin());
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -273,20 +273,16 @@ pub async fn execute_cli(
 
     let mut child = cmd.spawn()?;
 
-    if behavior.uses_stream_json_stdin() {
+    let initial_prompt_stdin = if behavior.uses_stream_json_stdin() {
         let Some(stdin) = child.stdin.take() else {
             let _ = child.start_kill();
             heartbeat_handle.abort();
             return Err(AgentError::Execution("no stdin".into()));
         };
-        if let Err(error) =
-            write_claude_initial_prompt_to_stdin(stdin, env::run_id(), env::prompt()).await
-        {
-            let _ = child.start_kill();
-            heartbeat_handle.abort();
-            return Err(error);
-        }
-    }
+        Some(stdin)
+    } else {
+        None
+    };
 
     let stdout = child
         .stdout
@@ -300,6 +296,14 @@ pub async fn execute_cli(
     // Stderr collector
     let mut stderr_handle =
         tokio::spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
+
+    let mut initial_prompt_write_handle = initial_prompt_stdin.map(|stdin| {
+        let run_id = env::run_id().to_string();
+        let prompt = env::prompt().to_string();
+        tokio::spawn(
+            async move { write_claude_initial_prompt_to_stdin(stdin, &run_id, &prompt).await },
+        )
+    });
 
     // Stream stdout JSONL, racing against heartbeat and process exit.
     //
@@ -405,8 +409,61 @@ pub async fn execute_cli(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut failure_diagnostic = None;
-    let event_result: Result<(), AgentError> = loop {
+    let mut event_result: Result<(), AgentError> = loop {
         tokio::select! {
+            prompt_write_result = async {
+                match initial_prompt_write_handle.as_mut() {
+                    Some(handle) => Some(handle.await),
+                    None => std::future::pending().await,
+                }
+            }, if initial_prompt_write_handle.is_some() => {
+                initial_prompt_write_handle = None;
+                match prompt_write_result {
+                    Some(Ok(Ok(()))) => {}
+                    Some(Ok(Err(error))) if termination_error.is_none() => {
+                        log_warn!(
+                            LOG_TAG,
+                            "Failed to write initial prompt to Claude stdin, SIGTERM pgid={}: {error}",
+                            pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+                        );
+                        if let Some(pid) = pgid {
+                            unsafe { libc::kill(-pid, libc::SIGTERM); }
+                        }
+                        termination_error = Some(error);
+                        termination_state = TerminationState::SigkillPending {
+                            reason: TerminationReason::InitialPromptStdin,
+                        };
+                        termination_deadline.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + Duration::from_secs(env::post_result_sigkill_grace_secs()),
+                        );
+                    }
+                    Some(Ok(Err(_))) => {}
+                    Some(Err(error)) if termination_error.is_none() => {
+                        let error = AgentError::Execution(format!(
+                            "initial prompt stdin task failed: {error}"
+                        ));
+                        log_warn!(
+                            LOG_TAG,
+                            "Initial prompt stdin task failed, SIGTERM pgid={}",
+                            pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+                        );
+                        if let Some(pid) = pgid {
+                            unsafe { libc::kill(-pid, libc::SIGTERM); }
+                        }
+                        termination_error = Some(error);
+                        termination_state = TerminationState::SigkillPending {
+                            reason: TerminationReason::InitialPromptStdin,
+                        };
+                        termination_deadline.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + Duration::from_secs(env::post_result_sigkill_grace_secs()),
+                        );
+                    }
+                    Some(Err(_)) => {}
+                    None => {}
+                }
+            }
             line_result = reader.next_line(), if !stdout_eof => {
                 match line_result {
                     Ok(Some(line)) => {
@@ -753,6 +810,32 @@ pub async fn execute_cli(
             }
         }
     };
+
+    if let Some(handle) = initial_prompt_write_handle.take() {
+        if handle.is_finished() {
+            match handle.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) if event_result.is_ok() => {
+                    event_result = Err(error);
+                }
+                Ok(Err(_)) => {}
+                Err(error) if event_result.is_ok() => {
+                    event_result = Err(AgentError::Execution(format!(
+                        "initial prompt stdin task failed: {error}"
+                    )));
+                }
+                Err(_) => {}
+            }
+        } else {
+            handle.abort();
+            let _ = handle.await;
+            if event_result.is_ok() {
+                event_result = Err(AgentError::Execution(
+                    "initial prompt stdin task did not finish before CLI loop exited".into(),
+                ));
+            }
+        }
+    }
 
     let event_result = match termination_error {
         Some(err) => Err(err),

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -51,20 +51,39 @@ use uuid::Uuid;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-fn claude_initial_prompt_frame(run_id: &str, prompt: &str) -> serde_json::Value {
-    let uuid = Uuid::new_v5(
+#[derive(serde::Serialize)]
+struct ClaudeInitialPromptFrame<'a> {
+    #[serde(rename = "type")]
+    event_type: &'static str,
+    uuid: String,
+    parent_tool_use_id: Option<&'static str>,
+    message: ClaudeInitialPromptMessage<'a>,
+}
+
+#[derive(serde::Serialize)]
+struct ClaudeInitialPromptMessage<'a> {
+    role: &'static str,
+    content: &'a str,
+}
+
+fn claude_initial_prompt_uuid(run_id: &str) -> String {
+    Uuid::new_v5(
         &Uuid::NAMESPACE_OID,
         format!("vm0:{run_id}:claude-initial-prompt").as_bytes(),
-    );
-    serde_json::json!({
-        "type": "user",
-        "uuid": uuid.to_string(),
-        "parent_tool_use_id": null,
-        "message": {
-            "role": "user",
-            "content": prompt,
+    )
+    .to_string()
+}
+
+fn claude_initial_prompt_frame<'a>(run_id: &str, prompt: &'a str) -> ClaudeInitialPromptFrame<'a> {
+    ClaudeInitialPromptFrame {
+        event_type: "user",
+        uuid: claude_initial_prompt_uuid(run_id),
+        parent_tool_use_id: None,
+        message: ClaudeInitialPromptMessage {
+            role: "user",
+            content: prompt,
         },
-    })
+    }
 }
 
 async fn write_claude_initial_prompt_to_stdin(
@@ -298,10 +317,10 @@ pub async fn execute_cli(
         tokio::spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
 
     let mut initial_prompt_write_handle = initial_prompt_stdin.map(|stdin| {
-        let run_id = env::run_id().to_string();
-        let prompt = env::prompt().to_string();
+        let run_id = env::run_id();
+        let prompt = env::prompt();
         tokio::spawn(
-            async move { write_claude_initial_prompt_to_stdin(stdin, &run_id, &prompt).await },
+            async move { write_claude_initial_prompt_to_stdin(stdin, run_id, prompt).await },
         )
     });
 
@@ -1007,7 +1026,8 @@ mod tests {
 
     #[test]
     fn claude_initial_prompt_frame_matches_stream_json_user_shape() {
-        let frame = claude_initial_prompt_frame("run_123", "hello stdin");
+        let frame = serde_json::to_value(claude_initial_prompt_frame("run_123", "hello stdin"))
+            .expect("serialize prompt frame");
 
         assert_eq!(
             frame.get("type").and_then(serde_json::Value::as_str),

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -47,8 +47,37 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 use termination::{TerminationReason, TerminationState};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use uuid::Uuid;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+
+fn claude_initial_prompt_frame(run_id: &str, prompt: &str) -> serde_json::Value {
+    let uuid = Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("vm0:{run_id}:claude-initial-prompt").as_bytes(),
+    );
+    serde_json::json!({
+        "type": "user",
+        "uuid": uuid.to_string(),
+        "parent_tool_use_id": null,
+        "message": {
+            "role": "user",
+            "content": prompt,
+        },
+    })
+}
+
+async fn write_claude_initial_prompt_to_stdin(
+    mut stdin: tokio::process::ChildStdin,
+    run_id: &str,
+    prompt: &str,
+) -> Result<(), AgentError> {
+    let mut line = serde_json::to_vec(&claude_initial_prompt_frame(run_id, prompt))?;
+    line.push(b'\n');
+    stdin.write_all(&line).await?;
+    stdin.flush().await?;
+    Ok(())
+}
 
 async fn tick_optional_interval(interval: &mut Option<tokio::time::Interval>) {
     match interval {
@@ -184,7 +213,11 @@ pub async fn execute_cli(
 
     let mut cmd = tokio::process::Command::new(bin);
     cmd.args(args)
-        .stdin(Stdio::null())
+        .stdin(if behavior.uses_stream_json_stdin() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .process_group(0)
@@ -239,6 +272,21 @@ pub async fn execute_cli(
     let mut log_file = tokio::fs::File::from_std(log_file);
 
     let mut child = cmd.spawn()?;
+
+    if behavior.uses_stream_json_stdin() {
+        let Some(stdin) = child.stdin.take() else {
+            let _ = child.start_kill();
+            heartbeat_handle.abort();
+            return Err(AgentError::Execution("no stdin".into()));
+        };
+        if let Err(error) =
+            write_claude_initial_prompt_to_stdin(stdin, env::run_id(), env::prompt()).await
+        {
+            let _ = child.start_kill();
+            heartbeat_handle.abort();
+            return Err(error);
+        }
+    }
 
     let stdout = child
         .stdout
@@ -871,13 +919,45 @@ fn with_carried_failure_reason(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliFailureDiagnostic, chat_stream_delta_from_event, select_failure_diagnostic,
-        set_cli_current_dir, with_carried_failure_reason,
+        CliFailureDiagnostic, chat_stream_delta_from_event, claude_initial_prompt_frame,
+        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
     };
     use crate::events;
     use crate::masker::SecretMasker;
     use agent_diagnostics::{FailureDetailSource, FailureReason};
     use serde_json::json;
+
+    #[test]
+    fn claude_initial_prompt_frame_matches_stream_json_user_shape() {
+        let frame = claude_initial_prompt_frame("run_123", "hello stdin");
+
+        assert_eq!(
+            frame.get("type").and_then(serde_json::Value::as_str),
+            Some("user")
+        );
+        assert_eq!(
+            frame
+                .pointer("/message/role")
+                .and_then(serde_json::Value::as_str),
+            Some("user")
+        );
+        assert_eq!(
+            frame
+                .pointer("/message/content")
+                .and_then(serde_json::Value::as_str),
+            Some("hello stdin")
+        );
+        assert!(
+            frame
+                .get("parent_tool_use_id")
+                .is_some_and(serde_json::Value::is_null)
+        );
+        let uuid = frame
+            .get("uuid")
+            .and_then(serde_json::Value::as_str)
+            .expect("uuid");
+        uuid::Uuid::parse_str(uuid).expect("valid uuid");
+    }
 
     #[tokio::test]
     async fn cli_current_dir_helper_sets_child_working_directory() {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -409,7 +409,7 @@ pub async fn execute_cli(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut failure_diagnostic = None;
-    let mut event_result: Result<(), AgentError> = loop {
+    let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             prompt_write_result = async {
                 match initial_prompt_write_handle.as_mut() {
@@ -418,9 +418,11 @@ pub async fn execute_cli(
                 }
             }, if initial_prompt_write_handle.is_some() => {
                 initial_prompt_write_handle = None;
+                let can_terminate_for_stdin_error =
+                    matches!(termination_state, TerminationState::Idle) && cli_status.is_none();
                 match prompt_write_result {
                     Some(Ok(Ok(()))) => {}
-                    Some(Ok(Err(error))) if termination_error.is_none() => {
+                    Some(Ok(Err(error))) if can_terminate_for_stdin_error => {
                         log_warn!(
                             LOG_TAG,
                             "Failed to write initial prompt to Claude stdin, SIGTERM pgid={}: {error}",
@@ -429,7 +431,6 @@ pub async fn execute_cli(
                         if let Some(pid) = pgid {
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
-                        termination_error = Some(error);
                         termination_state = TerminationState::SigkillPending {
                             reason: TerminationReason::InitialPromptStdin,
                         };
@@ -439,19 +440,15 @@ pub async fn execute_cli(
                         );
                     }
                     Some(Ok(Err(_))) => {}
-                    Some(Err(error)) if termination_error.is_none() => {
-                        let error = AgentError::Execution(format!(
-                            "initial prompt stdin task failed: {error}"
-                        ));
+                    Some(Err(error)) if can_terminate_for_stdin_error => {
                         log_warn!(
                             LOG_TAG,
-                            "Initial prompt stdin task failed, SIGTERM pgid={}",
+                            "Initial prompt stdin task failed, SIGTERM pgid={}: {error}",
                             pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                         );
                         if let Some(pid) = pgid {
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
-                        termination_error = Some(error);
                         termination_state = TerminationState::SigkillPending {
                             reason: TerminationReason::InitialPromptStdin,
                         };
@@ -815,25 +812,23 @@ pub async fn execute_cli(
         if handle.is_finished() {
             match handle.await {
                 Ok(Ok(())) => {}
-                Ok(Err(error)) if event_result.is_ok() => {
-                    event_result = Err(error);
+                Ok(Err(error)) => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Initial prompt stdin write finished after CLI loop with error: {error}"
+                    );
                 }
-                Ok(Err(_)) => {}
-                Err(error) if event_result.is_ok() => {
-                    event_result = Err(AgentError::Execution(format!(
-                        "initial prompt stdin task failed: {error}"
-                    )));
+                Err(error) => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Initial prompt stdin task failed after CLI loop: {error}"
+                    );
                 }
-                Err(_) => {}
             }
         } else {
             handle.abort();
             let _ = handle.await;
-            if event_result.is_ok() {
-                event_result = Err(AgentError::Execution(
-                    "initial prompt stdin task did not finish before CLI loop exited".into(),
-                ));
-            }
+            log_warn!(LOG_TAG, "Aborted unfinished initial prompt stdin task");
         }
     }
 

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -28,6 +28,7 @@ pub(super) enum TerminationState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TerminationReason {
     PostResult,
+    InitialPromptStdin,
     StuckTool,
     HeartbeatError,
     HeartbeatPanic,
@@ -37,6 +38,7 @@ impl TerminationReason {
     pub(super) fn label(self) -> &'static str {
         match self {
             TerminationReason::PostResult => "post-result reap",
+            TerminationReason::InitialPromptStdin => "initial-prompt stdin",
             TerminationReason::StuckTool => "stuck-tool watchdog",
             TerminationReason::HeartbeatError => "heartbeat error",
             TerminationReason::HeartbeatPanic => "heartbeat panic",

--- a/crates/guest-agent/tests/cli_stdin_early_exit.rs
+++ b/crates/guest-agent/tests/cli_stdin_early_exit.rs
@@ -1,0 +1,45 @@
+//! Claude failures before stdin is read should preserve CLI stderr/exit status.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+#[tokio::test]
+async fn claude_exit_before_stdin_read_preserves_stderr() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = tempfile::tempdir()?;
+    let mock = tmp.path().join("early-exit-claude");
+    std::fs::write(
+        &mock,
+        "#!/bin/sh\necho 'claude auth failed before stdin' >&2\nexit 7\n",
+    )?;
+    let mut permissions = std::fs::metadata(&mock)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&mock, permissions)?;
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "prompt written through stdin", 3, 1)?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, 7);
+    assert_eq!(
+        cli_result.stderr_lines,
+        vec!["claude auth failed before stdin"]
+    );
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_stdin_unread.rs
+++ b/crates/guest-agent/tests/cli_stdin_unread.rs
@@ -1,0 +1,49 @@
+//! A large Claude stdin prompt must not block stdout processing.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+#[tokio::test]
+async fn unread_claude_stdin_does_not_block_result_reap() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = tempfile::tempdir()?;
+    let mock = tmp.path().join("unread-stdin-claude");
+    std::fs::write(
+        &mock,
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"ok","num_turns":1}'
+tail -f /dev/null
+"#,
+    )?;
+    let mut permissions = std::fs::metadata(&mock)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&mock, permissions)?;
+
+    let large_prompt = "x".repeat(2 * 1024 * 1024);
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &large_prompt, 1, 1)?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should not block on unread stdin")?;
+
+    assert_eq!(cli_result.exit_code, common::SIGTERM_EXIT);
+    assert_eq!(
+        cli_result.claude_result.and_then(|result| result.num_turns),
+        Some(1)
+    );
+    Ok(())
+}

--- a/crates/guest-mock-claude/src/args.rs
+++ b/crates/guest-mock-claude/src/args.rs
@@ -1,5 +1,6 @@
 /// Parsed command-line arguments.
 pub(crate) struct ParsedArgs {
+    pub(crate) input_format: String,
     pub(crate) output_format: String,
     pub(crate) prompt: String,
 }
@@ -14,6 +15,7 @@ fn skip_flag_value(args: &[String], i: &mut usize) {
 
 /// Parse command-line arguments (matching the real Claude CLI interface).
 pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
+    let mut input_format = "text".to_string();
     let mut output_format = "text".to_string();
     let mut remaining: Vec<String> = Vec::new();
 
@@ -22,6 +24,14 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
         let arg = args.get(i).map(String::as_str).unwrap_or_default();
 
         match arg {
+            "--input-format" => {
+                if let Some(val) = args.get(i + 1) {
+                    input_format = val.clone();
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
             "--output-format" => {
                 if let Some(val) = args.get(i + 1) {
                     output_format = val.clone();
@@ -53,7 +63,8 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
             "--print"
             | "--verbose"
             | "--dangerously-skip-permissions"
-            | "--include-partial-messages" => {
+            | "--include-partial-messages"
+            | "--replay-user-messages" => {
                 i += 1;
             }
             "--" => {
@@ -76,6 +87,7 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
     let prompt = remaining.into_iter().last().unwrap_or_default();
 
     ParsedArgs {
+        input_format,
         output_format,
         prompt,
     }
@@ -89,7 +101,19 @@ mod tests {
     fn parse_args_empty() {
         let args: Vec<String> = vec![];
         let result = parse_args(&args);
+        assert_eq!(result.input_format, "text");
         assert_eq!(result.output_format, "text");
+        assert!(result.prompt.is_empty());
+    }
+
+    #[test]
+    fn parse_args_input_format() {
+        let args: Vec<String> = vec!["--input-format", "stream-json"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let result = parse_args(&args);
+        assert_eq!(result.input_format, "stream-json");
         assert!(result.prompt.is_empty());
     }
 
@@ -108,6 +132,8 @@ mod tests {
         let args: Vec<String> = vec![
             "--output-format",
             "stream-json",
+            "--input-format",
+            "stream-json",
             "--print",
             "--verbose",
             "--dangerously-skip-permissions",
@@ -122,6 +148,7 @@ mod tests {
         .map(String::from)
         .collect();
         let result = parse_args(&args);
+        assert_eq!(result.input_format, "stream-json");
         assert_eq!(result.output_format, "stream-json");
         assert_eq!(result.prompt, "ls -la");
     }
@@ -156,6 +183,23 @@ mod tests {
         let args: Vec<String> = vec!["--output-format".to_string()];
         let result = parse_args(&args);
         assert_eq!(result.output_format, "text");
+    }
+
+    #[test]
+    fn parse_args_input_format_missing_value() {
+        let args: Vec<String> = vec!["--input-format".to_string()];
+        let result = parse_args(&args);
+        assert_eq!(result.input_format, "text");
+    }
+
+    #[test]
+    fn parse_args_replay_user_messages_skipped() {
+        let args: Vec<String> = vec!["--replay-user-messages", "echo hi"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let result = parse_args(&args);
+        assert_eq!(result.prompt, "echo hi");
     }
 
     #[test]

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -4,9 +4,10 @@ use crate::transcript::{
     JsonlTranscript, assistant_text_event, create_session_history, generate_session_id, init_event,
     is_valid_session_history_id, result_event, tool_result_event, tool_use_event,
 };
+use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, ExitCode, Stdio};
 use std::time::Duration;
@@ -14,7 +15,15 @@ use std::time::Duration;
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 
 pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
-    match MockScenario::from_prompt(&parsed.prompt) {
+    let prompt = match prompt_from_input(&parsed) {
+        Ok(prompt) => prompt,
+        Err(message) => {
+            eprintln!("{message}");
+            return ExitCode::from(1);
+        }
+    };
+
+    match MockScenario::from_prompt(&prompt) {
         MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload),
         MockScenario::FailNoNewline(msg) => {
             eprint!("{msg}");
@@ -72,12 +81,52 @@ pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
             let session_id = generate_session_id();
 
             if parsed.output_format == "stream-json" {
-                run_stream_json_mode(&parsed.prompt, &session_id)
+                run_stream_json_mode(&prompt, &session_id)
             } else {
-                run_text_mode(&parsed.prompt)
+                run_text_mode(&prompt)
             }
         }
     }
+}
+
+fn prompt_from_input(parsed: &ParsedArgs) -> Result<String, String> {
+    if parsed.input_format == "stream-json" {
+        read_stream_json_prompt_from_stdin()
+    } else {
+        Ok(parsed.prompt.clone())
+    }
+}
+
+fn read_stream_json_prompt_from_stdin() -> Result<String, String> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|e| format!("read stream-json stdin: {e}"))?;
+
+    let line = input
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .ok_or_else(|| "stream-json stdin did not contain a user message".to_string())?;
+    let event: Value =
+        serde_json::from_str(line).map_err(|e| format!("parse stream-json stdin: {e}"))?;
+
+    if event.get("type").and_then(Value::as_str) != Some("user") {
+        return Err("stream-json stdin first message must have type \"user\"".to_string());
+    }
+    if let Some(role) = event.pointer("/message/role").and_then(Value::as_str)
+        && role != "user"
+    {
+        return Err("stream-json stdin first message role must be \"user\"".to_string());
+    }
+
+    event
+        .pointer("/message/content")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            "stream-json stdin first message must contain string message.content".to_string()
+        })
 }
 
 fn run_echo_jsonl_mode(payload: &str) -> ExitCode {

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::process::{Command, Stdio};
 
 use serde_json::Value;
@@ -53,6 +54,21 @@ fn event_kind(event: &Value) -> String {
         }
         _ => event_type.to_string(),
     }
+}
+
+fn stream_json_user_frame(prompt: &str) -> String {
+    format!(
+        "{}\n",
+        serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": prompt,
+            },
+            "uuid": "mock-test-user-1",
+            "parent_tool_use_id": null,
+        })
+    )
 }
 
 #[test]
@@ -164,6 +180,61 @@ fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std
         events[4].get("is_error").and_then(Value::as_bool),
         Some(false)
     );
+    Ok(())
+}
+
+#[test]
+fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut child = mock_claude()
+        .env("HOME", home.path())
+        .args([
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--",
+            "printf argv-wrong",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().ok_or("missing stdin")?;
+    stdin.write_all(stream_json_user_frame("printf stdin-ok").as_bytes())?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let result = events
+        .iter()
+        .find(|event| event.get("type").and_then(Value::as_str) == Some("result"))
+        .and_then(|event| event.get("result"))
+        .and_then(Value::as_str)
+        .ok_or("missing result")?;
+    assert_eq!(result, "stdin-ok");
+
+    let command = events
+        .iter()
+        .find(|event| {
+            event.get("type").and_then(Value::as_str) == Some("assistant")
+                && event
+                    .pointer("/message/content/0/type")
+                    .and_then(Value::as_str)
+                    == Some("tool_use")
+        })
+        .and_then(|event| event.pointer("/message/content/0/input/command"))
+        .and_then(Value::as_str)
+        .ok_or("missing command")?;
+    assert_eq!(command, "printf stdin-ok");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- launch Claude Code with `--input-format stream-json` and keep `--output-format stream-json`
- stop passing the initial prompt as a positional argv argument for Claude Code
- write the initial prompt as a JSONL `type: "user"` frame to Claude stdin, flush it, and close stdin
- teach guest-mock-claude to parse stream-json stdin input and cover stdin prompt precedence

Closes #17698

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p guest-mock-claude --all-targets -- -D warnings`
- pre-commit lefthook: crates cargo-fmt, cargo-doc, cargo-clippy
