### PR TITLE
fix: log claude provider overloads as info

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -110,6 +110,7 @@ pub enum FailureReason {
     InsufficientCredits,
     InvalidApiKey,
     InvalidCredentials,
+    ProviderOverloaded,
     ReconnectRequired,
     UsageLimit,
 }
@@ -121,6 +122,7 @@ impl FailureReason {
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
             Self::InvalidCredentials => "invalid_credentials",
+            Self::ProviderOverloaded => "provider_overloaded",
             Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
         }
@@ -351,6 +353,23 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "invalid_credentials");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_provider_overloaded_reason() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ProviderOverloaded);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "provider_overloaded");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -13,6 +13,7 @@ pub struct FailureDiagnostic {
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
     pub failure_detail_source: Option<FailureDetailSource>,
+    #[serde(default, deserialize_with = "deserialize_optional_failure_reason")]
     pub failure_reason: Option<FailureReason>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
@@ -127,6 +128,29 @@ impl FailureReason {
             Self::UsageLimit => "usage_limit",
         }
     }
+
+    #[must_use]
+    pub fn from_wire_value(value: &str) -> Option<Self> {
+        match value {
+            "insufficient_credits" => Some(Self::InsufficientCredits),
+            "invalid_api_key" => Some(Self::InvalidApiKey),
+            "invalid_credentials" => Some(Self::InvalidCredentials),
+            "provider_overloaded" => Some(Self::ProviderOverloaded),
+            "reconnect_required" => Some(Self::ReconnectRequired),
+            "usage_limit" => Some(Self::UsageLimit),
+            _ => None,
+        }
+    }
+}
+
+fn deserialize_optional_failure_reason<'de, D>(
+    deserializer: D,
+) -> Result<Option<FailureReason>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| FailureReason::from_wire_value(&value)))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -364,6 +388,10 @@ mod tests {
             FailureReason::ProviderOverloaded.as_str(),
             "provider_overloaded"
         );
