### PR TITLE
fix: clean slack test vm0 keys

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-state.test.ts
@@ -17,6 +17,7 @@ import { e2eSlackMockCallLog } from "@vm0/db/schema/e2e-slack-mock-call-log";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
+import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { describe, expect, it } from "vitest";
@@ -277,6 +278,9 @@ async function cleanupSlackSeedFixture(
   await writeDb.delete(orgMetadata).where(eq(orgMetadata.orgId, fixture.orgId));
 
   if (composeIds.length > 0) {
+    await writeDb
+      .delete(vm0ApiKeys)
+      .where(inArray(vm0ApiKeys.label, composeIds));
     await writeDb.delete(zeroAgents).where(inArray(zeroAgents.id, composeIds));
     await writeDb
       .delete(agentComposeVersions)
@@ -809,5 +813,68 @@ describe("DELETE /api/test/slack-state", () => {
         return call.method;
       }),
     ).toStrictEqual(expect.arrayContaining([...fixture.mockCallMethods]));
+  });
+
+  it("removes vm0 managed keys seeded for the default Slack agent", async () => {
+    mockEnv("ENV", "development");
+    const id = suffix();
+    const teamId = `T_DELETE_AGENT_${id}`;
+    const orgId = `org_delete_agent_${id}`;
+    const userId = `user_delete_agent_${id}`;
+    await trackSlackSeedFixture(Promise.resolve({ teamId, orgId }));
+    mockTestUserMembership(userId, orgId);
+
+    const postResponse = await postSlackState({
+      team_id: teamId,
+      slack_user_id: "U_E2E_DELETE_AGENT",
+      seed_default_agent: true,
+    });
+    const postBody = await readJson<TestSlackStatePostResponse>(postResponse);
+    expect(postResponse.status).toBe(200);
+    if (!postBody.default_agent_id) {
+      throw new Error("Expected seeded default agent id");
+    }
+
+    const seededKeys = await writeDb
+      .select({
+        vendor: vm0ApiKeys.vendor,
+        model: vm0ApiKeys.model,
+        label: vm0ApiKeys.label,
+      })
+      .from(vm0ApiKeys)
+      .where(eq(vm0ApiKeys.label, postBody.default_agent_id));
+
+    expect(seededKeys).toHaveLength(3);
+    expect(seededKeys).toStrictEqual(
+      expect.arrayContaining([
+        {
+          vendor: "anthropic",
+          model: "claude-sonnet-4-6",
+          label: postBody.default_agent_id,
+        },
+        {
+          vendor: "deepseek",
+          model: "deepseek-v4-pro",
+          label: postBody.default_agent_id,
+        },
+        {
+          vendor: "moonshot",
+          model: "kimi-k2.7-code",
+          label: postBody.default_agent_id,
+        },
+      ]),
+    );
+
+    const deleteResponse = await requestApp(`${ROUTE}?team_id=${teamId}`, {
+      method: "DELETE",
+    });
+
+    expect(deleteResponse.status).toBe(200);
+    await expect(
+      writeDb
+        .select({ id: vm0ApiKeys.id })
+        .from(vm0ApiKeys)
+        .where(eq(vm0ApiKeys.label, postBody.default_agent_id)),
+    ).resolves.toStrictEqual([]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -219,7 +219,11 @@ async function seedDefaultAgent(
 
 async function seedVm0ManagedKeys(db: Db, composeId: string): Promise<void> {
   await db.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, composeId));
-  await db.insert(vm0ApiKeys).values([
+  await db.insert(vm0ApiKeys).values(vm0ManagedKeyRows(composeId));
+}
+
+function vm0ManagedKeyRows(composeId: string) {
+  return [
     {
       vendor: "anthropic",
       model: "claude-sonnet-4-6",
@@ -238,7 +242,43 @@ async function seedVm0ManagedKeys(db: Db, composeId: string): Promise<void> {
       apiKey: `vm0-key-moonshot-${composeId}`,
       label: composeId,
     },
-  ]);
+  ];
+}
+
+async function deleteVm0ManagedKeysForSeededDefaultAgents(
+  db: Db,
+  orgId: string,
+): Promise<void> {
+  const composes = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, orgId),
+        eq(agentComposes.name, DEFAULT_AGENT_NAME),
+      ),
+    );
+
+  if (composes.length === 0) {
+    return;
+  }
+
+  const composeIds = composes.map((compose) => {
+    return compose.id;
+  });
+  const apiKeys = composes.flatMap((compose) => {
+    return vm0ManagedKeyRows(compose.id).map((row) => {
+      return row.apiKey;
+    });
+  });
+  await db
+    .delete(vm0ApiKeys)
+    .where(
+      and(
+        inArray(vm0ApiKeys.label, composeIds),
+        inArray(vm0ApiKeys.apiKey, apiKeys),
+      ),
+    );
 }
 
 async function getOrInsertCompose(
@@ -722,6 +762,9 @@ const deleteSlackState$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
   if (existing?.orgId) {
+    await deleteVm0ManagedKeysForSeededDefaultAgents(db, existing.orgId);
+    signal.throwIfAborted();
+
     const slackAgentRuns = await db
       .select({ id: agentRuns.id })
       .from(agentRuns)

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -751,6 +751,11 @@ const deleteSlackState$ = command(async ({ get, set }, signal: AbortSignal) => {
     .limit(1);
   signal.throwIfAborted();
 
+  if (existing?.orgId) {
+    await deleteVm0ManagedKeysForSeededDefaultAgents(db, existing.orgId);
+    signal.throwIfAborted();
+  }
+
   await db
     .delete(slackOrgConnections)
     .where(eq(slackOrgConnections.slackWorkspaceId, teamId));
@@ -762,9 +767,6 @@ const deleteSlackState$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
   if (existing?.orgId) {
-    await deleteVm0ManagedKeysForSeededDefaultAgents(db, existing.orgId);
-    signal.throwIfAborted();
-
     const slackAgentRuns = await db
       .select({ id: agentRuns.id })
       .from(agentRuns)

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -245,11 +245,11 @@ function vm0ManagedKeyRows(composeId: string) {
   ];
 }
 
-async function deleteVm0ManagedKeysForSeededDefaultAgents(
+async function deleteVm0ManagedKeysForSeededDefaultAgent(
   db: Db,
   orgId: string,
 ): Promise<void> {
-  const composes = await db
+  const [compose] = await db
     .select({ id: agentComposes.id })
     .from(agentComposes)
     .where(
@@ -257,25 +257,21 @@ async function deleteVm0ManagedKeysForSeededDefaultAgents(
         eq(agentComposes.orgId, orgId),
         eq(agentComposes.name, DEFAULT_AGENT_NAME),
       ),
-    );
+    )
+    .limit(1);
 
-  if (composes.length === 0) {
+  if (!compose) {
     return;
   }
 
-  const composeIds = composes.map((compose) => {
-    return compose.id;
-  });
-  const apiKeys = composes.flatMap((compose) => {
-    return vm0ManagedKeyRows(compose.id).map((row) => {
-      return row.apiKey;
-    });
+  const apiKeys = vm0ManagedKeyRows(compose.id).map((row) => {
+    return row.apiKey;
   });
   await db
     .delete(vm0ApiKeys)
     .where(
       and(
-        inArray(vm0ApiKeys.label, composeIds),
+        eq(vm0ApiKeys.label, compose.id),
         inArray(vm0ApiKeys.apiKey, apiKeys),
       ),
     );
@@ -752,7 +748,7 @@ const deleteSlackState$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
 
   if (existing?.orgId) {
-    await deleteVm0ManagedKeysForSeededDefaultAgents(db, existing.orgId);
+    await deleteVm0ManagedKeysForSeededDefaultAgent(db, existing.orgId);
     signal.throwIfAborted();
   }
 


### PR DESCRIPTION
## Summary
- clean vm0 managed model keys seeded by the Slack test-state endpoint when DELETE resets a workspace
- match only the exact fake keys generated for the seeded Slack default agent
- add coverage that POST seeds the keys and DELETE removes them

## Why
The flaky runner e2e failure was caused by Slack e2e setup leaving fake vm0_api_keys rows for claude-sonnet-4-6. Later vm0 meta-provider tests randomly selected those stale fake keys and failed with Invalid API key.

## Testing
- pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-state.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit hook: prettier, knip, turbo check-types