### PR TITLE
fix: preserve native lightbox media actions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -683,6 +683,14 @@ describe("zero attachment chips", () => {
         screen.getByTestId("artifact-dialog-image-zoom-controls"),
       ).toBeInTheDocument();
     });
+    const lightboxImage = screen.getByTestId("attachment-lightbox-image");
+    expect(lightboxImage.tagName).toBe("IMG");
+    expect(lightboxImage).not.toHaveAttribute("draggable", "false");
+    expect(lightboxImage).toHaveClass("zero-native-media-interaction");
+    expect(lightboxImage).toHaveStyle({
+      pointerEvents: "auto",
+      userSelect: "auto",
+    });
 
     click(screen.getByLabelText("Close"));
 
@@ -841,7 +849,11 @@ describe("zero attachment chips", () => {
       expect(screen.getByText("The rollout is ready.")).toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Share"));
+    const shareLink = screen.getByLabelText("Share");
+    expect(shareLink.tagName).toBe("A");
+    expect(shareLink).toHaveAttribute("href", releaseNotesUrl);
+
+    click(shareLink);
 
     await waitFor(() => {
       expect(screen.getByText("Link copied")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
 import {
   IconBrandGoogleDrive,
   IconDownload,
@@ -109,6 +109,18 @@ export type ArtifactDownloadSyncTarget = {
 
 async function shareArtifactUrl(url: string): Promise<void> {
   await copyAttachmentLinkToClipboard(url);
+}
+
+function isPlainPrimaryLinkClick(
+  event: MouseEvent<HTMLAnchorElement>,
+): boolean {
+  return (
+    event.button === 0 &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  );
 }
 
 function startGoogleDriveConnectAndSync(params: {
@@ -247,9 +259,13 @@ export function ArtifactShareButton({
 }) {
   return (
     <ArtifactActionTooltip label={ariaLabel}>
-      <button
-        type="button"
-        onClick={() => {
+      <a
+        href={publicAttachmentUrl(url)}
+        onClick={(event) => {
+          if (!isPlainPrimaryLinkClick(event)) {
+            return;
+          }
+          event.preventDefault();
           detach(shareArtifactUrl(url), Reason.DomCallback, "artifact share");
         }}
         aria-label={ariaLabel}
@@ -257,7 +273,7 @@ export function ArtifactShareButton({
         className={iconButtonClassName(className)}
       >
         <IconShare size={iconSize} stroke={1.5} />
-      </button>
+      </a>
     </ArtifactActionTooltip>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -18,6 +18,7 @@ import {
 const IMAGE_ZOOM_STEP = 0.15;
 const IMAGE_ZOOM_ANIMATION_MS = 180;
 const IMAGE_ZOOM_ANIMATION_TYPE = "linear";
+const NATIVE_MEDIA_INTERACTION_CLASS = "zero-native-media-interaction";
 
 type ZoomableArtifactImageSurface =
   | "attachment-lightbox"
@@ -153,14 +154,25 @@ export function ZoomableArtifactImageCanvas({
       centerZoomedOut
       smooth
       wheel={{ step: 0.008, wheelDisabled: true }}
-      trackPadPanning={{ disabled: false }}
-      panning={{ allowLeftClickPan: true }}
-      pinch={{ allowPanning: false, step: 5 }}
+      trackPadPanning={{
+        disabled: false,
+        excluded: [NATIVE_MEDIA_INTERACTION_CLASS],
+      }}
+      panning={{
+        allowLeftClickPan: true,
+        excluded: [NATIVE_MEDIA_INTERACTION_CLASS],
+      }}
+      pinch={{
+        allowPanning: false,
+        step: 5,
+        excluded: [NATIVE_MEDIA_INTERACTION_CLASS],
+      }}
       doubleClick={{
         mode: "toggle",
         step: IMAGE_ZOOM_STEP,
         animationTime: IMAGE_ZOOM_ANIMATION_MS,
         animationType: IMAGE_ZOOM_ANIMATION_TYPE,
+        excluded: [NATIVE_MEDIA_INTERACTION_CLASS],
       }}
       zoomAnimation={{
         animationTime: IMAGE_ZOOM_ANIMATION_MS,
@@ -214,13 +226,18 @@ export function ZoomableArtifactImageCanvas({
                 ref={imageRef}
                 src={src}
                 alt={alt}
-                draggable={false}
                 data-testid={imageTestId}
                 onLoad={onLoad}
                 onError={onError}
-                style={{ pointerEvents: "auto" }}
+                style={{
+                  WebkitTouchCallout: "default",
+                  WebkitUserSelect: "auto",
+                  pointerEvents: "auto",
+                  userSelect: "auto",
+                }}
                 className={cn(
-                  "block max-h-full max-w-full select-none object-contain",
+                  "block max-h-full max-w-full object-contain",
+                  NATIVE_MEDIA_INTERACTION_CLASS,
                   imageClassName,
                 )}
               />


### PR DESCRIPTION
## Summary
- let lightbox images receive native browser media interactions by excluding the real img from zoom/pan gesture handlers
- render artifact share controls as anchors while preserving click-to-copy behavior for plain clicks
- add coverage for native image/link affordances in the attachment lightbox

Fixes #17528

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pre-commit: prettier, knip, check-types