### PR TITLE
fix: increase stuck tool watchdog timeout

### DIFF
--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -27,9 +27,9 @@ pub const HTTP_UPLOAD_TIMEOUT_SECS: u64 = 60;
 
 /// Workaround for Claude Code bug where WebSearch/WebFetch hang indefinitely.
 /// Kill the CLI process if a network tool hasn't returned a result within
-/// this duration.  Override with `VM0_STUCK_TOOL_TIMEOUT_SECS` env var.
+/// this duration. Override with `VM0_STUCK_TOOL_TIMEOUT_SECS` env var.
 /// See: https://github.com/anthropics/claude-code/issues/11650
-pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 180;
+pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 300;
 
 /// How often (in seconds) to check for stuck tools in the select loop.
 pub const STUCK_TOOL_CHECK_INTERVAL_SECS: u64 = 5;

--- a/e2e/tests/03-runner/t43-stuck-tool-watchdog.bats
+++ b/e2e/tests/03-runner/t43-stuck-tool-watchdog.bats
@@ -44,7 +44,7 @@ EOF
 
     echo "# Step 2: Run with @stuck-tool prompt and 3s timeout..."
     # VM0_STUCK_TOOL_TIMEOUT_SECS=3 makes the watchdog trigger in ~3-8s
-    # instead of 60s, keeping the test fast.
+    # instead of the production default, keeping the test fast.
     run $VM0_CLI run "$AGENT_NAME" --no-auto-update "@stuck-tool"
 
     echo "# Step 3: Verify run failed..."


### PR DESCRIPTION
## Summary
- increase the Claude WebSearch/WebFetch stuck-tool watchdog default from 180s to 300s
- keep stuck-tool e2e coverage fast via the existing VM0_STUCK_TOOL_TIMEOUT_SECS override
- update the e2e comment so it does not hard-code an old production default

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test stuck_tool_reap_sigkill --test stuck_tool_stdout_eof_reap_sigkill
- pre-commit hook: cargo fmt, cargo clippy, cargo doc