### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,12 +111,12 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.177"
-CODEX_CLI_VERSION="0.139.0"
+CLAUDE_CODE_VERSION="2.1.178"
+CODEX_CLI_VERSION="0.140.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.27.3"
-PNPM_VERSION="11.6.0"
+PNPM_VERSION="11.7.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Updated pinned rootfs tool versions in `crates/runner/scripts/build-template.sh`.

## Version updates

- Claude Code CLI: `2.1.177` -> `2.1.178`
- Codex CLI: `0.139.0` -> `0.140.0`
- pnpm: `11.6.0` -> `11.7.0`

## Checked and already current

- Go: `1.26.4`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- agent-browser: `0.27.3`
- Node.js LTS major: `24.x`
- PostgreSQL major: `18`

## Notes

- Ubuntu remains pinned to `noble` / Ubuntu 24.04 as requested.

## Validation

- `git diff --check`
- `bash -n crates/runner/scripts/build-template.sh`