### PR TITLE
fix: prevent settings dialog auto-focusing Preference nav item

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -258,6 +258,11 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     >
       <DialogContent
         className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
+        onOpenAutoFocus={(event) => {
+          // Don't auto-focus the first nav item ("Preference") on open; it
+          // leaves an unwanted focus ring every time the dialog is opened.
+          event.preventDefault();
+        }}
         onInteractOutside={(event) => {
           if (isClerkModalTarget(event.target)) {
             event.preventDefault();


### PR DESCRIPTION
## Problem

Opening the settings dialog auto-focused the first sidebar nav button (**Preference**) every time, rendering an unwanted focus ring. Reported in #17776.

## Fix

Add `onOpenAutoFocus={(event) => event.preventDefault()}` to the settings `DialogContent`, preventing Radix's default behavior of focusing the first tabbable element on open. This matches the existing pattern already used in the codebase (e.g. `queue-drawer.tsx`). Radix still traps focus within the dialog and Escape/close behavior is unaffected.

## Testing

- `prettier --check` passes
- `oxlint` (pinned 1.57.0) passes: 0 warnings, 0 errors

Closes #17776

🤖 Generated with [Claude Code](https://claude.com/claude-code)