+        assert_eq!(
+            FailureReason::from_wire_value("provider_overloaded"),
+            Some(FailureReason::ProviderOverloaded)
+        );
 
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -414,6 +442,26 @@ mod tests {
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
         assert_eq!(diagnostic.failure_detail_source, None);
+        assert_eq!(diagnostic.failure_reason, None);
+    }
+
+    #[test]
+    fn failure_diagnostic_deserializes_unknown_failure_reason_as_none() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "failureClass": "cli_nonzero",
+            "framework": "claude_code",
+            "cliExitCode": 1,
+            "claudeNumTurns": 1,
+            "failureReason": "future_reason",
+            "sessionHistoryStatus": "present",
+            "promptShape": "plain",
+            "promptBytes": 13,
+            "firstLineBytes": 13
+        });
+
+        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
+
         assert_eq!(diagnostic.failure_reason, None);
     }
 }

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -360,6 +360,11 @@ mod tests {
 
     #[test]
     fn failure_diagnostic_serializes_provider_overloaded_reason() {
+        assert_eq!(
+            FailureReason::ProviderOverloaded.as_str(),
+            "provider_overloaded"
+        );
+
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
             AgentFramework::ClaudeCode,

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -13,7 +13,6 @@ pub struct FailureDiagnostic {
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
     pub failure_detail_source: Option<FailureDetailSource>,
-    #[serde(default, deserialize_with = "deserialize_optional_failure_reason")]
     pub failure_reason: Option<FailureReason>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
@@ -128,39 +127,6 @@ impl FailureReason {
             Self::UsageLimit => "usage_limit",
         }
     }
-
-    #[must_use]
-    pub fn from_wire_value(value: &str) -> Option<Self> {
-        match value {
-            "insufficient_credits" => Some(Self::InsufficientCredits),
-            "invalid_api_key" => Some(Self::InvalidApiKey),
-            "invalid_credentials" => Some(Self::InvalidCredentials),
-            "provider_overloaded" => Some(Self::ProviderOverloaded),
-            "reconnect_required" => Some(Self::ReconnectRequired),
-            "usage_limit" => Some(Self::UsageLimit),
-            _ => None,
-        }
-    }
-}
-
-fn deserialize_optional_failure_reason<'de, D>(
-    deserializer: D,
-) -> Result<Option<FailureReason>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum WireValue {
-        String(String),
-        Other(serde::de::IgnoredAny),
-    }
-
-    let value = Option::<WireValue>::deserialize(deserializer)?;
-    Ok(match value {
-        Some(WireValue::String(value)) => FailureReason::from_wire_value(&value),
-        Some(WireValue::Other(_)) | None => None,
-    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -398,10 +364,6 @@ mod tests {
             FailureReason::ProviderOverloaded.as_str(),
             "provider_overloaded"
         );
-        assert_eq!(
-            FailureReason::from_wire_value("provider_overloaded"),
-            Some(FailureReason::ProviderOverloaded)
-        );
 
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -452,46 +414,6 @@ mod tests {
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
         assert_eq!(diagnostic.failure_detail_source, None);
-        assert_eq!(diagnostic.failure_reason, None);
-    }
-
-    #[test]
-    fn failure_diagnostic_deserializes_unknown_failure_reason_as_none() {
-        let json = serde_json::json!({
-            "schemaVersion": 1,
-            "failureClass": "cli_nonzero",
-            "framework": "claude_code",
-            "cliExitCode": 1,
-            "claudeNumTurns": 1,
-            "failureReason": "future_reason",
-            "sessionHistoryStatus": "present",
-            "promptShape": "plain",
-            "promptBytes": 13,
-            "firstLineBytes": 13
-        });
-
-        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
-
-        assert_eq!(diagnostic.failure_reason, None);
-    }
-
-    #[test]
-    fn failure_diagnostic_deserializes_non_string_failure_reason_as_none() {
-        let json = serde_json::json!({
-            "schemaVersion": 1,
-            "failureClass": "cli_nonzero",
-            "framework": "claude_code",
-            "cliExitCode": 1,
-            "claudeNumTurns": 1,
-            "failureReason": 123,
-            "sessionHistoryStatus": "present",
-            "promptShape": "plain",
-            "promptBytes": 13,
-            "firstLineBytes": 13
-        });
-
-        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
-
         assert_eq!(diagnostic.failure_reason, None);
     }
 }

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -12,6 +12,10 @@ pub struct FailureDiagnostic {
     pub framework: AgentFramework,
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_failure_detail_source"
+    )]
     pub failure_detail_source: Option<FailureDetailSource>,
     #[serde(default, deserialize_with = "deserialize_optional_failure_reason")]
     pub failure_reason: Option<FailureReason>,
@@ -149,6 +153,16 @@ fn deserialize_optional_failure_reason<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
+    deserialize_optional_wire_value(deserializer, FailureReason::from_wire_value)
+}
+
+fn deserialize_optional_wire_value<'de, D, T>(
+    deserializer: D,
+    from_wire_value: fn(&str) -> Option<T>,
+) -> Result<Option<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum WireValue {
@@ -158,7 +172,7 @@ where
 
     let value = Option::<WireValue>::deserialize(deserializer)?;
     Ok(match value {
-        Some(WireValue::String(value)) => FailureReason::from_wire_value(&value),
+        Some(WireValue::String(value)) => from_wire_value(&value),
         Some(WireValue::Other(_)) | None => None,
     })
 }
@@ -182,6 +196,26 @@ impl FailureDetailSource {
             Self::FallbackExitCode => "fallback_exit_code",
         }
     }
+
+    #[must_use]
+    pub fn from_wire_value(value: &str) -> Option<Self> {
+        match value {
+            "claude_result" => Some(Self::ClaudeResult),
+            "codex_jsonl" => Some(Self::CodexJsonl),
+            "stderr" => Some(Self::Stderr),
+            "fallback_exit_code" => Some(Self::FallbackExitCode),
+            _ => None,
+        }
+    }
+}
+
+fn deserialize_optional_failure_detail_source<'de, D>(
+    deserializer: D,
+) -> Result<Option<FailureDetailSource>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_optional_wire_value(deserializer, FailureDetailSource::from_wire_value)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -463,6 +497,7 @@ mod tests {
             "framework": "claude_code",
             "cliExitCode": 1,
             "claudeNumTurns": 1,
+            "failureDetailSource": "future_source",
             "failureReason": "future_reason",
             "sessionHistoryStatus": "present",
             "promptShape": "plain",
@@ -472,6 +507,7 @@ mod tests {
 
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
+        assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
     }
 
@@ -483,6 +519,7 @@ mod tests {
             "framework": "claude_code",
             "cliExitCode": 1,
             "claudeNumTurns": 1,
+            "failureDetailSource": {},
             "failureReason": 123,
             "sessionHistoryStatus": "present",
             "promptShape": "plain",
@@ -492,6 +529,7 @@ mod tests {
 
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
+        assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
     }
 }

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -12,10 +12,6 @@ pub struct FailureDiagnostic {
     pub framework: AgentFramework,
     pub cli_exit_code: Option<i32>,
     pub claude_num_turns: Option<u64>,
-    #[serde(
-        default,
-        deserialize_with = "deserialize_optional_failure_detail_source"
-    )]
     pub failure_detail_source: Option<FailureDetailSource>,
     #[serde(default, deserialize_with = "deserialize_optional_failure_reason")]
     pub failure_reason: Option<FailureReason>,
