### PR TITLE
fix: redirect direct onboarding visits to paid flow

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -39,11 +39,51 @@ export const setupOnboardingPage$ = command(
     set(resetOnboardingStep$);
     signal.throwIfAborted();
 
+    const params = get(searchParams$);
+
+    const completedBillingCheckoutState = get(completedBillingCheckout$);
+    if (completedBillingCheckoutState) {
+      const continued = await set(
+        continueOnboardingAfterCheckout$,
+        completedBillingCheckoutState.sessionId,
+        signal,
+      );
+      signal.throwIfAborted();
+      if (continued) {
+        set(clearCompletedBillingCheckout$);
+        return;
+      }
+    }
+
+    const promptParam = params.get("prompt");
+    const hasUseCaseLink = (promptParam?.length ?? 0) > 0;
+
+    // Use-case deep links intentionally land already-onboarded users here, so
+    // compute that before deciding whether the page should send users home.
+    // Onboarding is purely admin workspace setup. If onboarding is not needed
+    // (non-admins, or admins whose workspace is already set up) and there's no
+    // use-case deep link, send the user home — the page has nothing to show.
+    const needsOnboarding = await get(zeroNeedsOnboarding$);
+    signal.throwIfAborted();
+
+    const features = get(featureSwitch$);
+    if (needsOnboarding && features[FeatureSwitchKey.PaidOnboardingRedirect]) {
+      set(redirectToConfiguredOnboarding$, params);
+      return;
+    }
+
+    if (!needsOnboarding && !hasUseCaseLink) {
+      set(detachedNavigateTo$, "/", { replace: true });
+      return;
+    }
+
+    // Connector pre-selection runs only after the paid-redirect decision, so
+    // direct paid links can forward raw query params without waiting on the
+    // connector catalog.
     // Consume ?connector= (comma-separated) to pre-select connectors. The
     // param is left on the URL so a refresh during onboarding still pre-fills
     // the same selection; it gets dropped naturally when finishing onboarding
     // navigates away to /agents/.../chat.
-    const params = get(searchParams$);
     const connectorParam = params.get("connector");
     if (connectorParam !== null) {
       const availableConnectors = await get(allConnectorTypes$);
@@ -79,46 +119,8 @@ export const setupOnboardingPage$ = command(
     // an editable prompt draft and switch onboarding into condensed mode
     // where the flow collapses to step 3, which grows a composer + "Try It"
     // CTA that goes straight to the web chat.
-    const promptParam = params.get("prompt");
     if (promptParam !== null && promptParam.length > 0) {
       set(markUseCaseMode$, promptParam);
-    }
-
-    const completedBillingCheckoutState = get(completedBillingCheckout$);
-    if (completedBillingCheckoutState) {
-      const continued = await set(
-        continueOnboardingAfterCheckout$,
-        completedBillingCheckoutState.sessionId,
-        signal,
-      );
-      signal.throwIfAborted();
-      if (continued) {
-        set(clearCompletedBillingCheckout$);
-        return;
-      }
-    }
-
-    // Detect use-case deep link early — `?prompt=...` (optionally with
-    // `&connector=...`) lets even already-onboarded users (including
-    // non-admins) land here intentionally to try a suggested task, so we
-    // must NOT auto-redirect them home then.
-    const hasUseCaseLink = (params.get("prompt")?.length ?? 0) > 0;
-
-    // Onboarding is purely admin workspace setup. If onboarding is not needed
-    // (non-admins, or admins whose workspace is already set up) and there's no
-    // use-case deep link, send the user home — the page has nothing to show.
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-
-    const features = get(featureSwitch$);
-    if (needsOnboarding && features[FeatureSwitchKey.PaidOnboardingRedirect]) {
-      set(redirectToConfiguredOnboarding$, params);
-      return;
-    }
-
-    if (!needsOnboarding && !hasUseCaseLink) {
-      set(detachedNavigateTo$, "/", { replace: true });
-      return;
     }
 
     const effectiveStep = await get(onboardingEffectiveStep$);

--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createElement } from "react";
 import { OnboardingPage } from "../../views/onboarding-page/onboarding-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -12,6 +13,7 @@ import {
   zeroNeedsOnboarding$,
   zeroSelectedConnectors$,
 } from "../zero-page/zero-onboarding.ts";
+import { redirectToConfiguredOnboarding$ } from "../zero-page/onboard-guard.ts";
 import {
   onboardingEffectiveStep$,
   continueOnboardingAfterCheckout$,
@@ -23,6 +25,7 @@ import {
 } from "../zero-page/billing.ts";
 import { allConnectorTypes$ } from "../zero-page/settings/connectors.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
   startOnboardingSessionRecording,
   stopOnboardingSessionRecording,
@@ -106,6 +109,12 @@ export const setupOnboardingPage$ = command(
     // use-case deep link, send the user home — the page has nothing to show.
     const needsOnboarding = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
+
+    const features = get(featureSwitch$);
+    if (needsOnboarding && features[FeatureSwitchKey.PaidOnboardingRedirect]) {
+      set(redirectToConfiguredOnboarding$, params);
+      return;
+    }
 
     if (!needsOnboarding && !hasUseCaseLink) {
       set(detachedNavigateTo$, "/", { replace: true });

--- a/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
+++ b/turbo/apps/platform/src/signals/onboarding-page/onboarding-page-setup.ts
@@ -40,6 +40,14 @@ export const setupOnboardingPage$ = command(
     signal.throwIfAborted();
 
     const params = get(searchParams$);
+    const promptParam = params.get("prompt");
+    const hasUseCaseLink = (promptParam?.length ?? 0) > 0;
+
+    // Seed use-case mode before async status checks so the visible onboarding
+    // step cannot race ahead as the regular connector flow.
+    if (promptParam !== null && promptParam.length > 0) {
+      set(markUseCaseMode$, promptParam);
+    }
 
     const completedBillingCheckoutState = get(completedBillingCheckout$);
     if (completedBillingCheckoutState) {
@@ -54,9 +62,6 @@ export const setupOnboardingPage$ = command(
         return;
       }
     }
-
-    const promptParam = params.get("prompt");
-    const hasUseCaseLink = (promptParam?.length ?? 0) > 0;
 
     // Use-case deep links intentionally land already-onboarded users here, so
     // compute that before deciding whether the page should send users home.
@@ -119,10 +124,6 @@ export const setupOnboardingPage$ = command(
     // an editable prompt draft and switch onboarding into condensed mode
     // where the flow collapses to step 3, which grows a composer + "Try It"
     // CTA that goes straight to the web chat.
-    if (promptParam !== null && promptParam.length > 0) {
-      set(markUseCaseMode$, promptParam);
-    }
-
     const effectiveStep = await get(onboardingEffectiveStep$);
     signal.throwIfAborted();
     if (effectiveStep === "4") {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -82,10 +82,34 @@ describe("zero onboarding", () => {
     });
   });
 
+  it("redirects direct onboarding visits to paid onboarding when enabled", async () => {
+    mockOnboardingNeeded();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hello%20world&connector=github&vm0_source=presentation",
+      featureSwitches: { [FeatureSwitchKey.PaidOnboardingRedirect]: true },
+    });
+
+    await waitFor(() => {
+      const url = new URL(window.location.href);
+      expect(url.origin).toBe("https://so.vm7.ai:8441");
+      expect(url.pathname).toBe("/onboarding/2afcf6");
+      expect(url.searchParams.get("prompt")).toBe("hello world");
+      expect(url.searchParams.get("connector")).toBe("github");
+      expect(url.searchParams.get("vm0_source")).toBe("presentation");
+      expect(url.searchParams.get("domain")).toBe("pr-123-api.vm6.ai");
+    });
+  });
+
   it("lets an admin create a workspace, choose connectors, and reach trial", async () => {
     mockOnboardingNeeded();
 
-    detachedSetupPage({ context, path: "/onboarding" });
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      featureSwitches: { [FeatureSwitchKey.PaidOnboardingRedirect]: false },
+    });
 
     await waitFor(() => {
       expect(
@@ -157,7 +181,11 @@ describe("zero onboarding", () => {
   it("shows an empty connector search result while choosing tools", async () => {
     mockOnboardingNeeded();
 
-    detachedSetupPage({ context, path: "/onboarding" });
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      featureSwitches: { [FeatureSwitchKey.PaidOnboardingRedirect]: false },
+    });
 
     await completeWorkspaceStep();
 
@@ -185,6 +213,7 @@ describe("zero onboarding", () => {
     detachedSetupPage({
       context,
       path: "/onboarding",
+      featureSwitches: { [FeatureSwitchKey.PaidOnboardingRedirect]: false },
       org: {
         activeOrg: { id: "org_current", name: "Current Org" },
         memberships: [

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -2,6 +2,7 @@ import {
   onboardingSetupContract,
   onboardingStatusContract,
 } from "@vm0/api-contracts/contracts/onboarding";
+import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
@@ -84,6 +85,34 @@ describe("zero onboarding", () => {
 
   it("redirects direct onboarding visits to paid onboarding when enabled", async () => {
     mockOnboardingNeeded();
+
+    detachedSetupPage({
+      context,
+      path: "/onboarding?prompt=hello%20world&connector=github&vm0_source=presentation",
+      featureSwitches: { [FeatureSwitchKey.PaidOnboardingRedirect]: true },
+    });
+
+    await waitFor(() => {
+      const url = new URL(window.location.href);
+      expect(url.origin).toBe("https://so.vm7.ai:8441");
+      expect(url.pathname).toBe("/onboarding/2afcf6");
+      expect(url.searchParams.get("prompt")).toBe("hello world");
+      expect(url.searchParams.get("connector")).toBe("github");
+      expect(url.searchParams.get("vm0_source")).toBe("presentation");
+      expect(url.searchParams.get("domain")).toBe("pr-123-api.vm6.ai");
+    });
+  });
+
+  it("redirects direct paid onboarding without loading connectors first", async () => {
+    mockOnboardingNeeded();
+    context.mocks.api(zeroConnectorsMainContract.list, ({ respond }) => {
+      return respond(500, {
+        error: {
+          message: "Failed to load connectors",
+          code: "INTERNAL_SERVER_ERROR",
+        },
+      });
+    });
 
     detachedSetupPage({
       context,


### PR DESCRIPTION
## Summary
- redirect direct /onboarding visits to the configured paid onboarding flow when PaidOnboardingRedirect is enabled and onboarding is still required
- keep checkout completion and disabled-switch in-app onboarding behavior intact
- add coverage for direct /onboarding paid redirects

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-onboarding.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pre-commit: prettier, knip, check-types