### PR TITLE
fix(mitm-addon): block cleartext firewall credential injection

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -169,6 +169,23 @@ _auth_state: dict[tuple[str, str], _FirewallAuthState] = {}
 _FORCE_REFRESH_COOLDOWN_SECS = 120.0
 
 
+def _non_empty_mapping(value: object) -> bool:
+    return isinstance(value, dict) and bool(value)
+
+
+def auth_config_injects_credentials(auth_config: object) -> bool:
+    """Return whether a firewall auth config can add managed credentials."""
+    if not isinstance(auth_config, dict):
+        return False
+    if _non_empty_mapping(auth_config.get("headers")):
+        return True
+    if _non_empty_mapping(auth_config.get("query")):
+        return True
+    if _non_empty_mapping(auth_config.get("awsSigv4")):
+        return True
+    return isinstance(auth_config.get("base"), str) and auth_config["base"] != ""
+
+
 def _get_auth_state(cache_key: tuple[str, str]) -> _FirewallAuthState:
     state = _auth_state.get(cache_key)
     if state is None:
@@ -238,6 +255,17 @@ def _build_firewall_auth_context(
         secret_connector_metadata_map=vm_info.get("secretConnectorMetadataMap"),
         vars_map=vm_info.get("vars"),
         firewall_billable=bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE]),
+    )
+
+
+def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) -> bool:
+    return auth_config_injects_credentials(
+        {
+            "headers": context.auth_headers,
+            "query": context.auth_query,
+            "awsSigv4": context.auth_aws_sigv4,
+            "base": context.auth_base,
+        }
     )
 
 
