### PR TITLE
fix: improve generation template prompt context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -600,10 +600,10 @@ describe("CHAT-02: completed chat callback", () => {
     expect(appended).toContain(
       "# Current Integration\nYou are currently running inside: Web",
     );
-    expect(appended).toContain("# Generation Template");
-    expect(appended).toContain("Type: presentation");
-    expect(appended).toContain(`Design system ID: ${template.designSystemId}`);
-    expect(appended).toContain(`Template ID: ${template.templateId}`);
+    expect(appended).toContain("# Artifact Template Context");
+    expect(appended).toContain("- Artifact type: presentation");
+    expect(appended).toContain(`(${template.designSystemId})`);
+    expect(appended).toContain(`(${template.templateId})`);
     expect(appended).toContain("--artifact-kind presentation-html");
     expect(Object.keys(autoContext.body.environment)).toContain(
       "ANTHROPIC_API_KEY",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -436,7 +436,7 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
     expect(run.appendSystemPrompt).toContain(
       "You are currently running inside: Web",
     );
-    expect(run.appendSystemPrompt).not.toContain("# Generation Template");
+    expect(run.appendSystemPrompt).not.toContain("# Artifact Template Context");
 
     const messages = await waitForThreadMessages(
       actor,
@@ -1784,18 +1784,18 @@ describe("CHAT-02: generation templates and attachments", () => {
     const presentationRun = await api.readRun(actor, presentation.runId);
     expect(presentationRun.prompt).toBe("make a launch deck");
     const presentationPrompt = presentationRun.appendSystemPrompt ?? "";
-    expect(presentationPrompt).toContain("# Generation Template");
+    expect(presentationPrompt).toContain("# Artifact Template Context");
     expect(presentationPrompt).toContain(
-      "Use the following registered resources for this run.",
+      "The user selected a presentation artifact template",
     );
-    expect(presentationPrompt).toContain("Type: presentation");
+    expect(presentationPrompt).toContain("- Artifact type: presentation");
+    expect(presentationPrompt).toContain(`(${template.designSystemId})`);
+    expect(presentationPrompt).toContain(`(${template.templateId})`);
     expect(presentationPrompt).toContain(
-      `Design system ID: ${template.designSystemId}`,
+      "The user's prompt remains the source of truth",
     );
-    expect(presentationPrompt).toContain(`Template ID: ${template.templateId}`);
-    expect(presentationPrompt).toContain("Instructions:");
     expect(presentationPrompt).toContain(
-      "- Keep the user's prompt as the source of the requested content.",
+      `zero generate presentation --design-system ${template.designSystemId} --template ${template.templateId}`,
     );
     expect(presentationPrompt).toContain("--artifact-kind presentation-html");
     await cancelChatRun(actor, presentation.runId);
@@ -1816,19 +1816,22 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const videoRun = await api.readRun(actor, video.runId);
     const videoPrompt = videoRun.appendSystemPrompt ?? "";
-    expect(videoPrompt).toContain("# Video Template Preset");
-    expect(videoPrompt).toContain(`- Preset name: ${preset.nameEn}`);
+    expect(videoPrompt).toContain("# Artifact Template Context");
     expect(videoPrompt).toContain(
-      `- Visual Tone: ${preset.dimensions.visualTone}`,
+      "The user selected a video artifact template preset",
+    );
+    expect(videoPrompt).toContain(`- Preset: ${preset.nameEn} (${preset.id})`);
+    expect(videoPrompt).toContain(
+      `- Visual tone: ${preset.dimensions.visualTone}`,
     );
     expect(videoPrompt).toContain(
-      `- Camera Style: ${preset.dimensions.cameraStyle}`,
+      `- Camera style: ${preset.dimensions.cameraStyle}`,
     );
     expect(videoPrompt).toContain(
-      `- Style Reference: ${preset.dimensions.styleReference}`,
+      `- Style reference: ${preset.dimensions.styleReference}`,
     );
     expect(videoPrompt).toContain(
-      "safe for all audiences, positive and uplifting, no violence, no explicit content",
+      "zero generate video --provider built-in --prompt",
     );
     expect(videoPrompt).not.toContain(preset.scene);
     await cancelChatRun(actor, video.runId);
@@ -1853,7 +1856,10 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const firstPrompt = (await api.readRun(actor, first.runId))
       .appendSystemPrompt;
-    expect(firstPrompt).toContain("# Attached illustration style");
+    expect(firstPrompt).toContain("# Artifact Template Context");
+    expect(firstPrompt).toContain(
+      "The user selected an illustration artifact template style",
+    );
     expect(firstPrompt).toContain(style.illustrationStyleId);
 
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
@@ -1876,7 +1882,9 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const secondPrompt = (await api.readRun(actor, second.runId))
       .appendSystemPrompt;
-    expect(secondPrompt).toContain("# Attached illustration style");
+    expect(secondPrompt).toContain(
+      "The user selected an illustration artifact template style",
+    );
     expect(secondPrompt).toContain(style.illustrationStyleId);
     await cancelChatRun(actor, second.runId);
 
@@ -1899,9 +1907,13 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const thirdPrompt = (await api.readRun(actor, third.runId))
       .appendSystemPrompt;
-    expect(thirdPrompt).toContain("# Video Template Preset");
-    expect(thirdPrompt).toContain(`- Preset name: ${preset.nameEn}`);
-    expect(thirdPrompt).toContain("# Attached illustration style");
+    expect(thirdPrompt).toContain(
+      "The user selected a video artifact template preset",
+    );
+    expect(thirdPrompt).toContain(`- Preset: ${preset.nameEn} (${preset.id})`);
+    expect(thirdPrompt).toContain(
+      "The user selected an illustration artifact template style",
+    );
     expect(thirdPrompt).toContain(style.illustrationStyleId);
     await cancelChatRun(actor, third.runId);
 
@@ -1909,8 +1921,12 @@ describe("CHAT-02: generation templates and attachments", () => {
     const fresh = await sendChatRun(actor, { agentId, prompt: "draw a cat" });
     const freshPrompt = (await api.readRun(actor, fresh.runId))
       .appendSystemPrompt;
-    expect(freshPrompt).not.toContain("# Attached illustration style");
-    expect(freshPrompt).not.toContain("# Video Template Preset");
+    expect(freshPrompt).not.toContain(
+      "The user selected an illustration artifact template style",
+    );
+    expect(freshPrompt).not.toContain(
+      "The user selected a video artifact template preset",
+    );
     expect(freshPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, fresh.runId);
   }, 120_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -20,8 +20,23 @@ describe("buildGenerationTemplatePrompt", () => {
 
     expect(result).toStrictEqual({
       status: "resolved",
-      prompt: expect.stringContaining(`Template ID: ${item.templateId}`),
+      prompt: expect.stringContaining(`Template: `),
     });
+    if (result.status !== "resolved") {
+      return;
+    }
+    expect(result.prompt).toContain("# Artifact Template Context");
+    expect(result.prompt).toContain(
+      "The user selected a presentation artifact template",
+    );
+    expect(result.prompt).toContain(`(${item.designSystemId})`);
+    expect(result.prompt).toContain(`(${item.templateId})`);
+    expect(result.prompt).toContain(
+      `zero generate presentation --design-system ${item.designSystemId} --template ${item.templateId}`,
+    );
+    expect(result.prompt).toContain(
+      "The user's prompt remains the source of truth",
+    );
   });
 
   it("builds illustration template guidance", () => {
@@ -38,11 +53,16 @@ describe("buildGenerationTemplatePrompt", () => {
     if (result.status !== "resolved") {
       return;
     }
-    // Names the attached style and the capability fact that applies it, so the
-    // agent does not re-ask for an already-selected style (vm0-ai/vm0#17525).
+    expect(result.prompt).toContain("# Artifact Template Context");
+    expect(result.prompt).toContain(
+      "The user selected an illustration artifact template style",
+    );
+    expect(result.prompt).toContain(
+      "The user's prompt remains the source of truth",
+    );
     expect(result.prompt).toContain(item.illustrationStyleId);
     expect(result.prompt).toContain(
-      `zero generate image --style ${item.illustrationStyleId}`,
+      `zero generate image --provider built-in --style ${item.illustrationStyleId}`,
     );
   });
 
@@ -58,28 +78,28 @@ describe("buildGenerationTemplatePrompt", () => {
 
     expect(result).toStrictEqual({
       status: "resolved",
-      prompt: expect.stringContaining("# Video Template Preset"),
+      prompt: expect.stringContaining("# Artifact Template Context"),
     });
     if (result.status !== "resolved") {
       return;
     }
-    expect(result.prompt).toContain(`Preset ID: ${item.id}`);
-    expect(result.prompt).toContain(`Preset name: ${item.nameEn}`);
     expect(result.prompt).toContain(
-      "Apply all dimensions and constraints below as hard generation constraints.",
+      "The user selected a video artifact template preset",
     );
-    expect(result.prompt).toContain("- Visual Tone:");
-    expect(result.prompt).toContain("- Camera Style:");
-    expect(result.prompt).toContain("- Editing Pace:");
-    expect(result.prompt).toContain("- Narrative Mode:");
-    expect(result.prompt).toContain("- Production Type:");
-    expect(result.prompt).toContain("- Emotional Tone:");
-    expect(result.prompt).toContain("- Style Reference:");
+    expect(result.prompt).toContain(`Preset: ${item.nameEn} (${item.id})`);
     expect(result.prompt).toContain(
-      "- Style constraints (inject into the video prompt):",
+      "The user's prompt remains the source of truth",
     );
     expect(result.prompt).toContain(
-      `reflect every dimension and constraint above for the style ${item.nameEn}`,
+      "zero generate video --provider built-in --prompt",
     );
+    expect(result.prompt).toContain("- Visual tone:");
+    expect(result.prompt).toContain("- Camera style:");
+    expect(result.prompt).toContain("- Editing pace:");
+    expect(result.prompt).toContain("- Narrative mode:");
+    expect(result.prompt).toContain("- Production type:");
+    expect(result.prompt).toContain("- Emotional tone:");
+    expect(result.prompt).toContain("- Style reference:");
+    expect(result.prompt).toContain("- Prompt style notes:");
   });
 });

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -86,18 +86,24 @@ function buildPresentationGenerationTemplatePrompt(
   return {
     status: "resolved",
     prompt: [
-      "# Generation Template",
-      "Use the following registered resources for this run.",
-      `Type: ${generationTemplate.type}`,
-      `Design system ID: ${designSystem.id}`,
-      `Design system name: ${designSystem.name}`,
-      `Template ID: ${template.id}`,
-      `Template name: ${template.name}`,
+      "# Artifact Template Context",
       "",
-      "Instructions:",
-      "- Resolve the design system and template from the resource registry.",
-      "- Apply them as generation constraints for the artifact.",
-      "- Keep the user's prompt as the source of the requested content.",
+      "The user selected a presentation artifact template for this chat.",
+      "This is context, not control: the selection signals interest in this template and design-system style, and the user may want a presentation artifact if that fits the current request.",
+      "The user's prompt remains the source of truth for the task, content, output format, and whether to generate anything. Other artifact templates, files, or attachments may also be present.",
+      "",
+      "Selected presentation resources:",
+      `- Artifact type: ${generationTemplate.type}`,
+      `- Design system: ${designSystem.name} (${designSystem.id})`,
+      `- Design system description: ${designSystem.description}`,
+      `- Template: ${template.name} (${template.id})`,
+      `- Template description: ${template.description}`,
+      "",
+      "Relevant Zero generation commands:",
+      "- Run `zero generate presentation -h` to inspect the current flags.",
+      "- Run `zero generate presentation` to list available design systems and templates.",
+      `- If producing a presentation from the user's request, use \`zero generate presentation --design-system ${designSystem.id} --template ${template.id} --prompt "<user request>"\`.`,
+      "- Follow the returned authoring packet. For a static HTML presentation, author the artifact and publish it with `zero host <dir> --site <slug> --artifact-kind presentation-html`.",
     ].join("\n"),
   };
 }
@@ -120,24 +126,28 @@ function buildVideoGenerationTemplatePrompt(
   return {
     status: "resolved",
     prompt: [
-      "# Video Template Preset",
-      `- Preset ID: ${preset.id}`,
-      `- Preset name: ${preset.nameEn}`,
+      "# Artifact Template Context",
       "",
-      "- Apply all dimensions and constraints below as hard generation constraints.",
-      "- Keep the user's prompt as the source of the requested content.",
-      `- Visual Tone: ${describeSlug(preset.dimensions.visualTone)}`,
-      `- Camera Style: ${describeSlug(preset.dimensions.cameraStyle)}`,
-      `- Editing Pace: ${describeSlug(preset.dimensions.editingPace)}`,
-      `- Narrative Mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
-      `- Production Type: ${describeSlug(preset.dimensions.productionType)}`,
-      `- Emotional Tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
-      `- Style Reference: ${describeSlug(preset.dimensions.styleReference)}`,
+      "The user selected a video artifact template preset for this chat.",
+      "This is context, not control: the selection signals interest in this video style, and the user may want a video artifact if that fits the current request.",
+      "The user's prompt remains the source of truth for the task, content, output format, and whether to generate anything. Other artifact templates, files, or attachments may also be present.",
       "",
-      `- Style constraints (inject into the video prompt): ${preset.promptConstraints}`,
+      "Selected video style preset:",
+      "- Artifact type: video",
+      `- Preset: ${preset.nameEn} (${preset.id})`,
+      `- Visual tone: ${describeSlug(preset.dimensions.visualTone)}`,
+      `- Camera style: ${describeSlug(preset.dimensions.cameraStyle)}`,
+      `- Editing pace: ${describeSlug(preset.dimensions.editingPace)}`,
+      `- Narrative mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
+      `- Production type: ${describeSlug(preset.dimensions.productionType)}`,
+      `- Emotional tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
+      `- Style reference: ${describeSlug(preset.dimensions.styleReference)}`,
+      `- Prompt style notes: ${preset.promptConstraints}`,
       "",
-      `- In the final video prompt, reflect every dimension and constraint above for the style ${preset.nameEn}.`,
-      "- End the final video prompt with: safe for all audiences, positive and uplifting, no violence, no explicit content",
+      "Relevant Zero generation commands:",
+      "- Run `zero generate video -h` to inspect the current flags, models, and built-in options.",
+      "- Run `zero generate video` to list available providers for video generation.",
+      '- If producing a video from the user\'s request, use `zero generate video --provider built-in --prompt "<user request plus relevant style context>"` or follow connector guidance when a connector/provider is requested.',
     ].join("\n"),
   };
 }
@@ -152,18 +162,25 @@ function buildIllustrationGenerationTemplatePrompt(
     return { status: "invalid", message: "Unknown generation image style" };
   }
 
-  // Context, not control: state the facts (which style is attached, that it
-  // persists, how it reaches image generation) and let the agent act on them.
-  // Replaces the earlier "Resolve the image style from the resource registry"
-  // instruction, which named a step without the facts to do it, so when unsure
-  // the agent re-asked for an already-selected style (vm0-ai/vm0#17525).
   return {
     status: "resolved",
     prompt: [
-      "# Attached illustration style",
+      "# Artifact Template Context",
       "",
-      `"${imageStyle.name}" (${imageStyle.id}), attached to this chat and persisting across follow-up messages.`,
-      `Apply it with \`zero generate image --style ${imageStyle.id}\`.`,
+      "The user selected an illustration artifact template style for this chat.",
+      "This is context, not control: the selection signals interest in this illustration style, and the user may want an illustration or image artifact if that fits the current request.",
+      "The user's prompt remains the source of truth for the task, content, output format, and whether to generate anything. Other artifact templates, files, or attachments may also be present.",
+      "This selected illustration style can persist across follow-up messages in the same chat.",
+      "",
+      "Selected illustration style:",
+      "- Artifact type: illustration",
+      `- Style: ${imageStyle.name} (${imageStyle.id})`,
+      `- Style description: ${imageStyle.description}`,
+      "",
+      "Relevant Zero generation commands:",
+      "- Run `zero generate image -h` to inspect the current flags, models, providers, and style registry options.",
+      "- Run `zero generate image` to list available providers for image generation.",
+      `- If producing an illustration or image from the user's request, use \`zero generate image --provider built-in --style ${imageStyle.id} --prompt "<user request>"\`.`,
     ].join("\n"),
   };
 }


### PR DESCRIPTION
## Summary
- Rewrites artifact template system prompt guidance around context-not-control language.
- Makes presentation, video, and illustration template prompts state the selected resource as user-interest context while keeping the user prompt authoritative.
- Adds type-specific `zero generate` command guidance without mentioning `/gen`, and accounts for multiple templates/attachments coexisting.
- Updates prompt unit and BDD assertions for the new wording.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm exec prettier --write apps/api/src/signals/routes/generation-template-prompt.ts apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "renders generation template guidance into the run system prompt"`

## Notes
- Default `pnpm check-types` hit a Node heap OOM in the api package locally; rerunning with `NODE_OPTIONS=--max-old-space-size=4096` passed.
- Broader selected BDD cases that proceed to runner job claims failed locally with `Job not found in queue` before reaching the updated assertions; the direct generation-template BDD case passed after initializing the local test database.

Referenced Context, not control: https://app.notion.com/p/Context-not-control-33d0e96f0134802c9bbcd5f7f3a46209?source=copy_link