### PR TITLE
fix: revert improve credit usage breakdown tooltip (#17675)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -3,7 +3,7 @@ import {
   zeroUsageRecordContract,
   type UsageRecordRow,
 } from "@vm0/api-contracts/contracts/zero-usage-record";
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
@@ -20,18 +20,7 @@ function usageRows(): UsageRecordRow[] {
       title: "Quarterly planning chat",
       credits: 980,
       tokens: 2200,
-      breakdown: [
-        {
-          kind: "connector",
-          credits: 18,
-          providers: [{ provider: "x", credits: 18 }],
-        },
-        {
-          kind: "image",
-          credits: 123,
-          providers: [{ provider: "fal-ai/nano-banana-2", credits: 123 }],
-        },
-      ],
+      breakdown: [],
       member: null,
       lastActivityAt: "2026-03-21T10:00:00Z",
     },
@@ -173,50 +162,5 @@ describe("personal usage settings", () => {
       expect(screen.getByText("Last 7 days")).toBeInTheDocument();
       expect(requestedRanges).toContain("7d");
     });
-  });
-
-  it("shows usage breakdown as hoverable legend items with friendly tooltip labels", async () => {
-    mockPersonalUsageStory();
-    await openUsageSettings();
-
-    await waitFor(() => {
-      expect(screen.getByText("Quarterly planning chat")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.queryByTestId("usage-kind-segment-connector"),
-    ).not.toBeInTheDocument();
-
-    const connectorLegend = screen.getByTestId("usage-kind-legend-connector");
-    expect(within(connectorLegend).getByText("18")).toBeInTheDocument();
-
-    fireEvent.pointerOver(connectorLegend);
-    fireEvent.pointerEnter(connectorLegend);
-    fireEvent.pointerMove(connectorLegend, { pointerType: "mouse" });
-    fireEvent.mouseOver(connectorLegend);
-    fireEvent.mouseEnter(connectorLegend);
-    fireEvent.mouseMove(connectorLegend);
-
-    await expect(
-      screen.findAllByText("Connectors 18"),
-    ).resolves.not.toHaveLength(0);
-    expect(screen.queryByText("Connectors - 18")).not.toBeInTheDocument();
-    expect(screen.getAllByText("x")).not.toHaveLength(0);
-
-    const imageLegend = screen.getByTestId("usage-kind-legend-image");
-    expect(within(imageLegend).getByText("123")).toBeInTheDocument();
-
-    fireEvent.pointerOver(imageLegend);
-    fireEvent.pointerEnter(imageLegend);
-    fireEvent.pointerMove(imageLegend, { pointerType: "mouse" });
-    fireEvent.mouseOver(imageLegend);
-    fireEvent.mouseEnter(imageLegend);
-    fireEvent.mouseMove(imageLegend);
-
-    await expect(screen.findAllByText("Image 123")).resolves.not.toHaveLength(
-      0,
-    );
-    expect(screen.getAllByText("Nano Banana 2")).not.toHaveLength(0);
-    expect(screen.queryByText("fal-ai/nano-banana-2")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, PointerEvent } from "react";
+import type { MouseEvent } from "react";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import {
   IconBrandGithub,
@@ -12,7 +12,6 @@ import {
   IconRobot,
   IconTerminal2,
 } from "@tabler/icons-react";
-import { getModelDisplayName } from "@vm0/core/model-display-name";
 import type { OrgMember } from "@vm0/api-contracts/contracts/org-members";
 import type {
   UsageRecordKind,
@@ -70,33 +69,25 @@ const SOURCE_META = {
 const KIND_META = {
   model: {
     label: "LLM models",
-    tooltipLabel: "LLM",
     color: "bg-usage-kind-model",
   },
   image: {
     label: "Image models",
-    tooltipLabel: "Image",
     color: "bg-usage-kind-image",
   },
   video: {
     label: "Video models",
-    tooltipLabel: "Video",
     color: "bg-usage-kind-video",
   },
   connector: {
     label: "Connectors",
-    tooltipLabel: "Connectors",
     color: "bg-usage-kind-connector",
   },
   other: {
     label: "Other",
-    tooltipLabel: "Other",
     color: "bg-usage-kind-other",
   },
-} as const satisfies Record<
-  UsageRecordKind,
-  { label: string; tooltipLabel: string; color: string }
->;
+} as const satisfies Record<UsageRecordKind, { label: string; color: string }>;
 
 const RANGE_OPTIONS = [
   { value: "today", label: "Today" },
@@ -132,108 +123,6 @@ function formatCredits(n: number): string {
     return `${(n / 1000).toFixed(1)}K`;
   }
   return n.toLocaleString();
-}
-
-const USAGE_PROVIDER_LABEL_OVERRIDES: Readonly<Record<string, string>> = {
-  "gpt-image-1": "GPT Image 1",
-  "gpt-image-1-mini": "GPT Image 1 Mini",
-  "gpt-image-1.5": "GPT Image 1.5",
-  "gpt-image-2": "GPT Image 2",
-  "flux-pro/v1.1": "FLUX Pro 1.1",
-  "flux-pro/v1.1-ultra": "FLUX Pro 1.1 Ultra",
-  "qwen-image": "Qwen Image",
-  "bytedance/seedream/v4/text-to-image": "Seedream 4",
-  "nano-banana-2": "Nano Banana 2",
-  "nanobanana-2": "Nano Banana 2",
-  "veo3.1/fast": "Veo 3.1 Fast",
-  "kling-video/v3/4k/text-to-video": "Kling Video v3 4K",
-  "dreamina-seedance-2-0-260128": "Seedance 2.0",
-  "dreamina-seedance-2-0-fast-260128": "Seedance 2.0 Fast",
-  "seedance-1-5-pro-251215": "Seedance 1.5 Pro",
-};
-
-const KNOWN_VENDOR_PREFIXES = [
-  "fal-ai/",
-  "fal/",
-  "openai/",
-  "anthropic/",
-  "google/",
-  "deepseek/",
-  "moonshotai/",
-  "minimax/",
-  "zai/",
-  "z-ai/",
-] as const;
-
-const UPPERCASE_USAGE_TOKENS = [
-  "ai",
-  "api",
-  "cli",
-  "glm",
-  "gpt",
-  "id",
-  "llm",
-  "sql",
-  "tts",
-  "url",
-  "vm0",
-] as const;
-
-function stripUsageProviderVendor(value: string): string {
-  const lower = value.toLowerCase();
-  const prefix = KNOWN_VENDOR_PREFIXES.find((knownPrefix) => {
-    return lower.startsWith(knownPrefix);
-  });
-  return prefix ? value.slice(prefix.length) : value;
-}
-
-function titleCaseUsageToken(token: string): string {
-  const lower = token.toLowerCase();
-  if (
-    UPPERCASE_USAGE_TOKENS.some((uppercaseToken) => {
-      return uppercaseToken === lower;
-    })
-  ) {
-    return lower.toUpperCase();
-  }
-  if (/^v\d+(?:\.\d+)*$/u.test(lower)) {
-    return lower.toUpperCase();
-  }
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-}
-
-function formatUsageIdentifier(value: string): string {
-  return value
-    .split(/[/._-]+/u)
-    .filter((token) => {
-      return token.length > 0;
-    })
-    .map(titleCaseUsageToken)
-    .join(" ");
-}
-
-function formatUsageProviderLabel(
-  kind: UsageRecordKind,
-  provider: string,
-): string {
-  if (provider.trim().length === 0) {
-    return "Unknown";
-  }
-  if (kind !== "model" && kind !== "image" && kind !== "video") {
-    return provider;
-  }
-
-  const normalized = provider.trim();
-  const knownDisplayName = getModelDisplayName(normalized);
-  if (knownDisplayName !== normalized) {
-    return knownDisplayName;
-  }
-
-  const withoutVendor = stripUsageProviderVendor(normalized);
-  const override =
-    USAGE_PROVIDER_LABEL_OVERRIDES[normalized] ??
-    USAGE_PROVIDER_LABEL_OVERRIDES[withoutVendor];
-  return override ?? formatUsageIdentifier(withoutVendor);
 }
 
 function formatDate(iso: string): string {
@@ -299,13 +188,7 @@ export function UsageRangeSelect({
   );
 }
 
-function stopUsageTooltipPropagation(
-  event: MouseEvent<HTMLElement> | PointerEvent<HTMLElement>,
-): void {
-  event.stopPropagation();
-}
-
-function UsageBreakdownLegend({ row }: { row: UsageRecordRow }) {
+function UsageBreakdownBar({ row, max }: { row: UsageRecordRow; max: number }) {
   const segments = row.breakdown.filter((segment) => {
     return segment.credits > 0;
   });
@@ -313,71 +196,64 @@ function UsageBreakdownLegend({ row }: { row: UsageRecordRow }) {
     return null;
   }
 
+  // Outer track is the full row width; the filled portion is scaled to this
+  // chat's size relative to the largest chat, so the bar reads as magnitude.
+  // The kind colors live inside the fill, so one bar carries both size and mix.
   return (
-    <div className="mt-2.5 flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
-      {segments.map((segment) => {
-        const meta = KIND_META[segment.kind];
-        return (
-          <Tooltip key={segment.kind}>
-            <TooltipTrigger asChild>
-              <span
-                className="inline-flex min-h-6 cursor-default items-center gap-1.5 rounded-md px-1.5 text-xs text-muted-foreground transition-colors hover:bg-[hsl(var(--gray-50))] hover:text-foreground"
-                data-testid={`usage-kind-legend-${segment.kind}`}
-              >
-                <span
-                  className={`${meta.color} h-2 w-2 shrink-0 rounded-full`}
+    <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-foreground/8">
+      <div
+        className="flex h-full overflow-hidden rounded-full"
+        style={{ width: `${(row.credits / max) * 100}%` }}
+      >
+        {segments.map((segment) => {
+          const meta = KIND_META[segment.kind];
+          const width = `${(segment.credits / row.credits) * 100}%`;
+          return (
+            <Tooltip key={segment.kind}>
+              <TooltipTrigger asChild>
+                <div
+                  className={`${meta.color} h-full cursor-default first:rounded-l-full last:rounded-r-full transition-shadow hover:z-10 hover:ring-2 hover:ring-foreground/30`}
+                  style={{ width }}
+                  data-testid={`usage-kind-segment-${segment.kind}`}
                 />
-                <span className="tabular-nums">
-                  {segment.credits.toLocaleString()}
-                </span>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent
-              side="top"
-              sideOffset={8}
-              style={{
-                backgroundColor: "hsl(var(--popover))",
-                color: "hsl(var(--popover-foreground))",
-              }}
-              className="pointer-events-auto max-w-64 select-text border shadow-md"
-              onClick={stopUsageTooltipPropagation}
-              onMouseDown={stopUsageTooltipPropagation}
-              onMouseUp={stopUsageTooltipPropagation}
-              onPointerDown={stopUsageTooltipPropagation}
-              onPointerUp={stopUsageTooltipPropagation}
-            >
-              <div className="font-medium text-foreground">
-                {meta.tooltipLabel} {segment.credits.toLocaleString()}
-              </div>
-              <div className="mt-1 flex flex-col gap-0.5">
-                {segment.providers.map((provider) => {
-                  return (
-                    <div
-                      key={provider.provider}
-                      className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
-                    >
-                      <span className="truncate">
-                        {formatUsageProviderLabel(
-                          segment.kind,
-                          provider.provider,
-                        )}
-                      </span>
-                      <span className="shrink-0 tabular-nums">
-                        {provider.credits.toLocaleString()}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        );
-      })}
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                sideOffset={8}
+                style={{
+                  backgroundColor: "hsl(var(--popover))",
+                  color: "hsl(var(--popover-foreground))",
+                }}
+                className="max-w-64 border shadow-md"
+              >
+                <div className="font-medium text-foreground">
+                  {meta.label} - {segment.credits.toLocaleString()}
+                </div>
+                <div className="mt-1 flex flex-col gap-0.5">
+                  {segment.providers.map((provider) => {
+                    return (
+                      <div
+                        key={provider.provider}
+                        className="flex min-w-0 justify-between gap-3 text-xs text-muted-foreground"
+                      >
+                        <span className="truncate">{provider.provider}</span>
+                        <span className="shrink-0 tabular-nums">
+                          {provider.credits.toLocaleString()}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
     </div>
   );
 }
 
-function UsageRow({ row }: { row: UsageRecordRow }) {
+function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
   const closeSettings = useSet(setSettingsDialogOpen$);
   const pageSignal = useGet(pageSignal$);
   const { label, Icon } = SOURCE_META[row.source];
@@ -416,7 +292,7 @@ function UsageRow({ row }: { row: UsageRecordRow }) {
             {row.member.email}
           </span>
         ) : null}
-        <UsageBreakdownLegend row={row} />
+        <UsageBreakdownBar row={row} max={max} />
       </span>
     </div>
   );
@@ -525,6 +401,12 @@ function UsageRecordList({
   scope: UsageRecordScope;
 }) {
   const loadMore = useSet(loadMoreUsageRecord$);
+  const maxCredits = Math.max(
+    1,
+    ...data.rows.map((row) => {
+      return row.credits;
+    }),
+  );
 
   return (
     <div className="flex flex-col gap-3">
@@ -538,7 +420,9 @@ function UsageRecordList({
             totalCredits={data.totalCredits}
           />
           {data.rows.map((row) => {
-            return <UsageRow key={usageRowKey(row)} row={row} />;
+            return (
+              <UsageRow key={usageRowKey(row)} row={row} max={maxCredits} />
+            );
           })}
         </div>
       </TooltipProvider>


### PR DESCRIPTION
Reverts #17675 (merge commit `35cc103`).

Requested by @Lunarivibe. This restores `personal-usage-record.tsx` and its test to the state prior to PR #17675.