### PR TITLE
fix: clarify provider session reconnect tooltip

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -226,7 +226,7 @@ export function connectorExpiryCountdownText(
 
 const reconnectReasonTooltipText = {
   provider_session_expired:
-    "The provider requires sign-in again. Reconnect to continue.",
+    "The provider session expired. Reconnect to continue.",
   authorization_expired_or_revoked:
     "Authorization expired or was revoked. Reconnect to continue.",
   credential_expired: "The stored credential expired. Reconnect to continue.",


### PR DESCRIPTION
## Summary

- Update the provider session reconnect tooltip to say the provider session expired.
- Keep the reconnect call to action unchanged.

## Tests

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`