### PR TITLE
refactor: centralize model-provider metadata test setup

### DIFF
--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -1,0 +1,104 @@
+"""Shared model-provider flow helpers for mitm-addon tests."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+from mitmproxy import http
+from mitmproxy.test import tutils
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from tests.flow_helpers import header_map
+
+RealFlowFactory = Callable[..., http.HTTPFlow]
+
+
+def make_model_provider_flow(
+    real_flow: RealFlowFactory,
+    tmp_path: Path,
+    *,
+    host: str,
+    original_url: str,
+    firewall_name: str,
+    path: str = "/",
+    method: str = "GET",
+    run_id: str = "run-abc-123",
+    network_log_path: Path | str | None = None,
+    proxy_log_path: Path | str | None = None,
+    firewall_action: str = "ALLOW",
+    firewall_billable: object = True,
+    sandbox_token: str | None = None,
+    cli_agent_type: str | None = None,
+    model_usage_provider: str | None = None,
+) -> http.HTTPFlow:
+    flow = real_flow(with_response=False, host=host, path=path, method=method)
+    flow.metadata[metadata_keys.VM_RUN_ID] = run_id
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(
+        network_log_path if network_log_path is not None else tmp_path / "network.jsonl"
+    )
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(
+        proxy_log_path if proxy_log_path is not None else tmp_path / "proxy.jsonl"
+    )
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = firewall_action
+    flow.metadata[metadata_keys.ORIGINAL_URL] = original_url
+    flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = (
+        "tok-xyz" if sandbox_token is None else sandbox_token
+    )
+    if cli_agent_type is not None:
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = cli_agent_type
+    if model_usage_provider is not None:
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = model_usage_provider
+    return flow
+
+
+def make_openai_responses_websocket_flow(
+    real_flow: RealFlowFactory,
+    tmp_path: Path,
+) -> http.HTTPFlow:
+    flow = make_model_provider_flow(
+        real_flow,
+        tmp_path,
+        host="api.openai.com",
+        original_url="https://api.openai.com/v1/responses",
+        firewall_name="model-provider:openai-api-key",
+        cli_agent_type="codex",
+    )
+    flow.response = tutils.tresp(
+        status_code=101,
+        headers=http.Headers(upgrade="websocket"),
+    )
+    mitm_addon.responseheaders(flow)
+    return flow
+
+
+def make_model_provider_sse_flow(
+    real_flow: RealFlowFactory,
+    tmp_path: Path,
+    *,
+    host: str,
+    original_url: str,
+    firewall_name: str,
+    cli_agent_type: str | None = None,
+) -> http.HTTPFlow:
+    flow = make_model_provider_flow(
+        real_flow,
+        tmp_path,
+        host=host,
+        original_url=original_url,
+        firewall_name=firewall_name,
+        cli_agent_type=cli_agent_type,
+    )
+    flow.response = tutils.tresp(
+        status_code=200,
+        headers=header_map({"content-type": "text/event-stream"}),
+    )
+    mitm_addon.responseheaders(flow)
+    return flow
+
+
+def model_provider_usage_sources(flow: http.HTTPFlow) -> dict:
+    sources = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES]
+    assert isinstance(sources, dict)
+    return sources

--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -6,10 +6,13 @@ from pathlib import Path
 
 import pytest
 from mitmproxy import http, websocket
-from mitmproxy.test import tutils
 from wsproto.frame_protocol import Opcode
 
 import mitm_addon
+from tests.model_provider_flow_helpers import (
+    make_openai_responses_websocket_flow,
+    model_provider_usage_sources,
+)
 
 _WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
 _ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
@@ -18,23 +21,7 @@ _ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
 def _openai_model_websocket_flow(
     tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
 ) -> http.HTTPFlow:
-    flow = real_flow(with_response=False, host="api.openai.com")
-    flow.metadata["vm_run_id"] = "run-abc-123"
-    flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-    flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-    flow.metadata["firewall_action"] = "ALLOW"
-    flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
-    flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-    flow.metadata["cli_agent_type"] = "codex"
-    flow.metadata["firewall_billable"] = True
-    flow.metadata["vm_sandbox_token"] = "tok-xyz"
-    flow.response = tutils.tresp(
-        status_code=101,
-        headers=http.Headers(upgrade="websocket"),
-    )
-
-    mitm_addon.responseheaders(flow)
-    return flow
+    return make_openai_responses_websocket_flow(real_flow, tmp_path)
 
 
 def _capture_deferred_websocket_trims(
@@ -125,6 +112,4 @@ def _feed_websocket_server_text_message(flow: http.HTTPFlow, content: str) -> No
 
 
 def _model_websocket_usage_sources(flow: http.HTTPFlow) -> dict:
-    sources = flow.metadata["model_provider_usage_sources"]
-    assert isinstance(sources, dict)
-    return sources
+    return model_provider_usage_sources(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -12,6 +12,7 @@ import pytest
 import zstandard
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import logging_utils
 import mitm_addon
 import usage
@@ -298,13 +299,13 @@ class TestModelProviderResponseUsage:
         proxy_log_path: Path | None = None,
         run_id: str = "run-abc-123",
     ) -> None:
-        flow.metadata["vm_run_id"] = run_id
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
+        flow.metadata[metadata_keys.VM_RUN_ID] = run_id
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
         if proxy_log_path is not None:
-            flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_billable"] = billable
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+            flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = billable
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
 
     def _set_model_provider_metadata(
         self,
@@ -323,10 +324,10 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
             run_id=run_id,
         )
-        flow.metadata["original_url"] = provider_case.original_url
-        flow.metadata["firewall_name"] = provider_case.firewall_name
+        flow.metadata[metadata_keys.ORIGINAL_URL] = provider_case.original_url
+        flow.metadata[metadata_keys.FIREWALL_NAME] = provider_case.firewall_name
         if provider_case.cli_agent_type is not None:
-            flow.metadata["cli_agent_type"] = provider_case.cli_agent_type
+            flow.metadata[metadata_keys.CLI_AGENT_TYPE] = provider_case.cli_agent_type
 
     def _model_provider_flow(
         self,
@@ -366,7 +367,7 @@ class TestModelProviderResponseUsage:
         self._run_response(flow)
 
         # JSON fallback should populate model_provider_usage in metadata
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected = _expected_usage(provider_case)
         assert extracted["model"] == expected["model"]
         assert extracted["tokens.input"] == expected["tokens.input"]
@@ -387,7 +388,7 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected = _expected_usage(provider_case)
         assert extracted["message_id"] == expected["message_id"]
         assert extracted["model"] == expected["model"]
@@ -417,7 +418,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
@@ -451,7 +452,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
@@ -479,7 +480,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
@@ -529,7 +530,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         entries = read_jsonl_entries_after_flush(proxy_log_path)
         assert len(entries) == 1
         assert entries[0]["level"] == "warn"
@@ -576,7 +577,7 @@ class TestModelProviderResponseUsage:
 
         self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected = _expected_usage(provider_case)
         assert extracted["model"] == expected["model"]
         assert extracted["tokens.input"] == expected["tokens.input"]
@@ -631,7 +632,7 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected_usage = _expected_usage(provider_case)
         assert extracted["model"] == expected_usage["model"]
         assert extracted["tokens.input"] == expected_usage["tokens.input"]
@@ -667,7 +668,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
@@ -690,7 +691,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
@@ -743,7 +744,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
@@ -766,7 +767,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert flow.metadata["model_provider_usage"] == {
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
             "message_id": "msg_1",
             "model": "claude-sonnet-4-6",
         }
@@ -809,7 +810,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert flow.metadata["model_provider_usage"] == expected_usage
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == expected_usage
         logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
@@ -828,7 +829,7 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected = _expected_usage(provider_case)
         assert extracted["message_id"] == expected["message_id"]
         assert extracted["model"] == expected["model"]
@@ -856,7 +857,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
     def test_non_billable_json_fallback_parse_error_stays_quiet(self, tmp_path, real_flow):
         """Non-billable model-provider fallback must not emit usage warnings."""
@@ -878,7 +879,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
@@ -938,7 +939,7 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected_usage = _expected_usage(provider_case)
         assert extracted["model"] == expected_usage["model"]
         assert extracted["tokens.input"] == expected_usage["tokens.input"]
@@ -978,7 +979,7 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected_usage = _expected_usage(provider_case)
         assert extracted["model"] == expected_usage["model"]
         assert extracted["tokens.input"] == expected_usage["tokens.input"]
@@ -1014,7 +1015,7 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        extracted = flow.metadata["model_provider_usage"]
+        extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
         expected_usage = _expected_usage(provider_case)
         assert extracted["model"] == expected_usage["model"]
         assert extracted["tokens.input"] == expected_usage["tokens.input"]
@@ -1049,7 +1050,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         entries = read_jsonl_entries_after_flush(proxy_log)
         usage_warnings = [
             entry
@@ -1087,7 +1088,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         assert "stream_buffer" not in flow.metadata
 
     def test_full_pipeline_model_json_ignores_usage_array_shape(self, tmp_path, real_flow):
@@ -1121,12 +1122,12 @@ class TestModelProviderResponseUsage:
         """Non-model-provider requests should not trigger usage reporting."""
         flow = real_flow(with_response=False, host="api.github.com")
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
-        flow.metadata["firewall_name"] = "github"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
         body = b'{"incomplete":'
         set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
@@ -1136,7 +1137,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         logging_utils.flush_log_path(str(proxy_log_path))
         assert not proxy_log_path.exists()
 
@@ -1144,8 +1145,8 @@ class TestModelProviderResponseUsage:
     def test_json_fallback_skips_malformed_firewall_name(self, tmp_path, real_flow, firewall_name):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         self._set_common_model_metadata(flow, tmp_path)
-        flow.metadata["original_url"] = ANTHROPIC_JSON_CASE.original_url
-        flow.metadata["firewall_name"] = firewall_name
+        flow.metadata[metadata_keys.ORIGINAL_URL] = ANTHROPIC_JSON_CASE.original_url
+        flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
         body = _standard_success_payload(ANTHROPIC_JSON_CASE)
         set_stream_buffer(flow, body)
         flow.response = tutils.tresp(
@@ -1155,7 +1156,7 @@ class TestModelProviderResponseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
 
 class TestModelProviderResponseUsageWebhookDelivery:
@@ -1170,14 +1171,14 @@ class TestModelProviderResponseUsageWebhookDelivery:
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-int-001"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-int-001"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "tokens.input": 100,
             "tokens.output": 500,

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -7,15 +7,16 @@ from pathlib import Path
 import pytest
 from mitmproxy import http
 from mitmproxy.flow import Error
-from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
-from tests.flow_helpers import header_map, response_stream
+from tests.flow_helpers import response_stream
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
+from tests.model_provider_flow_helpers import make_model_provider_sse_flow
 
 
 def _model_provider_sse_flow(
@@ -27,24 +28,14 @@ def _model_provider_sse_flow(
     firewall_name: str,
     cli_agent_type: str | None = None,
 ) -> http.HTTPFlow:
-    flow = real_flow(with_response=False, host=host)
-    flow.metadata["vm_run_id"] = "run-abc-123"
-    flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-    flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-    flow.metadata["firewall_action"] = "ALLOW"
-    flow.metadata["original_url"] = original_url
-    flow.metadata["firewall_name"] = firewall_name
-    flow.metadata["firewall_billable"] = True
-    flow.metadata["vm_sandbox_token"] = "tok-xyz"
-    if cli_agent_type is not None:
-        flow.metadata["cli_agent_type"] = cli_agent_type
-    flow.response = tutils.tresp(
-        status_code=200,
-        headers=header_map({"content-type": "text/event-stream"}),
+    return make_model_provider_sse_flow(
+        real_flow,
+        tmp_path,
+        host=host,
+        original_url=original_url,
+        firewall_name=firewall_name,
+        cli_agent_type=cli_agent_type,
     )
-
-    mitm_addon.responseheaders(flow)
-    return flow
 
 
 def _openai_responses_sse_flow(
@@ -61,7 +52,7 @@ def _openai_responses_sse_flow(
 
 
 def _model_sse_parse_warnings(flow: http.HTTPFlow) -> list[dict]:
-    proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
     if not jsonl_exists_after_flush(proxy_log):
         return []
     return [

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import usage
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -19,11 +20,11 @@ class TestReportModelProviderUsage:
     ):
         """Model-provider usage reaches the webhook boundary with correct payload."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_usage_provider"] = "claude-opus-4-6"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-opus-4-6"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "message_id": "msg-usage-1",
             "tokens.input": 100,
