### PR TITLE
feat: enable youtube connector by default

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -172,25 +172,6 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     });
   });
 
-  it("rejects YouTube OAuth start when the connector feature is disabled", async () => {
-    const userId = `user_${randomUUID()}`;
-    const orgId = `org_${randomUUID()}`;
-    orgIds.push(orgId);
-    mocks.clerk.session(userId, orgId);
-
-    const response = await requestOauthStart("youtube", {
-      headers: { authorization: "Bearer clerk-session" },
-    });
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: {
-        message: "youtube connector is not available",
-        code: "FORBIDDEN",
-      },
-    });
-  });
-
   it("rejects OAuth start when the auth method is statically hidden", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
@@ -293,17 +274,12 @@ describe("POST /api/zero/connectors/:type/oauth/start", () => {
     expect(storedState!.expiresAt.getTime()).toBeGreaterThan(now());
   });
 
-  it("starts YouTube OAuth when the connector feature is enabled", async () => {
+  it("starts YouTube OAuth without a feature switch", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     orgIds.push(orgId);
     mocks.clerk.session(userId, orgId);
     const db = store.set(writeDb$);
-    await db.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: { [FeatureSwitchKey.YouTubeConnector]: true },
-    });
 
     const response = await requestOauthStart("youtube", {
       headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -6,7 +6,6 @@ import {
   type ConnectorAuthMethodId,
 } from "@vm0/connectors/connectors";
 import { getConnectorAuthMethodAuthCodeGrantConfig } from "@vm0/connectors/connector-utils";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { connectors } from "@vm0/db/schema/connector";
 import { connectorOauthStates } from "@vm0/db/schema/connector-oauth-state";
 import { secrets } from "@vm0/db/schema/secret";

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2627,16 +2627,13 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth"]);
   });
 
-  it("exposes YouTube OAuth only when its switch is enabled", () => {
+  it("exposes YouTube OAuth without a feature switch", () => {
     expect(getConfiguredConnectorAuthMethodIds("youtube")).toStrictEqual([
       "oauth",
     ]);
-    expect(getAvailableConnectorAuthMethodIds("youtube", {})).toStrictEqual([]);
-    expect(
-      getAvailableConnectorAuthMethodIds("youtube", {
-        [FeatureSwitchKey.YouTubeConnector]: true,
-      }),
-    ).toStrictEqual(["oauth"]);
+    expect(getAvailableConnectorAuthMethodIds("youtube", {})).toStrictEqual([
+      "oauth",
+    ]);
   });
 
   it("exposes Doubao API-token auth without a feature switch", () => {

--- a/turbo/packages/connectors/src/connectors/youtube.ts
+++ b/turbo/packages/connectors/src/connectors/youtube.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const youtube = {
   youtube: {
@@ -9,7 +8,6 @@ export const youtube = {
       "Connect your YouTube account to search videos, get channel info, and fetch comments via the Data API",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.YouTubeConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant YouTube Data API access.",
         client: {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -31,7 +31,6 @@ export enum FeatureSwitchKey {
   GoogleMapsConnector = "googleMapsConnector",
   GoogleAnalyticsConnector = "googleAnalyticsConnector",
   GoogleSearchConsoleConnector = "googleSearchConsoleConnector",
-  YouTubeConnector = "youtubeConnector",
   DataExport = "dataExport",
   SpotifyConnector = "spotifyConnector",
   GitHubIntegration = "githubIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -170,11 +170,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Google Search Console connector",
     enabled: true,
   },
-  [FeatureSwitchKey.YouTubeConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the YouTube connector",
-    enabled: false,
-  },
   [FeatureSwitchKey.SpotifyConnector]: {
     maintainer: "ethan@vm0.ai",
     description: "Enable the Spotify connector integration",


### PR DESCRIPTION
## Summary
- Enable the YouTube connector for all users by removing its feature switch gate
- Remove the `youtubeConnector` feature switch key and registry entry
- Update connector and OAuth start tests to expect YouTube OAuth to be available by default

## Verification
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors check-types`
- pre-commit: prettier, knip, full `pnpm check-types`, commitlint
