### PR TITLE
feat: roll out google analytics connector

### DIFF
--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2587,14 +2587,9 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth"]);
   });
 
-  it("exposes Google Analytics OAuth only when its switch is enabled", () => {
+  it("exposes Google Analytics OAuth without a feature switch", () => {
     expect(
       getAvailableConnectorAuthMethodIds("google-analytics", {}),
-    ).toStrictEqual([]);
-    expect(
-      getAvailableConnectorAuthMethodIds("google-analytics", {
-        [FeatureSwitchKey.GoogleAnalyticsConnector]: true,
-      }),
     ).toStrictEqual(["oauth"]);
   });
 

--- a/turbo/packages/connectors/src/connectors/google-analytics.ts
+++ b/turbo/packages/connectors/src/connectors/google-analytics.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const googleAnalytics = {
   "google-analytics": {
@@ -18,7 +17,6 @@ export const googleAnalytics = {
       "Connect your Google account to access GA4 reports, properties, accounts, and audience data",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.GoogleAnalyticsConnector,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Google to grant Google Analytics access.",
         client: {


### PR DESCRIPTION
## Summary
- remove the Google Analytics OAuth auth-method feature gate so the connector is available without feature-switch state
- update connector availability coverage for the fully rolled out behavior

## Testing
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts -t getAvailableConnectorAuthMethodIds
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pre-commit hook: prettier, knip, pnpm check-types
