### PR TITLE
fix(platform): align template tab focus ring to the tab bar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1906,7 +1906,7 @@ function TemplatePickerTabs({
           <TabsTrigger
             value="slides"
             className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
               selectedCategory === "slides"
                 ? "border-foreground text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
@@ -1928,7 +1928,7 @@ function TemplatePickerTabs({
           <TabsTrigger
             value="illustration"
             className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
               selectedCategory === "illustration"
                 ? "border-foreground text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
@@ -1950,7 +1950,7 @@ function TemplatePickerTabs({
           <TabsTrigger
             value="video"
             className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none",
+              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
               selectedCategory === "video"
                 ? "border-foreground text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## Problem

Issue #17769 — but the fix the team wants is **keep the orange focus ring, fix its alignment**, not remove it.

The template tabs inherited the shared `TabsTrigger` focus ring with `ring-offset-2`, so on focus the orange box floats 4px outside the button and its **bottom edge overshoots the tab bar's divider** into the filter-pill row below — the misalignment in the report.

## Fix

Keep the ring (same `primary-600` color and width); make it **inset with no offset** so it stays inside the tab cell and its bottom edge lines up with the tab bar divider. Scoped to `TemplatePickerTabs`; other tablists are untouched.

```
focus-visible:ring-inset focus-visible:ring-offset-0
```

## Before / After (replica with the real classes + surrounding layout)

Top = current (overshoots below divider), bottom = inset (bottom aligns to divider):

![compare](https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f8c34efa-1d85-4a00-81bb-e74755264266/cmp.png)

## Test plan

- [ ] Focus a template tab → orange ring stays within the tab bar; bottom edge aligns with the divider; no overlap into the filter pills.
- [ ] Other tablists (account, connectors, memory) unchanged.

Note: supersedes #17878 (which removed the ring — wrong direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
