### PR TITLE
fix: preserve guest logs after runner timeout

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -24,7 +24,8 @@ use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, ResourceFailureDiagnostics,
     ResourceFailureKind, RunnerResult, SandboxReuseResult, USER_ENV_FILE_ENV_KEY,
-    agent_exit_failure_message, normalize_failure_exit_code, normalize_timeout_failure_exit_code,
+    agent_exit_failure_message, job_terminal_wait_timeout, normalize_failure_exit_code,
+    normalize_timeout_failure_exit_code,
 };
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
@@ -239,8 +240,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
-    // JOB_TIMEOUT configures both the guest-side process timeout and the
-    // host-side wait watchdog. They remain separate protocol mechanisms.
+    // JOB_TIMEOUT remains the guest-side runtime budget. The host waits a
+    // little longer for terminal proof so the guest timeout path can kill,
+    // drain stdout/stderr, and report ProcessTerminationKind::TimedOut.
     let t = Instant::now();
     let handle = sandbox
         .start_process(&StartProcessRequest {
@@ -275,7 +277,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // operation can be removed before sandbox cleanup closes the connection.
     let process_pid = handle.pid;
     let process_cancel = handle.take_cancel_handle();
-    let wait_process = sandbox.wait_process(handle, JOB_TIMEOUT);
+    let wait_process = sandbox.wait_process(handle, job_terminal_wait_timeout());
     tokio::pin!(wait_process);
     let (result, wait_cancelled, abort_stdout_drain) = tokio::select! {
         biased;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -51,6 +51,13 @@ use api_contracts::generated::constants::runners::paths::{
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
 /// Exit code used when the runner's job timeout stops an agent process.
 const JOB_TIMEOUT_EXIT_CODE: i32 = 124;
+/// Extra time for the host to receive guest timeout terminal proof.
+///
+/// The guest process still receives `JOB_TIMEOUT` as its runtime budget. This
+/// grace covers vsock-guest's 5s stdout/stderr drain deadline after timeout
+/// process-tree kill, plus normal scheduling overhead before it sends the
+/// terminal `TimedOut` result.
+const JOB_TERMINAL_GRACE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Maximum time to spend writing the guest cancel frame after a user cancel.
 const PROCESS_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 /// Grace period for the guest to report a terminal status after cancel is sent.
@@ -77,6 +84,9 @@ const STDOUT_STREAM_LIMIT_MARKER: &[u8] =
     b"[vm0] stdout stream reached the guest stream limit; later output was omitted\n";
 const STDOUT_STREAM_OVERFLOW_MARKER: &[u8] =
     b"[vm0] stdout stream overflowed the host queue; some output was dropped\n";
+fn job_terminal_wait_timeout() -> Duration {
+    JOB_TIMEOUT + JOB_TERMINAL_GRACE_TIMEOUT
+}
 const MIN_EPOCH_MS_TIMESTAMP: u64 = 1_000_000_000_000;
 const BOOTSTRAP_SENSITIVE_ENV_KEYS: &[&str] = &[
     "BASH_ENV",

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -47,7 +47,7 @@ use api_contracts::generated::constants::runners::paths::{
     CANONICAL_GUEST_HOME_DIR, CANONICAL_WORKING_DIR,
 };
 
-/// Maximum wall-clock time for a single job (2 hours).
+/// Maximum guest-side runtime budget for a single agent process (2 hours).
 const JOB_TIMEOUT: Duration = Duration::from_secs(7200);
 /// Exit code used when the runner's job timeout stops an agent process.
 const JOB_TIMEOUT_EXIT_CODE: i32 = 124;

--- a/crates/runner/src/executor/tests/sandbox_run_tests.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests.rs
@@ -22,10 +22,10 @@ use super::super::sandbox_run::{
     execute_reused_sandbox, log_proxy_register_failure, log_proxy_register_success, register_proxy,
 };
 use super::super::{
-    AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JobParams,
-    NewSandboxDispatch, ResourceFailureKind, STDOUT_STREAM_LIMIT_MARKER,
+    AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT, EXIT_SIGKILL, ExecutionFailureKind, JOB_TIMEOUT,
+    JobParams, NewSandboxDispatch, ResourceFailureKind, STDOUT_STREAM_LIMIT_MARKER,
     STDOUT_STREAM_OVERFLOW_MARKER, SandboxPreparedNotifier, USER_ENV_FILE_ENV_KEY, execute_job,
-    execute_job_reuse,
+    execute_job_reuse, job_terminal_wait_timeout,
 };
 use super::support::{
     CapturedEvent, CapturedEvents, DestroyPanicFactory, QueuedCopyFileSandbox, api_storage,
@@ -1133,6 +1133,71 @@ async fn execute_inner_guest_process_timeout_marks_failure_kind() {
         }
         ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
     }
+}
+
+#[tokio::test]
+async fn execute_inner_guest_process_timeout_waits_for_terminal_grace_and_copies_logs() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let mut exit = ProcessExit::new(1, 124, Vec::new(), b"Timeout".to_vec());
+    exit.termination = ProcessTerminationKind::TimedOut;
+    exit.guest_duration_ms = Some(7_200_084);
+    overrides.push_wait_process_exit(exit);
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let start_calls = overrides.start_process_calls();
+    assert_eq!(start_calls.len(), 1);
+    assert_eq!(start_calls[0].timeout, JOB_TIMEOUT);
+
+    let wait_calls = overrides.wait_process_calls();
+    assert_eq!(wait_calls.len(), 1);
+    assert_eq!(wait_calls[0].timeout, job_terminal_wait_timeout());
+
+    let failure = outcome.failure.as_ref().expect("expected timeout failure");
+    match failure.kind {
+        ExecutionFailureKind::RunnerJobTimeout {
+            timeout_ms,
+            elapsed_ms: _,
+            guest_duration_ms,
+        } => {
+            assert_eq!(timeout_ms, JOB_TIMEOUT.as_millis());
+            assert_eq!(guest_duration_ms, Some(7_200_084));
+        }
+        ExecutionFailureKind::Generic => panic!("expected runner job timeout failure kind"),
+    }
+
+    let copy_calls = overrides.copy_file_calls();
+    assert_eq!(copy_calls.len(), 3);
+    assert!(
+        copy_calls[0].path.ends_with("/system.log"),
+        "unexpected copy calls: {copy_calls:#?}"
+    );
+    assert!(
+        copy_calls[1].path.ends_with("/metrics.jsonl"),
+        "unexpected copy calls: {copy_calls:#?}"
+    );
+    assert!(
+        copy_calls[2].path.ends_with("/sandbox-ops.jsonl"),
+        "unexpected copy calls: {copy_calls:#?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -153,6 +153,13 @@ pub struct StartProcessCall {
     pub control: ProcessControlMode,
 }
 
+/// Captured `wait_process` request fields recorded for test assertions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WaitProcessCall {
+    /// Timeout passed to `Sandbox::wait_process`.
+    pub timeout: Duration,
+}
+
 /// Captured process-cancel request fields recorded for test assertions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessCancelCall {
@@ -448,6 +455,9 @@ pub struct MockSandboxOverrides {
     /// FIFO queue of full wait_process exits consumed by factory-created
     /// sandboxes. Empty queue follows the existing default/override behavior.
     wait_process_exits: Mutex<VecDeque<ProcessExit>>,
+    /// Recorded wait_process calls across all sandboxes built from this
+    /// override set.
+    wait_process_calls: Mutex<Vec<WaitProcessCall>>,
     /// FIFO queue of create results consumed by every factory built with
     /// these overrides. Empty queue → default Ok(()).
     create_results: Mutex<VecDeque<Result<()>>>,
@@ -476,6 +486,9 @@ pub struct MockSandboxOverrides {
     /// Recorded start_process output modes across all sandboxes built from
     /// this override set.
     start_process_calls: Mutex<Vec<StartProcessCall>>,
+    /// Recorded copy_file calls across all sandboxes built from this override
+    /// set.
+    copy_file_calls: Mutex<Vec<CopyFileCall>>,
     /// FIFO queue of stdout chunk batches emitted by factory-created
     /// sandboxes during streaming start_process calls.
     start_process_stdout_chunks: Mutex<VecDeque<Vec<ProcessOutputChunk>>>,
@@ -518,6 +531,7 @@ impl MockSandboxOverrides {
             wait_process_lifecycle_gate: Mutex::new(None),
             wait_process_error: None,
             wait_process_exits: Mutex::new(VecDeque::new()),
+            wait_process_calls: Mutex::new(Vec::new()),
             create_results: Mutex::new(VecDeque::new()),
             create_configs: Mutex::new(Vec::new()),
             start_results: Mutex::new(VecDeque::new()),
@@ -528,6 +542,7 @@ impl MockSandboxOverrides {
             destroy_gate: Mutex::new(None),
             destroy_behaviors: Mutex::new(VecDeque::new()),
             start_process_calls: Mutex::new(Vec::new()),
+            copy_file_calls: Mutex::new(Vec::new()),
             start_process_stdout_chunks: Mutex::new(VecDeque::new()),
             process_cancel_supported: Mutex::new(true),
             process_cancel_calls: Mutex::new(Vec::new()),
@@ -759,6 +774,22 @@ impl MockSandboxOverrides {
         self.start_process_calls.lock_ignoring_poison().clone()
     }
 
+    /// Return recorded wait-process calls across all sandboxes built from this
+    /// override set.
+    ///
+    /// The returned vector is a cloned snapshot in recorded order.
+    pub fn wait_process_calls(&self) -> Vec<WaitProcessCall> {
+        self.wait_process_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return recorded copy-file calls across all sandboxes built from this
+    /// override set.
+    ///
+    /// The returned vector is a cloned snapshot in recorded order.
+    pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
+        self.copy_file_calls.lock_ignoring_poison().clone()
+    }
+
     /// Queue stdout chunks emitted by the next streaming `start_process` call.
     /// Consumed FIFO across all sandboxes; empty queue emits no chunks.
     pub fn push_start_process_stdout_chunks(&self, chunks: Vec<ProcessOutputChunk>) {
@@ -978,8 +1009,9 @@ impl MockSandbox {
     /// The returned vector is a cloned snapshot in recorded order. Calls are
     /// recorded before mock validation errors such as invalid guest paths,
     /// oversized `max_bytes`, zero `max_bytes`, zero timeout, or invalid host
-    /// paths are returned. Copy-file calls are sandbox-local; shared overrides
-    /// do not expose a copy-file call accessor.
+    /// paths are returned. When this sandbox was built with shared overrides,
+    /// copy-file calls are also recorded in
+    /// [`MockSandboxOverrides::copy_file_calls`].
     pub fn copy_file_calls(&self) -> Vec<CopyFileCall> {
         self.copy_file_calls.lock_ignoring_poison().clone()
     }
@@ -1220,15 +1252,19 @@ impl Sandbox for MockSandbox {
         host_path: &Path,
         options: CopyFileOptions,
     ) -> Result<CopyFileResult> {
+        let call = CopyFileCall {
+            path: path.to_string(),
+            host_path: host_path.to_path_buf(),
+            max_bytes: options.max_bytes,
+            timeout: options.timeout,
+            missing_ok: options.missing_ok,
+        };
         self.copy_file_calls
             .lock_ignoring_poison()
-            .push(CopyFileCall {
-                path: path.to_string(),
-                host_path: host_path.to_path_buf(),
-                max_bytes: options.max_bytes,
-                timeout: options.timeout,
-                missing_ok: options.missing_ok,
-            });
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides.copy_file_calls.lock_ignoring_poison().push(call);
+        }
         validate_mock_guest_file_path(SandboxOperation::CopyFile, "copy_file", path)?;
         validate_mock_copy_host_path(host_path)?;
         if options.max_bytes == 0 {
@@ -1415,7 +1451,7 @@ impl Sandbox for MockSandbox {
     async fn wait_process(
         &self,
         mut handle: GuestProcessHandle,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<ProcessExit> {
         let Some(_waiter) = handle.take_waiter() else {
             return Err(SandboxError::Operation {
@@ -1429,6 +1465,10 @@ impl Sandbox for MockSandbox {
         handle.drop_unclaimed_stdout();
 
         if let Some(overrides) = &self.overrides {
+            overrides
+                .wait_process_calls
+                .lock_ignoring_poison()
+                .push(WaitProcessCall { timeout });
             // Block until the test signals (gives a window for cancellation).
             overrides.wait_for_wait_process_gate().await;
             // Return error when configured (simulates timeout or crash).


### PR DESCRIPTION
## Summary
- keep JOB_TIMEOUT as the guest-side agent runtime budget
- add a small host-side terminal grace window for receiving the guest TimedOut result
- record sandbox mock wait/copy calls and cover the timeout log-copy path with a regression test

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_guest_process_timeout_waits_for_terminal_grace_and_copies_logs
- cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_guest_process_timeout_marks_failure_kind
- cargo test --manifest-path crates/Cargo.toml -p runner timeout
- cargo test --manifest-path crates/Cargo.toml -p sandbox-mock
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner -p sandbox-mock --all-targets -- -D warnings
- git diff --check

Fixes #17876