### PR TITLE
fix: anchor composer ghost text, push quote pill up (#17796)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -536,6 +536,7 @@ function ComposerFeedbackRow({
   item,
   autoFocus,
   showDivider,
+  isLast,
   onChangeNote,
   onRemove,
   onKeyDown,
@@ -543,6 +544,7 @@ function ComposerFeedbackRow({
   item: FeedbackItem;
   autoFocus: boolean;
   showDivider: boolean;
+  isLast: boolean;
   onChangeNote: (note: string) => void;
   onRemove: () => void;
   onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
@@ -550,12 +552,14 @@ function ComposerFeedbackRow({
   return (
     <div
       className={cn(
-        // Bottom padding on every row; top padding only when a dashed divider
-        // separates stacked fragments. The first row gets no top inset so the
-        // quote chip sits as high as the attachment chips do (matching the
-        // composer's pt-3), letting the card extend upward instead of leaving a
-        // gap above the chip.
-        "flex flex-col gap-1.5 pb-1.5",
+        // Top padding only when a dashed divider separates stacked fragments.
+        // The first row gets no top inset so the quote chip sits as high as the
+        // attachment chips do (matching the composer's pt-3), letting the card
+        // extend upward instead of leaving a gap above the chip. The last row
+        // owns the resting box (see the note below) and so drops its bottom
+        // padding to sit flush above the toolbar like the normal textarea.
+        "flex flex-col gap-1.5",
+        !isLast && "pb-1.5",
         showDivider && "border-t border-dashed border-border/60 pt-1.5",
       )}
     >
@@ -595,7 +599,15 @@ function ComposerFeedbackRow({
         onKeyDown={onKeyDown}
         rows={1}
         placeholder="What should change about this?"
-        className="w-full resize-none overflow-hidden border-0 bg-transparent px-1 py-1 text-[0.9375rem] leading-snug text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
+        className={cn(
+          "w-full resize-none overflow-hidden border-0 bg-transparent px-1 text-[0.9375rem] text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0",
+          // The active (last) note mirrors the normal composer's resting box
+          // (min-h-[96px] + pt-4 + leading-6) so its ghost text stays anchored at
+          // the same baseline as the plain textarea. The quote pill therefore
+          // stacks above this box and pushes the card upward, instead of eating
+          // into the box and shoving the ghost text down toward the toolbar.
+          isLast ? "min-h-[96px] pb-0 pt-4 leading-6" : "py-1 leading-snug",
+        )}
       />
     </div>
   );
@@ -618,10 +630,12 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
   const newestId = feedback.items[feedback.items.length - 1]?.id;
 
   return (
-    // min-h keeps the card from shrinking below the textarea's resting height.
-    // px-4 / pt-3 mirror the attachment-chips inset so the feedback chip lines
-    // up with attachments on both the left and top edges.
-    <div className="flex min-h-[96px] flex-col px-4 pb-2 pt-3">
+    // The active note owns the resting box (min-h-[96px]) so it can't collapse;
+    // the container just supplies insets. px-4 / pt-3 mirror the attachment-chips
+    // inset so the quote chip lines up with attachments on the left and top
+    // edges, and pb-0 lets the note sit flush above the toolbar like the plain
+    // textarea does.
+    <div className="flex flex-col px-4 pb-0 pt-3">
       {feedback.items.map((item, index) => {
         return (
           <ComposerFeedbackRow
@@ -629,6 +643,7 @@ function ComposerFeedbackRows({ feedback }: { feedback: ComposerFeedback }) {
             item={item}
             autoFocus={item.id === newestId}
             showDivider={index > 0}
+            isLast={index === feedback.items.length - 1}
             onChangeNote={(note) => {
               return feedback.onChangeNote(item.id, note);
             }}


### PR DESCRIPTION
## Summary

Fixes #17796.

When a quote pill (referenced-message chip) is attached in the chat composer's feedback mode, the ghost-text placeholder ("What should change about this?") was being shoved **down** toward the toolbar — the input baseline jumped whenever a quote was attached.

Root cause: in feedback mode the quote pill and the note textarea shared a single `min-h-[96px]` box, so the pill consumed the top of that box and pushed the note (and its ghost text) down. The plain composer, by contrast, anchors its textarea's resting box directly above the toolbar.

## Change

- The active (last) note now owns the normal composer's resting box (`min-h-[96px]` + `pt-4` + `leading-6`), so its ghost text stays anchored at the **same baseline** as the plain textarea.
- The quote pill now stacks **above** that box, so attaching a quote pushes the card **upward** instead of moving the ghost text.
- Stacked (older) notes stay compact and stack above the active note, so the multi-quote case also grows upward.

## Expected behavior

- Ghost-text / input baseline position does **not** change when a quote is attached.
- The quote pill is pushed up, above the fixed input baseline.

## Testing

- `prettier --check` ✅
- `oxlint` ✅ (0 warnings, 0 errors)
- Layout-only change; existing feedback-composer tests assert on placeholder text and submit behavior, both unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