@@ -153,16 +149,6 @@ fn deserialize_optional_failure_reason<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    deserialize_optional_wire_value(deserializer, FailureReason::from_wire_value)
-}
-
-fn deserialize_optional_wire_value<'de, D, T>(
-    deserializer: D,
-    from_wire_value: fn(&str) -> Option<T>,
-) -> Result<Option<T>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum WireValue {
@@ -172,7 +158,7 @@ where
 
     let value = Option::<WireValue>::deserialize(deserializer)?;
     Ok(match value {
-        Some(WireValue::String(value)) => from_wire_value(&value),
+        Some(WireValue::String(value)) => FailureReason::from_wire_value(&value),
         Some(WireValue::Other(_)) | None => None,
     })
 }
@@ -196,26 +182,6 @@ impl FailureDetailSource {
             Self::FallbackExitCode => "fallback_exit_code",
         }
     }
-
-    #[must_use]
-    pub fn from_wire_value(value: &str) -> Option<Self> {
-        match value {
-            "claude_result" => Some(Self::ClaudeResult),
-            "codex_jsonl" => Some(Self::CodexJsonl),
-            "stderr" => Some(Self::Stderr),
-            "fallback_exit_code" => Some(Self::FallbackExitCode),
-            _ => None,
-        }
-    }
-}
-
-fn deserialize_optional_failure_detail_source<'de, D>(
-    deserializer: D,
-) -> Result<Option<FailureDetailSource>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    deserialize_optional_wire_value(deserializer, FailureDetailSource::from_wire_value)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -497,7 +463,6 @@ mod tests {
             "framework": "claude_code",
             "cliExitCode": 1,
             "claudeNumTurns": 1,
-            "failureDetailSource": "future_source",
             "failureReason": "future_reason",
             "sessionHistoryStatus": "present",
             "promptShape": "plain",
@@ -507,7 +472,6 @@ mod tests {
 
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
-        assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
     }
 
@@ -519,7 +483,6 @@ mod tests {
             "framework": "claude_code",
             "cliExitCode": 1,
             "claudeNumTurns": 1,
-            "failureDetailSource": {},
             "failureReason": 123,
             "sessionHistoryStatus": "present",
             "promptShape": "plain",
@@ -529,7 +492,6 @@ mod tests {
 
         let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
 
-        assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
     }
 }

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -149,8 +149,18 @@ fn deserialize_optional_failure_reason<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<String>::deserialize(deserializer)?;
-    Ok(value.and_then(|value| FailureReason::from_wire_value(&value)))
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum WireValue {
+        String(String),
+        Other(serde::de::IgnoredAny),
+    }
+
+    let value = Option::<WireValue>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(WireValue::String(value)) => FailureReason::from_wire_value(&value),
+        Some(WireValue::Other(_)) | None => None,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -454,6 +464,26 @@ mod tests {
             "cliExitCode": 1,
             "claudeNumTurns": 1,
             "failureReason": "future_reason",
+            "sessionHistoryStatus": "present",
+            "promptShape": "plain",
+            "promptBytes": 13,
+            "firstLineBytes": 13
+        });
+
+        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
+
+        assert_eq!(diagnostic.failure_reason, None);
+    }
+
+    #[test]
+    fn failure_diagnostic_deserializes_non_string_failure_reason_as_none() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "failureClass": "cli_nonzero",
+            "framework": "claude_code",
+            "cliExitCode": 1,
+            "claudeNumTurns": 1,
+            "failureReason": 123,
             "sessionHistoryStatus": "present",
             "promptShape": "plain",
             "promptBytes": 13,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -396,12 +396,13 @@ fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
 }
 
 fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
