### PR TITLE
fix: handle exec cancel terminal race

### DIFF
--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 
 use tokio::io::AsyncWriteExt;
 use tokio::time::Instant;
-use vsock_proto::{ExecControlStatus, MSG_EXEC_START};
+use vsock_proto::{ExecControlStatus, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use crate::{ConnectionState, FrameWriteObserver, Shared, normal_operation_transition_error};
 
@@ -18,6 +18,18 @@ use super::{
 pub(in crate::exec_operation) struct ExecOperationFrameWriteGuard {
     pub(in crate::exec_operation) shared: Arc<Shared>,
     pub(in crate::exec_operation) state: Arc<AtomicU8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::exec_operation) enum ExecCancelFrameWriteOutcome {
+    Sent,
+    AlreadyTerminal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FrameWriteDecision {
+    Write,
+    Skip,
 }
 
 impl ExecOperationFrameWriteGuard {
@@ -50,6 +62,51 @@ fn mark_exec_operation_host_cancel_requested(shared: &Arc<Shared>, seq: u32) {
     if let ConnectionState::Connected { operations, .. } = &mut *guard {
         operations.mark_host_cancel_requested(seq);
     }
+}
+
+fn mark_exec_operation_host_cancel_requested_for_wait(
+    shared: &Arc<Shared>,
+    seq: u32,
+) -> io::Result<ExecCancelFrameWriteOutcome> {
+    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &mut *guard {
+        ConnectionState::Connected { operations, .. } => {
+            if operations.mark_host_cancel_requested(seq) {
+                Ok(ExecCancelFrameWriteOutcome::Sent)
+            } else {
+                Ok(ExecCancelFrameWriteOutcome::AlreadyTerminal)
+            }
+        }
+        ConnectionState::Closed => Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        )),
+    }
+}
+
+pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait(
+    shared: &Arc<Shared>,
+    seq: u32,
+    diagnostic: &ExecOperationDiagnostic,
+) -> io::Result<ExecCancelFrameWriteOutcome> {
+    let payload = vsock_proto::encode_exec_cancel();
+    let decision = write_frame_with_pre_write_decision(
+        shared,
+        MSG_EXEC_CANCEL,
+        seq,
+        &payload,
+        Some(diagnostic.frame("cancel")),
+        || match mark_exec_operation_host_cancel_requested_for_wait(shared, seq)? {
+            ExecCancelFrameWriteOutcome::Sent => Ok(FrameWriteDecision::Write),
+            ExecCancelFrameWriteOutcome::AlreadyTerminal => Ok(FrameWriteDecision::Skip),
+        },
+    )
+    .await?;
+
+    Ok(match decision {
+        FrameWriteDecision::Write => ExecCancelFrameWriteOutcome::Sent,
+        FrameWriteDecision::Skip => ExecCancelFrameWriteOutcome::AlreadyTerminal,
+    })
 }
 
 fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> io::Result<()> {
@@ -175,6 +232,23 @@ pub(in crate::exec_operation) async fn write_frame_with_pre_write(
     diagnostic: Option<ExecOperationFrameDiagnostic>,
     pre_write: impl FnOnce() -> io::Result<()>,
 ) -> io::Result<()> {
+    let _decision =
+        write_frame_with_pre_write_decision(shared, msg_type, seq, payload, diagnostic, || {
+            pre_write()?;
+            Ok(FrameWriteDecision::Write)
+        })
+        .await?;
+    Ok(())
+}
+
+async fn write_frame_with_pre_write_decision(
+    shared: &Arc<Shared>,
+    msg_type: u8,
+    seq: u32,
+    payload: &[u8],
+    diagnostic: Option<ExecOperationFrameDiagnostic>,
+    pre_write: impl FnOnce() -> io::Result<FrameWriteDecision>,
+) -> io::Result<FrameWriteDecision> {
     let data = vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
     let state = Arc::new(AtomicU8::new(EXEC_OPERATION_FRAME_WRITE_NOT_STARTED));
@@ -183,7 +257,10 @@ pub(in crate::exec_operation) async fn write_frame_with_pre_write(
     let wait_started_at = Instant::now();
     let mut writer = shared.writer.lock().await;
     let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
-    pre_write()?;
+    let decision = pre_write()?;
+    if decision == FrameWriteDecision::Skip {
+        return Ok(FrameWriteDecision::Skip);
+    }
     state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
     let write_started_at = Instant::now();
     let result = writer.write_all(&data).await;
@@ -236,5 +313,5 @@ pub(in crate::exec_operation) async fn write_frame_with_pre_write(
 
     drop(guard);
 
-    Ok(())
+    Ok(FrameWriteDecision::Write)
 }

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -293,6 +293,28 @@ impl ExecWaitCore {
             }
         }
     }
+
+    pub(in crate::exec_operation) async fn wait_for_dispatched_terminal(
+        &mut self,
+        lifecycle: ExecWaitLifecycle,
+    ) -> io::Result<ExecOperationResult> {
+        // The state lock already proved dispatch removed the operation; only the
+        // terminal result delivery remains.
+        self.active_seq_or_closed(Self::operation_closed_message(lifecycle))?;
+        let rx = self.result_rx.as_mut().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                Self::operation_closed_message(lifecycle),
+            )
+        })?;
+
+        let result = rx
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"));
+        self.seq = None;
+        self.result_rx = None;
+        result?
+    }
 }
 
 impl ExecOperationHandle {
@@ -369,10 +391,18 @@ impl ExecOperationHandle {
             ExecCancelFrameWriteOutcome::AlreadyTerminal => None,
         };
 
-        let result = self
-            .wait_core
-            .wait_with_timeout(timeout, cancel_seq.is_some(), ExecWaitLifecycle::OneShot)
-            .await?;
+        let result = match cancel_seq {
+            Some(_) => {
+                self.wait_core
+                    .wait_with_timeout(timeout, true, ExecWaitLifecycle::OneShot)
+                    .await?
+            }
+            None => {
+                self.wait_core
+                    .wait_for_dispatched_terminal(ExecWaitLifecycle::OneShot)
+                    .await?
+            }
+        };
         Ok(ExecCancelWaitResult { result, cancel_seq })
     }
 }