@@ -81,10 +82,10 @@ class TestReportModelProviderUsage:
     ):
         """Provider falls back only when selected vm0 model metadata is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "msg-usage-1",
             "tokens.input": 100,
         }
@@ -98,10 +99,10 @@ class TestReportModelProviderUsage:
         assert body["events"][0]["provider"] == "unknown"
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "msg-usage-2",
             "model": "claude-sonnet-4-6",
             "tokens.input": 100,
@@ -118,10 +119,10 @@ class TestReportModelProviderUsage:
         self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "msg-usage-1",
             "tokens.input": 0,
             "tokens.output": -1,
@@ -146,10 +147,10 @@ class TestReportModelProviderUsage:
         credits should be charged.
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = False
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {"tokens.input": 100}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 100}
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
@@ -163,11 +164,11 @@ class TestReportModelProviderUsage:
     ):
         """BYOK model providers report observations without billing events."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = False
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "ignored-runtime-model",
             "message_id": "msg-byok-usage-1",
             "tokens.input": 100,
@@ -194,11 +195,11 @@ class TestReportModelProviderUsage:
         self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:vm0"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "msg-built-in-usage-1",
             "tokens.input": 100,
         }
@@ -228,8 +229,8 @@ class TestReportModelProviderUsage:
     def test_skips_non_model_provider(self, real_flow, fresh_usage_executor, usage_webhook_api):
         """Should NOT reach the webhook boundary for non-model-provider requests."""
         flow = real_flow(with_response=False, host="api.github.com")