-    let Some((_, detail)) = normalized.split_once("api error: 529") else {
-        return false;
-    };
-    detail
-        .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'))
-        .starts_with("overloaded")
+    const MARKER: &str = "api error: 529";
+    normalized.match_indices(MARKER).any(|(index, _)| {
+        let detail = &normalized[index + MARKER.len()..];
+        detail
+            .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'))
+            .starts_with("overloaded")
+    })
 }
 
 fn is_claude_subscription_access_disabled_error(normalized: &str) -> bool {
@@ -1268,6 +1269,16 @@ mod tests {
         );
 
         assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_later_claude_provider_overloaded() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 529 upstream failed. Background retry failed: API Error: 529 Overloaded.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::ProviderOverloaded));
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1217,6 +1217,35 @@ mod tests {
     }
 
     #[test]
+    fn cli_failure_reason_classifies_claude_result_provider_overloaded_diagnostic() {
+        let message = "API Error: 529 Overloaded. This is a server-side issue, usually temporary - try again in a moment.";
+        let msg = cli_failure_message(
+            1,
+            &["background stderr noise".to_string()],
+            Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
+        );
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic =
+            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::ProviderOverloaded)
+        );
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult)
+        );
+    }
+
+    #[test]
     fn cli_failure_reason_ignores_codex_provider_overloaded_text() {
         let reason = classify_cli_failure_reason(
             AgentFramework::Codex,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -399,9 +399,9 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
     const MARKER: &str = "api error: 529";
     normalized.match_indices(MARKER).any(|(index, _)| {
         let detail = &normalized[index + MARKER.len()..];
-        detail
-            .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'))
-            .starts_with("overloaded")
+        let detail = detail
+            .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'));
+        detail.starts_with("overloaded") || detail.contains("overloaded_error")
     })
 }
 
@@ -1276,6 +1276,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "API Error: 529 upstream failed. Background retry failed: API Error: 529 Overloaded.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::ProviderOverloaded));
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_provider_overloaded_error_type() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            r#"API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"The service is overloaded"}}"#,
         );
 
         assert_eq!(reason, Some(FailureReason::ProviderOverloaded));

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -350,6 +350,11 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::InvalidCredentials);
     }
+    if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_provider_overloaded_error(&normalized)
+    {
+        return Some(FailureReason::ProviderOverloaded);
+    }
     if matches!(framework, AgentFramework::Codex)
         && (normalized.contains("invalid_api_key")
             || normalized.contains("incorrect api key provided"))
@@ -388,6 +393,10 @@ fn is_insufficient_credits_error(normalized: &str) -> bool {
 fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
     normalized.contains("failed to authenticate")
         && normalized.contains("api error: 401 invalid authentication credentials")
+}
+
+fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
+    normalized.contains("api error: 529") && normalized.contains("overloaded")
 }
 
 fn is_claude_subscription_access_disabled_error(normalized: &str) -> bool {
@@ -1193,6 +1202,36 @@ mod tests {
     #[test]
     fn cli_failure_reason_ignores_generic_claude_401() {
         let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, "401 unauthorized");
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_provider_overloaded() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 529 Overloaded. This is a server-side issue, usually temporary - try again in a moment.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::ProviderOverloaded));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_codex_provider_overloaded_text() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            "API Error: 529 Overloaded. This is a server-side issue, usually temporary - try again in a moment.",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_generic_claude_529() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 529 upstream failed",
+        );
 
         assert_eq!(reason, None);
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -401,8 +401,21 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
         let detail = &normalized[index + MARKER.len()..];
         let detail = detail
             .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'));
-        detail.starts_with("overloaded") || detail.contains("overloaded_error")
+        detail.starts_with("overloaded") || contains_overloaded_error_type(detail)
     })
