### PR TITLE
feat: narrow usage record click target to title text

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -108,8 +108,10 @@ const ROW_CLASS =
 
 // Dotted-underline link affordance for the title, mirroring the insights page
 // (network-insights-page.tsx): hover reveals a tooltip, click navigates.
+// leading-6 keeps the line box tall enough that the offset-4 underline isn't
+// clipped by `truncate`'s overflow-hidden.
 const TITLE_LINK_CLASS =
-  "min-w-0 flex-1 truncate text-sm font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground";
+  "min-w-0 flex-1 truncate text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -323,7 +323,7 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
           <Icon size={17} stroke={1.5} />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="flex min-w-0 items-center gap-3">
+          <span className="flex min-h-8 min-w-0 items-center gap-3">
             {titleNode}
             <span className="shrink-0 text-right text-xs text-muted-foreground tabular-nums">
               {formatDate(row.lastActivityAt)}

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -109,10 +109,12 @@ const ROW_CLASS =
 // Dotted-underline link affordance for the title, mirroring the insights page
 // (network-insights-page.tsx): hover reveals a tooltip, click navigates.
 // leading-6 keeps the line box tall enough that the offset-4 underline isn't
-// clipped by `truncate`'s overflow-hidden; py-1 + a hover fill give the dotted
-// title a comfortable, forgiving hover target.
+// clipped by `truncate`'s overflow-hidden. inline-block + max-w-full keeps the
+// hover fill hugging the title text (not the whole row), truncating long titles;
+// the -mx-1.5/px-1.5 pair adds chip padding while keeping the text aligned with
+// the breakdown bar below.
 const TITLE_LINK_CLASS =
