### PR TITLE
fix: bound exec cancel_and_wait timeout

### DIFF
--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -1,8 +1,9 @@
 use std::io;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
 
 use tokio::io::AsyncWriteExt;
+use tokio::sync::oneshot;
 use tokio::time::Instant;
 use vsock_proto::{ExecControlStatus, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
@@ -84,12 +85,14 @@ fn mark_exec_operation_host_cancel_requested_for_wait(
     }
 }
 
-pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait(
+pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait_with_write_start(
     shared: &Arc<Shared>,
     seq: u32,
     diagnostic: &ExecOperationDiagnostic,
+    write_started_tx: Option<oneshot::Sender<()>>,
 ) -> io::Result<ExecCancelFrameWriteOutcome> {
     let payload = vsock_proto::encode_exec_cancel();
+    let mut write_started_tx = write_started_tx;
     let decision = write_frame_with_pre_write_decision(
         shared,
         MSG_EXEC_CANCEL,
@@ -97,7 +100,12 @@ pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait(
         &payload,
         Some(diagnostic.frame("cancel")),
         || match mark_exec_operation_host_cancel_requested_for_wait(shared, seq)? {
-            ExecCancelFrameWriteOutcome::Sent => Ok(FrameWriteDecision::Write),
+            ExecCancelFrameWriteOutcome::Sent => {
+                if let Some(write_started_tx) = write_started_tx.take() {
+                    let _ = write_started_tx.send(());
+                }
+                Ok(FrameWriteDecision::Write)
+            }
             ExecCancelFrameWriteOutcome::AlreadyTerminal => Ok(FrameWriteDecision::Skip),
         },
     )

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -1,6 +1,6 @@
 use std::io;
-use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, oneshot};
-use tokio::time::Instant;
+use tokio::time::{self, Instant};
 use vsock_proto::{
     ExecControlNonce, ExecControlStatus, ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL,
 };
@@ -14,8 +14,8 @@ use super::EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT;
 use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
     ExecCancelFrameWriteOutcome, clear_exec_operation_stream_sender, exec_cancel_write_observer,
-    mark_pending_exec_control_possible_guest_write, send_exec_cancel_frame_for_wait, write_frame,
-    write_frame_with_pre_write,
+    mark_pending_exec_control_possible_guest_write,
+    send_exec_cancel_frame_for_wait_with_write_start, write_frame, write_frame_with_pre_write,
 };
 use super::state::{PendingExecControl, PendingExecControlGuard};
 use super::types::{
@@ -52,6 +52,11 @@ pub(in crate::exec_operation) enum ExecWaitLifecycle {
 pub(in crate::exec_operation) struct ExecCancelWaitResult {
     pub(in crate::exec_operation) result: ExecOperationResult,
     pub(in crate::exec_operation) cancel_seq: Option<u32>,
+}
+
+enum ExecCancelWriteOutcome {
+    Terminal(ExecOperationResult),
+    CancelSent { seq: u32, remaining: Duration },
 }
 
 impl ExecWaitLifecycle {
@@ -166,6 +171,10 @@ pub(in crate::exec_operation) async fn send_exec_cancel_frame(
 }
 
 impl ExecWaitCore {
+    fn timeout_error(lifecycle: ExecWaitLifecycle) -> io::Error {
+        io::Error::new(io::ErrorKind::TimedOut, lifecycle.timeout_error_message())
+    }
+
     fn log_timeout(&self, seq: u32, poison_on_timeout: bool, lifecycle: ExecWaitLifecycle) {
         match lifecycle {
             ExecWaitLifecycle::OneShot => {
@@ -187,6 +196,43 @@ impl ExecWaitCore {
                 );
             }
         }
+    }
+
+    fn take_result_rx_or_closed(
+        &mut self,
+        lifecycle: ExecWaitLifecycle,
+    ) -> io::Result<oneshot::Receiver<io::Result<ExecOperationResult>>> {
+        self.result_rx.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                lifecycle.operation_closed_message(),
+            )
+        })
+    }
+
+    fn complete_taken_result(
+        &mut self,
+        result: Result<io::Result<ExecOperationResult>, oneshot::error::RecvError>,
+    ) -> io::Result<ExecOperationResult> {
+        self.seq = None;
+        self.result_rx = None;
+        result.map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?
+    }
+
+    fn abandon_timed_out_operation(
+        &mut self,
+        seq: u32,
+        poison_on_timeout: bool,
+        lifecycle: ExecWaitLifecycle,
+    ) -> io::Error {
+        self.shared.remove_operation(seq);
+        self.seq = None;
+        self.result_rx = None;
+        self.log_timeout(seq, poison_on_timeout, lifecycle);
+        if poison_on_timeout {
+            self.shared.poison_connection();
+        }
+        Self::timeout_error(lifecycle)
     }
 
     pub(in crate::exec_operation) fn new(
@@ -279,40 +325,93 @@ impl ExecWaitCore {
                 ))?
             }
             _ = tokio::time::sleep(timeout) => {
-                self.shared.remove_operation(seq);
-                self.seq = None;
-                self.result_rx = None;
-                self.log_timeout(seq, poison_on_timeout, lifecycle);
-                if poison_on_timeout {
-                    self.shared.poison_connection();
-                }
-                Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    lifecycle.timeout_error_message(),
-                ))
+                Err(self.abandon_timed_out_operation(seq, poison_on_timeout, lifecycle))
             }
         }
     }
 
