### PR TITLE
fix: make usage tooltip hover-only

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1550,7 +1550,6 @@ describe("chat lifecycle", () => {
   });
 
   it("shows run credit usage with friendly popover details", async () => {
-    const user = userEvent.setup({ delay: null });
     mockChatLifecycle(context, {
       threadId: "thread-usage-chip",
       chatMessages: [
@@ -1616,14 +1615,21 @@ describe("chat lifecycle", () => {
       copy.compareDocumentPosition(credit) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
+    click(credit);
+    expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
+
     fireEvent.pointerEnter(credit);
 
     await waitFor(() => {
-      expect(screen.getByText("Credit usage")).toBeInTheDocument();
+      expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
+        1,
+      );
       expect(screen.getAllByText("24,234").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("Kimi K2.5")).toBeInTheDocument();
+      expect(screen.getAllByText("Kimi K2.5").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("1,234").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
+      expect(screen.getAllByText("GPT Image 2").length).toBeGreaterThanOrEqual(
+        1,
+      );
       expect(screen.getAllByText("23,000").length).toBeGreaterThanOrEqual(1);
       expect(
         screen.queryByText("model/kimi-k2.5/tokens.input"),
@@ -1631,12 +1637,105 @@ describe("chat lifecycle", () => {
       expect(screen.queryByText("moonshot")).not.toBeInTheDocument();
     });
 
-    await user.click(credit);
+    fireEvent.pointerDown(credit, { button: 0 });
+    expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
+      1,
+    );
+    fireEvent.click(credit);
 
     await waitFor(() => {
-      expect(screen.getByText("Credit usage")).toBeInTheDocument();
-      expect(screen.getByText("Kimi K2.5")).toBeInTheDocument();
+      expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
+        1,
+      );
+      expect(screen.getAllByText("Kimi K2.5").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("1,234").length).toBeGreaterThanOrEqual(1);
+    });
+
+    fireEvent.pointerLeave(credit);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
+    });
+
+    click(credit);
+    expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
+  });
+
+  it("shows generation usage with model names only", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-generation-usage-model-names",
+      chatMessages: [
+        {
+          id: "msg-generation-usage-user",
+          role: "user",
+          content: "Generate image and video usage",
+          runId: "run-generation-usage",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-generation-usage-assistant",
+          role: "assistant",
+          content: "Generated media is ready.",
+          runId: "run-generation-usage",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-generation-usage",
+          role: "assistant",
+          content: null,
+          runId: "run-generation-usage",
+          usage: {
+            version: 1,
+            totalCredits: 1976,
+            settledAt: "2026-06-09T10:00:02Z",
+            breakdown: [
+              {
+                kind: "image",
+                credits: 96,
+                providers: [{ provider: "fal-ai/nano-banana-2", credits: 96 }],
+              },
+              {
+                kind: "video",
+                credits: 1880,
+                providers: [
+                  {
+                    provider: "dreamina-seedance-2-0-260128",
+                    credits: 1880,
+                  },
+                ],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-generation-usage-model-names",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunUsage]: true,
+      },
+    });
+
+    const credit = await screen.findByLabelText("Credit usage 1,976");
+    fireEvent.pointerEnter(credit);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
+        1,
+      );
+      expect(
+        screen.getAllByText("Nano Banana 2").length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("96").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Seedance 2.0").length).toBeGreaterThanOrEqual(
+        1,
+      );
+      expect(screen.getAllByText("1,880").length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText(/fal\.? ?ai/iu)).not.toBeInTheDocument();
+      expect(screen.queryByText(/dreamina/iu)).not.toBeInTheDocument();
     });
   });
 
@@ -1849,13 +1948,17 @@ describe("chat lifecycle", () => {
     fireEvent.pointerEnter(desktopThreadCredit);
 
     await waitFor(() => {
-      expect(screen.getByText("Thread credit usage")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("Thread credit usage").length,
+      ).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("125").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("Kimi K2.5")).toBeInTheDocument();
+      expect(screen.getAllByText("Kimi K2.5").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("45").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getAllByText("X").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("10").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
+      expect(screen.getAllByText("GPT Image 2").length).toBeGreaterThanOrEqual(
+        1,
+      );
       expect(screen.getAllByText("70").length).toBeGreaterThanOrEqual(1);
       expect(screen.queryByText("40")).not.toBeInTheDocument();
     });
@@ -1973,11 +2076,15 @@ describe("chat lifecycle", () => {
     fireEvent.pointerEnter(threadCredit);
 
     await waitFor(() => {
-      expect(screen.getByText("Thread credit usage")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("Thread credit usage").length,
+      ).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("125").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("Kimi K2.5")).toBeInTheDocument();
+      expect(screen.getAllByText("Kimi K2.5").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("75").length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
+      expect(screen.getAllByText("GPT Image 2").length).toBeGreaterThanOrEqual(
+        1,
+      );
       expect(screen.getAllByText("50").length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -2056,7 +2163,7 @@ describe("chat lifecycle", () => {
     fireEvent.pointerEnter(connectorCredit);
 
     await waitFor(() => {
-      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getAllByText("X").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("108").length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -2160,7 +2267,7 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Connector usage is ready.")).toBeInTheDocument();
-      expect(screen.getByText("X")).toBeInTheDocument();
+      expect(screen.getAllByText("X").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("108").length).toBeGreaterThanOrEqual(1);
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5674,9 +5674,46 @@ function formatUsageIdentifier(value: string): string {
     .join(" ");
 }
 
+function isUsageModelBackedKind(kind: string): boolean {
+  return kind === "model" || kind === "image" || kind === "video";
+}
+
+function isUsageCategoryPart(part: string): boolean {
+  return part.startsWith("tokens.") || part.startsWith("output_");
+}
+
+function stripUsageProviderPrefix(value: string): string {
+  const normalized = value.trim();
+  if (normalized.startsWith("fal-ai/")) {
+    return normalized.slice("fal-ai/".length);
+  }
+  if (normalized.startsWith("bytedance/")) {
+    return normalized.slice("bytedance/".length);
+  }
+  if (normalized.startsWith("dreamina-")) {
+    return normalized.slice("dreamina-".length);
+  }
+  return normalized;
+}
+
+function getUsageModelDisplayName(model: string): string {
+  const directDisplayName = getModelDisplayName(model);
+  if (directDisplayName !== model) {
+    return directDisplayName;
+  }
+
+  const strippedModel = stripUsageProviderPrefix(model);
+  const strippedDisplayName = getModelDisplayName(strippedModel);
+  if (strippedDisplayName !== strippedModel) {
+    return strippedDisplayName;
+  }
+
+  return formatUsageIdentifier(strippedModel);
+}
+
 function usageDisplayLabel(kind: string, provider: string): string {
-  if (kind === "model") {
-    return getModelDisplayName(provider);
+  if (isUsageModelBackedKind(kind) && provider && provider !== "unknown") {
+    return getUsageModelDisplayName(provider);
   }
 
   if (provider && provider !== "unknown") {
@@ -5692,12 +5729,12 @@ function parseUsageKind(kind: string): {
 } {
   const parts = kind.split("/");
   const parsedKind = parts[0];
-  if (parsedKind === "model" && parts.length >= 3) {
+  if (isUsageModelBackedKind(parsedKind) && parts.length >= 2) {
     const categoryIndex = parts.findIndex((part, index) => {
-      return index > 1 && part.startsWith("tokens.");
+      return index > 1 && isUsageCategoryPart(part);
     });
     const providerParts =
-      categoryIndex > 1 ? parts.slice(1, categoryIndex) : parts.slice(1, 2);
+      categoryIndex > 1 ? parts.slice(1, categoryIndex) : parts.slice(1);
     const provider = providerParts.join("/");
     if (provider) {
       return { kind: parsedKind, provider };
@@ -5747,58 +5784,45 @@ function UsageChip({
 }) {
   const total = formatCredits(usage.totalCredits);
   const displayRows = buildRunUsageDisplayRows(usage);
+  const showTooltip = () => {
+    setOpen(true);
+  };
+  const hideTooltip = () => {
+    setOpen(false);
+  };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open}>
       <PopoverAnchor asChild>
-        <button
-          type="button"
+        <span
+          tabIndex={0}
           className="inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground/70 hover:bg-accent hover:text-foreground transition-colors duration-150"
           aria-label={`${ariaLabel} ${total}`}
-          aria-expanded={open}
-          aria-haspopup="dialog"
-          onClick={() => {
-            setOpen(true);
+          onFocus={showTooltip}
+          onBlur={hideTooltip}
+          onPointerDown={(event) => {
+            event.preventDefault();
           }}
-          onFocus={() => {
-            setOpen(true);
+          onClick={(event) => {
+            event.preventDefault();
           }}
-          onBlur={() => {
-            setOpen(false);
-          }}
-          onMouseEnter={() => {
-            setOpen(true);
-          }}
-          onMouseLeave={() => {
-            setOpen(false);
-          }}
-          onPointerEnter={() => {
-            setOpen(true);
-          }}
-          onPointerLeave={() => {
-            setOpen(false);
-          }}
+          onMouseEnter={showTooltip}
+          onMouseLeave={hideTooltip}
+          onPointerEnter={showTooltip}
+          onPointerLeave={hideTooltip}
         >
           <IconCoins size={17} stroke={1.5} />
           <span>{total}</span>
-        </button>
+        </span>
       </PopoverAnchor>
       <PopoverContent
         side="bottom"
         align={contentAlign}
         className="w-72 p-3"
-        onPointerEnter={() => {
-          setOpen(true);
-        }}
-        onPointerLeave={() => {
-          setOpen(false);
-        }}
-        onMouseEnter={() => {
-          setOpen(true);
-        }}
-        onMouseLeave={() => {
-          setOpen(false);
-        }}
+        onPointerEnter={showTooltip}
+        onPointerLeave={hideTooltip}
+        onMouseEnter={showTooltip}
+        onMouseLeave={hideTooltip}
       >
         <div className="flex items-center justify-between gap-3 text-sm font-medium">
           <span>{title}</span>

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -53,6 +53,23 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "gpt-5.4-mini": "GPT-5.4 Mini",
   "gpt-5.3-codex": "GPT-5.3 Codex",
   "gpt-5.2": "GPT-5.2",
+  // Built-in image generation
+  "nano-banana-2": "Nano Banana 2",
+  "fal-ai/nano-banana-2": "Nano Banana 2",
+  "fal-ai/flux-pro/v1.1": "Flux Pro v1.1",
+  "fal-ai/flux-pro/v1.1-ultra": "Flux Pro v1.1 Ultra",
+  "fal-ai/qwen-image": "Qwen Image",
+  "fal-ai/bytedance/seedream/v4/text-to-image": "Seedream 4",
+  // Built-in video generation
+  "dreamina-seedance-2-0-260128": "Seedance 2.0",
+  "dreamina-seedance-2-0-fast-260128": "Seedance 2.0 Fast",
+  "seedance-2-0-260128": "Seedance 2.0",
+  "seedance-2-0-fast-260128": "Seedance 2.0 Fast",
+  "seedance-1-5-pro-251215": "Seedance 1.5 Pro",
+  "fal-ai/veo3.1": "Veo 3.1",
+  "fal-ai/veo3.1/fast": "Veo 3.1 Fast",
+  "fal-ai/kling-video/o3/standard/text-to-video": "Kling O3 Standard",
+  "fal-ai/kling-video/v3/4k/text-to-video": "Kling 3 4K",
 });
 
 /**


### PR DESCRIPTION
## Summary
- make the credit usage chip open from hover/focus only and prevent pointer/click flicker
- show generation usage rows with model names only, stripping provider prefixes like FAL.AI and Dreamina
- add Platform UI coverage for hover/click behavior and generation model display names

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --testNamePattern "usage"`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx packages/core/src/model-display-name.ts`
- `git diff --check`