@@ -1015,6 +1043,26 @@ def _preflight_firewall_auth(
             allow=context.allow,
             proxy_log_path=context.proxy_log_path,
             firewall_base=context.firewall_base,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+
+    request_scheme = flow.request.scheme.lower()
+    if request_scheme != "https" and _firewall_auth_context_injects_credentials(context):
+        log_proxy_entry(
+            context.proxy_log_path,
+            "warn",
+            "Refusing to inject firewall credentials over non-HTTPS transport",
+            type="firewall",
+            firewall_base=context.firewall_base,
+            request_scheme=request_scheme,
+        )
+        _set_matched_firewall_failure_response(
+            flow,
+            status=403,
+            action="BLOCK",
+            error_code="insecure_transport",
+            message="Firewall credentials cannot be injected over non-HTTPS transport",
+            permission=context.allow.name,
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -5,13 +5,18 @@ import json
 import os
 import re
 import stat
+import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from mitmproxy import ctx
 
 import matching
-from auth import evict_all_cache_keys, evict_stale_cache_keys
+from auth import (
+    auth_config_injects_credentials,
+    evict_all_cache_keys,
+    evict_stale_cache_keys,
+)
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
 
 VmContext = tuple[
@@ -170,6 +175,21 @@ def _resolve_base_url_template(
     return resolved
 
 
+def _validate_credentialed_builtin_base(
+    *,
+    firewall_name: str,
+    base: str,
+    auth_config: object,
+) -> None:
+    if not auth_config_injects_credentials(auth_config):
+        return
+    scheme = urllib.parse.urlsplit(base).scheme.lower()
+    if scheme != "https":
+        raise _FirewallEntryResolutionError(
+            f'builtin firewall "{firewall_name}" credentialed base URL must use https'
+        )
+
+
 def _resolve_builtin_firewall_entry(entry: dict) -> dict:
     raw_name = entry.get("name")
     if not isinstance(raw_name, str) or raw_name == "":
@@ -197,11 +217,17 @@ def _resolve_builtin_firewall_entry(entry: dict) -> dict:
             raise _FirewallEntryResolutionError(
                 f'builtin firewall "{raw_name}" api base must be a string'
             )
-        api["base"] = _resolve_base_url_template(
+        resolved_base = _resolve_base_url_template(
             firewall_name=raw_name,
             base=raw_base,
             vars_map=vars_map,
         )
+        _validate_credentialed_builtin_base(
+            firewall_name=raw_name,
+            base=resolved_base,
+            auth_config=api.get("auth"),
+        )
+        api["base"] = resolved_base
 
     return firewall
 

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -153,6 +153,95 @@ class TestGetVmContext:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.zendesk.com"
 
+    def test_credentialed_builtin_firewall_entry_rejects_http_dynamic_base(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {
+                            "runId": "run-strapi",
+                            "firewalls": [
+                                {
+                                    "kind": "builtin",
+                                    "name": "strapi",
+                                    "baseUrlVars": {
+                                        "STRAPI_BASE_URL": "http://strapi.example.test"
+                                    },
+                                }
+                            ],
+                        }
+                    },
+                    "updatedAt": 0,
+                }
+            )
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert "credentialed base URL must use https" in invalid_vm.message
+
+    def test_credentialed_builtin_firewall_entry_accepts_https_dynamic_base(self, tmp_path):
+        path = tmp_path / "registry.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "vms": {
+                        "10.200.0.1": {
+                            "runId": "run-strapi",
+                            "firewalls": [
+                                {
+                                    "kind": "builtin",
+                                    "name": "strapi",
+                                    "baseUrlVars": {
+                                        "STRAPI_BASE_URL": "https://strapi.example.test"
+                                    },
+                                }
+                            ],
+                        }
+                    },
+                    "updatedAt": 0,
+                }
+            )
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://strapi.example.test")
+
+    def test_inline_firewall_entry_allows_http_base(self, tmp_path):
+        path = tmp_path / "registry.json"
+        write_firewall_registry(path)
+        data = json.loads(path.read_text())
+        firewall = data["vms"]["10.200.0.1"]["firewalls"][0]["firewall"]
+        firewall["apis"][0]["base"] = "http://api.example.com"
+        path.write_text(json.dumps(data))
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, compiled_network_policies = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == "http://api.example.com"
+        assert isinstance(
+            matching.match_compiled_firewall_request(
+                "http://api.example.com/items",
+                "GET",
+                compiled_firewalls,
+                compiled_network_policies,
+            ),
+            matching.FirewallAllow,
+        )
+
     def test_builtin_firewall_entry_missing_dynamic_var_rejects_vm(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -1191,11 +1191,17 @@ async def test_http_host_spoof_does_not_trigger_vm0_api_auto_allow(
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
-        fake_firewall_headers(),
+        fake_firewall_headers() as auth_fetch,
     ):
         await mitm_addon.request(flow)
 
-    assert flow.response is None
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
     assert flow.metadata["firewall_base"] == "http://203.0.113.10/api/runs"
+    assert flow.metadata["firewall_action"] == "BLOCK"
+    assert flow.metadata["firewall_error"] == "insecure_transport"
     assert flow.metadata["original_url"] == "http://203.0.113.10/api/runs/heartbeat"
-    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert "Authorization" not in flow.request.headers
+    body = json.loads(flow.response.content)
+    assert body["error"] == "insecure_transport"

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -502,6 +502,126 @@ async def test_firewall_permission_allows_matched(
     assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
 
 
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+        {"query": {"api_key": "${{ secrets.API_TOKEN }}"}},
+        {
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            }
+        },
+        {"base": "${{ secrets.WEBHOOK_URL }}"},
+    ],
+    ids=["headers", "query", "aws-sigv4", "auth-base"],
+)
+async def test_http_firewall_with_managed_credentials_blocks_before_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    auth_config,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "http://api.github.com",
+                "auth": auth_config,
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        scheme="http",
+        port=80,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/octocat/hello",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "insecure_transport"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "http://api.github.com"
+    assert "Authorization" not in flow.request.headers
+    body = json.loads(flow.response.content)
+    assert body == {
+        "error": "insecure_transport",
+        "message": "Firewall credentials cannot be injected over non-HTTPS transport",
+        "permission": "github",
+        "base": "http://api.github.com",
+    }
+    [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_log_entry["level"] == "warn"
+    assert proxy_log_entry["type"] == "firewall"
+    assert proxy_log_entry["firewall_base"] == "http://api.github.com"
+    assert proxy_log_entry["request_scheme"] == "http"
+
+
+async def test_http_firewall_without_managed_credentials_still_matches(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "http://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        scheme="http",
+        port=80,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/octocat/hello",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_called_once()
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "http://api.github.com"
+    assert "Authorization" not in flow.request.headers
+
+
 async def test_oversized_auth_base_request_does_not_capture_request_body(
     tmp_path, real_flow, mitm_ctx, headers
 ):

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -1237,6 +1237,28 @@ describe("resolveFirewallBaseUrlVars", () => {
     ],
   };
 
+  const strapiFirewall = {
+    name: "strapi",
+    apis: [
+      {
+        base: "${{ vars.STRAPI_BASE_URL }}",
+        auth: {
+          headers: { Authorization: "Bearer ${{ secrets.STRAPI_TOKEN }}" },
+        },
+      },
+    ],
+  };
+
+  const nonCredentialFirewall = {
+    name: "diagnostic",
+    apis: [
+      {
+        base: "${{ vars.DIAGNOSTIC_BASE_URL }}",
+        auth: {},
+      },
+    ],
+  };
+
   it("resolves template base URL with provided vars", () => {
     const result = resolveFirewallBaseUrlVars([zendeskFirewall], {
       ZENDESK_SUBDOMAIN: "mycompany",
@@ -1278,6 +1300,28 @@ describe("resolveFirewallBaseUrlVars", () => {
         ZENDESK_SUBDOMAIN: "bad value with spaces",
       });
     }).toThrow("must not contain whitespace");
+  });
+
+  it("rejects credentialed template base URLs that resolve to http", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([strapiFirewall], {
+        STRAPI_BASE_URL: "http://strapi.example.test",
+      });
+    }).toThrow("credentialed base URL must use https");
+  });
+
+  it("accepts credentialed template base URLs that resolve to https", () => {
+    const result = resolveFirewallBaseUrlVars([strapiFirewall], {
+      STRAPI_BASE_URL: "https://strapi.example.test",
+    });
+    expect(result[0]!.apis[0]!.base).toBe("https://strapi.example.test");
+  });
+
+  it("keeps generic http matching available for non-credential template bases", () => {
+    const result = resolveFirewallBaseUrlVars([nonCredentialFirewall], {
+      DIAGNOSTIC_BASE_URL: "http://diagnostic.example.test",
+    });
+    expect(result[0]!.apis[0]!.base).toBe("http://diagnostic.example.test");
   });
 
   it("preserves auth headers unchanged", () => {

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -657,6 +657,33 @@ export function hasBaseUrlVars(base: string): boolean {
   return BASE_URL_VARS_PATTERN.test(base);
 }
 
+function firewallAuthInjectsCredentials(auth: FirewallApi["auth"]): boolean {
+  return (
+    Object.keys(auth.headers ?? {}).length > 0 ||
+    Object.keys(auth.query ?? {}).length > 0 ||
+    Object.keys(auth.awsSigv4 ?? {}).length > 0 ||
+    (typeof auth.base === "string" && auth.base.length > 0)
+  );
+}
+
+function baseUrlScheme(base: string): string {
+  const schemeEnd = base.indexOf("://");
+  if (schemeEnd === -1) return "";
+  return base.slice(0, schemeEnd).toLowerCase();
+}
+
+function validateCredentialedBaseUrlTransport(
+  base: string,
+  serviceName: string,
+  auth: FirewallApi["auth"],
+): void {
+  if (!firewallAuthInjectsCredentials(auth)) return;
+  if (baseUrlScheme(base) === REQUIRED_AUTH_BASE_URL_SCHEME) return;
+  throw new Error(
+    `Invalid base URL "${base}" in firewall "${serviceName}": credentialed base URL must use https`,
+  );
+}
+
 /**
  * Resolve `${{ vars.X }}` templates in firewall base URLs.
  * Returns a new array with all base URL templates replaced by actual values.
@@ -684,6 +711,7 @@ export function resolveFirewallBaseUrlVars(
           },
         );
         validateBaseUrl(resolved, fw.name);
+        validateCredentialedBaseUrlTransport(resolved, fw.name, api.auth);
         return { ...api, base: resolved };
       }),
     };


### PR DESCRIPTION
## Summary

- Block non-HTTPS matched requests before firewall auth resolution when the matched auth config can inject managed credentials through headers, query params, AWS SigV4, or auth.base.
- Reject credentialed builtin firewall entries whose resolved base URL is non-HTTPS during mitm-addon registry loading.
- Reject credentialed dynamic baseUrlVars in the TypeScript connector resolver while preserving generic HTTP base validation for non-credential firewalls.

Closes #17834

## Testing

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_request_handler_firewall_dispatch.py tests/test_registry_context.py tests/test_request_handler_authority_validation.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/`
- `cd turbo && pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-expander.test.ts`
- `cd turbo && pnpm -F @vm0/connectors lint`
- `cd turbo && pnpm exec prettier --check packages/connectors/src/firewall-types.ts packages/connectors/src/__tests__/firewall-expander.test.ts`

Known base failures, unrelated to this change:

- `cd turbo && pnpm -F @vm0/connectors check-types` fails because `src/firewalls/index.ts` imports `googleCloudDefaultUnknownPolicy`, but `google-cloud.generated.ts` does not export it.
- `cd turbo && pnpm -F @vm0/connectors test` fails in existing Google Cloud default-policy tests and YouTube/Google Maps generated auth expectation tests.
