### PR TITLE
fix: restore DeepSeek V4 Pro credit multiplier

### DIFF
--- a/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
@@ -25,11 +25,19 @@ const REMOVED_MODEL_CONTENT_TERMS = [
   "DeepSeek V4 Pro (×0.3)",
   "DeepSeek V4 Pro (×0,3)",
   "DeepSeek V4 Pro（×0.3）",
+  "DeepSeek V4 Pro (×0.06)",
+  "DeepSeek V4 Pro (×0,06)",
+  "DeepSeek V4 Pro（×0.06）",
   "V4 Pro (×0.3)",
   "V4 Pro (×0,3)",
   "V4 Pro（×0.3",
+  "V4 Pro (×0.06)",
+  "V4 Pro (×0,06)",
+  "V4 Pro（×0.06",
   "VM0 Managed at ×0.3",
   "VM0 Managed at ×0,3",
+  "VM0 Managed at ×0.06",
+  "VM0 Managed at ×0,06",
 ] as const;
 
 function readModelContent(locale: (typeof MODEL_CONTENT_LOCALES)[number]) {

--- a/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
@@ -6,6 +6,16 @@ import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-provid
 import { MODELS, isReasoningModel } from "../data";
 
 const MODEL_CONTENT_LOCALES = ["en", "de", "es", "ja"] as const;
+type ModelContent = Record<
+  string,
+  {
+    readonly alternatives?: readonly {
+      readonly reason?: string;
+      readonly slug?: string;
+    }[];
+  }
+>;
+
 const REMOVED_MODEL_CONTENT_TERMS = [
   "Claude Fable 5",
   "Fable 5",
@@ -39,6 +49,16 @@ const REMOVED_MODEL_CONTENT_TERMS = [
   "VM0 Managed at ×0.06",
   "VM0 Managed at ×0,06",
 ] as const;
+const STALE_DEEPSEEK_V4_PRO_ALTERNATIVE_MULTIPLIERS = [
+  "×0.3",
+  "×0,3",
+  "x0.3",
+  "x0,3",
+  "×0.06",
+  "×0,06",
+  "x0.06",
+  "x0,06",
+] as const;
 
 function readModelContent(locale: (typeof MODEL_CONTENT_LOCALES)[number]) {
   const json = readFileSync(
@@ -47,10 +67,30 @@ function readModelContent(locale: (typeof MODEL_CONTENT_LOCALES)[number]) {
   );
   const messages = JSON.parse(json) as {
     readonly models?: {
-      readonly content?: unknown;
+      readonly content?: ModelContent;
     };
   };
-  return JSON.stringify(messages.models?.content ?? {});
+  return messages.models?.content ?? {};
+}
+
+function stringifyModelContent(locale: (typeof MODEL_CONTENT_LOCALES)[number]) {
+  return JSON.stringify(readModelContent(locale));
+}
+
+function readDeepSeekV4ProAlternativeReasons(
+  locale: (typeof MODEL_CONTENT_LOCALES)[number],
+) {
+  return Object.values(readModelContent(locale)).flatMap((model) => {
+    return (
+      model.alternatives
+        ?.filter((alternative) => {
+          return alternative.slug === "deepseek-v4-pro";
+        })
+        .map((alternative) => {
+          return alternative.reason ?? "";
+        }) ?? []
+    );
+  });
 }
 
 describe("models page data", () => {
@@ -116,9 +156,19 @@ describe("models page data", () => {
 
   it("omits removed model names from localized model content", () => {
     for (const locale of MODEL_CONTENT_LOCALES) {
-      const content = readModelContent(locale);
+      const content = stringifyModelContent(locale);
       for (const term of REMOVED_MODEL_CONTENT_TERMS) {
         expect(content).not.toContain(term);
+      }
+    }
+  });
+
+  it("omits stale DeepSeek V4 Pro alternative multipliers from localized model content", () => {
+    for (const locale of MODEL_CONTENT_LOCALES) {
+      for (const reason of readDeepSeekV4ProAlternativeReasons(locale)) {
+        for (const term of STALE_DEEPSEEK_V4_PRO_ALTERNATIVE_MULTIPLIERS) {
+          expect(reason).not.toContain(term);
+        }
       }
     }
   });

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -4611,7 +4611,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Open-Source-Flaggschiff mit starken Code-Benchmarks bei ×0,3 Credits."
+            "reason": "Open-Source-Flaggschiff mit starken Code-Benchmarks bei ×0,1 Credits."
           }
         ],
         "routingNotes": "On VM0, Opus 4.7 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code.",
@@ -5094,7 +5094,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Ähnliche Reasoning-Qualität mit Open-Source-Lizenz zu ×0,3 Credits."
+            "reason": "Ähnliche Reasoning-Qualität mit Open-Source-Lizenz zu ×0,1 Credits."
           }
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Default model on VM0 Managed.",
@@ -5398,7 +5398,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Open-Source-Alternative mit ähnlichen Kosten (×0,3 Credits)."
+            "reason": "Open-Source-Alternative mit ähnlichen Kosten (×0,1 Credits)."
           },
           {
             "slug": "claude-sonnet-4-6",
@@ -5726,7 +5726,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Stärkere Code-Benchmarks mit ähnlichem Preis (×0,3 Credits)."
+            "reason": "Stärkere Code-Benchmarks mit ähnlichem Preis (×0,1 Credits)."
           }
         ],
         "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Default model on the Moonshot provider; also available on VM0 Managed and via OpenRouter.",
@@ -5897,7 +5897,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Stärkere Code-Benchmarks mit ähnlichem Preis (×0,3 Credits)."
+            "reason": "Stärkere Code-Benchmarks mit ähnlichem Preis (×0,1 Credits)."
           }
         ],
         "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Default model on the Moonshot provider; also available on VM0 Managed.",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -4611,7 +4611,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "×0.3クレジットで強力なコードベンチマーク。セルフホストセットアップに最適。"