-    pub(in crate::exec_operation) async fn wait_for_dispatched_terminal(
+    async fn send_cancel_before_terminal_with_deadline(
         &mut self,
+        timeout: Duration,
         lifecycle: ExecWaitLifecycle,
-    ) -> io::Result<ExecOperationResult> {
-        // The state lock already proved dispatch removed the operation; only the
-        // terminal result delivery remains.
-        self.active_seq_or_closed(lifecycle.operation_closed_message())?;
-        let rx = self.result_rx.take().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                lifecycle.operation_closed_message(),
-            )
-        })?;
-        self.seq = None;
+    ) -> io::Result<ExecCancelWriteOutcome> {
+        if let Some(result) = self.try_take_ready_result()? {
+            return Ok(ExecCancelWriteOutcome::Terminal(result));
+        }
 
-        let result = rx
-            .await
-            .map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"));
-        result?
+        let seq = self.active_seq_or_closed(lifecycle.operation_closed_message())?;
+        if timeout.is_zero() {
+            return Err(self.abandon_timed_out_operation(seq, false, lifecycle));
+        }
+        let Some(deadline) = Instant::now().checked_add(timeout) else {
+            self.shared.remove_operation(seq);
+            self.seq = None;
+            self.result_rx = None;
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "exec operation cancel timeout is too large",
+            ));
+        };
+        let mut result_rx = self.take_result_rx_or_closed(lifecycle)?;
+        let shared = Arc::clone(self.shared());
+        let diagnostic = self.diagnostic().clone();
+        let (write_started_tx, mut write_started_rx) = oneshot::channel();
+        let mut cancel_write = Box::pin(send_exec_cancel_frame_for_wait_with_write_start(
+            &shared,
+            seq,
+            &diagnostic,
+            Some(write_started_tx),
+        ));
+
+        let write_outcome = tokio::select! {
+            biased;
+            _ = &mut write_started_rx => {
+                time::timeout_at(deadline, &mut cancel_write)
+                    .await
+                    .unwrap_or_else(|_| {
+                        tracing::warn!(
+                            seq = seq,
+                            label = %diagnostic.label_log,
+                            elapsed_ms = diagnostic.elapsed_ms(),
+                            "{}",
+                            match lifecycle {
+                                ExecWaitLifecycle::OneShot => "exec operation cancel write timed out",
+                                ExecWaitLifecycle::Supervised => {
+                                    "supervised exec operation cancel write timed out"
+                                }
+                            }
+                        );
+                        Err(self.abandon_timed_out_operation(seq, true, lifecycle))
+                    })
+            }
+            result = &mut result_rx => {
+                return self
+                    .complete_taken_result(result)
+                    .map(ExecCancelWriteOutcome::Terminal);
+            }
+            _ = time::sleep_until(deadline) => {
+                return Err(self.abandon_timed_out_operation(seq, false, lifecycle));
+            }
+            result = &mut cancel_write => {
+                result
+            }
+        };
+
+        match write_outcome? {
+            ExecCancelFrameWriteOutcome::AlreadyTerminal => {
+                let result = result_rx.await;
+                self.complete_taken_result(result)
+                    .map(ExecCancelWriteOutcome::Terminal)
+            }
+            ExecCancelFrameWriteOutcome::Sent => {
+                self.result_rx = Some(result_rx);
+                lifecycle.log_cancel_sent(seq, &diagnostic);
+                Ok(ExecCancelWriteOutcome::CancelSent {
+                    seq,
+                    remaining: deadline.saturating_duration_since(Instant::now()),
+                })
+            }
+        }
     }
 }
 
