### PR TITLE
fix(guest-common): serialize sandbox telemetry appends

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1300,6 +1300,7 @@ version = "0.2.9"
 dependencies = [
  "chrono",
  "guest-contracts",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/guest-common/Cargo.toml
+++ b/crates/guest-common/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 chrono = { workspace = true, features = ["std", "clock"] }
 guest-contracts.workspace = true
+libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -2,9 +2,13 @@
 
 use crate::log;
 use serde::Serialize;
-use std::io::Write;
-use std::sync::LazyLock;
+use std::fs::File;
+use std::io::{self, Write};
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, RawFd};
 
 static RUN_ID: LazyLock<String> =
     LazyLock::new(|| std::env::var(guest_contracts::env::RUN_ID_ENV).unwrap_or_default());
@@ -18,9 +22,61 @@ static SANDBOX_OPS_LOG: LazyLock<String> = LazyLock::new(|| {
         .into_owned()
 });
 
+static SANDBOX_OPS_APPEND_LOCK: Mutex<()> = Mutex::new(());
+
 /// Path to sandbox operations log file (JSONL format).
 pub fn sandbox_ops_log() -> &'static str {
     &SANDBOX_OPS_LOG
+}
+
+#[cfg(unix)]
+struct FileLockGuard {
+    fd: RawFd,
+}
+
+#[cfg(unix)]
+impl FileLockGuard {
+    fn lock(file: &File) -> io::Result<Self> {
+        let fd = file.as_raw_fd();
+        flock_fd(fd, libc::LOCK_EX)?;
+        Ok(Self { fd })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        let _ = flock_fd(self.fd, libc::LOCK_UN);
+    }
+}
+
+#[cfg(unix)]
+fn flock_fd(fd: RawFd, operation: libc::c_int) -> io::Result<()> {
+    loop {
+        // SAFETY: `fd` is borrowed from an open `File`, and `flock` does not
+        // mutate Rust memory. The caller owns the descriptor for the lock's
+        // lifetime.
+        let result = unsafe { libc::flock(fd, operation) };
+        if result == 0 {
+            return Ok(());
+        }
+
+        let error = io::Error::last_os_error();
+        if error.kind() == io::ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(not(unix))]
+struct FileLockGuard;
+
+#[cfg(not(unix))]
+impl FileLockGuard {
+    fn lock(_file: &File) -> io::Result<Self> {
+        Ok(Self)
+    }
 }
 
 #[derive(Serialize)]
@@ -56,20 +112,28 @@ pub fn record_sandbox_op(
         return;
     }
 
-    let Ok(mut file) = guest_contracts::runtime_paths::open_private_append(path) else {
-        return; // Silently fail if can't open log
-    };
-
-    let Ok(json) = serde_json::to_string(&entry) else {
+    let Ok(mut record) = serde_json::to_vec(&entry) else {
         return;
     };
+    record.push(b'\n');
 
-    let _ = writeln!(file, "{json}");
+    let _ = append_sandbox_op_record(path, &record);
+}
+
+fn append_sandbox_op_record(path: &str, record: &[u8]) -> io::Result<()> {
+    let mut file = guest_contracts::runtime_paths::open_private_append(path)?;
+    let _append_guard = SANDBOX_OPS_APPEND_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _file_lock = FileLockGuard::lock(&file)?;
+
+    file.write_all(record)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
     use std::time::Duration;
 
     #[test]
@@ -89,9 +153,29 @@ mod tests {
         record_sandbox_op("op_a", Duration::from_millis(10), true, None);
         record_sandbox_op("op_b", Duration::from_millis(20), false, Some("fail"));
 
+        const THREAD_COUNT: usize = 8;
+        const RECORDS_PER_THREAD: usize = 64;
+
+        std::thread::scope(|scope| {
+            for thread_index in 0..THREAD_COUNT {
+                scope.spawn(move || {
+                    for record_index in 0..RECORDS_PER_THREAD {
+                        let action_type = format!("op_{thread_index}_{record_index}");
+                        let error = format!("error_{thread_index}_{record_index}");
+                        record_sandbox_op(
+                            &action_type,
+                            Duration::from_millis(record_index as u64),
+                            false,
+                            Some(&error),
+                        );
+                    }
+                });
+            }
+        });
+
         let content = std::fs::read_to_string(log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(lines.len(), 2);
+        assert_eq!(lines.len(), 2 + THREAD_COUNT * RECORDS_PER_THREAD);
 
         let a: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(a["action_type"], "op_a");
@@ -103,6 +187,21 @@ mod tests {
         assert_eq!(b["action_type"], "op_b");
         assert_eq!(b["error"], "fail");
         assert!(!b["success"].as_bool().unwrap());
+
+        let mut actions = HashSet::new();
+        for line in lines {
+            let entry: serde_json::Value = serde_json::from_str(line).unwrap();
+            actions.insert(entry["action_type"].as_str().unwrap().to_string());
+        }
+
+        assert_eq!(actions.len(), 2 + THREAD_COUNT * RECORDS_PER_THREAD);
+        assert!(actions.contains("op_a"));
+        assert!(actions.contains("op_b"));
+        for thread_index in 0..THREAD_COUNT {
+            for record_index in 0..RECORDS_PER_THREAD {
+                assert!(actions.contains(&format!("op_{thread_index}_{record_index}")));
+            }
+        }
 
         let _ = std::fs::remove_file(log_path);
         unsafe {


### PR DESCRIPTION
## Summary
- serialize sandbox operation telemetry appends with a process-global mutex and advisory file lock
- build complete JSONL record buffers before locking/writing
- add concurrent writer coverage for sandbox ops JSONL output

Fixes #17837.

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p guest-common`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent telemetry`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-common --all-targets -- -D warnings`
- pre-commit: cargo fmt, cargo clippy, cargo doc