### PR TITLE
fix: anchor slash command menu to the slash caret

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -2,7 +2,6 @@
 // inline decorations rather than a transparent-textarea + colored overlay, so the
 // color lives in the same layer as the text and moves/scrolls with it — there is
 // no second layer to keep aligned when the input scrolls (issue #17539).
-import { useRef } from "react";
 import {
   useGet,
   useSet,
@@ -188,24 +187,58 @@ function insertSkillToken(
     .run();
 }
 
-// A virtual Popover anchor that tracks the slash character rather than the whole
-// input box, so the suggestion menu opens at the `/` the user typed instead of a
-// fixed corner. `getBoundingClientRect` reads live, so Floating UI keeps the menu
-// aligned as the input scrolls or the window resizes.
-interface SlashAnchor {
-  getBoundingClientRect: () => DOMRect;
+// Viewport position of the slash that started the active query, used to place the
+// suggestion menu at the `/` the user typed instead of a fixed corner. The slash
+// and caret sit on the same line (the range regex never spans a newline), so their
+// distance in string offsets equals their distance in ProseMirror positions.
+interface SlashCaretPosition {
+  readonly left: number;
+  readonly top: number;
+  readonly height: number;
 }
 
-// Screen rect of the slash that started the active query. The slash and caret sit
-// on the same line (the range regex never spans a newline), so their distance in
-// string offsets equals their distance in ProseMirror positions.
-function slashCaretRect(editor: Editor, slashRange: SlashSkillRange): DOMRect {
+function slashCaretPosition(
+  editor: Editor,
+  slashRange: SlashSkillRange,
+): SlashCaretPosition {
   const slashPos = Math.max(
     editor.state.selection.head - (slashRange.end - slashRange.start),
     0,
   );
   const coords = editor.view.coordsAtPos(slashPos);
-  return new DOMRect(coords.left, coords.top, 0, coords.bottom - coords.top);
+  return {
+    left: coords.left,
+    top: coords.top,
+    height: coords.bottom - coords.top,
+  };
+}
+
+// Zero-size Popover anchor pinned to the active slash so the suggestion menu opens
+// at the `/` the user typed rather than a fixed corner. Falls back to the viewport
+// origin when there is no active slash (the menu is closed then anyway).
+function SlashCaretAnchor({
+  editor,
+  slashRange,
+}: {
+  readonly editor: Editor | null;
+  readonly slashRange: SlashSkillRange | null;
+}) {
+  const caret =
+    editor && slashRange ? slashCaretPosition(editor, slashRange) : null;
+  return (
+    <PopoverAnchor asChild>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed"
+        style={{
+          left: caret?.left ?? 0,
+          top: caret?.top ?? 0,
+          width: 0,
+          height: caret?.height ?? 0,
+        }}
+      />
+    </PopoverAnchor>
+  );
 }
 
 interface SlashMenuKeyContext {
@@ -411,19 +444,6 @@ export function TiptapSkillComposer({
     syncEditorState(editor, skillNames, input);
   }
 
-  // Stable virtual anchor; its rect is refreshed each render to follow the active
-  // slash, so the menu opens at the `/` without re-registering the anchor.
-  const slashAnchorRef = useRef<SlashAnchor>({
-    getBoundingClientRect: () => {
-      return new DOMRect();
-    },
-  });
-  slashAnchorRef.current.getBoundingClientRect = () => {
-    return editor && slashRange
-      ? slashCaretRect(editor, slashRange)
-      : new DOMRect();
-  };
-
   function insertSkill(skill: ComposerSlashSkill): void {
     if (!editor || !slashRange) {
       return;
@@ -454,11 +474,11 @@ export function TiptapSkillComposer({
 
   return (
     // Radix Popover (Floating UI) positions the menu cross-browser; the anchor is
-    // a virtual element tracking the slash the user typed, so the menu opens at
-    // the `/` rather than a fixed corner. `open` is fully controlled by composer
-    // state, so Escape/typing close it via showSlashSkillMenu.
+    // a zero-size element pinned to the slash the user typed (viewport coords from
+    // ProseMirror), so the menu opens at the `/` rather than a fixed corner. `open`
+    // is fully controlled by composer state, so Escape/typing close it.
     <Popover open={showSlashSkillMenu}>
-      <PopoverAnchor virtualRef={slashAnchorRef} />
+      <SlashCaretAnchor editor={editor} slashRange={slashRange} />
       <div className="relative min-h-[96px]">
         {input === "" && (
           <div

--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -2,6 +2,7 @@
 // inline decorations rather than a transparent-textarea + colored overlay, so the
 // color lives in the same layer as the text and moves/scrolls with it — there is
 // no second layer to keep aligned when the input scrolls (issue #17539).
+import { useRef } from "react";
 import {
   useGet,
   useSet,
@@ -185,6 +186,26 @@ function insertSkillToken(
       { type: "text", text: `/${skill.name}${suffix}` },
     ])
     .run();
+}
+
+// A virtual Popover anchor that tracks the slash character rather than the whole
+// input box, so the suggestion menu opens at the `/` the user typed instead of a
+// fixed corner. `getBoundingClientRect` reads live, so Floating UI keeps the menu
+// aligned as the input scrolls or the window resizes.
+interface SlashAnchor {
+  getBoundingClientRect: () => DOMRect;
+}
+
+// Screen rect of the slash that started the active query. The slash and caret sit
+// on the same line (the range regex never spans a newline), so their distance in
+// string offsets equals their distance in ProseMirror positions.
+function slashCaretRect(editor: Editor, slashRange: SlashSkillRange): DOMRect {
+  const slashPos = Math.max(
+    editor.state.selection.head - (slashRange.end - slashRange.start),
+    0,
+  );
+  const coords = editor.view.coordsAtPos(slashPos);
+  return new DOMRect(coords.left, coords.top, 0, coords.bottom - coords.top);
 }
 
 interface SlashMenuKeyContext {
@@ -390,6 +411,19 @@ export function TiptapSkillComposer({
     syncEditorState(editor, skillNames, input);
   }
 
+  // Stable virtual anchor; its rect is refreshed each render to follow the active
+  // slash, so the menu opens at the `/` without re-registering the anchor.
+  const slashAnchorRef = useRef<SlashAnchor>({
+    getBoundingClientRect: () => {
+      return new DOMRect();
+    },
+  });
+  slashAnchorRef.current.getBoundingClientRect = () => {
+    return editor && slashRange
+      ? slashCaretRect(editor, slashRange)
+      : new DOMRect();
+  };
+
   function insertSkill(skill: ComposerSlashSkill): void {
     if (!editor || !slashRange) {
       return;
@@ -419,25 +453,25 @@ export function TiptapSkillComposer({
   }
 
   return (
-    // Radix Popover (Floating UI) positions the menu cross-browser; the anchor
-    // is the input region so the menu sits above it. `open` is fully controlled
-    // by composer state, so Escape/typing close it via showSlashSkillMenu.
+    // Radix Popover (Floating UI) positions the menu cross-browser; the anchor is
+    // a virtual element tracking the slash the user typed, so the menu opens at
+    // the `/` rather than a fixed corner. `open` is fully controlled by composer
+    // state, so Escape/typing close it via showSlashSkillMenu.
     <Popover open={showSlashSkillMenu}>
-      <PopoverAnchor asChild>
-        <div className="relative min-h-[96px]">
-          {input === "" && (
-            <div
-              className="pointer-events-none absolute left-0 top-0 px-4 pt-4 text-[0.9375rem] leading-6 text-muted-foreground/40"
-              aria-hidden="true"
-            >
-              {sending
-                ? "Type your next message…"
-                : "Ask me to automate workflows, manage tasks..."}
-            </div>
-          )}
-          <EditorContent editor={editor} />
-        </div>
-      </PopoverAnchor>
+      <PopoverAnchor virtualRef={slashAnchorRef} />
+      <div className="relative min-h-[96px]">
+        {input === "" && (
+          <div
+            className="pointer-events-none absolute left-0 top-0 px-4 pt-4 text-[0.9375rem] leading-6 text-muted-foreground/40"
+            aria-hidden="true"
+          >
+            {sending
+              ? "Type your next message…"
+              : "Ask me to automate workflows, manage tasks..."}
+          </div>
+        )}
+        <EditorContent editor={editor} />
+      </div>
       {showSlashSkillMenu && (
         <SlashSkillMenu
           skills={suggestions}


### PR DESCRIPTION
## Problem

The `/` skill suggestion menu in the chat composer was anchored to the **full-width editor box**, so it always opened at the input's top-left corner — no matter where in the line the user typed `/`. Typing `/` at the right end of a line still popped the menu on the far left.

## Fix

Anchor the Radix Popover to a **virtual element positioned at the slash character** instead of the whole input region:

- New `slashCaretRect()` computes the slash's screen rect via ProseMirror's `editor.view.coordsAtPos()`. The slash and caret are always on the same line (the active-range regex never spans a newline), so the slash's ProseMirror position is `head - (range.end - range.start)`.
- A stable `virtualRef` (`SlashAnchor`) whose `getBoundingClientRect` reads live, so Floating UI keeps the menu aligned as the input scrolls or the window resizes.
- `PopoverAnchor` now uses `virtualRef` and no longer wraps the editor; `side="top" align="start"` left-aligns the menu to the `/`.

## Verification

- `pnpm -F @vm0/app exec tsc --noEmit` — clean
- `eslint` on the changed file — clean
- `chat-composer-models-and-templates.test.tsx` — 22/22 pass

Per the repo's PR-verification preference I did not start a local dev server; the caret-following behavior relies on `coordsAtPos`, which jsdom can't exercise (it returns zero rects, so tests stay green), so this is best confirmed on the PR app preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)