### PR TITLE
fix: keep selected illustration thumbnail in view and add hero click navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1533,6 +1533,91 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("navigates illustration variants by clicking the hero image halves and keeps the selected thumbnail in view", async () => {
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: 200,
+          bottom: 200,
+          width: 200,
+          height: 200,
+          toJSON: () => {
+            return {};
+          },
+        };
+      },
+    });
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatTemplatePicker]: true },
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    await waitFor(() => {
+      expect(tabByText("Illustration")).toBeInTheDocument();
+    });
+    click(tabByText("Illustration"));
+
+    const heroAlt = `${illustrationTemplate.title} illustration preview`;
+    const heroSrc = (index: number) => {
+      return r2ImageTransformUrl(illustrationTemplate.previewImages[index]!, {
+        width: 768,
+        height: 768,
+        quality: 72,
+      });
+    };
+    const lastIndex = illustrationTemplate.previewImages.length - 1;
+
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
+    });
+
+    // Clicking the right half advances to the next variant.
+    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 150 });
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
+    });
+
+    // Switching the variant scrolls the now-selected thumbnail fully into view.
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      inline: "nearest",
+    });
+
+    // Clicking the left half goes back to the previous variant.
+    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 10 });
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
+    });
+
+    // Clicking the left half from the first variant wraps to the last one.
+    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 10 });
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute(
+        "src",
+        heroSrc(lastIndex),
+      );
+    });
+  });
+
   it("keeps historical illustration labels behind the template picker feature switch", async () => {
     const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
     mockChatLifecycle(context, {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1469,9 +1469,13 @@ function PptCard({
 function IllustrationTemplateHero({
   item,
   source,
+  navigable,
+  onNavigate,
 }: {
   item: IllustrationTemplateItem;
   source: string;
+  navigable: boolean;
+  onNavigate: (direction: -1 | 1) => void;
 }) {
   const heroImage = illustrationHeroImageUrl(source);
 
@@ -1484,10 +1488,23 @@ function IllustrationTemplateHero({
         key={source}
         src={heroImage}
         alt={`${item.title} illustration preview`}
-        className="absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100"
+        className={cn(
+          "absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-150 data-[loaded=true]:opacity-100",
+          navigable && "cursor-pointer",
+        )}
         loading="lazy"
         decoding="async"
         fetchPriority="low"
+        onClick={
+          navigable
+            ? (event) => {
+                // Navigate by clicking the image halves instead of overlay
+                // buttons, so the native context menu (copy image) stays usable.
+                const rect = event.currentTarget.getBoundingClientRect();
+                onNavigate(event.clientX - rect.left < rect.width / 2 ? -1 : 1);
+              }
+            : undefined
+        }
         onLoad={(event) => {
           const image = event.currentTarget;
           detach(
@@ -1649,6 +1666,12 @@ async function selectDecodedIllustrationVariant({
   }
 }
 
+function scrollIllustrationThumbnailIntoView(
+  node: HTMLButtonElement | null,
+): void {
+  node?.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
 function IllustrationTemplateCard({
   item,
   selected,
@@ -1665,6 +1688,7 @@ function IllustrationTemplateCard({
   const images = item.previewImages;
   const safeIndex = Math.max(0, Math.min(activeIndex, images.length - 1));
   const heroSource = images[safeIndex] ?? item.previewImage;
+  const hasMultipleVariants = images.length > 1;
 
   return (
     <div
@@ -1676,8 +1700,18 @@ function IllustrationTemplateCard({
           : "border-border hover:border-muted-foreground/30",
       )}
     >
-      <IllustrationTemplateHero item={item} source={heroSource} />
-      {images.length > 1 && (
+      <IllustrationTemplateHero
+        item={item}
+        source={heroSource}
+        navigable={hasMultipleVariants}
+        onNavigate={(direction) => {
+          onVariantChange(
+            item.slug,
+            (safeIndex + direction + images.length) % images.length,
+          );
+        }}
+      />
+      {hasMultipleVariants && (
         <div className="flex items-center gap-2 overflow-x-auto px-3 pt-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {images.map((image, index) => {
             const active = index === safeIndex;
@@ -1689,6 +1723,10 @@ function IllustrationTemplateCard({
               <button
                 key={image}
                 type="button"
+                // Keep the selected thumbnail fully in view when the active
+                // variant changes (e.g. via hero navigation), so later
+                // thumbnails past the clipped strip edge stay reachable.
+                ref={active ? scrollIllustrationThumbnailIntoView : undefined}
                 aria-label={`Show variant ${index + 1}`}
                 aria-pressed={active}
                 className={cn(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1468,16 +1468,26 @@ function PptCard({
 
 function IllustrationTemplateHero({
   item,
+  images,
+  activeIndex,
   source,
-  navigable,
-  onNavigate,
+  onVariantChange,
 }: {
   item: IllustrationTemplateItem;
+  images: readonly string[];
+  activeIndex: number;
   source: string;
-  navigable: boolean;
-  onNavigate: (direction: -1 | 1) => void;
+  onVariantChange: (slug: string, index: number) => void;
 }) {
   const heroImage = illustrationHeroImageUrl(source);
+  const navigable = images.length > 1;
+  const variantAt = (direction: -1 | 1): number => {
+    return (activeIndex + direction + images.length) % images.length;
+  };
+  const preloadNeighbors = (): void => {
+    preloadIllustrationVariant(images, variantAt(1));
+    preloadIllustrationVariant(images, variantAt(-1));
+  };
 
   return (
     <div
@@ -1495,13 +1505,23 @@ function IllustrationTemplateHero({
         loading="lazy"
         decoding="async"
         fetchPriority="low"
+        onMouseEnter={navigable ? preloadNeighbors : undefined}
         onClick={
           navigable
             ? (event) => {
                 // Navigate by clicking the image halves instead of overlay
                 // buttons, so the native context menu (copy image) stays usable.
                 const rect = event.currentTarget.getBoundingClientRect();
-                onNavigate(event.clientX - rect.left < rect.width / 2 ? -1 : 1);
+                const direction =
+                  event.clientX - rect.left < rect.width / 2 ? -1 : 1;
+                selectIllustrationVariant({
+                  card: event.currentTarget.closest<HTMLElement>(
+                    "[data-illustration-template-card]",
+                  ),
+                  index: variantAt(direction),
+                  item,
+                  onVariantChange,
+                });
               }
             : undefined
         }
@@ -1666,6 +1686,58 @@ async function selectDecodedIllustrationVariant({
   }
 }
 
+function selectIllustrationVariant({
+  card,
+  index,
+  item,
+  onVariantChange,
+}: {
+  card: HTMLElement | null;
+  index: number;
+  item: IllustrationTemplateItem;
+  onVariantChange: (slug: string, index: number) => void;
+}): void {
+  const image = item.previewImages[index];
+  if (image === undefined) {
+    return;
+  }
+
+  const imageUrl = illustrationHeroImageUrl(image);
+  // Swap immediately only when the target hero is already decoded; otherwise
+  // decode it off-screen first so the hero never flashes a blank/loading frame.
+  if (card === null || illustrationPreviewImageDecoded(imageUrl)) {
+    onVariantChange(item.slug, index);
+    return;
+  }
+
+  card.dataset.targetVariantIndex = String(index);
+  detach(
+    selectDecodedIllustrationVariant({
+      card,
+      imageUrl,
+      index,
+      item,
+      onVariantChange,
+    }),
+    Reason.DomCallback,
+  );
+}
+
+function preloadIllustrationVariant(
+  images: readonly string[],
+  index: number,
+): void {
+  const image = images[index];
+  if (image === undefined) {
+    return;
+  }
+
+  detach(
+    decodeIllustrationPreviewImage(illustrationHeroImageUrl(image)),
+    Reason.DomCallback,
+  );
+}
+
 function scrollIllustrationThumbnailIntoView(
   node: HTMLButtonElement | null,
 ): void {
@@ -1702,14 +1774,10 @@ function IllustrationTemplateCard({
     >
       <IllustrationTemplateHero
         item={item}
+        images={images}
+        activeIndex={safeIndex}
         source={heroSource}
-        navigable={hasMultipleVariants}
-        onNavigate={(direction) => {
-          onVariantChange(
-            item.slug,
-            (safeIndex + direction + images.length) % images.length,
-          );
-        }}
+        onVariantChange={onVariantChange}
       />
       {hasMultipleVariants && (
         <div className="flex items-center gap-2 overflow-x-auto px-3 pt-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -1744,30 +1812,14 @@ function IllustrationTemplateCard({
                   );
                 }}
                 onClick={(event) => {
-                  const imageUrl = illustrationHeroImageUrl(image);
-                  const card = event.currentTarget.closest<HTMLElement>(
-                    "[data-illustration-template-card]",
-                  );
-                  if (
-                    card === null ||
-                    index === safeIndex ||
-                    illustrationPreviewImageDecoded(imageUrl)
-                  ) {
-                    onVariantChange(item.slug, index);
-                    return;
-                  }
-
-                  card.dataset.targetVariantIndex = String(index);
-                  detach(
-                    selectDecodedIllustrationVariant({
-                      card,
-                      imageUrl,
-                      index,
-                      item,
-                      onVariantChange,
-                    }),
-                    Reason.DomCallback,
-                  );
+                  selectIllustrationVariant({
+                    card: event.currentTarget.closest<HTMLElement>(
+                      "[data-illustration-template-card]",
+                    ),
+                    index,
+                    item,
+                    onVariantChange,
+                  });
                 }}
               >
                 <img


### PR DESCRIPTION
## Summary

Fixes #17774. In the artifact illustration template card, the variant thumbnail strip clipped thumbnails past the fourth item, making later illustrations unreachable. This change:

- **Auto-scrolls the thumbnail strip** so the currently selected thumbnail is always fully brought into view whenever the active variant changes (including via hero navigation). Implemented with a stable `ref` callback on the active thumbnail that calls `scrollIntoView({ block: "nearest", inline: "nearest" })` — no React hooks (views are hook-free).
- **Adds hero image click navigation**: clicking the left 50% of the main image switches to the previous variant, the right 50% to the next (wraps around). The handler lives directly on the `<img>` and derives the half from `getBoundingClientRect()` + `clientX` — **no overlay `div`s**, so the native image context menu (copy image) keeps working, per the issue's interaction requirement.

## Changes

- `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`
  - `IllustrationTemplateHero` now takes `navigable` + `onNavigate` and handles left/right-half clicks on the image itself.
  - `IllustrationTemplateCard` passes wrap-around navigation and gives the active thumbnail a `scrollIntoView` ref.
- Test added in `chat-composer-models-and-templates.test.tsx` covering hero-half navigation (next/prev/wrap) and that selecting a variant scrolls its thumbnail into view.

## Verification

Dependencies are not installed in this environment, so local checks were not run; relying on the PR CI pipeline (lint/types/tests). Changed files were formatted with Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)