@@ -567,10 +597,18 @@ impl SupervisedExecHandle {
         if cancel_seq.is_some() {
             self.clear_unclaimed_stream_sender();
         }
-        let result = self
-            .wait_core
-            .wait_with_timeout(timeout, cancel_seq.is_some(), ExecWaitLifecycle::Supervised)
-            .await?;
+        let result = match cancel_seq {
+            Some(_) => {
+                self.wait_core
+                    .wait_with_timeout(timeout, true, ExecWaitLifecycle::Supervised)
+                    .await?
+            }
+            None => {
+                self.wait_core
+                    .wait_for_dispatched_terminal(ExecWaitLifecycle::Supervised)
+                    .await?
+            }
+        };
         Ok(ExecCancelWaitResult { result, cancel_seq })
     }
 }

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -301,18 +301,17 @@ impl ExecWaitCore {
         // The state lock already proved dispatch removed the operation; only the
         // terminal result delivery remains.
         self.active_seq_or_closed(Self::operation_closed_message(lifecycle))?;
-        let rx = self.result_rx.as_mut().ok_or_else(|| {
+        let rx = self.result_rx.take().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::ConnectionReset,
                 Self::operation_closed_message(lifecycle),
             )
         })?;
+        self.seq = None;
 
         let result = rx
             .await
             .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"));
