### PR TITLE
fix: preserve chat composer line navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -105,7 +105,7 @@ function mockNavigatorUserAgent(userAgent: string): () => void {
     if (original) {
       Object.defineProperty(navigator, "userAgent", original);
     } else {
-      delete (navigator as Navigator & { userAgent?: string }).userAgent;
+      delete (navigator as { userAgent?: string }).userAgent;
     }
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -95,6 +95,21 @@ function linkByText(text: string): HTMLElement {
   return link;
 }
 
+function mockNavigatorUserAgent(userAgent: string): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(navigator, "userAgent", original);
+    } else {
+      delete (navigator as Navigator & { userAgent?: string }).userAgent;
+    }
+  };
+}
+
 function buildProvider(
   overrides: Partial<ModelProviderResponse> & {
     id: string;
@@ -488,6 +503,32 @@ async function findComposerEditor(): Promise<HTMLElement> {
   });
 }
 
+function placeCaretAfterText(root: HTMLElement, text: string): void {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    const content = node.textContent ?? "";
+    const index = content.indexOf(text);
+    if (index === -1) {
+      continue;
+    }
+
+    const range = document.createRange();
+    range.setStart(node, index + text.length);
+    range.collapse(true);
+    root.focus();
+    const selection = window.getSelection();
+    if (!selection) {
+      throw new Error("Selection API is not available");
+    }
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+    return;
+  }
+  throw new Error(`${text} text node not found`);
+}
+
 beforeEach(() => {
   context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
 });
@@ -695,6 +736,52 @@ describe("chat composer models", () => {
     await waitFor(() => {
       expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
     });
+  });
+
+  it("keeps Shift+Enter and Mac Ctrl+A/Ctrl+E scoped to composer lines", async () => {
+    const restoreUserAgent = mockNavigatorUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+    );
+    try {
+      const user = userEvent.setup({ delay: null });
+      mockOrgModelRoutes("kimi-k2.7-code");
+      mockAgent({ customSkills: [] });
+      context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+        return respond(200, []);
+      });
+
+      detachedSetupPage({
+        context,
+        path: `/agents/${AGENT_ID}/chat`,
+        featureSwitches: { [FeatureSwitchKey.ChatSlashSkillCommands]: true },
+      });
+
+      const editor = await findComposerEditor();
+      await user.click(editor);
+      await user.keyboard("first line{Shift>}{Enter}{/Shift}second line");
+      await user.keyboard("{Control>}a{/Control}X");
+
+      await waitFor(() => {
+        expect(editor.innerHTML).toContain(
+          "<p>first line</p><p>Xsecond line</p>",
+        );
+        expect(editor.innerHTML).not.toContain("<br>");
+      });
+
+      placeCaretAfterText(editor, "Xsecond line");
+      await user.keyboard("{Shift>}{Enter}{/Shift}third line");
+      placeCaretAfterText(editor, "Xsecond line");
+      await user.keyboard("{Control>}e{/Control}Y");
+
+      await waitFor(() => {
+        expect(editor.innerHTML).toContain(
+          "<p>first line</p><p>Xsecond lineY</p><p>third line</p>",
+        );
+        expect(editor.innerHTML).not.toContain("<br>");
+      });
+    } finally {
+      restoreUserAgent();
+    }
   });
 
   it("resolves workspace, user, and thread model choices in the visible picker", async () => {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-skill-composer.tsx
@@ -167,6 +167,84 @@ function isIOS(): boolean {
   );
 }
 
+function isMacKeyboard(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
+function serializeTextblockSegment(
+  node: ProseMirrorNode,
+  from: number,
+  to: number,
+): string {
+  return node.textBetween(from, to, "\n", (leafNode) => {
+    return leafNode.type.name === "hardBreak" ? "\n" : "";
+  });
+}
+
+function resolveMacControlLineNavigation(
+  editor: Editor,
+  event: KeyboardEvent,
+): number | null {
+  if (
+    !isMacKeyboard() ||
+    !event.ctrlKey ||
+    event.metaKey ||
+    event.altKey ||
+    event.shiftKey
+  ) {
+    return null;
+  }
+
+  const key = event.key.toLowerCase();
+  if (key !== "a" && key !== "e") {
+    return null;
+  }
+
+  const { $head } = editor.state.selection;
+  const { parent, parentOffset } = $head;
+  if (!parent.isTextblock) {
+    return null;
+  }
+
+  const beforeCaret = serializeTextblockSegment(parent, 0, parentOffset);
+  if (key === "a") {
+    const previousBreak = beforeCaret.lastIndexOf("\n");
+    return $head.start() + previousBreak + 1;
+  }
+
+  const afterCaret = serializeTextblockSegment(
+    parent,
+    parentOffset,
+    parent.content.size,
+  );
+  const nextBreak = afterCaret.indexOf("\n");
+  return (
+    $head.start() +
+    (nextBreak === -1 ? parent.content.size : parentOffset + nextBreak)
+  );
+}
+
+function insertPlainTextLineBreak(
+  editor: Editor,
+  event: KeyboardEvent,
+): boolean {
+  if (
+    event.key !== "Enter" ||
+    !event.shiftKey ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey
+  ) {
+    return false;
+  }
+
+  event.preventDefault();
+  return editor.commands.splitBlock();
+}
+
 // Replace the active `/query` text with the chosen token (reusing the space that
 // already follows the query, or appending one). The caret is moved past that
 // space so the inserted `/skill` reads as a finished token: typing the next word
@@ -462,6 +540,20 @@ export function TiptapSkillComposer({
   }
 
   function handleEditorKeyDown(event: KeyboardEvent): boolean {
+    // In the chat composer, Enter can be send, so Shift+Enter is the user's
+    // plain-text newline. Keep it as a normal paragraph split rather than a
+    // ProseMirror hardBreak so line navigation stays textarea-like.
+    if (insertPlainTextLineBreak(editor, event)) {
+      return true;
+    }
+
+    const lineNavigationPos = resolveMacControlLineNavigation(editor, event);
+    if (lineNavigationPos !== null) {
+      event.preventDefault();
+      editor.commands.setTextSelection(lineNavigationPos);
+      return true;
+    }
+
     if (
       showSlashSkillMenu &&
       handleSlashMenuKey(event, {


### PR DESCRIPTION
## Summary
- make Shift+Enter in the TipTap chat composer split paragraphs instead of inserting ProseMirror hard breaks
- preserve textarea-like Mac Ctrl+A/Ctrl+E line navigation for composer lines
- add regression coverage for slash-skill composer multiline editing

## Testing
- pnpm -C turbo exec prettier --write apps/platform/src/views/zero-page/tiptap-skill-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm -C turbo exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- git diff --check