### PR TITLE
fix: avoid systemd env for runner service secrets

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1945,7 +1945,7 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -f ${RUNNER_DIR}/status.json"
 
-            local SERVICE_SECRETS_SOURCE="${RUNNER_DIR}/.service-secrets.env.source"
+            local SERVICE_SECRETS_SOURCE="${RUNNER_DIR}/.service-secrets.env.source.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.${HOST_INDEX}"
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -f ${SERVICE_SECRETS_SOURCE}"
             # shellcheck disable=SC2029

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1945,14 +1945,30 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -f ${RUNNER_DIR}/status.json"
 
+            local SERVICE_SECRETS_SOURCE="${RUNNER_DIR}/.service-secrets.env.source"
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "sudo rm -f ${SERVICE_SECRETS_SOURCE}"
+            if ! printf 'VERCEL_AUTOMATION_BYPASS_SECRET=%s\n' "$VERCEL_BYPASS" \
+              | ssh "$REMOTE" "sudo sh -c 'umask 077; cat > \"\$1\" && chmod 600 \"\$1\"' sh ${SERVICE_SECRETS_SOURCE}"; then
+              # shellcheck disable=SC2029
+              ssh "$REMOTE" "sudo rm -f ${SERVICE_SECRETS_SOURCE}" || true
+              return 1
+            fi
+
             # Start as systemd transient service
+            local START_STATUS=0
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo ${BIN_DIR}/runner service start \
               --name ${RUNNER_NAME} \
               --config ${RUNNER_DIR}/runner.yaml \
-              --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
+              --service-secrets-file ${SERVICE_SECRETS_SOURCE} \
               --env USE_MOCK_CLAUDE=true \
-              --env USE_MOCK_CODEX=true"
+              --env USE_MOCK_CODEX=true" || START_STATUS=$?
+            # shellcheck disable=SC2029
+            ssh "$REMOTE" "sudo rm -f ${SERVICE_SECRETS_SOURCE}" || true
+            if [ "$START_STATUS" -ne 0 ]; then
+              return "$START_STATUS"
+            fi
 
             # Wait for the runner main loop to publish status.json before
             # health checks. systemd-run returns once the process starts, but

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1948,6 +1948,7 @@ jobs:
             local SERVICE_SECRETS_SOURCE="${RUNNER_DIR}/.service-secrets.env.source"
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -f ${SERVICE_SECRETS_SOURCE}"
+            # shellcheck disable=SC2029
             if ! printf 'VERCEL_AUTOMATION_BYPASS_SECRET=%s\n' "$VERCEL_BYPASS" \
               | ssh "$REMOTE" "sudo sh -c 'umask 077; cat > \"\$1\" && chmod 600 \"\$1\"' sh ${SERVICE_SECRETS_SOURCE}"; then
               # shellcheck disable=SC2029

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -39,30 +39,38 @@
     # ========================================
     # Phase 3b: Install systemd service (traffic cutover point)
     # ========================================
-    - name: Write runner service secrets file
-      copy:
-        dest: "{{ runner_dir }}/service-secrets.env"
-        owner: root
-        group: root
-        mode: "0600"
-        content: |
-          {% if sentry_dsn is defined and sentry_dsn %}
-          SENTRY_DSN={{ sentry_dsn }}
-          {% endif %}
-          {% if axiom_token_telemetry is defined and axiom_token_telemetry %}
-          AXIOM_TOKEN_TELEMETRY={{ axiom_token_telemetry }}
-          {% endif %}
-          {% if axiom_dataset_suffix is defined and axiom_dataset_suffix %}
-          AXIOM_DATASET_SUFFIX={{ axiom_dataset_suffix }}
-          {% endif %}
-      no_log: true
+    - name: Install runner service with private service secrets
+      block:
+        - name: Write runner service secrets source file
+          copy:
+            dest: "{{ runner_dir }}/.service-secrets.env.source"
+            owner: root
+            group: root
+            mode: "0600"
+            content: |
+              {% if sentry_dsn is defined and sentry_dsn %}
+              SENTRY_DSN={{ sentry_dsn }}
+              {% endif %}
+              {% if axiom_token_telemetry is defined and axiom_token_telemetry %}
+              AXIOM_TOKEN_TELEMETRY={{ axiom_token_telemetry }}
+              {% endif %}
+              {% if axiom_dataset_suffix is defined and axiom_dataset_suffix %}
+              AXIOM_DATASET_SUFFIX={{ axiom_dataset_suffix }}
+              {% endif %}
+          no_log: true
 
-    - name: Install and start runner service
-      command: >
-        {{ bin_dir }}/runner service install
-        --name {{ runner_name }}
-        --config {{ runner_dir }}/runner.yaml
-        --service-secrets-file {{ runner_dir }}/service-secrets.env
+        - name: Install and start runner service
+          command: >
+            {{ bin_dir }}/runner service install
+            --name {{ runner_name }}
+            --config {{ runner_dir }}/runner.yaml
+            --service-secrets-file {{ runner_dir }}/.service-secrets.env.source
+      always:
+        - name: Remove runner service secrets source file
+          file:
+            path: "{{ runner_dir }}/.service-secrets.env.source"
+            state: absent
+          no_log: true
 
     # ========================================
     # Phase 4: Health check

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -41,9 +41,17 @@
     # ========================================
     - name: Install runner service with private service secrets
       block:
+        - name: Create runner service secrets source file
+          tempfile:
+            state: file
+            path: "{{ runner_dir }}"
+            prefix: ".service-secrets.env.source."
+          register: service_secrets_source
+          no_log: true
+
         - name: Write runner service secrets source file
           copy:
-            dest: "{{ runner_dir }}/.service-secrets.env.source"
+            dest: "{{ service_secrets_source.path }}"
             owner: root
             group: root
             mode: "0600"
@@ -64,12 +72,13 @@
             {{ bin_dir }}/runner service install
             --name {{ runner_name }}
             --config {{ runner_dir }}/runner.yaml
-            --service-secrets-file {{ runner_dir }}/.service-secrets.env.source
+            --service-secrets-file {{ service_secrets_source.path }}
       always:
         - name: Remove runner service secrets source file
           file:
-            path: "{{ runner_dir }}/.service-secrets.env.source"
+            path: "{{ service_secrets_source.path }}"
             state: absent
+          when: service_secrets_source is defined and service_secrets_source.path is defined
           no_log: true
 
     # ========================================

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -18,9 +18,9 @@
 #   - runner_version: Semantic version of the runner being promoted
 #
 # Optional Variables:
-#   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
+#   - sentry_dsn: Written to the runner service secrets file as SENTRY_DSN
 #   - axiom_token_telemetry / axiom_dataset_suffix:
-#       Forwarded to the systemd unit as AXIOM_TOKEN_TELEMETRY /
+#       Written to the runner service secrets file as AXIOM_TOKEN_TELEMETRY /
 #       AXIOM_DATASET_SUFFIX. Both must be set for Axiom telemetry to activate.
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
 #       Passed to `runner gc` so R2-side cache cleanup runs.
@@ -39,20 +39,30 @@
     # ========================================
     # Phase 3b: Install systemd service (traffic cutover point)
     # ========================================
+    - name: Write runner service secrets file
+      copy:
+        dest: "{{ runner_dir }}/service-secrets.env"
+        owner: root
+        group: root
+        mode: "0600"
+        content: |
+          {% if sentry_dsn is defined and sentry_dsn %}
+          SENTRY_DSN={{ sentry_dsn }}
+          {% endif %}
+          {% if axiom_token_telemetry is defined and axiom_token_telemetry %}
+          AXIOM_TOKEN_TELEMETRY={{ axiom_token_telemetry }}
+          {% endif %}
+          {% if axiom_dataset_suffix is defined and axiom_dataset_suffix %}
+          AXIOM_DATASET_SUFFIX={{ axiom_dataset_suffix }}
+          {% endif %}
+      no_log: true
+
     - name: Install and start runner service
       command: >
         {{ bin_dir }}/runner service install
         --name {{ runner_name }}
         --config {{ runner_dir }}/runner.yaml
-        {% if sentry_dsn is defined and sentry_dsn %}
-        --env SENTRY_DSN={{ sentry_dsn }}
-        {% endif %}
-        {% if axiom_token_telemetry is defined and axiom_token_telemetry %}
-        --env AXIOM_TOKEN_TELEMETRY={{ axiom_token_telemetry }}
-        {% endif %}
-        {% if axiom_dataset_suffix is defined and axiom_dataset_suffix %}
-        --env AXIOM_DATASET_SUFFIX={{ axiom_dataset_suffix }}
-        {% endif %}
+        --service-secrets-file {{ runner_dir }}/service-secrets.env
 
     # ========================================
     # Phase 4: Health check

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -399,30 +399,35 @@
       set_fact:
         service_secrets_file_supported: "{{ '--service-secrets-file' in (service_install_help.stdout ~ service_install_help.stderr) }}"
 
-    - name: Write target runner service secrets file
+    - name: Install target runner service with private service secrets
       when:
         - not (skip_install | default(false))
         - service_secrets_file_supported | default(false)
-      copy:
-        dest: "{{ runner_dir }}/service-secrets.env"
-        owner: root
-        group: root
-        mode: "0600"
-        content: |
-          {% if sentry_dsn is defined and sentry_dsn %}
-          SENTRY_DSN={{ sentry_dsn }}
-          {% endif %}
-      no_log: true
+      block:
+        - name: Write target runner service secrets source file
+          copy:
+            dest: "{{ runner_dir }}/.service-secrets.env.source"
+            owner: root
+            group: root
+            mode: "0600"
+            content: |
+              {% if sentry_dsn is defined and sentry_dsn %}
+              SENTRY_DSN={{ sentry_dsn }}
+              {% endif %}
+          no_log: true
 
-    - name: Install and start target runner service
-      when:
-        - not (skip_install | default(false))
-        - service_secrets_file_supported | default(false)
-      command: >
-        {{ bin_dir }}/runner service install
-        --name {{ runner_name }}
-        --config {{ runner_dir }}/runner.yaml
-        --service-secrets-file {{ runner_dir }}/service-secrets.env
+        - name: Install and start target runner service
+          command: >
+            {{ bin_dir }}/runner service install
+            --name {{ runner_name }}
+            --config {{ runner_dir }}/runner.yaml
+            --service-secrets-file {{ runner_dir }}/.service-secrets.env.source
+      always:
+        - name: Remove target runner service secrets source file
+          file:
+            path: "{{ runner_dir }}/.service-secrets.env.source"
+            state: absent
+          no_log: true
 
     - name: Install and start target runner service with legacy env
       when:

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -404,9 +404,17 @@
         - not (skip_install | default(false))
         - service_secrets_file_supported | default(false)
       block:
+        - name: Create target runner service secrets source file
+          tempfile:
+            state: file
+            path: "{{ runner_dir }}"
+            prefix: ".service-secrets.env.source."
+          register: service_secrets_source
+          no_log: true
+
         - name: Write target runner service secrets source file
           copy:
-            dest: "{{ runner_dir }}/.service-secrets.env.source"
+            dest: "{{ service_secrets_source.path }}"
             owner: root
             group: root
             mode: "0600"
@@ -421,12 +429,13 @@
             {{ bin_dir }}/runner service install
             --name {{ runner_name }}
             --config {{ runner_dir }}/runner.yaml
