### PR TITLE
fix: preserve full presentation template thumbnails instead of cropping

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1151,7 +1151,7 @@ function TemplatePreview({
 
   return (
     <div
-      className="relative h-44 shrink-0 overflow-hidden bg-muted"
+      className="relative aspect-[16/9] shrink-0 overflow-hidden bg-muted"
       onMouseEnter={() => {
         preloadPresentationPreviewImages(slideImages);
         detach(
@@ -1429,7 +1429,7 @@ function PptCard({
   return (
     <div
       className={cn(
-        "group flex h-64 flex-col overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+        "group flex flex-col overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
         selected ? "border-primary ring-1 ring-primary" : "border-border",
       )}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1175,7 +1175,7 @@ function TemplatePreview({
             src={previewImage}
             alt=""
             title={`${item.title} card preview slide 1`}
-            className="absolute inset-0 h-full w-full object-cover"
+            className="absolute inset-0 h-full w-full object-contain"
             loading="lazy"
             onLoad={(event) => {
               event.currentTarget.parentElement
@@ -1200,7 +1200,7 @@ function TemplatePreview({
                     isHovering ? imageIndex + 1 : 1
                   }`}
                   className={cn(
-                    "absolute inset-0 h-full w-full object-cover opacity-0 transition-opacity duration-75",
+                    "absolute inset-0 h-full w-full object-contain opacity-0 transition-opacity duration-75",
                     active && "data-[loaded=true]:opacity-100",
                   )}
                   loading={isHovering ? "eager" : "lazy"}
@@ -1313,7 +1313,7 @@ function TemplatePreviewPage({
               src={selectedSlidePreviewImage}
               title={`${item.title} preview slide ${safeSlideIndex + 1}`}
               alt=""
-              className="aspect-[16/9] w-full object-cover"
+              className="aspect-[16/9] w-full object-contain"
               loading="lazy"
             />
             <button
@@ -1363,7 +1363,7 @@ function TemplatePreviewPage({
                   <img
                     src={thumbnailImage}
                     alt=""
-                    className="aspect-[16/9] w-full object-cover"
+                    className="aspect-[16/9] w-full object-contain"
                     loading="lazy"
                   />
                   <span className="absolute bottom-1 right-1 rounded bg-black/70 px-1.5 py-0.5 text-[10px] font-semibold text-white">


### PR DESCRIPTION
## Summary
Presentation template thumbnails used `object-cover`, which crops each slide to fill the thumbnail bounds and cuts off key text on text-heavy templates. This made it hard for users to evaluate/choose presentation templates from the preview.

This switches presentation thumbnails to `object-contain` so the full 16:9 slide fits within the bounds (letterboxed against the existing `bg-muted` background) instead of being cropped.

## Changes
In `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`:
- Grid card preview image (`TemplatePreview`)
- Hover slide-switch images (`TemplatePreview`)
- Enlarged preview main image (`TemplatePreviewPage`)
- Slide-strip thumbnails (`TemplatePreviewPage`)

Out of scope (intentionally left as `object-cover`): video template previews, illustration previews, and the tiny 20×20 selected-template chips — none are presentation slide previews used to evaluate text content.

## Test plan
- Open the artifact template picker → Presentation tab
- Verify grid cards, hover slide cycling, the enlarged preview, and the slide strip show the entire slide with no cropped text

Fixes #17687

🤖 Generated with [Claude Code](https://claude.com/claude-code)