### PR TITLE
feat: drop time range tab and rename insights title

### DIFF
--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -211,22 +211,6 @@ export const reloadInsights$ = command(({ set }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Active tab: daily diary vs. period-wide time-range view
-// ---------------------------------------------------------------------------
-
-export type InsightsTab = "daily" | "time-range";
-
-const internalActiveTab$ = state<InsightsTab>("daily");
-
-export const insightsActiveTab$ = computed((get) => {
-  return get(internalActiveTab$);
-});
-
-export const setInsightsActiveTab$ = command(({ set }, tab: InsightsTab) => {
-  set(internalActiveTab$, tab);
-});
-
-// ---------------------------------------------------------------------------
 // "Show all" toggle for per-day automations / chats cards (keyed by day date)
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
@@ -4,10 +4,6 @@ import {
   zeroInsightsContract,
   type InsightsResponse,
 } from "@vm0/api-contracts/contracts/zero-insights";
-import {
-  zeroUsageInsightContract,
-  type UsageInsightResponse,
-} from "@vm0/api-contracts/contracts/zero-usage-insight";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -58,16 +54,6 @@ function monthsBetweenTodayAnd(iso: string): number {
     today.getMonth() -
     target.getMonth()
   );
-}
-
-function getTabByText(text: string): HTMLElement {
-  const tab = queryAllByRoleFast("tab").find((el) => {
-    return el.textContent?.trim() === text;
-  });
-  if (!tab) {
-    throw new Error(`Could not find tab: ${text}`);
-  }
-  return tab;
 }
 
 function insightsResponse(): InsightsResponse & NetworkInsightsData {
@@ -305,45 +291,6 @@ function oldInsightsResponse(): InsightsResponse & NetworkInsightsData {
   };
 }
 
-function usageInsightResponse(): UsageInsightResponse {
-  return {
-    buckets: [
-      {
-        ts: `${localDateDaysAgo(1)} 00:00:00`,
-        series: { chat: 400, slack: 250 },
-        tokens: { chat: 800, slack: 500 },
-      },
-    ],
-    automations: [
-      {
-        automationId: "d0000000-0000-4000-a000-000000000001",
-        automationName: "Morning Briefing",
-        automationDescription: null,
-        credits: 300,
-        tokens: 600,
-      },
-    ],
-    automationOtherCount: 0,
-    automationOtherCredits: 0,
-    chats: [
-      {
-        threadId: "b0000000-0000-4000-a000-000000000001",
-        threadTitle: "Competitor scan",
-        credits: 120,
-        tokens: 240,
-      },
-    ],
-    chatOtherCount: 0,
-    chatOtherCredits: 0,
-    emailCredits: 0,
-    emailTokens: 0,
-    slackCredits: 250,
-    slackTokens: 500,
-    grandTotalCredits: 650,
-    grandTotalTokens: 1300,
-  };
-}
-
 function quoteVariantsInsightsResponse(): InsightsResponse &
   NetworkInsightsData {
   return {
@@ -467,7 +414,7 @@ describe("network insights page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { level: 1, name: "Insights & Usage" }),
+        screen.getByRole("heading", { level: 1, name: "Insights" }),
       ).toBeInTheDocument();
       expect(
         screen.getByText("Run an agent to see insights here."),
@@ -477,19 +424,16 @@ describe("network insights page", () => {
     expect(screen.queryByText("Time range")).not.toBeInTheDocument();
   });
 
-  it("shows daily network insights and switches to the time range usage view", async () => {
+  it("shows daily network insights", async () => {
     context.mocks.api(zeroInsightsContract.get, ({ respond }) => {
       return respond(200, insightsResponse());
-    });
-    context.mocks.api(zeroUsageInsightContract.get, ({ respond }) => {
-      return respond(200, usageInsightResponse());
     });
 
     detachedSetupPage({ context, path: "/insights" });
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { level: 1, name: "Insights & Usage" }),
+        screen.getByRole("heading", { level: 1, name: "Insights" }),
       ).toBeInTheDocument();
     });
     expect(screen.getByText("Yesterday")).toBeInTheDocument();
@@ -538,14 +482,6 @@ describe("network insights page", () => {
     expect(screen.queryByText("Hidden chat")).not.toBeInTheDocument();
     await user.click(screen.getByText("+1 more chat"));
     expect(screen.getByText("Hidden chat")).toBeInTheDocument();
-
-    click(getTabByText("Time range"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Morning Briefing")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Competitor scan")).toBeInTheDocument();
-    expect(screen.getByText("650")).toBeInTheDocument();
   });
 
   it("shows a no-activity message when the selected range excludes older data", async () => {
@@ -569,15 +505,12 @@ describe("network insights page", () => {
     context.mocks.api(zeroInsightsContract.get, ({ respond }) => {
       return respond(200, insightsResponse());
     });
-    context.mocks.api(zeroUsageInsightContract.get, ({ respond }) => {
-      return respond(200, usageInsightResponse());
-    });
 
     detachedSetupPage({ context, path: "/insights" });
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { level: 1, name: "Insights & Usage" }),
+        screen.getByRole("heading", { level: 1, name: "Insights" }),
       ).toBeInTheDocument();
     });
     expect(screen.getByText("Research Bot")).toBeInTheDocument();
@@ -637,7 +570,6 @@ describe("network insights page", () => {
     expect(screen.getByText("Archive Bot")).toBeInTheDocument();
     expect(screen.getByText("Mira")).toBeInTheDocument();
     expect(screen.queryByText("Research Bot")).not.toBeInTheDocument();
-    expect(screen.queryByText("Morning Briefing")).not.toBeInTheDocument();
   });
 
   it("summarizes different daily activity patterns", async () => {

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -15,9 +15,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  Tabs,
-  TabsList,
-  TabsTrigger,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -43,15 +40,11 @@ import {
   toggleExpandedAutomationDay$,
   expandedChatDays$,
   toggleExpandedChatDay$,
-  insightsActiveTab$,
-  setInsightsActiveTab$,
   type DayInsight,
   type DayAutomation,
   type DayChat,
-  type InsightsTab,
   type NetworkInsightsData,
 } from "../../signals/network-insights/network-insights-signals.ts";
-import { UsageInsightView } from "../usage-page/components/usage-insight-view.tsx";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
@@ -1315,8 +1308,6 @@ function formatAbsoluteTime(iso: string): string {
 function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const dateRange = useGet(insightsDateRange$);
   const setRange = useSet(setInsightsDateRange$);
-  const activeTab = useGet(insightsActiveTab$);
-  const setActiveTab = useSet(setInsightsActiveTab$);
   const prefsLoadable = useLastLoadable(userPreferences$);
   const adminLoadable = useLastLoadable(isOrgAdmin$);
   const userLoadable = useLastLoadable(user$);
@@ -1338,7 +1329,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
         <div>
           <div className="flex items-start justify-between gap-4">
             <div>
-              <h1 className="text-xl font-semibold">Insights &amp; Usage</h1>
+              <h1 className="text-xl font-semibold">Insights</h1>
               <p className="text-sm text-muted-foreground mt-1">
                 Monitor what your agents access, how credits are spent, which
                 permissions they use, and spot anything unusual.
@@ -1365,23 +1356,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
           )}
         </div>
 
-        {data.days.length > 0 && (
-          <Tabs
-            value={activeTab}
-            onValueChange={(v) => {
-              setActiveTab(v as InsightsTab);
-            }}
-          >
-            <TabsList>
-              <TabsTrigger value="daily">Daily breakdown</TabsTrigger>
-              <TabsTrigger value="time-range">Time range</TabsTrigger>
-            </TabsList>
-          </Tabs>
-        )}
-
-        {activeTab === "time-range" && data.days.length > 0 ? (
-          <UsageInsightView />
-        ) : filtered.length === 0 ? (
+        {filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
             <img
               src={emptyInsightsImg}


### PR DESCRIPTION
## What

On the network Insights page:
- Remove the **Time range** tab (the in-page usage view).
- Rename the page title from **Insights & Usage** → **Insights**.

Per Ming's request — the in-page usage tab has no tracked traffic and is being dropped.

## Details

- The tab UI (`Tabs`/`TabsList`/`TabsTrigger`) and the `time-range` branch rendering `UsageInsightView` are removed; the page now shows the daily breakdown directly.
- Removed the now-unused `insightsActiveTab$` / `setInsightsActiveTab$` / `InsightsTab` signals.
- The standalone `UsageInsightView` component and its `zero-usage-insight` API contract are untouched (still used by the dedicated usage page).
- Tests updated accordingly (title assertions, dropped tab-switch coverage and unused usage mocks).

Format + oxlint pass locally on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)