### PR TITLE
fix(ably-subscriber): track heartbeat from inbound activity

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -17,7 +17,7 @@ use super::handshake::{
 };
 use super::message::{decode_data, message_targets_channel};
 use super::session::{SessionState, TokenRenewalFailure};
-use super::state::{ChannelLifecycleState, idle_deadline, reconnect_spacing_delay, retry_delay};
+use super::state::{ChannelLifecycleState, reconnect_spacing_delay, retry_delay};
 use super::transport::{
     WsRead, WsTransport, WsWrite, connect_and_split, websocket_close_frame_reason,
     websocket_close_reason, websocket_error_reason,
@@ -164,57 +164,52 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         let mut close_before_reconnect = false;
         // Main message processing loop
         loop {
-            if let Some(attach_timed_out) = p.session.clear_elapsed_channel_operation_deadline(
-                Instant::now(),
-                p.timing.channel_retry_timeout,
-            ) {
-                if attach_timed_out {
-                    tracing::warn!(
-                        timeout_ms = p.timing.realtime_request_timeout.as_millis(),
-                        "Channel attach timed out, entering suspended channel retry"
-                    );
-                }
-                continue;
-            }
-
-            if let Some(should_attach) = p.session.clear_elapsed_channel_retry(Instant::now()) {
-                if should_attach
-                    && p.session
-                        .begin_channel_attach(p.timing.realtime_request_timeout)
-                {
-                    match send_attach(&mut p, &mut close_rx).await {
-                        LoopAction::Stop => return,
-                        LoopAction::Reconnect { disconnected_event } => {
-                            record_reconnect_disconnected_event(
-                                &mut disconnected_sent,
-                                disconnected_event,
-                            );
-                            immediate_retry = true;
-                            break;
-                        }
-                        LoopAction::Continue => {}
-                    }
-                }
-                continue;
-            }
-
             let Some(transport) = p.transport.as_mut() else {
                 tracing::warn!("WebSocket transport missing before receive loop");
                 break;
             };
-            let idle_deadline =
-                idle_deadline(p.session.max_idle_interval(), p.timing.heartbeat_margin);
+            let idle_deadline = transport
+                .ws_read
+                .idle_deadline(p.session.max_idle_interval(), p.timing.heartbeat_margin);
 
-            tokio::select! {
+            let event = tokio::select! {
                 biased;
 
                 _ = &mut close_rx => {
+                    ReceiveLoopEvent::CloseRequested
+                }
+
+                _ = sleep_until_optional(p.session.token_renewal_at()), if p.session.token_renewal_at().is_some() => {
+                    ReceiveLoopEvent::TokenRenewal
+                }
+
+                frame = transport.ws_read.next() => {
+                    ReceiveLoopEvent::Frame(frame)
+                }
+
+                _ = sleep_until_optional(idle_deadline.map(|(deadline, _)| deadline)), if idle_deadline.is_some() => {
+                    let Some((_, idle_timeout)) = idle_deadline else {
+                        continue;
+                    };
+                    ReceiveLoopEvent::HeartbeatTimeout { idle_timeout }
+                }
+
+                _ = sleep_until_optional(p.session.channel_operation_deadline()), if p.session.channel_operation_deadline().is_some() => {
+                    ReceiveLoopEvent::ChannelOperationDeadline
+                }
+
+                _ = sleep_until_optional(p.session.channel_retry_at()), if p.session.channel_retry_at().is_some() => {
+                    ReceiveLoopEvent::ChannelRetry
+                }
+            };
+
+            match event {
+                ReceiveLoopEvent::CloseRequested => {
                     tracing::info!("Close requested");
                     send_close_message(&mut p).await;
                     return;
                 }
-
-                _ = sleep_until_optional(p.session.token_renewal_at()), if p.session.token_renewal_at().is_some() => {
+                ReceiveLoopEvent::TokenRenewal => {
                     let connect_timeout = p.timing.connect_timeout;
                     let result = tokio::select! {
                         biased;
@@ -229,36 +224,60 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                         return;
                     }
                 }
-
-                _ = sleep_until_optional(p.session.channel_operation_deadline()), if p.session.channel_operation_deadline().is_some() => {}
-
-                _ = sleep_until_optional(p.session.channel_retry_at()), if p.session.channel_retry_at().is_some() => {}
-
-                frame = transport.ws_read.next() => {
-                    match frame {
-                        Some(Ok(tungstenite::Message::Binary(data))) => {
-                            match decode_msg(&data) {
-                                Ok(msg) => {
-                                    match handle_message(&mut p, msg, &mut close_rx).await {
-                                        LoopAction::Stop => return,
-                                        LoopAction::Reconnect {
-                                            disconnected_event,
-                                        } => {
-                                            record_reconnect_disconnected_event(
-                                                &mut disconnected_sent,
-                                                disconnected_event,
-                                            );
-                                            immediate_retry = true;
-                                            break;
-                                        }
-                                        LoopAction::Continue => {}
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!("Failed to decode message: {e}");
-                                }
+                ReceiveLoopEvent::ChannelOperationDeadline => {
+                    if let Some(attach_timed_out) =
+                        p.session.clear_elapsed_channel_operation_deadline(
+                            Instant::now(),
+                            p.timing.channel_retry_timeout,
+                        )
+                        && attach_timed_out
+                    {
+                        tracing::warn!(
+                            timeout_ms = p.timing.realtime_request_timeout.as_millis(),
+                            "Channel attach timed out, entering suspended channel retry"
+                        );
+                    }
+                }
+                ReceiveLoopEvent::ChannelRetry => {
+                    if let Some(should_attach) =
+                        p.session.clear_elapsed_channel_retry(Instant::now())
+                        && should_attach
+                        && p.session
+                            .begin_channel_attach(p.timing.realtime_request_timeout)
+                    {
+                        match send_attach(&mut p, &mut close_rx).await {
+                            LoopAction::Stop => return,
+                            LoopAction::Reconnect { disconnected_event } => {
+                                record_reconnect_disconnected_event(
+                                    &mut disconnected_sent,
+                                    disconnected_event,
+                                );
+                                immediate_retry = true;
+                                break;
                             }
+                            LoopAction::Continue => {}
                         }
+                    }
+                }
+                ReceiveLoopEvent::Frame(frame) => {
+                    match frame {
+                        Some(Ok(tungstenite::Message::Binary(data))) => match decode_msg(&data) {
+                            Ok(msg) => match handle_message(&mut p, msg, &mut close_rx).await {
+                                LoopAction::Stop => return,
+                                LoopAction::Reconnect { disconnected_event } => {
+                                    record_reconnect_disconnected_event(
+                                        &mut disconnected_sent,
+                                        disconnected_event,
+                                    );
+                                    immediate_retry = true;
+                                    break;
+                                }
+                                LoopAction::Continue => {}
+                            },
+                            Err(e) => {
+                                tracing::warn!("Failed to decode message: {e}");
+                            }
+                        },
                         Some(Ok(tungstenite::Message::Close(frame))) => {
                             let reason = websocket_close_reason(frame.as_ref());
                             if let Some(ref f) = frame {
@@ -269,7 +288,9 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                                     "WebSocket Close frame received",
                                 );
                             } else {
-                                tracing::info!("WebSocket Close frame received without close frame");
+                                tracing::info!(
+                                    "WebSocket Close frame received without close frame"
+                                );
                             }
                             disconnect_reason = Some(reason);
                             immediate_retry = true;
@@ -296,11 +317,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                         }
                     }
                 }
-
-                _ = sleep_until_optional(idle_deadline.map(|(deadline, _)| deadline)), if idle_deadline.is_some() => {
-                    let Some((_, idle_timeout)) = idle_deadline else {
-                        continue;
-                    };
+                ReceiveLoopEvent::HeartbeatTimeout { idle_timeout } => {
                     disconnect_reason = Some(format!("heartbeat timeout after {idle_timeout:?}"));
                     immediate_retry = true;
                     close_before_reconnect = true;
@@ -445,6 +462,15 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
             p.session.mark_reconnect_failed_if_not_suspended();
         }
     }
+}
+
+enum ReceiveLoopEvent {
+    CloseRequested,
+    TokenRenewal,
+    ChannelOperationDeadline,
+    ChannelRetry,
+    Frame(Option<Result<tungstenite::Message, tungstenite::Error>>),
+    HeartbeatTimeout { idle_timeout: Duration },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -164,13 +164,56 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
         let mut close_before_reconnect = false;
         // Main message processing loop
         loop {
-            let Some(transport) = p.transport.as_mut() else {
+            let Some(transport) = p.transport.as_ref() else {
                 tracing::warn!("WebSocket transport missing before receive loop");
                 break;
             };
             let idle_deadline = transport
                 .ws_read
                 .idle_deadline(p.session.max_idle_interval(), p.timing.heartbeat_margin);
+            let heartbeat_elapsed =
+                idle_deadline.is_some_and(|(deadline, _)| deadline <= Instant::now());
+
+            if !heartbeat_elapsed {
+                if let Some(attach_timed_out) = p.session.clear_elapsed_channel_operation_deadline(
+                    Instant::now(),
+                    p.timing.channel_retry_timeout,
+                ) {
+                    if attach_timed_out {
+                        tracing::warn!(
+                            timeout_ms = p.timing.realtime_request_timeout.as_millis(),
+                            "Channel attach timed out, entering suspended channel retry"
+                        );
+                    }
+                    continue;
+                }
+
+                if let Some(should_attach) = p.session.clear_elapsed_channel_retry(Instant::now()) {
+                    if should_attach
+                        && p.session
+                            .begin_channel_attach(p.timing.realtime_request_timeout)
+                    {
+                        match send_attach(&mut p, &mut close_rx).await {
+                            LoopAction::Stop => return,
+                            LoopAction::Reconnect { disconnected_event } => {
+                                record_reconnect_disconnected_event(
+                                    &mut disconnected_sent,
+                                    disconnected_event,
+                                );
+                                immediate_retry = true;
+                                break;
+                            }
+                            LoopAction::Continue => {}
+                        }
+                    }
+                    continue;
+                }
+            }
+
+            let Some(transport) = p.transport.as_mut() else {
+                tracing::warn!("WebSocket transport missing before receive loop");
+                break;
+            };
 
             let event = tokio::select! {
                 biased;

--- a/crates/ably-subscriber/src/connection/state.rs
+++ b/crates/ably-subscriber/src/connection/state.rs
@@ -110,11 +110,12 @@ pub(super) fn checked_deadline_from(start: Instant, duration: Duration) -> Optio
 }
 
 pub(super) fn idle_deadline(
+    last_inbound_activity_at: Instant,
     max_idle_interval: Option<Duration>,
     heartbeat_margin: Duration,
 ) -> Option<(Instant, Duration)> {
     let idle_timeout = max_idle_interval?.checked_add(heartbeat_margin)?;
-    let deadline = checked_deadline_after(idle_timeout)?;
+    let deadline = checked_deadline_from(last_inbound_activity_at, idle_timeout)?;
     Some((deadline, idle_timeout))
 }
 
@@ -423,7 +424,10 @@ mod tests {
 
     #[test]
     fn idle_deadline_is_disabled_without_max_idle_interval() {
-        assert_eq!(idle_deadline(None, Duration::from_secs(10)), None);
+        assert_eq!(
+            idle_deadline(Instant::now(), None, Duration::from_secs(10)),
+            None
+        );
     }
 
     #[test]
@@ -479,7 +483,11 @@ mod tests {
         };
 
         let state = ConnState::from_connected(&msg, token, &TimingConfig::default());
-        let _ = idle_deadline(state.max_idle_interval, Duration::from_secs(10));
+        let _ = idle_deadline(
+            Instant::now(),
+            state.max_idle_interval,
+            Duration::from_secs(10),
+        );
         let _ = checked_deadline_from(Instant::now(), state.connection_state_ttl);
         let _ = state.token_renewal_at;
     }

--- a/crates/ably-subscriber/src/connection/transport.rs
+++ b/crates/ably-subscriber/src/connection/transport.rs
@@ -1,19 +1,64 @@
-use futures_util::StreamExt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures_util::{Stream, StreamExt};
+use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 
+use super::state::idle_deadline;
 use crate::Error;
 use crate::types::redact_access_token;
 
 type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
-pub(crate) type WsRead = futures_util::stream::SplitStream<WsStream>;
+type WsSplitRead = futures_util::stream::SplitStream<WsStream>;
 pub(crate) type WsWrite = futures_util::stream::SplitSink<WsStream, tungstenite::Message>;
+
+pub(crate) struct WsRead {
+    inner: WsSplitRead,
+    last_inbound_activity_at: Instant,
+}
+
+impl WsRead {
+    fn new(inner: WsSplitRead) -> Self {
+        Self {
+            inner,
+            last_inbound_activity_at: Instant::now(),
+        }
+    }
+
+    pub(super) fn idle_deadline(
+        &self,
+        max_idle_interval: Option<Duration>,
+        heartbeat_margin: Duration,
+    ) -> Option<(Instant, Duration)> {
+        idle_deadline(
+            self.last_inbound_activity_at,
+            max_idle_interval,
+            heartbeat_margin,
+        )
+    }
+}
+
+impl Stream for WsRead {
+    type Item = Result<tungstenite::Message, tungstenite::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let result = Pin::new(&mut self.inner).poll_next(cx);
+        if matches!(&result, Poll::Ready(Some(Ok(_)))) {
+            self.last_inbound_activity_at = Instant::now();
+        }
+        result
+    }
+}
 
 pub(super) async fn connect_and_split(url: &str) -> Result<(WsWrite, WsRead), Error> {
     let (ws, _resp) = tokio_tungstenite::connect_async(url).await?;
-    Ok(ws.split())
+    let (ws_write, ws_read) = ws.split();
+    Ok((ws_write, WsRead::new(ws_read)))
 }
 
 pub(crate) struct WsTransport {

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -143,6 +143,40 @@ async fn expect_websocket_close_frame(ws: &mut WsStream) -> Result<(), Box<dyn s
     Ok(())
 }
 
+async fn expect_websocket_close_frame_while_ignoring_attach(
+    ws: &mut WsStream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let frame = ws
+                .next()
+                .await
+                .ok_or_else(|| std::io::Error::other("websocket closed before close frame"))??;
+            match frame {
+                tungstenite::Message::Close(_) => return Ok(()),
+                tungstenite::Message::Binary(data) => {
+                    let msg = decode_msg(&data)?;
+                    if msg.action != action::ATTACH {
+                        return Err(std::io::Error::other(format!(
+                            "expected ATTACH or close frame, got action {}",
+                            msg.action
+                        ))
+                        .into());
+                    }
+                }
+                other => {
+                    return Err(std::io::Error::other(format!(
+                        "expected ATTACH or close frame, got {other:?}"
+                    ))
+                    .into());
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| std::io::Error::other("timed out waiting for websocket close frame"))?
+}
+
 async fn expect_websocket_closed(ws: &mut WsStream) -> Result<(), Box<dyn std::error::Error>> {
     let frame = tokio::time::timeout(Duration::from_secs(5), ws.next())
         .await
@@ -2874,6 +2908,119 @@ async fn detached_while_attaching_suspends_and_retries_attach() {
         .unwrap();
     match event {
         Event::Message(msg) => assert_eq!(msg.name.as_deref(), Some("after-channel-retry")),
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn channel_retry_timers_do_not_extend_heartbeat_deadline() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    max_idle_interval_ms: 80,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for reattach")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for retry attach")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+
+        expect_websocket_close_frame_while_ignoring_attach(&mut conn)
+            .await
+            .unwrap();
+
+        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-channel-retry-heartbeat",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.heartbeat_margin = Duration::from_millis(40);
+    timing.realtime_request_timeout = Duration::from_millis(30);
+    timing.channel_retry_timeout = Duration::from_millis(30);
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Disconnected { .. }),
+        "expected Disconnected, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after heartbeat reconnect")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after heartbeat reconnect, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after heartbeat reconnect")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-channel-retry-heartbeat"));
+        }
         other => panic!("expected Message, got {other:?}"),
     }
 


### PR DESCRIPTION
## Summary

- track Ably WebSocket liveness on the `WsRead` read half whenever an inbound frame is received
- compute heartbeat deadlines from the last inbound WebSocket activity instead of each event-loop wake
- prioritize heartbeat timeout ahead of channel operation/retry timers while preserving close and token renewal priority
- add a regression integration test for channel retry timers on a silent socket

Fixes #17855.

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber channel_retry_timers_do_not_extend_heartbeat_deadline`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