-        self.seq = None;
-        self.result_rx = None;
         result?
     }
 }

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -315,10 +315,11 @@ impl ExecOperationHandle {
 
     /// Send an explicit cancel request and wait for a cancelled terminal result.
     ///
-    /// If the terminal result is already available before cancel is sent, this
-    /// returns that result without sending a duplicate cancel frame. If cancel
-    /// is sent but the terminal result does not arrive before `timeout`, the
-    /// connection is poisoned because guest process state is no longer known.
+    /// If terminal dispatch wins the race before cancel reaches the write
+    /// boundary, this returns that result without sending a stale cancel frame.
+    /// If cancel is sent but the terminal result does not arrive before
+    /// `timeout`, the connection is poisoned because guest process state is no
+    /// longer known.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
         let registered_at = self.wait_core.diagnostic().registered_at;
@@ -518,10 +519,11 @@ impl SupervisedExecHandle {
 
     /// Send `MSG_EXEC_CANCEL` and wait for the terminal exec result.
     ///
-    /// If the terminal result is already available before cancel is sent, this
-    /// returns that result without sending a duplicate cancel frame. If cancel
-    /// is sent but the terminal result does not arrive before `timeout`, the
-    /// connection is poisoned because guest process state is no longer known.
+    /// If terminal dispatch wins the race before cancel reaches the write
+    /// boundary, this returns that result without sending a stale cancel frame.
+    /// If cancel is sent but the terminal result does not arrive before
+    /// `timeout`, the connection is poisoned because guest process state is no
+    /// longer known.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
         let registered_at = self.wait_core.diagnostic().registered_at;

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -14,8 +14,8 @@ use super::EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT;
 use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
     ExecCancelFrameWriteOutcome, clear_exec_operation_stream_sender, exec_cancel_write_observer,
-    mark_pending_exec_control_possible_guest_write, send_exec_cancel_frame_for_wait,
-    write_frame, write_frame_with_pre_write,
+    mark_pending_exec_control_possible_guest_write, send_exec_cancel_frame_for_wait, write_frame,
+    write_frame_with_pre_write,
 };
 use super::state::{PendingExecControl, PendingExecControlGuard};
 use super::types::{
@@ -300,11 +300,11 @@ impl ExecWaitCore {
     ) -> io::Result<ExecOperationResult> {
         // The state lock already proved dispatch removed the operation; only the
         // terminal result delivery remains.
-        self.active_seq_or_closed(Self::operation_closed_message(lifecycle))?;
+        self.active_seq_or_closed(lifecycle.operation_closed_message())?;
         let rx = self.result_rx.take().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::ConnectionReset,
-                Self::operation_closed_message(lifecycle),
+                lifecycle.operation_closed_message(),
             )
         })?;
         self.seq = None;

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -13,8 +13,9 @@ use crate::{ConnectionState, FrameWriteObserver, Shared};
 use super::EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT;
 use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
