### PR TITLE
feat: open desktop setup when launch needs attention

### DIFF
--- a/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
@@ -4,6 +4,7 @@ import {
   COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
   COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
   hasReadyDesktopAuth,
+  isComputerUseSetupRequired,
   resolveComputerUseStartupGate,
 } from "./computer-use-startup-gate";
 import type { ComputerUsePermissionState } from "./computer-use-types";
@@ -33,6 +34,35 @@ describe("hasReadyDesktopAuth", () => {
       false,
     );
     expect(hasReadyDesktopAuth(signedInAuth)).toBe(true);
+  });
+});
+
+describe("isComputerUseSetupRequired", () => {
+  it("requires auth and local permissions to be ready", () => {
+    expect(
+      isComputerUseSetupRequired({
+        authState: signedOutAuth,
+        permissions: grantedPermissions,
+      }),
+    ).toBe(true);
+    expect(
+      isComputerUseSetupRequired({
+        authState: { ...signedInAuth, organization: null },
+        permissions: grantedPermissions,
+      }),
+    ).toBe(true);
+    expect(
+      isComputerUseSetupRequired({
+        authState: signedInAuth,
+        permissions: { accessibility: true, screenRecording: false },
+      }),
+    ).toBe(true);
+    expect(
+      isComputerUseSetupRequired({
+        authState: signedInAuth,
+        permissions: grantedPermissions,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/turbo/apps/desktop/src/computer-use-startup-gate.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.ts
@@ -30,6 +30,16 @@ export function hasReadyDesktopAuth(
   return authState?.status === "signed_in" && authState.organization !== null;
 }
 
+export function isComputerUseSetupRequired(args: {
+  readonly authState: DesktopAuthState | null;
+  readonly permissions: ComputerUsePermissionState;
+}): boolean {
+  return (
+    !hasReadyDesktopAuth(args.authState) ||
+    !hasRequiredComputerUsePermissions(args.permissions)
+  );
+}
+
 export function resolveComputerUseStartupGate(args: {
   readonly authState: DesktopAuthState;
   readonly permissions: ComputerUsePermissionState;

--- a/turbo/apps/desktop/src/desktop-launch-computer-use.test.ts
+++ b/turbo/apps/desktop/src/desktop-launch-computer-use.test.ts
@@ -18,27 +18,48 @@ function launchOptions(
     readonly consumeAuthCallback?: (
       callback: DesktopAuthCallback,
     ) => Promise<void>;
+    readonly isComputerUseSetupRequired?: () => Promise<boolean>;
+    readonly openSetupWindow?: () => Promise<void>;
     readonly requestAutoStartComputerUse?: () => void;
     readonly logAuthError?: (error: unknown) => void;
+    readonly logLaunchError?: (error: unknown) => void;
   } = {},
 ) {
   return {
     pendingCallback: null,
     consumeAuthCallback: vi.fn(async () => {}),
+    isComputerUseSetupRequired: vi.fn(async () => false),
+    openSetupWindow: vi.fn(async () => {}),
     requestAutoStartComputerUse: vi.fn(),
     logAuthError: vi.fn(),
+    logLaunchError: vi.fn(),
     ...overrides,
   };
 }
 
 describe("startDesktopLaunchComputerUse", () => {
-  it("auto-starts Computer Use when launch has no pending auth callback", async () => {
+  it("auto-starts Computer Use when setup is ready", async () => {
     const options = launchOptions();
 
     startDesktopLaunchComputerUse(options);
     await flushLaunchHandlers();
 
+    expect(options.isComputerUseSetupRequired).toHaveBeenCalledOnce();
     expect(options.requestAutoStartComputerUse).toHaveBeenCalledOnce();
+    expect(options.openSetupWindow).not.toHaveBeenCalled();
+    expect(options.consumeAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it("opens the setup window instead of auto-starting when setup is required", async () => {
+    const options = launchOptions({
+      isComputerUseSetupRequired: vi.fn(async () => true),
+    });
+
+    startDesktopLaunchComputerUse(options);
+    await flushLaunchHandlers();
+
+    expect(options.openSetupWindow).toHaveBeenCalledOnce();
+    expect(options.requestAutoStartComputerUse).not.toHaveBeenCalled();
     expect(options.consumeAuthCallback).not.toHaveBeenCalled();
   });
 
@@ -49,6 +70,8 @@ describe("startDesktopLaunchComputerUse", () => {
     await flushLaunchHandlers();
 
     expect(options.consumeAuthCallback).toHaveBeenCalledWith(pendingCallback);
+    expect(options.isComputerUseSetupRequired).not.toHaveBeenCalled();
+    expect(options.openSetupWindow).not.toHaveBeenCalled();
     expect(options.requestAutoStartComputerUse).not.toHaveBeenCalled();
     expect(options.logAuthError).not.toHaveBeenCalled();
   });
@@ -66,5 +89,20 @@ describe("startDesktopLaunchComputerUse", () => {
     await flushLaunchHandlers();
 
     expect(options.logAuthError).toHaveBeenCalledWith(error);
+  });
+
+  it("logs setup check failures and falls back to auto-start", async () => {
+    const error = new Error("setup check failed");
+    const options = launchOptions({
+      isComputerUseSetupRequired: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    startDesktopLaunchComputerUse(options);
+    await flushLaunchHandlers();
+
+    expect(options.logLaunchError).toHaveBeenCalledWith(error);
+    expect(options.requestAutoStartComputerUse).toHaveBeenCalledOnce();
   });
 });

--- a/turbo/apps/desktop/src/desktop-launch-computer-use.ts
+++ b/turbo/apps/desktop/src/desktop-launch-computer-use.ts
@@ -5,8 +5,22 @@ interface DesktopLaunchComputerUseOptions {
   readonly consumeAuthCallback: (
     callback: DesktopAuthCallback,
   ) => Promise<void>;
+  readonly isComputerUseSetupRequired: () => Promise<boolean>;
+  readonly openSetupWindow: () => Promise<void>;
   readonly requestAutoStartComputerUse: () => void;
   readonly logAuthError: (error: unknown) => void;
+  readonly logLaunchError: (error: unknown) => void;
+}
+
+async function launchComputerUseWithoutAuthCallback(
+  options: DesktopLaunchComputerUseOptions,
+): Promise<void> {
+  if (await options.isComputerUseSetupRequired()) {
+    await options.openSetupWindow();
+    return;
+  }
+
+  options.requestAutoStartComputerUse();
 }
 
 export function startDesktopLaunchComputerUse(
@@ -19,5 +33,8 @@ export function startDesktopLaunchComputerUse(
     return;
   }
 
-  options.requestAutoStartComputerUse();
+  void launchComputerUseWithoutAuthCallback(options).catch((error) => {
+    options.logLaunchError(error);
+    options.requestAutoStartComputerUse();
+  });
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -32,6 +32,7 @@ import {
   type DesktopComputerUseState,
 } from "./computer-use-types";
 import {
+  isComputerUseSetupRequired,
   resolveComputerUseStartupGate,
   type ComputerUseStartupGate,
 } from "./computer-use-startup-gate";
@@ -613,6 +614,10 @@ function logComputerUseAutoStartError(error: unknown): void {
   console.error("Desktop Computer Use auto-start failed", error);
 }
 
+function logComputerUseLaunchError(error: unknown): void {
+  console.error("Desktop Computer Use launch setup check failed", error);
+}
+
 async function loadAuthUrl(window: BrowserWindow, url: string): Promise<void> {
   try {
     await window.loadURL(url);
@@ -898,6 +903,16 @@ async function maybeStartComputerUseAfterAuth(): Promise<void> {
   }
 }
 
+async function shouldOpenComputerUseSetupWindowOnLaunch(): Promise<boolean> {
+  const permissions = await refreshComputerUsePermissionState();
+  if (!hasRequiredComputerUsePermissions(permissions)) {
+    return true;
+  }
+
+  const authState = await getAuthSession().getAuthState();
+  return isComputerUseSetupRequired({ authState, permissions });
+}
+
 function handleDesktopAuthCallback(rawUrl: string): void {
   openDesktopAuthCallback(rawUrl);
 }
@@ -1026,10 +1041,15 @@ if (!hasSingleInstanceLock) {
       pendingCallback: desktopAuthSession.takePendingCallback(),
       consumeAuthCallback: (callback) =>
         desktopAuthSession.consumeCode(callback.code, callback.handoffId),
+      isComputerUseSetupRequired: shouldOpenComputerUseSetupWindowOnLaunch,
+      openSetupWindow: async () => {
+        await createMainWindow();
+      },
       requestAutoStartComputerUse: () => {
         computerUseAutoStart.requestStart();
       },
       logAuthError: logDesktopAuthError,
+      logLaunchError: logComputerUseLaunchError,
     });
 
     app.on("activate", () => {


### PR DESCRIPTION
## Summary
- open the Zero Desktop main setup window on launch only when Computer Use setup is incomplete
- keep ready users on the quiet background autostart path
- cover setup-required launch gating with focused desktop unit tests

## Verification
- pnpm exec prettier --write apps/desktop/src/computer-use-startup-gate.ts apps/desktop/src/computer-use-startup-gate.test.ts apps/desktop/src/desktop-launch-computer-use.ts apps/desktop/src/desktop-launch-computer-use.test.ts apps/desktop/src/main.ts
- pnpm -F @vm0/desktop exec vitest run src/computer-use-startup-gate.test.ts src/desktop-launch-computer-use.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types