@@ -336,10 +435,14 @@ impl ExecOperationHandle {
 
     /// Send an explicit cancel request and wait for a cancelled terminal result.
     ///
-    /// If terminal dispatch wins the race before cancel reaches the write
-    /// boundary, this returns that result without sending a stale cancel frame.
-    /// If cancel is sent but the terminal result does not arrive before
-    /// `timeout`, the connection is poisoned because guest process state is no
+    /// If the terminal result is already available or wins the race before
+    /// cancel reaches the write boundary, this returns that result without
+    /// sending a stale cancel frame. `timeout` bounds the full operation:
+    /// waiting to write cancel, writing cancel, and waiting for terminal proof.
+    /// If the timeout elapses before cancel frame writing starts, cancel did
+    /// not reach the guest and the connection is not poisoned. If cancel is
+    /// sent but the terminal result does not arrive before the remaining
+    /// timeout, the connection is poisoned because guest process state is no
     /// longer known.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
@@ -366,43 +469,28 @@ impl ExecOperationHandle {
         mut self,
         timeout: Duration,
     ) -> io::Result<ExecCancelWaitResult> {
-        if let Some(result) = self.wait_core.try_take_ready_result()? {
-            return Ok(ExecCancelWaitResult {
-                result,
-                cancel_seq: None,
-            });
-        }
-
-        let seq = self
+        let (seq, remaining) = match self
             .wait_core
-            .active_seq_or_closed(ExecWaitLifecycle::OneShot.operation_closed_message())?;
-        let cancel_outcome = send_exec_cancel_frame_for_wait(
-            self.wait_core.shared(),
-            seq,
-            self.wait_core.diagnostic(),
-        )
-        .await?;
-        let cancel_seq = match cancel_outcome {
-            ExecCancelFrameWriteOutcome::Sent => {
-                ExecWaitLifecycle::OneShot.log_cancel_sent(seq, self.wait_core.diagnostic());
-                Some(seq)
+            .send_cancel_before_terminal_with_deadline(timeout, ExecWaitLifecycle::OneShot)
+            .await?
+        {
+            ExecCancelWriteOutcome::Terminal(result) => {
+                return Ok(ExecCancelWaitResult {
+                    result,
+                    cancel_seq: None,
+                });
             }
-            ExecCancelFrameWriteOutcome::AlreadyTerminal => None,
+            ExecCancelWriteOutcome::CancelSent { seq, remaining } => (seq, remaining),
         };
 
-        let result = match cancel_seq {
-            Some(_) => {
-                self.wait_core
-                    .wait_with_timeout(timeout, true, ExecWaitLifecycle::OneShot)
-                    .await?
-            }
-            None => {
-                self.wait_core
-                    .wait_for_dispatched_terminal(ExecWaitLifecycle::OneShot)
-                    .await?
-            }
-        };
-        Ok(ExecCancelWaitResult { result, cancel_seq })
+        let result = self
+            .wait_core
+            .wait_with_timeout(remaining, true, ExecWaitLifecycle::OneShot)
+            .await?;
+        Ok(ExecCancelWaitResult {
+            result,
+            cancel_seq: Some(seq),
+        })
     }
 }
 
@@ -548,10 +636,14 @@ impl SupervisedExecHandle {
 
     /// Send `MSG_EXEC_CANCEL` and wait for the terminal exec result.
     ///
-    /// If terminal dispatch wins the race before cancel reaches the write
-    /// boundary, this returns that result without sending a stale cancel frame.
-    /// If cancel is sent but the terminal result does not arrive before
-    /// `timeout`, the connection is poisoned because guest process state is no
+    /// If the terminal result is already available or wins the race before
+    /// cancel reaches the write boundary, this returns that result without
+    /// sending a stale cancel frame. `timeout` bounds the full operation:
+    /// waiting to write cancel, writing cancel, and waiting for terminal proof.
+    /// If the timeout elapses before cancel frame writing starts, cancel did
+    /// not reach the guest and the connection is not poisoned. If cancel is
+    /// sent but the terminal result does not arrive before the remaining
+    /// timeout, the connection is poisoned because guest process state is no
     /// longer known.
     pub async fn cancel_and_wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
@@ -569,46 +661,29 @@ impl SupervisedExecHandle {
         mut self,
         timeout: Duration,
     ) -> io::Result<ExecCancelWaitResult> {
-        if let Some(result) = self.wait_core.try_take_ready_result()? {
-            return Ok(ExecCancelWaitResult {
-                result,
-                cancel_seq: None,
-            });
-        }
-
-        let seq = self
+        let (seq, remaining) = match self
             .wait_core
-            .active_seq_or_closed(ExecWaitLifecycle::Supervised.operation_closed_message())?;
-        let cancel_outcome = send_exec_cancel_frame_for_wait(
-            self.wait_core.shared(),
-            seq,
-            self.wait_core.diagnostic(),
-        )
-        .await?;
-        let cancel_seq = match cancel_outcome {
-            ExecCancelFrameWriteOutcome::Sent => {
-                ExecWaitLifecycle::Supervised.log_cancel_sent(seq, self.wait_core.diagnostic());
-                Some(seq)
+            .send_cancel_before_terminal_with_deadline(timeout, ExecWaitLifecycle::Supervised)
+            .await?
+        {
+            ExecCancelWriteOutcome::Terminal(result) => {
+                return Ok(ExecCancelWaitResult {
+                    result,
+                    cancel_seq: None,
+                });
             }
-            ExecCancelFrameWriteOutcome::AlreadyTerminal => None,
+            ExecCancelWriteOutcome::CancelSent { seq, remaining } => (seq, remaining),
         };
 
-        if cancel_seq.is_some() {
-            self.clear_unclaimed_stream_sender();
-        }
-        let result = match cancel_seq {
-            Some(_) => {
-                self.wait_core
-                    .wait_with_timeout(timeout, true, ExecWaitLifecycle::Supervised)
-                    .await?
-            }
-            None => {
-                self.wait_core
-                    .wait_for_dispatched_terminal(ExecWaitLifecycle::Supervised)
-                    .await?
-            }
-        };
-        Ok(ExecCancelWaitResult { result, cancel_seq })
+        self.clear_unclaimed_stream_sender();
+        let result = self
+            .wait_core
+            .wait_with_timeout(remaining, true, ExecWaitLifecycle::Supervised)
+            .await?;
+        Ok(ExecCancelWaitResult {
+            result,
+            cancel_seq: Some(seq),
+        })
     }
 }
 

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -32,24 +32,27 @@
 //! Dropping it removes only host-side registration and never sends
 //! `MSG_EXEC_CANCEL`; use [`ExecOperationHandle::wait`] to observe the
 //! terminal result or [`ExecOperationHandle::cancel_and_wait`] to send
-//! cancellation and wait for the cancelled terminal result. If terminal
-//! dispatch wins the race before cancellation reaches the write boundary,
-//! cancel-and-wait returns that original terminal result instead. A plain wait
-//! timeout does not cancel the guest. If terminal proof is abandoned after a
-//! request may have reached the guest, the connection can remain open while
-//! later normal operations become unavailable on that connection. A timeout
-//! after an explicit cancel was sent poisons the connection because the guest
-//! process state is no longer known.
+//! cancellation and wait for the cancelled terminal result. If the terminal
+//! result is already available or dispatch wins the race before cancellation
+//! reaches the write boundary, cancel-and-wait returns that original terminal
+//! result instead. The `cancel_and_wait` timeout bounds both the cancel-frame
+//! write and the terminal-result wait. A plain wait timeout does not cancel the
+//! guest. If terminal proof is abandoned after a request may have reached the
+//! guest, the connection can remain open while later normal operations become
+//! unavailable on that connection. A timeout after an explicit cancel was sent
+//! poisons the connection because the guest process state is no longer known.
 //!
 //! [`SupervisedExecHandle`] owns the terminal result for a supervised process.
 //! Dropping it does not cancel the guest and does not remove the lifecycle
 //! registration; the host keeps tracking the operation until terminal result
 //! dispatch, connection close, or an explicit wait timeout. Use
 //! [`SupervisedExecHandle::cancel_and_wait`] to send cancellation and consume
-//! the terminal result. If terminal dispatch wins the race before cancellation
-//! reaches the write boundary, cancel-and-wait returns that original terminal
-//! result instead. [`SupervisedExecCancelHandle::cancel`] sends only the cancel
-//! frame and leaves terminal result ownership with the paired
+//! the terminal result under one total timeout covering cancel-frame write and
+//! terminal-result wait. If the terminal result is already available or
+//! dispatch wins the race before cancellation reaches the write boundary,
+//! cancel-and-wait returns that original terminal result instead.
+//! [`SupervisedExecCancelHandle::cancel`] sends only the cancel frame and
+//! leaves terminal result ownership with the paired
 //! [`SupervisedExecHandle`].
 //!
 //! Streaming exec operations expose a bounded receiver through

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -365,10 +365,7 @@ async fn exec_cancel_after_terminal_result_returns_result_without_cancel_frame()
     .await;
     wait_for_operation_count(&host, 0).await;
 
-    let result = handle
-        .cancel_and_wait(Duration::from_secs(5))
-        .await
-        .unwrap();
+    let result = handle.cancel_and_wait(Duration::ZERO).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
 
     assert_connection_accepts_exec_operation(&host, &mut guest).await;

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -229,7 +229,8 @@ async fn exec_cancel_writer_lock_timeout_before_write_does_not_poison_or_send_fr
     assert_eq!(start.msg_type, MSG_EXEC_START);
     let writer_guard = host.shared.writer.lock().await;
 
-    let mut cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let mut cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(1)).await });
     let err = tokio::time::timeout(Duration::from_secs(1), &mut cancel_task)
         .await
         .expect("cancel_and_wait should return before the test guard")

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -255,6 +255,31 @@ async fn exec_cancel_writer_lock_timeout_before_write_does_not_poison_or_send_fr
 }
 
 #[tokio::test]
