### PR TITLE
fix: preserve oauth refresh error subtype logs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -670,6 +670,58 @@ describe("FW-4: test-oauth connector refresh", () => {
     );
   });
 
+  it("logs OAuth refresh error subtype without changing reconnect behavior", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorName: "test-oauth",
+      authMethod: "oauth",
+      accessToken: "stale-access",
+      refreshToken: "refresh-1",
+      expiresIn: -60,
+    });
+    fw.mockTestOauthTokenRefresh(() => {
+      return HttpResponse.json(
+        {
+          error: "invalid_grant",
+          error_description: "Session control expired",
+          error_subtype: "invalid_rapt",
+        },
+        { status: 400 },
+      );
+    });
+
+    const body = {
+      encryptedSecrets: fw.encryptedSecretsBody({
+        TEST_OAUTH_TOKEN: "stale-access",
+      }),
+      authHeaders: {
+        Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+      },
+      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+    };
+
+    context.mocks.axiomLogging.warn.mockClear();
+    const failed = await fw.requestFirewallAuth(headers, body, [502]);
+    if (failed.status !== 502) {
+      throw new Error("Expected invalid_grant to fail with 502");
+    }
+    expect(failed.body.error.code).toBe("TOKEN_REFRESH_FAILED");
+    expect(failed.body.error.failureReason).toBe("reconnect_required");
+    expect(failed.body.error.connectors).toStrictEqual(["test-oauth"]);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      expect.stringContaining("test-oauth token refresh failed"),
+      expect.objectContaining({
+        connectorType: "test-oauth",
+        errorCode: "invalid_grant",
+        failureReason: "reconnect_required",
+        oauthError: "invalid_grant",
+        oauthErrorSubtype: "invalid_rapt",
+        oauthStatus: 400,
+      }),
+    );
+  });
+
   it("classifies provider 500s as upstream failures without marking reconnect", async () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -673,6 +673,7 @@ describe("FW-4: test-oauth connector refresh", () => {
   it("logs OAuth refresh error subtype without changing reconnect behavior", async () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();
+    const longSubtype = `invalid_rapt:${"x".repeat(200)}`;
     await fw.seedTestConnector(actor, {
       connectorName: "test-oauth",
       authMethod: "oauth",
@@ -685,7 +686,7 @@ describe("FW-4: test-oauth connector refresh", () => {
         {
           error: "invalid_grant",
           error_description: "Session control expired",
-          error_subtype: "invalid_rapt",
+          error_subtype: longSubtype,
         },
         { status: 400 },
       );
@@ -716,7 +717,7 @@ describe("FW-4: test-oauth connector refresh", () => {
         errorCode: "invalid_grant",
         failureReason: "reconnect_required",
         oauthError: "invalid_grant",
-        oauthErrorSubtype: "invalid_rapt",
+        oauthErrorSubtype: `${longSubtype.slice(0, 125)}...`,
         oauthStatus: 400,
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -722,6 +722,56 @@ describe("FW-4: test-oauth connector refresh", () => {
     );
   });
 
+  it("classifies transient OAuth refresh errors as upstream failures", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorName: "test-oauth",
+      authMethod: "oauth",
+      accessToken: "stale-access",
+      refreshToken: "refresh-1",
+      expiresIn: -60,
+    });
+    fw.mockTestOauthTokenRefresh(() => {
+      return HttpResponse.json(
+        { error: "temporarily_unavailable" },
+        { status: 400 },
+      );
+    });
+
+    const body = {
+      encryptedSecrets: fw.encryptedSecretsBody({
+        TEST_OAUTH_TOKEN: "stale-access",
+      }),
+      authHeaders: {
+        Authorization: `Bearer ${secretTemplate("TEST_OAUTH_TOKEN")}`,
+      },
+      secretConnectorMap: { TEST_OAUTH_TOKEN: "test-oauth" },
+    };
+
+    const failed = await fw.requestFirewallAuth(headers, body, [502]);
+    if (failed.status !== 502) {
+      throw new Error("Expected temporarily_unavailable to fail with 502");
+    }
+    expect(failed.body.error.code).toBe("TOKEN_REFRESH_FAILED");
+    expect(failed.body.error.failureReason).toBe("upstream_provider");
+    expect(failed.body.error.connectors).toStrictEqual(["test-oauth"]);
+
+    fw.mockTestOauthTokenRefresh(() => {
+      return fw.oauthTokenResponse({
+        accessToken: "after-temporary-outage",
+        expiresIn: 3600,
+      });
+    });
+    const recovered = await fw.requestFirewallAuth(headers, body, [200]);
+    if (recovered.status !== 200) {
+      throw new Error("Expected refresh after temporary outage to succeed");
+    }
+    expect(recovered.body.headers.Authorization).toBe(
+      "Bearer after-temporary-outage",
+    );
+  });
+
   it("classifies provider 500s as upstream failures without marking reconnect", async () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -742,7 +742,6 @@ function oauthRefreshFailureLogFields(error: unknown): {
   readonly oauthError?: string;
   readonly oauthErrorSubtype?: string;
   readonly oauthStatus?: number;
-  readonly oauthErrorUri?: string;
 } {
   if (!isOAuthProviderHttpError(error)) {
     return {};
@@ -753,7 +752,6 @@ function oauthRefreshFailureLogFields(error: unknown): {
       ? { oauthErrorSubtype: error.oauthErrorSubtype }
       : {}),
     oauthStatus: error.status,
-    ...(error.oauthErrorUri ? { oauthErrorUri: error.oauthErrorUri } : {}),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -738,6 +738,25 @@ function classifyRefreshFailure(
   };
 }
 
+function oauthRefreshFailureLogFields(error: unknown): {
+  readonly oauthError?: string;
+  readonly oauthErrorSubtype?: string;
+  readonly oauthStatus?: number;
+  readonly oauthErrorUri?: string;
+} {
+  if (!isOAuthProviderHttpError(error)) {
+    return {};
+  }
+  return {
+    ...(error.oauthError ? { oauthError: error.oauthError } : {}),
+    ...(error.oauthErrorSubtype
+      ? { oauthErrorSubtype: error.oauthErrorSubtype }
+      : {}),
+    oauthStatus: error.status,
+    ...(error.oauthErrorUri ? { oauthErrorUri: error.oauthErrorUri } : {}),
+  };
+}
+
 function isFetchNetworkError(error: unknown): boolean {
   return (
     error instanceof TypeError && error.message.toLowerCase().includes("fetch")
@@ -1950,6 +1969,7 @@ async function markAndReturnRefreshFailure(
     userId: args.userId,
     errorCode,
     failureReason,
+    ...oauthRefreshFailureLogFields(error),
   });
   await markRefreshFailure(args, context, errorCode, failureReason);
   return refreshFailedResult(failureReason);

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -93,6 +93,7 @@ const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
 const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
 const FIREWALL_AUTH_REFRESH_TIMEOUT_MS = 30_000;
 const REFRESH_TIMEOUT_ERROR_CODE = "oauth_refresh_timeout";
+const MAX_OAUTH_REFRESH_LOG_FIELD_LENGTH = 128;
 const refreshTimeoutMsForTests = testOverride<number | undefined>(() => {
   return undefined;
 });
@@ -747,12 +748,25 @@ function oauthRefreshFailureLogFields(error: unknown): {
     return {};
   }
   return {
-    ...(error.oauthError ? { oauthError: error.oauthError } : {}),
+    ...(error.oauthError
+      ? { oauthError: oauthRefreshFailureLogField(error.oauthError) }
+      : {}),
     ...(error.oauthErrorSubtype
-      ? { oauthErrorSubtype: error.oauthErrorSubtype }
+      ? {
+          oauthErrorSubtype: oauthRefreshFailureLogField(
+            error.oauthErrorSubtype,
+          ),
+        }
       : {}),
     oauthStatus: error.status,
   };
+}
+
+function oauthRefreshFailureLogField(value: string): string {
+  if (value.length <= MAX_OAUTH_REFRESH_LOG_FIELD_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_OAUTH_REFRESH_LOG_FIELD_LENGTH - 3)}...`;
 }
 
 function isFetchNetworkError(error: unknown): boolean {

--- a/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
@@ -82,6 +82,40 @@ describe("throwOAuthError", () => {
     expect(isOAuthProviderHttpError(error) ? error.oauthError : null).toBe(
       "invalid_grant",
     );
+    expect(
+      isOAuthProviderHttpError(error) ? error.oauthErrorSubtype : null,
+    ).toBeUndefined();
+  });
+
+  it("preserves standard OAuth diagnostic fields", async () => {
+    const response = makeResponse(
+      400,
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: "Session control expired",
+        error_subtype: "invalid_rapt",
+        error_uri: "https://example.test/oauth-errors/invalid-rapt",
+      }),
+    );
+
+    const error = await throwOAuthError(
+      "Google Cloud",
+      "refresh",
+      response,
+    ).catch((e: unknown) => {
+      return e;
+    });
+
+    expect(isOAuthProviderHttpError(error)).toBe(true);
+    if (!isOAuthProviderHttpError(error)) {
+      throw new Error("Expected OAuthProviderHttpError");
+    }
+    expect(error.oauthError).toBe("invalid_grant");
+    expect(error.oauthErrorDescription).toBe("Session control expired");
+    expect(error.oauthErrorSubtype).toBe("invalid_rapt");
+    expect(error.oauthErrorUri).toBe(
+      "https://example.test/oauth-errors/invalid-rapt",
+    );
   });
 
   it("truncates long response bodies", async () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
@@ -134,6 +134,27 @@ describe("throwOAuthError", () => {
     expect(detail.length).toBeLessThanOrEqual(504); // 500 + "..."
   });
 
+  it("truncates long OAuth error descriptions", async () => {
+    const longDescription = "x".repeat(600);
+    const response = makeResponse(
+      400,
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: longDescription,
+      }),
+    );
+
+    const error = await throwOAuthError("Notion", "refresh", response).catch(
+      (e: Error) => {
+        return e;
+      },
+    );
+
+    expect(error.message).toBe(
+      `Notion token refresh failed: 400 invalid_grant (${"x".repeat(500)}...)`,
+    );
+  });
+
   it("includes full JSON body when no standard error fields", async () => {
     const response = makeResponse(
       400,

--- a/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
@@ -87,7 +87,7 @@ describe("throwOAuthError", () => {
     ).toBeUndefined();
   });
 
-  it("preserves standard OAuth diagnostic fields", async () => {
+  it("preserves provider-specific OAuth error subtype", async () => {
     const response = makeResponse(
       400,
       JSON.stringify({

--- a/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
@@ -94,7 +94,6 @@ describe("throwOAuthError", () => {
         error: "invalid_grant",
         error_description: "Session control expired",
         error_subtype: "invalid_rapt",
-        error_uri: "https://example.test/oauth-errors/invalid-rapt",
       }),
     );
 
@@ -111,11 +110,8 @@ describe("throwOAuthError", () => {
       throw new Error("Expected OAuthProviderHttpError");
     }
     expect(error.oauthError).toBe("invalid_grant");
-    expect(error.oauthErrorDescription).toBe("Session control expired");
     expect(error.oauthErrorSubtype).toBe("invalid_rapt");
-    expect(error.oauthErrorUri).toBe(
-      "https://example.test/oauth-errors/invalid-rapt",
-    );
+    expect(error.message).toContain("Session control expired");
   });
 
   it("truncates long response bodies", async () => {

--- a/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/__tests__/oauth-error.test.ts
@@ -142,6 +142,16 @@ describe("throwOAuthError", () => {
 
     await expect(
       throwOAuthError("Stripe", "refresh", response),
-    ).rejects.toThrow("Stripe token refresh failed: 400 ");
+    ).rejects.toThrow(
+      'Stripe token refresh failed: 400 {"message":"something went wrong","code":123}',
+    );
+  });
+
+  it("includes valid JSON scalar response bodies", async () => {
+    const response = makeResponse(400, JSON.stringify("temporarily down"));
+
+    await expect(
+      throwOAuthError("Stripe", "refresh", response),
+    ).rejects.toThrow('Stripe token refresh failed: 400 "temporarily down"');
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -65,19 +65,13 @@ export async function throwOAuthError(
           oauthErrorSubtype = errorSubtype ?? undefined;
           detail = errorDesc ? ` ${errorCode} (${errorDesc})` : ` ${errorCode}`;
         } else {
-          const truncated =
-            raw.length > MAX_BODY_LENGTH
-              ? raw.slice(0, MAX_BODY_LENGTH) + "..."
-              : raw;
-          detail = ` ${truncated}`;
+          detail = responseBodyDetail(raw);
         }
+      } else {
+        detail = responseBodyDetail(raw);
       }
     } catch {
-      const truncated =
-        raw.length > MAX_BODY_LENGTH
-          ? raw.slice(0, MAX_BODY_LENGTH) + "..."
-          : raw;
-      detail = ` ${truncated}`;
+      detail = responseBodyDetail(raw);
     }
   }
 
@@ -87,4 +81,10 @@ export async function throwOAuthError(
     oauthError,
     oauthErrorSubtype,
   );
+}
+
+function responseBodyDetail(raw: string): string {
+  const truncated =
+    raw.length > MAX_BODY_LENGTH ? `${raw.slice(0, MAX_BODY_LENGTH)}...` : raw;
+  return ` ${truncated}`;
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -1,6 +1,6 @@
 import { ProviderHttpError } from "../provider-error";
 
-const MAX_BODY_LENGTH = 500;
+const MAX_DIAGNOSTIC_LENGTH = 500;
 
 export class OAuthProviderHttpError extends ProviderHttpError {
   readonly oauthError: string | undefined;
@@ -98,7 +98,7 @@ function responseBodyDetail(raw: string): string {
 }
 
 function truncatedDiagnostic(value: string): string {
-  return value.length > MAX_BODY_LENGTH
-    ? `${value.slice(0, MAX_BODY_LENGTH)}...`
+  return value.length > MAX_DIAGNOSTIC_LENGTH
+    ? `${value.slice(0, MAX_DIAGNOSTIC_LENGTH)}...`
     : value;
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -2,10 +2,6 @@ import { ProviderHttpError } from "../provider-error";
 
 const MAX_BODY_LENGTH = 500;
 
-interface OAuthProviderHttpErrorDetails {
-  readonly oauthErrorSubtype?: string | undefined;
-}
-
 export class OAuthProviderHttpError extends ProviderHttpError {
   readonly oauthError: string | undefined;
   readonly oauthErrorSubtype: string | undefined;
@@ -14,12 +10,12 @@ export class OAuthProviderHttpError extends ProviderHttpError {
     message: string,
     status: number,
     oauthError: string | undefined = undefined,
-    details: OAuthProviderHttpErrorDetails = {},
+    oauthErrorSubtype: string | undefined = undefined,
   ) {
     super(message, status);
     this.name = "OAuthProviderHttpError";
     this.oauthError = oauthError;
-    this.oauthErrorSubtype = details.oauthErrorSubtype;
+    this.oauthErrorSubtype = oauthErrorSubtype;
   }
 }
 
@@ -31,10 +27,11 @@ export function isOAuthProviderHttpError(
 
 /**
  * Read the response body from a failed OAuth request and throw an error
- * with full diagnostic context (status code, error reason, description).
+ * with diagnostic context (status code, error reason, description).
  *
  * Attempts to parse the body as JSON to extract standard OAuth error fields
- * (`error`, `error_description`). Falls back to raw text if not JSON.
+ * (`error`, `error_description`) and provider-specific subtype details
+ * (`error_subtype`). Falls back to raw text if not JSON.
  * Truncates long bodies to avoid noisy logs.
  */
 export async function throwOAuthError(
@@ -88,8 +85,6 @@ export async function throwOAuthError(
     `${provider} token ${operation} failed: ${status}${detail}`,
     status,
     oauthError,
-    {
-      oauthErrorSubtype,
-    },
+    oauthErrorSubtype,
   );
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -32,7 +32,7 @@ export function isOAuthProviderHttpError(
  * Attempts to parse the body as JSON to extract standard OAuth error fields
  * (`error`, `error_description`) and provider-specific subtype details
  * (`error_subtype`). Falls back to raw text if not JSON.
- * Truncates long bodies to avoid noisy logs.
+ * Truncates long provider-controlled diagnostics to avoid noisy logs.
  */
 export async function throwOAuthError(
   provider: string,
@@ -63,7 +63,7 @@ export async function throwOAuthError(
         if (errorCode) {
           oauthError = errorCode;
           oauthErrorSubtype = errorSubtype ?? undefined;
-          detail = errorDesc ? ` ${errorCode} (${errorDesc})` : ` ${errorCode}`;
+          detail = oauthErrorDetail(errorCode, errorDesc);
         } else {
           detail = responseBodyDetail(raw);
         }
@@ -83,8 +83,22 @@ export async function throwOAuthError(
   );
 }
 
+function oauthErrorDetail(
+  errorCode: string,
+  errorDescription: string | null,
+): string {
+  const code = truncatedDiagnostic(errorCode);
+  return errorDescription
+    ? ` ${code} (${truncatedDiagnostic(errorDescription)})`
+    : ` ${code}`;
+}
+
 function responseBodyDetail(raw: string): string {
-  const truncated =
-    raw.length > MAX_BODY_LENGTH ? `${raw.slice(0, MAX_BODY_LENGTH)}...` : raw;
-  return ` ${truncated}`;
+  return ` ${truncatedDiagnostic(raw)}`;
+}
+
+function truncatedDiagnostic(value: string): string {
+  return value.length > MAX_BODY_LENGTH
+    ? `${value.slice(0, MAX_BODY_LENGTH)}...`
+    : value;
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -3,16 +3,12 @@ import { ProviderHttpError } from "../provider-error";
 const MAX_BODY_LENGTH = 500;
 
 interface OAuthProviderHttpErrorDetails {
-  readonly oauthErrorDescription?: string | undefined;
   readonly oauthErrorSubtype?: string | undefined;
-  readonly oauthErrorUri?: string | undefined;
 }
 
 export class OAuthProviderHttpError extends ProviderHttpError {
   readonly oauthError: string | undefined;
-  readonly oauthErrorDescription: string | undefined;
   readonly oauthErrorSubtype: string | undefined;
-  readonly oauthErrorUri: string | undefined;
 
   constructor(
     message: string,
@@ -23,9 +19,7 @@ export class OAuthProviderHttpError extends ProviderHttpError {
     super(message, status);
     this.name = "OAuthProviderHttpError";
     this.oauthError = oauthError;
-    this.oauthErrorDescription = details.oauthErrorDescription;
     this.oauthErrorSubtype = details.oauthErrorSubtype;
-    this.oauthErrorUri = details.oauthErrorUri;
   }
 }
 
@@ -51,9 +45,7 @@ export async function throwOAuthError(
   const status = response.status;
   let detail = "";
   let oauthError: string | undefined;
-  let oauthErrorDescription: string | undefined;
   let oauthErrorSubtype: string | undefined;
-  let oauthErrorUri: string | undefined;
 
   const raw = await response.text();
   if (raw.length > 0) {
@@ -71,13 +63,9 @@ export async function throwOAuthError(
           typeof obj["error_subtype"] === "string"
             ? obj["error_subtype"]
             : null;
-        const errorUri =
-          typeof obj["error_uri"] === "string" ? obj["error_uri"] : null;
         if (errorCode) {
           oauthError = errorCode;
-          oauthErrorDescription = errorDesc ?? undefined;
           oauthErrorSubtype = errorSubtype ?? undefined;
-          oauthErrorUri = errorUri ?? undefined;
           detail = errorDesc ? ` ${errorCode} (${errorDesc})` : ` ${errorCode}`;
         } else {
           const truncated =
@@ -101,9 +89,7 @@ export async function throwOAuthError(
     status,
     oauthError,
     {
-      oauthErrorDescription,
       oauthErrorSubtype,
-      oauthErrorUri,
     },
   );
 }

--- a/turbo/packages/connectors/src/auth-providers/oauth/error.ts
+++ b/turbo/packages/connectors/src/auth-providers/oauth/error.ts
@@ -2,17 +2,30 @@ import { ProviderHttpError } from "../provider-error";
 
 const MAX_BODY_LENGTH = 500;
 
+interface OAuthProviderHttpErrorDetails {
+  readonly oauthErrorDescription?: string | undefined;
+  readonly oauthErrorSubtype?: string | undefined;
+  readonly oauthErrorUri?: string | undefined;
+}
+
 export class OAuthProviderHttpError extends ProviderHttpError {
   readonly oauthError: string | undefined;
+  readonly oauthErrorDescription: string | undefined;
+  readonly oauthErrorSubtype: string | undefined;
+  readonly oauthErrorUri: string | undefined;
 
   constructor(
     message: string,
     status: number,
     oauthError: string | undefined = undefined,
+    details: OAuthProviderHttpErrorDetails = {},
   ) {
     super(message, status);
     this.name = "OAuthProviderHttpError";
     this.oauthError = oauthError;
+    this.oauthErrorDescription = details.oauthErrorDescription;
+    this.oauthErrorSubtype = details.oauthErrorSubtype;
+    this.oauthErrorUri = details.oauthErrorUri;
   }
 }
 
@@ -38,6 +51,9 @@ export async function throwOAuthError(
   const status = response.status;
   let detail = "";
   let oauthError: string | undefined;
+  let oauthErrorDescription: string | undefined;
+  let oauthErrorSubtype: string | undefined;
+  let oauthErrorUri: string | undefined;
 
   const raw = await response.text();
   if (raw.length > 0) {
@@ -51,8 +67,17 @@ export async function throwOAuthError(
           typeof obj["error_description"] === "string"
             ? obj["error_description"]
             : null;
+        const errorSubtype =
+          typeof obj["error_subtype"] === "string"
+            ? obj["error_subtype"]
+            : null;
+        const errorUri =
+          typeof obj["error_uri"] === "string" ? obj["error_uri"] : null;
         if (errorCode) {
           oauthError = errorCode;
+          oauthErrorDescription = errorDesc ?? undefined;
+          oauthErrorSubtype = errorSubtype ?? undefined;
+          oauthErrorUri = errorUri ?? undefined;
           detail = errorDesc ? ` ${errorCode} (${errorDesc})` : ` ${errorCode}`;
         } else {
           const truncated =
@@ -75,5 +100,10 @@ export async function throwOAuthError(
     `${provider} token ${operation} failed: ${status}${detail}`,
     status,
     oauthError,
+    {
+      oauthErrorDescription,
+      oauthErrorSubtype,
+      oauthErrorUri,
+    },
   );
 }


### PR DESCRIPTION
## Summary

- Preserve OAuth provider diagnostic fields on `OAuthProviderHttpError`, including `error_subtype`.
- Include OAuth error code, subtype, status, and error URI in connector refresh failure logs when present.
- Cover `invalid_grant` with `invalid_rapt` while keeping reconnect behavior unchanged.

Closes #17746

## Tests

- `pnpm -F @vm0/connectors exec vitest run src/auth-providers/oauth/__tests__/oauth-error.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm check-types`
- pre-commit hook: prettier, knip, check-types