### PR TITLE
fix: restore chat thread focus for shortcuts

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -60,6 +60,10 @@ function isDocumentScrollTarget(root: HTMLElement, target: EventTarget | null) {
   );
 }
 
+function hasOpenDialog(doc: Document): boolean {
+  return doc.querySelector('[role="dialog"]') !== null;
+}
+
 function isKeyboardScrollAllowedTarget(
   root: HTMLElement,
   target: EventTarget | null,
@@ -118,6 +122,47 @@ export const setChatKeyboardScrollRoot$ = onRef(
     el.addEventListener("pointerdown", markActiveThread, { signal });
     el.addEventListener("pointerover", markActiveThread, { signal });
     document.addEventListener("keydown", onKeyDown, { signal });
+  }),
+);
+
+export const setMainChatThreadKeyboardFocusRef$ = onRef(
+  command((_, el: HTMLElement, signal: AbortSignal) => {
+    const doc = el.ownerDocument;
+    const win = doc.defaultView;
+
+    const focusMainThreadIfDocumentFocused = (
+      target: EventTarget | null = doc.activeElement,
+    ) => {
+      if (
+        !el.isConnected ||
+        hasOpenDialog(doc) ||
+        !isDocumentScrollTarget(el, target)
+      ) {
+        return;
+      }
+      el.focus({ preventScroll: true });
+    };
+
+    queueMicrotask(() => {
+      if (!signal.aborted) {
+        focusMainThreadIfDocumentFocused();
+      }
+    });
+
+    doc.addEventListener(
+      "focusin",
+      (event) => {
+        focusMainThreadIfDocumentFocused(event.target);
+      },
+      { signal },
+    );
+    win?.addEventListener(
+      "focus",
+      () => {
+        focusMainThreadIfDocumentFocused();
+      },
+      { signal },
+    );
   }),
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -7,6 +7,7 @@ import {
   chatThreadGithubPrsContract,
   chatThreadMarkReadContract,
   chatThreadMessagesContract,
+  chatThreadRenameContract,
   chatThreadsContract,
   type GenerationTemplateRequest,
   type ModelSelectionRequest,
@@ -303,6 +304,9 @@ function mockKeyboardNavigationThreads(): void {
       });
     },
   );
+  context.mocks.api(chatThreadRenameContract.rename, ({ respond }) => {
+    return respond(204);
+  });
 }
 
 function mockActiveRunThread(threadId: string): void {
@@ -3273,6 +3277,65 @@ describe("chat lifecycle", () => {
     expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
       "Current keyboard thread",
     );
+  });
+
+  it("returns document focus to the main chat thread after rename", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockResizeObserver();
+    mockKeyboardNavigationThreads();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Current keyboard thread")).toBeInTheDocument();
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    threadRegion.focus();
+    await user.keyboard("{F2}");
+
+    const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    await fill(
+      within(dialog).getByPlaceholderText("Chat title"),
+      "Renamed keyboard thread",
+    );
+    click(buttonByText("Rename"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Rename chat" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const previousBodyTabIndex = document.body.getAttribute("tabindex");
+    try {
+      document.body.tabIndex = -1;
+      document.body.focus();
+      await waitFor(() => {
+        expect(document.activeElement).toBe(threadRegion);
+      });
+    } finally {
+      if (previousBodyTabIndex === null) {
+        document.body.removeAttribute("tabindex");
+      } else {
+        document.body.setAttribute("tabindex", previousBodyTabIndex);
+      }
+    }
+
+    await user.keyboard("{F2}");
+
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "Rename chat",
+    });
+    expect(
+      within(reopenedDialog).getByPlaceholderText("Chat title"),
+    ).toHaveValue("Current keyboard thread");
   });
 
   it("opens run logs from assistant message actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -257,6 +257,7 @@ import {
   navigateToAdjacentThread$,
   scrollCurrentThread$,
   setChatKeyboardScrollRoot$,
+  setMainChatThreadKeyboardFocusRef$,
 } from "../../signals/chat-page/chat-keyboard.ts";
 import { sidebarChatThreads$ } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
@@ -1970,9 +1971,11 @@ function ChatArtifactInboxSlot({
 function ChatThread({
   thread,
   onKeyDown,
+  onFocusFallbackRef,
 }: {
   thread: ChatThreadSignals;
   onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
+  onFocusFallbackRef?: (el: HTMLElement | null) => void;
 }) {
   const openRenameDialog = useOpenCurrentChatThreadRenameDialog(thread);
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
@@ -1993,6 +1996,7 @@ function ChatThread({
       className="flex min-w-0 basis-0 flex-1 flex-col min-h-0 bg-transparent focus:outline-none"
       data-chat-thread-container-id={thread.threadId}
       onKeyDown={handleKeyDown}
+      ref={onFocusFallbackRef}
       tabIndex={-1}
     >
       <ChatThreadContent thread={thread} />
@@ -2100,6 +2104,9 @@ export function ZeroChatThreadPage() {
   const rightThread = useGet(currentRightThread$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
   const setKeyboardScrollRoot = useSet(setChatKeyboardScrollRoot$);
+  const setMainThreadKeyboardFocusRef = useSet(
+    setMainChatThreadKeyboardFocusRef$,
+  );
   const artifactRef = useGet(currentArtifactRef$);
   const artifactInboxThreadId = useGet(currentArtifactInboxThreadId$);
   const presentationEditorUrl = useGet(currentPresentationEditorUrl$);
@@ -2112,8 +2119,7 @@ export function ZeroChatThreadPage() {
   const activePresentationEditorUrl = presentationHtmlEditorEnabled
     ? presentationEditorUrl
     : null;
-  const artifactPanelOpen =
-    artifactRef !== null || artifactInboxThreadId !== null;
+  const artifactPanelOpen = Boolean(artifactRef || artifactInboxThreadId);
   const { style: artifactPanelStyle, transition: artifactTransition } =
     artifactPanelLayout(
       useGet(artifactPanelWidth$),
@@ -2155,6 +2161,7 @@ export function ZeroChatThreadPage() {
               key={leftThread.threadId}
               thread={leftThread}
               onKeyDown={makeChatThreadKeyDown(leftThread)}
+              onFocusFallbackRef={setMainThreadKeyboardFocusRef}
             />
           )}
           {rightThread && (


### PR DESCRIPTION
## Summary
- Focus the main chat thread when document/body/html receives focus so page shortcuts keep working after focus falls out of the thread.
- Wire the fallback through ccstate ref commands and only attach it to the left/main thread.
- Add a platform view test covering rename -> document focus -> F2 shortcut behavior.

## Verification
- pnpm exec prettier --write apps/platform/src/signals/chat-page/chat-keyboard.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm turbo run lint --log-order grouped --concurrency=1
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx

Note: full pnpm check-types reached api#check-types and failed from runner memory pressure (Node heap OOM, then exit 137 even with NODE_OPTIONS=--max-old-space-size=4096). Platform check-types passed separately.