### PR TITLE
refactor: remove time range tab from insights & usage page

### DIFF
--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -211,22 +211,6 @@ export const reloadInsights$ = command(({ set }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Active tab: daily diary vs. period-wide time-range view
-// ---------------------------------------------------------------------------
-
-export type InsightsTab = "daily" | "time-range";
-
-const internalActiveTab$ = state<InsightsTab>("daily");
-
-export const insightsActiveTab$ = computed((get) => {
-  return get(internalActiveTab$);
-});
-
-export const setInsightsActiveTab$ = command(({ set }, tab: InsightsTab) => {
-  set(internalActiveTab$, tab);
-});
-
-// ---------------------------------------------------------------------------
 // "Show all" toggle for per-day automations / chats cards (keyed by day date)
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
@@ -60,16 +60,6 @@ function monthsBetweenTodayAnd(iso: string): number {
   );
 }
 
-function getTabByText(text: string): HTMLElement {
-  const tab = queryAllByRoleFast("tab").find((el) => {
-    return el.textContent?.trim() === text;
-  });
-  if (!tab) {
-    throw new Error(`Could not find tab: ${text}`);
-  }
-  return tab;
-}
-
 function insightsResponse(): InsightsResponse & NetworkInsightsData {
   const date = localDateDaysAgo(1);
   const olderDate = localDateDaysAgo(20);
@@ -477,12 +467,9 @@ describe("network insights page", () => {
     expect(screen.queryByText("Time range")).not.toBeInTheDocument();
   });
 
-  it("shows daily network insights and switches to the time range usage view", async () => {
+  it("shows daily network insights", async () => {
     context.mocks.api(zeroInsightsContract.get, ({ respond }) => {
       return respond(200, insightsResponse());
-    });
-    context.mocks.api(zeroUsageInsightContract.get, ({ respond }) => {
-      return respond(200, usageInsightResponse());
     });
 
     detachedSetupPage({ context, path: "/insights" });
@@ -538,14 +525,6 @@ describe("network insights page", () => {
     expect(screen.queryByText("Hidden chat")).not.toBeInTheDocument();
     await user.click(screen.getByText("+1 more chat"));
     expect(screen.getByText("Hidden chat")).toBeInTheDocument();
-
-    click(getTabByText("Time range"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Morning Briefing")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Competitor scan")).toBeInTheDocument();
-    expect(screen.getByText("650")).toBeInTheDocument();
   });
 
   it("shows a no-activity message when the selected range excludes older data", async () => {

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -15,9 +15,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  Tabs,
-  TabsList,
-  TabsTrigger,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -43,15 +40,11 @@ import {
   toggleExpandedAutomationDay$,
   expandedChatDays$,
   toggleExpandedChatDay$,
-  insightsActiveTab$,
-  setInsightsActiveTab$,
   type DayInsight,
   type DayAutomation,
   type DayChat,
-  type InsightsTab,
   type NetworkInsightsData,
 } from "../../signals/network-insights/network-insights-signals.ts";
-import { UsageInsightView } from "../usage-page/components/usage-insight-view.tsx";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
@@ -1315,8 +1308,6 @@ function formatAbsoluteTime(iso: string): string {
 function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const dateRange = useGet(insightsDateRange$);
   const setRange = useSet(setInsightsDateRange$);
-  const activeTab = useGet(insightsActiveTab$);
-  const setActiveTab = useSet(setInsightsActiveTab$);
   const prefsLoadable = useLastLoadable(userPreferences$);
   const adminLoadable = useLastLoadable(isOrgAdmin$);
   const userLoadable = useLastLoadable(user$);
@@ -1365,23 +1356,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
           )}
         </div>
 
-        {data.days.length > 0 && (
-          <Tabs
-            value={activeTab}
-            onValueChange={(v) => {
-              setActiveTab(v as InsightsTab);
-            }}
-          >
-            <TabsList>
-              <TabsTrigger value="daily">Daily breakdown</TabsTrigger>
-              <TabsTrigger value="time-range">Time range</TabsTrigger>
-            </TabsList>
-          </Tabs>
-        )}
-
-        {activeTab === "time-range" && data.days.length > 0 ? (
-          <UsageInsightView />
-        ) : filtered.length === 0 ? (
+        {filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
             <img
               src={emptyInsightsImg}


### PR DESCRIPTION
## What

Removes the **Time range** tab from the *Insights & Usage* page (`/insights`), leaving only the **Daily breakdown** view.

Per discussion with Ming: the time-range usage view isn't getting traffic / can't be reliably tracked, so the tab is being dropped. Since only one tab would remain, the entire tab switcher is removed and the page renders the daily breakdown directly. The top-right date-range filter is unchanged.

## Changes

- `network-insights-page.tsx` — remove the `Tabs` switcher, the `time-range` branch rendering `UsageInsightView`, and the related imports/state.
- `network-insights-signals.ts` — drop the now-unused `InsightsTab` type and `insightsActiveTab$` / `setInsightsActiveTab$` signals.
- `network-insights-page.test.tsx` — rename the test and remove the tab-switch assertions + unused `getTabByText` helper.

`UsageInsightView` itself is untouched — it's still used by the standalone Zero usage page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)