### PR TITLE
feat: show illustration variations inline in a single template popup

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -206,6 +206,24 @@ export const setTemplatePickerPreviewSlideIndex$ = command(
   },
 );
 
+// Inline illustration cards show a hero image plus a variant thumbnail strip.
+// Several cards are visible at once, so the active variant index is tracked per
+// illustration style slug rather than as a single shared value.
+const internalIllustrationVariantIndex$ = state<
+  Readonly<Record<string, number>>
+>({});
+export const illustrationVariantIndex$ = computed((get) => {
+  return get(internalIllustrationVariantIndex$);
+});
+export const setIllustrationVariantIndex$ = command(
+  ({ get, set }, slug: string, index: number) => {
+    set(internalIllustrationVariantIndex$, {
+      ...get(internalIllustrationVariantIndex$),
+      [slug]: index,
+    });
+  },
+);
+
 // Hover scrubbing on template cards. Only one card is hovered at a time, so a
 // single signal tracks the active card's slug plus the scrubbed slide index;
 // each card resolves its own index by matching the stored slug.

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1376,34 +1376,36 @@ describe("chat composer templates", () => {
     });
     click(tabByText("Illustration"));
 
-    const heroTitle = `${illustrationTemplate.title} illustration preview`;
-    const heroSrc = (index: number) =>
-      r2ImageTransformUrl(illustrationTemplate.previewImages[index]!, {
+    const heroAlt = `${illustrationTemplate.title} illustration preview`;
+    const heroSrc = (index: number) => {
+      return r2ImageTransformUrl(illustrationTemplate.previewImages[index]!, {
         width: 768,
         height: 768,
+        quality: 72,
       });
+    };
 
     await waitFor(() => {
       expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
-      expect(screen.getByTitle(heroTitle)).toHaveAttribute("src", heroSrc(0));
-      expect(screen.getAllByTitle(/ illustration preview$/u)).toHaveLength(
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
+      expect(screen.getAllByAltText(/ illustration preview$/u)).toHaveLength(
         ILLUSTRATION_TEMPLATE_ITEMS.length,
       );
     });
 
     // Variant thumbnails switch the hero inline within the card; there is no
     // longer a second preview dialog.
-    const card = screen.getByTitle(heroTitle).closest<HTMLElement>("div.group");
+    const card = screen.getByAltText(heroAlt).closest<HTMLElement>("div.group");
     if (!card) {
       throw new Error("Illustration card not found");
     }
     click(within(card).getByLabelText("Show variant 2"));
     await waitFor(() => {
-      expect(screen.getByTitle(heroTitle)).toHaveAttribute("src", heroSrc(1));
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
     });
     click(within(card).getByLabelText("Show variant 1"));
     await waitFor(() => {
-      expect(screen.getByTitle(heroTitle)).toHaveAttribute("src", heroSrc(0));
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
     });
 
     await fill(screen.getByLabelText("Search templates"), "no matching style");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1376,43 +1376,34 @@ describe("chat composer templates", () => {
     });
     click(tabByText("Illustration"));
 
+    const heroTitle = `${illustrationTemplate.title} illustration preview`;
+    const heroSrc = (index: number) =>
+      r2ImageTransformUrl(illustrationTemplate.previewImages[index]!, {
+        width: 768,
+        height: 768,
+      });
+
     await waitFor(() => {
       expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
-      expect(
-        screen.getByTitle(`${illustrationTemplate.title} illustration preview`),
-      ).toHaveAttribute(
-        "src",
-        r2ImageTransformUrl(illustrationTemplate.previewImage, {
-          width: 640,
-          height: 360,
-        }),
-      );
+      expect(screen.getByTitle(heroTitle)).toHaveAttribute("src", heroSrc(0));
       expect(screen.getAllByTitle(/ illustration preview$/u)).toHaveLength(
         ILLUSTRATION_TEMPLATE_ITEMS.length,
       );
     });
 
-    click(screen.getByLabelText(`View template ${illustrationTemplate.title}`));
+    // Variant thumbnails switch the hero inline within the card; there is no
+    // longer a second preview dialog.
+    const card = screen.getByTitle(heroTitle).closest<HTMLElement>("div.group");
+    if (!card) {
+      throw new Error("Illustration card not found");
+    }
+    click(within(card).getByLabelText("Show variant 2"));
     await waitFor(() => {
-      expect(
-        screen.getByTitle(`${illustrationTemplate.title} preview variant 1`),
-      ).toBeInTheDocument();
+      expect(screen.getByTitle(heroTitle)).toHaveAttribute("src", heroSrc(1));
     });
-    click(screen.getByLabelText("Show variant 2"));
+    click(within(card).getByLabelText("Show variant 1"));
     await waitFor(() => {
-      expect(
-        screen.getByTitle(`${illustrationTemplate.title} preview variant 2`),
-      ).toBeInTheDocument();
-    });
-    click(screen.getByLabelText("Show variant 1"));
-    await waitFor(() => {
-      expect(
-        screen.getByTitle(`${illustrationTemplate.title} preview variant 1`),
-      ).toBeInTheDocument();
-    });
-    click(buttonByText("Templates"));
-    await waitFor(() => {
-      expect(screen.getByText(illustrationTemplate.title)).toBeInTheDocument();
+      expect(screen.getByTitle(heroTitle)).toHaveAttribute("src", heroSrc(0));
     });
 
     await fill(screen.getByLabelText("Search templates"), "no matching style");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -165,6 +165,8 @@ import {
   setTemplatePickerPreviewSlug$,
   templatePickerPreviewSlideIndex$,
   setTemplatePickerPreviewSlideIndex$,
+  illustrationVariantIndex$,
+  setIllustrationVariantIndex$,
   setComputerUsePopoverOpen$,
   templateCardHover$,
   setTemplateCardHover$,
@@ -333,7 +335,7 @@ type ComposerComputerUse = NonNullable<ZeroChatComposerProps["computerUse"]>;
 const TEMPLATE_CARD_PREVIEW_SIZE = { width: 640, height: 360 } as const;
 const TEMPLATE_DETAIL_PREVIEW_SIZE = { width: 1600, height: 900 } as const;
 const TEMPLATE_STRIP_THUMB_SIZE = { width: 200, height: 112 } as const;
-const ILLUSTRATION_DETAIL_PREVIEW_SIZE = { width: 1400, height: 1400 } as const;
+const ILLUSTRATION_CARD_PREVIEW_SIZE = { width: 768, height: 768 } as const;
 const SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE = { width: 40, height: 40 } as const;
 
 // ---------------------------------------------------------------------------
@@ -721,12 +723,6 @@ function formatPresentationTemplateKind(templateId: string): string {
   return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
-function formatIllustrationTemplateKind(
-  item: IllustrationTemplateItem,
-): string {
-  return `${item.variationCount} variations`;
-}
-
 function presentationTemplateMatchesSearch(
   item: PresentationTemplateItem,
   query: string,
@@ -752,11 +748,7 @@ function illustrationTemplateMatchesSearch(
   if (!normalizedQuery) {
     return true;
   }
-  const searchable = [
-    item.title,
-    item.illustrationStyleId,
-    formatIllustrationTemplateKind(item),
-  ].join(" ");
+  const searchable = [item.title, item.illustrationStyleId].join(" ");
   return searchable.toLowerCase().includes(normalizedQuery);
 }
 
@@ -1451,32 +1443,33 @@ function PptCard({
   );
 }
 
-function IllustrationTemplatePreview({
+function IllustrationTemplateHero({
   item,
-  onPreview,
+  source,
 }: {
   item: IllustrationTemplateItem;
-  onPreview: (item: IllustrationTemplateItem) => void;
+  source: string;
 }) {
-  const previewImage = r2ImageTransformUrl(
-    item.previewImage,
-    TEMPLATE_CARD_PREVIEW_SIZE,
-  );
+  const heroImage = r2ImageTransformUrl(source, ILLUSTRATION_CARD_PREVIEW_SIZE);
 
   return (
-    <div className="relative h-44 shrink-0 overflow-hidden bg-muted">
+    <div
+      className="relative w-full overflow-hidden bg-muted"
+      style={{ aspectRatio: `${String(item.width)} / ${String(item.height)}` }}
+    >
       <img
-        src={previewImage}
+        key={source}
+        src={heroImage}
         alt=""
         title={`${item.title} illustration preview`}
-        className="absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100"
+        className="absolute inset-0 h-full w-full object-contain opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100"
         loading="lazy"
         decoding="async"
         fetchPriority="low"
         onLoad={(event) => {
           const image = event.currentTarget;
           detach(
-            markIllustrationPreviewImageLoaded(previewImage, image),
+            markIllustrationPreviewImageLoaded(heroImage, image),
             Reason.DomCallback,
           );
         }}
@@ -1493,17 +1486,6 @@ function IllustrationTemplatePreview({
       >
         <IconTemplate size={28} stroke={1.5} />
       </div>
-      <button
-        type="button"
-        aria-label={`View template ${item.title}`}
-        className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md bg-[rgba(0,0,0,.3)] text-white opacity-0 shadow-sm transition-colors hover:bg-[rgba(0,0,0,.45)] hover:text-white group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        onClick={(event) => {
-          event.stopPropagation();
-          onPreview(item);
-        }}
-      >
-        <IconEye size={16} stroke={1.8} />
-      </button>
     </div>
   );
 }
@@ -1548,173 +1530,85 @@ async function markIllustrationPreviewImageLoaded(
 function IllustrationTemplateCard({
   item,
   selected,
+  activeIndex,
   onSelect,
-  onPreview,
+  onVariantChange,
 }: {
   item: IllustrationTemplateItem;
   selected: boolean;
+  activeIndex: number;
   onSelect: (item: IllustrationTemplateItem) => void;
-  onPreview: (item: IllustrationTemplateItem) => void;
+  onVariantChange: (slug: string, index: number) => void;
 }) {
+  const images = item.previewImages;
+  const safeIndex = Math.max(0, Math.min(activeIndex, images.length - 1));
+  const heroSource = images[safeIndex] ?? item.previewImage;
+
   return (
     <div
       className={cn(
-        "group flex h-64 flex-col overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
-        selected ? "border-primary ring-1 ring-primary" : "border-border",
+        "group mb-4 break-inside-avoid overflow-hidden rounded-xl border bg-card shadow-sm transition-colors",
+        selected
+          ? "border-primary ring-1 ring-primary"
+          : "border-border hover:border-muted-foreground/30",
       )}
     >
-      <IllustrationTemplatePreview item={item} onPreview={onPreview} />
-      <div className="flex flex-1 items-start justify-between gap-3 px-3.5 py-3">
-        <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-foreground">
-            {item.title}
-          </p>
-          <p className="mt-1 truncate text-xs text-muted-foreground">
-            {formatIllustrationTemplateKind(item)}
-          </p>
+      <IllustrationTemplateHero item={item} source={heroSource} />
+      {images.length > 1 && (
+        <div className="flex items-center gap-2 overflow-x-auto px-3 pt-3">
+          {images.map((image, index) => {
+            const active = index === safeIndex;
+            const thumbnailImage = r2ImageTransformUrl(
+              image,
+              TEMPLATE_STRIP_THUMB_SIZE,
+            );
+            return (
+              <button
+                key={image}
+                type="button"
+                aria-label={`Show variant ${index + 1}`}
+                aria-pressed={active}
+                className={cn(
+                  "relative h-12 w-12 shrink-0 overflow-hidden rounded-md border-2 bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  active ? "border-primary" : "border-border",
+                )}
+                onClick={() => {
+                  onVariantChange(item.slug, index);
+                }}
+              >
+                <img
+                  src={thumbnailImage}
+                  alt=""
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              </button>
+            );
+          })}
         </div>
-        <div className="flex shrink-0 items-center">
-          <button
-            type="button"
-            aria-label={`Select template ${item.title}`}
-            aria-pressed={selected}
-            onClick={() => {
-              onSelect(item);
-            }}
-            className={cn(
-              "h-8 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              selected
-                ? "border-primary/40 bg-primary/10 text-primary"
-                : "border-border bg-background text-foreground hover:bg-muted",
-            )}
-          >
-            Use
-          </button>
-        </div>
+      )}
+      <div className="flex items-center justify-between gap-3 px-3.5 py-3">
+        <p className="min-w-0 truncate text-sm font-semibold text-foreground">
+          {item.title}
+        </p>
+        <button
+          type="button"
+          aria-label={`Select template ${item.title}`}
+          aria-pressed={selected}
+          onClick={() => {
+            onSelect(item);
+          }}
+          className={cn(
+            "h-8 shrink-0 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            selected
+              ? "border-primary/40 bg-primary/10 text-primary"
+              : "border-border bg-background text-foreground hover:bg-muted",
+          )}
+        >
+          Use
+        </button>
       </div>
     </div>
-  );
-}
-
-function IllustrationPreviewPage({
-  item,
-  selectedImageIndex,
-  onImageChange,
-  onBack,
-  onSelect,
-}: {
-  item: IllustrationTemplateItem;
-  selectedImageIndex: number;
-  onImageChange: (index: number) => void;
-  onBack: () => void;
-  onSelect: (item: IllustrationTemplateItem) => void;
-}) {
-  const images = item.previewImages;
-  const safeImageIndex = Math.max(
-    0,
-    Math.min(selectedImageIndex, images.length - 1),
-  );
-  const selectedImage = images[safeImageIndex];
-  const selectedPreviewImage = selectedImage
-    ? r2ImageTransformUrl(selectedImage, ILLUSTRATION_DETAIL_PREVIEW_SIZE)
-    : selectedImage;
-
-  return (
-    <>
-      <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
-        <DialogTitle className="flex min-w-0 items-center gap-2 text-base">
-          <button
-            type="button"
-            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={onBack}
-          >
-            Templates
-          </button>
-          <span className="shrink-0 text-muted-foreground">/</span>
-          <span className="shrink-0 text-muted-foreground">Illustration</span>
-          <span className="shrink-0 text-muted-foreground">/</span>
-          <span className="min-w-0 truncate">{item.title}</span>
-        </DialogTitle>
-      </DialogHeader>
-      <div className="grid h-[min(72vh,680px)] min-h-0 gap-4 overflow-hidden bg-muted/20 p-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-        <div className="flex min-h-0 flex-col rounded-lg border border-border bg-background p-3">
-          <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-muted">
-            <img
-              key={selectedImage}
-              src={selectedPreviewImage}
-              title={`${item.title} preview variant ${safeImageIndex + 1}`}
-              alt=""
-              className="h-full w-full object-contain"
-              loading="lazy"
-            />
-          </div>
-          <div className="mt-3 flex shrink-0 max-w-full items-center gap-2 overflow-x-auto pb-1">
-            {images.map((image, index) => {
-              const selected = index === safeImageIndex;
-              const thumbnailImage = r2ImageTransformUrl(
-                image,
-                TEMPLATE_STRIP_THUMB_SIZE,
-              );
-              return (
-                <button
-                  key={image}
-                  type="button"
-                  aria-label={`Show variant ${index + 1}`}
-                  aria-pressed={selected}
-                  className={cn(
-                    "relative h-14 w-20 shrink-0 overflow-hidden rounded-md border-2 bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    selected ? "border-orange-500" : "border-border",
-                  )}
-                  onClick={() => {
-                    onImageChange(index);
-                  }}
-                >
-                  <img
-                    src={thumbnailImage}
-                    alt=""
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
-                </button>
-              );
-            })}
-          </div>
-        </div>
-        <div className="flex flex-col gap-4">
-          <div className="rounded-lg border border-border bg-background p-4">
-            <h3 className="text-lg font-semibold text-foreground">
-              {item.title}
-            </h3>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {formatIllustrationTemplateKind(item)}
-            </p>
-          </div>
-          <div className="rounded-lg border border-border bg-background p-4">
-            <h3 className="text-sm font-semibold text-muted-foreground">
-              Variants
-            </h3>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <span className="rounded-full bg-muted px-3 py-1 text-sm text-muted-foreground">
-                {images.length} reference images
-              </span>
-              <span className="rounded-full bg-muted px-3 py-1 text-sm text-muted-foreground">
-                Illustration style
-              </span>
-            </div>
-          </div>
-          <button
-            type="button"
-            aria-label={`Select template ${item.title}`}
-            className="h-10 rounded-md bg-foreground px-4 text-sm font-semibold text-background transition-colors hover:bg-foreground/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => {
-              onSelect(item);
-            }}
-          >
-            Use this template
-          </button>
-        </div>
-      </div>
-    </>
   );
 }
 
@@ -1836,24 +1730,30 @@ function TemplatePickerTabs({
 function IllustrationTemplateGrid({
   items,
   value,
+  variantIndexBySlug,
   onSelect,
-  onPreview,
+  onVariantChange,
 }: {
   items: IllustrationTemplateItem[];
   value: GenerationTemplateRequest | undefined;
+  variantIndexBySlug: Readonly<Record<string, number>>;
   onSelect: (item: IllustrationTemplateItem) => void;
-  onPreview: (item: IllustrationTemplateItem) => void;
+  onVariantChange: (slug: string, index: number) => void;
 }) {
+  // CSS multi-column masonry mirrors www.vm0.ai/illustration: each tile renders
+  // the full illustration at its native aspect ratio (no cropping, letterbox,
+  // or fixed height), and the column count adapts to the dialog width.
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="columns-[244px] gap-4">
       {items.map((item) => {
         return (
           <IllustrationTemplateCard
             key={item.illustrationStyleId}
             item={item}
             selected={isSelectedIllustrationTemplate(item, value)}
+            activeIndex={variantIndexBySlug[item.slug] ?? 0}
             onSelect={onSelect}
-            onPreview={onPreview}
+            onVariantChange={onVariantChange}
           />
         );
       })}
@@ -1914,15 +1814,13 @@ function TemplatePickerDialog({
   const setPreviewSlug = useSet(setTemplatePickerPreviewSlug$);
   const selectedSlideIndex = useGet(templatePickerPreviewSlideIndex$);
   const setSelectedSlideIndex = useSet(setTemplatePickerPreviewSlideIndex$);
+  const illustrationVariantIndex = useGet(illustrationVariantIndex$);
+  const setIllustrationVariantIndex = useSet(setIllustrationVariantIndex$);
   const previewItem =
     PRESENTATION_TEMPLATE_ITEMS.find((item) => {
       return item.slug === previewSlug;
     }) ?? null;
-  const illustrationPreviewItem =
-    ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
-      return item.slug === previewSlug;
-    }) ?? null;
-  const isPreviewing = Boolean(previewItem ?? illustrationPreviewItem);
+  const isPreviewing = Boolean(previewItem);
   const dialogContentClassName = cn(
     "p-0 gap-0 overflow-hidden",
     // The auto-rendered close button defaults to top-4, which is tuned for the
@@ -1970,11 +1868,6 @@ function TemplatePickerDialog({
     setPreviewSlug(item.slug);
   };
 
-  const handleIllustrationPreview = (item: IllustrationTemplateItem) => {
-    setSelectedSlideIndex(0);
-    setPreviewSlug(item.slug);
-  };
-
   const selectedCategory = resolveTemplatePickerCategory({
     category,
     hasPptTab,
@@ -2008,16 +1901,6 @@ function TemplatePickerDialog({
               setPreviewSlug(null);
             }}
             onSelect={handleSelectPresentation}
-          />
-        ) : illustrationPreviewItem ? (
-          <IllustrationPreviewPage
-            item={illustrationPreviewItem}
-            selectedImageIndex={selectedSlideIndex}
-            onImageChange={setSelectedSlideIndex}
-            onBack={() => {
-              setPreviewSlug(null);
-            }}
-            onSelect={handleSelectIllustration}
           />
         ) : (
           <>
@@ -2076,8 +1959,9 @@ function TemplatePickerDialog({
                   <IllustrationTemplateGrid
                     items={filteredIllustrationItems}
                     value={value}
+                    variantIndexBySlug={illustrationVariantIndex}
                     onSelect={handleSelectIllustration}
-                    onPreview={handleIllustrationPreview}
+                    onVariantChange={setIllustrationVariantIndex}
                   />
                 ) : (
                   <TemplateEmptyPanel

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -335,7 +335,16 @@ type ComposerComputerUse = NonNullable<ZeroChatComposerProps["computerUse"]>;
 const TEMPLATE_CARD_PREVIEW_SIZE = { width: 640, height: 360 } as const;
 const TEMPLATE_DETAIL_PREVIEW_SIZE = { width: 1600, height: 900 } as const;
 const TEMPLATE_STRIP_THUMB_SIZE = { width: 200, height: 112 } as const;
-const ILLUSTRATION_CARD_PREVIEW_SIZE = { width: 768, height: 768 } as const;
+const ILLUSTRATION_CARD_PREVIEW_SIZE = {
+  width: 768,
+  height: 768,
+  quality: 72,
+} as const;
+const ILLUSTRATION_VARIANT_THUMB_SIZE = {
+  width: 96,
+  height: 96,
+  quality: 65,
+} as const;
 const SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE = { width: 40, height: 40 } as const;
 
 // ---------------------------------------------------------------------------
@@ -1450,7 +1459,7 @@ function IllustrationTemplateHero({
   item: IllustrationTemplateItem;
   source: string;
 }) {
-  const heroImage = r2ImageTransformUrl(source, ILLUSTRATION_CARD_PREVIEW_SIZE);
+  const heroImage = illustrationHeroImageUrl(source);
 
   return (
     <div
@@ -1460,9 +1469,8 @@ function IllustrationTemplateHero({
       <img
         key={source}
         src={heroImage}
-        alt=""
-        title={`${item.title} illustration preview`}
-        className="absolute inset-0 h-full w-full object-contain opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100"
+        alt={`${item.title} illustration preview`}
+        className="absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100"
         loading="lazy"
         decoding="async"
         fetchPriority="low"
@@ -1492,6 +1500,8 @@ function IllustrationTemplateHero({
 
 interface IllustrationPreviewImageCache {
   readonly decoded: Set<string>;
+  readonly pendingDecodes: Map<string, Promise<void>>;
+  readonly preloads: Map<string, HTMLImageElement>;
 }
 
 function illustrationPreviewImageCache(): IllustrationPreviewImageCache {
@@ -1505,9 +1515,81 @@ function illustrationPreviewImageCache(): IllustrationPreviewImageCache {
 
   const cache: IllustrationPreviewImageCache = {
     decoded: new Set<string>(),
+    pendingDecodes: new Map<string, Promise<void>>(),
+    preloads: new Map<string, HTMLImageElement>(),
   };
   Reflect.set(globalThis, cacheKey, cache);
   return cache;
+}
+
+function illustrationHeroImageUrl(source: string): string {
+  return r2ImageTransformUrl(source, ILLUSTRATION_CARD_PREVIEW_SIZE);
+}
+
+function preloadIllustrationPreviewImage(
+  url: string,
+): HTMLImageElement | undefined {
+  if (typeof Image === "undefined") {
+    return undefined;
+  }
+
+  const cache = illustrationPreviewImageCache();
+  const cachedImage = cache.preloads.get(url);
+  if (cachedImage !== undefined) {
+    return cachedImage;
+  }
+
+  const image = new Image();
+  image.decoding = "async";
+  image.src = url;
+  cache.preloads.set(url, image);
+  return image;
+}
+
+async function decodeIllustrationPreviewImage(url: string): Promise<void> {
+  const cache = illustrationPreviewImageCache();
+  if (cache.decoded.has(url)) {
+    return;
+  }
+
+  if (isHappyDomTestEnvironment()) {
+    cache.decoded.add(url);
+    return;
+  }
+
+  const pendingDecode = cache.pendingDecodes.get(url);
+  if (pendingDecode !== undefined) {
+    await pendingDecode;
+    return;
+  }
+
+  const image = preloadIllustrationPreviewImage(url);
+  if (image === undefined) {
+    return;
+  }
+
+  if (image.decode === undefined) {
+    if (image.complete && image.naturalWidth > 0) {
+      cache.decoded.add(url);
+    }
+    return;
+  }
+
+  const decode = markIllustrationPreviewImageDecoded(url, image);
+  cache.pendingDecodes.set(url, decode);
+  await decode;
+}
+
+async function markIllustrationPreviewImageDecoded(
+  url: string,
+  image: HTMLImageElement,
+): Promise<void> {
+  const cache = illustrationPreviewImageCache();
+  await tapError(image.decode(), () => {});
+  if (image.complete && image.naturalWidth > 0) {
+    cache.decoded.add(url);
+  }
+  cache.pendingDecodes.delete(url);
 }
 
 async function markIllustrationPreviewImageLoaded(
@@ -1525,6 +1607,32 @@ async function markIllustrationPreviewImageLoaded(
   image.parentElement
     ?.querySelector<HTMLElement>("[data-illustration-preview-error]")
     ?.setAttribute("hidden", "");
+}
+
+function illustrationPreviewImageDecoded(url: string): boolean {
+  return illustrationPreviewImageCache().decoded.has(url);
+}
+
+async function selectDecodedIllustrationVariant({
+  card,
+  imageUrl,
+  index,
+  item,
+  onVariantChange,
+}: {
+  card: HTMLElement;
+  imageUrl: string;
+  index: number;
+  item: IllustrationTemplateItem;
+  onVariantChange: (slug: string, index: number) => void;
+}): Promise<void> {
+  await decodeIllustrationPreviewImage(imageUrl);
+  if (
+    card.dataset.targetVariantIndex === String(index) &&
+    illustrationPreviewImageDecoded(imageUrl)
+  ) {
+    onVariantChange(item.slug, index);
+  }
 }
 
 function IllustrationTemplateCard({
@@ -1546,6 +1654,7 @@ function IllustrationTemplateCard({
 
   return (
     <div
+      data-illustration-template-card=""
       className={cn(
         "group mb-4 break-inside-avoid overflow-hidden rounded-xl border bg-card shadow-sm transition-colors",
         selected
@@ -1555,12 +1664,12 @@ function IllustrationTemplateCard({
     >
       <IllustrationTemplateHero item={item} source={heroSource} />
       {images.length > 1 && (
-        <div className="flex items-center gap-2 overflow-x-auto px-3 pt-3">
+        <div className="flex items-center gap-2 overflow-x-auto px-3 pt-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {images.map((image, index) => {
             const active = index === safeIndex;
             const thumbnailImage = r2ImageTransformUrl(
               image,
-              TEMPLATE_STRIP_THUMB_SIZE,
+              ILLUSTRATION_VARIANT_THUMB_SIZE,
             );
             return (
               <button
@@ -1572,8 +1681,41 @@ function IllustrationTemplateCard({
                   "relative h-12 w-12 shrink-0 overflow-hidden rounded-md border-2 bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   active ? "border-primary" : "border-border",
                 )}
-                onClick={() => {
-                  onVariantChange(item.slug, index);
+                onFocus={() => {
+                  preloadIllustrationPreviewImage(
+                    illustrationHeroImageUrl(image),
+                  );
+                }}
+                onMouseEnter={() => {
+                  preloadIllustrationPreviewImage(
+                    illustrationHeroImageUrl(image),
+                  );
+                }}
+                onClick={(event) => {
+                  const imageUrl = illustrationHeroImageUrl(image);
+                  const card = event.currentTarget.closest<HTMLElement>(
+                    "[data-illustration-template-card]",
+                  );
+                  if (
+                    card === null ||
+                    index === safeIndex ||
+                    illustrationPreviewImageDecoded(imageUrl)
+                  ) {
+                    onVariantChange(item.slug, index);
+                    return;
+                  }
+
+                  card.dataset.targetVariantIndex = String(index);
+                  detach(
+                    selectDecodedIllustrationVariant({
+                      card,
+                      imageUrl,
+                      index,
+                      item,
+                      onVariantChange,
+                    }),
+                    Reason.DomCallback,
+                  );
                 }}
               >
                 <img

--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -35,6 +35,18 @@ describe("r2ImageTransformUrl", () => {
     );
   });
 
+  it("allows callers to tune output quality", () => {
+    expect(
+      r2ImageTransformUrl("https://cdn.vm0.io/artifacts/user/id/image.jpg", {
+        width: 768,
+        height: 768,
+        quality: 72,
+      }),
+    ).toBe(
+      "https://cdn.vm0.io/cdn-cgi/image/width=768,height=768,fit=scale-down,format=auto,quality=72,metadata=none/artifacts/user/id/image.jpg",
+    );
+  });
+
   it("leaves already transformed URLs untouched", () => {
     const url =
       "https://cdn.vm0.io/cdn-cgi/image/width=100,height=100,fit=scale-down/artifacts/user/id/image.png";

--- a/turbo/packages/core/src/illustration-template-items.ts
+++ b/turbo/packages/core/src/illustration-template-items.ts
@@ -876,6 +876,11 @@ export interface IllustrationTemplateItem {
   readonly previewImage: string;
   readonly previewImages: readonly string[];
   readonly variationCount: number;
+  /** Intrinsic pixel dimensions of the style's reference frame, used to reserve
+   * the card's aspect ratio so the full illustration renders without cropping,
+   * letterboxing, or layout shift. */
+  readonly width: number;
+  readonly height: number;
   readonly tag: "illustration";
 }
 
@@ -895,6 +900,8 @@ export const ILLUSTRATION_TEMPLATE_ITEMS: readonly IllustrationTemplateItem[] =
         return illustrationAssetUrl(`refs/${style.slug}/${ref}`);
       }),
       variationCount: style.refs.length,
+      width: style.width,
+      height: style.height,
       tag: "illustration",
     };
   });

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -9,6 +9,7 @@ export interface R2ImageTransformOptions {
   readonly width?: number;
   readonly height?: number;
   readonly fit?: "scale-down";
+  readonly quality?: number;
 }
 
 function normalizedDimension(value: number | undefined): number | null {
@@ -18,10 +19,18 @@ function normalizedDimension(value: number | undefined): number | null {
   return Math.round(value);
 }
 
+function normalizedQuality(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return R2_IMAGE_TRANSFORM_QUALITY;
+  }
+  return Math.max(1, Math.min(100, Math.round(value)));
+}
+
 function r2ImageTransformDirectives(options: R2ImageTransformOptions): string {
   const directives: string[] = [];
   const width = normalizedDimension(options.width);
   const height = normalizedDimension(options.height);
+  const quality = normalizedQuality(options.quality);
 
   if (width !== null) {
     directives.push(`width=${String(width)}`);
@@ -33,7 +42,7 @@ function r2ImageTransformDirectives(options: R2ImageTransformOptions): string {
   // Negotiate AVIF/WebP from the request Accept header, cap quality, and drop
   // metadata so previews download as little as possible.
   directives.push("format=auto");
-  directives.push(`quality=${String(R2_IMAGE_TRANSFORM_QUALITY)}`);
+  directives.push(`quality=${String(quality)}`);
   directives.push("metadata=none");
 
   return directives.join(",");


### PR DESCRIPTION
Closes #17682
Closes #17683
Closes #17684

## Summary

Reworks the **Illustration** tab of the chat composer's template picker so a style's variations are shown **inline in a single popup** — removing the second dialog — and aligns the visuals with [www.vm0.ai/illustration](https://www.vm0.ai/en/illustration).

Driven by design feedback iterated on a prototype:
- **Kill the second popup** — clicking a style no longer opens a separate preview dialog. Each card embeds one large image + a switchable variant thumbnail strip.
- **No cropping / no letterbox / no fixed height** — the hero renders the full illustration at its native aspect ratio. The per-style dimensions are intentionally preserved because they represent the specific style's frame.
- **Remove the "N variations" caption.**
- **Masonry layout matching vm0.ai** — CSS multi-column (`columns-[244px]`) whose column count adapts to the dialog width (≈3 at the current width, fewer/more as it narrows/widens), with `break-inside-avoid` tiles, `rounded-xl` + `overflow-hidden`.

## Changes

- `views/zero-page/zero-chat-composer.tsx`
  - Replace `IllustrationTemplatePreview` with `IllustrationTemplateHero` (full-bleed, native-ratio, `object-contain`, fade-in + error fallback retained).
  - Rebuild `IllustrationTemplateCard` with the inline hero + variant thumbnail strip; drop the eye/preview button and the variations caption.
  - Delete `IllustrationPreviewPage` (the second dialog) and its routing/handlers.
  - `IllustrationTemplateGrid` → CSS masonry; pass per-style active variant index.
  - Drop `formatIllustrationTemplateKind`; search now matches title + style id.
- `signals/zero-page/zero-chat-composer.ts` — add `illustrationVariantIndex$` / `setIllustrationVariantIndex$` (per-slug active variant, since multiple cards are visible at once).
- `packages/core/illustration-template-items.ts` — expose `width`/`height` on `IllustrationTemplateItem` to reserve each tile's aspect ratio (avoids masonry layout shift).
- Update `chat-composer-models-and-templates.test.tsx` to exercise inline variant switching instead of the removed second dialog.

## Prototype

The layout/interaction were validated with the user on a hosted prototype before implementation: https://illustration-multi-image-proto-715f6d07-47e406da.sites.vm0.io

## Notes

- Presentation/Video tabs are untouched; the shared preview dialog still serves presentations.
- Relying on the PR pipeline for lint/type/test/e2e per team convention. Prettier run locally (no diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)