### PR TITLE
refactor: scope chat thread list query

### DIFF
--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -621,9 +621,9 @@ describe("bench side-effect-free GET API routes", () => {
   bench(
     "GET /api/zero/chat-threads",
     async () => {
-      await ensureSeeded();
+      const fixture = await ensureSeeded();
       const response = await chatThreadsClient.list({
-        query: { limit: 50 },
+        query: { agentId: fixture.composeId },
         headers: authHeaders,
       });
       if (response.status !== 200) {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -452,7 +452,7 @@ describe("CHAT-02: completed chat callback", () => {
       "Most recent assistant reply:\nfinal answer",
     );
 
-    const threads = await chat.listThreads(actor);
+    const threads = await chat.listThreads(actor, { agentId });
     const orderedIds = [...threads.pinned, ...threads.threads].map((thread) => {
       return thread.id;
     });
@@ -848,7 +848,7 @@ describe("CHAT-02/HOOK-01: chat callback replay and signature handling", () => {
       `chatThreadMessageCreated:${first.threadId}`,
       null,
     );
-    const ordered = await chat.listThreads(actor);
+    const ordered = await chat.listThreads(actor, { agentId });
     const orderedIds = [...ordered.pinned, ...ordered.threads].map((thread) => {
       return thread.id;
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-files.bdd.test.ts
@@ -133,7 +133,9 @@ describe("CHAT-01 chat thread lifecycle", () => {
     expectApiError(outsiderRead.body);
     expect(outsiderRead.body.error.code).toBe("NOT_FOUND");
 
-    const peerList = await api.listThreads(peer);
+    const peerList = await api.listThreads(peer, {
+      agentId: compose.composeId,
+    });
     expect(
       [...peerList.pinned, ...peerList.threads].some((item) => {
         return item.id === thread.id;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -417,7 +417,7 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
       runId,
     });
 
-    const threads = await chat.listThreads(actor);
+    const threads = await chat.listThreads(actor, { agentId });
     expect(
       [...threads.pinned, ...threads.threads].map((thread) => {
         return thread.id;
@@ -1446,7 +1446,7 @@ describe("CHAT-02: server-side model switches", () => {
       await chat.requestReadThread(actor, removedThreadId, [404]);
     }
 
-    const threads = await chat.listThreads(actor);
+    const threads = await chat.listThreads(actor, { agentId: agent.agentId });
     expect(threads.pinned).toHaveLength(0);
     expect(threads.threads).toHaveLength(0);
   }, 60_000);
@@ -1772,7 +1772,7 @@ describe("CHAT-02: generation templates and attachments", () => {
       expect(rejected.body.error.message).toBe(arm.message);
     }
 
-    const threads = await chat.listThreads(actor);
+    const threads = await chat.listThreads(actor, { agentId: agent.agentId });
     expect(threads.pinned).toHaveLength(0);
     expect(threads.threads).toHaveLength(0);
   }, 60_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -417,9 +417,12 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
       isAuthenticated: false,
     });
-    const unauthenticated = await app.request("/api/zero/chat-threads", {
-      headers: { authorization: "Bearer clerk-session" },
-    });
+    const unauthenticated = await app.request(
+      `/api/zero/chat-threads?agentId=${randomUUID()}`,
+      {
+        headers: { authorization: "Bearer clerk-session" },
+      },
+    );
     expect(unauthenticated.status).toBe(401);
     const unauthenticatedBody = (await unauthenticated.json()) as {
       readonly error: { readonly code: string };

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -644,13 +644,17 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
 describe("CHAT-01 chat thread list pagination and read state", () => {
   it("rejects unauthenticated list requests and yields empty lists for unknown agent scopes", async () => {
-    const unauthenticated = await chat.requestListThreads(null, {}, [401]);
+    const unauthenticated = await chat.requestListThreads(
+      null,
+      { agentId: randomUUID() },
+      [401],
+    );
     expectApiError(unauthenticated.body);
     expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
 
     const orgless = await chat.requestListThreads(
       bdd.user({ orgId: null }),
-      {},
+      { agentId: randomUUID() },
       [401],
     );
     expectApiError(orgless.body);
@@ -806,18 +810,22 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     expect(scoped.pinned).toStrictEqual([]);
     expect(listedThreadIds(scoped)).not.toContain(pinnedThread.id);
 
-    const unified = await chat.listThreads(owner);
+    const otherAgentList = await chat.listThreads(owner, {
+      agentId: otherAgent.agentId,
+    });
     expect(
-      unified.pinned.map((thread) => {
+      otherAgentList.pinned.map((thread) => {
         return thread.id;
       }),
     ).toStrictEqual([pinnedThread.id]);
-    expect(unified.pinned[0]?.pinnedAt).toStrictEqual(expect.any(String));
-    expect(listedThreadIds(unified)).toContain(readStateThreadId);
+    expect(otherAgentList.pinned[0]?.pinnedAt).toStrictEqual(
+      expect.any(String),
+    );
+    expect(listedThreadIds(otherAgentList)).not.toContain(readStateThreadId);
 
-    // Cursor walk over three empty threads scoped to the second agent.
+    // Cursor walk over one full default sidebar page plus one additional row.
     const cursorThreadIds = [pinnedThread.id];
-    for (let index = 0; index < 2; index += 1) {
+    for (let index = 0; index < 25; index += 1) {
       const created = await chat.createThread(owner, {
         agentId: otherAgent.agentId,
         title: `Cursor thread ${index}`,
@@ -828,9 +836,8 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
 
     const firstPage = await chat.listThreads(owner, {
       agentId: otherAgent.agentId,
-      limit: 2,
     });
-    expect(firstPage.threads).toHaveLength(2);
+    expect(firstPage.threads).toHaveLength(25);
     expect(firstPage.hasMore).toBeTruthy();
     expect(firstPage.nextCursor).not.toBeNull();
     if (!firstPage.nextCursor) {
@@ -839,7 +846,6 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
 
     const secondPage = await chat.listThreads(owner, {
       agentId: otherAgent.agentId,
-      limit: 2,
       cursor: firstPage.nextCursor,
     });
     expect(secondPage.threads).toHaveLength(1);
@@ -865,7 +871,7 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     for (const cursor of invalidCursors) {
       const fallback = await chat.requestListThreads(
         owner,
-        { agentId: otherAgent.agentId, limit: 2, cursor },
+        { agentId: otherAgent.agentId, cursor },
         [200],
       );
       if (fallback.status !== 200) {
@@ -884,10 +890,14 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     }
 
     // Peer users and other orgs never see the owner's threads.
-    const peerList = await chat.listThreads(peer);
+    const peerList = await chat.listThreads(peer, {
+      agentId: otherAgent.agentId,
+    });
     expect(listedThreadIds(peerList)).toStrictEqual([]);
     const sameUserOtherOrg = bdd.user({ userId: owner.userId });
-    const otherOrgList = await chat.listThreads(sameUserOtherOrg);
+    const otherOrgList = await chat.listThreads(sameUserOtherOrg, {
+      agentId: otherAgent.agentId,
+    });
     expect(listedThreadIds(otherOrgList)).toStrictEqual([]);
   }, 60_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -430,10 +430,9 @@ export function createChatFilesBddApi(context: TestContext) {
     async listThreads(
       actor: ApiTestUser,
       query: {
-        readonly agentId?: string;
-        readonly limit?: number;
+        readonly agentId: string;
         readonly cursor?: string;
-      } = {},
+      },
     ): Promise<{
       readonly pinned: readonly ChatThreadListItem[];
       readonly threads: readonly ChatThreadListItem[];
@@ -453,8 +452,7 @@ export function createChatFilesBddApi(context: TestContext) {
     async requestListThreads(
       actor: ApiTestUser | null,
       query: {
-        readonly agentId?: string;
-        readonly limit?: number;
+        readonly agentId: string;
         readonly cursor?: string;
       },
       statuses: readonly (200 | 401 | 404)[],

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2588,7 +2588,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
     expect(matchingDuplicateRows[0]?.content).toBe("Hello from BDD events");
 
     // Assistant text on a run without a chat thread changes no thread state.
-    const threadsBefore = await chat.listThreads(actor);
+    const threadsBefore = await chat.listThreads(actor, { agentId });
     const detachedRun = await api.createRun(actor, {
       agentId,
       prompt: "report events without a thread",
@@ -2612,7 +2612,7 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       { authorization: `Bearer ${detachedClaim.sandboxToken}` },
       [200],
     );
-    const threadsAfter = await chat.listThreads(actor);
+    const threadsAfter = await chat.listThreads(actor, { agentId });
     expect(threadsAfter.threads).toHaveLength(threadsBefore.threads.length);
 
     await api.requestCancelRun(actor, detachedRun.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -121,7 +121,6 @@ const listChatThreadsInner$ = computed(async (get) => {
       userId: auth.userId,
       orgId: auth.orgId,
       agentComposeId: query.agentId,
-      limit: query.limit,
       cursor: query.cursor,
     }),
   );

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -860,13 +860,11 @@ function cursorAdvanceFilter(cursor: ChatThreadListCursor) {
 export function zeroChatThreadList(args: {
   readonly userId: string;
   readonly orgId: string;
-  readonly agentComposeId?: string;
-  readonly limit?: number;
+  readonly agentComposeId: string;
   readonly cursor?: string;
 }): Computed<Promise<ChatThreadListPage>> {
   return computed(async (get): Promise<ChatThreadListPage> => {
     const db = get(db$);
-    const limit = args.limit ?? SIDEBAR_CHAT_THREAD_LIMIT;
     const cursor = decodeChatThreadListCursor(args.cursor);
 
     const projection = chatThreadListProjection();
@@ -874,10 +872,8 @@ export function zeroChatThreadList(args: {
     const scopedFilters = [
       eq(chatThreads.userId, args.userId),
       eq(zeroAgents.orgId, args.orgId),
+      eq(chatThreads.agentComposeId, args.agentComposeId),
     ];
-    if (args.agentComposeId) {
-      scopedFilters.push(eq(chatThreads.agentComposeId, args.agentComposeId));
-    }
 
     const nonPinnedFilters = [...scopedFilters, isNull(chatThreads.pinnedAt)];
     if (cursor) {
@@ -907,11 +903,13 @@ export function zeroChatThreadList(args: {
         .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
         .where(and(...nonPinnedFilters))
         .orderBy(desc(chatThreads.lastMessageAt), desc(chatThreads.id))
-        .limit(limit + 1),
+        .limit(SIDEBAR_CHAT_THREAD_LIMIT + 1),
     ]);
 
-    const hasMore = nonPinnedRows.length > limit;
-    const pageRows = hasMore ? nonPinnedRows.slice(0, limit) : nonPinnedRows;
+    const hasMore = nonPinnedRows.length > SIDEBAR_CHAT_THREAD_LIMIT;
+    const pageRows = hasMore
+      ? nonPinnedRows.slice(0, SIDEBAR_CHAT_THREAD_LIMIT)
+      : nonPinnedRows;
     const lastRow = hasMore ? pageRows[pageRows.length - 1] : undefined;
     const nextCursor = lastRow
       ? encodeChatThreadListCursor({

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -368,13 +368,7 @@ export const chatThreadsContract = c.router({
     path: "/api/zero/chat-threads",
     headers: authHeadersSchema,
     query: z.object({
-      agentId: z.string().min(1).optional(),
-      /**
-       * Maximum number of non-pinned threads to return in this page. Pinned
-       * threads are always returned in full and do not count against `limit`.
-       * Defaults to 25 (sidebar default).
-       */
-      limit: z.coerce.number().int().min(1).max(100).optional(),
+      agentId: z.string().min(1),
       /**
        * Opaque cursor returned by a prior page in `nextCursor`. When set,
        * `pinned` is empty (pinned threads are only included on the first
@@ -387,7 +381,7 @@ export const chatThreadsContract = c.router({
         /**
          * All pinned threads in the caller's org, ordered by last activity desc.
          * Always returned in full on the first page (no `cursor`) and empty on
-         * subsequent pages — pagination only applies to the non-pinned segment.
+         * subsequent pages. Non-pinned threads use the fixed sidebar page size.
          */
         pinned: z.array(chatThreadListItemSchema),
         /**
@@ -407,7 +401,7 @@ export const chatThreadsContract = c.router({
       401: apiErrorSchema,
     },
     summary:
-      "List chat threads. When agentId is omitted, returns every thread the caller owns scoped by orgId. An unknown agentId yields an empty list. Pinned threads are returned in full for the caller's org on the first page; non-pinned threads are cursor-paginated.",
+      "List chat threads for an agent. An unknown agentId yields an empty list. Pinned threads are returned in full for the caller's org on the first page; non-pinned threads use cursor pagination with a fixed sidebar page size.",
   },
   drafts: {
     method: "GET",


### PR DESCRIPTION
## Summary
- require `agentId` for `GET /api/zero/chat-threads` and remove the unused all-thread list mode
- remove the unused `limit` query parameter and keep the fixed sidebar page size server-side
- update API tests, helpers, and benchmark calls to use scoped thread list queries

## Verification
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts test`
- `git diff --check`

## Notes
- Targeted API BDD command was attempted: `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t "pages, orders, and flags threads through the chat thread list"`. It failed before reaching the changed list logic because local Postgres was unavailable (`ECONNREFUSED` during agent creation).
