### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -366,26 +366,26 @@ install_packages() {
   rm -rf /var/lib/apt/lists/* /var/cache/apt/*
   '
 
-  # Chromium from Debian Bookworm security (Ubuntu 24.04 snap stub does not work).
+  # Chromium from Debian Trixie security (Ubuntu 24.04 snap stub does not work).
   # Installed separately to avoid cross-distro dependency conflicts.
   sudo chroot "$ROOTFS_DIR" bash -c 'set -e
     export DEBIAN_FRONTEND=noninteractive
     {
-      curl -fsSL https://ftp-master.debian.org/keys/archive-key-12.asc
-      curl -fsSL https://ftp-master.debian.org/keys/archive-key-12-security.asc
+      curl -fsSL https://ftp-master.debian.org/keys/archive-key-13.asc
+      curl -fsSL https://ftp-master.debian.org/keys/archive-key-13-security.asc
     } \
-      | gpg --dearmor -o /usr/share/keyrings/debian-bookworm.gpg
-    cat > /etc/apt/sources.list.d/debian-bookworm.list <<EOF
-deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main
-deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://security.debian.org/debian-security bookworm-security main
+      | gpg --dearmor -o /usr/share/keyrings/debian-trixie.gpg
+    cat > /etc/apt/sources.list.d/debian-trixie.list <<EOF
+deb [signed-by=/usr/share/keyrings/debian-trixie.gpg] http://deb.debian.org/debian trixie main
+deb [signed-by=/usr/share/keyrings/debian-trixie.gpg] http://security.debian.org/debian-security trixie-security main
 EOF
     apt-get update
-    apt-get install -y -t bookworm \
-      chromium/bookworm-security \
-      chromium-common/bookworm-security \
-      chromium-sandbox/bookworm-security
-    rm -f /etc/apt/sources.list.d/debian-bookworm.list \
-         /usr/share/keyrings/debian-bookworm.gpg
+    apt-get install -y -t trixie \
+      chromium/trixie-security \
+      chromium-common/trixie-security \
+      chromium-sandbox/trixie-security
+    rm -f /etc/apt/sources.list.d/debian-trixie.list \
+         /usr/share/keyrings/debian-trixie.gpg
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
   '
 


### PR DESCRIPTION
## Summary

- Updated the Chromium Debian package source used by `crates/runner/scripts/build-template.sh` from Debian Bookworm security to Debian Trixie security.

## Version updates

- Chromium Debian security package source: `149.0.7827.114-1~deb12u1` via Bookworm security -> `149.0.7827.114-1~deb13u1` via Trixie security.
- Debian archive keys: `archive-key-12.asc` / `archive-key-12-security.asc` -> `archive-key-13.asc` / `archive-key-13-security.asc`.

## Notes

- Ubuntu remains pinned to `noble` / Ubuntu 24.04 as requested.
- Checked the other pinned tool versions in the script; no newer stable/LTS updates were found for Go, Claude Code, Codex CLI, Google Workspace CLI, xurl, agent-browser, pnpm, Node.js LTS, or PostgreSQL major version.

## Validation

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Verified Debian 13 archive key URLs return 200.
- Verified Trixie security Chromium package metadata for amd64 and arm64.