-            --service-secrets-file {{ runner_dir }}/.service-secrets.env.source
+            --service-secrets-file {{ service_secrets_source.path }}
       always:
         - name: Remove target runner service secrets source file
           file:
-            path: "{{ runner_dir }}/.service-secrets.env.source"
+            path: "{{ service_secrets_source.path }}"
             state: absent
+          when: service_secrets_source is defined and service_secrets_source.path is defined
           no_log: true
 
     - name: Install and start target runner service with legacy env

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -57,7 +57,9 @@
 #                   the repo is private. Omit for public repos.
 #
 # Optional Variables:
-#   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
+#   - sentry_dsn: Written to the runner service secrets file as SENTRY_DSN
+#                 when the target runner supports --service-secrets-file.
+#                 Older rollback targets fall back to legacy --env.
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
 #       Passed to `runner build` for best-effort template cache download/upload
 #       and to `runner gc` for best-effort R2-side cleanup. Rollback does not
@@ -384,8 +386,48 @@
     # Rewrites the unit file, daemon-reloads, and `enable --now` starts the
     # unit. A fresh process initializes mode=Running (StatusTracker::new
     # hard-codes it; status.json is an export, not a control input).
-    - name: Install and start target runner service
+    - name: Check target runner service secrets flag support
       when: not (skip_install | default(false))
+      command: >
+        {{ bin_dir }}/runner service install --help
+      register: service_install_help
+      changed_when: false
+      failed_when: false
+
+    - name: Record target runner service secrets flag support
+      when: not (skip_install | default(false))
+      set_fact:
+        service_secrets_file_supported: "{{ '--service-secrets-file' in (service_install_help.stdout ~ service_install_help.stderr) }}"
+
+    - name: Write target runner service secrets file
+      when:
+        - not (skip_install | default(false))
+        - service_secrets_file_supported | default(false)
+      copy:
+        dest: "{{ runner_dir }}/service-secrets.env"
+        owner: root
+        group: root
+        mode: "0600"
+        content: |
+          {% if sentry_dsn is defined and sentry_dsn %}
+          SENTRY_DSN={{ sentry_dsn }}
+          {% endif %}
+      no_log: true
+
+    - name: Install and start target runner service
+      when:
+        - not (skip_install | default(false))
+        - service_secrets_file_supported | default(false)
+      command: >
+        {{ bin_dir }}/runner service install
+        --name {{ runner_name }}
+        --config {{ runner_dir }}/runner.yaml
+        --service-secrets-file {{ runner_dir }}/service-secrets.env
+
+    - name: Install and start target runner service with legacy env
+      when:
+        - not (skip_install | default(false))
+        - not (service_secrets_file_supported | default(false))
       command: >
         {{ bin_dir }}/runner service install
         --name {{ runner_name }}
@@ -393,6 +435,7 @@
         {% if sentry_dsn is defined and sentry_dsn %}
         --env SENTRY_DSN={{ sentry_dsn }}
         {% endif %}
+      no_log: true
 
     - name: Verify target runner health
       when: not (skip_install | default(false))

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -1,8 +1,10 @@
 //! Tracing layer that ships WARN+ events to Axiom.
 //!
-//! Disabled at construction when `AXIOM_TOKEN_TELEMETRY` or
-//! `AXIOM_DATASET_SUFFIX` is unset. Dual-write: the existing fmt subscriber
-//! keeps writing to stderr + file; this layer adds Axiom as an extra sink.
+//! Disabled at construction when no telemetry token or dataset suffix is
+//! provided. Production values come from service secrets first, with
+//! environment fallback for non-service commands. Dual-write: the existing fmt
+//! subscriber keeps writing to stderr + file; this layer adds Axiom as an extra
+//! sink.
 //!
 //! Uses the workspace reqwest client directly (no axiom-rs) so we don't pull
 //! a second reqwest major into the musl binary. Ingest endpoint:

--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -62,8 +62,6 @@ const _: () = assert!(
 const DEBUG_FIELD_MAX_BYTES: usize = 4 * 1024;
 const DEFAULT_AXIOM_URL: &str = "https://api.axiom.co";
 const SERVICE_NAME: &str = "runner";
-const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
-const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 /// Target used for this layer's own diagnostics. Dispatcher diagnostics
 /// (non-success ingest responses, HTTP errors) remain visible to local
 /// logging, while the Axiom per-layer filter keeps any observed diagnostics
@@ -100,15 +98,11 @@ impl AxiomGuard {
     }
 }
 
