### PR TITLE
fix: store credit purchases with distinct source

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -2507,7 +2507,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     expect(afterLegacyCredit.creditGrants).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          source: "auto_recharge",
+          source: "credit_purchase",
           amount: 100_000,
           expiresAt: checkoutCreditExpiresAt,
         }),
@@ -2564,7 +2564,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     expect(afterInvoiceCredit.creditGrants).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          source: "auto_recharge",
+          source: "credit_purchase",
           amount: 100_000,
           expiresAt: new Date(invoiceCreditExpiresAt * 1000).toISOString(),
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -413,7 +413,7 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.body.credits).toBe(100_000);
   });
 
-  it("maps auto_recharge expires records to Pay as you go segment", async () => {
+  it("maps pay-as-you-go expires records to Pay as you go segment", async () => {
     const fixture = await track(
       store.set(
         seedBillingStatusOrg$,
@@ -433,7 +433,7 @@ describe("GET /api/zero/billing/status", () => {
               expiresAt: new Date("2099-06-20T00:00:00Z"),
             },
             {
-              source: "auto_recharge",
+              source: "credit_purchase",
               amount: 10_000,
               expiresAt: new Date("2999-12-31T00:00:00Z"),
             },
@@ -466,7 +466,9 @@ describe("GET /api/zero/billing/status", () => {
     });
     expect(
       response.body.creditGrants.filter((grant) => {
-        return grant.source === "auto_recharge";
+        return (
+          grant.source === "auto_recharge" || grant.source === "credit_purchase"
+        );
       }),
     ).toHaveLength(2);
   });

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -594,7 +594,7 @@ async function handleCreditPurchaseInvoicePaid(
 
   await db.transaction(async (tx) => {
     const inserted = await createExpiresRecord(tx, orgId, {
-      source: "auto_recharge",
+      source: "credit_purchase",
       stripeInvoiceId: invoice.id,
       amount: creditsAmount,
       expiresAt,
@@ -706,7 +706,7 @@ async function handleCreditPurchaseCompleted(
 
   await db.transaction(async (tx) => {
     const inserted = await createExpiresRecord(tx, orgId, {
-      source: "auto_recharge",
+      source: "credit_purchase",
       stripeInvoiceId: session.id,
       amount: creditsAmount,
       expiresAt,

--- a/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-status.service.ts
@@ -109,6 +109,10 @@ function planTierFromAmount(amount: number): PlanCreditTier | null {
   return null;
 }
 
+function isPayAsYouGoCreditSource(source: string): boolean {
+  return source === "auto_recharge" || source === "credit_purchase";
+}
+
 function labelForCreditRecord(
   record: Pick<ActiveCreditRecord, "source" | "amount">,
 ): string {
@@ -128,7 +132,7 @@ function labelForCreditRecord(
   if (record.source === "one_time_purchase") {
     return "Promotional";
   }
-  if (record.source === "auto_recharge") {
+  if (isPayAsYouGoCreditSource(record.source)) {
     return "Pay as you go";
   }
   return "Credits";
@@ -187,7 +191,7 @@ function buildCreditBreakdown(args: {
         label: "Promotional",
         credits: record.remaining,
       });
-    } else if (record.source === "auto_recharge") {
+    } else if (isPayAsYouGoCreditSource(record.source)) {
       addSegment({
         category: "payAsYouGo",
         label: "Pay as you go",

--- a/turbo/packages/db/src/schema/credit-expires-record.ts
+++ b/turbo/packages/db/src/schema/credit-expires-record.ts
@@ -13,8 +13,9 @@ import { sql } from "drizzle-orm";
 /**
  * credit_expires_record — tracks credits with expiration times.
  * Free-tier starter credits (source='starter_grant') and subscription credits
- * (source='subscription_renewal') expire after 1 month; auto-recharge credits
- * do NOT expire and are NOT tracked here.
+ * (source='subscription_renewal') expire after their billing window. Credit
+ * purchases (source='credit_purchase') and auto-recharge grants
+ * (source='auto_recharge') are displayed as Pay as you go credits.
  * During deduction, expiring credits are consumed first (FEFO — First Expiring, First Out).
  */
 export const creditExpiresRecord = pgTable(


### PR DESCRIPTION
## Summary
- store credit purchase grants with `source = "credit_purchase"` instead of reusing `auto_recharge`
- keep both `credit_purchase` and `auto_recharge` displayed as Pay as you go credits
- update webhook and billing status coverage for the new source

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-status.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit: prettier, knip, full `pnpm check-types`
