### PR TITLE
fix: sync connector search with URL params

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -42,6 +42,7 @@ import {
   deleteConnector$,
   reloadConnectors$,
 } from "../../external/connectors.ts";
+import { replaceSearchParams$, searchParams$ } from "../../route.ts";
 import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
 import {
   jsonParseOr,
@@ -495,12 +496,27 @@ const hiddenConnectorTypes$ = computed((get): Set<ConnectorType> => {
 // Search filter
 // ---------------------------------------------------------------------------
 
-const internalConnectorsSearch$ = state("");
+const CONNECTORS_SEARCH_PARAM = "keywords";
 export const connectorsSearch$ = computed((get) => {
-  return get(internalConnectorsSearch$);
+  return get(searchParams$).get(CONNECTORS_SEARCH_PARAM) ?? "";
 });
-export const setConnectorsSearch$ = command(({ set }, v: string) => {
-  set(internalConnectorsSearch$, v);
+
+export const filteredConnectorTypes$ = computed(async (get) => {
+  const keyword = get(connectorsSearch$);
+  const allConnectorTypes = await get(allConnectorTypes$);
+  return allConnectorTypes.filter((connector) => {
+    return matchesConnectorSearch(keyword, connector);
+  });
+});
+
+export const setConnectorsSearch$ = command(({ get, set }, value: string) => {
+  const params = new URLSearchParams(get(searchParams$));
+  if (value.trim()) {
+    params.set(CONNECTORS_SEARCH_PARAM, value);
+  } else {
+    params.delete(CONNECTORS_SEARCH_PARAM);
+  }
+  set(replaceSearchParams$, params);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -21,6 +21,9 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { search } from "../../../signals/location.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -260,6 +263,15 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+    expect(search()).toBe("?keywords=vcs");
+
+    context.store.set(detachedNavigateTo$, ROUTES.connectors);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Find connectors")).toHaveValue("");
+      expect(search()).toBe("");
+    });
+    expect(screen.getByText("Slack")).toBeInTheDocument();
   });
 
   it("filters connectors by capability keywords", async () => {
@@ -274,6 +286,22 @@ describe("connectors page", () => {
     await fill(searchInput, "logs");
 
     await waitFor(() => {
+      expect(screen.getByText("Axiom")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
+  it("hydrates connector search from URL keywords", async () => {
+    mockConnectors([
+      { type: "github", externalUsername: "octocat" },
+      { type: "axiom", authMethod: "api-token" },
+    ]);
+
+    detachedSetupPage({ context, path: "/connectors?keywords=logs" });
+
+    const searchInput = await screen.findByPlaceholderText("Find connectors");
+    await waitFor(() => {
+      expect(searchInput).toHaveValue("logs");
       expect(screen.getByText("Axiom")).toBeInTheDocument();
     });
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -34,6 +34,7 @@ import {
   connectConnectorOAuthAuthCode$,
   connectorsSearch$,
   disconnectConnector$,
+  filteredConnectorTypes$,
   setConnectorsSearch$,
   selectedConnectorType$,
   setSelectedConnectorType$,
@@ -45,7 +46,6 @@ import {
   permissionDialogType$,
   setPermissionDialogType$,
   isStandaloneMode,
-  matchesConnectorSearch,
   getAvailableAuthCodeAuthMethod,
   getOnlyAvailableAuthCodeAuthMethod,
   getConnectorConnectLaunchMode,
@@ -595,6 +595,7 @@ function renderBuiltinList({
 
 export function ZeroConnectorsPage() {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
+  const filteredTypesLoadable = useLastLoadable(filteredConnectorTypes$);
   const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
   const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
@@ -615,7 +616,7 @@ export function ZeroConnectorsPage() {
   const attachScrollTracking = useSet(attachConnectorCategoryScrollTracking$);
   const resetActiveCategory = useSet(resetActiveConnectorCategory$);
   const categoryTrackingEnabled =
-    activeTab === "builtin" && allTypesLoadable.state === "hasData";
+    activeTab === "builtin" && filteredTypesLoadable.state === "hasData";
   const scrollContainerRef = useScrollTrackingRef(
     categoryTrackingEnabled,
     attachScrollTracking,
@@ -625,16 +626,14 @@ export function ZeroConnectorsPage() {
   const search = useGet(connectorsSearch$);
   const setSearch = useSet(setConnectorsSearch$);
 
+  const filteredConnectors =
+    filteredTypesLoadable.state === "hasData" ? filteredTypesLoadable.data : [];
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
   const disconnecting = disconnectLoadable.state === "loading";
 
-  const filtered = allConnectors.filter((c) => {
-    return matchesConnectorSearch(search, c);
-  });
-
   const connectHandler = (type: ConnectorType) => {
-    const ct = allConnectors.find((c) => {
+    const ct = filteredConnectors.find((c) => {
       return c.type === type;
     });
     if (!ct) {
@@ -712,13 +711,13 @@ export function ZeroConnectorsPage() {
   };
 
   const grouped = groupConnectorsByCategory(
-    filtered.map(getOptimisticConnector),
+    filteredConnectors.map(getOptimisticConnector),
   );
 
   const builtinList = renderBuiltinList({
-    loadingState: allTypesLoadable.state,
+    loadingState: filteredTypesLoadable.state,
     grouped,
-    filteredCount: filtered.length,
+    filteredCount: filteredConnectors.length,
     renderCard,
     search,
   });
@@ -760,12 +759,13 @@ export function ZeroConnectorsPage() {
 
       <main className="flex-1 px-4 sm:px-6 pt-3 pb-16">
         <div className="relative mx-auto w-full max-w-[900px]">
-          {activeTab === "builtin" && allTypesLoadable.state === "hasData" && (
-            <ConnectorCategoryMenu
-              activeCategoryId={activeCategoryId}
-              groups={grouped}
-            />
-          )}
+          {activeTab === "builtin" &&
+            filteredTypesLoadable.state === "hasData" && (
+              <ConnectorCategoryMenu
+                activeCategoryId={activeCategoryId}
+                groups={grouped}
+              />
+            )}
 
           <div className="min-w-0 flex w-full max-w-[900px] flex-col gap-6">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- derive /connectors search keyword from the `keywords` URL search param
- expose filtered connector results as a computed signal and render from it
- cover URL hydration and clearing search when re-entering /connectors without params

## Tests
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`