### PR TITLE
feat: honor custom credit expiry metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2409,6 +2409,11 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     });
     expect(campaignGrant?.amount).toBe(100_000);
 
+    const checkoutCreditExpiresAt = new Date(
+      Math.floor((now() + 45 * 86_400_000) / 1000) * 1000,
+    ).toISOString();
+    const invoiceCreditExpiresAt = Math.floor((now() + 90 * 86_400_000) / 1000);
+
     // Legacy custom credit checkouts without an invoice grant immediately.
     await api.postStripeEvent(
       stripeEvent({
@@ -2424,13 +2429,22 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
             purpose: "credit_purchase",
             orgId,
             creditsAmountMode: "amount_total",
+            creditsExpiresAt: checkoutCreditExpiresAt,
           },
         },
       }),
       [200],
     );
-    expect((await billing.readBillingStatus(actor)).credits).toBe(
-      baselineCredits + 200_000,
+    const afterLegacyCredit = await billing.readBillingStatus(actor);
+    expect(afterLegacyCredit.credits).toBe(baselineCredits + 200_000);
+    expect(afterLegacyCredit.creditGrants).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "auto_recharge",
+          amount: 100_000,
+          expiresAt: checkoutCreditExpiresAt,
+        }),
+      ]),
     );
 
     // Invoice-backed custom credit checkouts defer to invoice.paid, which
@@ -2471,14 +2485,23 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
             purpose: "credit_purchase",
             orgId,
             creditsAmountMode: "amount_subtotal",
+            creditsExpiresAt: String(invoiceCreditExpiresAt),
           },
           parent: null,
         },
       }),
       [200],
     );
-    expect((await billing.readBillingStatus(actor)).credits).toBe(
-      baselineCredits + 300_000,
+    const afterInvoiceCredit = await billing.readBillingStatus(actor);
+    expect(afterInvoiceCredit.credits).toBe(baselineCredits + 300_000);
+    expect(afterInvoiceCredit.creditGrants).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "auto_recharge",
+          amount: 100_000,
+          expiresAt: new Date(invoiceCreditExpiresAt * 1000).toISOString(),
+        }),
+      ]),
     );
   });
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -252,6 +252,7 @@ function subscriptionCreditExpiresAt(
 }
 
 const CREDITS_PER_DOLLAR = 1000;
+const CREDIT_PURCHASE_EXPIRES_AT_METADATA_KEY = "creditsExpiresAt";
 
 function creditsFromAmountCents(
   amountCents: number | null | undefined,
@@ -286,6 +287,35 @@ function checkoutSessionInvoiceId(
 
 function autoRechargeNeverExpiresAt(): Date {
   return new Date("2999-12-31T00:00:00Z");
+}
+
+function parseMetadataDate(value: string): Date | null {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  const parsedDate = /^\d+$/.test(trimmedValue)
+    ? new Date(Number(trimmedValue) * 1000)
+    : new Date(trimmedValue);
+
+  return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+}
+
+function creditPurchaseExpiresAt(
+  metadata: Readonly<Record<string, string>>,
+): Date | null {
+  const expiresAtValue = metadata[CREDIT_PURCHASE_EXPIRES_AT_METADATA_KEY];
+  if (!expiresAtValue) {
+    return autoRechargeNeverExpiresAt();
+  }
+
+  const expiresAt = parseMetadataDate(expiresAtValue);
+  if (!expiresAt || expiresAt.getTime() <= now()) {
+    return null;
+  }
+
+  return expiresAt;
 }
 
 function stripePreviewMetadataForEvent(
@@ -551,12 +581,23 @@ async function handleCreditPurchaseInvoicePaid(
     return { handled: true, drainOrgId: null };
   }
 
+  const expiresAt = creditPurchaseExpiresAt(metadata);
+  if (!expiresAt) {
+    L.warn("credit_purchase invoice has invalid credits expiration metadata", {
+      invoiceId: invoice.id,
+      orgId,
+      creditsExpiresAt:
+        metadata[CREDIT_PURCHASE_EXPIRES_AT_METADATA_KEY] ?? null,
+    });
+    return { handled: true, drainOrgId: null };
+  }
+
   await db.transaction(async (tx) => {
     const inserted = await createExpiresRecord(tx, orgId, {
       source: "auto_recharge",
       stripeInvoiceId: invoice.id,
       amount: creditsAmount,
-      expiresAt: autoRechargeNeverExpiresAt(),
+      expiresAt,
     });
 
     if (!inserted) {
@@ -652,12 +693,23 @@ async function handleCreditPurchaseCompleted(
     return null;
   }
 
+  const expiresAt = creditPurchaseExpiresAt(metadata);
+  if (!expiresAt) {
+    L.warn("credit_purchase checkout has invalid credits expiration metadata", {
+      sessionId: session.id,
+      orgId,
+      creditsExpiresAt:
+        metadata[CREDIT_PURCHASE_EXPIRES_AT_METADATA_KEY] ?? null,
+    });
+    return null;
+  }
+
   await db.transaction(async (tx) => {
     const inserted = await createExpiresRecord(tx, orgId, {
       source: "auto_recharge",
       stripeInvoiceId: session.id,
       amount: creditsAmount,
-      expiresAt: autoRechargeNeverExpiresAt(),
+      expiresAt,
     });
 
     if (!inserted) {


### PR DESCRIPTION
## Summary
- add support for custom credit purchase metadata `creditsExpiresAt` when writing credit expiry records
- keep the existing never-expiring default when the metadata is omitted
- cover legacy checkout and invoice-backed custom credit webhook grants

## Testing
- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm knip`
- `pnpm check-types`
- `pnpm turbo run lint`
- `pnpm vitest --run`