### PR TITLE
feat: enable google cloud connector by default

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -172,25 +172,6 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     });
   });
 
-  it("rejects Google Cloud OAuth start when the connector feature is disabled", async () => {
-    const userId = `user_${randomUUID()}`;
-    const orgId = `org_${randomUUID()}`;
-    orgIds.push(orgId);
-    mocks.clerk.session(userId, orgId);
-
-    const response = await requestOauthStart("google-cloud", {
-      headers: { authorization: "Bearer clerk-session" },
-    });
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: {
-        message: "google-cloud connector is not available",
-        code: "FORBIDDEN",
-      },
-    });
-  });
-
   it("rejects YouTube OAuth start when the connector feature is disabled", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
@@ -215,12 +196,6 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     const orgId = `org_${randomUUID()}`;
     orgIds.push(orgId);
     mocks.clerk.session(userId, orgId);
-    const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.GoogleCloudConnector]: true },
-    });
 
     const authMethods = CONNECTOR_TYPES["google-cloud"].authMethods;
     const originalOauth = authMethods.oauth;
@@ -253,17 +228,12 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     });
   });
 
-  it("starts Google Cloud OAuth when the connector feature is enabled", async () => {
+  it("starts Google Cloud OAuth without a feature switch", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     orgIds.push(orgId);
     mocks.clerk.session(userId, orgId);
     const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.GoogleCloudConnector]: true },
-    });
 
     const response = await requestOauthStart("google-cloud", {
       headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -327,38 +327,20 @@ describe("GET /api/zero/connectors/search", () => {
     ).toBeUndefined();
   });
 
-  it("matches connector tags while preserving feature-switch visibility", async () => {
+  it("matches Google Cloud connector tags without a feature switch", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorsSearchContract);
-    const disabledResponse = await accept(
+    const response = await accept(
       client.search({
         query: { keyword: "gcp" },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
-    expect(
-      disabledResponse.body.connectors.some((connector) => {
-        return connector.id === "google-cloud";
-      }),
-    ).toBeFalsy();
-
-    seededFeatureSwitches.push({ orgId, userId });
-    await enableFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.GoogleCloudConnector]: true,
-    });
-
-    const enabledResponse = await accept(
-      client.search({
-        query: { keyword: "gcp" },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    const connector = enabledResponse.body.connectors.find((candidate) => {
+    const connector = response.body.connectors.find((candidate) => {
       return candidate.id === "google-cloud";
     });
     expect(connector).toBeDefined();

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2621,14 +2621,9 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ]);
   });
 
-  it("exposes Google Cloud OAuth only when its switch is enabled", () => {
+  it("exposes Google Cloud OAuth without a feature switch", () => {
     expect(
       getAvailableConnectorAuthMethodIds("google-cloud", {}),
-    ).toStrictEqual([]);
-    expect(
-      getAvailableConnectorAuthMethodIds("google-cloud", {
-        [FeatureSwitchKey.GoogleCloudConnector]: true,
-      }),
     ).toStrictEqual(["oauth"]);
   });
 

--- a/turbo/packages/connectors/src/connectors/google-cloud.ts
+++ b/turbo/packages/connectors/src/connectors/google-cloud.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const googleCloud = {
   "google-cloud": {
@@ -17,7 +16,6 @@ export const googleCloud = {
       "Connect your Google account to access Google Cloud resources through Google Cloud APIs. Google IAM and enabled APIs determine which projects, resources, and actions are available.",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.GoogleCloudConnector,
         label: "OAuth (Recommended)",
         helpText:
           "Sign in with Google to grant Google Cloud access. The connector is not bound to one project; Google IAM controls accessible resources.",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -12,7 +12,6 @@ export enum FeatureSwitchKey {
   DocuSignConnector = "docusignConnector",
   DropboxConnector = "dropboxConnector",
   FigmaConnector = "figmaConnector",
-  GoogleCloudConnector = "googleCloudConnector",
   MercuryConnector = "mercuryConnector",
   NeonConnector = "neonConnector",
   GarminConnectConnector = "garminConnectConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -74,11 +74,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Figma design connector",
     enabled: false,
   },
-  [FeatureSwitchKey.GoogleCloudConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Google Cloud connector integration",
-    enabled: false,
-  },
   [FeatureSwitchKey.MercuryConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Mercury banking connector",


### PR DESCRIPTION
## Summary

- Remove the Google Cloud connector feature switch key and registry entry.
- Expose Google Cloud OAuth without requiring `googleCloudConnector` to be enabled.
- Update connector availability, OAuth start, and connector search tests for the default-on behavior.

## Verification

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts -t "Google Cloud"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts`
- `git diff --check`
- `pnpm -F @vm0/connectors check-types`
- pre-commit hook: prettier, knip, `pnpm check-types`
