### PR TITLE
fix: remove ambiguous presentation template card subtitle

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1434,13 +1434,10 @@ function PptCard({
       )}
     >
       <TemplatePreview item={item} onPreview={onPreview} />
-      <div className="flex flex-1 items-start justify-between gap-3 px-3.5 py-3">
+      <div className="flex flex-1 items-center justify-between gap-3 px-3.5 py-3">
         <div className="min-w-0">
           <p className="truncate text-sm font-semibold text-foreground">
             {item.title}
-          </p>
-          <p className="mt-1 truncate text-xs text-muted-foreground">
-            {formatPresentationTemplateKind(item.templateId)}
           </p>
         </div>
         <div className="flex shrink-0 items-center">


### PR DESCRIPTION
## Summary

Closes #17770.

Presentation template cards in the artifact template picker showed a description/subtitle line under the title with an ambiguous formatted template kind (e.g. `Zhangzara grove`, `Kami deck`). Users couldn't tell whether this was a style name, author, or deck type, so this PR removes it.

The card footer also looked vertically unbalanced (bottom padding appeared taller than the top). With the subtitle gone the footer now holds a single title line, so the content is vertically centered (`items-start` → `items-center`) to keep the spacing balanced.

## Changes

- Remove the subtitle `<p>` rendering `formatPresentationTemplateKind(item.templateId)` from `PptCard` in `zero-chat-composer.tsx`.
- Center the footer content vertically for balanced padding.

`formatPresentationTemplateKind` is kept — it's still used by search matching, the preview dialog, and the selected-template chip.

## Notes

- Scope is limited to the picker cards. The preview dialog's `{kind} · N preview slides` line is intentionally left as-is since the slide count there is informative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)