### PR TITLE
fix: clean up runner e2e zero agents

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2015,7 +2015,7 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
-    timeout-minutes: 5
+    timeout-minutes: 2
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -2047,83 +2047,6 @@ jobs:
           path: /tmp
       - name: Setup test token
         run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-runner.json ~/.vm0/config.json
-      - name: Clean runner E2E zero agents
-        run: |
-          set -euo pipefail
-          token="$(jq -r '.token // empty' ~/.vm0/config.json)"
-          if [ -z "$token" ]; then
-            echo "::error::Missing runner E2E token"
-            exit 1
-          fi
-          token_user_id="$(TOKEN="$token" node -e '
-            try {
-              const token = process.env.TOKEN ?? "";
-              const prefix = "vm0_pat_";
-              if (!token.startsWith(prefix)) process.exit(1);
-              const payloadPart = token.slice(prefix.length).split(".")[1];
-              if (!payloadPart) process.exit(1);
-              const payload = JSON.parse(Buffer.from(payloadPart, "base64url").toString("utf8"));
-              if (payload.scope !== "cli" || !payload.userId) process.exit(1);
-              process.stdout.write(payload.userId);
-            } catch {
-              process.exit(1);
-            }
-          ' || true)"
-          if [ -z "$token_user_id" ]; then
-            echo "::error::Failed to decode runner E2E token user id"
-            exit 1
-          fi
-          cleanup_tmp="$(mktemp -d)"
-          trap 'rm -rf "$cleanup_tmp"' EXIT
-
-          headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
-          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-            headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
-          fi
-
-          agents_file="$cleanup_tmp/agents.json"
-          list_status="$(curl -sS -o "$agents_file" -w "%{http_code}" "${headers[@]}" "${VM0_API_URL}/api/zero/agents")"
-          if [ "$list_status" != "200" ]; then
-            echo "::error::Failed to list runner E2E zero agents: HTTP ${list_status}"
-            cat "$agents_file"
-            exit 1
-          fi
-
-          jq -e 'type == "array"' "$agents_file" >/dev/null
-          listed="$(jq 'length' "$agents_file")"
-          mapfile -t agent_ids < <(jq -r --arg userId "$token_user_id" '.[] | select(.ownerId == $userId) | .agentId // empty' "$agents_file")
-          owned="${#agent_ids[@]}"
-          deleted=0
-          skipped_active=0
-          skipped_foreign=$((listed - owned))
-
-          for agent_id in "${agent_ids[@]}"; do
-            [ -n "$agent_id" ] || continue
-            body_file="$(mktemp "$cleanup_tmp/delete.XXXXXX")"
-            delete_status="$(curl -sS -o "$body_file" -w "%{http_code}" -X DELETE "${headers[@]}" "${VM0_API_URL}/api/zero/agents/${agent_id}" || true)"
-            case "$delete_status" in
-              204)
-                deleted=$((deleted + 1))
-                ;;
-              404)
-                ;;
-              409)
-                skipped_active=$((skipped_active + 1))
-                echo "::warning::Skipped active runner E2E zero agent ${agent_id}"
-                cat "$body_file"
-                ;;
-              *)
-                echo "::error::Failed to delete runner E2E zero agent ${agent_id}: HTTP ${delete_status}"
-                cat "$body_file"
-                exit 1
-                ;;
-            esac
-          done
-
-          echo "Runner E2E zero agent cleanup: listed=${listed} owned=${owned} deleted=${deleted} skipped_active=${skipped_active} skipped_foreign=${skipped_foreign}"
-        env:
-          VM0_API_URL: ${{ needs.deploy-api.outputs.preview-url }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Reset model-first defaults
         run: |
           set -euo pipefail

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2015,7 +2015,7 @@ jobs:
     if: |
       needs.prepare.outputs.job-ref != '' &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -2073,13 +2073,15 @@ jobs:
             echo "::error::Failed to decode runner E2E token user id"
             exit 1
           fi
+          cleanup_tmp="$(mktemp -d)"
+          trap 'rm -rf "$cleanup_tmp"' EXIT
 
           headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
           if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
             headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
           fi
 
-          agents_file="$(mktemp)"
+          agents_file="$cleanup_tmp/agents.json"
           list_status="$(curl -sS -o "$agents_file" -w "%{http_code}" "${headers[@]}" "${VM0_API_URL}/api/zero/agents")"
           if [ "$list_status" != "200" ]; then
             echo "::error::Failed to list runner E2E zero agents: HTTP ${list_status}"
@@ -2097,7 +2099,7 @@ jobs:
 
           for agent_id in "${agent_ids[@]}"; do
             [ -n "$agent_id" ] || continue
-            body_file="$(mktemp)"
+            body_file="$(mktemp "$cleanup_tmp/delete.XXXXXX")"
             delete_status="$(curl -sS -o "$body_file" -w "%{http_code}" -X DELETE "${headers[@]}" "${VM0_API_URL}/api/zero/agents/${agent_id}" || true)"
             case "$delete_status" in
               204)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2047,6 +2047,81 @@ jobs:
           path: /tmp
       - name: Setup test token
         run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-runner.json ~/.vm0/config.json
