### PR TITLE
refactor: dispatch trigger callbacks through ccstate

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -857,6 +857,32 @@ describe("Automations API", () => {
       .from(zeroRuns)
       .where(eq(zeroRuns.automationId, healthyId));
     expect(healthyRuns).toHaveLength(1);
+    const healthyRunId = healthyRuns[0]?.id;
+    if (!healthyRunId) {
+      throw new Error("Expected healthy automation run");
+    }
+    const callbacks = await db
+      .select({
+        url: agentRunCallbacks.url,
+        internalKind: agentRunCallbacks.internalKind,
+        payload: agentRunCallbacks.payload,
+      })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, healthyRunId));
+    expect(callbacks).toStrictEqual(
+      expect.arrayContaining([
+        {
+          url: null,
+          internalKind: "trigger:loop",
+          payload: { triggerId: healthyTrigger?.id },
+        },
+      ]),
+    );
+    expect(
+      callbacks.some((callback) => {
+        return callback.url?.endsWith("/api/internal/callbacks/chat");
+      }),
+    ).toBeTruthy();
 
     // The zombies were never touched: still due, never run.
     const zombieTriggers = await db

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -11,7 +11,6 @@ import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
-import { settle } from "../../utils";
 import {
   createBddApi,
   expectApiError,
@@ -24,10 +23,7 @@ import {
   createRunsAutomationsApi,
   uniqueAutomationName,
 } from "./helpers/api-bdd-runs-automations";
-import {
-  callbackDeliveryWithStatus,
-  createWebhookCallbackApi,
-} from "./helpers/api-bdd-webhooks";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 
 /**
  * helper gap:
@@ -59,6 +55,7 @@ const store = createStore();
 const writeDb = store.set(writeDb$);
 const OUTBOX_TEST_FROM = "Zero <bdd-outbox@mail.example.com>";
 const OUTBOX_TEST_CREATED_AT_OFFSET_MS = 10 * 60 * 1000;
+const CHAT_CALLBACK_PATH = "/api/internal/callbacks/chat";
 
 interface SeedEmailOutboxOptions {
   readonly subject: string;
@@ -1491,46 +1488,6 @@ describe("SCHED-02 and CHAIN-SCHEDULE: cron execution of due schedules", () => {
   });
 });
 
-const LOOP_CALLBACK_PATH = "/api/internal/callbacks/trigger/loop";
-const CRON_CALLBACK_PATH = "/api/internal/callbacks/trigger/cron";
-const CHAT_CALLBACK_PATH = "/api/internal/callbacks/chat";
-
-/**
- * Quiet capture handlers for every callback URL a schedule-fired run can
- * carry (trigger reschedule + chat), so terminal dispatch never hits an
- * unhandled MSW route. Returns the captures the chains assert on.
- */
-function captureScheduleCallbackDeliveries(
-  webhooks: ReturnType<typeof createWebhookCallbackApi>,
-) {
-  const loop = webhooks.captureInternalCallbackDeliveries(LOOP_CALLBACK_PATH);
-  const cron = webhooks.captureInternalCallbackDeliveries(CRON_CALLBACK_PATH);
-  const chat = webhooks.captureInternalCallbackDeliveries(CHAT_CALLBACK_PATH);
-  return { loop, cron, chat };
-}
-
-async function waitForCallbackDeliveryWithStatus(
-  deliveries: readonly ReturnType<typeof callbackDeliveryWithStatus>[],
-  status: "completed" | "failed" | "progress",
-): Promise<ReturnType<typeof callbackDeliveryWithStatus>> {
-  let delivery: ReturnType<typeof callbackDeliveryWithStatus> | undefined;
-  await expect
-    .poll(async () => {
-      const result = await settle(
-        Promise.resolve().then(() => {
-          return callbackDeliveryWithStatus(deliveries, status);
-        }),
-      );
-      delivery = result.ok ? result.value : undefined;
-      return delivery !== undefined;
-    })
-    .toBe(true);
-  if (!delivery) {
-    throw new Error(`Expected a captured ${status} callback delivery`);
-  }
-  return delivery;
-}
-
 async function completeScheduleRun(
   sandboxToken: string,
   runId: string,
@@ -1556,18 +1513,16 @@ async function completeScheduleRun(
   );
 }
 
-describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", () => {
-  it("advances and skips loop schedules through replayed reschedule callbacks", async () => {
+describe("HOOK-01: schedule reschedule callbacks through internal dispatch", () => {
+  it("advances and skips loop schedules through direct trigger callbacks", async () => {
     const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledScheduleActor();
     const prompt = "Run the loop callback report.";
-    // Pin the clock so every replay stays inside the 5-minute signature
-    // tolerance window of its captured X-VM0-Timestamp.
     const base = now();
     mockNow(base);
-    const deliveries = captureScheduleCallbackDeliveries(webhooks);
+    webhooks.captureInternalCallbackDeliveries(CHAT_CALLBACK_PATH);
 
     const deployed = await api.deployAutomation(actor, {
       name: uniqueAutomationName("bdd-loop-cb"),
@@ -1591,157 +1546,45 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(runId);
 
-    // A sandbox heartbeat dispatches a progress delivery to the loop path;
-    // replaying it skips without touching the schedule.
+    // A sandbox heartbeat dispatches progress callbacks. Trigger recurrence
+    // callbacks are direct-dispatch no-ops for progress and must not issue an
+    // internal HTTP self-call.
     await webhooks.requestAgentHeartbeat(
       { runId },
       { authorization: `Bearer ${claim.sandboxToken}` },
       [200],
     );
-    const progressDelivery = await waitForCallbackDeliveryWithStatus(
-      deliveries.loop,
-      "progress",
-    );
-    const progressReplay = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      progressDelivery,
-    );
-    expect(progressReplay.status).toBe(200);
-    await expect(progressReplay.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
-    expect(
-      mustFindSchedule(
-        (await api.listAutomations(actor)).automations,
-        deployed.automation.id,
-      ).consecutiveFailures,
-    ).toBe(0);
-
-    await completeScheduleRun(claim.sandboxToken, runId);
-    const completedDelivery = await waitForCallbackDeliveryWithStatus(
-      deliveries.loop,
-      "completed",
-    );
-    const chatCompletedDelivery = await waitForCallbackDeliveryWithStatus(
-      deliveries.chat,
-      "completed",
-    );
-
-    const tamperedReplay = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      completedDelivery,
-      { signature: webhooks.tamperedSignature(completedDelivery) },
-    );
-    expect(tamperedReplay.status).toBe(401);
-
-    // A signature of the wrong length fails before the timing-safe compare.
-    const malformedSignatureReplay = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      completedDelivery,
-      { signature: "invalid-signature" },
-    );
-    expect(malformedSignatureReplay.status).toBe(401);
-
-    // Cross-path replays verify their signatures (callback rows resolve by
-    // callbackId, not path) and then fail the path-specific payload parse.
-    const chatOnLoop = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      chatCompletedDelivery,
-    );
-    expect(chatOnLoop.status).toBe(400);
-    await expect(chatOnLoop.json()).resolves.toStrictEqual({
-      error: "Invalid or missing payload",
-    });
-    const loopOnCron = await webhooks.replayInternalCallback(
-      CRON_CALLBACK_PATH,
-      completedDelivery,
-    );
-    expect(loopOnCron.status).toBe(400);
-    await expect(loopOnCron.json()).resolves.toStrictEqual({
-      error: "Invalid or missing payload",
-    });
-
-    // The completion advance reads the interval from the database at replay
-    // time: redeploy with a new interval, move the pinned clock (still inside
-    // the signature tolerance), and replay the same captured delivery.
-    const redeployed = await api.deployAutomation(actor, {
-      name: deployed.automation.name,
-      agentId,
-      intervalSeconds: 1200,
-      prompt,
-      description: "Loop reschedule callback schedule",
-      timezone: "UTC",
-      enabled: true,
-    });
-    mockNow(base + 721_000);
-    const queryCallsBefore = context.mocks.axiom.query.mock.calls.length;
-    const advancedReplay = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      completedDelivery,
-    );
-    expect(advancedReplay.status).toBe(200);
-    await expect(advancedReplay.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
-    // The reschedule callback never reads run output or writes a summary;
-    // the chat callback owns the summary (D9).
-    expect(context.mocks.axiom.query.mock.calls).toHaveLength(queryCallsBefore);
-    const advancedSchedule = mustFindSchedule(
+    const progressSchedule = mustFindSchedule(
       (await api.listAutomations(actor)).automations,
       deployed.automation.id,
     );
-    expect(advancedSchedule).toMatchObject({
+    expect(progressSchedule.consecutiveFailures).toBe(0);
+    expect(progressSchedule.nextRunAt).toBeNull();
+
+    await completeScheduleRun(claim.sandboxToken, runId);
+
+    await expect
+      .poll(async () => {
+        return mustFindSchedule(
+          (await api.listAutomations(actor)).automations,
+          deployed.automation.id,
+        ).nextRunAt;
+      })
+      .not.toBeNull();
+    const completedSchedule = mustFindSchedule(
+      (await api.listAutomations(actor)).automations,
+      deployed.automation.id,
+    );
+    expect(completedSchedule).toMatchObject({
       consecutiveFailures: 0,
       enabled: true,
-      nextRunAt: redeployed.automation.nextRunAt,
     });
-
-    // Signed-shape posts for unknown runs fail the callback lookup before
-    // signature verification.
-    const missingCallback = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      {
-        body: JSON.stringify({
-          runId: randomUUID(),
-          status: "completed",
-          payload: { automationId: deployed.automation.id },
-        }),
-        headers: {
-          "content-type": "application/json",
-          "x-vm0-signature": "0".repeat(64),
-          "x-vm0-timestamp": String(Math.floor(now() / 1000)),
-        },
-      },
-    );
-    expect(missingCallback.status).toBe(404);
-
-    // Disabled and deleted schedules skip the completion advance.
-    await api.disableAutomation(actor, deployed.automation);
-    const disabledReplay = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      completedDelivery,
-    );
-    expect(disabledReplay.status).toBe(200);
-    await expect(disabledReplay.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
+    expect(completedSchedule.nextRunAt).not.toBeNull();
     await api.deleteAutomation(actor, deployed.automation);
-    const deletedReplay = await webhooks.replayInternalCallback(
-      LOOP_CALLBACK_PATH,
-      completedDelivery,
-    );
-    expect(deletedReplay.status).toBe(200);
-    await expect(deletedReplay.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
     clearMockNow();
   });
 
-  it("increments cron failures and auto-disables after three replayed failed callbacks", async () => {
+  it("increments cron failures through direct trigger callbacks", async () => {
     const api = createRunsAutomationsApi(context);
     const chat = createChatFilesBddApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -1749,7 +1592,7 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     const prompt = "Run the cron failure report.";
     const base = now();
     mockNow(base);
-    const deliveries = captureScheduleCallbackDeliveries(webhooks);
+    webhooks.captureInternalCallbackDeliveries(CHAT_CALLBACK_PATH);
 
     const deployed = await api.deployAutomation(actor, {
       name: uniqueAutomationName("bdd-cron-cb"),
@@ -1769,14 +1612,9 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
     );
     const runId = scheduleRunIdFromThread(thread.messages, prompt);
 
-    // Cancelling the dispatched run delivers a failed callback
-    // (error "Run cancelled") that the chain replays three times — the
-    // handler re-reads consecutiveFailures from the database on each replay.
+    // Cancelling the dispatched run delivers a failed callback directly through
+    // the typed trigger callback command.
     await api.requestCancelRun(actor, runId, [200]);
-    const failedDelivery = await waitForCallbackDeliveryWithStatus(
-      deliveries.cron,
-      "failed",
-    );
 
     // "*/5 * * * *" advances to the next 5-minute boundary after the pinned
     // clock, computed here instead of importing the cron service.
@@ -1784,12 +1622,14 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
       (Math.floor((base + 6 * 60_000) / 300_000) + 1) * 300_000,
     ).toISOString();
 
-    const firstReplay = await webhooks.replayInternalCallback(
-      CRON_CALLBACK_PATH,
-      failedDelivery,
-    );
-    expect(firstReplay.status).toBe(200);
-    await expect(firstReplay.json()).resolves.toStrictEqual({ success: true });
+    await expect
+      .poll(async () => {
+        return mustFindSchedule(
+          (await api.listAutomations(actor)).automations,
+          deployed.automation.id,
+        ).consecutiveFailures;
+      })
+      .toBe(1);
     expect(
       mustFindSchedule(
         (await api.listAutomations(actor)).automations,
@@ -1800,46 +1640,6 @@ describe("HOOK-01: schedule reschedule callbacks through replayed deliveries", (
       enabled: true,
       nextRunAt: expectedNextRunAt,
     });
-
-    const secondReplay = await webhooks.replayInternalCallback(
-      CRON_CALLBACK_PATH,
-      failedDelivery,
-    );
-    expect(secondReplay.status).toBe(200);
-    expect(
-      mustFindSchedule(
-        (await api.listAutomations(actor)).automations,
-        deployed.automation.id,
-      ),
-    ).toMatchObject({ consecutiveFailures: 2, enabled: true });
-
-    const thirdReplay = await webhooks.replayInternalCallback(
-      CRON_CALLBACK_PATH,
-      failedDelivery,
-    );
-    expect(thirdReplay.status).toBe(200);
-    expect(
-      mustFindSchedule(
-        (await api.listAutomations(actor)).automations,
-        deployed.automation.id,
-      ),
-    ).toMatchObject({
-      consecutiveFailures: 3,
-      enabled: false,
-      nextRunAt: null,
-    });
-
-    // The fourth replay hits the disabled arm of the cron handler.
-    const fourthReplay = await webhooks.replayInternalCallback(
-      CRON_CALLBACK_PATH,
-      failedDelivery,
-    );
-    expect(fourthReplay.status).toBe(200);
-    await expect(fourthReplay.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
-
     await api.deleteAutomation(actor, deployed.automation);
     clearMockNow();
   });

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
@@ -1,28 +1,18 @@
 import { command } from "ccstate";
-import {
-  internalCallbacksTriggerContract,
-  triggerCronCallbackPayloadSchema,
-  triggerLoopCallbackPayloadSchema,
-  type TriggerCronCallbackPayload,
-  type TriggerLoopCallbackPayload,
-} from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
-import { automationTriggers } from "@vm0/db/schema/automation";
-import { eq } from "drizzle-orm";
+import { internalCallbacksTriggerContract } from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
 
 import {
   callbackPayload$,
   callbackRoute,
 } from "../../lib/callback-route/callback-route";
 import type { RouteEntry } from "../route";
-import { writeDb$ } from "../external/db";
-import { nowDate } from "../external/time";
-import { TimeTrigger } from "../services/automations/time-trigger";
+import { handleTriggerInternalCallback$ } from "../services/internal-trigger-run-callback.service";
+import type { InternalRunCallbackKind } from "../services/internal-run-callback";
 
-const MAX_CONSECUTIVE_FAILURES = 3;
-
-type TriggerPayload =
-  | { readonly kind: "cron"; readonly data: TriggerCronCallbackPayload }
-  | { readonly kind: "loop"; readonly data: TriggerLoopCallbackPayload };
+type TriggerInternalRunCallbackKind = Extract<
+  InternalRunCallbackKind,
+  "trigger:cron" | "trigger:loop"
+>;
 
 function successResponse(skipped?: true): {
   readonly status: 200;
@@ -38,22 +28,6 @@ function errorResponse(message: string): {
   return { status: 400, body: { error: message } };
 }
 
-function parseCronPayload(payload: unknown): TriggerPayload | null {
-  const result = triggerCronCallbackPayloadSchema.safeParse(payload);
-  if (!result.success) {
-    return null;
-  }
-  return { kind: "cron", data: result.data };
-}
-
-function parseLoopPayload(payload: unknown): TriggerPayload | null {
-  const result = triggerLoopCallbackPayloadSchema.safeParse(payload);
-  if (!result.success) {
-    return null;
-  }
-  return { kind: "loop", data: result.data };
-}
-
 /**
  * Completion callback for `automation_triggers` time rows, keyed on
  * `trigger_id`: a completed run resets the consecutive-failure counter, a
@@ -62,68 +36,28 @@ function parseLoopPayload(payload: unknown): TriggerPayload | null {
  * this callback is what reschedules the trigger. `once` triggers were disabled
  * at claim, so their callback lands in the disabled-skip branch.
  */
-function createTriggerCallbackHandler(
-  parsePayload: (payload: unknown) => TriggerPayload | null,
-) {
+function createTriggerCallbackHandler(kind: TriggerInternalRunCallbackKind) {
   return command(async ({ get, set }, signal: AbortSignal) => {
     const callback = get(callbackPayload$);
-    const payload = parsePayload(callback.payload);
-    if (!payload) {
-      return errorResponse("Invalid or missing payload");
-    }
 
-    if (callback.status === "progress") {
-      return successResponse(true);
-    }
-
-    const writeDb = set(writeDb$);
-    const [trigger] = await writeDb
-      .select()
-      .from(automationTriggers)
-      .where(eq(automationTriggers.id, payload.data.triggerId))
-      .limit(1);
-    signal.throwIfAborted();
-
-    if (!trigger || !trigger.enabled) {
-      return successResponse(true);
-    }
-
-    const completedAt = nowDate();
-    const consecutiveFailures =
-      callback.status === "completed" ? 0 : trigger.consecutiveFailures + 1;
-    const shouldDisable = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
-    const nextRunAt = new TimeTrigger().advanceAfterCompletion({
-      triggerType: payload.kind,
-      cronExpression:
-        payload.kind === "cron" ? payload.data.cronExpression : undefined,
-      intervalSeconds: trigger.intervalSeconds,
-      timezone: trigger.timezone,
-      completedAt,
-      shouldDisable,
-    });
-
-    await writeDb
-      .update(automationTriggers)
-      .set({
-        consecutiveFailures,
-        ...(shouldDisable && { enabled: false }),
-        nextRunAt,
-        updatedAt: completedAt,
-      })
-      .where(eq(automationTriggers.id, payload.data.triggerId));
+    const result = await set(
+      handleTriggerInternalCallback$,
+      { kind, callback },
+      signal,
+    );
     signal.throwIfAborted();
 
     // The run summary is owned by the chat callback (triggerSource "chat"); this
     // reschedule callback only advances next_run_at / consecutive-failure
     // bookkeeping and must NOT write a second summary (D9).
-    return successResponse();
+    return result.success
+      ? successResponse(result.skipped)
+      : errorResponse(result.error);
   });
 }
 
-const handleCronTriggerCallback$ =
-  createTriggerCallbackHandler(parseCronPayload);
-const handleLoopTriggerCallback$ =
-  createTriggerCallbackHandler(parseLoopPayload);
+const handleCronTriggerCallback$ = createTriggerCallbackHandler("trigger:cron");
+const handleLoopTriggerCallback$ = createTriggerCallbackHandler("trigger:loop");
 
 export const internalCallbacksTriggerRoutes: readonly RouteEntry[] = [
   {

--- a/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
@@ -1,14 +1,16 @@
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 
 import { testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
-import { now } from "../../../lib/time";
+import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import { seedAgentRunCallback$ } from "../../routes/__tests__/helpers/agent-run-callback";
@@ -20,13 +22,20 @@ import {
   seedUsageInsightFixture$,
   type UsageInsightFixture,
 } from "../../routes/__tests__/helpers/zero-usage-insight";
-import { dispatchRunCallbacks$ } from "../agent-run-callback.service";
+import {
+  dispatchRunCallbacks,
+  dispatchRunCallbacks$,
+} from "../agent-run-callback.service";
 import { createZeroRun$ } from "../zero-runs-create.service";
 
 const context = testContext();
 const store = createStore();
 
 const AGENT_CALLBACK_URL = "http://localhost:3000/api/internal/callbacks/agent";
+const TRIGGER_CRON_CALLBACK_URL =
+  "http://localhost:3000/api/internal/callbacks/trigger/cron";
+const TRIGGER_LOOP_CALLBACK_URL =
+  "http://localhost:3000/api/internal/callbacks/trigger/loop";
 const OPENROUTER_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
 
@@ -122,6 +131,24 @@ function failIfAgentCallbackRouteIsFetched(): () => number {
   };
 }
 
+function failIfCallbackRouteIsFetched(url: string): () => number {
+  let requests = 0;
+  server.use(
+    http.post(url, () => {
+      requests += 1;
+      return HttpResponse.text(
+        "internal callback route should not be fetched",
+        {
+          status: 500,
+        },
+      );
+    }),
+  );
+  return () => {
+    return requests;
+  };
+}
+
 async function readCallback(callbackId: string) {
   const db = store.set(writeDb$);
   const [callback] = await db
@@ -149,6 +176,68 @@ async function readSummary(runId: string): Promise<string | null | undefined> {
   return row?.summary;
 }
 
+async function readTrigger(triggerId: string) {
+  const db = store.set(writeDb$);
+  const [row] = await db
+    .select()
+    .from(automationTriggers)
+    .where(eq(automationTriggers.id, triggerId))
+    .limit(1);
+  return row;
+}
+
+async function seedAutomationTrigger(
+  fixture: AgentCallbackRunFixture,
+  options: {
+    readonly kind: "cron" | "loop";
+    readonly consecutiveFailures?: number;
+    readonly intervalSeconds?: number;
+    readonly cronExpression?: string;
+  },
+): Promise<string> {
+  const db = store.set(writeDb$);
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({ userId: fixture.userId, agentComposeId: fixture.composeId })
+    .returning({ id: chatThreads.id });
+  if (!thread) {
+    throw new Error("Failed to seed trigger chat thread");
+  }
+  const [automation] = await db
+    .insert(automations)
+    .values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      name: `callback-test-${fixture.runId.slice(0, 8)}`,
+      instruction: "Run a scheduled task",
+      agentId: fixture.composeId,
+      chatThreadId: thread.id,
+      interpreterKind: "time",
+    })
+    .returning({ id: automations.id });
+  if (!automation) {
+    throw new Error("Failed to seed automation");
+  }
+  const isCron = options.kind === "cron";
+  const [trigger] = await db
+    .insert(automationTriggers)
+    .values({
+      automationId: automation.id,
+      kind: options.kind,
+      cronExpression: isCron ? (options.cronExpression ?? "0 9 * * *") : null,
+      intervalSeconds: isCron ? null : (options.intervalSeconds ?? 300),
+      timezone: "UTC",
+      nextRunAt: null,
+      enabled: true,
+      consecutiveFailures: options.consecutiveFailures ?? 0,
+    })
+    .returning({ id: automationTriggers.id });
+  if (!trigger) {
+    throw new Error("Failed to seed automation trigger");
+  }
+  return trigger.id;
+}
+
 async function seedVm0ProviderKey(
   label: string,
 ): Promise<Vm0ProviderKeyFixture> {
@@ -162,6 +251,10 @@ async function seedVm0ProviderKey(
   });
   return { label };
 }
+
+afterEach(() => {
+  clearMockNow();
+});
 
 describe("dispatchRunCallbacks$ agent internal dispatch", () => {
   it("dispatches typed agent callbacks through ccstate without fetching the route", async () => {
@@ -352,5 +445,178 @@ describe("dispatchRunCallbacks$ agent internal dispatch", () => {
         payload: { triggerAgentId: composeId },
       },
     ]);
+  });
+});
+
+describe("dispatchRunCallbacks$ trigger internal dispatch", () => {
+  it("dispatches typed loop trigger callbacks through ccstate without fetching the route", async () => {
+    mockNow(new Date("2026-05-13T04:00:00.000Z"));
+    const fixture = await seedAgentCallbackRun();
+    const triggerId = await seedAutomationTrigger(fixture, {
+      kind: "loop",
+      consecutiveFailures: 2,
+      intervalSeconds: 300,
+    });
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "trigger:loop",
+        payload: { triggerId },
+      },
+      context.signal,
+    );
+    const routeRequests = failIfCallbackRouteIsFetched(
+      TRIGGER_LOOP_CALLBACK_URL,
+    );
+    const db = store.set(writeDb$);
+
+    const results = await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "completed" },
+      context.signal,
+    );
+
+    expect(results).toStrictEqual([{ callbackId, success: true }]);
+    expect(routeRequests()).toBe(0);
+    await expect(readTrigger(triggerId)).resolves.toMatchObject({
+      consecutiveFailures: 0,
+      enabled: true,
+      nextRunAt: new Date("2026-05-13T04:05:00.000Z"),
+    });
+    await expect(readSummary(fixture.runId)).resolves.toBeNull();
+    await expect(readCallback(callbackId)).resolves.toMatchObject({
+      url: null,
+      internalKind: "trigger:loop",
+      status: "delivered",
+      attempts: 1,
+      lastError: null,
+    });
+  });
+
+  it("dispatches legacy cron trigger URLs through the same ccstate path", async () => {
+    const fixture = await seedAgentCallbackRun();
+    const triggerId = await seedAutomationTrigger(fixture, {
+      kind: "cron",
+      consecutiveFailures: 2,
+    });
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        url: TRIGGER_CRON_CALLBACK_URL,
+        payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+      },
+      context.signal,
+    );
+    const routeRequests = failIfCallbackRouteIsFetched(
+      TRIGGER_CRON_CALLBACK_URL,
+    );
+    const db = store.set(writeDb$);
+
+    const results = await store.set(
+      dispatchRunCallbacks$,
+      {
+        db,
+        runId: fixture.runId,
+        status: "failed",
+        error: "Agent crashed",
+      },
+      context.signal,
+    );
+
+    expect(results).toStrictEqual([{ callbackId, success: true }]);
+    expect(routeRequests()).toBe(0);
+    await expect(readTrigger(triggerId)).resolves.toMatchObject({
+      consecutiveFailures: 3,
+      enabled: false,
+      nextRunAt: null,
+    });
+    await expect(readCallback(callbackId)).resolves.toMatchObject({
+      url: TRIGGER_CRON_CALLBACK_URL,
+      internalKind: null,
+      status: "delivered",
+      attempts: 1,
+      lastError: null,
+    });
+  });
+
+  it("marks invalid typed trigger callback payloads as failed", async () => {
+    const fixture = await seedAgentCallbackRun();
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "trigger:loop",
+        payload: {},
+      },
+      context.signal,
+    );
+    const routeRequests = failIfCallbackRouteIsFetched(
+      TRIGGER_LOOP_CALLBACK_URL,
+    );
+    const db = store.set(writeDb$);
+
+    const results = await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "completed" },
+      context.signal,
+    );
+
+    expect(results).toStrictEqual([
+      {
+        callbackId,
+        success: false,
+        error: "Invalid or missing payload",
+      },
+    ]);
+    expect(routeRequests()).toBe(0);
+    await expect(readCallback(callbackId)).resolves.toMatchObject({
+      status: "failed",
+      attempts: 1,
+      lastError: "Invalid or missing payload",
+    });
+  });
+
+  it("dispatches typed trigger callbacks from the non-ccstate wrapper", async () => {
+    const fixture = await seedAgentCallbackRun();
+    const triggerId = await seedAutomationTrigger(fixture, {
+      kind: "loop",
+      consecutiveFailures: 2,
+    });
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "trigger:loop",
+        payload: { triggerId },
+      },
+      context.signal,
+    );
+    const routeRequests = failIfCallbackRouteIsFetched(
+      TRIGGER_LOOP_CALLBACK_URL,
+    );
+    const db = store.set(writeDb$);
+
+    const results = await dispatchRunCallbacks(
+      db,
+      fixture.runId,
+      "failed",
+      undefined,
+      "Run failed",
+    );
+
+    expect(results).toStrictEqual([{ callbackId, success: true }]);
+    expect(routeRequests()).toBe(0);
+    await expect(readTrigger(triggerId)).resolves.toMatchObject({
+      consecutiveFailures: 3,
+      enabled: false,
+      nextRunAt: null,
+    });
+    await expect(readCallback(callbackId)).resolves.toMatchObject({
+      status: "delivered",
+      attempts: 1,
+      lastError: null,
+    });
   });
 });

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -14,10 +14,15 @@ import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { handleAgentInternalCallback$ } from "./internal-agent-run-callback.service";
 import {
-  legacyInternalRunCallbackKind,
+  internalRunCallbackKindForRecord,
+  type InternalRunCallbackDispatchResult,
   type InternalRunCallbackEnvelope,
   type InternalRunCallbackKind,
 } from "./internal-run-callback";
+import {
+  handleTriggerInternalCallback,
+  handleTriggerInternalCallback$,
+} from "./internal-trigger-run-callback.service";
 
 const L = logger("AgentRunCallback");
 
@@ -70,35 +75,34 @@ interface DispatchInternalCallbackInput {
   readonly envelope: InternalRunCallbackEnvelope;
 }
 
-function resolveCallbackUrl(url: string): string {
-  return env("ENV") === "development" && url.startsWith("https://tunnel-")
-    ? url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
-    : url;
-}
-
-function internalCallbackKindForRecord(
-  callback: CallbackRecord,
-): InternalRunCallbackKind | null {
-  if (callback.internalKind === "agent") {
-    return callback.internalKind;
-  }
-  return legacyInternalRunCallbackKind(callback.url);
-}
-
 const dispatchInternalCallback$ = command(
   async (
     { set },
     input: DispatchInternalCallbackInput,
     signal: AbortSignal,
-  ): Promise<void> => {
+  ): Promise<InternalRunCallbackDispatchResult> => {
     switch (input.kind) {
       case "agent": {
         await set(handleAgentInternalCallback$, input.envelope, signal);
-        break;
+        return { success: true };
+      }
+      case "trigger:cron":
+      case "trigger:loop": {
+        return await set(
+          handleTriggerInternalCallback$,
+          { kind: input.kind, callback: input.envelope },
+          signal,
+        );
       }
     }
   },
 );
+
+function resolveCallbackUrl(url: string): string {
+  return env("ENV") === "development" && url.startsWith("https://tunnel-")
+    ? url.replace(/^https:\/\/tunnel-[^/]+/, "http://localhost:3000")
+    : url;
+}
 
 const dispatchSingleInternalCallback$ = command(
   async (
@@ -134,6 +138,25 @@ const dispatchSingleInternalCallback$ = command(
         error: responseResult.error,
       });
       return { callbackId, success: false, error: errorMessage };
+    }
+
+    if (!responseResult.value.success) {
+      await markCallbackFailed(
+        input.db,
+        callbackId,
+        responseResult.value.error,
+      );
+      signal.throwIfAborted();
+      L.warn("Internal callback dispatch failed", {
+        callbackId,
+        runId: input.runId,
+        error: responseResult.value.error,
+      });
+      return {
+        callbackId,
+        success: false,
+        error: responseResult.value.error,
+      };
     }
 
     await markCallbackDelivered(input.db, callbackId);
@@ -247,7 +270,7 @@ export const dispatchRunCallbacks$ = command(
 
     const results: DispatchResult[] = [];
     for (const callback of callbacks) {
-      const internalKind = internalCallbackKindForRecord(callback);
+      const internalKind = internalRunCallbackKindForRecord(callback);
       const dispatchResult = internalKind
         ? await set(
             dispatchSingleInternalCallback$,
@@ -281,7 +304,7 @@ export const dispatchRunCallbacks$ = command(
 async function dispatchSingleCallback(
   input: DispatchSingleCallbackInput,
 ): Promise<DispatchResult> {
-  const internalKind = internalCallbackKindForRecord(input.callback);
+  const internalKind = internalRunCallbackKindForRecord(input.callback);
   if (internalKind) {
     return await dispatchInternalCallback(input);
   }
@@ -291,10 +314,71 @@ async function dispatchSingleCallback(
 async function dispatchInternalCallback(
   input: DispatchSingleCallbackInput,
 ): Promise<DispatchResult> {
+  const internalKind = internalRunCallbackKindForRecord(input.callback);
+  if (!internalKind) {
+    const errorMessage = "Unknown internal callback kind";
+    await markCallbackFailed(input.db, input.callback.id, errorMessage);
+    return {
+      callbackId: input.callback.id,
+      success: false,
+      error: errorMessage,
+    };
+  }
+
   await markCallbackAttemptStarted(input.db, input.callback.id);
   const callbackId = input.callback.id;
+  const responseResult = await settle(
+    dispatchInternalCallbackWithoutCcstate(input, internalKind),
+  );
+
+  if (!responseResult.ok) {
+    const errorMessage =
+      responseResult.error instanceof Error
+        ? responseResult.error.message
+        : "Unknown error";
+    await markCallbackFailed(input.db, callbackId, errorMessage);
+    L.error("Internal callback dispatch threw", {
+      callbackId,
+      runId: input.runId,
+      error: responseResult.error,
+    });
+    return { callbackId, success: false, error: errorMessage };
+  }
+
+  if (!responseResult.value.success) {
+    await markCallbackFailed(input.db, callbackId, responseResult.value.error);
+    L.warn("Internal callback dispatch failed", {
+      callbackId,
+      runId: input.runId,
+      error: responseResult.value.error,
+    });
+    return {
+      callbackId,
+      success: false,
+      error: responseResult.value.error,
+    };
+  }
+
   await markCallbackDelivered(input.db, callbackId);
   return { callbackId, success: true };
+}
+
+async function dispatchInternalCallbackWithoutCcstate(
+  input: DispatchSingleCallbackInput,
+  kind: InternalRunCallbackKind,
+): Promise<InternalRunCallbackDispatchResult> {
+  switch (kind) {
+    case "agent": {
+      return { success: true };
+    }
+    case "trigger:cron":
+    case "trigger:loop": {
+      return await handleTriggerInternalCallback(input.db, {
+        kind,
+        callback: callbackEnvelope(input),
+      });
+    }
+  }
 }
 
 function callbackEnvelope(

--- a/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
@@ -10,7 +10,7 @@ import { now } from "../../lib/time";
 import { db$ } from "../external/db";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import { legacyInternalRunCallbackKind } from "./internal-run-callback";
+import { internalRunCallbackKindForRecord } from "./internal-run-callback";
 
 function resolveCallbackUrl(url: string): string {
   return env("ENV") === "development" && url.startsWith("https://tunnel-")
@@ -64,9 +64,11 @@ export const dispatchProgressCallbacks$ = command(
 
     await Promise.allSettled(
       callbacks.map(async (callback) => {
+        const internalKind = internalRunCallbackKindForRecord(callback);
         if (
-          callback.internalKind === "agent" ||
-          legacyInternalRunCallbackKind(callback.url) === "agent"
+          internalKind === "agent" ||
+          internalKind === "trigger:cron" ||
+          internalKind === "trigger:loop"
         ) {
           return;
         }

--- a/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
@@ -6,6 +6,7 @@ import type {
 } from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
 
 import { internalApiBaseUrl } from "../../../lib/internal-api-url";
+import type { InternalRunCallbackKind } from "../internal-run-callback";
 
 /**
  * Identifies how an Automation should be interpreted into an agent run. The
@@ -38,11 +39,19 @@ interface Automation {
   readonly timezone: string;
 }
 
-interface RunCallback {
+interface HttpRunCallback {
   readonly url: string;
   readonly secret: string;
   readonly payload: unknown;
 }
+
+interface InternalRunCallback {
+  readonly internalKind: InternalRunCallbackKind;
+  readonly secret: string;
+  readonly payload: unknown;
+}
+
+type RunCallback = HttpRunCallback | InternalRunCallback;
 
 /**
  * The run-identity metadata an interpreter attaches to its produced run. A time
@@ -300,7 +309,7 @@ function buildTriggerCallbacks(
   if (automation.triggerType === "loop") {
     const payload: TriggerLoopCallbackPayload = { triggerId };
     callbacks.push({
-      url: `${internalApiBaseUrl()}/api/internal/callbacks/trigger/loop`,
+      internalKind: "trigger:loop",
       secret: generateCallbackSecret(),
       payload,
     });
@@ -316,7 +325,7 @@ function buildTriggerCallbacks(
       timezone: automation.timezone,
     };
     callbacks.push({
-      url: `${internalApiBaseUrl()}/api/internal/callbacks/trigger/cron`,
+      internalKind: "trigger:cron",
       secret: generateCallbackSecret(),
       payload,
     });

--- a/turbo/apps/api/src/signals/services/internal-run-callback.ts
+++ b/turbo/apps/api/src/signals/services/internal-run-callback.ts
@@ -1,10 +1,18 @@
 import { safeUrlParse } from "../utils";
 
-export const internalRunCallbackKinds = ["agent"] as const;
+export const internalRunCallbackKinds = [
+  "agent",
+  "trigger:cron",
+  "trigger:loop",
+] as const;
 
 export type InternalRunCallbackKind = (typeof internalRunCallbackKinds)[number];
 
 export type InternalRunCallbackStatus = "completed" | "failed" | "progress";
+
+export type InternalRunCallbackDispatchResult =
+  | { readonly success: true; readonly skipped?: true }
+  | { readonly success: false; readonly error: string };
 
 export interface InternalRunCallbackEnvelope {
   readonly callbackId?: string;
@@ -15,7 +23,36 @@ export interface InternalRunCallbackEnvelope {
   readonly payload: unknown;
 }
 
-export function legacyInternalRunCallbackKind(
+interface InternalRunCallbackRecord {
+  readonly url: string | null;
+  readonly internalKind: string | null;
+}
+
+function isInternalRunCallbackKind(
+  value: string | null,
+): value is InternalRunCallbackKind {
+  switch (value) {
+    case "agent":
+    case "trigger:cron":
+    case "trigger:loop": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+export function internalRunCallbackKindForRecord(
+  callback: InternalRunCallbackRecord,
+): InternalRunCallbackKind | null {
+  if (isInternalRunCallbackKind(callback.internalKind)) {
+    return callback.internalKind;
+  }
+  return legacyInternalRunCallbackKind(callback.url);
+}
+
+function legacyInternalRunCallbackKind(
   url: string | null,
 ): InternalRunCallbackKind | null {
   if (!url) {
@@ -26,6 +63,12 @@ export function legacyInternalRunCallbackKind(
   switch (path) {
     case "/api/internal/callbacks/agent": {
       return "agent";
+    }
+    case "/api/internal/callbacks/trigger/cron": {
+      return "trigger:cron";
+    }
+    case "/api/internal/callbacks/trigger/loop": {
+      return "trigger:loop";
     }
     default: {
       return null;

--- a/turbo/apps/api/src/signals/services/internal-trigger-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-trigger-run-callback.service.ts
@@ -1,0 +1,113 @@
+import { command } from "ccstate";
+import {
+  triggerCronCallbackPayloadSchema,
+  triggerLoopCallbackPayloadSchema,
+  type TriggerCronCallbackPayload,
+  type TriggerLoopCallbackPayload,
+} from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
+import { automationTriggers } from "@vm0/db/schema/automation";
+import { eq } from "drizzle-orm";
+
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { TimeTrigger } from "./automations/time-trigger";
+import type {
+  InternalRunCallbackDispatchResult,
+  InternalRunCallbackEnvelope,
+  InternalRunCallbackKind,
+} from "./internal-run-callback";
+
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+type TriggerInternalRunCallbackKind = Extract<
+  InternalRunCallbackKind,
+  "trigger:cron" | "trigger:loop"
+>;
+
+type TriggerPayload =
+  | { readonly kind: "cron"; readonly data: TriggerCronCallbackPayload }
+  | { readonly kind: "loop"; readonly data: TriggerLoopCallbackPayload };
+
+interface HandleTriggerInternalCallbackInput {
+  readonly kind: TriggerInternalRunCallbackKind;
+  readonly callback: InternalRunCallbackEnvelope;
+}
+
+function parseTriggerPayload(
+  kind: TriggerInternalRunCallbackKind,
+  payload: unknown,
+): TriggerPayload | null {
+  switch (kind) {
+    case "trigger:cron": {
+      const result = triggerCronCallbackPayloadSchema.safeParse(payload);
+      return result.success ? { kind: "cron", data: result.data } : null;
+    }
+    case "trigger:loop": {
+      const result = triggerLoopCallbackPayloadSchema.safeParse(payload);
+      return result.success ? { kind: "loop", data: result.data } : null;
+    }
+  }
+}
+
+export async function handleTriggerInternalCallback(
+  db: Db,
+  input: HandleTriggerInternalCallbackInput,
+  signal?: AbortSignal,
+): Promise<InternalRunCallbackDispatchResult> {
+  const payload = parseTriggerPayload(input.kind, input.callback.payload);
+  if (!payload) {
+    return { success: false, error: "Invalid or missing payload" };
+  }
+
+  if (input.callback.status === "progress") {
+    return { success: true, skipped: true };
+  }
+
+  const [trigger] = await db
+    .select()
+    .from(automationTriggers)
+    .where(eq(automationTriggers.id, payload.data.triggerId))
+    .limit(1);
+  signal?.throwIfAborted();
+
+  if (!trigger || !trigger.enabled) {
+    return { success: true, skipped: true };
+  }
+
+  const completedAt = nowDate();
+  const consecutiveFailures =
+    input.callback.status === "completed" ? 0 : trigger.consecutiveFailures + 1;
+  const shouldDisable = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
+  const nextRunAt = new TimeTrigger().advanceAfterCompletion({
+    triggerType: payload.kind,
+    cronExpression:
+      payload.kind === "cron" ? payload.data.cronExpression : undefined,
+    intervalSeconds: trigger.intervalSeconds,
+    timezone: trigger.timezone,
+    completedAt,
+    shouldDisable,
+  });
+
+  await db
+    .update(automationTriggers)
+    .set({
+      consecutiveFailures,
+      ...(shouldDisable && { enabled: false }),
+      nextRunAt,
+      updatedAt: completedAt,
+    })
+    .where(eq(automationTriggers.id, payload.data.triggerId));
+  signal?.throwIfAborted();
+
+  return { success: true };
+}
+
+export const handleTriggerInternalCallback$ = command(
+  async (
+    { set },
+    input: HandleTriggerInternalCallbackInput,
+    signal: AbortSignal,
+  ): Promise<InternalRunCallbackDispatchResult> => {
+    return await handleTriggerInternalCallback(set(writeDb$), input, signal);
+  },
+);


### PR DESCRIPTION
## Summary

Part of #17809. Closes #17897.

- add typed internal callback kinds for trigger cron/loop callbacks
- move trigger recurrence handling into a ccstate service command used by both HTTP compatibility routes and the internal dispatcher
- write new automation trigger callback rows with `internalKind` instead of `/api/internal/callbacks/trigger/*` URLs
- map legacy pending trigger callback URLs to the same internal dispatch path
- skip progress self-calls for trigger callbacks and update schedule BDD expectations for direct dispatch

## Verification

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/services/__tests__/agent-run-callback.service.test.ts src/signals/routes/__tests__/internal-callbacks-trigger.test.ts src/signals/routes/__tests__/automations.test.ts src/signals/routes/__tests__/runs-schedules.bdd.test.ts`
- pre-commit: prettier, knip, full `turbo run check-types --concurrency=1`
