### PR TITLE
feat: polish chat feedback UI (translucent toolbar + right-facing quote)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -570,7 +570,7 @@ function ComposerFeedbackRow({
             <IconQuote
               size={12}
               stroke={1.5}
-              className="text-muted-foreground"
+              className="-scale-x-100 text-muted-foreground"
             />
           </span>
           <span className="min-w-0 truncate text-xs font-medium">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -73,7 +73,7 @@ function FeedbackToolbar({
       onOpenAutoFocus={(event) => {
         return event.preventDefault();
       }}
-      className="w-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg"
+      className="w-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-[hsl(var(--card)/0.75)] p-1 text-foreground shadow-lg backdrop-blur-md"
     >
       <div className="flex items-center gap-0.5">
         <button


### PR DESCRIPTION
## What

Two small polish tweaks to the chat feedback UI:

1. **Translucent selection toolbar** — the floating Copy / Provide feedback popover that appears over a highlighted passage is now semi-transparent with a frosted-glass backdrop, so the message text underneath shows through instead of being fully hidden by a solid surface.
2. **Right-facing quote chip icon** — the quote chip in the composer (the reference pill dropped in when you pick Provide feedback) now shows a right-facing (closing) quotation mark instead of the default left-facing opening mark.

## Changes

`zero-chat-feedback-selection.tsx` — `PopoverContent` background:
- `bg-card` -> `bg-[hsl(var(--card)/0.75)]` (translucent card surface)
- added `backdrop-blur-md` so text behind stays a soft frosted layer and button labels remain legible

`zero-chat-composer.tsx` — quote chip `IconQuote`:
- added `-scale-x-100` to mirror the glyph horizontally (left -> right facing)

Both reuse existing tokens/utilities, so light and dark themes track automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)