-    clear_exec_operation_stream_sender, exec_cancel_write_observer,
-    mark_pending_exec_control_possible_guest_write, write_frame, write_frame_with_pre_write,
+    ExecCancelFrameWriteOutcome, clear_exec_operation_stream_sender, exec_cancel_write_observer,
+    mark_pending_exec_control_possible_guest_write, send_exec_cancel_frame_for_wait,
+    write_frame, write_frame_with_pre_write,
 };
 use super::state::{PendingExecControl, PendingExecControlGuard};
 use super::types::{
@@ -353,22 +354,25 @@ impl ExecOperationHandle {
         let seq = self
             .wait_core
             .active_seq_or_closed(ExecWaitLifecycle::OneShot.operation_closed_message())?;
-        send_exec_cancel_frame(
+        let cancel_outcome = send_exec_cancel_frame_for_wait(
             self.wait_core.shared(),
             seq,
             self.wait_core.diagnostic(),
-            ExecWaitLifecycle::OneShot,
         )
         .await?;
+        let cancel_seq = match cancel_outcome {
+            ExecCancelFrameWriteOutcome::Sent => {
+                ExecWaitLifecycle::OneShot.log_cancel_sent(seq, self.wait_core.diagnostic());
+                Some(seq)
+            }
+            ExecCancelFrameWriteOutcome::AlreadyTerminal => None,
+        };
 
         let result = self
             .wait_core
-            .wait_with_timeout(timeout, true, ExecWaitLifecycle::OneShot)
+            .wait_with_timeout(timeout, cancel_seq.is_some(), ExecWaitLifecycle::OneShot)
             .await?;
-        Ok(ExecCancelWaitResult {
-            result,
-            cancel_seq: Some(seq),
-        })
+        Ok(ExecCancelWaitResult { result, cancel_seq })
     }
 }
 
@@ -544,23 +548,28 @@ impl SupervisedExecHandle {
         let seq = self
             .wait_core
             .active_seq_or_closed(ExecWaitLifecycle::Supervised.operation_closed_message())?;
-        send_exec_cancel_frame(
+        let cancel_outcome = send_exec_cancel_frame_for_wait(
             self.wait_core.shared(),
             seq,
             self.wait_core.diagnostic(),
-            ExecWaitLifecycle::Supervised,
         )
         .await?;
+        let cancel_seq = match cancel_outcome {
+            ExecCancelFrameWriteOutcome::Sent => {
+                ExecWaitLifecycle::Supervised.log_cancel_sent(seq, self.wait_core.diagnostic());
+                Some(seq)
+            }
+            ExecCancelFrameWriteOutcome::AlreadyTerminal => None,
+        };
 
-        self.clear_unclaimed_stream_sender();
+        if cancel_seq.is_some() {
+            self.clear_unclaimed_stream_sender();
+        }
         let result = self
             .wait_core
-            .wait_with_timeout(timeout, true, ExecWaitLifecycle::Supervised)
+            .wait_with_timeout(timeout, cancel_seq.is_some(), ExecWaitLifecycle::Supervised)
             .await?;
-        Ok(ExecCancelWaitResult {
-            result,
-            cancel_seq: Some(seq),
-        })
+        Ok(ExecCancelWaitResult { result, cancel_seq })
     }
 }
 

--- a/crates/vsock-host/src/exec_operation/state.rs
+++ b/crates/vsock-host/src/exec_operation/state.rs
@@ -66,9 +66,12 @@ impl Operations {
         self.operations.get_mut(&seq)
     }
 
-    pub(in crate::exec_operation) fn mark_host_cancel_requested(&mut self, seq: u32) {
+    pub(in crate::exec_operation) fn mark_host_cancel_requested(&mut self, seq: u32) -> bool {
         if let Some(operation) = self.operations.get_mut(&seq) {
             operation.host_cancel_requested = true;
+            true
+        } else {
+            false
         }
     }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -32,7 +32,9 @@
 //! Dropping it removes only host-side registration and never sends
 //! `MSG_EXEC_CANCEL`; use [`ExecOperationHandle::wait`] to observe the
 //! terminal result or [`ExecOperationHandle::cancel_and_wait`] to send
-//! cancellation and wait for the cancelled terminal result. A plain wait
+//! cancellation and wait for the cancelled terminal result. If terminal
+//! dispatch wins the race before cancellation reaches the write boundary,
+//! cancel-and-wait returns that original terminal result instead. A plain wait
 //! timeout does not cancel the guest. If terminal proof is abandoned after a
 //! request may have reached the guest, the connection can remain open while
 //! later normal operations become unavailable on that connection. A timeout
@@ -44,8 +46,10 @@
 //! registration; the host keeps tracking the operation until terminal result
 //! dispatch, connection close, or an explicit wait timeout. Use
 //! [`SupervisedExecHandle::cancel_and_wait`] to send cancellation and consume
-//! the terminal result. [`SupervisedExecCancelHandle::cancel`] sends only the
-//! cancel frame and leaves terminal result ownership with the paired
+//! the terminal result. If terminal dispatch wins the race before cancellation
+//! reaches the write boundary, cancel-and-wait returns that original terminal
+//! result instead. [`SupervisedExecCancelHandle::cancel`] sends only the cancel
+//! frame and leaves terminal result ownership with the paired
 //! [`SupervisedExecHandle`].
 //!
 //! Streaming exec operations expose a bounded receiver through

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -245,6 +245,37 @@ async fn exec_cancel_after_terminal_result_returns_result_without_cancel_frame()
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn exec_cancel_terminal_before_cancel_write_returns_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "cancel-before-write-race").await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+
+    let writer_guard = host.shared.writer.lock().await;
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    tokio::task::yield_now().await;
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"done",
+        b"",
+    )
+    .await;
+    wait_for_operation_count(&host, 0).await;
+
+    drop(writer_guard);
+    let result = cancel_task.await.unwrap().unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(is_connected(&host));
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
 #[tokio::test]
 async fn exec_cancel_non_cancelled_terminal_result_cleans_operation_without_poisoning() {
     let (host, mut guest) = setup_host_and_guest().await;

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use vsock_proto::{ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START};
+use tokio::io::AsyncWriteExt;
+use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use super::super::support::{
     assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
@@ -274,6 +275,36 @@ async fn exec_cancel_terminal_before_cancel_write_returns_result() {
         .unwrap()
         .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(is_connected(&host));
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn exec_cancel_error_before_cancel_write_returns_error_without_cancel_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "cancel-before-error-race").await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+
+    let writer_guard = host.shared.writer.lock().await;
+    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    tokio::task::yield_now().await;
+
+    let payload = vsock_proto::encode_error("guest rejected exec");
+    let frame = vsock_proto::encode(MSG_ERROR, start.seq, &payload).unwrap();
+    guest.write_all(&frame).await.unwrap();
+    wait_for_operation_count(&host, 0).await;
+
+    drop(writer_guard);
+    let err = tokio::time::timeout(Duration::from_secs(5), cancel_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "guest rejected exec");
     assert!(is_connected(&host));
 
     assert_connection_accepts_exec_operation(&host, &mut guest).await;

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -254,8 +254,7 @@ async fn exec_cancel_terminal_before_cancel_write_returns_result() {
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
     let writer_guard = host.shared.writer.lock().await;
-    let cancel_task =
-        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
     tokio::task::yield_now().await;
 
     send_exec_result(
@@ -269,7 +268,11 @@ async fn exec_cancel_terminal_before_cancel_write_returns_result() {
     wait_for_operation_count(&host, 0).await;
 
     drop(writer_guard);
-    let result = cancel_task.await.unwrap().unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(5), cancel_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(is_connected(&host));
 

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -240,6 +240,49 @@ async fn supervised_exec_cancel_after_terminal_result_returns_result_without_can
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-before-write-race"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let writer_guard = host.shared.writer.lock().await;
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    tokio::task::yield_now().await;
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"done",
+        b"",
+    )
+    .await;
+    wait_for_operation_count(&host, 0).await;
+
+    drop(writer_guard);
+    let result = cancel_task.await.unwrap().unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(is_connected(&host));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
 #[tokio::test]
 async fn supervised_exec_cancel_non_cancelled_terminal_result_cleans_without_poisoning() {
     let (host, mut guest) = setup_host_and_guest().await;

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -9,7 +9,7 @@ use super::super::super::support::{
     operation_count, read_guest_message, send_exec_result, send_exec_started, setup_host_and_guest,
     wait_for_operation_count,
 };
-use super::support::supervised_request;
+use super::support::{send_guest_error, supervised_request};
 use crate::ExecOwnedCapturedOutput;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
@@ -277,6 +277,46 @@ async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
         .unwrap()
         .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert!(is_connected(&host));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn supervised_exec_cancel_error_before_cancel_write_returns_error_without_cancel_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-before-error-race"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let writer_guard = host.shared.writer.lock().await;
+    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    tokio::task::yield_now().await;
+
+    send_guest_error(&mut guest, start.seq, "guest rejected supervised exec").await;
+    wait_for_operation_count(&host, 0).await;
+
+    drop(writer_guard);
+    let err = tokio::time::timeout(Duration::from_secs(5), cancel_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "guest rejected supervised exec");
     assert!(is_connected(&host));
     assert_eq!(
         normal_operation_readiness(&host),

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -257,8 +257,7 @@ async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
     let handle = task.await.unwrap().unwrap();
 
     let writer_guard = host.shared.writer.lock().await;
-    let cancel_task =
-        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
     tokio::task::yield_now().await;
 
     send_exec_result(
@@ -272,7 +271,11 @@ async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
     wait_for_operation_count(&host, 0).await;
 
     drop(writer_guard);
-    let result = cancel_task.await.unwrap().unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(5), cancel_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(is_connected(&host));
     assert_eq!(


### PR DESCRIPTION
## Summary

- linearize cancel-and-wait frame writes against terminal dispatch using shared exec operation state
- skip stale cancel frames when terminal dispatch already removed the operation
- add one-shot and supervised regression coverage for terminal-before-cancel-write races

Fixes #17708

## Tests

- cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation::cancel
- cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation::supervised::cancel
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
