### PR TITLE
docs: document generated Rust route bindings

### DIFF
--- a/crates/api-contracts/src/generated/routes.rs
+++ b/crates/api-contracts/src/generated/routes.rs
@@ -2,27 +2,44 @@
 // Do not edit by hand.
 // Regenerate with: cd turbo && pnpm -F @vm0/api-contracts generate:rust
 
+//! Generated Rust route bindings for selected `@vm0/api-contracts` routes.
+//! Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.
+//! Route descriptions are generated from TypeScript contract summaries.
+
+/// Generated route bindings under `runners`.
 pub mod runners {
+    /// Generated route bindings under `runners::heartbeat`.
     pub mod heartbeat {
+        /// Report runner heartbeat with capacity and state.
+        /// Route contract: `POST /api/runners/heartbeat`.
         pub const HEARTBEAT: crate::Route = crate::Route {
             method: crate::Method::Post,
             path: "/api/runners/heartbeat",
         };
     }
 
+    /// Generated route bindings under `runners::jobs`.
     pub mod jobs {
+        /// Generated route bindings under `runners::jobs::by_id`.
         pub mod by_id {
+            /// Generated route bindings under `runners::jobs::by_id::claim`.
             pub mod claim {
+                /// Claim a pending job for execution.
+                /// Route contract: `POST /api/runners/jobs/:id/claim`.
                 pub const CLAIM: crate::RouteTemplate = crate::RouteTemplate {
                     method: crate::Method::Post,
                     path: "/api/runners/jobs/:id/claim",
                 };
 
+                /// Path parameters for `POST /api/runners/jobs/:id/claim`.
                 #[derive(Debug, Clone, Copy)]
                 pub struct Params<'a> {
+                    /// Value for the `:id` path parameter.
                     pub id: &'a str,
                 }
 
+                /// Build the concrete path for `POST /api/runners/jobs/:id/claim`.
+                /// Percent-encodes each path parameter as a URL path segment.
                 #[must_use]
                 pub fn path(params: Params<'_>) -> String {
                     format!(
@@ -31,6 +48,7 @@ pub mod runners {
                     )
                 }
 
+                /// Build a resolved route for `POST /api/runners/jobs/:id/claim`.
                 #[must_use]
                 pub fn route(params: Params<'_>) -> crate::ResolvedRoute {
                     crate::ResolvedRoute::new(CLAIM.method, path(params))
@@ -39,15 +57,22 @@ pub mod runners {
         }
     }
 
+    /// Generated route bindings under `runners::poll`.
     pub mod poll {
+        /// Poll for pending jobs (long-polling with 30s timeout).
+        /// Route contract: `POST /api/runners/poll`.
         pub const POLL: crate::Route = crate::Route {
             method: crate::Method::Post,
             path: "/api/runners/poll",
         };
     }
 
+    /// Generated route bindings under `runners::realtime`.
     pub mod realtime {
+        /// Generated route bindings under `runners::realtime::token`.
         pub mod token {
+            /// Get Ably token for runner group job notifications.
+            /// Route contract: `POST /api/runners/realtime/token`.
             pub const CREATE: crate::Route = crate::Route {
                 method: crate::Method::Post,
                 path: "/api/runners/realtime/token",
@@ -56,15 +81,23 @@ pub mod runners {
     }
 }
 
+/// Generated route bindings under `webhooks`.
 pub mod webhooks {
+    /// Generated route bindings under `webhooks::agent`.
     pub mod agent {
+        /// Generated route bindings under `webhooks::agent::checkpoints`.
         pub mod checkpoints {
+            /// Create checkpoint for agent run.
+            /// Route contract: `POST /api/webhooks/agent/checkpoints`.
             pub const CREATE: crate::Route = crate::Route {
                 method: crate::Method::Post,
                 path: "/api/webhooks/agent/checkpoints",
             };
 
+            /// Generated route bindings under `webhooks::agent::checkpoints::prepare_history`.
             pub mod prepare_history {
+                /// Get presigned URL for uploading session history to S3.
+                /// Route contract: `POST /api/webhooks/agent/checkpoints/prepare-history`.
                 pub const PREPARE: crate::Route = crate::Route {
                     method: crate::Method::Post,
                     path: "/api/webhooks/agent/checkpoints/prepare-history",
@@ -72,36 +105,52 @@ pub mod webhooks {
             }
         }
 
+        /// Generated route bindings under `webhooks::agent::complete`.
         pub mod complete {
+            /// Handle agent run completion.
+            /// Route contract: `POST /api/webhooks/agent/complete`.
             pub const COMPLETE: crate::Route = crate::Route {
                 method: crate::Method::Post,
                 path: "/api/webhooks/agent/complete",
             };
         }
 
+        /// Generated route bindings under `webhooks::agent::events`.
         pub mod events {
+            /// Receive agent events from sandbox.
+            /// Route contract: `POST /api/webhooks/agent/events`.
             pub const SEND: crate::Route = crate::Route {
                 method: crate::Method::Post,
                 path: "/api/webhooks/agent/events",
             };
         }
 
+        /// Generated route bindings under `webhooks::agent::heartbeat`.
         pub mod heartbeat {
+            /// Receive heartbeat from sandbox.
+            /// Route contract: `POST /api/webhooks/agent/heartbeat`.
             pub const SEND: crate::Route = crate::Route {
                 method: crate::Method::Post,
                 path: "/api/webhooks/agent/heartbeat",
             };
         }
 
+        /// Generated route bindings under `webhooks::agent::storages`.
         pub mod storages {
+            /// Generated route bindings under `webhooks::agent::storages::commit`.
             pub mod commit {
+                /// Commit uploaded storage from sandbox.
+                /// Route contract: `POST /api/webhooks/agent/storages/commit`.
                 pub const COMMIT: crate::Route = crate::Route {
                     method: crate::Method::Post,
                     path: "/api/webhooks/agent/storages/commit",
                 };
             }
 
+            /// Generated route bindings under `webhooks::agent::storages::prepare`.
             pub mod prepare {
+                /// Prepare for direct S3 upload from sandbox.
+                /// Route contract: `POST /api/webhooks/agent/storages/prepare`.
                 pub const PREPARE: crate::Route = crate::Route {
                     method: crate::Method::Post,
                     path: "/api/webhooks/agent/storages/prepare",
@@ -109,7 +158,10 @@ pub mod webhooks {
             }
         }
 
+        /// Generated route bindings under `webhooks::agent::telemetry`.
         pub mod telemetry {
+            /// Receive telemetry data from sandbox.
+            /// Route contract: `POST /api/webhooks/agent/telemetry`.
             pub const SEND: crate::Route = crate::Route {
                 method: crate::Method::Post,
                 path: "/api/webhooks/agent/telemetry",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
@@ -80,7 +80,11 @@ function validBinding(
   overrides: Partial<RustRouteBinding> = {},
 ): RustRouteBinding {
   return {
-    route: { method: "POST", path: "/api/webhooks/agent/events" },
+    route: {
+      method: "POST",
+      path: "/api/webhooks/agent/events",
+      summary: "Send an example route",
+    },
     rustModulePath: ["webhooks", "agent", "events"],
     rustConstName: "SEND",
     ...overrides,
@@ -135,12 +139,41 @@ describe("Rust route bindings", () => {
     expect(rendered).toContain("crate::route::encode_path_segment(params.id)");
   });
 
+  it("renders Rust docs for route modules, constants, params, and helpers", () => {
+    const rendered = renderRustRoutes(rustRouteBindings);
+
+    expect(rendered).toContain(
+      "//! Generated Rust route bindings for selected `@vm0/api-contracts` routes.",
+    );
+    expect(rendered).toContain(
+      "/// Generated route bindings under `runners::jobs::by_id::claim`.",
+    );
+    expect(rendered).toContain("/// Claim a pending job for execution.");
+    expect(rendered).toContain(
+      "/// Route contract: `POST /api/runners/jobs/:id/claim`.",
+    );
+    expect(rendered).toContain(
+      "/// Path parameters for `POST /api/runners/jobs/:id/claim`.",
+    );
+    expect(rendered).toContain("/// Value for the `:id` path parameter.");
+    expect(rendered).toContain(
+      "/// Build the concrete path for `POST /api/runners/jobs/:id/claim`.",
+    );
+    expect(rendered).toContain(
+      "/// Percent-encodes each path parameter as a URL path segment.",
+    );
+    expect(rendered).toContain(
+      "/// Build a resolved route for `POST /api/runners/jobs/:id/claim`.",
+    );
+  });
+
   it("renders Rust-safe field names for keyword path params", () => {
     const rendered = renderRustRoutes([
       validBinding({
         route: {
           method: "POST",
           path: "/api/items/:async/:await/:dyn/:gen/:try/:union/:type",
+          summary: "Fetch an item by keyword parameters",
         },
         rustModulePath: ["items", "by_keyword"],
         rustConstName: "FETCH",
@@ -162,7 +195,11 @@ describe("Rust route bindings", () => {
   it("renders typed params for routes with multiple path params", () => {
     const rendered = renderRustRoutes([
       validBinding({
-        route: { method: "POST", path: "/api/orgs/:orgId/items/:itemId" },
+        route: {
+          method: "POST",
+          path: "/api/orgs/:orgId/items/:itemId",
+          summary: "Fetch an organization item",
+        },
         rustModulePath: ["orgs", "items"],
         rustConstName: "FETCH",
       }),
@@ -178,7 +215,11 @@ describe("Rust route bindings", () => {
   it("escapes Rust format braces in static route segments with path params", () => {
     const rendered = renderRustRoutes([
       validBinding({
-        route: { method: "POST", path: "/api/{version}/items/:id" },
+        route: {
+          method: "POST",
+          path: "/api/{version}/items/:id",
+          summary: "Fetch an item for a literal version route",
+        },
         rustModulePath: ["items", "by_id"],
         rustConstName: "FETCH",
       }),
@@ -190,7 +231,11 @@ describe("Rust route bindings", () => {
   it("fails clearly when a registry entry is malformed", () => {
     const malformedBindings = [
       validBinding({
-        route: { method: "TRACE", path: "/api/webhooks/agent/events" },
+        route: {
+          method: "TRACE",
+          path: "/api/webhooks/agent/events",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -202,7 +247,11 @@ describe("Rust route bindings", () => {
   it("fails clearly when a route path is invalid", () => {
     const malformedBindings = [
       validBinding({
-        route: { method: "POST", path: "api/webhooks/agent/events" },
+        route: {
+          method: "POST",
+          path: "api/webhooks/agent/events",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -214,7 +263,11 @@ describe("Rust route bindings", () => {
   it("fails clearly when route path param syntax is unsupported", () => {
     const malformedBindings = [
       validBinding({
-        route: { method: "POST", path: "/api/runners/jobs/prefix-:id" },
+        route: {
+          method: "POST",
+          path: "/api/runners/jobs/prefix-:id",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -226,7 +279,11 @@ describe("Rust route bindings", () => {
   it("fails clearly when a route path param name is invalid", () => {
     const malformedBindings = [
       validBinding({
-        route: { method: "POST", path: "/api/runners/jobs/:1id" },
+        route: {
+          method: "POST",
+          path: "/api/runners/jobs/:1id",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -238,7 +295,11 @@ describe("Rust route bindings", () => {
   it("fails clearly when route path params are duplicated", () => {
     const malformedBindings = [
       validBinding({
-        route: { method: "POST", path: "/api/runners/jobs/:id/:id" },
+        route: {
+          method: "POST",
+          path: "/api/runners/jobs/:id/:id",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -250,7 +311,11 @@ describe("Rust route bindings", () => {
   it("fails clearly when path params collide as Rust field names", () => {
     const malformedBindings = [
       validBinding({
-        route: { method: "POST", path: "/api/:fooBar/:foo_bar" },
+        route: {
+          method: "POST",
+          path: "/api/:fooBar/:foo_bar",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -287,7 +352,11 @@ describe("Rust route bindings", () => {
     const malformedBindings = [
       validBinding(),
       validBinding({
-        route: { method: "POST", path: "/api/webhooks/agent/heartbeat" },
+        route: {
+          method: "POST",
+          path: "/api/webhooks/agent/heartbeat",
+          summary: "Send an example route",
+        },
       }),
     ];
 
@@ -307,5 +376,37 @@ describe("Rust route bindings", () => {
     expect(() => {
       normalizeRouteBindings(malformedBindings);
     }).toThrow("duplicate route binding");
+  });
+
+  it("fails clearly when a route summary is invalid", () => {
+    for (const route of [
+      {
+        method: "POST",
+        path: "/api/webhooks/agent/events",
+      },
+      {
+        method: "POST",
+        path: "/api/webhooks/agent/events",
+        summary: "",
+      },
+    ]) {
+      expect(() => {
+        normalizeRouteBindings([validBinding({ route })]);
+      }).toThrow("missing route summary");
+    }
+  });
+
+  it("fails clearly when a route summary spans multiple lines", () => {
+    expect(() => {
+      normalizeRouteBindings([
+        validBinding({
+          route: {
+            method: "POST",
+            path: "/api/webhooks/agent/events",
+            summary: "Send an example route\nwith extra detail",
+          },
+        }),
+      ]);
+    }).toThrow("multiline route summary");
   });
 });

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -73,6 +73,7 @@ export type RustMethodVariant =
 export interface NormalizedRouteBinding {
   readonly method: HttpMethod;
   readonly path: string;
+  readonly summary: string;
   readonly pathParams: readonly PathParamBinding[];
   readonly rustMethodVariant: RustMethodVariant;
   readonly rustModulePath: readonly string[];
@@ -88,6 +89,12 @@ interface ModuleNode {
   readonly routes: NormalizedRouteBinding[];
   readonly children: Map<string, ModuleNode>;
 }
+
+const rustRouteRootDoc = [
+  "Generated Rust route bindings for selected `@vm0/api-contracts` routes.",
+  "Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.",
+  "Route descriptions are generated from TypeScript contract summaries.",
+] as const;
 
 export interface NormalizedTypeBinding {
   readonly schema: JsonObject;
@@ -214,6 +221,7 @@ export function normalizeRouteBindings(
     const label = routeLabel(binding);
     const method = validateHttpMethod(binding.route.method, label);
     const path = validateRoutePath(binding.route.path, label);
+    const summary = validateRouteSummary(binding.route.summary, label);
     const pathParams = extractPathParams(path, label);
     const rustModulePath = validateRustModulePath(
       binding.rustModulePath,
@@ -236,6 +244,7 @@ export function normalizeRouteBindings(
     normalized.push({
       method,
       path,
+      summary,
       pathParams,
       rustMethodVariant: toRustMethodVariant(method),
       rustModulePath,
@@ -256,7 +265,9 @@ export function renderRustRoutes(
     "// Do not edit by hand.",
     "// Regenerate with: cd turbo && pnpm -F @vm0/api-contracts generate:rust",
     "",
-    ...renderModuleNode(root, ""),
+    ...renderInnerRustDoc(rustRouteRootDoc),
+    "",
+    ...renderModuleNode(root, "", []),
   ];
 
   return `${lines.join("\n")}\n`;
@@ -463,6 +474,23 @@ function validateRoutePath(value: unknown, label: string): string {
   }
 
   return value;
+}
+
+function validateRouteSummary(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} is missing route summary`);
+  }
+
+  if (value.includes("\n") || value.includes("\r")) {
+    throw new Error(`${label} has multiline route summary`);
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label} is missing route summary`);
+  }
+
+  return trimmed;
 }
 
 function extractPathParams(
@@ -1319,7 +1347,11 @@ function renderStringEnum(
   return typeName;
 }
 
-function renderModuleNode(node: ModuleNode, indent: string): string[] {
+function renderModuleNode(
+  node: ModuleNode,
+  indent: string,
+  modulePath: readonly string[],
+): string[] {
   const lines: string[] = [];
   const routes = [...node.routes].sort(compareRouteBindings);
   const children = [...node.children.entries()].sort(
@@ -1331,6 +1363,7 @@ function renderModuleNode(node: ModuleNode, indent: string): string[] {
   for (const route of routes) {
     const routeType = route.pathParams.length > 0 ? "RouteTemplate" : "Route";
     appendBlankLineIfNeeded(lines);
+    lines.push(...renderRouteConstDoc(route, indent));
     lines.push(
       `${indent}pub const ${route.rustConstName}: crate::${routeType} = crate::${routeType} {`,
     );
@@ -1342,18 +1375,22 @@ function renderModuleNode(node: ModuleNode, indent: string): string[] {
 
     if (route.pathParams.length > 0) {
       lines.push("");
+      lines.push(...renderParamsDoc(route, indent));
       lines.push(`${indent}#[derive(Debug, Clone, Copy)]`);
       lines.push(`${indent}pub struct Params<'a> {`);
       for (const param of route.pathParams) {
+        lines.push(...renderPathParamDoc(param, `${indent}    `));
         lines.push(`${indent}    pub ${param.rustName}: &'a str,`);
       }
       lines.push(`${indent}}`);
       lines.push("");
+      lines.push(...renderPathHelperDoc(route, indent));
       lines.push(`${indent}#[must_use]`);
       lines.push(`${indent}pub fn path(params: Params<'_>) -> String {`);
       lines.push(...renderParameterizedPath(route, `${indent}    `));
       lines.push(`${indent}}`);
       lines.push("");
+      lines.push(...renderRouteHelperDoc(route, indent));
       lines.push(`${indent}#[must_use]`);
       lines.push(
         `${indent}pub fn route(params: Params<'_>) -> crate::ResolvedRoute {`,
@@ -1367,12 +1404,85 @@ function renderModuleNode(node: ModuleNode, indent: string): string[] {
 
   for (const [moduleName, child] of children) {
     appendBlankLineIfNeeded(lines);
+    const childPath = [...modulePath, moduleName];
+    lines.push(...renderRouteModuleDoc(childPath, indent));
     lines.push(`${indent}pub mod ${moduleName} {`);
-    lines.push(...renderModuleNode(child, `${indent}    `));
+    lines.push(...renderModuleNode(child, `${indent}    `, childPath));
     lines.push(`${indent}}`);
   }
 
   return lines;
+}
+
+function renderRouteModuleDoc(
+  modulePath: readonly string[],
+  indent: string,
+): string[] {
+  return renderOuterRustDoc(
+    [`Generated route bindings under \`${modulePath.join("::")}\`.`],
+    indent,
+  );
+}
+
+function renderRouteConstDoc(
+  route: NormalizedRouteBinding,
+  indent: string,
+): string[] {
+  return renderOuterRustDoc(
+    [
+      rustDocSentence(route.summary),
+      `Route contract: \`${routeContract(route)}\`.`,
+    ],
+    indent,
+  );
+}
+
+function renderParamsDoc(
+  route: NormalizedRouteBinding,
+  indent: string,
+): string[] {
+  return renderOuterRustDoc(
+    [`Path parameters for \`${routeContract(route)}\`.`],
+    indent,
+  );
+}
+
+function renderPathParamDoc(param: PathParamBinding, indent: string): string[] {
+  return renderOuterRustDoc(
+    [`Value for the \`:${param.routeName}\` path parameter.`],
+    indent,
+  );
+}
+
+function renderPathHelperDoc(
+  route: NormalizedRouteBinding,
+  indent: string,
+): string[] {
+  return renderOuterRustDoc(
+    [
+      `Build the concrete path for \`${routeContract(route)}\`.`,
+      "Percent-encodes each path parameter as a URL path segment.",
+    ],
+    indent,
+  );
+}
+
+function renderRouteHelperDoc(
+  route: NormalizedRouteBinding,
+  indent: string,
+): string[] {
+  return renderOuterRustDoc(
+    [`Build a resolved route for \`${routeContract(route)}\`.`],
+    indent,
+  );
+}
+
+function routeContract(route: NormalizedRouteBinding): string {
+  return `${route.method} ${route.path}`;
+}
+
+function rustDocSentence(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
 }
 
 function renderParameterizedPath(

--- a/turbo/packages/api-contracts/src/rust-bindings/routes.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/routes.ts
@@ -18,6 +18,7 @@ import {
 export interface RouteLike {
   readonly method?: unknown;
   readonly path?: unknown;
+  readonly summary?: unknown;
 }
 
 export interface RustRouteBinding {


### PR DESCRIPTION
## Summary
- Generate Rust route binding docs from TypeScript route contract summaries
- Document generated route modules, constants, path params, and helper functions
- Validate route summaries before rendering generated Rust docs

## Tests
- pnpm -F @vm0/api-contracts test
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- cargo test --manifest-path crates/Cargo.toml -p api-contracts
- cargo doc --manifest-path crates/Cargo.toml -p api-contracts --no-deps
- git diff --check
- pre-commit hook: full turbo check-types, knip, cargo doc, cargo clippy

Closes #17697