### PR TITLE
feat(ui): add tablist keyboard navigation to Tabs

### DIFF
--- a/turbo/packages/ui/src/components/ui/tabs.tsx
+++ b/turbo/packages/ui/src/components/ui/tabs.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useRef } from "react";
 import { cn } from "../../lib/utils";
 
 interface TabsContextValue {
@@ -43,14 +43,74 @@ function Tabs({ value, onValueChange, children, className }: TabsProps) {
   );
 }
 
+/**
+ * Resolve the index of the tab to focus next for a roving-tabindex tablist.
+ * Returns null for keys that are not tablist navigation keys.
+ */
+function nextTabIndex(
+  key: string,
+  current: number,
+  total: number,
+): number | null {
+  if (key === "Home") {
+    return 0;
+  }
+  if (key === "End") {
+    return total - 1;
+  }
+  const base = current === -1 ? 0 : current;
+  if (key === "ArrowRight") {
+    return (base + 1) % total;
+  }
+  if (key === "ArrowLeft") {
+    return (base - 1 + total) % total;
+  }
+  return null;
+}
+
 function TabsList({ children, className }: TabsListProps) {
+  const { onValueChange } = useTabsContext();
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const list = listRef.current;
+    if (!list) {
+      return;
+    }
+    const tabs = Array.from(
+      list.querySelectorAll<HTMLButtonElement>('[role="tab"]:not([disabled])'),
+    );
+    if (tabs.length === 0) {
+      return;
+    }
+    const current = tabs.indexOf(
+      list.ownerDocument.activeElement as HTMLButtonElement,
+    );
+    const next = nextTabIndex(event.key, current, tabs.length);
+    if (next === null) {
+      return;
+    }
+    const target = tabs[next];
+    if (!target) {
+      return;
+    }
+    event.preventDefault();
+    target.focus();
+    const value = target.dataset.value;
+    if (value !== undefined) {
+      onValueChange(value);
+    }
+  };
+
   return (
     <div
+      ref={listRef}
       className={cn(
         "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
         className,
       )}
       role="tablist"
+      onKeyDown={handleKeyDown}
     >
       {children}
     </div>
@@ -71,6 +131,8 @@ function TabsTrigger({
       type="button"
       role="tab"
       aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      data-value={value}
       disabled={disabled}
       onClick={() => {
         return onValueChange(value);

--- a/turbo/packages/ui/src/components/ui/tabs.tsx
+++ b/turbo/packages/ui/src/components/ui/tabs.tsx
@@ -69,9 +69,11 @@ function nextTabIndex(
 }
 
 function TabsList({ children, className }: TabsListProps) {
-  const { onValueChange } = useTabsContext();
   const listRef = useRef<HTMLDivElement>(null);
 
+  // Manual activation: arrow keys only move focus between tabs, so a focused
+  // but not-yet-selected tab is a real, visibly-focused state. Selection
+  // happens on Enter/Space/click, which a native <button> already handles.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const list = listRef.current;
     if (!list) {
@@ -96,10 +98,6 @@ function TabsList({ children, className }: TabsListProps) {
     }
     event.preventDefault();
     target.focus();
-    const value = target.dataset.value;
-    if (value !== undefined) {
-      onValueChange(value);
-    }
   };
 
   return (
@@ -132,7 +130,6 @@ function TabsTrigger({
       role="tab"
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
-      data-value={value}
       disabled={disabled}
       onClick={() => {
         return onValueChange(value);


### PR DESCRIPTION
## Problem

In the artifact template picker dialog (and every other `Tabs` instance), the tab bar could not be operated with the keyboard. The shared `Tabs` component (`turbo/packages/ui/src/components/ui/tabs.tsx`) is a hand-rolled tablist that never implemented the WAI-ARIA tab keyboard pattern:

- **No roving tabIndex** — all `role="tab"` buttons were in the Tab order (default `tabIndex=0`).
- **No arrow-key handling** — `TabsTrigger` only had `onClick`, so pressing ← / → on a tab did nothing.
- **No focus indication for an unselected tab** — a focused-but-not-selected tab was unreachable, so it never showed a focus ring.

## Change

Implement the standard tablist keyboard interaction in the shared component, so the fix applies everywhere `Tabs` is used:

- **Roving tabIndex** — only the active tab is in the Tab sequence (`tabIndex=0`); the rest are `-1`. Tab moves into and out of the tablist as a single stop.
- **Arrow navigation (manual activation)** — `ArrowLeft` / `ArrowRight` move focus between (enabled) tabs **without** changing the selection. The focused tab shows its focus ring even when it is not the selected one. This is the WAI-ARIA "manual activation" variant, which suits this dialog because switching a tab re-renders a large template grid.
- **Home / End** — jump focus to the first / last tab.
- **Selection** stays on `Enter` / `Space` / click, handled natively by `<button>`.

Disabled tabs are skipped. No call-site changes required — all usages are horizontal, controlled (`value` / `onValueChange`) tablists.

## Notes

- Keyboard-navigation only. The separate orange focus-ring restyle (issue #17769) is intentionally **not** included here — pending design decision, lands in its own change.
- `role="tabpanel"` / `aria-controls` wiring is out of scope: panels are rendered by call sites, not this component.

## Test plan

- [ ] Open the template picker; Tab into the tab bar (focus lands on selected tab, ring visible).
- [ ] Press ← / → → focus ring moves across tabs, including unselected ones; panel does not change until Enter/Space.
- [ ] Press Enter/Space on a focused tab → it becomes selected and the panel switches; Home/End jump to ends.
- [ ] Tab treats the whole tab bar as one stop, then continues to the search box / cards.
- [ ] Spot-check other tablists (account, connectors, memory, automations) still switch via click and keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)