+}
+
+fn contains_overloaded_error_type(detail: &str) -> bool {
+    const TOKEN: &str = "overloaded_error";
+    detail.match_indices(TOKEN).any(|(index, _)| {
+        let before = detail[..index].chars().next_back();
+        let after = detail[index + TOKEN.len()..].chars().next();
+        !before.is_some_and(is_error_type_char) && !after.is_some_and(is_error_type_char)
+    })
+}
+
+fn is_error_type_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '_' | '-')
 }
 
 fn is_claude_subscription_access_disabled_error(normalized: &str) -> bool {
@@ -1296,6 +1309,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "API Error: 529 not overloaded",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_prefixed_claude_overloaded_error_type() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            r#"API Error: 529 {"type":"error","error":{"type":"not_overloaded_error"}}"#,
         );
 
         assert_eq!(reason, None);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -401,7 +401,17 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
         let detail = &normalized[index + MARKER.len()..];
         let detail = detail
             .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'));
-        detail.starts_with("overloaded") || contains_overloaded_error_type(detail)
+        starts_with_overloaded_word(detail) || contains_overloaded_error_type(detail)
+    })
+}
+
+fn starts_with_overloaded_word(detail: &str) -> bool {
+    const TOKEN: &str = "overloaded";
+    detail.strip_prefix(TOKEN).is_some_and(|remaining| {
+        remaining
+            .chars()
+            .next()
+            .is_none_or(|c| !is_error_type_char(c))
     })
 }
 
@@ -1319,6 +1329,16 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             r#"API Error: 529 {"type":"error","error":{"type":"not_overloaded_error"}}"#,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_claude_overloaded_prefix_word() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 529 overloadedness check failed",
         );
 
         assert_eq!(reason, None);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -396,7 +396,12 @@ fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
 }
 
 fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
-    normalized.contains("api error: 529") && normalized.contains("overloaded")
+    let Some((_, detail)) = normalized.split_once("api error: 529") else {
+        return false;
+    };
+    detail
+        .trim_start_matches(|c: char| c.is_ascii_whitespace() || matches!(c, ':' | '-' | '.'))
+        .starts_with("overloaded")
 }
 
 fn is_claude_subscription_access_disabled_error(normalized: &str) -> bool {
@@ -1261,6 +1266,24 @@ mod tests {
             AgentFramework::ClaudeCode,
             "API Error: 529 upstream failed",
         );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_negated_claude_overloaded_text() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "API Error: 529 not overloaded",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_claude_overloaded_without_529() {
+        let reason =
+            classify_cli_failure_reason(AgentFramework::ClaudeCode, "API Error: 503 Overloaded");
 
         assert_eq!(reason, None);
     }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -903,7 +903,7 @@ mod tests {
             let diagnostic = job_failure_diagnostic(Some(reason));
             let failure = executor::ExecutionFailure::new(
                 1,
-                format!("quota failure: {}", reason.as_str()),
+                format!("classified failure: {}", reason.as_str()),
                 Some(diagnostic),
             );
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -732,6 +732,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                 FailureReason::InsufficientCredits
                     | FailureReason::InvalidApiKey
                     | FailureReason::InvalidCredentials
+                    | FailureReason::ProviderOverloaded
                     | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
             )
@@ -895,6 +896,7 @@ mod tests {
             FailureReason::InsufficientCredits,
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::ProviderOverloaded,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {
@@ -950,6 +952,7 @@ mod tests {
         for reason in [
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::ProviderOverloaded,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -255,6 +255,7 @@ async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
     )
     .with_cli_exit_code(1)
     .with_failure_detail_source(agent_diagnostics::FailureDetailSource::ClaudeResult)
+    .with_failure_reason(agent_diagnostics::FailureReason::ProviderOverloaded)
     .with_session_history_status(agent_diagnostics::SessionHistoryStatus::Present);
     sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
 


### PR DESCRIPTION
## Summary
- add `provider_overloaded` as a structured agent diagnostic failure reason
- classify Claude Code `API Error: 529 Overloaded` failures narrowly in guest-agent
- log `CliNonzero + provider_overloaded` runner failures at info while leaving non-CLI/internal failures at error
- leave Axiom WARN+ ingestion unchanged, so these info events are not expected in current runner Axiom logs

## Testing
- `cargo fmt --all --check` from `crates`
- `cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics provider_overloaded`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo test --manifest-path crates/Cargo.toml -p runner info_level_reason_on_non_cli_failure_logs_job_execution_failed_at_error`

Closes #17803