### PR TITLE
fix: guard nbd cooldown deadline overflow

### DIFF
--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -12,10 +12,32 @@ use super::lease::DeviceLease;
 use super::scan::ScanRequest;
 use super::{DEFAULT_COOLDOWN_MS, DeviceFreeCheck, MAX_PENDING};
 
-/// A device claim with a timestamp marking when it was released.
+#[derive(Clone, Copy)]
+enum CooldownExpiration {
+    At(Instant),
+    Never,
+}
+
+impl CooldownExpiration {
+    fn from_release(released_at: Instant, cooldown: Duration) -> Self {
+        match released_at.checked_add(cooldown) {
+            Some(deadline) => Self::At(deadline),
+            None => Self::Never,
+        }
+    }
+
+    fn deadline(self) -> Option<Instant> {
+        match self {
+            Self::At(deadline) => Some(deadline),
+            Self::Never => None,
+        }
+    }
+}
+
+/// A device claim waiting for its cooldown expiration.
 pub(super) struct CooldownSlot {
     claim: NbdDeviceClaim,
-    pub(super) released_at: Instant,
+    expiration: CooldownExpiration,
 }
 
 impl CooldownSlot {
@@ -23,14 +45,22 @@ impl CooldownSlot {
         self.claim.index()
     }
 
-    fn deadline(&self, cooldown: Duration) -> Instant {
-        self.released_at + cooldown
+    fn deadline(&self) -> Option<Instant> {
+        self.expiration.deadline()
+    }
+
+    #[cfg(test)]
+    pub(super) fn expire_for_test(&mut self) {
+        self.expiration = CooldownExpiration::At(Instant::now());
     }
 }
 
 /// Configuration for the device pool.
 pub struct DevicePoolConfig {
     /// Cooldown period before a released device can be reused.
+    ///
+    /// If a released claim's deadline cannot be represented as an [`Instant`],
+    /// the claim remains in a non-expiring cooldown until pool cleanup or drop.
     pub cooldown: Duration,
 }
 
@@ -157,7 +187,7 @@ impl DevicePool {
 
         if pending_scans == 0
             && !self.deferred_acquire_errors.is_empty()
-            && self.cooldown.is_empty()
+            && !self.cooldown_timer_pending()
         {
             self.fail_deferred_acquire_errors();
         }
@@ -295,7 +325,7 @@ impl DevicePool {
         }
         self.cooldown.push_back(CooldownSlot {
             claim,
-            released_at: Instant::now(),
+            expiration: CooldownExpiration::from_release(Instant::now(), self.config.cooldown),
         });
     }
 
@@ -359,7 +389,10 @@ impl DevicePool {
     pub(super) fn process_expired_cooldown(&mut self) {
         let now = Instant::now();
         while let Some(slot) = self.cooldown.front() {
-            if slot.deadline(self.config.cooldown) > now {
+            let Some(deadline) = slot.deadline() else {
+                break;
+            };
+            if deadline > now {
                 break;
             }
             let Some(slot) = self.cooldown.pop_front() else {
@@ -385,9 +418,11 @@ impl DevicePool {
     }
 
     pub(super) fn next_cooldown_deadline(&self) -> Option<Instant> {
-        self.cooldown
-            .front()
-            .map(|slot| slot.deadline(self.config.cooldown))
+        self.cooldown.front().and_then(CooldownSlot::deadline)
+    }
+
+    fn cooldown_timer_pending(&self) -> bool {
+        self.next_cooldown_deadline().is_some()
     }
 
     /// Collect all indices currently tracked by the pool (cooldown + in-flight)

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -422,6 +422,8 @@ impl DevicePool {
     }
 
     fn cooldown_timer_pending(&self) -> bool {
+        // Cooldown slots are FIFO and every slot uses the same pool cooldown, so
+        // only the front slot can produce the next timer-driven state change.
         self.next_cooldown_deadline().is_some()
     }
 

--- a/crates/nbd-cow/src/pool/tests.rs
+++ b/crates/nbd-cow/src/pool/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::device_lock::{self, NbdDeviceClaim};
 use crate::error::{NbdCowError, Result};

--- a/crates/nbd-cow/src/pool/tests/cooldown.rs
+++ b/crates/nbd-cow/src/pool/tests/cooldown.rs
@@ -134,29 +134,25 @@ async fn overflowing_cooldown_keeps_actor_responsive_and_lock_held() {
 }
 
 #[tokio::test]
-async fn non_expiring_cooldown_does_not_block_deferred_scan_failure() {
+async fn non_expiring_cooldown_does_not_block_acquire_after_scan_failure() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut pool = test_pool(0, Duration::MAX, dir.path(), always_free);
     pool.in_flight.insert(3);
+    let handle = DevicePoolHandle::from_pool(pool);
 
-    pool.release_claim(claim(3, dir.path()));
-    let (respond_to, mut response) = oneshot::channel();
-    pool.waiting_acquires.push_back(respond_to);
-    pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
-    pool.ensure_waiting_progress(0);
-
-    let result = response
-        .try_recv()
-        .expect("waiter should receive scan failure behind non-expiring cooldown");
+    handle.release_clean(lease(3, dir.path())).await;
+    let result = tokio::time::timeout(Duration::from_secs(1), handle.acquire())
+        .await
+        .expect("acquire hung behind non-expiring cooldown");
     assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
-    assert_eq!(pool.snapshot().cooldown, vec![3]);
+    assert_eq!(handle.snapshot().await.cooldown, vec![3]);
     assert!(
         device_lock::try_acquire_device_claim_in(3, dir.path())
             .expect("lock probe")
             .is_none()
     );
 
-    pool.cleanup().await;
+    handle.cleanup().await;
     assert!(
         device_lock::try_acquire_device_claim_in(3, dir.path())
             .expect("lock probe")

--- a/crates/nbd-cow/src/pool/tests/cooldown.rs
+++ b/crates/nbd-cow/src/pool/tests/cooldown.rs
@@ -75,21 +75,86 @@ async fn expired_cooldown_with_failed_recheck_drops_claim_and_scans() {
     pool.in_flight.insert(3);
 
     pool.release_claim(claim(3, dir.path()));
-    let (respond_to, response) = oneshot::channel();
+    let (respond_to, mut response) = oneshot::channel();
     pool.waiting_acquires.push_back(respond_to);
     pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
     assert_eq!(pool.waiting_acquires.len(), 1);
     assert_eq!(pool.deferred_acquire_errors.len(), 1);
+    pool.ensure_waiting_progress(0);
+    assert!(matches!(
+        response.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
 
     pool.cooldown
         .front_mut()
         .expect("released claim should be cooling down")
-        .released_at = Instant::now() - Duration::from_secs(61);
+        .expire_for_test();
     pool.process_expired_cooldown();
     pool.ensure_waiting_progress(0);
 
     let result = response.await.expect("waiter should receive scan failure");
     assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
+    assert!(
+        device_lock::try_acquire_device_claim_in(3, dir.path())
+            .expect("lock probe")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn overflowing_cooldown_keeps_actor_responsive_and_lock_held() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut pool = test_pool(8, Duration::MAX, dir.path(), always_free);
+    pool.in_flight.insert(3);
+    let handle = DevicePoolHandle::from_pool(pool);
+
+    handle.release_clean(lease(3, dir.path())).await;
+    let snapshot = tokio::time::timeout(Duration::from_secs(1), handle.snapshot())
+        .await
+        .expect("snapshot timed out after overflowing cooldown release");
+
+    assert_eq!(snapshot.cooldown, vec![3]);
+    assert!(
+        device_lock::try_acquire_device_claim_in(3, dir.path())
+            .expect("lock probe")
+            .is_none()
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), handle.cleanup())
+        .await
+        .expect("cleanup timed out after overflowing cooldown release");
+    assert!(
+        device_lock::try_acquire_device_claim_in(3, dir.path())
+            .expect("lock probe")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn non_expiring_cooldown_does_not_block_deferred_scan_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut pool = test_pool(0, Duration::MAX, dir.path(), always_free);
+    pool.in_flight.insert(3);
+
+    pool.release_claim(claim(3, dir.path()));
+    let (respond_to, response) = oneshot::channel();
+    pool.waiting_acquires.push_back(respond_to);
+    pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
+    pool.ensure_waiting_progress(0);
+
+    let result = response
+        .await
+        .expect("waiter should receive scan failure behind non-expiring cooldown");
+    assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
+    assert_eq!(pool.snapshot().cooldown, vec![3]);
+    assert!(
+        device_lock::try_acquire_device_claim_in(3, dir.path())
+            .expect("lock probe")
+            .is_none()
+    );
+
+    pool.cleanup().await;
     assert!(
         device_lock::try_acquire_device_claim_in(3, dir.path())
             .expect("lock probe")

--- a/crates/nbd-cow/src/pool/tests/cooldown.rs
+++ b/crates/nbd-cow/src/pool/tests/cooldown.rs
@@ -93,7 +93,9 @@ async fn expired_cooldown_with_failed_recheck_drops_claim_and_scans() {
     pool.process_expired_cooldown();
     pool.ensure_waiting_progress(0);
 
-    let result = response.await.expect("waiter should receive scan failure");
+    let result = response
+        .try_recv()
+        .expect("waiter should receive scan failure");
     assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
     assert!(
         device_lock::try_acquire_device_claim_in(3, dir.path())
@@ -138,13 +140,13 @@ async fn non_expiring_cooldown_does_not_block_deferred_scan_failure() {
     pool.in_flight.insert(3);
 
     pool.release_claim(claim(3, dir.path()));
-    let (respond_to, response) = oneshot::channel();
+    let (respond_to, mut response) = oneshot::channel();
     pool.waiting_acquires.push_back(respond_to);
     pool.handle_scan_join(Some(Ok(Err(NbdCowError::NoFreeDevice))));
     pool.ensure_waiting_progress(0);
 
     let result = response
-        .await
+        .try_recv()
         .expect("waiter should receive scan failure behind non-expiring cooldown");
     assert!(matches!(result, Err(NbdCowError::NoFreeDevice)));
     assert_eq!(pool.snapshot().cooldown, vec![3]);

--- a/crates/nbd-cow/src/pool/tests/cooldown.rs
+++ b/crates/nbd-cow/src/pool/tests/cooldown.rs
@@ -159,3 +159,37 @@ async fn non_expiring_cooldown_does_not_block_acquire_after_scan_failure() {
             .is_some()
     );
 }
+
+#[tokio::test]
+async fn non_expiring_cooldown_does_not_block_multiple_acquires() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut pool = test_pool(0, Duration::MAX, dir.path(), always_free);
+    pool.in_flight.insert(3);
+    let handle = DevicePoolHandle::from_pool(pool);
+
+    handle.release_clean(lease(3, dir.path())).await;
+    let first = tokio::spawn({
+        let handle = handle.clone();
+        async move { handle.acquire().await }
+    });
+    let second = tokio::spawn({
+        let handle = handle.clone();
+        async move { handle.acquire().await }
+    });
+
+    let (first_result, second_result) = tokio::time::timeout(Duration::from_secs(1), async {
+        let first_result = first.await.expect("first acquire task panicked");
+        let second_result = second.await.expect("second acquire task panicked");
+        (first_result, second_result)
+    })
+    .await
+    .expect("acquires hung behind non-expiring cooldown");
+
+    assert!(matches!(first_result, Err(NbdCowError::NoFreeDevice)));
+    assert!(matches!(second_result, Err(NbdCowError::NoFreeDevice)));
+    let snapshot = handle.snapshot().await;
+    assert_eq!(snapshot.cooldown, vec![3]);
+    assert_eq!(snapshot.waiting_acquires, 0);
+
+    handle.cleanup().await;
+}


### PR DESCRIPTION
## Summary

- compute NBD cooldown expirations once with checked `Instant` arithmetic
- represent unrepresentable cooldown deadlines as non-expiring cooldown slots
- avoid blocking deferred acquire failures behind non-expiring cooldown entries
- add regression coverage for overflowing cooldowns and waiter progress

Closes #17728

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow pool::tests::cooldown`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow pool::tests::waiting`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --lib`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings`
- `git diff --check`
