### PR TITLE
feat: move computer use into connectors menu

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -23,7 +23,7 @@ import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { mockNow, now } from "../../../lib/time";
 import {
   resetSecretKmsClientForTests,
   setSecretKmsClientForTests,
@@ -47,6 +47,16 @@ const mocks = createZeroRouteMocks(context);
 
 const SESSION_HEADERS = { authorization: "Bearer clerk-session" } as const;
 const CRON_SECRET = "test-cron-secret";
+// Keep global-cron fixtures invisible to parallel test workers using real time.
+const ISOLATED_CRON_POLL_TIME_MS = Date.UTC(2099, 0, 1, 0, 0, 0);
+
+function isolatedCronPastDue(): Date {
+  return new Date(ISOLATED_CRON_POLL_TIME_MS - 60_000);
+}
+
+function isolateCronPollTime(): void {
+  mockNow(ISOLATED_CRON_POLL_TIME_MS);
+}
 
 afterEach(() => {
   resetSecretKmsClientForTests();
@@ -782,7 +792,7 @@ describe("Automations API", () => {
     setSecretKmsClientForTests(fakeKmsClient().client);
     mockEnv("CRON_SECRET", CRON_SECRET);
 
-    const pastDue = new Date(now() - 60_000);
+    const pastDue = isolatedCronPastDue();
     const fixture = await trackAutomations(
       store.set(
         seedAutomationsScenario$,
@@ -828,6 +838,7 @@ describe("Automations API", () => {
       .set({ enabled: true, nextRunAt: pastDue })
       .where(inArray(automationTriggers.automationId, [...zombieIds]));
 
+    isolateCronPollTime();
     const response = await accept(
       cronApi().execute({
         headers: { authorization: `Bearer ${CRON_SECRET}` },
@@ -878,7 +889,7 @@ describe("Automations API", () => {
     setSecretKmsClientForTests(fakeKmsClient().client);
     mockEnv("CRON_SECRET", CRON_SECRET);
 
-    const pastDue = new Date(now() - 60_000);
+    const pastDue = isolatedCronPastDue();
     const fixture = await trackAutomations(
       store.set(
         seedAutomationsScenario$,
@@ -910,6 +921,7 @@ describe("Automations API", () => {
       );
 
     const automationId = fixture.automationIds[0]!;
+    isolateCronPollTime();
     const response = await accept(
       cronApi().execute({
         headers: { authorization: `Bearer ${CRON_SECRET}` },

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, like, or } from "drizzle-orm";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import {
@@ -22,6 +22,7 @@ import {
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { secrets } from "@vm0/db/schema/secret";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { describe, expect, it } from "vitest";
@@ -376,6 +377,21 @@ async function updateFeatureSwitches(
 
 async function disableComputerUse(actor: ApiTestUser): Promise<void> {
   await updateFeatureSwitches(actor, { [FeatureSwitchKey.ComputerUse]: false });
+}
+
+async function readThreadComputerUseHostId(
+  threadId: string,
+): Promise<string | null> {
+  const db = store.set(writeDb$);
+  const [thread] = await db
+    .select({ computerUseHostId: chatThreads.computerUseHostId })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  if (!thread) {
+    throw new Error("Expected chat thread to exist");
+  }
+  return thread.computerUseHostId;
 }
 
 /**
@@ -1329,6 +1345,18 @@ describe("CHAT-02: explicit provider pins", () => {
     const devSeedKey = `vm0-key-bdd-dev-seed-${keySuffix}`;
     const writeDb = store.set(writeDb$);
 
+    await writeDb
+      .delete(vm0ApiKeys)
+      .where(
+        and(
+          eq(vm0ApiKeys.vendor, "openrouter"),
+          eq(vm0ApiKeys.model, "z-ai/glm-5.1"),
+          or(
+            like(vm0ApiKeys.apiKey, "vm0-key-bdd-fake-%"),
+            like(vm0ApiKeys.apiKey, "vm0-key-bdd-dev-seed-%"),
+          ),
+        ),
+      );
     await writeDb.insert(vm0ApiKeys).values([
       {
         vendor: "openrouter",
@@ -1393,7 +1421,14 @@ describe("CHAT-02: explicit provider pins", () => {
     await writeDb
       .delete(vm0ApiKeys)
       .where(
-        or(eq(vm0ApiKeys.apiKey, fakeKey), eq(vm0ApiKeys.apiKey, devSeedKey)),
+        and(
+          eq(vm0ApiKeys.vendor, "openrouter"),
+          eq(vm0ApiKeys.model, "z-ai/glm-5.1"),
+          or(
+            like(vm0ApiKeys.apiKey, "vm0-key-bdd-fake-%"),
+            like(vm0ApiKeys.apiKey, "vm0-key-bdd-dev-seed-%"),
+          ),
+        ),
       );
   }, 90_000);
 
@@ -2177,7 +2212,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
 });
 
 describe("CHAT-02/FILE-03: computer-use host grants", () => {
-  it("grants computer-use capability only for a selected online host", async () => {
+  it("grants computer-use capability only for a selected host", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.proxyChatCallbackToApp();
     await cu.enableComputerUse(actor);
@@ -2214,6 +2249,12 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       prompt: "open the remote browser",
       computerUseHostId: hostId,
     });
+    const grantedRun = await api.readRun(actor, granted.runId);
+    expect(grantedRun.appendSystemPrompt).toContain("# Computer Use");
+    expect(grantedRun.appendSystemPrompt).toContain(
+      "Computer Use is enabled for this run on Zero Desktop.",
+    );
+    expect(grantedRun.appendSystemPrompt).not.toContain(hostId);
     const grantedClaim = await claimChatRun(runnerGroup, granted.runId);
     await cu.heartbeatComputerUseHost(hostToken);
     await cu.requestCreateComputerUseWriteCommand(
@@ -2251,6 +2292,26 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       [403],
     );
     await cancelChatRun(actor, cleared.runId);
+
+    mockNow(now() + 91_000);
+    const staleGranted = await sendChatRun(actor, {
+      agentId,
+      threadId: granted.threadId,
+      prompt: "use the computer after it went offline",
+      computerUseHostId: hostId,
+    });
+    const staleRun = await api.readRun(actor, staleGranted.runId);
+    expect(staleRun.appendSystemPrompt).toContain(
+      "Computer Use is enabled for this run on Zero Desktop.",
+    );
+    clearMockNow();
+    const staleClaim = await claimChatRun(runnerGroup, staleGranted.runId);
+    await cu.heartbeatComputerUseHost(hostToken);
+    await cu.requestCreateComputerUseWriteCommand(
+      { bearer: zeroTokenFromClaim(staleClaim.claim) },
+      [200],
+    );
+    await cancelChatRun(actor, staleGranted.runId);
   }, 120_000);
 
   it("rejects unusable computer-use host selections", async () => {
@@ -2289,9 +2350,24 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     expect(unknownHost.body.error.message).toBe("Computer-use host not found");
 
     // Stopping a host revokes it, so an explicit selection reports it as
-    // missing rather than offline.
+    // missing rather than offline, and clears any thread binding immediately.
     const stopped = await cu.startComputerUseHost(actor);
+    const stoppedPinned = await chat.requestSendMessage(
+      actor,
+      {
+        agentId: agent.agentId,
+        prompt: "pin the host before stopping it",
+        computerUseHostId: stopped.hostId,
+      },
+      [201],
+    );
+    if (stoppedPinned.status !== 201) {
+      throw new Error("Expected the stopped-host pin send to be accepted");
+    }
     await cu.stopComputerUseHost(stopped.hostToken);
+    await expect(
+      readThreadComputerUseHostId(stoppedPinned.body.threadId),
+    ).resolves.toBeNull();
     const revokedHost = await chat.requestSendMessage(
       actor,
       {
@@ -2322,6 +2398,9 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     }
     expect(pinned.body.runId).toBeNull();
     await cu.deleteComputerUseHost(actor, sticky.hostId);
+    await expect(
+      readThreadComputerUseHostId(pinned.body.threadId),
+    ).resolves.toBeNull();
     const clearedSend = await chat.requestSendMessage(
       actor,
       {
@@ -2363,26 +2442,22 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     await cu.enableComputerUse(actor);
 
     // A host that stopped heartbeating goes stale-offline (status still
-    // online, not revoked), which is the explicit-selection conflict arm.
-    // Only one host can be online per user, so the surviving host is aged
-    // past the heartbeat window instead of starting another one.
+    // online, not revoked), but explicit selections are still accepted so the
+    // run can use the host if it reconnects while running.
     mockNow(now() + 91_000);
-    const offlineHost = await chat.requestSendMessage(
+    const offlineHostSend = await chat.requestSendMessage(
       actor,
       {
         agentId: agent.agentId,
         prompt: "use a stale host",
         computerUseHostId: survivor.hostId,
       },
-      [409],
+      [201],
     );
-    expectApiError(offlineHost.body);
-    expect(offlineHost.body.error.message).toBe(
-      "Selected computer-use host is offline",
-    );
+    expect(offlineHostSend.body).toMatchObject({ runId: null });
 
-    // The sticky-host fallthrough tolerates a stale host instead of failing:
-    // a send without the field on the pinned thread is still accepted.
+    // The sticky-host fallthrough also tolerates a stale host instead of
+    // failing: a send without the field on the pinned thread is accepted.
     const staleStickySend = await chat.requestSendMessage(
       actor,
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -245,6 +245,59 @@ describe("FILE-03 desktop computer-use runtime", () => {
     ).toStrictEqual([first.hostId]);
   });
 
+  it("publishes computer-use host list changes", async () => {
+    const actor = bdd.user();
+    await api.enableComputerUse(actor);
+    const base = now();
+    mockNow(base);
+
+    context.mocks.ably.publish.mockClear();
+    const host = await api.startComputerUseHost(actor, {
+      hostName: "Studio Mac",
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "computerUseHostsChanged",
+      null,
+    );
+
+    context.mocks.ably.publish.mockClear();
+    await api.heartbeatComputerUseHost(host.hostToken, {
+      hostName: "Studio Mac",
+    });
+    expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+
+    mockNow(base + 120_000);
+    await api.heartbeatComputerUseHost(host.hostToken, {
+      hostName: "Studio Mac",
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "computerUseHostsChanged",
+      null,
+    );
+
+    context.mocks.ably.publish.mockClear();
+    await api.stopComputerUseHost(host.hostToken);
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "computerUseHostsChanged",
+      null,
+    );
+
+    clearMockNow();
+    const restarted = await api.startComputerUseHost(actor, {
+      hostName: "Recovered Desktop",
+    });
+    context.mocks.ably.publish.mockClear();
+    await api.deleteComputerUseHost(actor, restarted.hostId);
+    expect(context.mocks.ably.publish).toHaveBeenCalledTimes(1);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "computerUseHostsChanged",
+      null,
+    );
+  });
+
   it("rejects host-token routes with missing or invalid host tokens", async () => {
     const garbageToken = "vm0-bdd-garbage-host-token";
     const commandId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -406,11 +406,12 @@ export function createComputerUseBddApi(context: TestContext) {
 
     async heartbeatComputerUseHost(
       hostToken: string,
+      options: ComputerUseHostStartOptions = {},
     ): Promise<{ readonly ok: true; readonly hostId: string }> {
       const response = await accept(
         heartbeatClient().heartbeat({
           headers: hostHeaders(hostToken),
-          body: hostRuntimeBody(),
+          body: hostRuntimeBody(options),
         }),
         [200],
       );

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -54,7 +54,6 @@ import { internalApiBaseUrl } from "../../lib/internal-api-url";
 import type { AuthContext } from "../../types/auth";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
-import { hostIsOnline } from "../services/zero-computer-use.service";
 import {
   cancelRun$,
   dispatchCancelSideEffects$,
@@ -190,8 +189,13 @@ interface PreparedNormalSend {
   readonly thread: ResolvedThread;
   readonly priorContext: string;
   readonly generationTemplatePrompt: string;
-  readonly computerUseHostId: string | null;
+  readonly computerUseHostGrant: ResolvedComputerUseHostGrant | null;
   readonly persistedExplicitSelection: boolean;
+}
+
+interface ResolvedComputerUseHostGrant {
+  readonly hostId: string;
+  readonly displayName: string;
 }
 
 type NormalSendFailure =
@@ -462,17 +466,30 @@ function buildAppendSystemPrompt(
   incompleteContext: string,
   priorContext: string,
   generationTemplatePrompt: string,
+  computerUseHostDisplayName: string | null,
 ): string {
   return [
     buildWebChatPrompt(),
     priorContext,
     incompleteContext,
     generationTemplatePrompt,
+    computerUseHostDisplayName
+      ? buildComputerUseSystemPrompt(computerUseHostDisplayName)
+      : "",
   ]
     .filter((part) => {
       return part.length > 0;
     })
     .join("\n\n");
+}
+
+function buildComputerUseSystemPrompt(displayName: string): string {
+  return [
+    "# Computer Use",
+    `Computer Use is enabled for this run on ${displayName}.`,
+    "Use Zero CLI computer-use commands to inspect apps, read app state, and perform desktop actions.",
+    "The computer may go offline while this run is active. If a command reports that the computer is unavailable or offline, ask the user to reconnect Zero Computer Use on that computer, then retry.",
+  ].join("\n");
 }
 
 function buildFullPrompt(
@@ -1319,14 +1336,17 @@ async function updateThreadComputerUseHost(params: {
     );
 }
 
-async function selectedComputerUseHostIsOnline(params: {
+async function selectedComputerUseHostGrant(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly hostId: string;
-}): Promise<"online" | "offline" | "missing"> {
+}): Promise<ResolvedComputerUseHostGrant | "missing"> {
   const [host] = await params.db
-    .select()
+    .select({
+      id: computerUseHosts.id,
+      displayName: computerUseHosts.displayName,
+    })
     .from(computerUseHosts)
     .where(
       and(
@@ -1340,7 +1360,10 @@ async function selectedComputerUseHostIsOnline(params: {
   if (!host) {
     return "missing";
   }
-  return hostIsOnline(host, nowDate()) ? "online" : "offline";
+  return {
+    hostId: host.id,
+    displayName: host.displayName,
+  };
 }
 
 async function resolveComputerUseHostGrant(params: {
@@ -1349,7 +1372,7 @@ async function resolveComputerUseHostGrant(params: {
   readonly userId: string;
   readonly body: NormalSendBody;
   readonly thread: ResolvedThread;
-}): Promise<string | null | NormalSendFailure> {
+}): Promise<ResolvedComputerUseHostGrant | null | NormalSendFailure> {
   const explicitSelection = hasComputerUseHostSelection(params.body);
   const requestedHostId = explicitSelection
     ? params.body.computerUseHostId
@@ -1380,13 +1403,13 @@ async function resolveComputerUseHostGrant(params: {
     return null;
   }
 
-  const hostStatus = await selectedComputerUseHostIsOnline({
+  const hostGrant = await selectedComputerUseHostGrant({
     db: params.db,
     orgId: params.orgId,
     userId: params.userId,
     hostId: requestedHostId,
   });
-  if (hostStatus === "missing") {
+  if (hostGrant === "missing") {
     if (explicitSelection) {
       return notFound("Computer-use host not found");
     }
@@ -1396,12 +1419,6 @@ async function resolveComputerUseHostGrant(params: {
       userId: params.userId,
       hostId: null,
     });
-    return null;
-  }
-  if (hostStatus === "offline") {
-    if (explicitSelection) {
-      return conflict("Selected computer-use host is offline");
-    }
     return null;
   }
 
@@ -1416,7 +1433,7 @@ async function resolveComputerUseHostGrant(params: {
       hostId: requestedHostId,
     });
   }
-  return requestedHostId;
+  return hostGrant;
 }
 
 async function createChatThread(
@@ -2136,7 +2153,7 @@ const prepareNormalSend$ = command(
         modelSelection: args.body.modelSelection,
       });
     signal.throwIfAborted();
-    const computerUseHostId = await resolveComputerUseHostGrant({
+    const computerUseHostGrant = await resolveComputerUseHostGrant({
       db,
       orgId: args.orgId,
       userId: args.userId,
@@ -2144,8 +2161,8 @@ const prepareNormalSend$ = command(
       thread,
     });
     signal.throwIfAborted();
-    if (typeof computerUseHostId !== "string" && computerUseHostId !== null) {
-      return computerUseHostId;
+    if (computerUseHostGrant !== null && "status" in computerUseHostGrant) {
+      return computerUseHostGrant;
     }
 
     return {
@@ -2154,7 +2171,7 @@ const prepareNormalSend$ = command(
       thread,
       priorContext,
       generationTemplatePrompt,
-      computerUseHostId,
+      computerUseHostGrant,
       persistedExplicitSelection,
     };
   },
@@ -2478,7 +2495,7 @@ const createNormalChatRun$ = command(
         auth: args.auth,
         apiStartTime: args.apiStartTime,
         chatThreadId: prepared.thread.threadId,
-        computerUseHostId: prepared.computerUseHostId ?? undefined,
+        computerUseHostId: prepared.computerUseHostGrant?.hostId,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:
           modelPin.modelProviderCredentialScope ?? undefined,
@@ -2510,6 +2527,7 @@ const createNormalChatRun$ = command(
           prepared.thread.incompleteContext,
           prepared.priorContext,
           prepared.generationTemplatePrompt,
+          prepared.computerUseHostGrant?.displayName ?? null,
         ),
       },
       signal,

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -19,15 +19,18 @@ import {
   computerUseCommands,
   computerUseHosts,
 } from "@vm0/db/schema/computer-use-host";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
 import { downloadS3Buffer, putS3Object } from "../external/s3";
 
 const COMPUTER_USE_HOST_CLOSED_AFTER_MS = 90 * 1000;
 const COMPUTER_USE_RUNNING_COMMAND_DEFAULT_TIMEOUT_MS = 120 * 1000;
+const COMPUTER_USE_HOSTS_CHANGED_TOPIC = "computerUseHostsChanged";
 const L = logger("ZeroComputerUse");
 
 const COMPUTER_USE_READ_COMMANDS = [
@@ -158,13 +161,55 @@ function normalizeCapabilities(capabilities: readonly string[]): string[] {
     .slice(0, 50);
 }
 
-export function hostIsOnline(host: ComputerUseHostRow, now: Date): boolean {
+function sameStringArray(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+function samePermissions(
+  left: ComputerUseHostRow["permissions"],
+  right: ComputerUseHostRow["permissions"],
+): boolean {
+  return (
+    left.accessibility === right.accessibility &&
+    left.screenRecording === right.screenRecording
+  );
+}
+
+function hostIsOnline(host: ComputerUseHostRow, now: Date): boolean {
   return (
     host.status === "online" &&
     host.revokedAt === null &&
     now.getTime() - host.lastSeenAt.getTime() <=
       COMPUTER_USE_HOST_CLOSED_AFTER_MS
   );
+}
+
+async function publishComputerUseHostsChanged(userId: string): Promise<void> {
+  await publishUserSignal([userId], COMPUTER_USE_HOSTS_CHANGED_TOPIC);
+}
+
+async function clearComputerUseHostThreadBindings(params: {
+  readonly tx: ComputerUseTx;
+  readonly userId: string;
+  readonly hostId: string;
+}): Promise<void> {
+  await params.tx
+    .update(chatThreads)
+    .set({ computerUseHostId: null, updatedAt: nowDate() })
+    .where(
+      and(
+        eq(chatThreads.userId, params.userId),
+        eq(chatThreads.computerUseHostId, params.hostId),
+      ),
+    );
 }
 
 function hostSupportsCommand(
@@ -710,6 +755,8 @@ export const startComputerUseHost$ = command(
       return { status: "started" as const, hostId: host.id, hostToken };
     });
     signal.throwIfAborted();
+    await publishComputerUseHostsChanged(params.userId);
+    signal.throwIfAborted();
     return result;
   },
 );
@@ -732,31 +779,59 @@ export const heartbeatComputerUseHost$ = command(
   ): Promise<HeartbeatComputerUseHostResult> => {
     const db = set(writeDb$);
     const now = nowDate();
-    const result = await db.transaction(async (tx) => {
-      const lockedHost = await hostFromToken(tx, params.hostToken, signal);
-      if (!lockedHost) {
-        return { status: "invalid_token" as const };
-      }
+    const { result, publishChanged, userId } = await db.transaction(
+      async (tx) => {
+        const lockedHost = await hostFromToken(tx, params.hostToken, signal);
+        if (!lockedHost) {
+          return {
+            result: { status: "invalid_token" as const },
+            publishChanged: false,
+            userId: null,
+          };
+        }
+        const displayName = normalizeHostName(params.hostName);
+        const appVersion = normalizeVersion(params.appVersion);
+        const osVersion = normalizeOsVersion(params.osVersion);
+        const supportedCapabilities = normalizeCapabilities(
+          params.supportedCapabilities,
+        );
+        const publishChanged =
+          !hostIsOnline(lockedHost, now) ||
+          lockedHost.displayName !== displayName ||
+          lockedHost.appVersion !== appVersion ||
+          lockedHost.osVersion !== osVersion ||
+          !sameStringArray(
+            lockedHost.supportedCapabilities,
+            supportedCapabilities,
+          ) ||
+          !samePermissions(lockedHost.permissions, params.permissions);
 
-      await tx
-        .update(computerUseHosts)
-        .set({
-          displayName: normalizeHostName(params.hostName),
-          appVersion: normalizeVersion(params.appVersion),
-          osVersion: normalizeOsVersion(params.osVersion),
-          supportedCapabilities: normalizeCapabilities(
-            params.supportedCapabilities,
-          ),
-          permissions: params.permissions,
-          status: "online",
-          lastSeenAt: now,
-          updatedAt: now,
-        })
-        .where(eq(computerUseHosts.id, lockedHost.id));
-      signal.throwIfAborted();
-      return { status: "ok" as const, hostId: lockedHost.id };
-    });
+        await tx
+          .update(computerUseHosts)
+          .set({
+            displayName,
+            appVersion,
+            osVersion,
+            supportedCapabilities,
+            permissions: params.permissions,
+            status: "online",
+            lastSeenAt: now,
+            updatedAt: now,
+          })
+          .where(eq(computerUseHosts.id, lockedHost.id));
+        signal.throwIfAborted();
+        return {
+          result: { status: "ok" as const, hostId: lockedHost.id },
+          publishChanged,
+          userId: lockedHost.userId,
+        };
+      },
+    );
     signal.throwIfAborted();
+    if (result.status === "ok" && publishChanged && userId) {
+      await publishComputerUseHostsChanged(userId);
+      signal.throwIfAborted();
+    }
     return result;
   },
 );
@@ -771,20 +846,35 @@ export const stopComputerUseHost$ = command(
   ): Promise<StopComputerUseHostResult> => {
     const db = set(writeDb$);
     const now = nowDate();
-    const result = await db.transaction(async (tx) => {
+    const { result, userId } = await db.transaction(async (tx) => {
       const host = await hostFromToken(tx, params.hostToken, signal);
       if (!host) {
-        return { status: "invalid_token" as const };
+        return {
+          result: { status: "invalid_token" as const },
+          userId: null,
+        };
       }
 
       await tx
         .update(computerUseHosts)
         .set({ status: "offline", revokedAt: now, updatedAt: now })
         .where(eq(computerUseHosts.id, host.id));
+      await clearComputerUseHostThreadBindings({
+        tx,
+        userId: host.userId,
+        hostId: host.id,
+      });
       signal.throwIfAborted();
-      return { status: "stopped" as const, hostId: host.id };
+      return {
+        result: { status: "stopped" as const, hostId: host.id },
+        userId: host.userId,
+      };
     });
     signal.throwIfAborted();
+    if (userId) {
+      await publishComputerUseHostsChanged(userId);
+      signal.throwIfAborted();
+    }
     return result;
   },
 );
@@ -831,20 +921,35 @@ export const deleteComputerUseHost$ = command(
   > => {
     const db = set(writeDb$);
     const now = nowDate();
-    const [host] = await db
-      .update(computerUseHosts)
-      .set({ status: "offline", revokedAt: now, updatedAt: now })
-      .where(
-        and(
-          eq(computerUseHosts.id, params.hostId),
-          eq(computerUseHosts.orgId, params.orgId),
-          eq(computerUseHosts.userId, params.userId),
-          isNull(computerUseHosts.revokedAt),
-        ),
-      )
-      .returning({ id: computerUseHosts.id });
+    const result = await db.transaction(async (tx) => {
+      const [host] = await tx
+        .update(computerUseHosts)
+        .set({ status: "offline", revokedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(computerUseHosts.id, params.hostId),
+            eq(computerUseHosts.orgId, params.orgId),
+            eq(computerUseHosts.userId, params.userId),
+            isNull(computerUseHosts.revokedAt),
+          ),
+        )
+        .returning({ id: computerUseHosts.id });
+      if (!host) {
+        return { status: "not_found" as const };
+      }
+      await clearComputerUseHostThreadBindings({
+        tx,
+        userId: params.userId,
+        hostId: host.id,
+      });
+      return { status: "deleted" as const };
+    });
     signal.throwIfAborted();
-    return host ? { status: "deleted" } : { status: "not_found" };
+    if (result.status === "deleted") {
+      await publishComputerUseHostsChanged(params.userId);
+      signal.throwIfAborted();
+    }
+    return result;
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -41,7 +41,7 @@ export interface AppendQueuedMessageArgs {
   hasTextContent: boolean;
   modelSelection: ModelSelectionRequest | null;
   generationTemplate: GenerationTemplateRequest | undefined;
-  computerUseHostId: string | null;
+  computerUseHostId?: string | null;
 }
 
 export interface RecallMessageArgs {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -80,6 +80,7 @@ import {
   readThreadMeta$,
 } from "../external/idb-thread-meta-store.ts";
 import { reloadBillingStatus$ } from "../zero-page/billing.ts";
+import { subscribeComputerUseHostsChanged$ } from "../zero-page/computer-use-hosts.ts";
 import {
   applyStreamingDelta$,
   clearStreamingDraftsForThread$,
@@ -464,7 +465,9 @@ export interface ChatThreadSignals {
     [ModelProviderSelection | null, AbortSignal]
   >;
   computerUseHostId$: Computed<Promise<string | null>>;
+  computerUseHostIdExplicit$: Computed<boolean>;
   setComputerUseHostId$: Command<void, [string | null]>;
+  clearComputerUseHostIdOverride$: Command<void, []>;
   sendMessage$: Command<
     Promise<void>,
     [
@@ -476,7 +479,12 @@ export interface ChatThreadSignals {
   >;
   queueMessage$: Command<
     Promise<void>,
-    [string, GenerationTemplateRequest | undefined, string | null, AbortSignal]
+    [
+      string,
+      GenerationTemplateRequest | undefined,
+      string | null | undefined,
+      AbortSignal,
+    ]
   >;
   recallMessage$: Command<Promise<void>, [EnrichedChatMessage, AbortSignal]>;
   cancelRun$: Command<Promise<void>, [AbortSignal]>;
@@ -641,15 +649,25 @@ function createComputerUseHostSelection(
     return thread?.computerUseHostId ?? null;
   });
 
+  const computerUseHostIdExplicit$ = computed((get): boolean => {
+    return get(internalUserOverride$).kind === "set";
+  });
+
   const setComputerUseHostId$ = command(
     ({ set }, computerUseHostId: string | null) => {
       set(internalUserOverride$, { kind: "set", value: computerUseHostId });
     },
   );
 
+  const clearComputerUseHostIdOverride$ = command(({ set }) => {
+    set(internalUserOverride$, { kind: "unset" });
+  });
+
   return {
     computerUseHostId$,
+    computerUseHostIdExplicit$,
     setComputerUseHostId$,
+    clearComputerUseHostIdOverride$,
   };
 }
 
@@ -1976,6 +1994,7 @@ function createRunTracking({
     await Promise.all([
       set(backfillHistoryBoundary$, signal),
       set(markThreadReadIfNeeded$, signal),
+      set(subscribeComputerUseHostsChanged$, signal),
       set(
         dataSource.subscribeRealtime$,
         {
@@ -2236,7 +2255,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
       { get, set },
       prompt: string,
       generationTemplate: GenerationTemplateRequest | undefined,
-      computerUseHostId: string | null,
+      computerUseHostId: string | null | undefined,
       signal: AbortSignal,
     ) => {
       L.debug("queueMessage$ start", { threadId, promptLen: prompt.length });
@@ -2303,7 +2322,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
             hasTextContent: result.hasTextContent,
             modelSelection,
             generationTemplate,
-            computerUseHostId,
+            ...(computerUseHostId === undefined ? {} : { computerUseHostId }),
           },
           signal,
         ),
@@ -2553,8 +2572,7 @@ export function createChatThreadSignals(
     threadData$,
     dataSource,
   );
-  const { computerUseHostId$, setComputerUseHostId$ } =
-    createComputerUseHostSelection(threadData$);
+  const computerUseHostSelection = createComputerUseHostSelection(threadData$);
   const { recordScrollHeightForPrepend$, ...scrollSignals } =
     createScrollSignals(threadId);
   const { skeletonVisible$, showSkeleton$, hideSkeleton$ } =
@@ -2636,8 +2654,7 @@ export function createChatThreadSignals(
     threadData$,
     modelSelection$,
     setModelSelection$,
-    computerUseHostId$,
-    setComputerUseHostId$,
+    ...computerUseHostSelection,
     ...messageCommands,
     cancelRun$,
     ...scrollSignals,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -20,7 +20,10 @@ import {
 } from "../agent-chat.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { loadRightThread$ } from "./chat-thread-panes.ts";
-import { talkDraft$ } from "../zero-page/chat-draft.ts";
+import {
+  talkDraft$,
+  type ZeroChatAttachment,
+} from "../zero-page/chat-draft.ts";
 import {
   createChatThreadSignals,
   ensureDraft$,
@@ -92,7 +95,7 @@ interface SendNewThreadMessageRequest {
   prompt: string;
   modelSelection: ModelSelectionRequest | null;
   generationTemplate: GenerationTemplateRequest | undefined;
-  computerUseHostId: string | null;
+  computerUseHostId?: string | null;
 }
 
 interface SendNewThreadMessageResult {
@@ -102,6 +105,12 @@ interface SendNewThreadMessageResult {
 
 interface SendNewThreadMessagePending extends PendingChatThread {
   sendResult: Promise<SendNewThreadMessageResult>;
+}
+
+function hasVisualDraftAttachments(
+  attachments: readonly ZeroChatAttachment[],
+): boolean {
+  return attachments.some(isVisualAttachment);
 }
 
 async function appendQueuedMessage(
@@ -128,7 +137,9 @@ async function appendQueuedMessage(
         clientMessageId: append.clientMessageId,
         modelSelection: append.modelSelection,
         generationTemplate: append.generationTemplate,
-        computerUseHostId: append.computerUseHostId,
+        ...(append.computerUseHostId === undefined
+          ? {}
+          : { computerUseHostId: append.computerUseHostId }),
         attachFiles: append.attachments ?? undefined,
       },
       fetchOptions: { signal },
@@ -153,7 +164,7 @@ function queuedReplayAppendArgs({
   threadId: string;
   agentId: string;
   modelSelection: ModelSelectionRequest | null;
-  computerUseHostId: string | null;
+  computerUseHostId?: string | null;
   entry: OptimisticChatMessageEntry;
 }): AppendQueuedMessageArgs {
   return {
@@ -182,7 +193,7 @@ async function replayQueuedOptimisticMessages({
   threadId: string;
   agentId: string;
   modelSelection: ModelSelectionRequest | null;
-  computerUseHostId: string | null;
+  computerUseHostId?: string | null;
   entries: OptimisticChatMessageEntry[];
   signal: AbortSignal;
 }): Promise<void> {
@@ -474,19 +485,15 @@ export const sidebarChatThreads$ = computed(
 const sendNewThreadMessage$ = command(
   async (
     { get, set },
-    {
-      agentId,
-      prompt,
-      modelSelection,
-      generationTemplate,
-      computerUseHostId,
-    }: SendNewThreadMessageRequest,
+    request: SendNewThreadMessageRequest,
     signal: AbortSignal,
   ): Promise<SendNewThreadMessagePending | null> => {
+    const { agentId, prompt, modelSelection, generationTemplate } = request;
+    const { computerUseHostId } = request;
     const draft = get(talkDraft$);
-    const hasVisualAttachments = get(draft.attachments$).some((attachment) => {
-      return isVisualAttachment(attachment);
-    });
+    const hasVisualAttachments = hasVisualDraftAttachments(
+      get(draft.attachments$),
+    );
     let effectiveSelectedModel = modelSelection?.selectedModel;
     if (!effectiveSelectedModel && hasVisualAttachments) {
       const policies = await get(orgModelPolicies$);
@@ -510,11 +517,9 @@ const sendNewThreadMessage$ = command(
       },
       signal,
     );
-
     if (!prepared) {
       return null;
     }
-
     const threadId = crypto.randomUUID();
     const clientMessageId = crypto.randomUUID();
     const messageCreatedAt = nowDate().toISOString();
@@ -541,7 +546,6 @@ const sendNewThreadMessage$ = command(
       signal,
     );
     set(draft.clear$);
-
     const createClient = get(zeroClient$);
     const client = createClient(chatMessagesContract);
     const queuedOptimisticMessages$ =
@@ -561,7 +565,7 @@ const sendNewThreadMessage$ = command(
             clientMessageId,
             modelSelection,
             generationTemplate,
-            computerUseHostId,
+            ...(computerUseHostId === undefined ? {} : { computerUseHostId }),
             attachFiles: prepared.attachFiles,
           },
           fetchOptions: { signal },
@@ -585,15 +589,14 @@ const sendNewThreadMessage$ = command(
         threadId: result.body.threadId,
         agentId,
         modelSelection: replayModelSelection,
-        computerUseHostId: replayComputerUseHostId,
+        computerUseHostId:
+          computerUseHostId === undefined ? undefined : replayComputerUseHostId,
         entries: queuedMessages,
         signal,
       });
       set(reloadChatThreads$);
-
       return { threadId: result.body.threadId, runId: result.body.runId };
     })();
-
     return {
       pane: "main",
       threadId,

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -98,7 +98,7 @@ const appendQueuedMessage$ = command(
           clientMessageId,
           modelSelection,
           generationTemplate,
-          computerUseHostId,
+          ...(computerUseHostId === undefined ? {} : { computerUseHostId }),
           attachFiles: attachments ?? undefined,
         },
         fetchOptions: { signal },

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -25,6 +25,7 @@ import {
 import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
+import { subscribeComputerUseHostsChanged$ } from "./computer-use-hosts.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -91,5 +92,7 @@ export const setupAgentChatPage$ = command(
     if (queue === "1") {
       set(openQueueDrawer$, signal);
     }
+
+    await set(subscribeComputerUseHostsChanged$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -8,6 +8,7 @@ import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForNavigation } from "../api-base.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import { setAblyLoop$ } from "../realtime.ts";
 
 const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
   "/api/zero/desktop/updates/stable/darwin/arm64/dmg";
@@ -19,20 +20,35 @@ export const ZERO_DESKTOP_DOWNLOAD_URL = new URL(
 
 const computerUseHostsReload$ = state(0);
 
-export const reloadOnlineComputerUseHosts$ = command(({ set }) => {
+const reloadComputerUseHosts$ = command(({ set }) => {
   set(computerUseHostsReload$, (n) => {
     return n + 1;
   });
 });
 
-interface OnlineComputerUseHost extends Pick<
+export const subscribeComputerUseHostsChanged$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const switches = get(featureSwitch$);
+    if (!switches[FeatureSwitchKey.ComputerUse]) {
+      return;
+    }
+
+    const onChanged$ = command(({ set }) => {
+      set(reloadComputerUseHosts$);
+      return false;
+    });
+    await set(setAblyLoop$, "computerUseHostsChanged", onChanged$, signal);
+  },
+);
+
+interface ListedComputerUseHost extends Pick<
   ComputerUseHost,
-  "id" | "displayName" | "lastSeenAt"
+  "id" | "displayName" | "lastSeenAt" | "status"
 > {
   readonly hostName: string;
 }
 
-export function selectedOnlineComputerUseHostId(
+export function selectedComputerUseHostId(
   hosts: readonly { readonly id: string }[],
   selectedHostId: string | null | undefined,
 ): string | null {
@@ -46,8 +62,24 @@ export function selectedOnlineComputerUseHostId(
     : null;
 }
 
-export const onlineComputerUseHosts$ = computed(
-  async (get): Promise<OnlineComputerUseHost[]> => {
+export function visibleComputerUseHosts(
+  hosts: readonly ListedComputerUseHost[],
+  selectedHostId: string | null | undefined,
+): ListedComputerUseHost[] {
+  const selected = selectedComputerUseHostId(hosts, selectedHostId);
+  const selectedHost = selected
+    ? hosts.find((host) => {
+        return host.id === selected;
+      })
+    : undefined;
+  const onlineHosts = hosts.filter((host) => {
+    return host.status === "online" && host.id !== selected;
+  });
+  return selectedHost ? [selectedHost, ...onlineHosts] : onlineHosts;
+}
+
+export const computerUseHosts$ = computed(
+  async (get): Promise<ListedComputerUseHost[]> => {
     get(computerUseHostsReload$);
     const switches = get(featureSwitch$);
     if (!switches[FeatureSwitchKey.ComputerUse]) {
@@ -62,17 +94,14 @@ export const onlineComputerUseHosts$ = computed(
       return [];
     }
 
-    return result.body.hosts
-      .filter((host) => {
-        return host.status === "online";
-      })
-      .map((host) => {
-        return {
-          id: host.id,
-          hostName: host.hostName ?? host.displayName,
-          displayName: host.displayName,
-          lastSeenAt: host.lastSeenAt,
-        };
-      });
+    return result.body.hosts.map((host) => {
+      return {
+        id: host.id,
+        hostName: host.hostName ?? host.displayName,
+        displayName: host.displayName,
+        lastSeenAt: host.lastSeenAt,
+        status: host.status,
+      };
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -105,36 +105,6 @@ export const setNewThreadComputerUseHostId$ = command(
   },
 );
 
-// -- Computer Use popover open state ----------------------------------------
-
-const internalComputerUsePopoverOpen$ = state(false);
-const internalComputerUsePopoverIgnoreClose$ = state(false);
-
-export const computerUsePopoverOpen$ = computed((get) => {
-  return get(internalComputerUsePopoverOpen$);
-});
-
-export const setComputerUsePopoverOpen$ = command(
-  ({ get, set }, open: boolean) => {
-    if (open) {
-      set(internalComputerUsePopoverOpen$, true);
-      set(internalComputerUsePopoverIgnoreClose$, true);
-      return;
-    }
-
-    if (get(internalComputerUsePopoverIgnoreClose$)) {
-      set(internalComputerUsePopoverIgnoreClose$, false);
-      return;
-    }
-
-    set(internalComputerUsePopoverOpen$, false);
-  },
-);
-
-export const clearComputerUsePopoverCloseSuppression$ = command(({ set }) => {
-  set(internalComputerUsePopoverIgnoreClose$, false);
-});
-
 const internalComputerUseDownloadDialogOpen$ = state(false);
 export const computerUseDownloadDialogOpen$ = computed((get) => {
   return get(internalComputerUseDownloadDialogOpen$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4371,21 +4371,19 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
+    await user.click(await screen.findByLabelText("Connectors"));
 
     await waitFor(() => {
       expect(screen.getByText("Studio Mac")).toBeInTheDocument();
       expect(screen.getByText("Office Mac")).toBeInTheDocument();
       expect(screen.queryByText("Offline Desktop")).not.toBeInTheDocument();
       expect(screen.getByText("Connect my computer")).toBeInTheDocument();
-      expect(screen.getByRole("radio", { name: "Studio Mac" })).toHaveAttribute(
-        "aria-checked",
-        "false",
-      );
-      expect(screen.getByRole("radio", { name: "Office Mac" })).toHaveAttribute(
-        "aria-checked",
-        "false",
-      );
+      expect(
+        screen.getByRole("switch", { name: "Connect Studio Mac" }),
+      ).toHaveAttribute("aria-checked", "false");
+      expect(
+        screen.getByRole("switch", { name: "Connect Office Mac" }),
+      ).toHaveAttribute("aria-checked", "false");
     });
   });
 
@@ -4403,7 +4401,7 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
+    await user.click(await screen.findByLabelText("Connectors"));
     await user.click(await screen.findByText("Connect my computer"));
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -4455,11 +4453,10 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
-    expect(screen.getByRole("radio", { name: "Studio Mac" })).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
+    await user.click(await screen.findByLabelText("Connectors"));
+    expect(
+      screen.getByRole("switch", { name: "Connect Studio Mac" }),
+    ).toHaveAttribute("aria-checked", "false");
 
     const textarea = (await screen.findByPlaceholderText(
       PLACEHOLDER,
@@ -4470,11 +4467,11 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Open the app on my computer"),
       ).toBeInTheDocument();
-      expect(sentComputerUseHostId).toBeNull();
+      expect(sentComputerUseHostId).toBeUndefined();
     });
   });
 
-  it("refreshes online computers when the chat composer popover opens", async () => {
+  it("refreshes computers when the computer-use hosts Ably event arrives", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "computer-use-refresh";
     let hostOnline = true;
@@ -4505,26 +4502,26 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("computerUseHostsChanged"),
+      ).toBeTruthy();
+    });
+
+    await user.click(await screen.findByLabelText("Connectors"));
 
     await waitFor(() => {
       expect(screen.getByText("Studio Mac")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByLabelText("Computer Use"));
-    await waitFor(() => {
-      expect(screen.queryByText("Connect my computer")).not.toBeInTheDocument();
-    });
-
-    const requestCountAfterFirstOpen = requestCount;
+    const requestCountAfterInitialLoad = requestCount;
     hostOnline = false;
 
-    await user.click(screen.getByLabelText("Computer Use"));
+    context.mocks.ably.trigger("computerUseHostsChanged");
 
     await waitFor(() => {
-      expect(requestCount).toBeGreaterThan(requestCountAfterFirstOpen);
+      expect(requestCount).toBeGreaterThan(requestCountAfterInitialLoad);
       expect(screen.queryByText("Studio Mac")).not.toBeInTheDocument();
-      expect(screen.getByText("No online computers")).toBeInTheDocument();
     });
   });
 
@@ -4562,8 +4559,10 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
-    await user.click(await screen.findByRole("radio", { name: "Studio Mac" }));
+    await user.click(await screen.findByLabelText("Connectors"));
+    await user.click(
+      await screen.findByRole("switch", { name: "Connect Studio Mac" }),
+    );
 
     const textarea = (await screen.findByPlaceholderText(
       PLACEHOLDER,
@@ -4582,10 +4581,14 @@ describe("chat lifecycle", () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "computer-use-saved-selection";
     const hostId = "11111111-1111-4111-8111-111111111111";
+    let sentComputerUseHostId: string | null | undefined;
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Computer Use",
       computerUseHostId: hostId,
+      onRunCreate: (body) => {
+        sentComputerUseHostId = body.computerUseHostId;
+      },
     });
     context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
       return respond(200, {
@@ -4611,17 +4614,66 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
+    await user.click(await screen.findByLabelText("Connectors"));
 
-    const selectedComputer = await screen.findByRole("radio", {
-      name: "Studio Mac",
+    const selectedComputer = await screen.findByRole("switch", {
+      name: "Disconnect Studio Mac",
     });
     expect(selectedComputer).toHaveAttribute("aria-checked", "true");
     await user.click(selectedComputer);
 
+    const textarea = (await screen.findByPlaceholderText(
+      PLACEHOLDER,
+    )) as HTMLTextAreaElement;
+    await sendMessageInUI(user, textarea, "Do not use my computer");
+
     await waitFor(() => {
-      expect(selectedComputer).toHaveAttribute("aria-checked", "false");
+      expect(screen.getByText("Do not use my computer")).toBeInTheDocument();
+      expect(sentComputerUseHostId).toBeNull();
     });
+  });
+
+  it("shows a saved offline Computer Use host selection", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "computer-use-saved-offline-selection";
+    const hostId = "22222222-2222-4222-8222-222222222222";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Computer Use",
+      computerUseHostId: hostId,
+    });
+    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+      return respond(200, {
+        hosts: [
+          {
+            id: hostId,
+            displayName: "Studio Mac",
+            appVersion: "1.0.0",
+            osVersion: "macOS 15.0",
+            supportedCapabilities: ["app.open"],
+            permissions: { accessibility: true, screenRecording: true },
+            status: "offline",
+            lastSeenAt: "2026-06-10T12:00:00Z",
+            createdAt: "2026-06-10T11:00:00Z",
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
+    });
+
+    await user.click(await screen.findByLabelText("Connectors"));
+
+    const hostName = await screen.findByText("Studio Mac");
+    expect(hostName).toBeInTheDocument();
+    expect(screen.getByText("Offline")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Disconnect Studio Mac" }),
+    ).toHaveAttribute("aria-checked", "true");
   });
 
   it("shows a computer use empty state when host listing is unavailable", async () => {
@@ -4643,7 +4695,7 @@ describe("chat lifecycle", () => {
       featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
-    await user.click(await screen.findByLabelText("Computer Use"));
+    await user.click(await screen.findByLabelText("Connectors"));
 
     await waitFor(() => {
       expect(screen.getByText("No online computers")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -57,9 +57,9 @@ import {
   setNewThreadComputerUseHostId$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
-  onlineComputerUseHosts$,
-  reloadOnlineComputerUseHosts$,
-  selectedOnlineComputerUseHostId,
+  computerUseHosts$,
+  selectedComputerUseHostId as resolveSelectedComputerUseHostId,
+  visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
@@ -422,18 +422,20 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
 function useNewThreadComputerUse() {
   const features = useLastResolved(featureSwitch$);
   const computerUseEnabled = features?.[FeatureSwitchKey.ComputerUse] ?? false;
-  const computerUseHostsLoadable = useLastLoadable(onlineComputerUseHosts$);
-  const lastResolvedComputerUseHosts =
-    useLastResolved(onlineComputerUseHosts$) ?? [];
+  const computerUseHostsLoadable = useLastLoadable(computerUseHosts$);
+  const lastResolvedComputerUseHosts = useLastResolved(computerUseHosts$) ?? [];
   const computerUseHosts =
     computerUseHostsLoadable.state === "hasData"
       ? computerUseHostsLoadable.data
       : lastResolvedComputerUseHosts;
   const storedComputerUseHostId = useGet(newThreadComputerUseHostId$);
-  const reloadComputerUseHosts = useSet(reloadOnlineComputerUseHosts$);
-  const selectedComputerUseHostId = selectedOnlineComputerUseHostId(
+  const selectedComputerUseHostId = resolveSelectedComputerUseHostId(
     computerUseHosts,
     storedComputerUseHostId,
+  );
+  const visibleHosts = visibleComputerUseHosts(
+    computerUseHosts,
+    selectedComputerUseHostId,
   );
   const setComputerUseHostId = useSet(setNewThreadComputerUseHostId$);
 
@@ -446,13 +448,12 @@ function useNewThreadComputerUse() {
     },
     computerUse: computerUseEnabled
       ? {
-          hosts: computerUseHosts,
+          hosts: visibleHosts,
           loading:
             computerUseHostsLoadable.state === "loading" &&
             computerUseHosts.length === 0,
           selectedHostId: selectedComputerUseHostId,
           onChange: setComputerUseHostId,
-          onRefresh: reloadComputerUseHosts,
           downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
         }
       : undefined,
@@ -497,7 +498,9 @@ export function AgentChatPage() {
             prompt: message,
             modelSelection,
             generationTemplate: selectedGenerationTemplate,
-            computerUseHostId: selectedComputerUseHostId,
+            ...(selectedComputerUseHostId
+              ? { computerUseHostId: selectedComputerUseHostId }
+              : {}),
           },
           rootSignal,
         );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2737,7 +2737,7 @@ function ConnectorsPopoverButton({
       ? sorted.filter((c) => {
           return matchesConnectorSearch(search, c);
         })
-      : sorted.slice(0, 5);
+      : sorted;
 
   const handleOpenChange = (open: boolean) => {
     if (open) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -17,7 +17,6 @@ import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import {
   IconAlertTriangle,
   IconArrowUp,
-  IconCheck,
   IconChevronLeft,
   IconChevronRight,
   IconDeviceDesktop,
@@ -50,6 +49,7 @@ import {
   CardContent,
   Input,
   Popover,
+  PopoverClose,
   PopoverContent,
   PopoverTrigger,
   Skeleton,
@@ -145,9 +145,7 @@ import {
   setPendingConnectType$,
   composerSavingType$,
   setComposerSavingType$,
-  clearComputerUsePopoverCloseSuppression$,
   computerUseDownloadDialogOpen$,
-  computerUsePopoverOpen$,
   addDialogSearch$,
   setAddDialogSearch$,
   popoverSearch$,
@@ -171,7 +169,6 @@ import {
   setTemplatePickerPreviewSlideIndex$,
   illustrationVariantIndex$,
   setIllustrationVariantIndex$,
-  setComputerUsePopoverOpen$,
   templateCardHover$,
   setTemplateCardHover$,
   type TemplatePickerVideoGroup,
@@ -282,7 +279,6 @@ interface ZeroChatComposerProps {
     loading: boolean;
     selectedHostId: string | null;
     onChange: (hostId: string | null) => void;
-    onRefresh: () => void;
     downloadUrl: string;
   };
   /** When true, render a skeleton in the model picker slot. */
@@ -328,6 +324,7 @@ interface ComposerComputerUseHost {
   id: string;
   hostName: string;
   displayName: string;
+  status: "online" | "offline";
 }
 
 type ComposerModelPicker = NonNullable<ZeroChatComposerProps["modelPicker"]>;
@@ -2487,15 +2484,17 @@ function ComposerTemplatePickerSlot({
 
 function ConnectorTriggerIcons({
   connectors,
+  hasComputerUse,
 }: {
   connectors: ComposerConnectorItem[];
+  hasComputerUse: boolean;
 }) {
   const enabled = connectors
     .filter((c) => {
       return c.authorized;
     })
     .slice(0, 3);
-  if (enabled.length === 0) {
+  if (enabled.length === 0 && !hasComputerUse) {
     return <IconPlug size={18} stroke={1.5} />;
   }
   return (
@@ -2509,6 +2508,13 @@ function ConnectorTriggerIcons({
           </span>
         );
       })}
+      {hasComputerUse && (
+        <span className="relative shrink-0">
+          <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
+            <IconDeviceDesktop size={16} stroke={1.5} />
+          </span>
+        </span>
+      )}
     </span>
   );
 }
@@ -2606,16 +2612,104 @@ function AddConnectorsDialog({
   );
 }
 
+function ComputerUseConnectorMenuSection({
+  computerUse,
+  onOpenDownloadDialog,
+}: {
+  computerUse: ComposerComputerUse;
+  onOpenDownloadDialog: () => void;
+}) {
+  return (
+    <div className="border-t border-border/50 py-1">
+      <PopoverClose asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent"
+          onClick={onOpenDownloadDialog}
+        >
+          <IconPlug
+            size={16}
+            stroke={1.5}
+            className="shrink-0 text-muted-foreground"
+          />
+          Connect my computer
+        </button>
+      </PopoverClose>
+      {computerUse.loading ? (
+        <div className="flex flex-col animate-pulse">
+          {Array.from({ length: 2 }, (_, i) => {
+            return (
+              <div key={i} className="flex items-center gap-2 px-3 py-2">
+                <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
+                <span className="h-3.5 w-24 rounded bg-muted/50 flex-1" />
+                <span className="h-3 w-6 rounded-full bg-muted/50" />
+              </div>
+            );
+          })}
+        </div>
+      ) : computerUse.hosts.length > 0 ? (
+        <div
+          className="flex max-h-[108px] flex-col overflow-y-auto"
+          role="group"
+          aria-label="Computer Use hosts"
+        >
+          {computerUse.hosts.map((host) => {
+            const checked = computerUse.selectedHostId === host.id;
+            return (
+              <div
+                key={host.id}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 transition-colors",
+                  checked ? "bg-primary/5" : "hover:bg-muted/50",
+                )}
+              >
+                <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
+                  <IconDeviceDesktop size={16} stroke={1.5} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm text-foreground">
+                    {host.displayName}
+                  </span>
+                  {host.status === "offline" && (
+                    <span className="block text-[11px] leading-3 text-muted-foreground">
+                      Offline
+                    </span>
+                  )}
+                </span>
+                <LoadingSwitch
+                  checked={checked}
+                  onCheckedChange={onDomEventFn((nextChecked) => {
+                    computerUse.onChange(nextChecked ? host.id : null);
+                  })}
+                  loading={false}
+                  ariaLabel={`${checked ? "Disconnect" : "Connect"} ${host.displayName}`}
+                  size="sm"
+                />
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="px-3 py-2 text-sm text-muted-foreground">
+          No online computers
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ConnectorsPopoverButton({
   agentConnectors,
   connectorsLoading,
   savingType,
+  computerUse,
   onOpenAddDialog,
   onToggle,
 }: {
   agentConnectors: ComposerConnectorItem[];
   connectorsLoading: boolean;
   savingType: string | null;
+  computerUse: ComposerComputerUse | undefined;
   onOpenAddDialog: () => void;
   onToggle: (type: ConnectorType, checked: boolean) => void | Promise<void>;
 }) {
@@ -2623,6 +2717,8 @@ function ConnectorsPopoverButton({
   const setSearch = useSet(setPopoverSearch$);
   const sortOrder = useGet(popoverSortOrder$);
   const setSortOrder = useSet(setPopoverSortOrder$);
+  const downloadDialogOpen = useGet(computerUseDownloadDialogOpen$);
+  const setDownloadDialogOpen = useSet(setComputerUseDownloadDialogOpen$);
   const showSearch = agentConnectors.length > 20;
 
   // Use snapshot order if available, otherwise sort by added status
@@ -2641,7 +2737,7 @@ function ConnectorsPopoverButton({
       ? sorted.filter((c) => {
           return matchesConnectorSearch(search, c);
         })
-      : sorted;
+      : sorted.slice(0, 5);
 
   const handleOpenChange = (open: boolean) => {
     if (open) {
@@ -2671,7 +2767,10 @@ function ConnectorsPopoverButton({
                 className="inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5"
                 aria-label="Connectors"
               >
-                <ConnectorTriggerIcons connectors={agentConnectors} />
+                <ConnectorTriggerIcons
+                  connectors={agentConnectors}
+                  hasComputerUse={Boolean(computerUse?.selectedHostId)}
+                />
               </button>
             </TooltipTrigger>
           </PopoverTrigger>
@@ -2738,13 +2837,15 @@ function ConnectorsPopoverButton({
             )}
           </div>
         )}
-        <div
-          className={cn(
-            "p-1 flex flex-col",
-            (agentConnectors.length > 0 || connectorsLoading) &&
-              "border-t border-border/50",
-          )}
-        >
+        {computerUse && (
+          <ComputerUseConnectorMenuSection
+            computerUse={computerUse}
+            onOpenDownloadDialog={() => {
+              setDownloadDialogOpen(true);
+            }}
+          />
+        )}
+        <div className="border-t border-border/50 p-1 flex flex-col">
           <button
             type="button"
             className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
@@ -2761,153 +2862,14 @@ function ConnectorsPopoverButton({
           </button>
         </div>
       </PopoverContent>
+      {computerUse && (
+        <ComputerUseDownloadDialog
+          open={downloadDialogOpen}
+          onOpenChange={setDownloadDialogOpen}
+          downloadUrl={computerUse.downloadUrl}
+        />
+      )}
     </Popover>
-  );
-}
-
-function ComputerUsePopoverButton({
-  computerUse,
-}: {
-  computerUse: ComposerComputerUse;
-}) {
-  const active = computerUse.selectedHostId !== null;
-  const open = useGet(computerUsePopoverOpen$);
-  const setOpen = useSet(setComputerUsePopoverOpen$);
-  const downloadDialogOpen = useGet(computerUseDownloadDialogOpen$);
-  const setDownloadDialogOpen = useSet(setComputerUseDownloadDialogOpen$);
-  const clearCloseSuppression = useSet(
-    clearComputerUsePopoverCloseSuppression$,
-  );
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (nextOpen) {
-      setOpen(true);
-      computerUse.onRefresh();
-      window.setTimeout(() => {
-        clearCloseSuppression();
-      }, 300);
-      return;
-    }
-
-    setOpen(false);
-  };
-
-  return (
-    <>
-      <Popover open={open} onOpenChange={handleOpenChange}>
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <PopoverTrigger asChild>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  className={cn(
-                    "inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent sm:h-9 sm:min-w-9 sm:px-1.5",
-                    active && "text-primary",
-                  )}
-                  aria-label="Computer Use"
-                >
-                  <IconDeviceDesktop size={18} stroke={1.5} />
-                </button>
-              </TooltipTrigger>
-            </PopoverTrigger>
-            <TooltipContent side="top" className="text-xs">
-              Computer
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <PopoverContent
-          side="top"
-          align="start"
-          className="w-72 p-0 rounded-lg"
-        >
-          <div className="py-1">
-            {computerUse.loading ? (
-              <div className="flex flex-col animate-pulse">
-                {Array.from({ length: 2 }, (_, i) => {
-                  return (
-                    <div key={i} className="flex items-center gap-2 px-3 py-2">
-                      <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
-                      <span className="h-3.5 w-24 rounded bg-muted/50 flex-1" />
-                      <span className="h-3 w-6 rounded-full bg-muted/50" />
-                    </div>
-                  );
-                })}
-              </div>
-            ) : computerUse.hosts.length > 0 ? (
-              <div
-                className="flex max-h-72 flex-col overflow-y-auto"
-                role="radiogroup"
-                aria-label="Computer Use host"
-              >
-                {computerUse.hosts.map((host) => {
-                  const checked = computerUse.selectedHostId === host.id;
-                  return (
-                    <button
-                      key={host.id}
-                      type="button"
-                      role="radio"
-                      aria-checked={checked}
-                      onClick={() => {
-                        computerUse.onChange(checked ? null : host.id);
-                      }}
-                      className={cn(
-                        "flex w-full items-center gap-2 px-3 py-2 text-left transition-colors",
-                        checked ? "bg-primary/5" : "hover:bg-muted/50",
-                      )}
-                    >
-                      <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
-                        <IconDeviceDesktop size={16} stroke={1.5} />
-                      </span>
-                      <span className="text-sm flex-1 truncate text-foreground">
-                        {host.hostName}
-                      </span>
-                      <span
-                        className={cn(
-                          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors",
-                          checked
-                            ? "border-primary bg-primary text-primary-foreground"
-                            : "border-border text-transparent",
-                        )}
-                        aria-hidden="true"
-                      >
-                        {checked && <IconCheck size={11} stroke={3} />}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="px-3 py-2 text-sm text-muted-foreground">
-                No online computers
-              </div>
-            )}
-          </div>
-          <div className="border-t border-border/50 p-1">
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
-              onClick={() => {
-                setOpen(false);
-                setDownloadDialogOpen(true);
-              }}
-            >
-              <IconPlug
-                size={18}
-                stroke={1.5}
-                className="shrink-0 text-muted-foreground"
-              />
-              Connect my computer
-            </button>
-          </div>
-        </PopoverContent>
-      </Popover>
-      <ComputerUseDownloadDialog
-        open={downloadDialogOpen}
-        onOpenChange={setDownloadDialogOpen}
-        downloadUrl={computerUse.downloadUrl}
-      />
-    </>
   );
 }
 
@@ -3896,14 +3858,12 @@ export function ZeroChatComposer({
                     agentConnectors={agentConnectors}
                     connectorsLoading={connectorsLoading}
                     savingType={savingType}
+                    computerUse={computerUse}
                     onOpenAddDialog={() => {
                       return setShowAddDialog(true);
                     }}
                     onToggle={handleToggle}
                   />
-                  {computerUse && (
-                    <ComputerUsePopoverButton computerUse={computerUse} />
-                  )}
                   <ComposerTemplatePickerSlot picker={templatePicker} />
                 </div>
                 <div className="flex items-center gap-1 sm:gap-2">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -212,9 +212,9 @@ import {
   threadGenerationTemplate$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
-  onlineComputerUseHosts$,
-  reloadOnlineComputerUseHosts$,
-  selectedOnlineComputerUseHostId,
+  computerUseHosts$,
+  selectedComputerUseHostId as resolveSelectedComputerUseHostId,
+  visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
@@ -3282,12 +3282,14 @@ function useChatComposerModel(
 function useChatThreadComposerSendState({
   thread,
   modelSelection,
-  computerUseHostId,
+  computerUseHostIdForSend,
+  clearComputerUseHostOverride,
   setInput,
 }: {
   thread: ChatThreadSignals;
   modelSelection: ModelProviderSelection | null;
-  computerUseHostId: string | null;
+  computerUseHostIdForSend: string | null | undefined;
+  clearComputerUseHostOverride: () => void;
   setInput: (text: string) => void;
 }) {
   const [sendLoadable, send] = useLoadableSet(thread.sendMessage$);
@@ -3311,6 +3313,10 @@ function useChatThreadComposerSendState({
     clearGenerationTemplate();
     detach(
       (async () => {
+        const computerUsePatch =
+          computerUseHostIdForSend === undefined
+            ? {}
+            : { computerUseHostId: computerUseHostIdForSend };
         await send(
           text,
           modelSelection,
@@ -3318,10 +3324,11 @@ function useChatThreadComposerSendState({
             ...(selectedGenerationTemplate
               ? { generationTemplate: selectedGenerationTemplate }
               : {}),
-            computerUseHostId,
+            ...computerUsePatch,
           },
           rootSignal,
         );
+        clearComputerUseHostOverride();
       })(),
       Reason.DomCallback,
     );
@@ -3335,12 +3342,14 @@ function useChatThreadComposerSendState({
     clearGenerationTemplate();
     detach(
       (async () => {
+        const computerUseHostId = computerUseHostIdForSend;
         await queueMessage(
           text,
           selectedGenerationTemplate,
           computerUseHostId,
           rootSignal,
         );
+        clearComputerUseHostOverride();
       })(),
       Reason.DomCallback,
     );
@@ -3362,37 +3371,49 @@ function useChatThreadComposerSendState({
 function useChatThreadComputerUse(thread: ChatThreadSignals) {
   const features = useLastResolved(featureSwitch$);
   const computerUseEnabled = features?.[FeatureSwitchKey.ComputerUse] ?? false;
-  const computerUseHostsLoadable = useLastLoadable(onlineComputerUseHosts$);
-  const lastResolvedComputerUseHosts =
-    useLastResolved(onlineComputerUseHosts$) ?? [];
+  const computerUseHostsLoadable = useLastLoadable(computerUseHosts$);
+  const lastResolvedComputerUseHosts = useLastResolved(computerUseHosts$) ?? [];
   const computerUseHosts =
     computerUseHostsLoadable.state === "hasData"
       ? computerUseHostsLoadable.data
       : lastResolvedComputerUseHosts;
   const storedComputerUseHostId = useLastResolved(thread.computerUseHostId$);
-  const reloadComputerUseHosts = useSet(reloadOnlineComputerUseHosts$);
+  const computerUseHostIdExplicit = useGet(thread.computerUseHostIdExplicit$);
   const selectedComputerUseHostId =
     computerUseHostsLoadable.state === "hasData" || computerUseHosts.length > 0
-      ? selectedOnlineComputerUseHostId(
+      ? resolveSelectedComputerUseHostId(
           computerUseHosts,
           storedComputerUseHostId,
         )
       : (storedComputerUseHostId ?? null);
+  const visibleHosts = visibleComputerUseHosts(
+    computerUseHosts,
+    selectedComputerUseHostId,
+  );
   const setComputerUseHostId = useSet(thread.setComputerUseHostId$);
+  const clearComputerUseHostOverride = useSet(
+    thread.clearComputerUseHostIdOverride$,
+  );
+  const computerUseHostIdForSend = computerUseHostIdExplicit
+    ? selectedComputerUseHostId
+    : undefined;
 
   return {
     selectedComputerUseHostId: computerUseEnabled
       ? selectedComputerUseHostId
       : null,
+    computerUseHostIdForSend: computerUseEnabled
+      ? computerUseHostIdForSend
+      : undefined,
+    clearComputerUseHostOverride,
     computerUse: computerUseEnabled
       ? {
-          hosts: computerUseHosts,
+          hosts: visibleHosts,
           loading:
             computerUseHostsLoadable.state === "loading" &&
             computerUseHosts.length === 0,
           selectedHostId: selectedComputerUseHostId,
           onChange: setComputerUseHostId,
-          onRefresh: reloadComputerUseHosts,
           downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
         }
       : undefined,
@@ -3491,8 +3512,11 @@ function ChatThreadComposer({
   const setInputRef = useSet(thread.setInputRef$);
   const queueDraftSync = useSet(thread.queueDraftSync$);
   const pageSignal = useGet(pageSignal$);
-  const { selectedComputerUseHostId, computerUse } =
-    useChatThreadComputerUse(thread);
+  const {
+    computerUseHostIdForSend,
+    clearComputerUseHostOverride,
+    computerUse,
+  } = useChatThreadComputerUse(thread);
 
   const { queuedItems, onRemoveQueuedItem } = useChatComposerQueue(
     thread,
@@ -3508,7 +3532,8 @@ function ChatThreadComposer({
     useChatThreadComposerSendState({
       thread,
       modelSelection,
-      computerUseHostId: selectedComputerUseHostId,
+      computerUseHostIdForSend,
+      clearComputerUseHostOverride,
       setInput,
     });
   const sending = (allFinishedResolved && !allFinished) || sendLoading;


### PR DESCRIPTION
## Summary
- move Computer Use host selection into the connectors popover, gated by the Computer Use feature switch
- show the first five connectors by default and refresh Computer Use hosts from the Ably `computerUseHostsChanged` event instead of menu-open polling
- persist Computer Use binding on chat threads, send explicit per-message overrides only when the user changes selection, and let the API fall back to the thread binding otherwise
- clear thread bindings when hosts are stopped/deleted/revoked, while granting run access based on binding rather than online status
- inject Computer Use run guidance only when a run has a valid host binding
- isolate the global automation cron test fixtures from concurrent API tests

## Testing
- `pnpm -F @vm0/db db:migrate`
- `pnpm format`
- `pnpm turbo run lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm check-types`
- `pnpm knip`
- `pnpm vitest` (535 files, 7397 tests)

## Notes
- Full `pnpm vitest` still prints existing MSW logs from `automations.bdd.test.ts` cancel callbacks. They are caught within the same scenario and did not reproduce the cross-test global cron race fixed in this PR.