### PR TITLE
fix(sandbox-fc): validate firecracker artifact prerequisites

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufReader, Read};
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
@@ -466,15 +466,16 @@ impl CowLayer {
     /// Returns an error if the block count doesn't match `expected_blocks`
     /// or if the file is truncated.
     fn load_bitmap(path: &Path, expected_blocks: usize) -> Result<BitVec> {
-        let mut file = File::open(path)?;
+        let file = File::open(path)?;
         let file_len = file.metadata()?.len();
         if file_len < 8 {
             return Err(NbdCowError::Io(std::io::Error::other(
                 "bitmap file too short for header",
             )));
         }
+        let mut reader = BufReader::new(file);
         let mut header = [0u8; 8];
-        file.read_exact(&mut header)?;
+        reader.read_exact(&mut header)?;
         let num_blocks = u64::from_le_bytes(header) as usize;
         if num_blocks != expected_blocks {
             return Err(NbdCowError::Io(std::io::Error::other(format!(
@@ -489,16 +490,15 @@ impl CowLayer {
                 "bitmap data truncated: got {bitmap_data_len} bytes, expected {expected_data_len}",
             ))));
         }
-        let mut bitmap_bytes = vec![0u8; expected_data_len];
-        file.read_exact(&mut bitmap_bytes)?;
-        let mut words: Vec<usize> = Vec::with_capacity(expected_words);
-        for i in 0..expected_words {
-            let offset = i * 8;
-            let word_bytes: [u8; 8] = bitmap_bytes
-                .get(offset..offset + 8)
-                .ok_or_else(|| NbdCowError::Io(std::io::Error::other("bitmap word out of bounds")))?
-                .try_into()
-                .map_err(|_| NbdCowError::Io(std::io::Error::other("bitmap word parse error")))?;
+        let mut words: Vec<usize> = Vec::new();
+        words.try_reserve_exact(expected_words).map_err(|e| {
+            NbdCowError::Io(std::io::Error::other(format!(
+                "bitmap word allocation failed: {e}"
+            )))
+        })?;
+        for _ in 0..expected_words {
+            let mut word_bytes = [0u8; 8];
+            reader.read_exact(&mut word_bytes)?;
             words.push(u64::from_le_bytes(word_bytes) as usize);
         }
         let mut bv = BitVec::from_vec(words);

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -521,11 +521,63 @@ pub fn validate_bitmap(path: &Path, expected_blocks: usize) -> Result<()> {
     CowLayer::load_bitmap(path, expected_blocks).map(drop)
 }
 
+/// Validate that a dirty-bitmap sidecar does not reference COW data beyond the
+/// current COW file length.
+pub fn validate_bitmap_cow_coverage(
+    bitmap_path: &Path,
+    cow_file_len: u64,
+    block_size: usize,
+    expected_blocks: usize,
+) -> Result<()> {
+    if block_size == 0 {
+        return Err(NbdCowError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "block_size must be positive",
+        )));
+    }
+
+    let dirty = CowLayer::load_bitmap(bitmap_path, expected_blocks)?;
+    let Some(last_dirty_block) = dirty.last_one() else {
+        return Ok(());
+    };
+    let dirty_blocks = last_dirty_block.checked_add(1).ok_or_else(|| {
+        NbdCowError::Io(std::io::Error::other(
+            "dirty bitmap block index overflowed file length check",
+        ))
+    })?;
+    let required_len = u64::try_from(dirty_blocks)
+        .ok()
+        .and_then(|blocks| {
+            u64::try_from(block_size)
+                .ok()
+                .and_then(|size| blocks.checked_mul(size))
+        })
+        .ok_or_else(|| {
+            NbdCowError::Io(std::io::Error::other(
+                "dirty bitmap required COW length overflowed",
+            ))
+        })?;
+
+    if cow_file_len < required_len {
+        return Err(NbdCowError::Io(std::io::Error::other(format!(
+            "dirty bitmap references COW data requiring at least {required_len} bytes, but COW file is {cow_file_len} bytes"
+        ))));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write as IoWrite;
     use tempfile::NamedTempFile;
+
+    fn write_bitmap_file(path: &Path, blocks: u64, word: u64) {
+        let mut data = blocks.to_le_bytes().to_vec();
+        data.extend_from_slice(&word.to_le_bytes());
+        std::fs::write(path, data).unwrap();
+    }
 
     fn create_base_image(data: &[u8]) -> NamedTempFile {
         let mut f = NamedTempFile::new().unwrap();
@@ -864,6 +916,38 @@ mod tests {
         let loaded = CowLayer::load_bitmap(bitmap_file.path(), 1).unwrap();
 
         assert_eq!(loaded.count_ones(), 0);
+    }
+
+    #[test]
+    fn bitmap_cow_coverage_rejects_truncated_dirty_block() {
+        let bitmap_file = NamedTempFile::new().unwrap();
+        write_bitmap_file(bitmap_file.path(), 2, 0b10);
+
+        let result = validate_bitmap_cow_coverage(bitmap_file.path(), 4096, 4096, 2);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("dirty bitmap references COW data")
+        );
+    }
+
+    #[test]
+    fn bitmap_cow_coverage_accepts_clean_bitmap_with_short_cow_file() {
+        let bitmap_file = NamedTempFile::new().unwrap();
+        write_bitmap_file(bitmap_file.path(), 2, 0);
+
+        validate_bitmap_cow_coverage(bitmap_file.path(), 0, 4096, 2).unwrap();
+    }
+
+    #[test]
+    fn bitmap_cow_coverage_accepts_covering_cow_file() {
+        let bitmap_file = NamedTempFile::new().unwrap();
+        write_bitmap_file(bitmap_file.path(), 2, 0b10);
+
+        validate_bitmap_cow_coverage(bitmap_file.path(), 8192, 4096, 2).unwrap();
     }
 
     #[test]

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -178,17 +178,17 @@ impl CowLayer {
 
         // If bitmap has dirty bits, COW file must already exist — open it eagerly.
         let cow_fd = if dirty.count_ones() > 0 {
-            Some(
-                File::options()
-                    .read(true)
-                    .write(true)
-                    .open(cow_path)
-                    .map_err(|e| {
-                        NbdCowError::Io(std::io::Error::other(format!(
-                            "dirty bitmap present but COW file cannot be opened: {e}"
-                        )))
-                    })?,
-            )
+            let fd = File::options()
+                .read(true)
+                .write(true)
+                .open(cow_path)
+                .map_err(|e| {
+                    NbdCowError::Io(std::io::Error::other(format!(
+                        "dirty bitmap present but COW file cannot be opened: {e}"
+                    )))
+                })?;
+            validate_dirty_cow_coverage(&dirty, fd.metadata()?.len(), block_size)?;
+            Some(fd)
         } else {
             None
         };
@@ -550,6 +550,12 @@ pub fn validate_bitmap_cow_coverage(
     }
 
     let dirty = CowLayer::load_bitmap(bitmap_path, expected_blocks)?;
+    validate_dirty_cow_coverage(&dirty, cow_file_len, block_size)
+}
+
+fn validate_dirty_cow_coverage(dirty: &BitVec, cow_file_len: u64, block_size: usize) -> Result<()> {
+    debug_assert!(block_size > 0);
+
     let Some(last_dirty_block) = dirty.last_one() else {
         return Ok(());
     };
@@ -1081,6 +1087,23 @@ mod tests {
         assert!(
             matches!(&err, NbdCowError::Io(e) if e.kind() == std::io::ErrorKind::NotFound),
             "expected missing broken bitmap target error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn create_with_dirty_bitmap_beyond_cow_file_errors() {
+        let base = create_base_image(&vec![0xAA; 8192]);
+        let cow_file = NamedTempFile::new().unwrap();
+        write_bitmap_file(&bitmap_path_for(cow_file.path()), 2, 0b10);
+
+        let err = match CowLayer::new(base.path(), cow_file.path(), 8192, 4096, 1024 * 1024) {
+            Ok(_) => panic!("expected truncated COW file to fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("dirty bitmap references COW data"),
+            "expected dirty bitmap coverage error, got {err:?}"
         );
     }
 

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -6,7 +6,7 @@
 //! materialized when snapshots are kept.
 
 use std::collections::BTreeMap;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read};
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
@@ -453,10 +453,20 @@ impl CowLayer {
         })?;
         let dir_fd = File::open(parent)?;
         let tmp_path = bitmap_tmp_path_for(path);
-        if let Err(e) = File::create(&tmp_path).and_then(|f| {
-            f.write_all_at(&data, 0)?;
-            f.sync_all()
-        }) {
+        match std::fs::remove_file(&tmp_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+        if let Err(e) = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .and_then(|f| {
+                f.write_all_at(&data, 0)?;
+                f.sync_all()
+            })
+        {
             let _ = std::fs::remove_file(&tmp_path);
             return Err(e.into());
         }
@@ -1002,6 +1012,32 @@ mod tests {
 
         assert!(bitmap_path.exists());
         assert!(!tmp_path.exists());
+        CowLayer::load_bitmap(&bitmap_path, 1).unwrap();
+    }
+
+    #[test]
+    fn bitmap_save_replaces_stale_tmp_symlink_without_following() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base_path = tmp.path().join("base.img");
+        std::fs::write(&base_path, vec![0; 4096]).unwrap();
+        let cow_path = tmp.path().join("cow.img");
+        let cow = CowLayer::new(&base_path, &cow_path, 4096, 4096, 1024 * 1024).unwrap();
+        let bitmap_path = bitmap_path_for(&cow_path);
+        let tmp_path = bitmap_tmp_path_for(&bitmap_path);
+        let symlink_target = tmp.path().join("tmp-symlink-target");
+        std::fs::write(&symlink_target, b"keep").unwrap();
+        std::os::unix::fs::symlink(&symlink_target, &tmp_path).unwrap();
+
+        cow.save_bitmap(&bitmap_path).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&bitmap_path)
+                .unwrap()
+                .file_type()
+                .is_file()
+        );
+        assert!(!tmp_path.exists());
+        assert_eq!(std::fs::read(&symlink_target).unwrap(), b"keep");
         CowLayer::load_bitmap(&bitmap_path, 1).unwrap();
     }
 

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::fs::File;
+use std::io::Read;
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
@@ -465,34 +466,31 @@ impl CowLayer {
     /// Returns an error if the block count doesn't match `expected_blocks`
     /// or if the file is truncated.
     fn load_bitmap(path: &Path, expected_blocks: usize) -> Result<BitVec> {
-        let data = std::fs::read(path)?;
-        if data.len() < 8 {
+        let mut file = File::open(path)?;
+        let file_len = file.metadata()?.len();
+        if file_len < 8 {
             return Err(NbdCowError::Io(std::io::Error::other(
                 "bitmap file too short for header",
             )));
         }
-        let header: [u8; 8] = data
-            .get(..8)
-            .ok_or_else(|| NbdCowError::Io(std::io::Error::other("bitmap header too short")))?
-            .try_into()
-            .map_err(|_| NbdCowError::Io(std::io::Error::other("bitmap header parse error")))?;
+        let mut header = [0u8; 8];
+        file.read_exact(&mut header)?;
         let num_blocks = u64::from_le_bytes(header) as usize;
         if num_blocks != expected_blocks {
             return Err(NbdCowError::Io(std::io::Error::other(format!(
                 "bitmap block count mismatch: file has {num_blocks}, expected {expected_blocks}"
             ))));
         }
-        let bitmap_bytes = data
-            .get(8..)
-            .ok_or_else(|| NbdCowError::Io(std::io::Error::other("bitmap data missing")))?;
         let expected_words = num_blocks.div_ceil(64);
         let expected_data_len = expected_words * 8;
-        if bitmap_bytes.len() < expected_data_len {
+        let bitmap_data_len = file_len.saturating_sub(8);
+        if bitmap_data_len < expected_data_len as u64 {
             return Err(NbdCowError::Io(std::io::Error::other(format!(
-                "bitmap data truncated: got {} bytes, expected {expected_data_len}",
-                bitmap_bytes.len()
+                "bitmap data truncated: got {bitmap_data_len} bytes, expected {expected_data_len}",
             ))));
         }
+        let mut bitmap_bytes = vec![0u8; expected_data_len];
+        file.read_exact(&mut bitmap_bytes)?;
         let mut words: Vec<usize> = Vec::with_capacity(expected_words);
         for i in 0..expected_words {
             let offset = i * 8;
@@ -516,6 +514,11 @@ pub fn bitmap_path_for(cow_path: &Path) -> PathBuf {
     let mut name = cow_path.as_os_str().to_os_string();
     name.push(".bitmap");
     PathBuf::from(name)
+}
+
+/// Validate that a dirty-bitmap sidecar matches the expected block count.
+pub fn validate_bitmap(path: &Path, expected_blocks: usize) -> Result<()> {
+    CowLayer::load_bitmap(path, expected_blocks).map(drop)
 }
 
 #[cfg(test)]
@@ -848,6 +851,19 @@ mod tests {
 
         let result = CowLayer::load_bitmap(bitmap_file.path(), 128);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn bitmap_load_ignores_extra_tail_bytes() {
+        let bitmap_file = NamedTempFile::new().unwrap();
+        let mut data = 1u64.to_le_bytes().to_vec();
+        data.extend_from_slice(&0u64.to_le_bytes());
+        data.extend_from_slice(&[0xAA; 16]);
+        std::fs::write(bitmap_file.path(), data).unwrap();
+
+        let loaded = CowLayer::load_bitmap(bitmap_file.path(), 1).unwrap();
+
+        assert_eq!(loaded.count_ones(), 0);
     }
 
     #[test]

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -131,9 +131,10 @@ impl CowLayer {
     ///
     /// # Errors
     ///
-    /// Returns an invalid-input error if `block_size` is zero or if `size` is
-    /// not an exact multiple of `block_size`. The COW layer stores and restores
-    /// full blocks internally, so partial final blocks are not supported.
+    /// Returns an invalid-input error if `block_size` is zero, if `size` is
+    /// zero, or if `size` is not an exact multiple of `block_size`. The COW
+    /// layer stores and restores full blocks internally, so partial final blocks
+    /// are not supported.
     ///
     /// Returns an I/O error if the base image cannot be opened, or if an
     /// existing bitmap sidecar or its associated COW file cannot be restored.
@@ -148,6 +149,12 @@ impl CowLayer {
             return Err(NbdCowError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "block_size must be positive",
+            )));
+        }
+        if size == 0 {
+            return Err(NbdCowError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "device size must be positive",
             )));
         }
         if !size.is_multiple_of(block_size as u64) {
@@ -643,6 +650,16 @@ mod tests {
         let cow_file = NamedTempFile::new().unwrap();
 
         let result = CowLayer::new(base.path(), cow_file.path(), 4096, 0, 1024 * 1024);
+
+        assert_invalid_input(result);
+    }
+
+    #[test]
+    fn constructor_rejects_zero_size() {
+        let base = create_base_image(&[]);
+        let cow_file = NamedTempFile::new().unwrap();
+
+        let result = CowLayer::new(base.path(), cow_file.path(), 0, 4096, 1024 * 1024);
 
         assert_invalid_input(result);
     }

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -159,14 +159,21 @@ impl CowLayer {
         let base_fd = File::open(base_path)?;
         let num_blocks = (size as usize).div_ceil(block_size);
 
-        // Auto-detect restore mode: load bitmap if sidecar file exists.
+        // Auto-detect restore mode: load bitmap if a sidecar directory entry exists.
         let bitmap_path = bitmap_path_for(cow_path);
-        let dirty = if bitmap_path.exists() {
-            let bv = Self::load_bitmap(&bitmap_path, num_blocks)?;
-            tracing::info!(dirty_blocks = bv.count_ones(), "restored dirty bitmap");
-            bv
-        } else {
-            bitvec![0; num_blocks]
+        let dirty = match std::fs::symlink_metadata(&bitmap_path) {
+            Ok(_) => {
+                let bv = Self::load_bitmap(&bitmap_path, num_blocks)?;
+                tracing::info!(dirty_blocks = bv.count_ones(), "restored dirty bitmap");
+                bv
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => bitvec![0; num_blocks],
+            Err(e) => {
+                return Err(NbdCowError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("stat dirty bitmap sidecar {}: {e}", bitmap_path.display()),
+                )));
+            }
         };
 
         // If bitmap has dirty bits, COW file must already exist — open it eagerly.
@@ -1056,6 +1063,25 @@ mod tests {
         let mut buf = vec![0u8; 4096];
         cow.read(0, &mut buf).unwrap();
         assert!(buf.iter().all(|&b| b == 0xAA));
+    }
+
+    #[test]
+    fn create_with_broken_bitmap_symlink_errors() {
+        let base = create_base_image(&vec![0xAA; 4096]);
+        let tmp = tempfile::tempdir().unwrap();
+        let cow_path = tmp.path().join("cow.img");
+        let bitmap_path = bitmap_path_for(&cow_path);
+        std::os::unix::fs::symlink(tmp.path().join("missing-bitmap"), &bitmap_path).unwrap();
+
+        let err = match CowLayer::new(base.path(), &cow_path, 4096, 4096, 1024 * 1024) {
+            Ok(_) => panic!("expected broken bitmap symlink to fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            matches!(&err, NbdCowError::Io(e) if e.kind() == std::io::ErrorKind::NotFound),
+            "expected missing broken bitmap target error, got {err:?}"
+        );
     }
 
     // ---------- flush_buffered recovery tests ----------

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -445,7 +445,7 @@ impl CowLayer {
             )))
         })?;
         let dir_fd = File::open(parent)?;
-        let tmp_path = PathBuf::from(format!("{}.tmp", path.display()));
+        let tmp_path = bitmap_tmp_path_for(path);
         if let Err(e) = File::create(&tmp_path).and_then(|f| {
             f.write_all_at(&data, 0)?;
             f.sync_all()
@@ -516,6 +516,12 @@ pub fn bitmap_path_for(cow_path: &Path) -> PathBuf {
     PathBuf::from(name)
 }
 
+pub(crate) fn bitmap_tmp_path_for(bitmap_path: &Path) -> PathBuf {
+    let mut name = bitmap_path.as_os_str().to_os_string();
+    name.push(".tmp");
+    PathBuf::from(name)
+}
+
 /// Validate that a dirty-bitmap sidecar matches the expected block count.
 pub fn validate_bitmap(path: &Path, expected_blocks: usize) -> Result<()> {
     CowLayer::load_bitmap(path, expected_blocks).map(drop)
@@ -570,7 +576,9 @@ pub fn validate_bitmap_cow_coverage(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::io::Write as IoWrite;
+    use std::os::unix::ffi::OsStringExt;
     use tempfile::NamedTempFile;
 
     fn write_bitmap_file(path: &Path, blocks: u64, word: u64) {
@@ -961,6 +969,27 @@ mod tests {
         // guarantee by passing a degenerate path.
         let err = cow.save_bitmap(Path::new("/")).unwrap_err();
         assert!(matches!(err, NbdCowError::Io(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn bitmap_save_handles_non_utf8_parent_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let non_utf8_dir = tmp.path().join(PathBuf::from(OsString::from_vec(
+            b"bitmap-parent-\xff".to_vec(),
+        )));
+        std::fs::create_dir(&non_utf8_dir).unwrap();
+        let base_path = non_utf8_dir.join("base.img");
+        std::fs::write(&base_path, vec![0; 4096]).unwrap();
+        let cow_path = non_utf8_dir.join("cow.img");
+        let cow = CowLayer::new(&base_path, &cow_path, 4096, 4096, 1024 * 1024).unwrap();
+        let bitmap_path = bitmap_path_for(&cow_path);
+        let tmp_path = bitmap_tmp_path_for(&bitmap_path);
+
+        cow.save_bitmap(&bitmap_path).unwrap();
+
+        assert!(bitmap_path.exists());
+        assert!(!tmp_path.exists());
+        CowLayer::load_bitmap(&bitmap_path, 1).unwrap();
     }
 
     #[test]

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -1694,7 +1694,7 @@ mod tests {
             let base = tmp.path().join("base.img");
             let cow_file = tmp.path().join("cow.img");
             let bitmap_file = cow::bitmap_path_for(&cow_file);
-            let bitmap_tmp_path = PathBuf::from(format!("{}.tmp", bitmap_file.display()));
+            let bitmap_tmp_path = cow::bitmap_tmp_path_for(&bitmap_file);
             let lock_dir = tmp.path().join("locks");
             std::fs::create_dir(&lock_dir).expect("create lock dir");
             create_test_base_image(&base);

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -838,10 +838,14 @@ fn create_cow_file(
         Some(golden) => {
             sparse_copy(golden, cow_file)?;
             ensure_owner_read_write(cow_file)?;
+            let cow_file_len = std::fs::metadata(cow_file)
+                .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?
+                .len();
             // Snapshot restore requires the dirty bitmap sidecar to preserve COW reads.
             let golden_bitmap = nbd_cow::cow::bitmap_path_for(golden);
             let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
             sparse_copy(&golden_bitmap, &cow_bitmap)?;
+            validate_cow_bitmap(&cow_bitmap, cow_file_len, config.base_size)?;
         }
         None => {
             let f = std::fs::File::create(cow_file)
@@ -851,6 +855,36 @@ fn create_cow_file(
         }
     }
     Ok(())
+}
+
+fn validate_cow_bitmap(
+    bitmap_path: &Path,
+    cow_file_len: u64,
+    base_size: u64,
+) -> Result<(), CowPoolError> {
+    if base_size == 0 {
+        return Err(CowPoolError::CowFileCreation(
+            "base image size is empty".to_string(),
+        ));
+    }
+
+    let block_size = nbd_cow::BLOCK_SIZE as u64;
+    if !base_size.is_multiple_of(block_size) {
+        return Err(CowPoolError::CowFileCreation(format!(
+            "base image size {base_size} is not a multiple of {block_size} bytes"
+        )));
+    }
+
+    let expected_blocks = usize::try_from(base_size / block_size).map_err(|_| {
+        CowPoolError::CowFileCreation("base image block count is too large".to_string())
+    })?;
+    nbd_cow::cow::validate_bitmap_cow_coverage(
+        bitmap_path,
+        cow_file_len,
+        nbd_cow::BLOCK_SIZE,
+        expected_blocks,
+    )
+    .map_err(|e| CowPoolError::CowFileCreation(format!("invalid COW bitmap: {e}")))
 }
 
 fn ensure_owner_read_write(path: &Path) -> Result<(), CowPoolError> {
@@ -926,6 +960,12 @@ mod tests {
             base_size: 64 * 1024 * 1024,
             golden_cow: None,
         }
+    }
+
+    fn write_bitmap_file(path: &Path, blocks: u64, word: u64) {
+        let mut data = blocks.to_le_bytes().to_vec();
+        data.extend_from_slice(&word.to_le_bytes());
+        std::fs::write(path, data).unwrap();
     }
 
     fn test_slot(dir: &Path, id: &str) -> PrewarmedSlot {
@@ -1887,6 +1927,52 @@ mod tests {
     }
 
     #[test]
+    fn create_slot_with_invalid_golden_bitmap_removes_partial_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let golden = tmp.path().join("golden.img");
+        let golden_bitmap = nbd_cow::cow::bitmap_path_for(&golden);
+        std::fs::write(&golden, b"golden").unwrap();
+        std::fs::write(&golden_bitmap, b"invalid").unwrap();
+
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces.clone(),
+            base_size: nbd_cow::BLOCK_SIZE as u64,
+            golden_cow: Some(golden),
+        };
+        let err = create_slot(&config).unwrap_err();
+        assert!(
+            matches!(err, CowPoolError::CowFileCreation(_)),
+            "expected CowFileCreation, got {err}"
+        );
+        let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn create_slot_with_dirty_bitmap_beyond_golden_cow_removes_partial_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let golden = tmp.path().join("golden.img");
+        let golden_bitmap = nbd_cow::cow::bitmap_path_for(&golden);
+        std::fs::write(&golden, b"").unwrap();
+        write_bitmap_file(&golden_bitmap, 1, 1);
+
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces.clone(),
+            base_size: nbd_cow::BLOCK_SIZE as u64,
+            golden_cow: Some(golden),
+        };
+        let err = create_slot(&config).unwrap_err();
+        assert!(
+            matches!(err, CowPoolError::CowFileCreation(_)),
+            "expected CowFileCreation, got {err}"
+        );
+        let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
     fn create_slot_with_non_utf8_golden_cow_copies_bitmap() {
         let tmp = tempfile::tempdir().unwrap();
         let workspaces = tmp.path().join("workspaces");
@@ -1894,16 +1980,19 @@ mod tests {
         let golden = tmp.path().join(PathBuf::from(golden_name));
         let golden_bitmap = nbd_cow::cow::bitmap_path_for(&golden);
         std::fs::write(&golden, b"golden").unwrap();
-        std::fs::write(&golden_bitmap, b"bitmap").unwrap();
+        write_bitmap_file(&golden_bitmap, 1, 0);
 
         let config = CowPoolConfig {
             workspaces_dir: workspaces,
-            base_size: 64 * 1024 * 1024,
+            base_size: nbd_cow::BLOCK_SIZE as u64,
             golden_cow: Some(golden),
         };
         let slot = create_slot(&config).unwrap();
         let cow_bitmap = nbd_cow::cow::bitmap_path_for(&slot.cow_file());
-        assert_eq!(std::fs::read(cow_bitmap).unwrap(), b"bitmap");
+        assert_eq!(
+            std::fs::read(cow_bitmap).unwrap(),
+            std::fs::read(golden_bitmap).unwrap()
+        );
         destroy_slot_sync(slot);
     }
 
@@ -1914,12 +2003,12 @@ mod tests {
         let golden = tmp.path().join("golden.img");
         let golden_bitmap = nbd_cow::cow::bitmap_path_for(&golden);
         std::fs::write(&golden, b"golden").unwrap();
-        std::fs::write(&golden_bitmap, b"bitmap").unwrap();
+        write_bitmap_file(&golden_bitmap, 1, 0);
         std::fs::set_permissions(&golden, std::fs::Permissions::from_mode(0o444)).unwrap();
 
         let config = CowPoolConfig {
             workspaces_dir: workspaces,
-            base_size: 64 * 1024 * 1024,
+            base_size: nbd_cow::BLOCK_SIZE as u64,
             golden_cow: Some(golden),
         };
         let slot = create_slot(&config).unwrap();

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -6,6 +6,7 @@
 
 use std::collections::VecDeque;
 use std::io::ErrorKind;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
@@ -836,6 +837,7 @@ fn create_cow_file(
     match &config.golden_cow {
         Some(golden) => {
             sparse_copy(golden, cow_file)?;
+            ensure_owner_read_write(cow_file)?;
             // Snapshot restore requires the dirty bitmap sidecar to preserve COW reads.
             let golden_bitmap = nbd_cow::cow::bitmap_path_for(golden);
             let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
@@ -851,10 +853,25 @@ fn create_cow_file(
     Ok(())
 }
 
+fn ensure_owner_read_write(path: &Path) -> Result<(), CowPoolError> {
+    let metadata =
+        std::fs::metadata(path).map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
+    let mut permissions = metadata.permissions();
+    let mode = permissions.mode();
+    let mode_with_owner_rw = mode | 0o600;
+    if mode_with_owner_rw != mode {
+        permissions.set_mode(mode_with_owner_rw);
+        std::fs::set_permissions(path, permissions)
+            .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
+    }
+    Ok(())
+}
+
 /// Synchronous sparse copy via `cp --sparse=always`.
 fn sparse_copy(src: &Path, dst: &Path) -> Result<(), CowPoolError> {
     let output = std::process::Command::new("cp")
         .arg("--sparse=always")
+        .arg("--")
         .arg(src)
         .arg(dst)
         .output()
@@ -900,6 +917,7 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::os::unix::ffi::OsStringExt;
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::Mutex;
 
     fn test_config(dir: &Path) -> CowPoolConfig {
@@ -1886,6 +1904,36 @@ mod tests {
         let slot = create_slot(&config).unwrap();
         let cow_bitmap = nbd_cow::cow::bitmap_path_for(&slot.cow_file());
         assert_eq!(std::fs::read(cow_bitmap).unwrap(), b"bitmap");
+        destroy_slot_sync(slot);
+    }
+
+    #[test]
+    fn create_slot_with_read_only_golden_cow_makes_workspace_cow_writable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let golden = tmp.path().join("golden.img");
+        let golden_bitmap = nbd_cow::cow::bitmap_path_for(&golden);
+        std::fs::write(&golden, b"golden").unwrap();
+        std::fs::write(&golden_bitmap, b"bitmap").unwrap();
+        std::fs::set_permissions(&golden, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces,
+            base_size: 64 * 1024 * 1024,
+            golden_cow: Some(golden),
+        };
+        let slot = create_slot(&config).unwrap();
+        let cow_file = slot.cow_file();
+
+        assert_eq!(
+            std::fs::metadata(&cow_file).unwrap().permissions().mode() & 0o600,
+            0o600
+        );
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(cow_file)
+            .unwrap();
         destroy_slot_sync(slot);
     }
 

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -837,9 +837,9 @@ fn create_cow_file(
         Some(golden) => {
             sparse_copy(golden, cow_file)?;
             // Also copy the bitmap sidecar if it exists (for snapshot restore).
-            let golden_bitmap = PathBuf::from(format!("{}.bitmap", golden.display()));
+            let golden_bitmap = nbd_cow::cow::bitmap_path_for(golden);
             if golden_bitmap.exists() {
-                let cow_bitmap = PathBuf::from(format!("{}.bitmap", cow_file.display()));
+                let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
                 sparse_copy(&golden_bitmap, &cow_bitmap)?;
             }
         }
@@ -900,6 +900,8 @@ pub(crate) fn destroy_slot_async(slot: PrewarmedSlot) -> impl std::future::Futur
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
     use std::sync::Mutex;
 
     fn test_config(dir: &Path) -> CowPoolConfig {
@@ -1831,7 +1833,7 @@ mod tests {
         let workspaces = tmp.path().join("workspaces");
         let golden = tmp.path().join("golden.img");
         std::fs::write(&golden, b"golden").unwrap();
-        std::fs::create_dir(format!("{}.bitmap", golden.display())).unwrap();
+        std::fs::create_dir(nbd_cow::cow::bitmap_path_for(&golden)).unwrap();
 
         let config = CowPoolConfig {
             workspaces_dir: workspaces.clone(),
@@ -1861,7 +1863,28 @@ mod tests {
         };
         let slot = create_slot(&config).unwrap();
         assert!(slot.workspace().join("cow.img").exists());
-        assert!(!PathBuf::from(format!("{}.bitmap", slot.cow_file().display())).exists());
+        assert!(!nbd_cow::cow::bitmap_path_for(&slot.cow_file()).exists());
+        destroy_slot_sync(slot);
+    }
+
+    #[test]
+    fn create_slot_with_non_utf8_golden_cow_copies_bitmap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let golden_name = OsString::from_vec(b"golden-\xff.img".to_vec());
+        let golden = tmp.path().join(PathBuf::from(golden_name));
+        let golden_bitmap = nbd_cow::cow::bitmap_path_for(&golden);
+        std::fs::write(&golden, b"golden").unwrap();
+        std::fs::write(&golden_bitmap, b"bitmap").unwrap();
+
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces,
+            base_size: 64 * 1024 * 1024,
+            golden_cow: Some(golden),
+        };
+        let slot = create_slot(&config).unwrap();
+        let cow_bitmap = nbd_cow::cow::bitmap_path_for(&slot.cow_file());
+        assert_eq!(std::fs::read(cow_bitmap).unwrap(), b"bitmap");
         destroy_slot_sync(slot);
     }
 

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -836,12 +836,10 @@ fn create_cow_file(
     match &config.golden_cow {
         Some(golden) => {
             sparse_copy(golden, cow_file)?;
-            // Also copy the bitmap sidecar if it exists (for snapshot restore).
+            // Snapshot restore requires the dirty bitmap sidecar to preserve COW reads.
             let golden_bitmap = nbd_cow::cow::bitmap_path_for(golden);
-            if golden_bitmap.exists() {
-                let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
-                sparse_copy(&golden_bitmap, &cow_bitmap)?;
-            }
+            let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
+            sparse_copy(&golden_bitmap, &cow_bitmap)?;
         }
         None => {
             let f = std::fs::File::create(cow_file)
@@ -1850,21 +1848,24 @@ mod tests {
     }
 
     #[test]
-    fn create_slot_with_golden_cow_without_bitmap_succeeds() {
+    fn create_slot_with_golden_cow_without_bitmap_fails() {
         let tmp = tempfile::tempdir().unwrap();
         let workspaces = tmp.path().join("workspaces");
         let golden = tmp.path().join("golden.img");
         std::fs::write(&golden, b"golden").unwrap();
 
         let config = CowPoolConfig {
-            workspaces_dir: workspaces,
+            workspaces_dir: workspaces.clone(),
             base_size: 64 * 1024 * 1024,
             golden_cow: Some(golden),
         };
-        let slot = create_slot(&config).unwrap();
-        assert!(slot.workspace().join("cow.img").exists());
-        assert!(!nbd_cow::cow::bitmap_path_for(&slot.cow_file()).exists());
-        destroy_slot_sync(slot);
+        let err = create_slot(&config).unwrap_err();
+        assert!(
+            matches!(err, CowPoolError::CowFileCreation(_)),
+            "expected CowFileCreation, got {err}"
+        );
+        let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+        assert_eq!(entries.len(), 0);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -836,6 +836,7 @@ fn create_cow_file(
     std::fs::create_dir_all(workspace).map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
     match &config.golden_cow {
         Some(golden) => {
+            let expected_blocks = validate_base_size(config.base_size)?;
             sparse_copy(golden, cow_file)?;
             ensure_owner_read_write(cow_file)?;
             let cow_file_len = std::fs::metadata(cow_file)
@@ -845,9 +846,10 @@ fn create_cow_file(
             let golden_bitmap = nbd_cow::cow::bitmap_path_for(golden);
             let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
             sparse_copy(&golden_bitmap, &cow_bitmap)?;
-            validate_cow_bitmap(&cow_bitmap, cow_file_len, config.base_size)?;
+            validate_cow_bitmap(&cow_bitmap, cow_file_len, expected_blocks)?;
         }
         None => {
+            validate_base_size(config.base_size)?;
             let f = std::fs::File::create(cow_file)
                 .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
             f.set_len(config.base_size)
@@ -860,8 +862,18 @@ fn create_cow_file(
 fn validate_cow_bitmap(
     bitmap_path: &Path,
     cow_file_len: u64,
-    base_size: u64,
+    expected_blocks: usize,
 ) -> Result<(), CowPoolError> {
+    nbd_cow::cow::validate_bitmap_cow_coverage(
+        bitmap_path,
+        cow_file_len,
+        nbd_cow::BLOCK_SIZE,
+        expected_blocks,
+    )
+    .map_err(|e| CowPoolError::CowFileCreation(format!("invalid COW bitmap: {e}")))
+}
+
+fn validate_base_size(base_size: u64) -> Result<usize, CowPoolError> {
     if base_size == 0 {
         return Err(CowPoolError::CowFileCreation(
             "base image size is empty".to_string(),
@@ -878,13 +890,7 @@ fn validate_cow_bitmap(
     let expected_blocks = usize::try_from(base_size / block_size).map_err(|_| {
         CowPoolError::CowFileCreation("base image block count is too large".to_string())
     })?;
-    nbd_cow::cow::validate_bitmap_cow_coverage(
-        bitmap_path,
-        cow_file_len,
-        nbd_cow::BLOCK_SIZE,
-        expected_blocks,
-    )
-    .map_err(|e| CowPoolError::CowFileCreation(format!("invalid COW bitmap: {e}")))
+    Ok(expected_blocks)
 }
 
 fn ensure_owner_read_write(path: &Path) -> Result<(), CowPoolError> {
@@ -2036,6 +2042,46 @@ mod tests {
         let meta = std::fs::metadata(&cow_file).unwrap();
         assert_eq!(meta.len(), 64 * 1024 * 1024);
         destroy_slot_sync(slot);
+    }
+
+    #[test]
+    fn create_slot_fresh_mode_rejects_empty_base_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces.clone(),
+            base_size: 0,
+            golden_cow: None,
+        };
+
+        let err = create_slot(&config).unwrap_err();
+
+        assert!(
+            err.to_string().contains("base image size is empty"),
+            "expected empty base size error, got {err}"
+        );
+        let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn create_slot_fresh_mode_rejects_unaligned_base_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspaces = tmp.path().join("workspaces");
+        let config = CowPoolConfig {
+            workspaces_dir: workspaces.clone(),
+            base_size: nbd_cow::BLOCK_SIZE as u64 + 1,
+            golden_cow: None,
+        };
+
+        let err = create_slot(&config).unwrap_err();
+
+        assert!(
+            err.to_string().contains("not a multiple"),
+            "expected unaligned base size error, got {err}"
+        );
+        let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+        assert_eq!(entries.len(), 0);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -110,9 +110,16 @@ fn check_artifact_prerequisites(config: &PrerequisiteConfig<'_>, errors: &mut Ve
     if let Some(snapshot) = config.mode.snapshot() {
         check_readable_file(&snapshot.snapshot_path, "snapshot state", errors);
         check_readable_file(&snapshot.memory_path, "snapshot memory", errors);
-        check_readable_file(&snapshot.cow_path, "snapshot cow", errors);
+        let snapshot_cow_len =
+            check_readable_file(&snapshot.cow_path, "snapshot cow", errors).map(|m| m.len());
         let bitmap_path = nbd_cow::cow::bitmap_path_for(&snapshot.cow_path);
-        check_bitmap_file(&bitmap_path, "snapshot cow bitmap", rootfs_blocks, errors);
+        check_bitmap_file(
+            &bitmap_path,
+            "snapshot cow bitmap",
+            rootfs_blocks,
+            snapshot_cow_len,
+            errors,
+        );
     }
 }
 
@@ -193,12 +200,27 @@ fn check_bitmap_file(
     path: &Path,
     label: &str,
     expected_blocks: Option<usize>,
+    cow_file_len: Option<u64>,
     errors: &mut Vec<String>,
 ) {
-    if check_readable_file(path, label, errors).is_some()
-        && let Some(expected_blocks) = expected_blocks
-        && let Err(e) = nbd_cow::cow::validate_bitmap(path, expected_blocks)
-    {
+    if check_readable_file(path, label, errors).is_none() {
+        return;
+    }
+
+    let Some(expected_blocks) = expected_blocks else {
+        return;
+    };
+
+    let result = match cow_file_len {
+        Some(cow_file_len) => nbd_cow::cow::validate_bitmap_cow_coverage(
+            path,
+            cow_file_len,
+            nbd_cow::BLOCK_SIZE,
+            expected_blocks,
+        ),
+        None => nbd_cow::cow::validate_bitmap(path, expected_blocks),
+    };
+    if let Err(e) = result {
         errors.push(format!("{label} is invalid: {}: {e}", path.display()));
     }
 }
@@ -651,5 +673,28 @@ mod tests {
 
         assert_error_contains(&errors, "snapshot cow bitmap is invalid");
         assert_error_contains(&errors, "bitmap data truncated");
+    }
+
+    #[test]
+    fn restore_mode_rejects_snapshot_cow_too_short_for_dirty_bitmap() {
+        let fixture = ArtifactFixture::new();
+        write_sized_file(&fixture.snapshot.cow_path, 0);
+        write_bitmap_file(&fixture.bitmap_path(), 1, 1);
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_error_contains(&errors, "snapshot cow bitmap is invalid");
+        assert_error_contains(&errors, "dirty bitmap references COW data");
+    }
+
+    #[test]
+    fn restore_mode_accepts_short_snapshot_cow_for_clean_bitmap() {
+        let fixture = ArtifactFixture::new();
+        write_sized_file(&fixture.snapshot.cow_path, 0);
+        write_bitmap_file(&fixture.bitmap_path(), 1, 0);
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_no_errors(&errors);
     }
 }

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -102,14 +102,20 @@ fn prerequisite_result(errors: Vec<String>) -> Result<(), SandboxError> {
 }
 
 fn check_artifact_prerequisites(config: &PrerequisiteConfig<'_>, errors: &mut Vec<String>) {
-    check_executable_file(config.binary_path, "firecracker binary", errors);
-    check_readable_file(config.kernel_path, "kernel", errors);
+    let binary_metadata = check_executable_file(config.binary_path, "firecracker binary", errors);
+    check_non_empty_file_size(
+        config.binary_path,
+        "firecracker binary",
+        binary_metadata,
+        errors,
+    );
+    check_non_empty_readable_file(config.kernel_path, "kernel", errors);
     let rootfs_blocks = check_readable_file(config.rootfs_path, "rootfs", errors)
         .and_then(|metadata| check_rootfs_size(config.rootfs_path, metadata.len(), errors));
 
     if let Some(snapshot) = config.mode.snapshot() {
-        check_readable_file(&snapshot.snapshot_path, "snapshot state", errors);
-        check_readable_file(&snapshot.memory_path, "snapshot memory", errors);
+        check_non_empty_readable_file(&snapshot.snapshot_path, "snapshot state", errors);
+        check_non_empty_readable_file(&snapshot.memory_path, "snapshot memory", errors);
         let snapshot_cow_len =
             check_readable_file(&snapshot.cow_path, "snapshot cow", errors).map(|m| m.len());
         let bitmap_path = nbd_cow::cow::bitmap_path_for(&snapshot.cow_path);
@@ -150,10 +156,33 @@ fn check_readable_file(path: &Path, label: &str, errors: &mut Vec<String>) -> Op
     Some(metadata)
 }
 
-fn check_executable_file(path: &Path, label: &str, errors: &mut Vec<String>) {
-    if let Some(metadata) = check_regular_file(path, label, errors) {
-        check_executable(path, label, &metadata, errors);
+fn check_non_empty_readable_file(
+    path: &Path,
+    label: &str,
+    errors: &mut Vec<String>,
+) -> Option<Metadata> {
+    let metadata = check_readable_file(path, label, errors);
+    check_non_empty_file_size(path, label, metadata, errors)
+}
+
+fn check_non_empty_file_size(
+    path: &Path,
+    label: &str,
+    metadata: Option<Metadata>,
+    errors: &mut Vec<String>,
+) -> Option<Metadata> {
+    let metadata = metadata?;
+    if metadata.len() == 0 {
+        errors.push(format!("{label} is empty: {}", path.display()));
+        return None;
     }
+    Some(metadata)
+}
+
+fn check_executable_file(path: &Path, label: &str, errors: &mut Vec<String>) -> Option<Metadata> {
+    let metadata = check_regular_file(path, label, errors)?;
+    check_executable(path, label, &metadata, errors);
+    Some(metadata)
 }
 
 fn check_executable(path: &Path, label: &str, metadata: &Metadata, errors: &mut Vec<String>) {
@@ -626,6 +655,22 @@ mod tests {
         let errors = artifact_errors(fixture.fresh_config());
 
         assert_error_contains(&errors, "rootfs is empty");
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_empty_boot_and_snapshot_artifacts() {
+        let fixture = ArtifactFixture::new();
+        write_sized_file(&fixture.binary_path, 0);
+        write_sized_file(&fixture.kernel_path, 0);
+        write_sized_file(&fixture.snapshot.snapshot_path, 0);
+        write_sized_file(&fixture.snapshot.memory_path, 0);
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_error_contains(&errors, "firecracker binary is empty");
+        assert_error_contains(&errors, "kernel is empty");
+        assert_error_contains(&errors, "snapshot state is empty");
+        assert_error_contains(&errors, "snapshot memory is empty");
     }
 
     #[test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -1,3 +1,5 @@
+use std::fs::Metadata;
+use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
@@ -72,15 +74,7 @@ pub(crate) async fn check_prerequisites(
 ) -> Result<(), SandboxError> {
     let mut errors = Vec::new();
 
-    check_file_exists(config.binary_path, "firecracker binary", &mut errors);
-    check_executable(config.binary_path, "firecracker binary", &mut errors);
-    check_file_exists(config.kernel_path, "kernel", &mut errors);
-    check_file_exists(config.rootfs_path, "rootfs", &mut errors);
-    if let Some(snapshot) = config.mode.snapshot() {
-        check_file_exists(&snapshot.snapshot_path, "snapshot state", &mut errors);
-        check_file_exists(&snapshot.memory_path, "snapshot memory", &mut errors);
-        check_file_exists(&snapshot.cow_path, "snapshot cow", &mut errors);
-    }
+    check_artifact_prerequisites(config, &mut errors);
     check_kvm(&mut errors);
     let commands = required_commands(config.mode);
     check_required_commands(&commands, &mut errors);
@@ -106,17 +100,73 @@ fn prerequisite_result(errors: Vec<String>) -> Result<(), SandboxError> {
     }
 }
 
-fn check_file_exists(path: &Path, label: &str, errors: &mut Vec<String>) {
-    if !path.exists() {
-        errors.push(format!("{label} not found: {}", path.display()));
+fn check_artifact_prerequisites(config: &PrerequisiteConfig<'_>, errors: &mut Vec<String>) {
+    check_executable_file(config.binary_path, "firecracker binary", errors);
+    check_readable_file(config.kernel_path, "kernel", errors);
+    if let Some(metadata) = check_readable_file(config.rootfs_path, "rootfs", errors) {
+        check_rootfs_size(config.rootfs_path, metadata.len(), errors);
+    }
+
+    if let Some(snapshot) = config.mode.snapshot() {
+        check_readable_file(&snapshot.snapshot_path, "snapshot state", errors);
+        check_readable_file(&snapshot.memory_path, "snapshot memory", errors);
+        check_readable_file(&snapshot.cow_path, "snapshot cow", errors);
+        let bitmap_path = nbd_cow::cow::bitmap_path_for(&snapshot.cow_path);
+        check_readable_file(&bitmap_path, "snapshot cow bitmap", errors);
     }
 }
 
-fn check_executable(path: &Path, label: &str, errors: &mut Vec<String>) {
-    if let Ok(meta) = path.metadata()
-        && meta.permissions().mode() & 0o111 == 0
-    {
+fn check_regular_file(path: &Path, label: &str, errors: &mut Vec<String>) -> Option<Metadata> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => Some(metadata),
+        Ok(_) => {
+            errors.push(format!("{label} is not a regular file: {}", path.display()));
+            None
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            errors.push(format!("{label} not found: {}", path.display()));
+            None
+        }
+        Err(e) => {
+            errors.push(format!("failed to stat {label}: {}: {e}", path.display()));
+            None
+        }
+    }
+}
+
+fn check_readable_file(path: &Path, label: &str, errors: &mut Vec<String>) -> Option<Metadata> {
+    let metadata = check_regular_file(path, label, errors)?;
+    if let Err(e) = std::fs::File::open(path) {
+        errors.push(format!("{label} is not readable: {}: {e}", path.display()));
+        return None;
+    }
+    Some(metadata)
+}
+
+fn check_executable_file(path: &Path, label: &str, errors: &mut Vec<String>) {
+    if let Some(metadata) = check_regular_file(path, label, errors) {
+        check_executable(path, label, &metadata, errors);
+    }
+}
+
+fn check_executable(path: &Path, label: &str, metadata: &Metadata, errors: &mut Vec<String>) {
+    if metadata.permissions().mode() & 0o111 == 0 {
         errors.push(format!("{label} is not executable: {}", path.display()));
+    }
+}
+
+fn check_rootfs_size(path: &Path, size: u64, errors: &mut Vec<String>) {
+    if size == 0 {
+        errors.push(format!("rootfs is empty: {}", path.display()));
+        return;
+    }
+
+    let block_size = nbd_cow::BLOCK_SIZE as u64;
+    if !size.is_multiple_of(block_size) {
+        errors.push(format!(
+            "rootfs size {size} is not a multiple of {block_size} bytes: {}",
+            path.display()
+        ));
     }
 }
 
@@ -166,9 +216,120 @@ fn ensure_runtime_dir(errors: &mut Vec<String>) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::fs::File;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::{Path, PathBuf};
 
     use super::*;
+
+    struct ArtifactFixture {
+        _dir: tempfile::TempDir,
+        binary_path: PathBuf,
+        kernel_path: PathBuf,
+        rootfs_path: PathBuf,
+        snapshot: SnapshotConfig,
+    }
+
+    impl ArtifactFixture {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let binary_path = dir.path().join("firecracker");
+            let kernel_path = dir.path().join("vmlinux");
+            let rootfs_path = dir.path().join("rootfs.ext4");
+            let snapshot_path = dir.path().join("snapshot.bin");
+            let memory_path = dir.path().join("memory.bin");
+            let cow_path = dir.path().join("cow.img");
+            let bitmap_path = nbd_cow::cow::bitmap_path_for(&cow_path);
+
+            write_sized_file(&binary_path, 1);
+            std::fs::set_permissions(&binary_path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod binary");
+            write_sized_file(&kernel_path, 1);
+            write_sized_file(&rootfs_path, nbd_cow::BLOCK_SIZE as u64);
+            write_sized_file(&snapshot_path, 1);
+            write_sized_file(&memory_path, 1);
+            write_sized_file(&cow_path, nbd_cow::BLOCK_SIZE as u64);
+            write_sized_file(&bitmap_path, 8);
+
+            Self {
+                _dir: dir,
+                binary_path,
+                kernel_path,
+                rootfs_path,
+                snapshot: SnapshotConfig {
+                    snapshot_path,
+                    memory_path,
+                    cow_path,
+                    drive_bind_path: PathBuf::from("/tmp/cow-device-bind"),
+                    workspace_drive_bind_path: PathBuf::from("/tmp/workspace-device-bind"),
+                    vsock_bind_dir: PathBuf::from("/tmp/vsock"),
+                },
+            }
+        }
+
+        fn bitmap_path(&self) -> PathBuf {
+            nbd_cow::cow::bitmap_path_for(&self.snapshot.cow_path)
+        }
+
+        fn fresh_config(&self) -> PrerequisiteConfig<'_> {
+            PrerequisiteConfig {
+                binary_path: &self.binary_path,
+                kernel_path: &self.kernel_path,
+                rootfs_path: &self.rootfs_path,
+                mode: PrerequisiteMode::FactoryFresh,
+            }
+        }
+
+        fn snapshot_create_config(&self) -> PrerequisiteConfig<'_> {
+            PrerequisiteConfig {
+                binary_path: &self.binary_path,
+                kernel_path: &self.kernel_path,
+                rootfs_path: &self.rootfs_path,
+                mode: PrerequisiteMode::SnapshotCreate,
+            }
+        }
+
+        fn restore_config(&self) -> PrerequisiteConfig<'_> {
+            PrerequisiteConfig {
+                binary_path: &self.binary_path,
+                kernel_path: &self.kernel_path,
+                rootfs_path: &self.rootfs_path,
+                mode: PrerequisiteMode::FactorySnapshotRestore {
+                    snapshot: &self.snapshot,
+                },
+            }
+        }
+    }
+
+    fn write_sized_file(path: &Path, size: u64) {
+        let file = File::create(path).unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+        file.set_len(size)
+            .unwrap_or_else(|e| panic!("set size {}: {e}", path.display()));
+    }
+
+    fn replace_file_with_dir(path: &Path) {
+        std::fs::remove_file(path).unwrap_or_else(|e| panic!("remove {}: {e}", path.display()));
+        std::fs::create_dir(path).unwrap_or_else(|e| panic!("create dir {}: {e}", path.display()));
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|e| panic!("chmod dir {}: {e}", path.display()));
+    }
+
+    fn artifact_errors(config: PrerequisiteConfig<'_>) -> Vec<String> {
+        let mut errors = Vec::new();
+        check_artifact_prerequisites(&config, &mut errors);
+        errors
+    }
+
+    fn assert_no_errors(errors: &[String]) {
+        assert!(errors.is_empty(), "unexpected errors: {errors:#?}");
+    }
+
+    fn assert_error_contains(errors: &[String], expected: &str) {
+        assert!(
+            errors.iter().any(|error| error.contains(expected)),
+            "expected error containing {expected:?}, got {errors:#?}"
+        );
+    }
 
     fn snapshot_config() -> SnapshotConfig {
         SnapshotConfig {
@@ -286,5 +447,123 @@ mod tests {
         }
         .snapshot();
         assert!(matches!(restore_snapshot, Some(s) if std::ptr::eq(s, &snapshot)));
+    }
+
+    #[test]
+    fn valid_fresh_artifacts_pass() {
+        let fixture = ArtifactFixture::new();
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_no_errors(&errors);
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_directory_artifacts() {
+        let fixture = ArtifactFixture::new();
+        let bitmap_path = fixture.bitmap_path();
+        for path in [
+            &fixture.binary_path,
+            &fixture.kernel_path,
+            &fixture.rootfs_path,
+            &fixture.snapshot.snapshot_path,
+            &fixture.snapshot.memory_path,
+            &fixture.snapshot.cow_path,
+            &bitmap_path,
+        ] {
+            replace_file_with_dir(path);
+        }
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_error_contains(&errors, "firecracker binary is not a regular file");
+        assert_error_contains(&errors, "kernel is not a regular file");
+        assert_error_contains(&errors, "rootfs is not a regular file");
+        assert_error_contains(&errors, "snapshot state is not a regular file");
+        assert_error_contains(&errors, "snapshot memory is not a regular file");
+        assert_error_contains(&errors, "snapshot cow is not a regular file");
+        assert_error_contains(&errors, "snapshot cow bitmap is not a regular file");
+    }
+
+    #[test]
+    fn artifact_prerequisites_report_missing_paths() {
+        let fixture = ArtifactFixture::new();
+        std::fs::remove_file(&fixture.kernel_path).expect("remove kernel");
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_error_contains(&errors, "kernel not found");
+    }
+
+    #[test]
+    fn artifact_prerequisites_accept_symlink_to_file() {
+        let fixture = ArtifactFixture::new();
+        let kernel_target = fixture.kernel_path.with_file_name("linked-vmlinux");
+        write_sized_file(&kernel_target, 1);
+        std::fs::remove_file(&fixture.kernel_path).expect("remove kernel");
+        symlink(&kernel_target, &fixture.kernel_path).expect("symlink kernel");
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_no_errors(&errors);
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_symlink_to_directory() {
+        let fixture = ArtifactFixture::new();
+        let kernel_target = fixture.kernel_path.with_file_name("kernel-dir");
+        std::fs::create_dir(&kernel_target).expect("create kernel dir");
+        std::fs::remove_file(&fixture.kernel_path).expect("remove kernel");
+        symlink(&kernel_target, &fixture.kernel_path).expect("symlink kernel");
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_error_contains(&errors, "kernel is not a regular file");
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_non_executable_binary() {
+        let fixture = ArtifactFixture::new();
+        std::fs::set_permissions(&fixture.binary_path, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod binary");
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_error_contains(&errors, "firecracker binary is not executable");
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_empty_rootfs() {
+        let fixture = ArtifactFixture::new();
+        write_sized_file(&fixture.rootfs_path, 0);
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_error_contains(&errors, "rootfs is empty");
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_unaligned_rootfs() {
+        let fixture = ArtifactFixture::new();
+        write_sized_file(&fixture.rootfs_path, nbd_cow::BLOCK_SIZE as u64 + 1);
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_error_contains(&errors, "rootfs size");
+        assert_error_contains(&errors, "not a multiple");
+    }
+
+    #[test]
+    fn restore_mode_requires_snapshot_cow_bitmap() {
+        let fixture = ArtifactFixture::new();
+        std::fs::remove_file(fixture.bitmap_path()).expect("remove bitmap");
+
+        let fresh_errors = artifact_errors(fixture.fresh_config());
+        let snapshot_create_errors = artifact_errors(fixture.snapshot_create_config());
+        let restore_errors = artifact_errors(fixture.restore_config());
+
+        assert_no_errors(&fresh_errors);
+        assert_no_errors(&snapshot_create_errors);
+        assert_error_contains(&restore_errors, "snapshot cow bitmap not found");
     }
 }

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -3,6 +3,7 @@ use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+use nix::unistd::{AccessFlags, access};
 use sandbox::SandboxError;
 
 use crate::config::SnapshotConfig;
@@ -152,6 +153,13 @@ fn check_executable_file(path: &Path, label: &str, errors: &mut Vec<String>) {
 fn check_executable(path: &Path, label: &str, metadata: &Metadata, errors: &mut Vec<String>) {
     if metadata.permissions().mode() & 0o111 == 0 {
         errors.push(format!("{label} is not executable: {}", path.display()));
+        return;
+    }
+    if let Err(e) = access(path, AccessFlags::X_OK) {
+        errors.push(format!(
+            "{label} is not executable: {}: {e}",
+            path.display()
+        ));
     }
 }
 
@@ -525,6 +533,21 @@ mod tests {
     fn artifact_prerequisites_reject_non_executable_binary() {
         let fixture = ArtifactFixture::new();
         std::fs::set_permissions(&fixture.binary_path, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod binary");
+
+        let errors = artifact_errors(fixture.fresh_config());
+
+        assert_error_contains(&errors, "firecracker binary is not executable");
+    }
+
+    #[test]
+    fn artifact_prerequisites_reject_binary_without_current_user_execute_access() {
+        if nix::unistd::geteuid().as_raw() == 0 {
+            return;
+        }
+
+        let fixture = ArtifactFixture::new();
+        std::fs::set_permissions(&fixture.binary_path, std::fs::Permissions::from_mode(0o001))
             .expect("chmod binary");
 
         let errors = artifact_errors(fixture.fresh_config());

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -3,7 +3,7 @@ use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use nix::unistd::{AccessFlags, access};
+use nix::unistd::{AccessFlags, eaccess};
 use sandbox::SandboxError;
 
 use crate::config::SnapshotConfig;
@@ -104,16 +104,15 @@ fn prerequisite_result(errors: Vec<String>) -> Result<(), SandboxError> {
 fn check_artifact_prerequisites(config: &PrerequisiteConfig<'_>, errors: &mut Vec<String>) {
     check_executable_file(config.binary_path, "firecracker binary", errors);
     check_readable_file(config.kernel_path, "kernel", errors);
-    if let Some(metadata) = check_readable_file(config.rootfs_path, "rootfs", errors) {
-        check_rootfs_size(config.rootfs_path, metadata.len(), errors);
-    }
+    let rootfs_blocks = check_readable_file(config.rootfs_path, "rootfs", errors)
+        .and_then(|metadata| check_rootfs_size(config.rootfs_path, metadata.len(), errors));
 
     if let Some(snapshot) = config.mode.snapshot() {
         check_readable_file(&snapshot.snapshot_path, "snapshot state", errors);
         check_readable_file(&snapshot.memory_path, "snapshot memory", errors);
         check_readable_file(&snapshot.cow_path, "snapshot cow", errors);
         let bitmap_path = nbd_cow::cow::bitmap_path_for(&snapshot.cow_path);
-        check_readable_file(&bitmap_path, "snapshot cow bitmap", errors);
+        check_bitmap_file(&bitmap_path, "snapshot cow bitmap", rootfs_blocks, errors);
     }
 }
 
@@ -155,7 +154,7 @@ fn check_executable(path: &Path, label: &str, metadata: &Metadata, errors: &mut 
         errors.push(format!("{label} is not executable: {}", path.display()));
         return;
     }
-    if let Err(e) = access(path, AccessFlags::X_OK) {
+    if let Err(e) = eaccess(path, AccessFlags::X_OK) {
         errors.push(format!(
             "{label} is not executable: {}: {e}",
             path.display()
@@ -163,10 +162,10 @@ fn check_executable(path: &Path, label: &str, metadata: &Metadata, errors: &mut 
     }
 }
 
-fn check_rootfs_size(path: &Path, size: u64, errors: &mut Vec<String>) {
+fn check_rootfs_size(path: &Path, size: u64, errors: &mut Vec<String>) -> Option<usize> {
     if size == 0 {
         errors.push(format!("rootfs is empty: {}", path.display()));
-        return;
+        return None;
     }
 
     let block_size = nbd_cow::BLOCK_SIZE as u64;
@@ -175,6 +174,32 @@ fn check_rootfs_size(path: &Path, size: u64, errors: &mut Vec<String>) {
             "rootfs size {size} is not a multiple of {block_size} bytes: {}",
             path.display()
         ));
+        return None;
+    }
+
+    match usize::try_from(size / block_size) {
+        Ok(blocks) => Some(blocks),
+        Err(_) => {
+            errors.push(format!(
+                "rootfs block count is too large: {}",
+                path.display()
+            ));
+            None
+        }
+    }
+}
+
+fn check_bitmap_file(
+    path: &Path,
+    label: &str,
+    expected_blocks: Option<usize>,
+    errors: &mut Vec<String>,
+) {
+    if check_readable_file(path, label, errors).is_some()
+        && let Some(expected_blocks) = expected_blocks
+        && let Err(e) = nbd_cow::cow::validate_bitmap(path, expected_blocks)
+    {
+        errors.push(format!("{label} is invalid: {}: {e}", path.display()));
     }
 }
 
@@ -257,7 +282,7 @@ mod tests {
             write_sized_file(&snapshot_path, 1);
             write_sized_file(&memory_path, 1);
             write_sized_file(&cow_path, nbd_cow::BLOCK_SIZE as u64);
-            write_sized_file(&bitmap_path, 8);
+            write_bitmap_file(&bitmap_path, 1, 0);
 
             Self {
                 _dir: dir,
@@ -313,6 +338,13 @@ mod tests {
         let file = File::create(path).unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
         file.set_len(size)
             .unwrap_or_else(|e| panic!("set size {}: {e}", path.display()));
+    }
+
+    fn write_bitmap_file(path: &Path, blocks: u64, word: u64) {
+        let mut data = blocks.to_le_bytes().to_vec();
+        data.extend_from_slice(&word.to_le_bytes());
+        std::fs::write(path, data)
+            .unwrap_or_else(|e| panic!("write bitmap {}: {e}", path.display()));
     }
 
     fn replace_file_with_dir(path: &Path) {
@@ -467,6 +499,15 @@ mod tests {
     }
 
     #[test]
+    fn valid_restore_artifacts_pass() {
+        let fixture = ArtifactFixture::new();
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_no_errors(&errors);
+    }
+
+    #[test]
     fn artifact_prerequisites_reject_directory_artifacts() {
         let fixture = ArtifactFixture::new();
         let bitmap_path = fixture.bitmap_path();
@@ -588,5 +629,27 @@ mod tests {
         assert_no_errors(&fresh_errors);
         assert_no_errors(&snapshot_create_errors);
         assert_error_contains(&restore_errors, "snapshot cow bitmap not found");
+    }
+
+    #[test]
+    fn restore_mode_rejects_mismatched_snapshot_cow_bitmap() {
+        let fixture = ArtifactFixture::new();
+        write_bitmap_file(&fixture.bitmap_path(), 2, 0);
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_error_contains(&errors, "snapshot cow bitmap is invalid");
+        assert_error_contains(&errors, "bitmap block count mismatch");
+    }
+
+    #[test]
+    fn restore_mode_rejects_truncated_snapshot_cow_bitmap() {
+        let fixture = ArtifactFixture::new();
+        std::fs::write(fixture.bitmap_path(), 1u64.to_le_bytes()).expect("write bitmap");
+
+        let errors = artifact_errors(fixture.restore_config());
+
+        assert_error_contains(&errors, "snapshot cow bitmap is invalid");
+        assert_error_contains(&errors, "bitmap data truncated");
     }
 }


### PR DESCRIPTION
## Summary

- Validate Firecracker artifact paths as symlink-following regular files before host prerequisite checks.
- Require readable kernel, rootfs, snapshot state, snapshot memory, snapshot COW, and restore bitmap artifacts.
- Require the Firecracker binary to be a regular executable file and validate rootfs size before NBD/COW setup.
- Add tempfile-backed tests for directory paths, symlinks, missing artifacts, rootfs size, and restore bitmap requirements.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc prerequisites`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- pre-commit hooks: cargo fmt/doc/clippy

Closes #17802
