### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
@@ -1396,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1639,7 +1639,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.15",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",


### PR DESCRIPTION
## Summary
- Ran `cargo update --verbose` in the Rust workspace at `crates/`.
- Updated 1 dependency in `crates/Cargo.lock`: `h2` `0.4.14` -> `0.4.15`.

## Dependencies that could not be updated
- `generic-array` remains at `0.14.7` although `0.14.9` is available. A forced precise update fails because transitive `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` through `digest v0.10.7` and downstream paths including `aws-sdk-s3` / `runner`. There was no safe local minor/patch `Cargo.toml` version bump to unblock it.

## Manual version bumps
- None.

## Test status
- PASS: `cargo test --workspace -- --test-threads=1`
- Local note: the successful run used `TMPDIR=/tmp/vt`, `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target`, `CARGO_BUILD_JOBS=1`, `CARGO_PROFILE_TEST_DEBUG=0`, and `umask 077` to avoid automation sandbox tmpdir/resource limits.