+            "reason": "×0.1クレジットで強力なコードベンチマーク。セルフホストセットアップに最適。"
           }
         ],
         "routingNotes": "On VM0, Opus 4.7 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code.",
@@ -5102,7 +5102,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "×0.3クレジットでオープンソースライセンスの同等推論品質。"
+            "reason": "×0.1クレジットでオープンソースライセンスの同等推論品質。"
           }
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Default model on VM0 Managed.",
@@ -5406,7 +5406,7 @@
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "類似コスト（×0.3クレジット）のオープンソース代替。"
+            "reason": "類似コスト（×0.1クレジット）のオープンソース代替。"
           },
           {
             "slug": "claude-sonnet-4-6",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -245,14 +245,14 @@ describe("model-first canonical catalog", () => {
         "claude-opus-4-8": 2,
         "claude-opus-4-7": 2,
         "claude-opus-4-6": 2,
-        "deepseek-v4-pro": 0.06,
+        "deepseek-v4-pro": 0.1,
         "kimi-k2.7-code": 0.3,
       }),
     );
     expect(getVm0ModelMultiplier("claude-opus-4-8")).toBe(2);
     expect(getVm0ModelMultiplier("claude-opus-4-7")).toBe(2);
     expect(getVm0ModelMultiplier("claude-opus-4-6")).toBe(2);
-    expect(getVm0ModelMultiplier("deepseek-v4-pro")).toBe(0.06);
+    expect(getVm0ModelMultiplier("deepseek-v4-pro")).toBe(0.1);
     expect(getVm0ModelMultiplier("kimi-k2.7-code")).toBe(0.3);
     expect(getVm0ModelMultiplier("custom/model")).toBeUndefined();
   });

--- a/turbo/packages/api-contracts/src/contracts/model-credit-multipliers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-credit-multipliers.ts
@@ -34,7 +34,7 @@ export const VM0_MODEL_CREDIT_MULTIPLIER = Object.freeze<
   "claude-opus-4-7": 2,
   "claude-opus-4-6": 2,
   "claude-sonnet-4-6": 1,
-  "deepseek-v4-pro": 0.06,
+  "deepseek-v4-pro": 0.1,
   "kimi-k2.7-code": 0.3,
   "MiniMax-M3": 0.2,
   "glm-5.1": 0.4,


### PR DESCRIPTION
## Summary

Restore DeepSeek V4 Pro's VM0 Built-in credit multiplier to `0.1`.

## Context

PR #17562 updated DeepSeek V4 Pro from `0.06` to `0.1` and was merged on 2026-06-13. PR #17568 later touched the same canonical multiplier file while adding Kimi K2.7 Code and brought DeepSeek back to `0.06`, which is why frontend surfaces are showing the old value again.

## Changes

- Update `VM0_MODEL_CREDIT_MULTIPLIER["deepseek-v4-pro"]` from `0.06` to `0.1`.
- Update the API contracts multiplier test.
- Add `/models` content guard terms for stale `0.06` DeepSeek copy.

## Validation

- `pnpm exec prettier --check 'packages/api-contracts/src/contracts/model-credit-multipliers.ts' 'packages/api-contracts/src/contracts/__tests__/model-providers.test.ts' 'apps/web/app/[locale]/models/__tests__/data.test.ts'`
- `pnpm exec vitest run packages/api-contracts/src/contracts/__tests__/model-providers.test.ts`
- `pnpm exec vitest run 'apps/web/app/[locale]/models/__tests__/data.test.ts'`
- `pnpm --filter @vm0/api-contracts lint`
- `pnpm --filter web lint`
- `pnpm --filter @vm0/api-contracts check-types`
- `pnpm --filter web check-types`