-        flow.metadata["firewall_name"] = "github"
-        flow.metadata["model_provider_usage"] = {"tokens.input": 50}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 50}
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
@@ -243,10 +244,10 @@ class TestReportModelProviderUsage:
         self, real_flow, fresh_usage_executor, usage_webhook_api, firewall_name
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = firewall_name
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {"tokens.input": 50}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 50}
 
         with usage_webhook_api() as webhook:
             accepted = usage.report_model_provider_usage(flow, "run-abc-123")
@@ -261,8 +262,8 @@ class TestReportModelProviderUsage:
     ):
         """Should NOT reach the webhook boundary when model_provider_usage is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
         # No model_provider_usage in metadata
 
         with usage_webhook_api() as webhook:
@@ -275,8 +276,8 @@ class TestReportModelProviderUsage:
     def test_skips_when_no_run_id(self, real_flow, fresh_usage_executor, usage_webhook_api):
         """Should NOT reach the webhook boundary when run_id is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["model_provider_usage"] = {"tokens.input": 50}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 50}
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "")
@@ -290,12 +291,12 @@ class TestReportModelProviderUsage:
     ):
         """Should write to proxy log and skip when sandbox_token is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = ""
-        flow.metadata["model_provider_usage"] = {"tokens.input": 50}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 50}
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
@@ -312,12 +313,12 @@ class TestReportModelProviderUsage:
     def test_warns_when_missing_api_url(self, tmp_path, real_flow, fresh_usage_executor, mitm_ctx):
         """Should write to proxy log and skip when api_url is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {"tokens.input": 50}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 50}
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
 
         with mitm_ctx(api_url=""):
             usage.report_model_provider_usage(flow, "run-abc-123")
