### PR TITLE
fix: anchor inline feedback note so the quote grows the composer upward

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -539,6 +539,7 @@ function ComposerFeedbackRow({
   item,
   autoFocus,
   showDivider,
+  fill,
   onChangeNote,
   onRemove,
   onKeyDown,
@@ -546,6 +547,7 @@ function ComposerFeedbackRow({
   item: FeedbackItem;
   autoFocus: boolean;
   showDivider: boolean;
+  fill: boolean;
   onChangeNote: (note: string) => void;
   onRemove: () => void;
   onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
@@ -598,7 +600,15 @@ function ComposerFeedbackRow({
         onKeyDown={onKeyDown}
         rows={1}
         placeholder="What should change about this?"
-        className="w-full resize-none overflow-hidden border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
+        className={cn(
+          "w-full resize-none overflow-hidden border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0",
+          // The active (newest) note carries the composer's resting height so the
+          // ghost text stays anchored above the toolbar — matching the textarea
+          // body. Quote chips then stack above it and grow the card upward,
+          // mirroring the attachment-chips layout, instead of the chip eating
+          // into a fixed-height container and pushing the ghost text down.
+          fill && "min-h-[96px]",
+        )}
       />
     </div>
   );
@@ -621,10 +631,12 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
   const newestId = feedback.items[feedback.items.length - 1]?.id;
 
   return (
-    // min-h keeps the card from shrinking below the textarea's resting height.
     // px-4 / pt-3 mirror the attachment-chips inset so the feedback chip lines
-    // up with attachments on both the left and top edges.
-    <div className="flex min-h-[96px] flex-col px-4 pb-2 pt-3">
+    // up with attachments on both the left and top edges. The resting height
+    // lives on the newest note (via `fill`) rather than this container, so the
+    // quote chip grows the card upward instead of being capped inside a fixed
+    // height — keeping the layout consistent with the attachment-chips band.
+    <div className="flex flex-col px-4 pb-2 pt-3">
       {feedback.items.map((item, index) => {
         return (
           <ComposerFeedbackRow
@@ -632,6 +644,7 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
             item={item}
             autoFocus={item.id === newestId}
             showDivider={index > 0}
+            fill={item.id === newestId}
             onChangeNote={(note) => {
               return feedback.onChangeNote(item.id, note);
             }}


### PR DESCRIPTION
## Summary

Fixes #17745 — the **inline feedback** composer pushed the ghost text (`What should change about this?`) downward when a quote was attached, inconsistent with the add-attachment layout.

### Root cause

The quote chip and the note shared a single `min-h-[96px]` container (`ComposerFeedbackRows`). With the note rendered as a tiny `rows={1}` textarea, the quote chip **ate into** that fixed 96px and pushed the ghost text down, leaving dead space below it. The card never grew upward.

By contrast, the attachment layout (`AttachmentChips` + `ComposerInputSlot`) renders the chip band **above** a separate full-height (`min-h-[96px]`) input body, so the input stays anchored above the toolbar and the chips extend the card upward.

### Fix

Move the resting height off the container and onto the **active (newest) note** via a `fill` prop:

- `ComposerFeedbackRows`: drop `min-h-[96px]` from the container; pass `fill={item.id === newestId}`.
- `ComposerFeedbackRow`: the `fill` note carries `min-h-[96px]`, so it keeps its full body anchored above the toolbar while the quote chip stacks above and grows the card **upward** — matching the attachment-chips band.

### Result

- Ghost text stays anchored (no downward shift).
- The quote grows the composer upward.
- Layout is now consistent with the add-attachment composer.

## Test plan

- [ ] Open the inline feedback composer (select a passage → comment).
- [ ] Confirm the ghost text stays anchored above the toolbar and the quote chip sits above it, growing the card upward.
- [ ] Confirm the layout matches the add-attachment composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
