### PR TITLE
refactor: centralize runner execution context test fixtures

### DIFF
--- a/crates/runner/src/cmd/start/tests/support/jobs.rs
+++ b/crates/runner/src/cmd/start/tests/support/jobs.rs
@@ -1,44 +1,12 @@
 use super::super::super::*;
 use super::env::MockRunEnv;
 use crate::provider::JobCandidate;
+use crate::test_fixtures::execution_context_for_test;
 
 pub(in super::super) const TEST_SESSION_LAST_COMPLETED_AT: &str = "2026-05-28T00:00:00.000Z";
 
 pub(in super::super) fn minimal_context(run_id: RunId) -> crate::types::ExecutionContext {
-    crate::types::ExecutionContext {
-        run_id,
-        prompt: "test".into(),
-        append_system_prompt: None,
-        _agent_compose_version_id: None,
-        vars: None,
-        checkpoint_id: None,
-        sandbox_token: "tok".into(),
-        storage_manifest: None,
-        environment: None,
-        resume_session: None,
-        secret_values: None,
-        encrypted_secrets: None,
-        secret_connector_map: None,
-        secret_connector_metadata_map: None,
-        cli_agent_type: String::new(),
-        debug_no_mock_claude: None,
-        debug_no_mock_codex: None,
-        api_start_time: None,
-        user_timezone: None,
-        capture_network_bodies: None,
-        firewalls: None,
-        network_policies: None,
-        disallowed_tools: None,
-        tools: None,
-        settings: None,
-        experimental_profile: None,
-        feature_flags: None,
-        billable_firewalls: vec![],
-        model_usage_provider: None,
-        chat_stream_channel: None,
-        chat_stream_topic: None,
-        chat_stream_token: None,
-    }
+    execution_context_for_test(run_id)
 }
 
 /// Push a job to the mock provider and pre-configure its claim result.

--- a/crates/runner/src/executor/tests/support/context.rs
+++ b/crates/runner/src/executor/tests/support/context.rs
@@ -7,6 +7,7 @@ use crate::types::ExecutionContext;
 pub(in crate::executor::tests) fn minimal_context() -> ExecutionContext {
     let mut ctx = execution_context_for_test(RunId::nil());
     ctx.prompt = "test prompt".into();
+    ctx.sandbox_token = "tok".into();
     ctx
 }
 

--- a/crates/runner/src/executor/tests/support/context.rs
+++ b/crates/runner/src/executor/tests/support/context.rs
@@ -1,43 +1,13 @@
 use std::collections::HashMap;
 
 use crate::ids::RunId;
