### PR TITLE
feat: enable paid onboarding redirect

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -50,6 +50,7 @@ describe("zero onboarding", () => {
     detachedSetupPage({
       context,
       path: "/?prompt=hello%20world&connector=github&vm0_source=presentation",
+      featureSwitches: { [FeatureSwitchKey.PaidOnboardingRedirect]: false },
     });
 
     await waitFor(() => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -9,6 +9,9 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.PaidOnboardingRedirect, {})).toBe(
+      true,
+    );
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -74,6 +77,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates();
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(states[FeatureSwitchKey.PaidOnboardingRedirect]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -358,7 +358,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "linghan@vm0.ai",
     description:
       "Redirect admins who need workspace onboarding to the external paid-onboarding SO flow instead of the in-app /onboarding flow.",
-    enabled: false,
+    enabled: true,
   },
 };
 


### PR DESCRIPTION
## Summary
- enable the PaidOnboardingRedirect feature switch by default
- update feature switch assertions for the enabled rollout
- keep the in-app onboarding fallback test explicit when the switch is disabled

## Tests
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-onboarding.test.tsx
- pnpm -F @vm0/core lint
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm check-types
- pre-commit: prettier, knip, check-types