-/// Initialize the Axiom layer. Returns `None` when required env is missing —
-/// caller should install a `None` layer in that case (no-op). Production
-/// entry point; always targets `DEFAULT_AXIOM_URL`.
-pub(crate) fn init() -> Option<(AxiomLayer, AxiomGuard)> {
-    init_from_env_values(
-        DEFAULT_AXIOM_URL,
-        std::env::var(AXIOM_TOKEN_ENV).ok(),
-        std::env::var(AXIOM_SUFFIX_ENV).ok(),
-    )
+pub(crate) fn init_with_values(
+    token: Option<String>,
+    suffix: Option<String>,
+) -> Option<(AxiomLayer, AxiomGuard)> {
+    init_from_env_values(DEFAULT_AXIOM_URL, token, suffix)
 }
 
 fn init_from_env_values(
@@ -123,8 +117,8 @@ fn init_from_env_values(
 
 /// Core init with an explicit base URL. Exists so module tests can point
 /// at an `httpmock` server without leaking an `AXIOM_URL` override into the
-/// runner's production env surface — production code should always call
-/// [`init`], which hard-codes [`DEFAULT_AXIOM_URL`].
+/// runner's production env surface — production code should call
+/// [`init_with_values`], which hard-codes [`DEFAULT_AXIOM_URL`].
 fn init_with_base_url(
     base_url: &str,
     token: &str,

--- a/crates/runner/src/cmd/mod.rs
+++ b/crates/runner/src/cmd/mod.rs
@@ -22,5 +22,5 @@ pub use kill::{KillArgs, run_kill};
 pub use local::{LocalArgs, run_local};
 pub use service::{ServiceArgs, run_service};
 pub use setup::run_setup;
-pub use start::{StartArgs, run_start};
+pub(crate) use start::{StartArgs, run_start_with_service_secrets};
 pub use workspace_image_cache::{WorkspaceImageCacheArgs, run_workspace_image_cache};

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -52,6 +52,10 @@ struct ServiceRunArgs {
     /// Environment variables to pass to the service (KEY=VALUE)
     #[arg(long, value_name = "KEY=VALUE")]
     env: Vec<String>,
+    /// File containing allowlisted service secrets. Secret values are staged
+    /// privately and passed to the service by path, not systemd environment.
+    #[arg(long)]
+    service_secrets_file: Option<PathBuf>,
     /// Use local file queue provider instead of API
     #[arg(long)]
     local: bool,
@@ -218,6 +222,7 @@ fn generate_unit_file(
     exe_path: &Path,
     config_path: &Path,
     env_vars: &[String],
+    service_secrets_file: Option<&Path>,
     local: bool,
 ) -> String {
     let mut env_lines = String::new();
@@ -226,6 +231,12 @@ fn generate_unit_file(
         env_lines.push_str(&format!("Environment=\"{escaped}\"\n"));
     }
     let local_flag = if local { " --local" } else { "" };
+    let service_secrets_arg = service_secrets_file
+        .map(|path| {
+            let path = escape_systemd_value(&path.display().to_string());
+            format!(" --service-secrets-file \"{path}\"")
+        })
+        .unwrap_or_default();
     let exe = escape_systemd_value(&exe_path.display().to_string());
     let config = escape_systemd_value(&config_path.display().to_string());
     format!(
@@ -237,7 +248,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=\"{exe}\" start --config \"{config}\"{local_flag}
+ExecStart=\"{exe}\" start --config \"{config}\"{service_secrets_arg}{local_flag}
 Restart=on-failure
 RestartSec=5
 KillSignal=SIGTERM
@@ -270,13 +281,93 @@ fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
             ));
         }
         let eq_pos = entry.find('=');
-        if eq_pos.is_none_or(|p| p == 0) {
+        let Some(eq_pos) = eq_pos else {
+            return Err(RunnerError::Config(format!(
+                "invalid --env value '{entry}': expected KEY=VALUE format"
+            )));
+        };
+        if eq_pos == 0 {
             return Err(RunnerError::Config(format!(
                 "invalid --env value '{entry}': expected KEY=VALUE format"
             )));
         }
+        let key = &entry[..eq_pos];
+        if crate::service_secrets::is_service_secret_key(key) {
+            return Err(RunnerError::Config(format!(
+                "invalid --env key {key}: service secrets must be passed with --service-secrets-file"
+            )));
+        }
     }
     Ok(())
+}
+
+fn service_secrets_path_for_suffix(suffix: &str) -> RunnerResult<PathBuf> {
+    let home = HomePaths::new()?;
+    Ok(crate::service_secrets::canonical_service_secrets_path(
+        &home, suffix,
+    ))
+}
+
+async fn stage_service_secrets_for_suffix(
+    suffix: &str,
+    source: Option<&Path>,
+) -> RunnerResult<Option<PathBuf>> {
+    let Some(source) = source else {
+        return Ok(None);
+    };
+    validate_systemd_path("service secrets source file path", source)?;
+    let destination = service_secrets_path_for_suffix(suffix)?;
+    crate::service_secrets::stage_service_secrets_file(source, &destination).await?;
+    Ok(Some(destination))
+}
+
+async fn remove_service_secrets_for_suffix(suffix: &str) -> RunnerResult<()> {
+    let path = service_secrets_path_for_suffix(suffix)?;
+    crate::service_secrets::remove_service_secrets_file(&path).await
+}
+
+fn unit_suffix(unit: &str) -> Option<&str> {
+    unit.strip_prefix(UNIT_PREFIX)
+}
+
+fn build_systemd_run_args(
+    unit: &str,
+    exe_path: &Path,
+    config_path: &Path,
+    env_vars: &[String],
+    service_secrets_file: Option<&Path>,
+    local: bool,
+) -> Vec<OsString> {
+    let unit_arg = format!("--unit={unit}");
+    let desc_arg = format!("--description=VM0 Runner ({unit})");
+    let syslog_arg = format!("--property=SyslogIdentifier={unit}");
+    let mut args = vec![
+        OsString::from(unit_arg),
+        OsString::from(desc_arg),
+        OsString::from("--property=Type=exec"),
+        OsString::from("--property=Restart=on-failure"),
+        OsString::from("--property=RestartSec=5"),
+        OsString::from("--property=StandardOutput=journal"),
+        OsString::from("--property=StandardError=journal"),
+        OsString::from("--property=KillSignal=SIGTERM"),
+        OsString::from("--property=TimeoutStopSec=300"),
+        OsString::from(syslog_arg),
+    ];
+    for entry in env_vars {
+        args.push(OsString::from(format!("--setenv={entry}")));
+    }
+    args.push(exe_path.as_os_str().to_os_string());
+    args.push(OsString::from("start"));
+    args.push(OsString::from("--config"));
+    args.push(config_path.as_os_str().to_os_string());
+    if let Some(path) = service_secrets_file {
+        args.push(OsString::from("--service-secrets-file"));
+        args.push(path.as_os_str().to_os_string());
+    }
+    if local {
+        args.push(OsString::from("--local"));
+    }
+    args
 }
 
 fn validate_systemd_path(label: &str, path: &Path) -> RunnerResult<()> {
@@ -558,8 +649,8 @@ fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
         drop(file);
         if let Err(e) = std::fs::rename(&tmp, path) {
             // Unlike short-lived dirs elsewhere in the crate, unit files live
-            // in /etc/systemd/system/ which no GC path sweeps, and the staged
-            // content contains Environment= secrets.
+            // in /etc/systemd/system/ which no GC path sweeps, so failed
+            // staging must not leave unit content behind.
             let _ = std::fs::remove_file(&tmp);
             return Err(RunnerError::Internal(format!(
                 "rename {} -> {}: {e}",
@@ -1122,32 +1213,22 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     )?;
     validate_systemd_path("current executable path", &exe_path)?;
     validate_systemd_path("config path", &config_path)?;
+    let service_secrets_file =
+        stage_service_secrets_for_suffix(&args.name, args.service_secrets_file.as_deref()).await?;
+    if let Some(path) = &service_secrets_file {
+        validate_systemd_path("service secrets file path", path)?;
+    }
 
-    let unit_arg = format!("--unit={unit}");
-    let desc_arg = format!("--description=VM0 Runner ({unit})");
-    let syslog_arg = format!("--property=SyslogIdentifier={unit}");
     let mut cmd = tokio::process::Command::new("systemd-run");
-    cmd.args([
-        &*unit_arg,
-        &*desc_arg,
-        "--property=Type=exec",
-        "--property=Restart=on-failure",
-        "--property=RestartSec=5",
-        "--property=StandardOutput=journal",
-        "--property=StandardError=journal",
-        "--property=KillSignal=SIGTERM",
-        "--property=TimeoutStopSec=300",
-        &*syslog_arg,
-    ]);
-    for entry in &args.env {
-        cmd.arg(format!("--setenv={entry}"));
-    }
-    cmd.arg(&exe_path)
-        .args(["start", "--config"])
-        .arg(&config_path);
-    if args.local {
-        cmd.arg("--local");
-    }
+    let command_args = build_systemd_run_args(
+        &unit,
+        &exe_path,
+        &config_path,
+        &args.env,
+        service_secrets_file.as_deref(),
+        args.local,
+    );
+    cmd.args(&command_args);
 
     let status = cmd
         .status()
@@ -1172,6 +1253,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
 /// See [`check_active_jobs_gate`] for the policy.
 async fn stop(args: ServiceStopArgs) -> RunnerResult<()> {
     let unit = unit_name(&args.name)?;
+    let _service_lock = acquire_service_lock(&unit).await?;
     check_active_jobs_gate(&unit, &args.name, args.force, "stop").await?;
     let svc = format!("{unit}.service");
 
@@ -1191,6 +1273,15 @@ async fn stop(args: ServiceStopArgs) -> RunnerResult<()> {
     // Clear "failed" latch so systemd fully unloads the transient unit.
     // (stop alone does not clear the failed state.)
     let _ = run_systemctl(&["reset-failed", &svc]).await;
+    if !unit_file_path(&unit).exists()
+        && let Err(e) = remove_service_secrets_for_suffix(&args.name).await
+    {
+        warn!(
+            unit = %unit,
+            error = %e,
+            "failed to remove transient service secrets file"
+        );
+    }
     Ok(())
 }
 
@@ -1207,12 +1298,33 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
     )?;
     validate_systemd_path("current executable path", &exe_path)?;
     validate_systemd_path("config path", &config_path)?;
+    let service_secrets_file =
+        stage_service_secrets_for_suffix(&args.name, args.service_secrets_file.as_deref()).await?;
+    if let Some(path) = &service_secrets_file {
+        validate_systemd_path("service secrets file path", path)?;
+    }
 
-    let unit_content = generate_unit_file(&unit, &exe_path, &config_path, &args.env, args.local);
+    let unit_content = generate_unit_file(
+        &unit,
+        &exe_path,
+        &config_path,
+        &args.env,
+        service_secrets_file.as_deref(),
+        args.local,
+    );
     let upath = unit_file_path(&unit);
 
     cleanup_unit_staging_files(&upath)?;
     write_unit_file(&upath, &unit_content)?;
+    if service_secrets_file.is_none()
+        && let Err(e) = remove_service_secrets_for_suffix(&args.name).await
+    {
+        warn!(
+            unit = %unit,
+            error = %e,
+            "failed to remove stale service secrets file"
+        );
+    }
 
     run_systemctl(&["daemon-reload"]).await?;
     let svc = format!("{unit}.service");
@@ -1245,6 +1357,12 @@ pub(crate) async fn uninstall_service_unit(unit: &str) -> RunnerResult<()> {
 
     if let Err(e) = run_systemctl(&["daemon-reload"]).await {
         warn!(unit = %unit, error = %e, "failed to reload systemd daemon");
+    }
+
+    if let Some(suffix) = unit_suffix(unit)
+        && let Err(e) = remove_service_secrets_for_suffix(suffix).await
+    {
+        warn!(unit = %unit, error = %e, "failed to remove service secrets file");
     }
 
     info!(unit = %unit, "service uninstalled");
@@ -1898,6 +2016,7 @@ mod tests {
             Path::new("/var/lib/vm0-runner/bin/v0.1.0/vm0-runner"),
             Path::new("/home/ubuntu/runner.yaml"),
             &[],
+            None,
             false,
         );
         assert!(content.contains("Description=VM0 Runner (vm0-runner-v0.1.0)"));
@@ -1918,7 +2037,6 @@ mod tests {
     #[test]
     fn test_generate_unit_file_with_env() {
         let env = vec![
-            "VERCEL_AUTOMATION_BYPASS_SECRET=xxx".to_string(),
             "USE_MOCK_CLAUDE=true".to_string(),
             "MY_DESC=hello world".to_string(),
         ];
@@ -1927,18 +2045,60 @@ mod tests {
             Path::new("/var/lib/vm0-runner/bin/v0.1.0/vm0-runner"),
             Path::new("/home/ubuntu/runner.yaml"),
             &env,
+            None,
             false,
         );
         assert!(!content.contains("EnvironmentFile="));
-        assert!(content.contains("Environment=\"VERCEL_AUTOMATION_BYPASS_SECRET=xxx\""));
         assert!(content.contains("Environment=\"USE_MOCK_CLAUDE=true\""));
         assert!(content.contains("Environment=\"MY_DESC=hello world\""));
         let first_env_pos = content
-            .find("Environment=\"VERCEL_AUTOMATION_BYPASS_SECRET=xxx\"")
+            .find("Environment=\"USE_MOCK_CLAUDE=true\"")
             .unwrap();
         let install_pos = content.find("[Install]").unwrap();
         assert!(first_env_pos < install_pos);
         assert!(content.contains("\n\n[Install]"));
+    }
+
+    #[test]
+    fn test_generate_unit_file_with_service_secrets_file() {
+        let env = vec!["USE_MOCK_CLAUDE=true".to_string()];
+        let content = generate_unit_file(
+            "vm0-runner-v0.1.0",
+            Path::new("/usr/bin/runner"),
+            Path::new("/etc/runner.yaml"),
+            &env,
+            Some(Path::new(
+                "/var/lib/vm0-runner/runners/v0.1.0/service-secrets.env",
+            )),
+            false,
+        );
+
+        assert!(content.contains(
+            "ExecStart=\"/usr/bin/runner\" start --config \"/etc/runner.yaml\" --service-secrets-file \"/var/lib/vm0-runner/runners/v0.1.0/service-secrets.env\"\n"
+        ));
+        assert!(content.contains("Environment=\"USE_MOCK_CLAUDE=true\""));
+        assert!(!content.contains("SENTRY_DSN="));
+        assert!(!content.contains("AXIOM_TOKEN_TELEMETRY="));
+        assert!(!content.contains("VERCEL_AUTOMATION_BYPASS_SECRET="));
+        assert!(!content.contains("EnvironmentFile="));
+    }
+
+    #[test]
+    fn test_generate_unit_file_escapes_service_secrets_file_path() {
+        let content = generate_unit_file(
+            "vm0-runner-v0.1.0",
+            Path::new("/usr/bin/runner"),
+            Path::new("/etc/runner.yaml"),
+            &[],
+            Some(Path::new(
+                "/var/lib/vm0-runner/runners/v0%1/service \"secrets\".env",
+            )),
+            false,
+        );
+
+        assert!(content.contains(
+            r#"--service-secrets-file "/var/lib/vm0-runner/runners/v0%%1/service \"secrets\".env""#
+        ));
     }
 
     #[test]
@@ -1948,6 +2108,7 @@ mod tests {
             Path::new("/opt/my runner/vm0-runner"),
             Path::new("/opt/my config/runner.yaml"),
             &[],
+            None,
             false,
         );
         assert!(content.contains(
@@ -1963,6 +2124,7 @@ mod tests {
             Path::new("/usr/bin/runner"),
             Path::new("/etc/runner.yaml"),
             &[],
+            None,
             true,
         );
         assert!(content.contains(
@@ -2044,6 +2206,7 @@ mod tests {
             Path::new("/usr/bin/runner"),
             Path::new("/etc/runner.yaml"),
             &env,
+            None,
             false,
         );
         assert!(content.contains(r#"Environment="MSG=say \"hi\"""#));
@@ -2062,6 +2225,7 @@ mod tests {
             Path::new("/opt/runner-v1%2.0/bin/runner"),
             Path::new("/etc/cache%20.yaml"),
             &[],
+            None,
             false,
         );
         assert!(content.contains(
@@ -2091,10 +2255,49 @@ mod tests {
         assert!(validate_env_vars(&["NOEQUALS".to_string()]).is_err());
         assert!(validate_env_vars(&["=VALUE".to_string()]).is_err());
         assert!(validate_env_vars(&["".to_string()]).is_err());
+        assert!(validate_env_vars(&["SENTRY_DSN=secret".to_string()]).is_err());
+        assert!(validate_env_vars(&["AXIOM_TOKEN_TELEMETRY=secret".to_string()]).is_err());
+        assert!(validate_env_vars(&["AXIOM_DATASET_SUFFIX=prod".to_string()]).is_err());
+        assert!(
+            validate_env_vars(&["VERCEL_AUTOMATION_BYPASS_SECRET=secret".to_string()]).is_err()
+        );
         // Bare newline / CR / NUL would silently corrupt the unit file.
         assert!(validate_env_vars(&["KEY=line1\nline2".to_string()]).is_err());
         assert!(validate_env_vars(&["KEY=foo\rbar".to_string()]).is_err());
         assert!(validate_env_vars(&["KEY=with\0nul".to_string()]).is_err());
+    }
+
+    #[test]
+    fn build_systemd_run_args_passes_service_secrets_file_without_setenv() {
+        let env = vec!["USE_MOCK_CLAUDE=true".to_string()];
+        let args = build_systemd_run_args(
+            "vm0-runner-v0.1.0",
+            Path::new("/usr/bin/runner"),
+            Path::new("/etc/runner.yaml"),
+            &env,
+            Some(Path::new(
+                "/var/lib/vm0-runner/runners/v0.1.0/service-secrets.env",
+            )),
+            true,
+        );
+
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert!(rendered.contains(&"--setenv=USE_MOCK_CLAUDE=true".to_string()));
+        assert!(rendered.contains(&"--service-secrets-file".to_string()));
+        assert!(
+            rendered
+                .contains(&"/var/lib/vm0-runner/runners/v0.1.0/service-secrets.env".to_string())
+        );
+        assert!(rendered.contains(&"--local".to_string()));
+        assert!(!rendered.iter().any(|arg| arg.contains("SENTRY_DSN=")));
+        assert!(
+            !rendered
+                .iter()
+                .any(|arg| arg.contains("VERCEL_AUTOMATION_BYPASS_SECRET="))
+        );
     }
 
     #[test]
@@ -2292,9 +2495,8 @@ mod tests {
     #[test]
     fn write_unit_file_cleans_up_staging_on_rename_failure() {
         // Rename fails when the target path is an existing directory
-        // (EISDIR). Verifies the staged content — which may contain
-        // Environment= secrets — is removed so it doesn't persist in
-        // /etc/systemd/system/.
+        // (EISDIR). Verifies staged unit content is removed so it doesn't
+        // persist in /etc/systemd/system/.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("target.service");
         std::fs::create_dir(&path).unwrap();

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1240,18 +1240,45 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     );
     cmd.args(&command_args);
 
-    let status = cmd
-        .status()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("spawn systemd-run: {e}")))?;
+    let status = match cmd.status().await {
+        Ok(status) => status,
+        Err(e) => {
+            cleanup_failed_transient_start_service_secrets(
+                &unit,
+                &args.name,
+                service_secrets_file.is_some(),
+            )
+            .await;
+            return Err(RunnerError::Internal(format!("spawn systemd-run: {e}")));
+        }
+    };
 
     if !status.success() {
+        cleanup_failed_transient_start_service_secrets(
+            &unit,
+            &args.name,
+            service_secrets_file.is_some(),
+        )
+        .await;
         return Err(RunnerError::Internal(format!(
             "systemd-run failed: {status}"
         )));
     }
     info!(unit = %unit, "transient service started");
     Ok(())
+}
+
+async fn cleanup_failed_transient_start_service_secrets(unit: &str, suffix: &str, staged: bool) {
+    if !staged || unit_file_path(unit).exists() {
+        return;
+    }
+    if let Err(e) = remove_service_secrets_for_suffix(suffix).await {
+        warn!(
+            unit = %unit,
+            error = %e,
+            "failed to remove service secrets file after transient start failure"
+        );
+    }
 }
 
 /// `service stop` — stop the named unit.

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -49,7 +49,7 @@ struct ServiceRunArgs {
     /// Service name suffix (e.g. v0.2.0 → unit vm0-runner-v0.2.0)
     #[arg(long)]
     name: String,
-    /// Environment variables to pass to the service (KEY=VALUE)
+    /// Non-secret environment variables to pass to the service (KEY=VALUE)
     #[arg(long, value_name = "KEY=VALUE")]
     env: Vec<String>,
     /// File containing allowlisted service secrets. Secret values are staged
@@ -287,15 +287,21 @@ fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
             )));
         };
         if eq_pos == 0 {
-            return Err(RunnerError::Config(format!(
-                "invalid --env value '{entry}': expected KEY=VALUE format"
-            )));
+            return Err(RunnerError::Config(
+                "invalid --env value: KEY must not be empty".to_string(),
+            ));
         }
-        let key = &entry[..eq_pos];
+        let raw_key = &entry[..eq_pos];
+        let key = raw_key.trim();
         if crate::service_secrets::is_service_secret_key(key) {
             return Err(RunnerError::Config(format!(
                 "invalid --env key {key}: service secrets must be passed with --service-secrets-file"
             )));
+        }
+        if key != raw_key {
+            return Err(RunnerError::Config(
+                "invalid --env value: KEY must not contain surrounding whitespace".to_string(),
+            ));
         }
     }
     Ok(())
@@ -1199,6 +1205,10 @@ async fn check_active_jobs_gate(
 async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     let unit = unit_name(&args.name)?;
     validate_env_vars(&args.env)?;
+    // `service start` stages the same per-runner service secrets path as
+    // `service install`, while stop/uninstall may remove that path. Serialize
+    // all service lifecycle commands for the same unit.
+    let _service_lock = acquire_service_lock(&unit).await?;
 
     if is_unit_active(&unit).await? {
         return Err(RunnerError::Internal(format!(
@@ -2256,11 +2266,15 @@ mod tests {
         assert!(validate_env_vars(&["=VALUE".to_string()]).is_err());
         assert!(validate_env_vars(&["".to_string()]).is_err());
         assert!(validate_env_vars(&["SENTRY_DSN=secret".to_string()]).is_err());
+        assert!(validate_env_vars(&[" SENTRY_DSN=secret".to_string()]).is_err());
+        assert!(validate_env_vars(&["SENTRY_DSN =secret".to_string()]).is_err());
         assert!(validate_env_vars(&["AXIOM_TOKEN_TELEMETRY=secret".to_string()]).is_err());
         assert!(validate_env_vars(&["AXIOM_DATASET_SUFFIX=prod".to_string()]).is_err());
         assert!(
             validate_env_vars(&["VERCEL_AUTOMATION_BYPASS_SECRET=secret".to_string()]).is_err()
         );
+        assert!(validate_env_vars(&[" KEY=VALUE".to_string()]).is_err());
+        assert!(validate_env_vars(&["KEY =VALUE".to_string()]).is_err());
         // Bare newline / CR / NUL would silently corrupt the unit file.
         assert!(validate_env_vars(&["KEY=line1\nline2".to_string()]).is_err());
         assert!(validate_env_vars(&["KEY=foo\rbar".to_string()]).is_err());

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1326,6 +1326,10 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
 
     cleanup_unit_staging_files(&upath)?;
     write_unit_file(&upath, &unit_content)?;
+
+    // Reload before removing stale secrets so systemd never restarts with an
+    // old ExecStart that references a deleted secrets file.
+    run_systemctl(&["daemon-reload"]).await?;
     if service_secrets_file.is_none()
         && let Err(e) = remove_service_secrets_for_suffix(&args.name).await
     {
@@ -1335,8 +1339,6 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
             "failed to remove stale service secrets file"
         );
     }
-
-    run_systemctl(&["daemon-reload"]).await?;
     let svc = format!("{unit}.service");
     run_systemctl(&["enable", "--now", &svc]).await?;
 

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -168,6 +168,18 @@ fn unit_file_path(name: &str) -> PathBuf {
     PathBuf::from(format!("/etc/systemd/system/{name}.service"))
 }
 
+fn unit_file_path_exists(name: &str) -> RunnerResult<bool> {
+    let path = unit_file_path(name);
+    match std::fs::symlink_metadata(&path) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(RunnerError::Internal(format!(
+            "stat unit file {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
 async fn acquire_service_lock(unit: &str) -> RunnerResult<nix::fcntl::Flock<std::fs::File>> {
     let home = HomePaths::new()?;
     crate::lock::acquire(home.service_lock(unit)).await
@@ -1216,6 +1228,11 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
             args.name
         )));
     }
+    if unit_file_path_exists(&unit)? {
+        return Err(RunnerError::Config(format!(
+            "unit {unit} has a persistent unit file; use runner service install or uninstall it before transient service start"
+        )));
+    }
 
     let config_path = resolve_config_path(&args.config)?;
     let exe_path = validate_current_exe_path(
@@ -1269,7 +1286,18 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
 }
 
 async fn cleanup_failed_transient_start_service_secrets(unit: &str, suffix: &str, staged: bool) {
-    if !staged || unit_file_path(unit).exists() {
+    let persistent_unit_exists = match unit_file_path_exists(unit) {
+        Ok(exists) => exists,
+        Err(e) => {
+            warn!(
+                unit = %unit,
+                error = %e,
+                "skipping transient service secrets cleanup because persistent unit state is unknown"
+            );
+            true
+        }
+    };
+    if !staged || persistent_unit_exists {
         return;
     }
     if let Err(e) = remove_service_secrets_for_suffix(suffix).await {
@@ -1310,14 +1338,24 @@ async fn stop(args: ServiceStopArgs) -> RunnerResult<()> {
     // Clear "failed" latch so systemd fully unloads the transient unit.
     // (stop alone does not clear the failed state.)
     let _ = run_systemctl(&["reset-failed", &svc]).await;
-    if !unit_file_path(&unit).exists()
-        && let Err(e) = remove_service_secrets_for_suffix(&args.name).await
-    {
-        warn!(
-            unit = %unit,
-            error = %e,
-            "failed to remove transient service secrets file"
-        );
+    match unit_file_path_exists(&unit) {
+        Ok(false) => {
+            if let Err(e) = remove_service_secrets_for_suffix(&args.name).await {
+                warn!(
+                    unit = %unit,
+                    error = %e,
+                    "failed to remove transient service secrets file"
+                );
+            }
+        }
+        Ok(true) => {}
+        Err(e) => {
+            warn!(
+                unit = %unit,
+                error = %e,
+                "skipping transient service secrets cleanup because persistent unit state is unknown"
+            );
+        }
     }
     Ok(())
 }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -60,6 +60,7 @@ use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::SharedRunCancellationMap;
+use crate::service_secrets::ServiceSecrets;
 use crate::status::{RunnerMode, StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
@@ -159,6 +160,9 @@ pub struct StartArgs {
     /// Runner authentication token (overrides config)
     #[arg(long, env = "VM0_RUNNER_TOKEN")]
     token: Option<String>,
+    /// Path to a private service secrets file staged by `runner service`.
+    #[arg(long, hide = true)]
+    pub(crate) service_secrets_file: Option<PathBuf>,
     /// Use local file queue provider instead of API (for testing)
     #[arg(long)]
     local: bool,
@@ -220,18 +224,19 @@ async fn shutdown_startup_resources_after_factory_failure(
     status.set_mode(RunnerMode::Stopped).await;
 }
 
-/// Load config and run the main poll loop.
-pub async fn run_start(
+pub(crate) async fn run_start_with_service_secrets(
     args: StartArgs,
     runtime_provider: &dyn RuntimeProvider,
+    service_secrets: ServiceSecrets,
 ) -> RunnerResult<()> {
-    run_start_with_home(args, runtime_provider, HomePaths::new).await
+    run_start_with_home(args, runtime_provider, HomePaths::new, service_secrets).await
 }
 
 async fn run_start_with_home(
     args: StartArgs,
     runtime_provider: &dyn RuntimeProvider,
     load_home: impl FnOnce() -> RunnerResult<HomePaths>,
+    service_secrets: ServiceSecrets,
 ) -> RunnerResult<()> {
     // Register lifecycle signals (SIGTERM/SIGINT/SIGUSR1/SIGUSR2) before
     // any slow startup work. Tokio's `signal()` installs the process-wide
@@ -371,7 +376,9 @@ async fn run_start_with_home(
     let cancel = CancellationToken::new();
     let http = HttpClient::new(HttpClientConfig {
         api_url: server.url.clone(),
-        vercel_bypass: std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok(),
+        vercel_bypass: service_secrets
+            .vercel_automation_bypass_secret()
+            .map(str::to_owned),
     })?;
     let name = runner_config.name;
     let group = runner_config.group;
@@ -565,6 +572,7 @@ async fn run_start_with_home(
         network_log_drain,
         mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
         home: home.clone(),
+        host_env: crate::executor::HostEnv::from_service_secrets(&service_secrets),
         workspace_cache: Some(SessionWorkspaceCache::shared(
             paths.clone(),
             &home,

--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -443,10 +443,12 @@ server:
             config: config_path,
             api_url: None,
             token: None,
+            service_secrets_file: None,
             local: true,
         },
         &provider,
         || Ok(home),
+        crate::service_secrets::ServiceSecrets::default(),
     )
     .await
     .expect_err("local provider setup should fail before runtime creation");

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -253,6 +253,7 @@ fn build_mock_run_config_with_runtime(
             network_log_drain: NetworkLogDrainCoordinator::noop(),
             mitm_jsonl_flush: None,
             home,
+            host_env: executor::HostEnv::default(),
             workspace_cache: None,
         }),
         shutdown: ShutdownHandles {

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -15,7 +15,7 @@ use super::diagnostics::{
     log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
 };
-use super::env::{build_env_json, build_user_env_json, write_user_env_file};
+use super::env::{build_env_json_with_host_env, build_user_env_json, write_user_env_file};
 use super::guest_state::{fix_guest_clock, reseed_guest_entropy, sync_guest_timezone};
 use super::session_restore::restore_session;
 use super::storage::{download_storages, filter_unchanged_storages};
@@ -211,7 +211,13 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // into the CLI child after guest-agent has started.
     let user_env_map = build_user_env_json(context);
     let user_env_file = write_user_env_file(sandbox, context.run_id, &user_env_map).await?;
-    let mut env_map = build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result)?;
+    let mut env_map = build_env_json_with_host_env(
+        context,
+        &config.api_url,
+        sandbox.id(),
+        start.reuse_result,
+        &config.host_env,
+    )?;
     if let Some(path) = user_env_file {
         env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
     }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -210,16 +210,6 @@ pub(super) async fn write_user_env_file(
 ///
 /// This intentionally excludes `context.environment`. User/model/connector
 /// environment is transferred separately and injected only into the CLI child.
-pub(super) fn build_env_json(
-    context: &ExecutionContext,
-    api_url: &str,
-    sandbox_id: &str,
-    reuse_result: SandboxReuseResult,
-) -> RunnerResult<HashMap<String, String>> {
-    let host_env = HostEnv::from_process();
-    build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, &host_env)
-}
-
 pub(super) fn build_env_json_with_host_env(
     context: &ExecutionContext,
     api_url: &str,
@@ -421,16 +411,20 @@ pub(super) fn insert_guest_agent_tuning_env(
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(super) struct HostEnv {
-    pub(super) vercel_automation_bypass_secret: Option<String>,
-    pub(super) use_mock_claude: Option<String>,
-    pub(super) use_mock_codex: Option<String>,
+pub(crate) struct HostEnv {
+    pub(crate) vercel_automation_bypass_secret: Option<String>,
+    pub(crate) use_mock_claude: Option<String>,
+    pub(crate) use_mock_codex: Option<String>,
 }
 
 impl HostEnv {
-    pub(super) fn from_process() -> Self {
+    pub(crate) fn from_service_secrets(
+        service_secrets: &crate::service_secrets::ServiceSecrets,
+    ) -> Self {
         Self {
-            vercel_automation_bypass_secret: std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok(),
+            vercel_automation_bypass_secret: service_secrets
+                .vercel_automation_bypass_secret()
+                .map(str::to_owned),
             use_mock_claude: std::env::var(guest_contracts::env::USE_MOCK_CLAUDE_ENV).ok(),
             use_mock_codex: std::env::var(guest_contracts::env::USE_MOCK_CODEX_ENV).ok(),
         }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -113,6 +113,8 @@ use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceImageActiveLeaseRequest, WorkspaceImageLease,
 };
 
+pub(crate) use env::HostEnv;
+
 fn guest_runtime_dir(run_id: RunId) -> RunnerResult<String> {
     let run_id = run_id.to_string();
     let path = guest_contracts::runtime_paths::run_dir_for_home(CANONICAL_GUEST_HOME_DIR, &run_id)
@@ -141,6 +143,7 @@ pub struct ExecutorConfig {
     pub network_log_drain: NetworkLogDrainCoordinator,
     pub mitm_jsonl_flush: Option<MitmJsonlFlushHandle>,
     pub home: HomePaths,
+    pub host_env: HostEnv,
     pub workspace_cache: Option<SessionWorkspaceCache>,
 }
 

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -37,6 +37,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
         network_log_drain: NetworkLogDrainCoordinator::noop(),
         mitm_jsonl_flush: None,
         home: HomePaths::with_root(dir.to_path_buf()),
+        host_env: crate::executor::HostEnv::default(),
         workspace_cache: None,
     }
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -208,14 +208,13 @@ fn init_tracing_stderr(axiom_layer: Option<axiom_layer::AxiomLayer>) {
 async fn load_cli_service_secrets(
     cli: &Cli,
 ) -> error::RunnerResult<service_secrets::ServiceSecrets> {
-    let service_secrets = match &cli.command {
-        Command::Start(args) => {
-            service_secrets::load_start_service_secrets(args.service_secrets_file.as_deref())
-                .await?
-        }
-        _ => service_secrets::ServiceSecrets::default(),
-    };
-    Ok(service_secrets.with_env_fallback())
+    match &cli.command {
+        Command::Start(args) => match args.service_secrets_file.as_deref() {
+            Some(path) => service_secrets::load_start_service_secrets(Some(path)).await,
+            None => Ok(service_secrets::ServiceSecrets::default().with_env_fallback()),
+        },
+        _ => Ok(service_secrets::ServiceSecrets::default().with_env_fallback()),
+    }
 }
 
 #[tokio::main]
@@ -235,8 +234,9 @@ async fn main() -> ExitCode {
     };
 
     // Initialize Sentry panic reporting after CLI parsing so `runner start`
-    // can source service DSNs from --service-secrets-file. Disabled (zero
-    // overhead) when neither the service secret nor SENTRY_DSN is set.
+    // can source service DSNs from --service-secrets-file. When a service
+    // secrets file is present, it is authoritative; direct/non-service runs
+    // still use process-env fallback.
     let _sentry_guard = sentry::init((
         service_secrets.sentry_dsn().unwrap_or_default().to_string(),
         sentry::ClientOptions {
@@ -248,7 +248,7 @@ async fn main() -> ExitCode {
     ));
 
     // Axiom layer (dual-write with fmt). Returns None — zero overhead — when
-    // AXIOM_TOKEN_TELEMETRY / AXIOM_DATASET_SUFFIX are unset.
+    // the selected service-secret/env source lacks token or dataset suffix.
     let (axiom_layer, axiom_guard) = match axiom_layer::init_with_values(
         service_secrets.axiom_token_telemetry().map(str::to_owned),
         service_secrets.axiom_dataset_suffix().map(str::to_owned),
@@ -328,6 +328,57 @@ async fn main() -> ExitCode {
 mod tests {
     use super::*;
 
+    use tokio::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+    const SERVICE_SECRET_ENV_KEYS: &[&str] = &[
+        "SENTRY_DSN",
+        "AXIOM_TOKEN_TELEMETRY",
+        "AXIOM_DATASET_SUFFIX",
+        "VERCEL_AUTOMATION_BYPASS_SECRET",
+    ];
+
+    struct EnvRestore {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvRestore {
+        fn set(vars: &[(&'static str, &str)]) -> Self {
+            let saved = SERVICE_SECRET_ENV_KEYS
+                .iter()
+                .map(|key| (*key, std::env::var(key).ok()))
+                .collect();
+
+            // SAFETY: tests that mutate these process-wide environment keys
+            // hold ENV_LOCK for the full lifetime of EnvRestore.
+            unsafe {
+                for key in SERVICE_SECRET_ENV_KEYS {
+                    std::env::remove_var(key);
+                }
+                for (key, value) in vars {
+                    std::env::set_var(key, value);
+                }
+            }
+
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            // SAFETY: tests that mutate these process-wide environment keys
+            // hold ENV_LOCK for the full lifetime of EnvRestore.
+            unsafe {
+                for (key, value) in &self.saved {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn sanitize_name_passthrough() {
         assert_eq!(sanitize_name("my-runner_01"), "my-runner_01");
@@ -383,6 +434,67 @@ mod tests {
         assert!(
             Cli::try_parse_from(["runner", "gc-workspace-image-cache", "--dry-run"]).is_err(),
             "old top-level gc-workspace-image-cache command should not be accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_with_service_secrets_file_does_not_fall_back_to_env() {
+        let _guard = ENV_LOCK.lock().await;
+        let _env = EnvRestore::set(&[
+            ("SENTRY_DSN", "env-sentry"),
+            ("AXIOM_TOKEN_TELEMETRY", "env-token"),
+            ("AXIOM_DATASET_SUFFIX", "prod"),
+            ("VERCEL_AUTOMATION_BYPASS_SECRET", "env-bypass"),
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        let service_secrets_file = dir.path().join("service-secrets.env");
+        tokio::fs::write(
+            &service_secrets_file,
+            "VERCEL_AUTOMATION_BYPASS_SECRET=file-bypass\n",
+        )
+        .await
+        .unwrap();
+
+        let cli = Cli::try_parse_from([
+            "runner",
+            "start",
+            "--config",
+            "/tmp/runner.yaml",
+            "--service-secrets-file",
+            &service_secrets_file.display().to_string(),
+        ])
+        .unwrap();
+
+        let secrets = load_cli_service_secrets(&cli).await.unwrap();
+
+        assert_eq!(secrets.sentry_dsn(), None);
+        assert_eq!(secrets.axiom_token_telemetry(), None);
+        assert_eq!(secrets.axiom_dataset_suffix(), None);
+        assert_eq!(
+            secrets.vercel_automation_bypass_secret(),
+            Some("file-bypass")
+        );
+    }
+
+    #[tokio::test]
+    async fn start_without_service_secrets_file_uses_env_fallback() {
+        let _guard = ENV_LOCK.lock().await;
+        let _env = EnvRestore::set(&[
+            ("SENTRY_DSN", "env-sentry"),
+            ("AXIOM_TOKEN_TELEMETRY", "env-token"),
+            ("AXIOM_DATASET_SUFFIX", "prod"),
+            ("VERCEL_AUTOMATION_BYPASS_SECRET", "env-bypass"),
+        ]);
+        let cli = Cli::try_parse_from(["runner", "start", "--config", "/tmp/runner.yaml"]).unwrap();
+
+        let secrets = load_cli_service_secrets(&cli).await.unwrap();
+
+        assert_eq!(secrets.sentry_dsn(), Some("env-sentry"));
+        assert_eq!(secrets.axiom_token_telemetry(), Some("env-token"));
+        assert_eq!(secrets.axiom_dataset_suffix(), Some("prod"));
+        assert_eq!(
+            secrets.vercel_automation_bypass_secret(),
+            Some("env-bypass")
         );
     }
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -37,6 +37,7 @@ mod run_cancellation;
 mod run_resolution;
 mod runner_dirname;
 mod runtime_overrides;
+mod service_secrets;
 mod state_file;
 mod status;
 mod storage_cache;
@@ -204,12 +205,40 @@ fn init_tracing_stderr(axiom_layer: Option<axiom_layer::AxiomLayer>) {
         .init();
 }
 
+async fn load_cli_service_secrets(
+    cli: &Cli,
+) -> error::RunnerResult<service_secrets::ServiceSecrets> {
+    let service_secrets = match &cli.command {
+        Command::Start(args) => {
+            service_secrets::load_start_service_secrets(args.service_secrets_file.as_deref())
+                .await?
+        }
+        _ => service_secrets::ServiceSecrets::default(),
+    };
+    Ok(service_secrets.with_env_fallback())
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
-    // Initialize Sentry panic reporting before anything else.
-    // Disabled (zero overhead) when SENTRY_DSN is not set.
+    if !nix::unistd::getuid().is_root() {
+        eprintln!("error: runner must be run as root");
+        return ExitCode::FAILURE;
+    }
+
+    let cli = Cli::parse();
+    let service_secrets = match load_cli_service_secrets(&cli).await {
+        Ok(service_secrets) => service_secrets,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Initialize Sentry panic reporting after CLI parsing so `runner start`
+    // can source service DSNs from --service-secrets-file. Disabled (zero
+    // overhead) when neither the service secret nor SENTRY_DSN is set.
     let _sentry_guard = sentry::init((
-        std::env::var("SENTRY_DSN").unwrap_or_default(),
+        service_secrets.sentry_dsn().unwrap_or_default().to_string(),
         sentry::ClientOptions {
             release: Some(env!("CARGO_PKG_VERSION").into()),
             default_integrations: false,
@@ -218,16 +247,12 @@ async fn main() -> ExitCode {
         .add_integration(sentry::integrations::panic::PanicIntegration::default()),
     ));
 
-    if !nix::unistd::getuid().is_root() {
-        eprintln!("error: runner must be run as root");
-        return ExitCode::FAILURE;
-    }
-
-    let cli = Cli::parse();
-
     // Axiom layer (dual-write with fmt). Returns None — zero overhead — when
     // AXIOM_TOKEN_TELEMETRY / AXIOM_DATASET_SUFFIX are unset.
-    let (axiom_layer, axiom_guard) = match axiom_layer::init() {
+    let (axiom_layer, axiom_guard) = match axiom_layer::init_with_values(
+        service_secrets.axiom_token_telemetry().map(str::to_owned),
+        service_secrets.axiom_dataset_suffix().map(str::to_owned),
+    ) {
         Some((layer, guard)) => (Some(layer), Some(guard)),
         None => (None, None),
     };
@@ -268,9 +293,13 @@ async fn main() -> ExitCode {
         }
         Command::Exec(args) => cmd::run_exec(args, &sandbox_fc::FirecrackerControl).await,
         Command::Kill(args) => cmd::run_kill(args, &sandbox_fc::FirecrackerControl).await,
-        Command::Start(args) => cmd::run_start(*args, &sandbox_fc::FirecrackerRuntimeProvider)
-            .await
-            .map(|()| ExitCode::SUCCESS),
+        Command::Start(args) => cmd::run_start_with_service_secrets(
+            *args,
+            &sandbox_fc::FirecrackerRuntimeProvider,
+            service_secrets,
+        )
+        .await
+        .map(|()| ExitCode::SUCCESS),
         Command::Service(args) => cmd::run_service(args).await.map(|()| ExitCode::SUCCESS),
         Command::Gc(args) => cmd::run_gc(args).await.map(|()| ExitCode::SUCCESS),
         Command::WorkspaceImageCache(args) => cmd::run_workspace_image_cache(args)

--- a/crates/runner/src/service_secrets.rs
+++ b/crates/runner/src/service_secrets.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -156,18 +157,67 @@ pub(crate) async fn stage_service_secrets_file(
         ))
     })?;
     crate::private_fs::ensure_private_dir(parent).await?;
+    remove_stale_service_secrets_staging_files(parent).await?;
     crate::private_fs::write_private_file(destination, secrets.to_file_contents().as_bytes()).await
 }
 
 pub(crate) async fn remove_service_secrets_file(path: &Path) -> RunnerResult<()> {
-    match tokio::fs::remove_file(path).await {
+    let remove_result = match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(RunnerError::Config(format!(
             "remove service secrets file {}: {e}",
             path.display()
         ))),
+    };
+
+    let cleanup_result = match path.parent() {
+        Some(parent) => remove_stale_service_secrets_staging_files(parent).await,
+        None => Ok(()),
+    };
+    remove_result?;
+    cleanup_result
+}
+
+async fn remove_stale_service_secrets_staging_files(parent: &Path) -> RunnerResult<()> {
+    let mut entries = match tokio::fs::read_dir(parent).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "read service secrets directory {}: {e}",
+                parent.display()
+            )));
+        }
+    };
+
+    while let Some(entry) = entries.next_entry().await.map_err(|e| {
+        RunnerError::Config(format!(
+            "read service secrets directory entry {}: {e}",
+            parent.display()
+        ))
+    })? {
+        if !is_service_secrets_staging_file_name(&entry.file_name()) {
+            continue;
+        }
+        let path = entry.path();
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(RunnerError::Config(format!(
+                    "remove stale service secrets staging file {}: {e}",
+                    path.display()
+                )));
+            }
+        }
     }
+    Ok(())
+}
+
+fn is_service_secrets_staging_file_name(name: &OsStr) -> bool {
+    let name = name.to_string_lossy();
+    name.starts_with(".service-secrets.env.") && name.ends_with(".tmp")
 }
 
 async fn read_private_service_secrets(path: &Path) -> RunnerResult<ServiceSecrets> {
@@ -440,6 +490,70 @@ mod tests {
         let loaded = read_private_service_secrets(&destination).await.unwrap();
         assert_eq!(loaded.sentry_dsn(), Some("sentry"));
         assert_eq!(loaded.axiom_dataset_suffix(), Some("prod"));
+    }
+
+    #[tokio::test]
+    async fn stage_service_secrets_file_removes_stale_staging_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.env");
+        let destination = dir
+            .path()
+            .join("runners")
+            .join("v0.1.0")
+            .join(SERVICE_SECRETS_FILE_NAME);
+        let parent = destination.parent().unwrap();
+        tokio::fs::create_dir_all(parent).await.unwrap();
+        tokio::fs::write(&source, "SENTRY_DSN=sentry\n")
+            .await
+            .unwrap();
+        let stale_tmp = parent.join(".service-secrets.env.crashed.tmp");
+        let unrelated_tmp = parent.join(".runner.yaml.crashed.tmp");
+        tokio::fs::write(&stale_tmp, "SENTRY_DSN=old-secret\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&unrelated_tmp, "runner config")
+            .await
+            .unwrap();
+
+        stage_service_secrets_file(&source, &destination)
+            .await
+            .unwrap();
+
+        assert!(!stale_tmp.exists());
+        assert!(unrelated_tmp.exists());
+        assert_eq!(
+            tokio::fs::read_to_string(&destination).await.unwrap(),
+            "SENTRY_DSN=sentry\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_service_secrets_file_removes_canonical_and_stale_staging_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir
+            .path()
+            .join("runners")
+            .join("v0.1.0")
+            .join(SERVICE_SECRETS_FILE_NAME);
+        let parent = destination.parent().unwrap();
+        tokio::fs::create_dir_all(parent).await.unwrap();
+        let stale_tmp = parent.join(".service-secrets.env.crashed.tmp");
+        let unrelated_tmp = parent.join(".runner.yaml.crashed.tmp");
+        tokio::fs::write(&destination, "SENTRY_DSN=sentry\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&stale_tmp, "SENTRY_DSN=old-secret\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&unrelated_tmp, "runner config")
+            .await
+            .unwrap();
+
+        remove_service_secrets_file(&destination).await.unwrap();
+
+        assert!(!destination.exists());
+        assert!(!stale_tmp.exists());
+        assert!(unrelated_tmp.exists());
     }
 
     #[cfg(unix)]

--- a/crates/runner/src/service_secrets.rs
+++ b/crates/runner/src/service_secrets.rs
@@ -183,10 +183,30 @@ async fn read_private_service_secrets(path: &Path) -> RunnerResult<ServiceSecret
 }
 
 async fn read_source_file_to_string(path: &Path) -> RunnerResult<String> {
-    let file = tokio::fs::File::open(path).await.map_err(|e| {
+    let file = open_source_file(path).await?;
+    read_limited_utf8(file, path).await
+}
+
+async fn open_source_file(path: &Path) -> RunnerResult<tokio::fs::File> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        options.custom_flags(nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+    }
+    let file = options.open(path).await.map_err(|e| {
         RunnerError::Config(format!("open service secrets file {}: {e}", path.display()))
     })?;
-    read_limited_utf8(file, path).await
+    let metadata = file.metadata().await.map_err(|e| {
+        RunnerError::Config(format!("stat service secrets file {}: {e}", path.display()))
+    })?;
+    if !metadata.is_file() {
+        return Err(RunnerError::Config(format!(
+            "service secrets file {} is not a regular file",
+            path.display()
+        )));
+    }
+    Ok(file)
 }
 
 async fn read_limited_utf8(file: tokio::fs::File, path: &Path) -> RunnerResult<String> {
@@ -420,5 +440,25 @@ mod tests {
         let loaded = read_private_service_secrets(&destination).await.unwrap();
         assert_eq!(loaded.sentry_dsn(), Some("sentry"));
         assert_eq!(loaded.axiom_dataset_suffix(), Some("prod"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stage_service_secrets_file_rejects_fifo_source_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.env");
+        nix::unistd::mkfifo(&source, nix::sys::stat::Mode::from_bits_truncate(0o600)).unwrap();
+        let destination = dir
+            .path()
+            .join("runners")
+            .join("v0.1.0")
+            .join(SERVICE_SECRETS_FILE_NAME);
+
+        let err = stage_service_secrets_file(&source, &destination)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("is not a regular file"));
     }
 }

--- a/crates/runner/src/service_secrets.rs
+++ b/crates/runner/src/service_secrets.rs
@@ -242,7 +242,7 @@ async fn open_source_file(path: &Path) -> RunnerResult<tokio::fs::File> {
     options.read(true);
     #[cfg(unix)]
     {
-        options.custom_flags(nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK);
+        options.custom_flags(nix::libc::O_CLOEXEC | nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW);
     }
     let file = options.open(path).await.map_err(|e| {
         RunnerError::Config(format!("open service secrets file {}: {e}", path.display()))
@@ -574,5 +574,32 @@ mod tests {
             .to_string();
 
         assert!(err.contains("is not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stage_service_secrets_file_rejects_symlink_source() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.env");
+        let source = dir.path().join("source.env");
+        let destination = dir
+            .path()
+            .join("runners")
+            .join("v0.1.0")
+            .join(SERVICE_SECRETS_FILE_NAME);
+        tokio::fs::write(&target, "SENTRY_DSN=sentry\n")
+            .await
+            .unwrap();
+        symlink(&target, &source).unwrap();
+
+        let err = stage_service_secrets_file(&source, &destination)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("open service secrets file"));
+        assert!(!destination.exists());
     }
 }

--- a/crates/runner/src/service_secrets.rs
+++ b/crates/runner/src/service_secrets.rs
@@ -1,0 +1,424 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncReadExt;
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::paths::HomePaths;
+
+pub(crate) const SENTRY_DSN_ENV: &str = "SENTRY_DSN";
+pub(crate) const AXIOM_TOKEN_ENV: &str = "AXIOM_TOKEN_TELEMETRY";
+pub(crate) const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
+pub(crate) const VERCEL_AUTOMATION_BYPASS_SECRET_ENV: &str = "VERCEL_AUTOMATION_BYPASS_SECRET";
+pub(crate) const SERVICE_SECRETS_FILE_NAME: &str = "service-secrets.env";
+
+const SERVICE_SECRETS_FILE_READ_MAX_BYTES: u64 = 64 * 1024;
+const ALLOWED_SERVICE_SECRET_KEYS: [&str; 4] = [
+    SENTRY_DSN_ENV,
+    AXIOM_TOKEN_ENV,
+    AXIOM_SUFFIX_ENV,
+    VERCEL_AUTOMATION_BYPASS_SECRET_ENV,
+];
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub(crate) struct ServiceSecrets {
+    sentry_dsn: Option<String>,
+    axiom_token_telemetry: Option<String>,
+    axiom_dataset_suffix: Option<String>,
+    vercel_automation_bypass_secret: Option<String>,
+}
+
+impl fmt::Debug for ServiceSecrets {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServiceSecrets")
+            .field(
+                "sentry_dsn",
+                &self.sentry_dsn.as_ref().map(|_| "[redacted]"),
+            )
+            .field(
+                "axiom_token_telemetry",
+                &self.axiom_token_telemetry.as_ref().map(|_| "[redacted]"),
+            )
+            .field("axiom_dataset_suffix", &self.axiom_dataset_suffix)
+            .field(
+                "vercel_automation_bypass_secret",
+                &self
+                    .vercel_automation_bypass_secret
+                    .as_ref()
+                    .map(|_| "[redacted]"),
+            )
+            .finish()
+    }
+}
+
+impl ServiceSecrets {
+    pub(crate) fn from_env() -> Self {
+        Self {
+            sentry_dsn: non_empty_env(SENTRY_DSN_ENV),
+            axiom_token_telemetry: non_empty_env(AXIOM_TOKEN_ENV),
+            axiom_dataset_suffix: non_empty_env(AXIOM_SUFFIX_ENV),
+            vercel_automation_bypass_secret: non_empty_env(VERCEL_AUTOMATION_BYPASS_SECRET_ENV),
+        }
+    }
+
+    pub(crate) fn with_env_fallback(mut self) -> Self {
+        let env = Self::from_env();
+        if self.sentry_dsn.is_none() {
+            self.sentry_dsn = env.sentry_dsn;
+        }
+        if self.axiom_token_telemetry.is_none() {
+            self.axiom_token_telemetry = env.axiom_token_telemetry;
+        }
+        if self.axiom_dataset_suffix.is_none() {
+            self.axiom_dataset_suffix = env.axiom_dataset_suffix;
+        }
+        if self.vercel_automation_bypass_secret.is_none() {
+            self.vercel_automation_bypass_secret = env.vercel_automation_bypass_secret;
+        }
+        self
+    }
+
+    pub(crate) fn sentry_dsn(&self) -> Option<&str> {
+        self.sentry_dsn.as_deref()
+    }
+
+    pub(crate) fn axiom_token_telemetry(&self) -> Option<&str> {
+        self.axiom_token_telemetry.as_deref()
+    }
+
+    pub(crate) fn axiom_dataset_suffix(&self) -> Option<&str> {
+        self.axiom_dataset_suffix.as_deref()
+    }
+
+    pub(crate) fn vercel_automation_bypass_secret(&self) -> Option<&str> {
+        self.vercel_automation_bypass_secret.as_deref()
+    }
+
+    fn to_file_contents(&self) -> String {
+        let mut content = String::new();
+        if let Some(value) = &self.sentry_dsn {
+            content.push_str(SENTRY_DSN_ENV);
+            content.push('=');
+            content.push_str(value);
+            content.push('\n');
+        }
+        if let Some(value) = &self.axiom_token_telemetry {
+            content.push_str(AXIOM_TOKEN_ENV);
+            content.push('=');
+            content.push_str(value);
+            content.push('\n');
+        }
+        if let Some(value) = &self.axiom_dataset_suffix {
+            content.push_str(AXIOM_SUFFIX_ENV);
+            content.push('=');
+            content.push_str(value);
+            content.push('\n');
+        }
+        if let Some(value) = &self.vercel_automation_bypass_secret {
+            content.push_str(VERCEL_AUTOMATION_BYPASS_SECRET_ENV);
+            content.push('=');
+            content.push_str(value);
+            content.push('\n');
+        }
+        content
+    }
+}
+
+pub(crate) fn is_service_secret_key(key: &str) -> bool {
+    ALLOWED_SERVICE_SECRET_KEYS.contains(&key)
+}
+
+pub(crate) fn canonical_service_secrets_path(home: &HomePaths, name: &str) -> PathBuf {
+    home.runners_dir()
+        .join(name)
+        .join(SERVICE_SECRETS_FILE_NAME)
+}
+
+pub(crate) async fn load_start_service_secrets(
+    service_secrets_file: Option<&Path>,
+) -> RunnerResult<ServiceSecrets> {
+    match service_secrets_file {
+        Some(path) => read_private_service_secrets(path).await,
+        None => Ok(ServiceSecrets::default()),
+    }
+}
+
+pub(crate) async fn stage_service_secrets_file(
+    source: &Path,
+    destination: &Path,
+) -> RunnerResult<()> {
+    let content = read_source_file_to_string(source).await?;
+    let secrets = parse_service_secrets_file(&content, &source.display().to_string())?;
+    let parent = destination.parent().ok_or_else(|| {
+        RunnerError::Config(format!(
+            "{} does not have a parent directory; refusing to write service secrets",
+            destination.display()
+        ))
+    })?;
+    crate::private_fs::ensure_private_dir(parent).await?;
+    crate::private_fs::write_private_file(destination, secrets.to_file_contents().as_bytes()).await
+}
+
+pub(crate) async fn remove_service_secrets_file(path: &Path) -> RunnerResult<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RunnerError::Config(format!(
+            "remove service secrets file {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+async fn read_private_service_secrets(path: &Path) -> RunnerResult<ServiceSecrets> {
+    let content = crate::private_fs::read_private_file_to_string_with_max(
+        path,
+        SERVICE_SECRETS_FILE_READ_MAX_BYTES,
+    )
+    .await?
+    .ok_or_else(|| {
+        RunnerError::Config(format!("service secrets file {} not found", path.display()))
+    })?;
+    parse_service_secrets_file(&content, &path.display().to_string())
+}
+
+async fn read_source_file_to_string(path: &Path) -> RunnerResult<String> {
+    let file = tokio::fs::File::open(path).await.map_err(|e| {
+        RunnerError::Config(format!("open service secrets file {}: {e}", path.display()))
+    })?;
+    read_limited_utf8(file, path).await
+}
+
+async fn read_limited_utf8(file: tokio::fs::File, path: &Path) -> RunnerResult<String> {
+    let read_limit = SERVICE_SECRETS_FILE_READ_MAX_BYTES
+        .checked_add(1)
+        .ok_or_else(|| {
+            RunnerError::Config(format!(
+                "service secrets file {} read limit is too large",
+                path.display()
+            ))
+        })?;
+    let mut limited = file.take(read_limit);
+    let mut contents = Vec::new();
+    limited.read_to_end(&mut contents).await.map_err(|e| {
+        RunnerError::Config(format!("read service secrets file {}: {e}", path.display()))
+    })?;
+    if contents.len() as u64 > SERVICE_SECRETS_FILE_READ_MAX_BYTES {
+        return Err(RunnerError::Config(format!(
+            "service secrets file {} exceeds {} bytes",
+            path.display(),
+            SERVICE_SECRETS_FILE_READ_MAX_BYTES
+        )));
+    }
+    String::from_utf8(contents).map_err(|e| {
+        RunnerError::Config(format!(
+            "read service secrets file {} as UTF-8: {e}",
+            path.display()
+        ))
+    })
+}
+
+fn parse_service_secrets_file(content: &str, label: &str) -> RunnerResult<ServiceSecrets> {
+    if content.contains('\0') {
+        return Err(RunnerError::Config(format!(
+            "{label}: NUL characters are not allowed"
+        )));
+    }
+
+    let mut secrets = ServiceSecrets::default();
+    for (line_number, raw_line) in content.lines().enumerate() {
+        let line_number = line_number + 1;
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.contains('\r') {
+            return Err(RunnerError::Config(format!(
+                "{label}:{line_number}: carriage returns are not allowed"
+            )));
+        }
+
+        let Some((key, raw_value)) = line.split_once('=') else {
+            return Err(RunnerError::Config(format!(
+                "{label}:{line_number}: expected KEY=VALUE"
+            )));
+        };
+        let key = key.trim();
+        let value = raw_value.trim();
+        if !is_service_secret_key(key) {
+            return Err(RunnerError::Config(format!(
+                "{label}:{line_number}: unsupported service secret key {key:?}; allowed keys: {}",
+                ALLOWED_SERVICE_SECRET_KEYS.join(", ")
+            )));
+        }
+        if value.contains('\0') || value.contains('\r') || value.contains('\n') {
+            return Err(RunnerError::Config(format!(
+                "{label}:{line_number}: control characters are not allowed in service secret values"
+            )));
+        }
+
+        set_secret_value(&mut secrets, key, value.to_string(), label, line_number)?;
+    }
+    Ok(secrets)
+}
+
+fn set_secret_value(
+    secrets: &mut ServiceSecrets,
+    key: &str,
+    value: String,
+    label: &str,
+    line_number: usize,
+) -> RunnerResult<()> {
+    let slot = match key {
+        SENTRY_DSN_ENV => &mut secrets.sentry_dsn,
+        AXIOM_TOKEN_ENV => &mut secrets.axiom_token_telemetry,
+        AXIOM_SUFFIX_ENV => &mut secrets.axiom_dataset_suffix,
+        VERCEL_AUTOMATION_BYPASS_SECRET_ENV => &mut secrets.vercel_automation_bypass_secret,
+        _ => {
+            return Err(RunnerError::Config(format!(
+                "{label}:{line_number}: unsupported service secret key {key:?}"
+            )));
+        }
+    };
+    if slot.is_some() {
+        return Err(RunnerError::Config(format!(
+            "{label}:{line_number}: duplicate service secret key {key}"
+        )));
+    }
+    if !value.is_empty() {
+        *slot = Some(value);
+    }
+    Ok(())
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_service_secrets_accepts_allowed_keys() {
+        let secrets = parse_service_secrets_file(
+            "\n# telemetry\nSENTRY_DSN = sentry\nAXIOM_TOKEN_TELEMETRY=token\nAXIOM_DATASET_SUFFIX = prod\nVERCEL_AUTOMATION_BYPASS_SECRET=bypass=with=equals\n",
+            "test.env",
+        )
+        .unwrap();
+
+        assert_eq!(secrets.sentry_dsn(), Some("sentry"));
+        assert_eq!(secrets.axiom_token_telemetry(), Some("token"));
+        assert_eq!(secrets.axiom_dataset_suffix(), Some("prod"));
+        assert_eq!(
+            secrets.vercel_automation_bypass_secret(),
+            Some("bypass=with=equals")
+        );
+    }
+
+    #[test]
+    fn parse_service_secrets_treats_empty_values_as_absent() {
+        let secrets = parse_service_secrets_file("SENTRY_DSN=\n", "test.env").unwrap();
+
+        assert_eq!(secrets.sentry_dsn(), None);
+        assert_eq!(secrets.to_file_contents(), "");
+    }
+
+    #[test]
+    fn parse_service_secrets_rejects_unknown_key_without_leaking_value() {
+        let err = parse_service_secrets_file("UNKNOWN=super-secret-value\n", "test.env")
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("unsupported service secret key"));
+        assert!(err.contains("UNKNOWN"));
+        assert!(!err.contains("super-secret-value"));
+    }
+
+    #[test]
+    fn parse_service_secrets_rejects_duplicates_without_leaking_value() {
+        let err = parse_service_secrets_file(
+            "SENTRY_DSN=first-secret\nSENTRY_DSN=second-secret\n",
+            "test.env",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("duplicate service secret key SENTRY_DSN"));
+        assert!(!err.contains("first-secret"));
+        assert!(!err.contains("second-secret"));
+    }
+
+    #[test]
+    fn parse_service_secrets_rejects_malformed_lines_without_leaking_value() {
+        let err = parse_service_secrets_file("secret-without-equals\n", "test.env")
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("expected KEY=VALUE"));
+        assert!(!err.contains("secret-without-equals"));
+    }
+
+    #[test]
+    fn parse_service_secrets_rejects_nul_without_leaking_value() {
+        let err = parse_service_secrets_file("SENTRY_DSN=secret\0value\n", "test.env")
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("NUL characters are not allowed"));
+        assert!(!err.contains("secret"));
+    }
+
+    #[test]
+    fn service_secrets_debug_redacts_sensitive_values() {
+        let secrets = parse_service_secrets_file(
+            "SENTRY_DSN=sentry-secret\nAXIOM_TOKEN_TELEMETRY=token-secret\nAXIOM_DATASET_SUFFIX=prod\nVERCEL_AUTOMATION_BYPASS_SECRET=bypass-secret\n",
+            "test.env",
+        )
+        .unwrap();
+        let debug = format!("{secrets:?}");
+
+        assert!(debug.contains("[redacted]"));
+        assert!(debug.contains("prod"));
+        assert!(!debug.contains("sentry-secret"));
+        assert!(!debug.contains("token-secret"));
+        assert!(!debug.contains("bypass-secret"));
+    }
+
+    #[test]
+    fn canonical_service_secrets_path_lives_under_runner_dir() {
+        let home = HomePaths::with_root(PathBuf::from("/test"));
+
+        assert_eq!(
+            canonical_service_secrets_path(&home, "v0.1.0"),
+            PathBuf::from("/test/runners/v0.1.0/service-secrets.env")
+        );
+    }
+
+    #[tokio::test]
+    async fn stage_service_secrets_file_writes_canonical_private_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.env");
+        let destination = dir
+            .path()
+            .join("runners")
+            .join("v0.1.0")
+            .join(SERVICE_SECRETS_FILE_NAME);
+        tokio::fs::write(
+            &source,
+            "# comment\nSENTRY_DSN = sentry\nAXIOM_DATASET_SUFFIX=prod\n",
+        )
+        .await
+        .unwrap();
+
+        stage_service_secrets_file(&source, &destination)
+            .await
+            .unwrap();
+
+        let content = tokio::fs::read_to_string(&destination).await.unwrap();
+        assert_eq!(content, "SENTRY_DSN=sentry\nAXIOM_DATASET_SUFFIX=prod\n");
+        let loaded = read_private_service_secrets(&destination).await.unwrap();
+        assert_eq!(loaded.sentry_dsn(), Some("sentry"));
+        assert_eq!(loaded.axiom_dataset_suffix(), Some("prod"));
+    }
+}

--- a/crates/runner/src/service_secrets.rs
+++ b/crates/runner/src/service_secrets.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use tokio::io::AsyncReadExt;
 
@@ -14,6 +15,8 @@ pub(crate) const VERCEL_AUTOMATION_BYPASS_SECRET_ENV: &str = "VERCEL_AUTOMATION_
 pub(crate) const SERVICE_SECRETS_FILE_NAME: &str = "service-secrets.env";
 
 const SERVICE_SECRETS_FILE_READ_MAX_BYTES: u64 = 64 * 1024;
+const SERVICE_SECRETS_SOURCE_FILE_PREFIX: &str = ".service-secrets.env.source.";
+const STALE_SERVICE_SECRETS_SOURCE_MIN_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 const ALLOWED_SERVICE_SECRET_KEYS: [&str; 4] = [
     SENTRY_DSN_ENV,
     AXIOM_TOKEN_ENV,
@@ -157,7 +160,7 @@ pub(crate) async fn stage_service_secrets_file(
         ))
     })?;
     crate::private_fs::ensure_private_dir(parent).await?;
-    remove_stale_service_secrets_staging_files(parent).await?;
+    remove_stale_service_secrets_ephemeral_files(parent).await?;
     crate::private_fs::write_private_file(destination, secrets.to_file_contents().as_bytes()).await
 }
 
@@ -172,14 +175,14 @@ pub(crate) async fn remove_service_secrets_file(path: &Path) -> RunnerResult<()>
     };
 
     let cleanup_result = match path.parent() {
-        Some(parent) => remove_stale_service_secrets_staging_files(parent).await,
+        Some(parent) => remove_stale_service_secrets_ephemeral_files(parent).await,
         None => Ok(()),
     };
     remove_result?;
     cleanup_result
 }
 
-async fn remove_stale_service_secrets_staging_files(parent: &Path) -> RunnerResult<()> {
+async fn remove_stale_service_secrets_ephemeral_files(parent: &Path) -> RunnerResult<()> {
     let mut entries = match tokio::fs::read_dir(parent).await {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -197,7 +200,8 @@ async fn remove_stale_service_secrets_staging_files(parent: &Path) -> RunnerResu
             parent.display()
         ))
     })? {
-        if !is_service_secrets_staging_file_name(&entry.file_name()) {
+        let file_name = entry.file_name();
+        if !should_remove_service_secrets_ephemeral_file(&entry.path(), &file_name).await? {
             continue;
         }
         let path = entry.path();
@@ -218,6 +222,51 @@ async fn remove_stale_service_secrets_staging_files(parent: &Path) -> RunnerResu
 fn is_service_secrets_staging_file_name(name: &OsStr) -> bool {
     let name = name.to_string_lossy();
     name.starts_with(".service-secrets.env.") && name.ends_with(".tmp")
+}
+
+async fn should_remove_service_secrets_ephemeral_file(
+    path: &Path,
+    name: &OsStr,
+) -> RunnerResult<bool> {
+    if is_service_secrets_staging_file_name(name) {
+        return Ok(true);
+    }
+    if !is_service_secrets_source_file_name(name) {
+        return Ok(false);
+    }
+    is_file_older_than(path, STALE_SERVICE_SECRETS_SOURCE_MIN_AGE).await
+}
+
+fn is_service_secrets_source_file_name(name: &OsStr) -> bool {
+    name.to_string_lossy()
+        .starts_with(SERVICE_SECRETS_SOURCE_FILE_PREFIX)
+}
+
+async fn is_file_older_than(path: &Path, min_age: Duration) -> RunnerResult<bool> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => {
+            return Err(RunnerError::Config(format!(
+                "stat service secrets ephemeral file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+    let file_type = metadata.file_type();
+    if !metadata.is_file() && !file_type.is_symlink() {
+        return Ok(false);
+    }
+    let modified = metadata.modified().map_err(|e| {
+        RunnerError::Config(format!(
+            "stat service secrets ephemeral file mtime {}: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default()
+        >= min_age)
 }
 
 async fn read_private_service_secrets(path: &Path) -> RunnerResult<ServiceSecrets> {
@@ -368,6 +417,18 @@ fn non_empty_env(key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn set_modified(path: &Path, modified: SystemTime) {
+        let file = std::fs::OpenOptions::new().read(true).open(path).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(modified))
+            .unwrap();
+    }
+
+    fn stale_source_mtime() -> SystemTime {
+        SystemTime::now()
+            .checked_sub(STALE_SERVICE_SECRETS_SOURCE_MIN_AGE + Duration::from_secs(1))
+            .unwrap()
+    }
 
     #[test]
     fn parse_service_secrets_accepts_allowed_keys() {
@@ -528,6 +589,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stage_service_secrets_file_removes_stale_source_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.env");
+        let destination = dir
+            .path()
+            .join("runners")
+            .join("v0.1.0")
+            .join(SERVICE_SECRETS_FILE_NAME);
+        let parent = destination.parent().unwrap();
+        tokio::fs::create_dir_all(parent).await.unwrap();
+        tokio::fs::write(&source, "SENTRY_DSN=sentry\n")
+            .await
+            .unwrap();
+        let stale_source = parent.join(".service-secrets.env.source.cancelled");
+        let fresh_source = parent.join(".service-secrets.env.source.current");
+        tokio::fs::write(&stale_source, "SENTRY_DSN=old-secret\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&fresh_source, "SENTRY_DSN=new-secret\n")
+            .await
+            .unwrap();
+        set_modified(&stale_source, stale_source_mtime());
+
+        stage_service_secrets_file(&source, &destination)
+            .await
+            .unwrap();
+
+        assert!(!stale_source.exists());
+        assert!(fresh_source.exists());
+    }
+
+    #[tokio::test]
     async fn remove_service_secrets_file_removes_canonical_and_stale_staging_files() {
         let dir = tempfile::tempdir().unwrap();
         let destination = dir
@@ -545,6 +638,11 @@ mod tests {
         tokio::fs::write(&stale_tmp, "SENTRY_DSN=old-secret\n")
             .await
             .unwrap();
+        let stale_source = parent.join(".service-secrets.env.source.cancelled");
+        tokio::fs::write(&stale_source, "SENTRY_DSN=old-secret\n")
+            .await
+            .unwrap();
+        set_modified(&stale_source, stale_source_mtime());
         tokio::fs::write(&unrelated_tmp, "runner config")
             .await
             .unwrap();
@@ -553,6 +651,7 @@ mod tests {
 
         assert!(!destination.exists());
         assert!(!stale_tmp.exists());
+        assert!(!stale_source.exists());
         assert!(unrelated_tmp.exists());
     }
 


### PR DESCRIPTION
## Summary

- add a typed allowlisted service secrets file for runner service install/start
- stage service secrets under /var/lib/vm0-runner/runners/<name>/service-secrets.env and pass only that path to runner start
- initialize Sentry, Axiom, HTTP bypass, and executor host env from typed service secrets instead of systemd env
- migrate promote/rollback playbooks to use --service-secrets-file with legacy rollback fallback for old runner binaries

Fixes #17730

## Tests

- cargo fmt --manifest-path crates/runner/Cargo.toml --check
- cargo clippy --manifest-path crates/runner/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path crates/runner/Cargo.toml
- ansible-playbook -i 'localhost,' ansible/playbooks/promote-runner.yml --syntax-check -e runner_version=0.1.0
- ansible-playbook -i 'localhost,' ansible/playbooks/rollback-runner.yml --syntax-check -e runner_version=0.1.0 -e rollback_mode=graceful -e api_url=http://localhost:3000 -e official_runner_secret=dummy