### PR TITLE
fix: keep caret after inserted skill token so the slash menu dismisses

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -167,8 +167,14 @@ function isIOS(): boolean {
   );
 }
 
-// Replace the active `/query` text with the chosen token (plus a trailing space
-// unless one already follows). The decoration plugin colors it automatically.
+// Replace the active `/query` text with the chosen token (reusing the space that
+// already follows the query, or appending one). The caret is moved past that
+// space so the inserted `/skill` reads as a finished token: typing the next word
+// can't merge into it, and — since menu visibility is a pure function of the
+// caret position — `beforeCaret` no longer ends in a live `/token`, so the menu
+// closes. Without this, selecting a skill when text already follows the query
+// left the caret between the token and its space, keeping the menu open. The
+// decoration plugin colors the token automatically.
 function insertSkillToken(
   editor: Editor,
   slashRange: SlashSkillRange,
@@ -177,13 +183,16 @@ function insertSkillToken(
 ): void {
   const head = editor.state.selection.head;
   const span = slashRange.end - slashRange.start;
+  const from = head - span;
+  const token = `/${skill.name}`;
   const suffix = input.slice(slashRange.end).startsWith(" ") ? "" : " ";
   editor
     .chain()
     .focus()
-    .insertContentAt({ from: head - span, to: head }, [
-      { type: "text", text: `/${skill.name}${suffix}` },
+    .insertContentAt({ from, to: head }, [
+      { type: "text", text: `${token}${suffix}` },
     ])
+    .setTextSelection(from + token.length + 1)
     .run();
 }
 


### PR DESCRIPTION
## Problem

When a skill is selected from the slash (`/`) suggestion menu **while text
already follows the query**, the SKILLS popup does not dismiss.

Reproduction (matches the reported screenshot `/tell-a-joke fdsfsf`):
1. In the chat composer, get the input into a state where the slash query is
   immediately followed by a space, e.g. `/tell| fdsfsf` (caret right after the
   query, a space next).
2. Press Enter / click to select `/tell-a-joke`.
3. **Bug:** the menu stays open; the caret is parked between the token and the
   space, so continuing to type would merge into the token
   (`/tell-a-jokex fdsfsf`) and break the highlight.

## Root cause

Popup visibility is a pure function of `(input, caretIndex)` —
`findActiveSlashSkillRange` only looks at `beforeCaret` and matches a trailing
`/[a-z0-9-]*`.

In `insertSkillToken`, when the character after the query is already a space the
`suffix` is set to `""` (no space appended). TipTap's `insertContentAt` then
leaves the caret immediately after the inserted token (before the pre-existing
space). `beforeCaret` is therefore still `/tell-a-joke`, which keeps matching the
slash regex, so `showSlashSkillMenu` never flips to `false`.

The trigger is specifically "the character following the query is a space" — not
simply "text exists after the caret" (a non-space following char appends a space
and the caret lands after it, which dismisses correctly).

## Fix

Move the caret past the (reused or appended) trailing space after insertion, so
the inserted `/skill` always reads as a finished token. Two things fall out of
this single change:
- The next keystroke can no longer merge into the token.
- `beforeCaret` ends in a space, so the existing pure-function visibility check
  returns `null` and the menu dismisses — no extra dismissal state needed
  (keeps the YAGNI/no-defensive-state design).

## Verification

Verified against the exact dependency versions (`@tiptap/core` /
`@tiptap/starter-kit` 3.21.0, headless) with a standalone reproduction mirroring
`insertSkillToken` + `caretStringIndex` + the slash regex. Before the fix only
the "space follows the query" case left the caret one position short and kept the
menu open; after the fix all cases land the caret after the trailing space and
the menu closes:

| Case | Before caret | After-fix caret | Menu |
|------|--------------|-----------------|------|
| no trailing text | 13 | 13 | closes |
| trailing text, no space | 13 | 13 | closes |
| trailing text after a space (the bug) | **12 → open** | 13 | closes |
| two spaces | — | 13 | closes |
| non-empty query + space | — | 13 | closes |

### Note on test coverage
No jsdom integration test is added: reproducing the case requires repositioning
the caret back into the query (so a space follows it), and ProseMirror delegates
horizontal arrow-key caret movement to the browser, which jsdom does not
implement (the existing composer tests only ever type forward + Enter). The
proper home for an automated regression here is a real-browser e2e — happy to add
one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