+async fn exec_cancel_oversized_timeout_cleans_without_cancel_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "cancel-timeout-overflow").await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+
+    let err = handle.cancel_and_wait(Duration::MAX).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("oversized timeout must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after oversized timeout: {err}"),
+    }
+}
+
+#[tokio::test]
 async fn exec_cancel_terminal_result_wins_while_cancel_write_is_blocked() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -221,6 +221,83 @@ async fn exec_cancel_sends_cancel_and_waits_for_cancelled_result() {
 }
 
 #[tokio::test]
+async fn exec_cancel_writer_lock_timeout_before_write_does_not_poison_or_send_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "cancel-lock-timeout").await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    let writer_guard = host.shared.writer.lock().await;
+
+    let mut cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let err = tokio::time::timeout(Duration::from_secs(1), &mut cancel_task)
+        .await
+        .expect("cancel_and_wait should return before the test guard")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out cancel must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after cancel timeout: {err}"),
+    }
+}
+
+#[tokio::test]
+async fn exec_cancel_terminal_result_wins_while_cancel_write_is_blocked() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "cancel-result-race").await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+    let writer_guard = host.shared.writer.lock().await;
+
+    let mut cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"done",
+        b"",
+    )
+    .await;
+
+    let result = tokio::time::timeout(Duration::from_secs(1), &mut cancel_task)
+        .await
+        .expect("terminal result should win before cancel write starts")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("completed operation must not receive stale cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after terminal race: {err}"),
+    }
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn exec_cancel_after_terminal_result_returns_result_without_cancel_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -255,7 +332,8 @@ async fn exec_cancel_terminal_before_cancel_write_returns_result() {
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
     let writer_guard = host.shared.writer.lock().await;
-    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     tokio::task::yield_now().await;
 
     send_exec_result(
@@ -289,7 +367,8 @@ async fn exec_cancel_error_before_cancel_write_returns_error_without_cancel_fram
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
     let writer_guard = host.shared.writer.lock().await;
-    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     tokio::task::yield_now().await;
 
     let payload = vsock_proto::encode_error("guest rejected exec");
@@ -347,7 +426,8 @@ async fn exec_cancel_result_timeout_poisons_connection() {
     let start = read_guest_message(&mut guest).await;
     assert_eq!(start.msg_type, MSG_EXEC_START);
 
-    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(50)).await });
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
     assert_eq!(cancel.seq, start.seq);

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -255,6 +255,31 @@ async fn exec_cancel_writer_lock_timeout_before_write_does_not_poison_or_send_fr
 }
 
 #[tokio::test]