+      - name: Clean runner E2E zero agents
+        run: |
+          set -euo pipefail
+          token="$(jq -r '.token // empty' ~/.vm0/config.json)"
+          if [ -z "$token" ]; then
+            echo "::error::Missing runner E2E token"
+            exit 1
+          fi
+          token_user_id="$(TOKEN="$token" node -e '
+            try {
+              const token = process.env.TOKEN ?? "";
+              const prefix = "vm0_pat_";
+              if (!token.startsWith(prefix)) process.exit(1);
+              const payloadPart = token.slice(prefix.length).split(".")[1];
+              if (!payloadPart) process.exit(1);
+              const payload = JSON.parse(Buffer.from(payloadPart, "base64url").toString("utf8"));
+              if (payload.scope !== "cli" || !payload.userId) process.exit(1);
+              process.stdout.write(payload.userId);
+            } catch {
+              process.exit(1);
+            }
+          ' || true)"
+          if [ -z "$token_user_id" ]; then
+            echo "::error::Failed to decode runner E2E token user id"
+            exit 1
+          fi
+
+          headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
+          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+            headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+          fi
+
+          agents_file="$(mktemp)"
+          list_status="$(curl -sS -o "$agents_file" -w "%{http_code}" "${headers[@]}" "${VM0_API_URL}/api/zero/agents")"
+          if [ "$list_status" != "200" ]; then
+            echo "::error::Failed to list runner E2E zero agents: HTTP ${list_status}"
+            cat "$agents_file"
+            exit 1
+          fi
+
+          jq -e 'type == "array"' "$agents_file" >/dev/null
+          listed="$(jq 'length' "$agents_file")"
+          mapfile -t agent_ids < <(jq -r --arg userId "$token_user_id" '.[] | select(.ownerId == $userId) | .agentId // empty' "$agents_file")
+          owned="${#agent_ids[@]}"
+          deleted=0
+          skipped_active=0
+          skipped_foreign=$((listed - owned))
+
+          for agent_id in "${agent_ids[@]}"; do
+            [ -n "$agent_id" ] || continue
+            body_file="$(mktemp)"
+            delete_status="$(curl -sS -o "$body_file" -w "%{http_code}" -X DELETE "${headers[@]}" "${VM0_API_URL}/api/zero/agents/${agent_id}" || true)"
+            case "$delete_status" in
+              204)
+                deleted=$((deleted + 1))
+                ;;
+              404)
+                ;;
+              409)
+                skipped_active=$((skipped_active + 1))
+                echo "::warning::Skipped active runner E2E zero agent ${agent_id}"
+                cat "$body_file"
+                ;;
+              *)
+                echo "::error::Failed to delete runner E2E zero agent ${agent_id}: HTTP ${delete_status}"
+                cat "$body_file"
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "Runner E2E zero agent cleanup: listed=${listed} owned=${owned} deleted=${deleted} skipped_active=${skipped_active} skipped_foreign=${skipped_foreign}"
+        env:
+          VM0_API_URL: ${{ needs.deploy-api.outputs.preview-url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Reset model-first defaults
         run: |
           set -euo pipefail

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -133,6 +133,24 @@ zero_curl() {
     curl -fsS "${hdrs[@]}" "$@" "$base$path"
 }
 
+create_private_zero_agent() {
+    local display_name="$1"
+    local payload response agent_id
+
+    payload=$(jq -nc \
+        --arg displayName "$display_name" \
+        '{displayName: $displayName, visibility: "private"}')
+    response=$(zero_curl "/api/zero/agents" -X POST -d "$payload") || return 1
+    agent_id=$(printf '%s' "$response" | jq -r '.agentId // empty')
+    if [[ -z "$agent_id" ]]; then
+        echo "# Failed to extract agentId from zero agent create response" >&2
+        echo "# Response: $response" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$agent_id"
+}
+
 zero_usage_runs_response() {
     local run_id="$1"
     zero_curl "/api/zero/usage/runs?runId=$run_id&pageSize=1"

--- a/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
+++ b/e2e/tests/03-runner/t-codex-zero-byok-smoke.bats
@@ -70,12 +70,17 @@ EOF
     # zero-compose-service.ts updateComposeMetadata.
     _codex_zero_curl "/api/zero/composes/$AGENT_ID/metadata" \
         -X PATCH -d '{"displayName":"BYOK codex e2e"}' >/dev/null
+    _codex_zero_curl "/api/zero/agents/$AGENT_ID" \
+        -X PATCH -d '{"visibility":"private"}' >/dev/null
 }
 
 teardown_file() {
     # Best-effort cleanup; never mask the actual test failure.
     if [[ -n "${THREAD_ID:-}" ]]; then
         _codex_zero_curl "/api/zero/chat-threads/$THREAD_ID" -X DELETE >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${AGENT_ID:-}" ]]; then
+        $ZERO_CLI agent delete "$AGENT_ID" -y >/dev/null 2>&1 || true
     fi
     disable_codex_beta
     if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then

--- a/e2e/tests/03-runner/t30-vm0-model-provider-inject.bats
+++ b/e2e/tests/03-runner/t30-vm0-model-provider-inject.bats
@@ -15,17 +15,15 @@ setup() {
 
 teardown() {
     [ -n "$THREAD_ID" ] && zero_curl "/api/zero/chat-threads/$THREAD_ID" -X DELETE >/dev/null 2>&1 || true
-    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" 2>/dev/null || true
+    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" -y 2>/dev/null || true
 }
 
 @test "model-provider credential is injected into container" {
-    local provider_id create_out
+    local provider_id
     provider_id=$(zero_model_provider_id_by_type "claude-code-oauth-token")
 
-    create_out=$($ZERO_CLI agent create --display-name "e2e-mp-inject-${UNIQUE_ID}")
-    AGENT_ID=$(echo "$create_out" | grep -oP 'Agent ID:\s+\K[a-f0-9-]{36}')
-    [ -n "$AGENT_ID" ] || {
-        echo "# Failed to extract Agent ID from: $create_out" >&2
+    AGENT_ID=$(create_private_zero_agent "e2e-mp-inject-${UNIQUE_ID}") || {
+        echo "# Failed to create private zero agent" >&2
         return 1
     }
 

--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -146,11 +146,8 @@ EOF
 }
 
 @test "firewall: slack default write permission deny in zero run" {
-    local create_out
-    create_out=$($ZERO_CLI agent create --display-name "${AGENT_NAME}-slack-deny")
-    AGENT_ID=$(echo "$create_out" | grep -oP 'Agent ID:\s+\K[a-f0-9-]{36}')
-    [ -n "$AGENT_ID" ] || {
-        echo "# Failed to extract Agent ID from: $create_out" >&2
+    AGENT_ID=$(create_private_zero_agent "${AGENT_NAME}-slack-deny") || {
+        echo "# Failed to create private zero agent" >&2
         return 1
     }
 

--- a/e2e/tests/03-runner/t53-test-oauth-connector.bats
+++ b/e2e/tests/03-runner/t53-test-oauth-connector.bats
@@ -50,7 +50,29 @@ setup_file() {
     cd - >/dev/null
 }
 
+test_oauth_agent_ids_file() {
+    printf '%s\n' "$BATS_FILE_TMPDIR/test-oauth-agent-ids"
+}
+
+track_test_oauth_agent() {
+    local agent_id="$1"
+    [ -n "$agent_id" ] && printf '%s\n' "$agent_id" >> "$(test_oauth_agent_ids_file)"
+}
+
+cleanup_tracked_test_oauth_agents() {
+    local ids_file
+    ids_file="$(test_oauth_agent_ids_file)"
+    [ -f "$ids_file" ] || return 0
+
+    local agent_id
+    while IFS= read -r agent_id; do
+        [ -n "$agent_id" ] && $ZERO_CLI agent delete "$agent_id" -y >/dev/null 2>&1 || true
+    done < "$ids_file"
+}
+
 teardown_file() {
+    cleanup_tracked_test_oauth_agents
+
     $ZERO_CLI secret delete -y TEST_OAUTH_ACCESS_TOKEN 2>/dev/null || true
     $ZERO_CLI secret delete -y TEST_OAUTH_REFRESH_TOKEN 2>/dev/null || true
 
@@ -299,6 +321,7 @@ EOF
         echo "# Failed to extract composeId from compose output"
         return 1
     }
+    track_test_oauth_agent "$COMPOSE_ID"
 
     run enable_test_oauth_for_compose "$COMPOSE_ID"
     echo "$output"
@@ -380,6 +403,7 @@ EOF
         echo "# Failed to extract composeId from compose output"
         return 1
     }
+    track_test_oauth_agent "$COMPOSE_ID"
 
     run enable_test_oauth_for_compose "$COMPOSE_ID"
     echo "$output"

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -27,18 +27,9 @@ setup_file() {
     export ANTHROPIC_PROVIDER_ID
     ANTHROPIC_PROVIDER_ID=$(zero_model_provider_id_by_type "anthropic-api-key")
 
-    # Create a private zero agent for this file so CI does not consume the
-    # shared org's limited public-agent slots.
-    local create_out
-    create_out=$(zero_curl "/api/zero/agents" \
-        -X POST \
-        --data "$(jq -nc \
-            --arg displayName "e2e-billable-${UNIQUE_ID}" \
-            '{displayName: $displayName, visibility: "private"}')")
     export AGENT_ID
-    AGENT_ID=$(echo "$create_out" | jq -r '.agentId // empty')
-    [ -n "$AGENT_ID" ] || {
-        echo "# Failed to extract Agent ID from: $create_out" >&2
+    AGENT_ID=$(create_private_zero_agent "e2e-billable-${UNIQUE_ID}") || {
+        echo "# Failed to create private zero agent" >&2
         return 1
     }
 }

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -27,9 +27,18 @@ setup_file() {
     export ANTHROPIC_PROVIDER_ID
     ANTHROPIC_PROVIDER_ID=$(zero_model_provider_id_by_type "anthropic-api-key")
 
+    # Create a private zero agent for this file so CI does not consume the
+    # shared org's limited public-agent slots.
+    local create_out
+    create_out=$(zero_curl "/api/zero/agents" \
+        -X POST \
+        --data "$(jq -nc \
+            --arg displayName "e2e-billable-${UNIQUE_ID}" \
+            '{displayName: $displayName, visibility: "private"}')")
     export AGENT_ID
-    AGENT_ID=$(create_private_zero_agent "e2e-billable-${UNIQUE_ID}") || {
-        echo "# Failed to create private zero agent" >&2
+    AGENT_ID=$(echo "$create_out" | jq -r '.agentId // empty')
+    [ -n "$AGENT_ID" ] || {
+        echo "# Failed to extract Agent ID from: $create_out" >&2
         return 1
     }
 }

--- a/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
+++ b/e2e/tests/03-runner/t54-vm0-billable-firewall.bats
@@ -47,7 +47,7 @@ teardown_file() {
     for thread_id in $THREAD_IDS; do
         zero_curl "/api/zero/chat-threads/$thread_id" -X DELETE >/dev/null 2>&1 || true
     done
-    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" 2>/dev/null || true
+    [ -n "$AGENT_ID" ] && $ZERO_CLI agent delete "$AGENT_ID" -y 2>/dev/null || true
 }
 
 @test "t54-0: BYOK provider — firewall not billable" {

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -881,6 +881,19 @@ describe("CLI-TEST: test-enable-connector", () => {
       "slack",
     ]);
 
+    const publicAgent = await bdd.createAgent(actor, {
+      displayName: `Public test agent ${actor.userId.slice(-12)}`,
+      visibility: "public",
+    });
+    await authDevice.requestTestEnableConnector(
+      { email: actor.email },
+      { composeId: publicAgent.agentId, connectorTypes: ["github"] },
+      [200],
+    );
+    const updatedPublicAgent = await bdd.readAgent(actor, publicAgent.agentId);
+    expect(updatedPublicAgent.visibility).toBe("private");
+    expect(updatedPublicAgent.displayName).toBe(publicAgent.displayName);
+
     const customEmailCompose = await authDevice.createCompose(
       actor,
       composeContent(`cli-auth-bdd-custom-${actor.userId.slice(-12)}`),

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -908,6 +908,26 @@ describe("CLI-TEST: test-enable-connector", () => {
     });
   });
 
+  it("does not enable connectors for another test user's compose", async () => {
+    const owner = bdd.user();
+    await authDevice.provisionTestOrg(owner);
+    const compose = await authDevice.createCompose(
+      owner,
+      composeContent(`cli-auth-bdd-owner-${owner.userId.slice(-12)}`),
+    );
+
+    const other = bdd.user();
+    await authDevice.provisionTestOrg(other);
+    const response = await authDevice.requestTestEnableConnector(
+      { email: other.email },
+      { composeId: compose.composeId, connectorTypes: ["github"] },
+      [404],
+    );
+    expect(response.body).toStrictEqual({
+      error: `Compose not found: ${compose.composeId}`,
+    });
+  });
+
   it("allows protected preview rewrites for enable-connector", async () => {
     const actor = bdd.user();
     await authDevice.provisionTestOrg(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -869,6 +869,9 @@ describe("CLI-TEST: test-enable-connector", () => {
       connectorTypes: ["github", "slack"],
     });
 
+    const agent = await bdd.readAgent(actor, compose.composeId);
+    expect(agent.visibility).toBe("private");
+
     const userConnectors = await authDevice.readUserConnectors(
       actor,
       compose.composeId,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3484,9 +3484,11 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     expectApiError(revokedPoll.body);
     await runs.requestReadRun(doomed, run.runId, [404]);
     expect((await gh.readInstallation(doomed)).isConnected).toBeFalsy();
-    await expect(
-      runs.listUserPermissionGrants(doomed, sharedAgent.agentId),
-    ).resolves.toStrictEqual([]);
+    await waitForExpectation(async () => {
+      await expect(
+        runs.listUserPermissionGrants(doomed, sharedAgent.agentId),
+      ).resolves.toStrictEqual([]);
+    });
     const peerGrants = await runs.listUserPermissionGrants(
       peer,
       sharedAgent.agentId,

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -406,7 +406,13 @@ const enableTestConnectors$ = command(
         name: agentComposes.name,
       })
       .from(agentComposes)
-      .where(eq(agentComposes.id, bodyResult.data.composeId))
+      .where(
+        and(
+          eq(agentComposes.id, bodyResult.data.composeId),
+          eq(agentComposes.orgId, orgId),
+          eq(agentComposes.userId, userId),
+        ),
+      )
       .limit(1);
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -424,6 +424,7 @@ const enableTestConnectors$ = command(
         orgId: compose.orgId,
         owner: compose.userId,
         name: compose.name,
+        visibility: "private",
       })
       .onConflictDoNothing();
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -426,7 +426,13 @@ const enableTestConnectors$ = command(
         name: compose.name,
         visibility: "private",
       })
-      .onConflictDoNothing();
+      .onConflictDoUpdate({
+        target: zeroAgents.id,
+        set: {
+          visibility: "private",
+          updatedAt: nowDate(),
+        },
+      });
     signal.throwIfAborted();
 
     await writeDb.insert(userConnectors).values(


### PR DESCRIPTION
## Summary
- Make runner E2E zero-agent fixtures private where the tests do not need public visibility, avoiding the shared public-agent quota.
- Make the test-only `test-enable-connector` seed private zero agents and converge existing seeded rows to private.
- Add missing normal teardown deletion for runner E2E agents, including non-interactive `-y` deletes.

## Tests
- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types`
- `pnpm -F api exec vitest src/signals/routes/__tests__/cli-auth.bdd.test.ts --run`
- `bash -n e2e/helpers/setup.bash e2e/tests/03-runner/t42-firewall-placeholder.bats e2e/tests/03-runner/t30-vm0-model-provider-inject.bats e2e/tests/03-runner/t53-test-oauth-connector.bats e2e/tests/03-runner/t54-vm0-billable-firewall.bats e2e/tests/03-runner/t-codex-zero-byok-smoke.bats`
- `git diff --check`

Fixes #17869