### PR TITLE
fix: rebalance generation template prompt context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -600,10 +600,10 @@ describe("CHAT-02: completed chat callback", () => {
     expect(appended).toContain(
       "# Current Integration\nYou are currently running inside: Web",
     );
-    expect(appended).toContain("# Generation Template");
-    expect(appended).toContain("Type: presentation");
-    expect(appended).toContain(`Design system ID: ${template.designSystemId}`);
-    expect(appended).toContain(`Template ID: ${template.templateId}`);
+    expect(appended).toContain("# Artifact Template Context");
+    expect(appended).toContain("- Artifact type: presentation");
+    expect(appended).toContain(`(${template.designSystemId})`);
+    expect(appended).toContain(`(${template.templateId})`);
     expect(appended).toContain("--artifact-kind presentation-html");
     expect(Object.keys(autoContext.body.environment)).toContain(
       "ANTHROPIC_API_KEY",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2029,7 +2029,11 @@ describe("CHAT-02: generation templates and attachments", () => {
     const freshPrompt = (await api.readRun(actor, fresh.runId))
       .appendSystemPrompt;
     expect(freshPrompt).not.toContain("# Artifact Template Context");
-    expect(freshPrompt).not.toContain("zero generate");
+    // The base agent prompt always carries generic `zero generate` guidance, so
+    // assert the absence of the template-specific command, not the bare verb.
+    expect(freshPrompt).not.toContain(
+      "zero generate image --provider built-in --style",
+    );
     expect(freshPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, fresh.runId);
   }, 120_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -453,7 +453,7 @@ describe("CHAT-02: web chat send and client-id idempotency", () => {
     expect(run.appendSystemPrompt).toContain(
       "You are currently running inside: Web",
     );
-    expect(run.appendSystemPrompt).not.toContain("# Generation Template");
+    expect(run.appendSystemPrompt).not.toContain("# Artifact Template Context");
 
     const messages = await waitForThreadMessages(
       actor,
@@ -1896,18 +1896,18 @@ describe("CHAT-02: generation templates and attachments", () => {
     const presentationRun = await api.readRun(actor, presentation.runId);
     expect(presentationRun.prompt).toBe("make a launch deck");
     const presentationPrompt = presentationRun.appendSystemPrompt ?? "";
-    expect(presentationPrompt).toContain("# Generation Template");
+    expect(presentationPrompt).toContain("# Artifact Template Context");
     expect(presentationPrompt).toContain(
-      "Use the following registered resources for this run.",
+      "The user deliberately selected this artifact template",
     );
-    expect(presentationPrompt).toContain("Type: presentation");
+    expect(presentationPrompt).toContain("- Artifact type: presentation");
+    expect(presentationPrompt).toContain(`(${template.designSystemId})`);
+    expect(presentationPrompt).toContain(`(${template.templateId})`);
     expect(presentationPrompt).toContain(
-      `Design system ID: ${template.designSystemId}`,
+      "It does not force you to generate: the user's prompt decides the task",
     );
-    expect(presentationPrompt).toContain(`Template ID: ${template.templateId}`);
-    expect(presentationPrompt).toContain("Instructions:");
     expect(presentationPrompt).toContain(
-      "- Keep the user's prompt as the source of the requested content.",
+      `zero generate presentation --design-system ${template.designSystemId} --template ${template.templateId}`,
     );
     expect(presentationPrompt).toContain("--artifact-kind presentation-html");
     await cancelChatRun(actor, presentation.runId);
@@ -1928,16 +1928,16 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const videoRun = await api.readRun(actor, video.runId);
     const videoPrompt = videoRun.appendSystemPrompt ?? "";
-    expect(videoPrompt).toContain("# Video Template Preset");
-    expect(videoPrompt).toContain(`- Preset name: ${preset.nameEn}`);
+    expect(videoPrompt).toContain("# Artifact Template Context");
+    expect(videoPrompt).toContain(`Preset: ${preset.nameEn} (${preset.id})`);
     expect(videoPrompt).toContain(
-      `- Visual Tone: ${preset.dimensions.visualTone}`,
+      `- Visual tone: ${preset.dimensions.visualTone}`,
     );
     expect(videoPrompt).toContain(
-      `- Camera Style: ${preset.dimensions.cameraStyle}`,
+      `- Camera style: ${preset.dimensions.cameraStyle}`,
     );
     expect(videoPrompt).toContain(
-      `- Style Reference: ${preset.dimensions.styleReference}`,
+      `- Style reference: ${preset.dimensions.styleReference}`,
     );
     expect(videoPrompt).toContain(
       "safe for all audiences, positive and uplifting, no violence, no explicit content",
@@ -1965,7 +1965,10 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const firstPrompt = (await api.readRun(actor, first.runId))
       .appendSystemPrompt;
-    expect(firstPrompt).toContain("# Attached illustration style");
+    expect(firstPrompt).toContain("# Artifact Template Context");
+    expect(firstPrompt).toContain(
+      `zero generate image --provider built-in --style ${style.illustrationStyleId}`,
+    );
     expect(firstPrompt).toContain(style.illustrationStyleId);
 
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
@@ -1988,7 +1991,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const secondPrompt = (await api.readRun(actor, second.runId))
       .appendSystemPrompt;
-    expect(secondPrompt).toContain("# Attached illustration style");
+    expect(secondPrompt).toContain("# Artifact Template Context");
     expect(secondPrompt).toContain(style.illustrationStyleId);
     await cancelChatRun(actor, second.runId);
 
@@ -2011,9 +2014,13 @@ describe("CHAT-02: generation templates and attachments", () => {
     });
     const thirdPrompt = (await api.readRun(actor, third.runId))
       .appendSystemPrompt;
-    expect(thirdPrompt).toContain("# Video Template Preset");
-    expect(thirdPrompt).toContain(`- Preset name: ${preset.nameEn}`);
-    expect(thirdPrompt).toContain("# Attached illustration style");
+    // Both template types coexist in the thread, so the combined prompt carries
+    // each type's distinguishing command and facts.
+    expect(thirdPrompt).toContain(`Preset: ${preset.nameEn} (${preset.id})`);
+    expect(thirdPrompt).toContain("zero generate video --provider built-in");
+    expect(thirdPrompt).toContain(
+      `zero generate image --provider built-in --style ${style.illustrationStyleId}`,
+    );
     expect(thirdPrompt).toContain(style.illustrationStyleId);
     await cancelChatRun(actor, third.runId);
 
@@ -2021,8 +2028,8 @@ describe("CHAT-02: generation templates and attachments", () => {
     const fresh = await sendChatRun(actor, { agentId, prompt: "draw a cat" });
     const freshPrompt = (await api.readRun(actor, fresh.runId))
       .appendSystemPrompt;
-    expect(freshPrompt).not.toContain("# Attached illustration style");
-    expect(freshPrompt).not.toContain("# Video Template Preset");
+    expect(freshPrompt).not.toContain("# Artifact Template Context");
+    expect(freshPrompt).not.toContain("zero generate");
     expect(freshPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, fresh.runId);
   }, 120_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -18,10 +18,22 @@ describe("buildGenerationTemplatePrompt", () => {
       },
     });
 
-    expect(result).toStrictEqual({
-      status: "resolved",
-      prompt: expect.stringContaining(`Template ID: ${item.templateId}`),
-    });
+    expect(result.status).toBe("resolved");
+    if (result.status !== "resolved") {
+      return;
+    }
+    expect(result.prompt).toContain("# Artifact Template Context");
+    expect(result.prompt).toContain(
+      "The user deliberately selected this artifact template",
+    );
+    expect(result.prompt).toContain(
+      "It does not force you to generate: the user's prompt decides the task",
+    );
+    expect(result.prompt).toContain(`(${item.designSystemId})`);
+    expect(result.prompt).toContain(`(${item.templateId})`);
+    expect(result.prompt).toContain(
+      `zero generate presentation --design-system ${item.designSystemId} --template ${item.templateId}`,
+    );
   });
 
   it("builds illustration template guidance", () => {
@@ -38,11 +50,12 @@ describe("buildGenerationTemplatePrompt", () => {
     if (result.status !== "resolved") {
       return;
     }
-    // Names the attached style and the capability fact that applies it, so the
+    expect(result.prompt).toContain("# Artifact Template Context");
+    // States the attached style and the exact command that applies it, so the
     // agent does not re-ask for an already-selected style (vm0-ai/vm0#17525).
     expect(result.prompt).toContain(item.illustrationStyleId);
     expect(result.prompt).toContain(
-      `zero generate image --style ${item.illustrationStyleId}`,
+      `zero generate image --provider built-in --style ${item.illustrationStyleId}`,
     );
   });
 
@@ -58,28 +71,30 @@ describe("buildGenerationTemplatePrompt", () => {
 
     expect(result).toStrictEqual({
       status: "resolved",
-      prompt: expect.stringContaining("# Video Template Preset"),
+      prompt: expect.stringContaining("# Artifact Template Context"),
     });
     if (result.status !== "resolved") {
       return;
     }
-    expect(result.prompt).toContain(`Preset ID: ${item.id}`);
-    expect(result.prompt).toContain(`Preset name: ${item.nameEn}`);
+    expect(result.prompt).toContain(`Preset: ${item.nameEn} (${item.id})`);
+    expect(result.prompt).toContain("- Visual tone:");
+    expect(result.prompt).toContain("- Camera style:");
+    expect(result.prompt).toContain("- Editing pace:");
+    expect(result.prompt).toContain("- Narrative mode:");
+    expect(result.prompt).toContain("- Production type:");
+    expect(result.prompt).toContain("- Emotional tone:");
+    expect(result.prompt).toContain("- Style reference:");
+    expect(result.prompt).toContain("- Prompt style notes:");
     expect(result.prompt).toContain(
-      "Apply all dimensions and constraints below as hard generation constraints.",
+      "Reflect the style dimensions and prompt notes above in the final video prompt.",
     );
-    expect(result.prompt).toContain("- Visual Tone:");
-    expect(result.prompt).toContain("- Camera Style:");
-    expect(result.prompt).toContain("- Editing Pace:");
-    expect(result.prompt).toContain("- Narrative Mode:");
-    expect(result.prompt).toContain("- Production Type:");
-    expect(result.prompt).toContain("- Emotional Tone:");
-    expect(result.prompt).toContain("- Style Reference:");
+    // The content-safety guardrail is the only video moderation in the repo, so
+    // it must survive every rewrite of this prompt.
     expect(result.prompt).toContain(
-      "- Style constraints (inject into the video prompt):",
+      "safe for all audiences, positive and uplifting, no violence, no explicit content",
     );
     expect(result.prompt).toContain(
-      `reflect every dimension and constraint above for the style ${item.nameEn}`,
+      "zero generate video --provider built-in --prompt",
     );
   });
 });

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -59,6 +59,30 @@ export function buildGenerationTemplatePrompt(
   return buildPresentationGenerationTemplatePrompt(generationTemplate);
 }
 
+// Shared framing for every artifact-template block, kept in one place so the
+// three builders cannot drift. It balances two jobs that pull in opposite
+// directions:
+//   1. The user *deliberately* selected this template — a strong signal, so it is
+//      the default style for that artifact, and the agent must not re-ask for an
+//      already-selected style (vm0-ai/vm0#17525).
+//   2. The selection must not hijack unrelated turns. This block is injected on
+//      every run while the template is thread-sticky (see resolveThread-
+//      GenerationTemplatePrompt), including messages that have nothing to do with
+//      generation, so the "does not force you to generate" boundary is load-
+//      bearing, not decorative.
+// State the facts and hand back the decision, rather than naming a step ("resolve
+// from the registry") without the facts needed to act on it.
+function templateFraming(artifactNoun: string): readonly string[] {
+  return [
+    "# Artifact Template Context",
+    "",
+    `- The user deliberately selected this artifact template for the chat — treat it as the default style for any ${artifactNoun} you produce here, including in follow-up messages.`,
+    `- It does not force you to generate: the user's prompt decides the task, content, output format, and whether to produce an artifact at all. If a request isn't about producing ${artifactNoun}, just answer it normally.`,
+    "- Other artifact templates, files, or attachments may also be present.",
+    "",
+  ];
+}
+
 function buildPresentationGenerationTemplatePrompt(
   generationTemplate: PresentationGenerationTemplateInput,
 ): GenerationTemplatePromptResult {
@@ -86,18 +110,18 @@ function buildPresentationGenerationTemplatePrompt(
   return {
     status: "resolved",
     prompt: [
-      "# Generation Template",
-      "Use the following registered resources for this run.",
-      `Type: ${generationTemplate.type}`,
-      `Design system ID: ${designSystem.id}`,
-      `Design system name: ${designSystem.name}`,
-      `Template ID: ${template.id}`,
-      `Template name: ${template.name}`,
+      ...templateFraming("a presentation"),
+      "Selected presentation style:",
+      `- Artifact type: ${generationTemplate.type}`,
+      `- Design system: ${designSystem.name} (${designSystem.id})`,
+      `- Design system description: ${designSystem.description}`,
+      `- Template: ${template.name} (${template.id})`,
+      `- Template description: ${template.description}`,
       "",
-      "Instructions:",
-      "- Resolve the design system and template from the resource registry.",
-      "- Apply them as generation constraints for the artifact.",
-      "- Keep the user's prompt as the source of the requested content.",
+      "When you produce a presentation from the user's request:",
+      `- Run: zero generate presentation --design-system ${designSystem.id} --template ${template.id} --prompt "<user request>"`,
+      "- Follow the returned authoring packet. For a static HTML presentation, publish it with `zero host <dir> --site <slug> --artifact-kind presentation-html`.",
+      "- If a flag above no longer applies, run `zero generate presentation -h` to discover the current options.",
     ].join("\n"),
   };
 }
@@ -120,24 +144,24 @@ function buildVideoGenerationTemplatePrompt(
   return {
     status: "resolved",
     prompt: [
-      "# Video Template Preset",
-      `- Preset ID: ${preset.id}`,
-      `- Preset name: ${preset.nameEn}`,
+      ...templateFraming("a video"),
+      "Selected video style preset:",
+      "- Artifact type: video",
+      `- Preset: ${preset.nameEn} (${preset.id})`,
+      `- Visual tone: ${describeSlug(preset.dimensions.visualTone)}`,
+      `- Camera style: ${describeSlug(preset.dimensions.cameraStyle)}`,
+      `- Editing pace: ${describeSlug(preset.dimensions.editingPace)}`,
+      `- Narrative mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
+      `- Production type: ${describeSlug(preset.dimensions.productionType)}`,
+      `- Emotional tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
+      `- Style reference: ${describeSlug(preset.dimensions.styleReference)}`,
+      `- Prompt style notes: ${preset.promptConstraints}`,
       "",
-      "- Apply all dimensions and constraints below as hard generation constraints.",
-      "- Keep the user's prompt as the source of the requested content.",
-      `- Visual Tone: ${describeSlug(preset.dimensions.visualTone)}`,
-      `- Camera Style: ${describeSlug(preset.dimensions.cameraStyle)}`,
-      `- Editing Pace: ${describeSlug(preset.dimensions.editingPace)}`,
-      `- Narrative Mode: ${describeSlug(preset.dimensions.narrativeMode)}`,
-      `- Production Type: ${describeSlug(preset.dimensions.productionType)}`,
-      `- Emotional Tone: ${describeSlug(preset.dimensions.emotionalTone)}`,
-      `- Style Reference: ${describeSlug(preset.dimensions.styleReference)}`,
-      "",
-      `- Style constraints (inject into the video prompt): ${preset.promptConstraints}`,
-      "",
-      `- In the final video prompt, reflect every dimension and constraint above for the style ${preset.nameEn}.`,
-      "- End the final video prompt with: safe for all audiences, positive and uplifting, no violence, no explicit content",
+      "When you produce a video from the user's request:",
+      "- Reflect the style dimensions and prompt notes above in the final video prompt.",
+      "- Always end the final video prompt with: safe for all audiences, positive and uplifting, no violence, no explicit content.",
+      `- Run: zero generate video --provider built-in --prompt "<user request, plus the style dimensions and the safety line above>" — or follow connector guidance when a connector/provider is requested.`,
+      "- If a flag above no longer applies, run `zero generate video -h` to discover the current flags, models, and providers.",
     ].join("\n"),
   };
 }
@@ -152,18 +176,18 @@ function buildIllustrationGenerationTemplatePrompt(
     return { status: "invalid", message: "Unknown generation image style" };
   }
 
-  // Context, not control: state the facts (which style is attached, that it
-  // persists, how it reaches image generation) and let the agent act on them.
-  // Replaces the earlier "Resolve the image style from the resource registry"
-  // instruction, which named a step without the facts to do it, so when unsure
-  // the agent re-asked for an already-selected style (vm0-ai/vm0#17525).
   return {
     status: "resolved",
     prompt: [
-      "# Attached illustration style",
+      ...templateFraming("an illustration or image"),
+      "Selected illustration style:",
+      "- Artifact type: illustration",
+      `- Style: ${imageStyle.name} (${imageStyle.id})`,
+      `- Style description: ${imageStyle.description}`,
       "",
-      `"${imageStyle.name}" (${imageStyle.id}), attached to this chat and persisting across follow-up messages.`,
-      `Apply it with \`zero generate image --style ${imageStyle.id}\`.`,
+      "When you produce an illustration or image from the user's request:",
+      `- Run: zero generate image --provider built-in --style ${imageStyle.id} --prompt "<user request>"`,
+      "- If a flag above no longer applies, run `zero generate image -h` to discover the current flags, models, providers, and styles.",
     ].join("\n"),
   };
 }


### PR DESCRIPTION
## Summary

Reworks the presentation, video, and illustration artifact-template system prompts in `generation-template-prompt.ts`. Builds on the "state facts, not steps" direction of the (now-closed) #17763, while fixing two problems that version introduced and one it left implicit.

The block is injected on **every** thread-sticky run (see `resolveThreadGenerationTemplatePrompt`), including messages unrelated to generation — so the framing has to do two opposing jobs at once: signal "use this style" without letting the selection hijack unrelated turns.

## What changed

- **Single source for the framing.** Extracted `templateFraming(artifactNoun)` so the three builders can't drift (the previous prose was copy-pasted three times and only one substring was test-guarded). Compressed it to three parallel bullets, each one idea:
  1. *deliberately selected* → treat as the default style (strong signal — fixes the re-asking from #17525)
  2. *does not force you to generate* → user prompt decides task/content/whether to generate; if the turn isn't about this artifact, just answer normally (the boundary that keeps the sticky block from hijacking unrelated messages)
  3. *other templates/files/attachments may also be present* (non-exclusivity)
- **Restored the video content-safety guardrail.** `safe for all audiences, positive and uplifting, no violence, no explicit content` is the **only** video moderation string in the repo; #17763 dropped it with no replacement. It is back as an unconditional instruction, with a unit assertion guarding it.
- **Keeps the preset actually applied.** Video block re-states "reflect the style dimensions and prompt notes in the final video prompt", so a wanted video isn't under-styled.
- **Removed the `-h`-vs-exact-command contradiction.** The exact `zero generate ...` command is the primary path; `-h` is the fallback for when a flag no longer applies.
- **States facts, not steps.** Keeps resource id / name / description inline instead of "resolve from the registry".
- Updated unit + BDD assertions for the new wording.

## Notes

- Avoided the internal "context, not control" slogan in the prompt text itself (no behavioral value to the model); the behavior is expressed directly in the bullets.
- Per repo convention, relying on the PR pipeline for type-check/lint/test; `prettier` was run locally on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)