+async fn exec_cancel_zero_timeout_cleans_without_cancel_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = start_capture_operation(&host, "cancel-timeout-zero").await;
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, MSG_EXEC_START);
+
+    let err = handle.cancel_and_wait(Duration::ZERO).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("zero-timeout cancel must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after zero-timeout cancel: {err}"),
+    }
+}
+
+#[tokio::test]
 async fn exec_cancel_oversized_timeout_cleans_without_cancel_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -118,6 +118,39 @@ async fn supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans
 }
 
 #[tokio::test]
+async fn supervised_exec_cancel_oversized_timeout_cleans_without_cancel_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-timeout-overflow"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let err = handle.cancel_and_wait(Duration::MAX).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("oversized timeout must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after oversized timeout: {err}"),
+    }
+}
+
+#[tokio::test]
 async fn supervised_exec_cancel_and_wait_terminal_result_wins_while_cancel_write_is_blocked() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -76,6 +76,99 @@ async fn supervised_exec_cancel_and_wait_sends_cancel_and_waits_for_cancelled_re
 }
 
 #[tokio::test]
+async fn supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans_registration() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-lock-timeout"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+    let writer_guard = host.shared.writer.lock().await;
+
+    let mut cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let err = tokio::time::timeout(Duration::from_secs(1), &mut cancel_task)
+        .await
+        .expect("cancel_and_wait should return before the test guard")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("timed-out cancel must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after cancel timeout: {err}"),
+    }
+}
+
+#[tokio::test]
+async fn supervised_exec_cancel_and_wait_terminal_result_wins_while_cancel_write_is_blocked() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-result-race"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+    let writer_guard = host.shared.writer.lock().await;
+
+    let mut cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"done",
+        b"",
+    )
+    .await;
+
+    let result = tokio::time::timeout(Duration::from_secs(1), &mut cancel_task)
+        .await
+        .expect("terminal result should win before cancel write starts")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    tokio::task::yield_now().await;
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("completed operation must not receive stale cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after terminal race: {err}"),
+    }
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn supervised_exec_cancel_handle_sends_cancel_without_consuming_wait() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -257,7 +350,8 @@ async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
     let handle = task.await.unwrap().unwrap();
 
     let writer_guard = host.shared.writer.lock().await;