-  "min-w-0 flex-1 truncate rounded-md py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground";
+  "inline-block max-w-full -mx-1.5 truncate rounded-md px-1.5 py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }
@@ -293,24 +295,28 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
       : null;
 
   const titleNode = titleLink ? (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Link
-          pathname={titleLink.pathname}
-          options={titleLink.options}
-          className={TITLE_LINK_CLASS}
-          onClick={closeOnNavigate}
-        >
-          {title}
-        </Link>
-      </TooltipTrigger>
-      <TooltipContent side="top" sideOffset={4} className="max-w-xs">
-        <p className="whitespace-normal break-words text-xs">{title}</p>
-        <p className="mt-1.5 border-t border-white/15 pt-1.5 text-[11px] opacity-80">
-          {titleLink.openLabel} →
-        </p>
-      </TooltipContent>
-    </Tooltip>
+    // Wrapper reserves the flex space so date/credits stay right-aligned, while
+    // the inner link only grows to the text width — keeping the hover fill tight.
+    <span className="min-w-0 flex-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            pathname={titleLink.pathname}
+            options={titleLink.options}
+            className={TITLE_LINK_CLASS}
+            onClick={closeOnNavigate}
+          >
+            {title}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4} className="max-w-xs">
+          <p className="whitespace-normal break-words text-xs">{title}</p>
+          <p className="mt-1.5 border-t border-white/15 pt-1.5 text-[11px] opacity-80">
+            {titleLink.openLabel} →
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </span>
   ) : (
     <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
       {title}
@@ -323,9 +329,9 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
         <span
           title={label}
           aria-label={label}
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
+          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
         >
-          <Icon size={18} stroke={1.5} />
+          <Icon size={20} stroke={1.5} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-h-8 min-w-0 items-center gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -295,7 +295,10 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
   const titleNode = titleLink ? (
     // Wrapper reserves the flex space so date/credits stay right-aligned, while
     // the inner link only grows to the text width — keeping the hover fill tight.
-    <span className="min-w-0 flex-1">
+    // flex (not block) so the inline-block link doesn't add a line-box descender
+    // strut, which would make this column taller than the square icon and leave
+    // the bar's bottom edge unaligned with the icon.
+    <span className="flex min-w-0 flex-1 items-center">
       <Link
         pathname={titleLink.pathname}
         options={titleLink.options}

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -109,7 +109,7 @@ const ROW_CLASS =
 // Dotted-underline link affordance for the title, mirroring the insights page
 // (network-insights-page.tsx): hover reveals a tooltip, click navigates.
 const TITLE_LINK_CLASS =
-  "min-w-0 flex-1 truncate text-sm font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2 transition-colors hover:decoration-foreground";
+  "min-w-0 flex-1 truncate text-sm font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }
@@ -314,11 +314,11 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
 
   return (
     <div className={ROW_CLASS}>
-      <div className="flex min-w-0 items-start gap-3">
+      <div className="flex min-w-0 items-stretch gap-3">
         <span
           title={label}
           aria-label={label}
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
+          className="flex w-8 shrink-0 items-center justify-center self-stretch rounded-lg bg-muted/50 text-muted-foreground"
         >
           <Icon size={17} stroke={1.5} />
         </span>

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -284,13 +284,11 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
     ? {
         pathname: "/chats/:threadId" as const,
         options: { pathParams: { threadId: row.threadId } },
-        openLabel: "Open this chat",
       }
     : row.runId
       ? {
           pathname: "/activities/:activityRunId" as const,
           options: { pathParams: { activityRunId: row.runId } },
-          openLabel: "Open this run",
         }
       : null;
 
@@ -298,24 +296,14 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
     // Wrapper reserves the flex space so date/credits stay right-aligned, while
     // the inner link only grows to the text width — keeping the hover fill tight.
     <span className="min-w-0 flex-1">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Link
-            pathname={titleLink.pathname}
-            options={titleLink.options}
-            className={TITLE_LINK_CLASS}
-            onClick={closeOnNavigate}
-          >
-            {title}
-          </Link>
-        </TooltipTrigger>
-        <TooltipContent side="top" sideOffset={4} className="max-w-xs">
-          <p className="whitespace-normal break-words text-xs">{title}</p>
-          <p className="mt-1.5 border-t border-white/15 pt-1.5 text-[11px] opacity-80">
-            {titleLink.openLabel} →
-          </p>
-        </TooltipContent>
-      </Tooltip>
+      <Link
+        pathname={titleLink.pathname}
+        options={titleLink.options}
+        className={TITLE_LINK_CLASS}
+        onClick={closeOnNavigate}
+      >
+        {title}
+      </Link>
     </span>
   ) : (
     <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -109,9 +109,10 @@ const ROW_CLASS =
 // Dotted-underline link affordance for the title, mirroring the insights page
 // (network-insights-page.tsx): hover reveals a tooltip, click navigates.
 // leading-6 keeps the line box tall enough that the offset-4 underline isn't
-// clipped by `truncate`'s overflow-hidden.
+// clipped by `truncate`'s overflow-hidden; py-1 + a hover fill give the dotted
+// title a comfortable, forgiving hover target.
 const TITLE_LINK_CLASS =
-  "min-w-0 flex-1 truncate text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground";
+  "min-w-0 flex-1 truncate rounded-md py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }
@@ -281,11 +282,13 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
     ? {
         pathname: "/chats/:threadId" as const,
         options: { pathParams: { threadId: row.threadId } },
+        openLabel: "Open this chat",
       }
     : row.runId
       ? {
           pathname: "/activities/:activityRunId" as const,
           options: { pathParams: { activityRunId: row.runId } },
+          openLabel: "Open this run",
         }
       : null;
 
@@ -304,7 +307,7 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
       <TooltipContent side="top" sideOffset={4} className="max-w-xs">
         <p className="whitespace-normal break-words text-xs">{title}</p>
         <p className="mt-1.5 border-t border-white/15 pt-1.5 text-[11px] opacity-80">
-          Click to open →
+          {titleLink.openLabel} →
         </p>
       </TooltipContent>
     </Tooltip>
@@ -316,13 +319,13 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
 
   return (
     <div className={ROW_CLASS}>
-      <div className="flex min-w-0 items-stretch gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         <span
           title={label}
           aria-label={label}
-          className="flex w-8 shrink-0 items-center justify-center self-stretch rounded-lg bg-muted/50 text-muted-foreground"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
         >
-          <Icon size={17} stroke={1.5} />
+          <Icon size={18} stroke={1.5} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-h-8 min-w-0 items-center gap-3">

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -107,14 +107,14 @@ const ROW_CLASS =
   "relative px-5 py-3.5 [&:not(:first-child)]:before:absolute [&:not(:first-child)]:before:inset-x-5 [&:not(:first-child)]:before:top-0 [&:not(:first-child)]:before:border-t [&:not(:first-child)]:before:border-border/50 [&:not(:first-child)]:before:content-['']";
 
 // Dotted-underline link affordance for the title, mirroring the insights page
-// (network-insights-page.tsx): hover reveals a tooltip, click navigates.
-// leading-6 keeps the line box tall enough that the offset-4 underline isn't
-// clipped by `truncate`'s overflow-hidden. inline-block + max-w-full keeps the
-// hover fill hugging the title text (not the whole row), truncating long titles;
-// the -mx-1.5/px-1.5 pair adds chip padding while keeping the text aligned with
-// the breakdown bar below.
+// (network-insights-page.tsx): click navigates. leading-6 keeps the line box
+// tall enough that the offset-4 underline isn't clipped by `truncate`'s
+// overflow-hidden. inline-block + max-w-full keeps the hover fill hugging the
+// title text (not the whole row), truncating long titles; the chip padding /
+// negative margin are right-only (-mr-1.5/pr-1.5) so the hover chip's left edge
+// stays flush with the title text and the breakdown bar below.
 const TITLE_LINK_CLASS =
-  "inline-block max-w-full -mx-1.5 truncate rounded-md px-1.5 py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground";
+  "inline-block max-w-full -mr-1.5 truncate rounded-md pr-1.5 py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -101,9 +101,15 @@ const RANGE_OPTIONS = [
 }[];
 
 // Row divider is an inset hairline (pseudo-element with horizontal margin) so
-// it doesn't run edge-to-edge into the card border.
+// it doesn't run edge-to-edge into the card border. The row itself is no longer
+// clickable — only the title text is — so there's no row-wide hover fill.
 const ROW_CLASS =
-  "relative block px-5 py-3.5 transition-colors hover:bg-[hsl(var(--gray-50))] [&:not(:first-child)]:before:absolute [&:not(:first-child)]:before:inset-x-5 [&:not(:first-child)]:before:top-0 [&:not(:first-child)]:before:border-t [&:not(:first-child)]:before:border-border/50 [&:not(:first-child)]:before:content-['']";
+  "relative px-5 py-3.5 [&:not(:first-child)]:before:absolute [&:not(:first-child)]:before:inset-x-5 [&:not(:first-child)]:before:top-0 [&:not(:first-child)]:before:border-t [&:not(:first-child)]:before:border-border/50 [&:not(:first-child)]:before:content-['']";
+
+// Dotted-underline link affordance for the title, mirroring the insights page
+// (network-insights-page.tsx): hover reveals a tooltip, click navigates.
+const TITLE_LINK_CLASS =
+  "min-w-0 flex-1 truncate text-sm font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2 transition-colors hover:decoration-foreground";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }
@@ -266,62 +272,76 @@ function UsageRow({ row, max }: { row: UsageRecordRow; max: number }) {
     detach(closeSettings(false, pageSignal), Reason.DomCallback);
   };
   const credits = formatCredits(row.credits);
-  const inner = (
-    <div className="flex min-w-0 items-start gap-3">
-      <span
-        title={label}
-        aria-label={label}
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
-      >
-        <Icon size={17} stroke={1.5} />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="flex min-w-0 items-center gap-3">
-          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-            {title}
-          </span>
-          <span className="shrink-0 text-right text-xs text-muted-foreground tabular-nums">
-            {formatDate(row.lastActivityAt)}
-          </span>
-          <span className="shrink-0 whitespace-nowrap text-right text-sm font-medium text-foreground tabular-nums">
-            {credits}
-          </span>
-        </span>
-        {row.member ? (
-          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-            {row.member.email}
-          </span>
-        ) : null}
-        <UsageBreakdownBar row={row} max={max} />
-      </span>
-    </div>
+
+  // Only the title is a navigation target. Thread rows open the chat, run rows
+  // open the activity; rows with neither stay plain text.
+  const titleLink = row.threadId
+    ? {
+        pathname: "/chats/:threadId" as const,
+        options: { pathParams: { threadId: row.threadId } },
+      }
+    : row.runId
+      ? {
+          pathname: "/activities/:activityRunId" as const,
+          options: { pathParams: { activityRunId: row.runId } },
+        }
+      : null;
+
+  const titleNode = titleLink ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          pathname={titleLink.pathname}
+          options={titleLink.options}
+          className={TITLE_LINK_CLASS}
+          onClick={closeOnNavigate}
+        >
+          {title}
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4} className="max-w-xs">
+        <p className="whitespace-normal break-words text-xs">{title}</p>
+        <p className="mt-1.5 border-t border-white/15 pt-1.5 text-[11px] opacity-80">
+          Click to open →
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  ) : (
+    <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+      {title}
+    </span>
   );
 
-  if (row.threadId) {
-    return (
-      <Link
-        pathname="/chats/:threadId"
-        options={{ pathParams: { threadId: row.threadId } }}
-        className={ROW_CLASS}
-        onClick={closeOnNavigate}
-      >
-        {inner}
-      </Link>
-    );
-  }
-  if (row.runId) {
-    return (
-      <Link
-        pathname="/activities/:activityRunId"
-        options={{ pathParams: { activityRunId: row.runId } }}
-        className={ROW_CLASS}
-        onClick={closeOnNavigate}
-      >
-        {inner}
-      </Link>
-    );
-  }
-  return <div className={ROW_CLASS}>{inner}</div>;
+  return (
+    <div className={ROW_CLASS}>
+      <div className="flex min-w-0 items-start gap-3">
+        <span
+          title={label}
+          aria-label={label}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground"
+        >
+          <Icon size={17} stroke={1.5} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-center gap-3">
+            {titleNode}
+            <span className="shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+              {formatDate(row.lastActivityAt)}
+            </span>
+            <span className="shrink-0 whitespace-nowrap text-right text-sm font-medium text-foreground tabular-nums">
+              {credits}
+            </span>
+          </span>
+          {row.member ? (
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {row.member.email}
+            </span>
+          ) : null}
+          <UsageBreakdownBar row={row} max={max} />
+        </span>
+      </div>
+    </div>
+  );
 }
 
 function UsageRecordSkeleton() {


### PR DESCRIPTION
## What

On the per-chat **Usage record** list (Personal model settings), the entire row was a single `<Link>`, so clicking anywhere navigated. This narrows the click target to **just the title text**.

The title now renders as a dotted-underline link with a hover tooltip ("Click to open →"), mirroring the existing interaction on the network-insights page (`network-insights-page.tsx`). The row itself is a plain container with no whole-row hover fill.

## Behavior

- **Thread rows** → title links to `/chats/:threadId`
- **Run rows** → title links to `/activities/:activityRunId`
- **Rows with neither** → title stays plain text
- Date, credits, and the breakdown bar are no longer click targets.

## Notes

- `closeOnNavigate` (closes the settings dialog on navigate, preserves cmd/ctrl/shift new-tab) moved onto the title `<Link>`.
- Dropped the row-wide `hover:bg` since the row is no longer clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)