### PR TITLE
fix: allow codex model capacity error

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -116,6 +116,19 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(unrelatedRateLimit)).toBe(true);
   });
 
+  it("shows Codex model capacity errors verbatim", () => {
+    const modelCapacity =
+      "Selected model is at capacity. Please try a different model.";
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: modelCapacity,
+      }),
+    ).toBe(modelCapacity);
+    expect(isActionableRunError(modelCapacity)).toBe(true);
+    expect(isGenericRunErrorForDisplay(modelCapacity)).toBe(false);
+  });
+
   it("shows Claude Code subscription reconnect guidance for upstream 401s", () => {
     expect(
       formatRunErrorForExternalSurface({

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -173,6 +173,7 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   "Cannot continue session",
   "Invalid signature in thinking block",
   "Run cancelled",
+  "Selected model is at capacity. Please try a different model.",
   // Upstream model usage/quota limits are shown verbatim (the CLI already
   // emits clean, user-friendly copy with reset time and upgrade links).
   // Codex: "You've hit your usage limit …"


### PR DESCRIPTION
## Summary
- add the Codex "Selected model is at capacity. Please try a different model." message to the run error allowlist
- preserve that error verbatim instead of collapsing it to the generic Oops message

## Tests
- cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/errors.test.ts
- cd turbo && pnpm check-types