### PR TITLE
test: handle external onboarding auth redirects

### DIFF
--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -153,7 +153,9 @@ async function signInWithEmailCode(
       .click();
   }
 
-  await submitEmailCode(page, remainingTimeout(deadline, 30_000));
+  if (flow !== "redirected") {
+    await submitEmailCode(page, remainingTimeout(deadline, 30_000));
+  }
 
   if (redirectUrl && !isOnboardingOrChatUrl(new URL(page.url()))) {
     await page.goto(redirectUrl, { waitUntil: "domcontentloaded" });
@@ -172,9 +174,14 @@ async function clickIfVisible(
 async function waitForEmailCodeFlow(
   page: Page,
   timeout: number,
-): Promise<"otp" | "alt"> {
+): Promise<"otp" | "alt" | "redirected"> {
   const result = await page.waitForFunction(
     () => {
+      const { pathname } = window.location;
+      if (!pathname.includes("/sign-up") && !pathname.includes("/sign-in")) {
+        return "redirected";
+      }
+
       const hasOtp = Boolean(
         document.querySelector('input[data-input-otp="true"]'),
       );
@@ -196,7 +203,7 @@ async function waitForEmailCodeFlow(
     { timeout },
   );
   const flow = await result.jsonValue();
-  if (flow === "otp" || flow === "alt") {
+  if (flow === "otp" || flow === "alt" || flow === "redirected") {
     return flow;
   }
   throw new Error(`Unexpected Clerk sign-in flow: ${String(flow)}`);


### PR DESCRIPTION
## Summary
- treat leaving Clerk auth pages during email sign-in as a completed auth redirect
- avoid waiting for OTP when external onboarding already has an authenticated session and renders the workspace setup page

## Testing
- cd e2e && VM0_API_URL=https://staging-www.vm6.ai JOB_REF=staging-local-fix npx playwright test --config playwright/playwright.config.ts --project setup
- cd e2e && VM0_API_URL=https://staging-www.vm6.ai npx playwright test --config playwright/playwright.config.ts --list
- git diff --check