### PR TITLE
fix(platform): coordinate template tab focus state with underline

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1906,10 +1906,10 @@ function TemplatePickerTabs({
           <TabsTrigger
             value="slides"
             className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
               selectedCategory === "slides"
                 ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
+                : "border-transparent text-muted-foreground hover:text-foreground focus-visible:border-muted-foreground focus-visible:text-foreground",
             )}
           >
             <IconPresentation
@@ -1928,10 +1928,10 @@ function TemplatePickerTabs({
           <TabsTrigger
             value="illustration"
             className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
               selectedCategory === "illustration"
                 ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
+                : "border-transparent text-muted-foreground hover:text-foreground focus-visible:border-muted-foreground focus-visible:text-foreground",
             )}
           >
             <IconPhoto
@@ -1950,10 +1950,10 @@ function TemplatePickerTabs({
           <TabsTrigger
             value="video"
             className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-0 focus-visible:ring-offset-0",
               selectedCategory === "video"
                 ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
+                : "border-transparent text-muted-foreground hover:text-foreground focus-visible:border-muted-foreground focus-visible:text-foreground",
             )}
           >
             <IconVideo


### PR DESCRIPTION
## Problem

Issue #17769. The artifact template picker tab bar (`Presentation` / `Illustration` / `Video`) is an **underline-style** tablist, but each `TabsTrigger` inherited the shared component's focus ring — `focus-visible:ring-2 ring-ring ring-offset-2`, where `--ring` is `primary-600` (`#EB8868`). On focus that paints an **orange rectangular box** around the whole tab, which clashes with the underline design. It is most obvious on a focused-but-not-selected tab (e.g. `Video` selected, `Presentation` focused).

## Fix

Keep the focus indicator inside the underline language and drop the box. Scoped to `TemplatePickerTabs` only — other tablists keep their default ring (their focus is fine on production).

- `focus-visible:ring-0 focus-visible:ring-offset-0` on every template tab → no orange box.
- Focused **unselected** tab → `focus-visible:border-muted-foreground focus-visible:text-foreground`: a muted underline + darker text, clearly distinct from the solid `foreground` underline of the **selected** tab.
- Selected tab keeps its underline; no extra box on focus.

## Before / After

Focused = `Presentation`, selected = `Video`:

![before-after](https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/00b035f5-c3e0-40e3-804e-82696d3e280d/cmp.png)

## Test plan

- [ ] Open the template picker; keyboard-focus `Presentation` while `Video` is selected → light underline on `Presentation`, solid underline stays on `Video`, no orange box.
- [ ] Focus the selected tab → underline only, no box.
- [ ] Confirm other tablists (account, connectors, memory) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