@@ -335,10 +336,10 @@ class TestReportModelProviderUsage:
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "tokens.input": 10,
         }
@@ -357,10 +358,10 @@ class TestReportModelProviderUsage:
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "message_id": "msg_real_anthropic_id",
             "tokens.input": 10,
@@ -380,10 +381,10 @@ class TestReportModelProviderUsage:
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.id = "flow-uuid-xyz-123"
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage_sources"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {
             "resp_ws_1": {
                 "model": "gpt-5.5",
                 "message_id": "resp_ws_1",
@@ -442,10 +443,10 @@ class TestReportModelProviderUsage:
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.id = "flow-uuid-xyz-123"
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage_sources"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {
             "resp_ws_1": {
                 "model": "gpt-5.5",
                 "message_id": "resp_ws_1",
@@ -489,10 +490,10 @@ class TestReportModelProviderUsage:
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.id = "flow-uuid-xyz-123"
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage_sources"] = {
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {
             "resp_invalid": "invalid",
             "": {"model": "gpt-5.5", "tokens.input": 10},
             42: {"model": "gpt-5.4", "tokens.input": 3},
@@ -516,10 +517,10 @@ class TestReportModelProviderUsage:
         second = real_flow(with_response=False, host="api.anthropic.com")
         second.id = "flow-second"
         for flow in (first, second):
-            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-            flow.metadata["firewall_billable"] = True
-            flow.metadata["vm_sandbox_token"] = "tok-xyz"
-            flow.metadata["model_provider_usage"] = {
+            flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+            flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
                 "model": "claude-sonnet-4-6",
                 "tokens.input": 10,
             }
@@ -541,10 +542,10 @@ class TestReportModelProviderUsage:
         second = real_flow(with_response=False, host="api.anthropic.com")
         second.id = "flow-second"
         for flow in (first, second):
-            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-            flow.metadata["firewall_billable"] = True
-            flow.metadata["vm_sandbox_token"] = "tok-xyz"
-            flow.metadata["model_provider_usage"] = {
+            flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+            flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
                 "model": "claude-sonnet-4-6",
                 "message_id": "msg_real_anthropic_id",
                 "tokens.input": 10,
@@ -567,11 +568,11 @@ class TestReportModelProviderUsage:
         second = real_flow(with_response=False, host="api.anthropic.com")
         second.id = "flow-second"
         for flow in (first, second):
-            flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-            flow.metadata["firewall_billable"] = False
-            flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
-            flow.metadata["vm_sandbox_token"] = "tok-xyz"
-            flow.metadata["model_provider_usage"] = {
+            flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+            flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+            flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+            flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
                 "model": "ignored-runtime-model",
                 "message_id": "msg_real_anthropic_id",
                 "tokens.input": 10,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from mitmproxy import http
 
+import flow_metadata_keys as metadata_keys
 from tests.model_provider_websocket_helpers import (
     _capture_deferred_websocket_trims,
     _feed_websocket_server_message,
@@ -28,7 +29,7 @@ def _openai_model_websocket_metadata_flow(
     tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
 ) -> http.HTTPFlow:
     flow = _openai_model_websocket_flow(tmp_path, real_flow)
-    flow.metadata["vm_sandbox_token"] = ""
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
     return flow
 
 
@@ -186,7 +187,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
     def test_model_websocket_malformed_frame_preserves_prior_usage(self, tmp_path, real_flow):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
             "tokens.input": 10,
@@ -195,7 +196,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
         _feed_websocket_server_message(flow, b'{"type":"response.completed"')
 
-        assert flow.metadata["model_provider_usage"] == {
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
             "tokens.input": 10,
@@ -206,7 +207,7 @@ class TestModelProviderWebSocketUsageMetadata:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
-        flow.metadata["model_provider_usage_sources"] = "invalid"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = "invalid"
 
         _feed_websocket_server_message(
             flow,
@@ -230,14 +231,14 @@ class TestModelProviderWebSocketUsageMetadata:
                 "tokens.output": 4,
             }
         }
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
 
     def test_model_websocket_ignores_invalid_frames_with_non_dict_usage_metadata(
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
-        flow.metadata["model_provider_usage"] = "invalid"
-        flow.metadata["model_provider_usage_sources"] = "invalid"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = "invalid"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = "invalid"
 
         _feed_websocket_server_message(
             flow,
@@ -248,9 +249,9 @@ class TestModelProviderWebSocketUsageMetadata:
                 }
             ).encode(),
         )
-        assert flow.metadata["model_provider_usage"] == "invalid"
-        assert flow.metadata["model_provider_usage_sources"] == "invalid"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == "invalid"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] == "invalid"
 
         _feed_websocket_server_message(flow, b'{"type":"response.completed"')
-        assert flow.metadata["model_provider_usage"] == "invalid"
-        assert flow.metadata["model_provider_usage_sources"] == "invalid"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == "invalid"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] == "invalid"

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -10,6 +10,7 @@ from mitmproxy import http
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.model_provider_websocket_helpers import (
@@ -150,7 +151,7 @@ class TestModelProviderWebSocketUsage:
 
         events = webhook.usage_events()
         by_category = _sum_quantities_by_category(events)
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert _model_websocket_usage_sources(flow) == {}
         assert by_category == {
             "tokens.input": 40,
@@ -360,7 +361,7 @@ class TestModelProviderWebSocketUsage:
             ),
         )
 
-        assert flow.metadata["model_provider_usage"] == {
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {
             "model": "gpt-5.5",
             "tokens.input": 7,
             "tokens.output": 1,
@@ -604,7 +605,7 @@ class TestModelProviderWebSocketUsage:
         webhook = self._run_websocket_message_and_end(flow)
 
         assert webhook.request_count == 0
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert _model_websocket_usage_sources(flow) == {}
 
     def test_model_websocket_deferred_trim_keeps_latest_server_message(
@@ -634,7 +635,7 @@ class TestModelProviderWebSocketUsage:
             "tokens.input": 10,
             "tokens.output": 4,
         }
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert len(deferred_websocket_trim_scheduler) == 1
 
         _run_deferred_websocket_trims(deferred_websocket_trim_scheduler)
@@ -658,7 +659,7 @@ class TestModelProviderWebSocketUsage:
 
         mitm_addon.websocket_message(flow)
 
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert _model_websocket_usage_sources(flow) == {}
         assert len(deferred_websocket_trim_scheduler) == 1
 
@@ -708,7 +709,7 @@ class TestModelProviderWebSocketUsage:
             "tokens.input": 11,
             "tokens.output": 5,
         }
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
 
     def test_non_model_websocket_message_retention_is_unchanged(
         self,
@@ -716,7 +717,7 @@ class TestModelProviderWebSocketUsage:
         deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
     ):
         flow = real_flow(with_response=False, host="example.com")
-        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
         first = _append_websocket_message(flow, from_client=True, content=b"client")
         second = _append_websocket_message(flow, from_client=False, content=b"server")
 

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -15,6 +15,7 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
+from tests.model_provider_flow_helpers import make_model_provider_flow
 from tests.usage_helpers import set_stream_buffer
 
 
@@ -25,17 +26,15 @@ class TestUsageReportingIdempotency:
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """If mitmproxy fires both hooks for one flow, model usage reports once."""
-        flow = real_flow(with_response=False, host="api.openai.com")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow = make_model_provider_flow(
+            real_flow,
+            tmp_path,
+            host="api.openai.com",
+            original_url="https://api.openai.com/v1/responses",
+            firewall_name="model-provider:openai-api-key",
+            cli_agent_type="codex",
+        )
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "gpt-5.5",
             "tokens.output": 20,
         }
@@ -57,7 +56,7 @@ class TestUsageReportingIdempotency:
 
         events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         if jsonl_exists_after_flush(proxy_log):
             entries = read_jsonl_entries_after_flush(proxy_log)
             assert not any(
@@ -69,17 +68,15 @@ class TestUsageReportingIdempotency:
         self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
     ):
         """A no-event response pass must not mark the flow reported."""
-        flow = real_flow(with_response=False, host="api.openai.com")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.openai.com/v1/responses"
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {"model": "gpt-5.5"}
+        flow = make_model_provider_flow(
+            real_flow,
+            tmp_path,
+            host="api.openai.com",
+            original_url="https://api.openai.com/v1/responses",
+            firewall_name="model-provider:openai-api-key",
+            cli_agent_type="codex",
+        )
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"model": "gpt-5.5"}
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -89,7 +86,7 @@ class TestUsageReportingIdempotency:
             mitm_addon.response(flow)
             assert webhook.request_count == 0
 
-            flow.metadata["model_provider_usage"]["tokens.output"] = 20
+            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.output"] = 20
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
@@ -107,17 +104,18 @@ class TestUsageReportingIdempotency:
         observations could be aggregated twice before the webhook payload is
         built.
         """
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.id = "flow-uuid-xyz-123"
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-fallback"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow = make_model_provider_flow(
+            real_flow,
+            tmp_path,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+            run_id="run-fallback",
+            network_log_path=log_path,
+        )
+        flow.id = "flow-uuid-xyz-123"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "tokens.input": 10,
             # no message_id set
@@ -155,17 +153,18 @@ class TestUsageReportingIdempotency:
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
     ):
         """Provider message_id metadata must not block ordinary usage reporting."""
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.id = "flow-should-not-win"
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-preserved"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow = make_model_provider_flow(
+            real_flow,
+            tmp_path,
+            host="api.anthropic.com",
+            original_url="https://api.anthropic.com/v1/messages",
+            firewall_name="model-provider:anthropic-api-key",
+            run_id="run-preserved",
+            network_log_path=log_path,
+        )
+        flow.id = "flow-should-not-win"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "message_id": "msg_real_anthropic_id",
             "tokens.input": 10,


### PR DESCRIPTION
## Summary
- Add a narrow model-provider flow helper for shared request/firewall metadata setup in mitm-addon tests.
- Migrate model-provider WebSocket, SSE, idempotency, reporter, and response-usage tests to shared metadata constants where they seed internal flow metadata.
- Keep public webhook/log/schema and normalized usage payload fields as string literals.

## Tests
- `PYTHONPATH=/tmp/mitm-addon-pydeps python3 -m ruff check tests/model_provider_flow_helpers.py tests/model_provider_websocket_helpers.py tests/test_model_provider_websocket_metadata.py tests/test_model_provider_websocket_usage.py tests/test_model_provider_sse_usage.py tests/test_usage_reporting_idempotency.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `PYTHONPATH=/tmp/mitm-addon-pydeps python3 -m ruff format --check tests/model_provider_flow_helpers.py tests/model_provider_websocket_helpers.py tests/test_model_provider_websocket_metadata.py tests/test_model_provider_websocket_usage.py tests/test_model_provider_sse_usage.py tests/test_usage_reporting_idempotency.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `PYTHONPATH=/tmp/mitm-addon-pydeps python3 -m basedpyright tests/model_provider_flow_helpers.py tests/model_provider_websocket_helpers.py tests/test_model_provider_websocket_metadata.py tests/test_model_provider_websocket_usage.py tests/test_model_provider_sse_usage.py tests/test_usage_reporting_idempotency.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`
- `PYTHONPATH=/tmp/mitm-addon-pydeps python3 -m pytest tests/test_model_provider_websocket_metadata.py tests/test_model_provider_websocket_usage.py tests/test_model_provider_sse_usage.py tests/test_usage_reporting_idempotency.py tests/test_model_provider_usage.py tests/test_model_provider_response_usage.py`

Closes #17702