+use crate::test_fixtures::execution_context_for_test;
 use crate::types::ExecutionContext;
 
 pub(in crate::executor::tests) fn minimal_context() -> ExecutionContext {
-    ExecutionContext {
-        run_id: RunId::nil(),
-        prompt: "test prompt".into(),
-        append_system_prompt: None,
-        _agent_compose_version_id: None,
-        vars: None,
-        checkpoint_id: None,
-        sandbox_token: "tok".into(),
-        storage_manifest: None,
-        environment: None,
-        resume_session: None,
-        secret_values: None,
-        encrypted_secrets: None,
-        secret_connector_map: None,
-        secret_connector_metadata_map: None,
-        cli_agent_type: String::new(),
-        debug_no_mock_claude: None,
-        debug_no_mock_codex: None,
-        api_start_time: None,
-        user_timezone: None,
-        capture_network_bodies: None,
-        firewalls: None,
-        network_policies: None,
-        disallowed_tools: None,
-        tools: None,
-        settings: None,
-        experimental_profile: None,
-        feature_flags: None,
-        billable_firewalls: vec![],
-        model_usage_provider: None,
-        chat_stream_channel: None,
-        chat_stream_topic: None,
-        chat_stream_token: None,
-    }
+    let mut ctx = execution_context_for_test(RunId::nil());
+    ctx.prompt = "test prompt".into();
+    ctx
 }
 
 pub(in crate::executor::tests) fn context_with_env(

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -42,6 +42,8 @@ mod status;
 mod storage_cache;
 mod storage_fingerprints;
 mod telemetry;
+#[cfg(test)]
+mod test_fixtures;
 mod types;
 mod workspace_image_cache;
 mod workspace_mount;

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -353,42 +353,10 @@ impl JobProvider for MockJobProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::execution_context_for_test;
 
     fn minimal_context(run_id: RunId) -> ExecutionContext {
-        ExecutionContext {
-            run_id,
-            prompt: "test".into(),
-            append_system_prompt: None,
-            _agent_compose_version_id: None,
-            vars: None,
-            checkpoint_id: None,
-            sandbox_token: "tok".into(),
-            storage_manifest: None,
-            environment: None,
-            resume_session: None,
-            secret_values: None,
-            encrypted_secrets: None,
-            secret_connector_map: None,
-            secret_connector_metadata_map: None,
-            cli_agent_type: String::new(),
-            debug_no_mock_claude: None,
-            debug_no_mock_codex: None,
-            api_start_time: None,
-            user_timezone: None,
-            capture_network_bodies: None,
-            firewalls: None,
-            network_policies: None,
-            disallowed_tools: None,
-            tools: None,
-            settings: None,
-            experimental_profile: None,
-            feature_flags: None,
-            billable_firewalls: vec![],
-            model_usage_provider: None,
-            chat_stream_channel: None,
-            chat_stream_topic: None,
-            chat_stream_token: None,
-        }
+        execution_context_for_test(run_id)
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -292,42 +292,12 @@ pub trait JobProvider: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::execution_context_for_test;
 
     fn minimal_context(run_id: RunId) -> ExecutionContext {
-        ExecutionContext {
-            run_id,
-            prompt: "test".into(),
-            append_system_prompt: None,
-            _agent_compose_version_id: None,
-            vars: None,
-            checkpoint_id: None,
-            sandbox_token: "sandbox-token".into(),
-            storage_manifest: None,
-            environment: None,
-            resume_session: None,
-            secret_values: None,
-            encrypted_secrets: None,
-            secret_connector_map: None,
-            secret_connector_metadata_map: None,
-            cli_agent_type: String::new(),
-            debug_no_mock_claude: None,
-            debug_no_mock_codex: None,
-            api_start_time: None,
-            user_timezone: None,
-            capture_network_bodies: None,
-            firewalls: None,
-            network_policies: None,
-            disallowed_tools: None,
-            tools: None,
-            settings: None,
-            experimental_profile: None,
-            feature_flags: None,
-            billable_firewalls: vec![],
-            model_usage_provider: None,
-            chat_stream_channel: None,
-            chat_stream_topic: None,
-            chat_stream_token: None,
-        }
+        let mut ctx = execution_context_for_test(run_id);
+        ctx.sandbox_token = "sandbox-token".into();
+        ctx
     }
 
     #[test]

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -1,0 +1,39 @@
+use crate::ids::RunId;
+use crate::types::ExecutionContext;
+
+pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
+    ExecutionContext {
+        run_id,
+        prompt: "test".into(),
+        append_system_prompt: None,
+        _agent_compose_version_id: None,
+        vars: None,
+        checkpoint_id: None,
+        sandbox_token: "tok".into(),
+        storage_manifest: None,
+        environment: None,
+        resume_session: None,
+        secret_values: None,
+        encrypted_secrets: None,
+        secret_connector_map: None,
+        secret_connector_metadata_map: None,
+        cli_agent_type: String::new(),
+        debug_no_mock_claude: None,
+        debug_no_mock_codex: None,
+        api_start_time: None,
+        user_timezone: None,
+        capture_network_bodies: None,
+        firewalls: None,
+        network_policies: None,
+        disallowed_tools: None,
+        tools: None,
+        settings: None,
+        experimental_profile: None,
+        feature_flags: None,
+        billable_firewalls: vec![],
+        model_usage_provider: None,
+        chat_stream_channel: None,
+        chat_stream_topic: None,
+        chat_stream_token: None,
+    }
+}


### PR DESCRIPTION
## Summary

- Add a test-only runner fixture for synthetic `ExecutionContext` values
- Update provider, mock provider, executor, and start-loop test helpers to delegate to the shared fixture
- Keep behavior-dependent prompt/token defaults explicit in local wrappers

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --package runner --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::tests::claimed_job`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::mock::tests::claim`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::env_tests::build_env_json_required_keys`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::env_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner`

Closes #17799