-    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     tokio::task::yield_now().await;
 
     send_exec_result(
@@ -303,7 +397,8 @@ async fn supervised_exec_cancel_error_before_cancel_write_returns_error_without_
     let handle = task.await.unwrap().unwrap();
 
     let writer_guard = host.shared.writer.lock().await;
-    let cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     tokio::task::yield_now().await;
 
     send_guest_error(&mut guest, start.seq, "guest rejected supervised exec").await;
@@ -362,4 +457,33 @@ async fn supervised_exec_cancel_non_cancelled_terminal_result_cleans_without_poi
     assert!(is_connected(&host));
 
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn supervised_exec_cancel_result_timeout_poisons_connection() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-timeout"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(50)).await });
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+
+    let err = cancel_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
 }

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -92,7 +92,8 @@ async fn supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans
     let handle = task.await.unwrap().unwrap();
     let writer_guard = host.shared.writer.lock().await;
 
-    let mut cancel_task = tokio::spawn(async move { handle.cancel_and_wait(Duration::ZERO).await });
+    let mut cancel_task =
+        tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(1)).await });
     let err = tokio::time::timeout(Duration::from_secs(1), &mut cancel_task)
         .await
         .expect("cancel_and_wait should return before the test guard")

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -118,6 +118,39 @@ async fn supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans
 }
 
 #[tokio::test]
+async fn supervised_exec_cancel_zero_timeout_cleans_without_cancel_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(supervised_request("cancel-timeout-zero"))
+                .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let err = handle.cancel_and_wait(Duration::ZERO).await.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+
+    let mut buf = [0u8; 1024];
+    match guest.try_read(&mut buf) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("zero-timeout cancel must not send exec cancel; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after zero-timeout cancel: {err}"),
+    }
+}
+
+#[tokio::test]
 async fn supervised_exec_cancel_oversized_timeout_cleans_without_cancel_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);


### PR DESCRIPTION
## Summary

- make `cancel_and_wait(timeout)` use one total deadline for cancel-frame write plus terminal wait
- race terminal result delivery while cancel write is still blocked before write-start
- preserve existing connection poison behavior once cancel write starts or cancel is sent
- document the updated timeout semantics

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::exec_operation::cancel`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host tests::exec_operation::supervised::cancel`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features`
- pre-commit hooks: cargo-doc, cargo-clippy, cargo-fmt

Closes #17709
