### PR TITLE
feat(runner): add local submit env overrides

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -491,13 +491,12 @@ jobs:
           fi
 
           REMOTE="${METAL_USER}@${HOST}"
-          ssh "$REMOTE" bash -s -- \
-            "$BIN_DIR" \
-            "$JOB_REF" \
-            "$DEFAULT_ROOTFS_HASH" \
-            "$DEFAULT_SNAPSHOT_HASH" \
-            "$OFFICIAL_RUNNER_SECRET" \
-            "$ANTHROPIC_API_KEY" <<'REMOTE_SCRIPT'
+          {
+            # Keep the CI provider key off SSH/bash argv; the runner CLI still
+            # receives it through --secret-env because that is the behavior
+            # under test.
+            printf 'ANTHROPIC_API_KEY=%q\n' "$ANTHROPIC_API_KEY"
+            cat <<'REMOTE_SCRIPT'
           set -euo pipefail
 
           BIN_DIR=$1
@@ -505,7 +504,6 @@ jobs:
           ROOTFS_HASH=$3
           SNAPSHOT_HASH=$4
           OFFICIAL_RUNNER_SECRET=$5
-          ANTHROPIC_API_KEY=$6
 
           SVC="${JOB_REF}-local-env"
           RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
@@ -593,6 +591,12 @@ jobs:
 
           echo "PASS: local submit ran real Claude Code with Haiku and returned RESULT=579"
           REMOTE_SCRIPT
+          } | ssh "$REMOTE" bash -s -- \
+            "$BIN_DIR" \
+            "$JOB_REF" \
+            "$DEFAULT_ROOTFS_HASH" \
+            "$DEFAULT_SNAPSHOT_HASH" \
+            "$OFFICIAL_RUNNER_SECRET"
 
   runner-benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -458,6 +458,151 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
+  runner-local-submit-env-smoke:
+    runs-on: ubuntu-latest
+    needs: [runner-build]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Test local submit environment forwarding
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          HOST: ${{ needs.runner-build.outputs.host }}
+          JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+          BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+        run: |
+          set -euo pipefail
+
+          REMOTE="${METAL_USER}@${HOST}"
+          ssh "$REMOTE" bash -s -- \
+            "$BIN_DIR" \
+            "$JOB_REF" \
+            "$DEFAULT_ROOTFS_HASH" \
+            "$DEFAULT_SNAPSHOT_HASH" \
+            "$OFFICIAL_RUNNER_SECRET" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+
+          BIN_DIR=$1
+          JOB_REF=$2
+          ROOTFS_HASH=$3
+          SNAPSHOT_HASH=$4
+          OFFICIAL_RUNNER_SECRET=$5
+
+          SVC="${JOB_REF}-local-env"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+          GROUP="vm0/local-env-${JOB_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-env-${JOB_REF}"
+
+          fail() {
+            echo "FAIL: $1" >&2
+            exit 1
+          }
+
+          print_service_logs() {
+            echo "--- ${SVC} service logs ---"
+            sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
+          }
+
+          cleanup() {
+            echo "--- Cleanup local env smoke runner ---"
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+          }
+          trap cleanup EXIT
+
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+
+          echo "--- Generating local runner config ---"
+          sudo "$BIN_DIR/runner" config \
+            --profile vm0/default \
+            --rootfs-hash "$ROOTFS_HASH" \
+            --snapshot-hash "$SNAPSHOT_HASH" \
+            --name "$SVC" \
+            --group "$GROUP" \
+            --runner-dirname "$SVC" \
+            --max-concurrent 1 \
+            --api-url https://not-a-real-server.test \
+            --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+          echo "--- Starting local runner ---"
+          sudo "$BIN_DIR/runner" service start \
+            --name "$SVC" \
+            --config "$RUNNER_DIR/runner.yaml" \
+            --local \
+            --env USE_MOCK_CLAUDE=true \
+            --env USE_MOCK_CODEX=true
+
+          PROMPT="$(cat <<'PROMPT_SCRIPT'
+          set -euo pipefail
+          printf "LOCAL_SUBMIT_VISIBLE=%s\n" "${LOCAL_SUBMIT_VISIBLE:-missing}"
+          printf "LOCAL_SUBMIT_EMPTY=%s\n" "${LOCAL_SUBMIT_EMPTY:-}"
+          printf "VM0_STUCK_TOOL_TIMEOUT_SECS=%s\n" "${VM0_STUCK_TOOL_TIMEOUT_SECS:-missing}"
+          printf "ANTHROPIC_API_KEY=%s\n" "${ANTHROPIC_API_KEY:-missing}"
+          PROMPT_SCRIPT
+          )"
+
+          echo "--- Submitting env smoke job ---"
+          if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
+            --group "$GROUP" \
+            --timeout 180 \
+            --env LOCAL_SUBMIT_VISIBLE=visible-from-env \
+            --env LOCAL_SUBMIT_EMPTY= \
+            --env VM0_STUCK_TOOL_TIMEOUT_SECS=3 \
+            --secret-env ANTHROPIC_API_KEY=sk-local-submit-env-smoke \
+            --prompt "$PROMPT" 2>&1); then
+            echo "$SUBMIT_OUTPUT"
+            print_service_logs
+            fail "local submit env smoke failed"
+          fi
+          echo "$SUBMIT_OUTPUT"
+
+          SUBMIT_JSON="$(awk '/^\{/{line=$0} END{print line}' <<<"$SUBMIT_OUTPUT")"
+          [ -n "$SUBMIT_JSON" ] || fail "local submit output did not include a JSON response"
+          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")"
+          [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
+          STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
+
+          print_failure_context() {
+            echo "--- Guest stdout stream tail ---"
+            sudo tail -200 "$STREAM_LOG" || true
+            print_service_logs
+          }
+
+          echo "--- Forwarded env lines from guest stdout ---"
+          sudo grep -E 'LOCAL_SUBMIT_VISIBLE=|LOCAL_SUBMIT_EMPTY=|VM0_STUCK_TOOL_TIMEOUT_SECS=|ANTHROPIC_API_KEY=' "$STREAM_LOG" || true
+
+          sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG" || {
+            print_failure_context
+            fail "ordinary --env value was not visible to the guest CLI"
+          }
+          sudo grep -q 'LOCAL_SUBMIT_EMPTY=' "$STREAM_LOG" || {
+            print_failure_context
+            fail "empty --env value was not visible to the guest CLI"
+          }
+          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=missing' "$STREAM_LOG" || {
+            print_failure_context
+            fail "guest-agent tuning env leaked into the guest CLI environment"
+          }
+          sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" || {
+            print_failure_context
+            fail "--secret-env value was not visible to the guest CLI"
+          }
+
+          echo "PASS: local submit forwarded env and secret-env to the guest CLI"
+          REMOTE_SCRIPT
+
   runner-benchmark:
     runs-on: ubuntu-latest
     needs: [runner-build]
@@ -1605,6 +1750,7 @@ jobs:
       - api-contracts-rust-bindings
       - mitm-addon-test
       - runner-build
+      - runner-local-submit-env-smoke
       - runner-benchmark
       - runner-exec
       - runner-cancel
@@ -1654,6 +1800,7 @@ jobs:
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
+          check_result "runner-local-submit-env-smoke" "${{ needs.runner-local-submit-env-smoke.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"
           check_result "runner-cancel" "${{ needs.runner-cancel.result }}" "true"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -472,10 +472,11 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
-      - name: Test local submit environment forwarding
+      - name: Test local submit with real Claude Code
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
           BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
@@ -484,13 +485,19 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::CI_ANTHROPIC_API_KEY is required for real Claude local submit smoke"
+            exit 1
+          fi
+
           REMOTE="${METAL_USER}@${HOST}"
           ssh "$REMOTE" bash -s -- \
             "$BIN_DIR" \
             "$JOB_REF" \
             "$DEFAULT_ROOTFS_HASH" \
             "$DEFAULT_SNAPSHOT_HASH" \
-            "$OFFICIAL_RUNNER_SECRET" <<'REMOTE_SCRIPT'
+            "$OFFICIAL_RUNNER_SECRET" \
+            "$ANTHROPIC_API_KEY" <<'REMOTE_SCRIPT'
           set -euo pipefail
 
           BIN_DIR=$1
@@ -498,6 +505,7 @@ jobs:
           ROOTFS_HASH=$3
           SNAPSHOT_HASH=$4
           OFFICIAL_RUNNER_SECRET=$5
+          ANTHROPIC_API_KEY=$6
 
           SVC="${JOB_REF}-local-env"
           RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
@@ -540,31 +548,21 @@ jobs:
           sudo "$BIN_DIR/runner" service start \
             --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" \
-            --local \
-            --env USE_MOCK_CLAUDE=true \
-            --env USE_MOCK_CODEX=true
+            --local
 
-          PROMPT="$(cat <<'PROMPT_SCRIPT'
-          set -euo pipefail
-          printf "LOCAL_SUBMIT_VISIBLE=%s\n" "${LOCAL_SUBMIT_VISIBLE:-missing}"
-          printf "LOCAL_SUBMIT_EMPTY=%s\n" "${LOCAL_SUBMIT_EMPTY:-}"
-          printf "VM0_STUCK_TOOL_TIMEOUT_SECS=%s\n" "${VM0_STUCK_TOOL_TIMEOUT_SECS:-missing}"
-          printf "ANTHROPIC_API_KEY=%s\n" "${ANTHROPIC_API_KEY:-missing}"
-          PROMPT_SCRIPT
-          )"
+          PROMPT='Compute 123+456 and reply with exactly: RESULT=<answer>'
 
-          echo "--- Submitting env smoke job ---"
+          echo "--- Submitting real Claude Code smoke job ---"
           if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
             --group "$GROUP" \
             --timeout 180 \
-            --env LOCAL_SUBMIT_VISIBLE=visible-from-env \
-            --env LOCAL_SUBMIT_EMPTY= \
-            --env VM0_STUCK_TOOL_TIMEOUT_SECS=3 \
-            --secret-env ANTHROPIC_API_KEY=sk-local-submit-env-smoke \
+            --cli-agent-type claude-code \
+            --env ANTHROPIC_MODEL=claude-haiku-4-5 \
+            --secret-env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
             --prompt "$PROMPT" 2>&1); then
             echo "$SUBMIT_OUTPUT"
             print_service_logs
-            fail "local submit env smoke failed"
+            fail "real Claude Code local submit smoke failed"
           fi
           echo "$SUBMIT_OUTPUT"
 
@@ -580,27 +578,20 @@ jobs:
             print_service_logs
           }
 
-          echo "--- Forwarded env lines from guest stdout ---"
-          sudo grep -E 'LOCAL_SUBMIT_VISIBLE=|LOCAL_SUBMIT_EMPTY=|VM0_STUCK_TOOL_TIMEOUT_SECS=|ANTHROPIC_API_KEY=' "$STREAM_LOG" || true
+          if sudo grep -q 'Using mock-claude for testing' "$STREAM_LOG"; then
+            print_failure_context
+            fail "real Claude Code smoke used mock Claude"
+          fi
 
-          sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG" || {
+          echo "--- Real Claude Code result lines from guest stdout ---"
+          sudo grep -E 'RESULT=579|Claude Code Completed' "$STREAM_LOG" || true
+
+          sudo grep -q 'RESULT=579' "$STREAM_LOG" || {
             print_failure_context
-            fail "ordinary --env value was not visible to the guest CLI"
-          }
-          sudo grep -q 'LOCAL_SUBMIT_EMPTY=' "$STREAM_LOG" || {
-            print_failure_context
-            fail "empty --env value was not visible to the guest CLI"
-          }
-          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=missing' "$STREAM_LOG" || {
-            print_failure_context
-            fail "guest-agent tuning env leaked into the guest CLI environment"
-          }
-          sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" || {
-            print_failure_context
-            fail "--secret-env value was not visible to the guest CLI"
+            fail "real Claude Code did not return RESULT=579"
           }
 
-          echo "PASS: local submit forwarded env and secret-env to the guest CLI"
+          echo "PASS: local submit ran real Claude Code with Haiku and returned RESULT=579"
           REMOTE_SCRIPT
 
   runner-benchmark:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2005,6 +2005,162 @@ jobs:
           echo "total-capacity=${TOTAL}" >> "$GITHUB_OUTPUT"
           echo "Total capacity across all hosts: ${TOTAL}"
 
+  runner-local-submit-env-smoke:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: runner-local-submit-env-smoke-${{ needs.prepare.outputs.job-ref }}
+      cancel-in-progress: true
+    needs: [prepare, deploy-runner-prepare]
+    if: |
+      needs.prepare.outputs.job-ref != '' &&
+      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Test local submit environment forwarding
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
+          ROOTFS_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash-map }}
+          SNAPSHOT_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.snapshot-hash-map }}
+        run: |
+          set -euo pipefail
+
+          HOST="$(printf '%s\n' "$METAL_HOSTS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d' | head -n 1)"
+          if [ -z "$HOST" ]; then
+            echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
+            exit 1
+          fi
+
+          ROOTFS_HASH="$(echo "$ROOTFS_HASH_MAP" | jq -r --arg h "$HOST" '.[$h] // empty')"
+          SNAPSHOT_HASH="$(echo "$SNAPSHOT_HASH_MAP" | jq -r --arg h "$HOST" '.[$h] // empty')"
+          if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
+            echo "::error::No rootfs/snapshot hash found for ${HOST}"
+            exit 1
+          fi
+
+          REMOTE="${METAL_USER}@${HOST}"
+          ssh "$REMOTE" bash -s -- \
+            "$BIN_DIR" \
+            "$JOB_REF" \
+            "$ROOTFS_HASH" \
+            "$SNAPSHOT_HASH" \
+            "$OFFICIAL_RUNNER_SECRET" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+
+          BIN_DIR=$1
+          JOB_REF=$2
+          ROOTFS_HASH=$3
+          SNAPSHOT_HASH=$4
+          OFFICIAL_RUNNER_SECRET=$5
+
+          SVC="${JOB_REF}-local-env"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+          GROUP="vm0/local-env-${JOB_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-env-${JOB_REF}"
+
+          fail() {
+            echo "FAIL: $1" >&2
+            exit 1
+          }
+
+          print_service_logs() {
+            echo "--- ${SVC} service logs ---"
+            sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
+          }
+
+          cleanup() {
+            echo "--- Cleanup local env smoke runner ---"
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            sudo rm -rf "$GROUP_DIR"
+          }
+          trap cleanup EXIT
+
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          sudo rm -rf "$GROUP_DIR"
+
+          echo "--- Generating local runner config ---"
+          sudo "$BIN_DIR/runner" config \
+            --profile vm0/default \
+            --rootfs-hash "$ROOTFS_HASH" \
+            --snapshot-hash "$SNAPSHOT_HASH" \
+            --name "$SVC" \
+            --group "$GROUP" \
+            --runner-dirname "$SVC" \
+            --max-concurrent 1 \
+            --api-url https://not-a-real-server.test \
+            --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+          echo "--- Starting local runner ---"
+          sudo "$BIN_DIR/runner" service start \
+            --name "$SVC" \
+            --config "$RUNNER_DIR/runner.yaml" \
+            --local \
+            --env USE_MOCK_CLAUDE=true \
+            --env USE_MOCK_CODEX=true
+
+          PROMPT="$(cat <<'PROMPT_SCRIPT'
+          set -euo pipefail
+          printf "LOCAL_SUBMIT_VISIBLE=%s\n" "${LOCAL_SUBMIT_VISIBLE:-missing}"
+          printf "LOCAL_SUBMIT_EMPTY=%s\n" "${LOCAL_SUBMIT_EMPTY:-}"
+          printf "VM0_STUCK_TOOL_TIMEOUT_SECS=%s\n" "${VM0_STUCK_TOOL_TIMEOUT_SECS:-missing}"
+          printf "ANTHROPIC_API_KEY=%s\n" "${ANTHROPIC_API_KEY:-missing}"
+          PROMPT_SCRIPT
+          )"
+
+          echo "--- Submitting env smoke job ---"
+          if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
+            --group "$GROUP" \
+            --timeout 180 \
+            --env LOCAL_SUBMIT_VISIBLE=visible-from-env \
+            --env LOCAL_SUBMIT_EMPTY= \
+            --env VM0_STUCK_TOOL_TIMEOUT_SECS=3 \
+            --secret-env ANTHROPIC_API_KEY=sk-local-submit-env-smoke \
+            --prompt "$PROMPT" 2>&1); then
+            echo "$SUBMIT_OUTPUT"
+            print_service_logs
+            fail "local submit env smoke failed"
+          fi
+          echo "$SUBMIT_OUTPUT"
+
+          RUN_ID="$(echo "$SUBMIT_OUTPUT" | jq -r '.run_id // empty')"
+          [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
+          STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
+
+          for _ in $(seq 1 20); do
+            if sudo test -s "$STREAM_LOG" \
+              && sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG"; then
+              break
+            fi
+            sleep 1
+          done
+
+          echo "--- Forwarded env lines from guest stdout ---"
+          sudo grep -E 'LOCAL_SUBMIT_VISIBLE=|LOCAL_SUBMIT_EMPTY=|VM0_STUCK_TOOL_TIMEOUT_SECS=|ANTHROPIC_API_KEY=' "$STREAM_LOG" || true
+
+          sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG" \
+            || fail "ordinary --env value was not visible to the guest CLI"
+          sudo grep -q 'LOCAL_SUBMIT_EMPTY=' "$STREAM_LOG" \
+            || fail "empty --env value was not visible to the guest CLI"
+          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=3' "$STREAM_LOG" \
+            || fail "guest-agent tuning env was not visible to the guest CLI"
+          sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" \
+            || fail "--secret-env value was not visible to the guest CLI"
+
+          echo "PASS: local submit forwarded env and secret-env to the guest CLI"
+          REMOTE_SCRIPT
+
   # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
   # Bootstrap runner E2E test account (runs once, in parallel with deploy-runner-start)
   e2e-runner-bootstrap:
@@ -2097,6 +2253,7 @@ jobs:
         deploy-web,
         deploy-runner-prepare,
         deploy-runner-start,
+        runner-local-submit-env-smoke,
         e2e-runner-bootstrap,
       ]
     if: |
@@ -2355,6 +2512,7 @@ jobs:
       - cli-e2e-01-serial
       - deploy-runner-prepare
       - deploy-runner-start
+      - runner-local-submit-env-smoke
       - e2e-runner-bootstrap
       - cli-e2e-03-runner
       - lighthouse-web
@@ -2438,6 +2596,7 @@ jobs:
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
+          check_result "runner-local-submit-env-smoke" "${{ needs.runner-local-submit-env-smoke.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "e2e-runner-bootstrap" "${{ needs.e2e-runner-bootstrap.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           # Informational: any result is acceptable (not a merge blocker)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2168,9 +2168,9 @@ jobs:
             print_failure_context
             fail "empty --env value was not visible to the guest CLI"
           }
-          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=3' "$STREAM_LOG" || {
+          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=missing' "$STREAM_LOG" || {
             print_failure_context
-            fail "guest-agent tuning env was not visible to the guest CLI"
+            fail "guest-agent tuning env leaked into the guest CLI environment"
           }
           sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" || {
             print_failure_context

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2005,181 +2005,6 @@ jobs:
           echo "total-capacity=${TOTAL}" >> "$GITHUB_OUTPUT"
           echo "Total capacity across all hosts: ${TOTAL}"
 
-  runner-local-submit-env-smoke:
-    runs-on: ubuntu-latest
-    concurrency:
-      group: runner-local-submit-env-smoke-${{ needs.prepare.outputs.job-ref }}
-      cancel-in-progress: true
-    needs: [prepare, deploy-runner-prepare]
-    if: |
-      needs.prepare.outputs.job-ref != '' &&
-      needs.prepare.outputs.turbo-runner-consumer-needed == 'true'
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup SSH via Cloudflare Tunnel
-        uses: ./.github/actions/setup-ssh-tunnel
-        with:
-          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
-          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-
-      - name: Test local submit environment forwarding
-        env:
-          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
-          ROOTFS_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.rootfs-hash-map }}
-          SNAPSHOT_HASH_MAP: ${{ needs.deploy-runner-prepare.outputs.snapshot-hash-map }}
-        run: |
-          set -euo pipefail
-
-          HOST="$(
-            awk -v hosts="$METAL_HOSTS" 'BEGIN {
-              count = split(hosts, values, ",")
-              for (i = 1; i <= count; i++) {
-                gsub(/^[[:space:]]+|[[:space:]]+$/, "", values[i])
-                if (values[i] != "") {
-                  print values[i]
-                  exit
-                }
-              }
-            }'
-          )"
-          if [ -z "$HOST" ]; then
-            echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
-            exit 1
-          fi
-
-          ROOTFS_HASH="$(jq -r --arg h "$HOST" '.[$h] // empty' <<<"$ROOTFS_HASH_MAP")"
-          SNAPSHOT_HASH="$(jq -r --arg h "$HOST" '.[$h] // empty' <<<"$SNAPSHOT_HASH_MAP")"
-          if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
-            echo "::error::No rootfs/snapshot hash found for ${HOST}"
-            exit 1
-          fi
-
-          REMOTE="${METAL_USER}@${HOST}"
-          ssh "$REMOTE" bash -s -- \
-            "$BIN_DIR" \
-            "$JOB_REF" \
-            "$ROOTFS_HASH" \
-            "$SNAPSHOT_HASH" \
-            "$OFFICIAL_RUNNER_SECRET" <<'REMOTE_SCRIPT'
-          set -euo pipefail
-
-          BIN_DIR=$1
-          JOB_REF=$2
-          ROOTFS_HASH=$3
-          SNAPSHOT_HASH=$4
-          OFFICIAL_RUNNER_SECRET=$5
-
-          SVC="${JOB_REF}-local-env"
-          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
-          GROUP="vm0/local-env-${JOB_REF}"
-          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-env-${JOB_REF}"
-
-          fail() {
-            echo "FAIL: $1" >&2
-            exit 1
-          }
-
-          print_service_logs() {
-            echo "--- ${SVC} service logs ---"
-            sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
-          }
-
-          cleanup() {
-            echo "--- Cleanup local env smoke runner ---"
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
-            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
-          }
-          trap cleanup EXIT
-
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
-          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
-
-          echo "--- Generating local runner config ---"
-          sudo "$BIN_DIR/runner" config \
-            --profile vm0/default \
-            --rootfs-hash "$ROOTFS_HASH" \
-            --snapshot-hash "$SNAPSHOT_HASH" \
-            --name "$SVC" \
-            --group "$GROUP" \
-            --runner-dirname "$SVC" \
-            --max-concurrent 1 \
-            --api-url https://not-a-real-server.test \
-            --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
-
-          echo "--- Starting local runner ---"
-          sudo "$BIN_DIR/runner" service start \
-            --name "$SVC" \
-            --config "$RUNNER_DIR/runner.yaml" \
-            --local \
-            --env USE_MOCK_CLAUDE=true \
-            --env USE_MOCK_CODEX=true
-
-          PROMPT="$(cat <<'PROMPT_SCRIPT'
-          set -euo pipefail
-          printf "LOCAL_SUBMIT_VISIBLE=%s\n" "${LOCAL_SUBMIT_VISIBLE:-missing}"
-          printf "LOCAL_SUBMIT_EMPTY=%s\n" "${LOCAL_SUBMIT_EMPTY:-}"
-          printf "VM0_STUCK_TOOL_TIMEOUT_SECS=%s\n" "${VM0_STUCK_TOOL_TIMEOUT_SECS:-missing}"
-          printf "ANTHROPIC_API_KEY=%s\n" "${ANTHROPIC_API_KEY:-missing}"
-          PROMPT_SCRIPT
-          )"
-
-          echo "--- Submitting env smoke job ---"
-          if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
-            --group "$GROUP" \
-            --timeout 180 \
-            --env LOCAL_SUBMIT_VISIBLE=visible-from-env \
-            --env LOCAL_SUBMIT_EMPTY= \
-            --env VM0_STUCK_TOOL_TIMEOUT_SECS=3 \
-            --secret-env ANTHROPIC_API_KEY=sk-local-submit-env-smoke \
-            --prompt "$PROMPT" 2>&1); then
-            echo "$SUBMIT_OUTPUT"
-            print_service_logs
-            fail "local submit env smoke failed"
-          fi
-          echo "$SUBMIT_OUTPUT"
-
-          SUBMIT_JSON="$(awk '/^\{/{line=$0} END{print line}' <<<"$SUBMIT_OUTPUT")"
-          [ -n "$SUBMIT_JSON" ] || fail "local submit output did not include a JSON response"
-          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")"
-          [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
-          STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
-
-          print_failure_context() {
-            echo "--- Guest stdout stream tail ---"
-            sudo tail -200 "$STREAM_LOG" || true
-            print_service_logs
-          }
-
-          echo "--- Forwarded env lines from guest stdout ---"
-          sudo grep -E 'LOCAL_SUBMIT_VISIBLE=|LOCAL_SUBMIT_EMPTY=|VM0_STUCK_TOOL_TIMEOUT_SECS=|ANTHROPIC_API_KEY=' "$STREAM_LOG" || true
-
-          sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG" || {
-            print_failure_context
-            fail "ordinary --env value was not visible to the guest CLI"
-          }
-          sudo grep -q 'LOCAL_SUBMIT_EMPTY=' "$STREAM_LOG" || {
-            print_failure_context
-            fail "empty --env value was not visible to the guest CLI"
-          }
-          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=missing' "$STREAM_LOG" || {
-            print_failure_context
-            fail "guest-agent tuning env leaked into the guest CLI environment"
-          }
-          sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" || {
-            print_failure_context
-            fail "--secret-env value was not visible to the guest CLI"
-          }
-
-          echo "PASS: local submit forwarded env and secret-env to the guest CLI"
-          REMOTE_SCRIPT
-
   # Run CLI E2E tests - Phase 3: Runner tests (needs runner deployed)
   # Bootstrap runner E2E test account (runs once, in parallel with deploy-runner-start)
   e2e-runner-bootstrap:
@@ -2272,7 +2097,6 @@ jobs:
         deploy-web,
         deploy-runner-prepare,
         deploy-runner-start,
-        runner-local-submit-env-smoke,
         e2e-runner-bootstrap,
       ]
     if: |
@@ -2531,7 +2355,6 @@ jobs:
       - cli-e2e-01-serial
       - deploy-runner-prepare
       - deploy-runner-start
-      - runner-local-submit-env-smoke
       - e2e-runner-bootstrap
       - cli-e2e-03-runner
       - lighthouse-web
@@ -2615,7 +2438,6 @@ jobs:
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
-          check_result "runner-local-submit-env-smoke" "${{ needs.runner-local-submit-env-smoke.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "e2e-runner-bootstrap" "${{ needs.e2e-runner-bootstrap.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "cli-e2e-03-runner" "${{ needs.cli-e2e-03-runner.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           # Informational: any result is acceptable (not a merge blocker)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2037,14 +2037,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          HOST="$(printf '%s\n' "$METAL_HOSTS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d' | head -n 1)"
+          HOST="$(
+            awk -v hosts="$METAL_HOSTS" 'BEGIN {
+              count = split(hosts, values, ",")
+              for (i = 1; i <= count; i++) {
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", values[i])
+                if (values[i] != "") {
+                  print values[i]
+                  exit
+                }
+              }
+            }'
+          )"
           if [ -z "$HOST" ]; then
             echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
             exit 1
           fi
 
-          ROOTFS_HASH="$(echo "$ROOTFS_HASH_MAP" | jq -r --arg h "$HOST" '.[$h] // empty')"
-          SNAPSHOT_HASH="$(echo "$SNAPSHOT_HASH_MAP" | jq -r --arg h "$HOST" '.[$h] // empty')"
+          ROOTFS_HASH="$(jq -r --arg h "$HOST" '.[$h] // empty' <<<"$ROOTFS_HASH_MAP")"
+          SNAPSHOT_HASH="$(jq -r --arg h "$HOST" '.[$h] // empty' <<<"$SNAPSHOT_HASH_MAP")"
           if [ -z "$ROOTFS_HASH" ] || [ -z "$SNAPSHOT_HASH" ]; then
             echo "::error::No rootfs/snapshot hash found for ${HOST}"
             exit 1
@@ -2083,12 +2094,12 @@ jobs:
           cleanup() {
             echo "--- Cleanup local env smoke runner ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
-            sudo rm -rf "$GROUP_DIR"
+            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
           }
           trap cleanup EXIT
 
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
-          sudo rm -rf "$GROUP_DIR"
+          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
 
           echo "--- Generating local runner config ---"
           sudo "$BIN_DIR/runner" config \
@@ -2134,29 +2145,35 @@ jobs:
           fi
           echo "$SUBMIT_OUTPUT"
 
-          RUN_ID="$(echo "$SUBMIT_OUTPUT" | jq -r '.run_id // empty')"
+          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_OUTPUT")"
           [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
           STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
 
-          for _ in $(seq 1 20); do
-            if sudo test -s "$STREAM_LOG" \
-              && sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG"; then
-              break
-            fi
-            sleep 1
-          done
+          print_failure_context() {
+            echo "--- Guest stdout stream tail ---"
+            sudo tail -200 "$STREAM_LOG" || true
+            print_service_logs
+          }
 
           echo "--- Forwarded env lines from guest stdout ---"
           sudo grep -E 'LOCAL_SUBMIT_VISIBLE=|LOCAL_SUBMIT_EMPTY=|VM0_STUCK_TOOL_TIMEOUT_SECS=|ANTHROPIC_API_KEY=' "$STREAM_LOG" || true
 
-          sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG" \
-            || fail "ordinary --env value was not visible to the guest CLI"
-          sudo grep -q 'LOCAL_SUBMIT_EMPTY=' "$STREAM_LOG" \
-            || fail "empty --env value was not visible to the guest CLI"
-          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=3' "$STREAM_LOG" \
-            || fail "guest-agent tuning env was not visible to the guest CLI"
-          sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" \
-            || fail "--secret-env value was not visible to the guest CLI"
+          sudo grep -q 'LOCAL_SUBMIT_VISIBLE=visible-from-env' "$STREAM_LOG" || {
+            print_failure_context
+            fail "ordinary --env value was not visible to the guest CLI"
+          }
+          sudo grep -q 'LOCAL_SUBMIT_EMPTY=' "$STREAM_LOG" || {
+            print_failure_context
+            fail "empty --env value was not visible to the guest CLI"
+          }
+          sudo grep -q 'VM0_STUCK_TOOL_TIMEOUT_SECS=3' "$STREAM_LOG" || {
+            print_failure_context
+            fail "guest-agent tuning env was not visible to the guest CLI"
+          }
+          sudo grep -Eq 'ANTHROPIC_API_KEY=(sk-local-submit-env-smoke|\*\*\*)' "$STREAM_LOG" || {
+            print_failure_context
+            fail "--secret-env value was not visible to the guest CLI"
+          }
 
           echo "PASS: local submit forwarded env and secret-env to the guest CLI"
           REMOTE_SCRIPT

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2145,7 +2145,9 @@ jobs:
           fi
           echo "$SUBMIT_OUTPUT"
 
-          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_OUTPUT")"
+          SUBMIT_JSON="$(awk '/^\{/{line=$0} END{print line}' <<<"$SUBMIT_OUTPUT")"
+          [ -n "$SUBMIT_JSON" ] || fail "local submit output did not include a JSON response"
+          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")"
           [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
           STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
 

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -14,7 +14,6 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = guest_contracts::env::USER_ENV_FILE_ENV;
 const USER_ENV_PRIVATE_DIR_NAME: &str = "user-env";
 const USER_ENV_FILENAME: &str = "env.json";
-const ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
 
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
@@ -350,47 +349,21 @@ fn validate_user_env(user_env: &HashMap<String, String>) -> Result<(), String> {
     entries.sort_by_key(|(key, _)| *key);
 
     for (key, value) in entries {
-        if !is_valid_env_key(key) {
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
             return Err(format!(
                 "{USER_ENV_FILE_ENV_KEY} contains invalid env key {:?}",
-                sanitize_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
             ));
         }
         if value.contains('\0') {
             return Err(format!(
                 "{USER_ENV_FILE_ENV_KEY} contains NUL byte for env key {:?}",
-                sanitize_env_key_for_diagnostic(key)
+                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
             ));
         }
     }
 
     Ok(())
-}
-
-fn is_valid_env_key(key: &str) -> bool {
-    let mut chars = key.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first.is_ascii_alphabetic()) {
-        return false;
-    }
-    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-fn sanitize_env_key_for_diagnostic(key: &str) -> String {
-    let mut chars = key.escape_debug();
-    let mut truncated = String::new();
-    for _ in 0..ENV_KEY_DIAGNOSTIC_MAX_CHARS {
-        let Some(ch) = chars.next() else {
-            return truncated;
-        };
-        truncated.push(ch);
-    }
-    if chars.next().is_some() {
-        truncated.push_str("...");
-    }
-    truncated
 }
 
 #[allow(clippy::panic)] // Entry points must call init_user_env; bypassing it is a code bug.

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -34,6 +34,19 @@ pub const MOCK_CODEX_PATH_ENV: &str = "VM0_MOCK_CODEX_PATH";
 /// boundary.
 pub const WORKING_DIR_ENV: &str = "VM0_WORKING_DIR";
 
+pub const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
+    STUCK_TOOL_TIMEOUT_SECS_ENV,
+    POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+    POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+];
+
+const NON_VM0_RUNNER_OWNED_ENV_KEYS: &[&str] = &[
+    CLI_AGENT_TYPE_ENV,
+    USE_MOCK_CLAUDE_ENV,
+    USE_MOCK_CODEX_ENV,
+    VERCEL_PROTECTION_BYPASS_ENV,
+];
+
 const USER_ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
 
 /// Returns whether `key` is supported by vm0 guest shell exec env injection.
@@ -50,6 +63,14 @@ pub fn is_shell_identifier_env_key(key: &str) -> bool {
         return false;
     }
     chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+pub fn is_guest_agent_tuning_env_key(key: &str) -> bool {
+    GUEST_AGENT_TUNING_ENV_KEYS.contains(&key)
+}
+
+pub fn is_runner_owned_env_key(key: &str) -> bool {
+    key.starts_with("VM0_") || NON_VM0_RUNNER_OWNED_ENV_KEYS.contains(&key)
 }
 
 pub fn sanitize_user_env_key_for_diagnostic(key: &str) -> String {
@@ -115,5 +136,32 @@ mod tests {
         assert!(diagnostic.starts_with(r"BAD\n"));
         assert!(diagnostic.ends_with("..."));
         assert!(!diagnostic.contains('\n'));
+    }
+
+    #[test]
+    fn runner_owned_key_detection_covers_bootstrap_namespaces() {
+        for key in [
+            API_URL_ENV,
+            WORKING_DIR_ENV,
+            CLI_AGENT_TYPE_ENV,
+            USE_MOCK_CLAUDE_ENV,
+            USE_MOCK_CODEX_ENV,
+            VERCEL_PROTECTION_BYPASS_ENV,
+        ] {
+            assert!(is_runner_owned_env_key(key), "{key} should be runner-owned");
+        }
+        assert!(!is_runner_owned_env_key("CUSTOM_ENV"));
+    }
+
+    #[test]
+    fn guest_agent_tuning_keys_are_explicit() {
+        assert!(is_guest_agent_tuning_env_key(STUCK_TOOL_TIMEOUT_SECS_ENV));
+        assert!(is_guest_agent_tuning_env_key(
+            POST_RESULT_SIGTERM_GRACE_SECS_ENV
+        ));
+        assert!(is_guest_agent_tuning_env_key(
+            POST_RESULT_SIGKILL_GRACE_SECS_ENV
+        ));
+        assert!(!is_guest_agent_tuning_env_key(API_URL_ENV));
     }
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -34,6 +34,8 @@ pub const MOCK_CODEX_PATH_ENV: &str = "VM0_MOCK_CODEX_PATH";
 /// boundary.
 pub const WORKING_DIR_ENV: &str = "VM0_WORKING_DIR";
 
+const USER_ENV_KEY_DIAGNOSTIC_MAX_CHARS: usize = 128;
+
 /// Returns whether `key` is supported by vm0 guest shell exec env injection.
 ///
 /// This is the shell identifier format accepted by the guest env script's
@@ -48,6 +50,21 @@ pub fn is_shell_identifier_env_key(key: &str) -> bool {
         return false;
     }
     chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+pub fn sanitize_user_env_key_for_diagnostic(key: &str) -> String {
+    let mut chars = key.escape_debug();
+    let mut truncated = String::new();
+    for _ in 0..USER_ENV_KEY_DIAGNOSTIC_MAX_CHARS {
+        let Some(ch) = chars.next() else {
+            return truncated;
+        };
+        truncated.push(ch);
+    }
+    if chars.next().is_some() {
+        truncated.push_str("...");
+    }
+    truncated
 }
 
 #[cfg(test)]
@@ -80,6 +97,7 @@ mod tests {
             "BAD-NAME",
             "BAD.NAME",
             "BAD NAME",
+            "ÅKEY",
             "\u{00e9}clair",
         ] {
             assert!(
@@ -87,5 +105,15 @@ mod tests {
                 "{key} should not be a supported shell exec env key"
             );
         }
+    }
+
+    #[test]
+    fn user_env_key_diagnostic_escapes_and_truncates() {
+        let key = format!("BAD\n{}", "X".repeat(200));
+        let diagnostic = sanitize_user_env_key_for_diagnostic(&key);
+
+        assert!(diagnostic.starts_with(r"BAD\n"));
+        assert!(diagnostic.ends_with("..."));
+        assert!(!diagnostic.contains('\n'));
     }
 }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
@@ -14,6 +14,7 @@ use std::time::Duration;
 use clap::Args;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::host_file;
 use crate::ids::RunId;
 use crate::local_queue::{self, JobRequest, JobResponse};
 use crate::paths::HomePaths;
@@ -353,7 +354,7 @@ impl SubmitPlan {
 
             let key = &entry[..eq_pos];
             let value = &entry[eq_pos + 1..];
-            if !Self::is_valid_env_key(key) {
+            if !guest_contracts::env::is_shell_identifier_env_key(key) {
                 return Err(RunnerError::Config(format!(
                     "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
                 )));
@@ -364,17 +365,6 @@ impl SubmitPlan {
         }
 
         Ok(Some(map))
-    }
-
-    fn is_valid_env_key(key: &str) -> bool {
-        let mut chars = key.chars();
-        let Some(first) = chars.next() else {
-            return false;
-        };
-        if !(first == '_' || first.is_ascii_alphabetic()) {
-            return false;
-        }
-        chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
     }
 
     fn validate_disjoint_env_keys(
@@ -402,15 +392,30 @@ impl SubmitPlan {
             .queue
             .job_dir
             .join(format!("{}.job.tmp", self.queue.job_id));
-        if let Err(e) = std::fs::write(&tmp_path, &self.request_json) {
+        let result = (|| {
+            let mut file = std::fs::File::options()
+                .write(true)
+                .create_new(true)
+                .mode(host_file::PRIVATE_FILE_MODE)
+                .custom_flags(host_file::private_file_open_flags())
+                .open(&tmp_path)
+                .map_err(|e| RunnerError::Internal(format!("open job file tmp: {e}")))?;
+            host_file::secure_regular_private_file(&file, &tmp_path, "job file").map_err(|e| {
+                RunnerError::Internal(format!("validate job file tmp {}: {e}", tmp_path.display()))
+            })?;
+            file.write_all(&self.request_json)
+                .map_err(|e| RunnerError::Internal(format!("write job file: {e}")))?;
+            drop(file);
+
+            std::fs::rename(&tmp_path, &self.queue.job)
+                .map_err(|e| RunnerError::Internal(format!("rename job file: {e}")))?;
+            Ok(())
+        })();
+
+        if result.is_err() {
             let _ = remove_file_if_exists(&tmp_path);
-            return Err(RunnerError::Internal(format!("write job file: {e}")));
         }
-        if let Err(e) = std::fs::rename(&tmp_path, &self.queue.job) {
-            let _ = remove_file_if_exists(&tmp_path);
-            return Err(RunnerError::Internal(format!("rename job file: {e}")));
-        }
-        Ok(())
+        result
     }
 
     async fn wait_for_result(&self) -> RunnerResult<SubmitOutcome> {
@@ -954,6 +959,34 @@ mod tests {
 
             assert!(err.to_string().contains(expected), "got: {err}");
         }
+    }
+
+    #[test]
+    fn write_job_file_creates_private_job_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        std::fs::create_dir_all(queue.job.parent().unwrap()).unwrap();
+        let plan = SubmitPlan {
+            group: "test/group".into(),
+            profile: crate::profile::DEFAULT_PROFILE.to_owned(),
+            queue,
+            timeout: Duration::ZERO,
+            request_json: br#"{"secretEnvironment":{"ANTHROPIC_API_KEY":"sk-local-secret"}}"#
+                .to_vec(),
+        };
+
+        plan.write_job_file().unwrap();
+
+        let mode = std::fs::metadata(&plan.queue.job)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, host_file::PRIVATE_FILE_MODE);
     }
 
     #[test]

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -336,9 +336,9 @@ impl SubmitPlan {
 
         let mut map = HashMap::new();
         for entry in entries {
-            if entry.contains(['\n', '\r', '\0']) {
+            if entry.contains('\0') {
                 return Err(RunnerError::Config(format!(
-                    "invalid {flag} value: newline or NUL characters are not allowed"
+                    "invalid {flag} value: NUL characters are not allowed"
                 )));
             }
             let Some(eq_pos) = entry.find('=') else {
@@ -873,8 +873,12 @@ mod tests {
             "FOO=bar".into(),
             "URL=https://example.test/path?a=1&b=2".into(),
             "EMPTY=".into(),
+            "MULTILINE=line1\nline2".into(),
         ];
-        args.secret_env = vec!["ANTHROPIC_API_KEY=sk-ant-local-secret".into()];
+        args.secret_env = vec![
+            "ANTHROPIC_API_KEY=sk-ant-local-secret".into(),
+            "PRIVATE_KEY=-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----".into(),
+        ];
 
         let code = run_submit_with_home(args, home).await.unwrap();
         let request = watcher.await.unwrap();
@@ -889,10 +893,18 @@ mod tests {
         );
         assert_eq!(environment.get("EMPTY").map(String::as_str), Some(""));
         assert_eq!(
+            environment.get("MULTILINE").map(String::as_str),
+            Some("line1\nline2")
+        );
+        assert_eq!(
             secret_environment
                 .get("ANTHROPIC_API_KEY")
                 .map(String::as_str),
             Some("sk-ant-local-secret")
+        );
+        assert_eq!(
+            secret_environment.get("PRIVATE_KEY").map(String::as_str),
+            Some("-----BEGIN KEY-----\r\nsecret\r\n-----END KEY-----")
         );
     }
 
@@ -901,11 +913,6 @@ mod tests {
         let cases = vec![
             (vec!["FOO".to_string()], Vec::new(), "expected KEY=VALUE"),
             (vec!["=VALUE".to_string()], Vec::new(), "expected KEY=VALUE"),
-            (
-                vec!["KEY=line1\nline2".to_string()],
-                Vec::new(),
-                "newline or NUL",
-            ),
             (
                 vec!["BAD-KEY=value".to_string()],
                 Vec::new(),
@@ -928,13 +935,8 @@ mod tests {
             ),
             (
                 Vec::new(),
-                vec!["KEY=foo\rbar".to_string()],
-                "newline or NUL",
-            ),
-            (
-                Vec::new(),
                 vec!["KEY=with\0nul".to_string()],
-                "newline or NUL",
+                "NUL characters",
             ),
             (
                 vec!["FOO=1".to_string(), "FOO=2".to_string()],

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -265,8 +265,8 @@ impl SubmitPlan {
         };
 
         let feature_flags = Self::parse_feature_flags(&feature_flags)?;
-        let environment = Self::parse_env_entries("--env", &env)?;
-        let secret_environment = Self::parse_env_entries("--secret-env", &secret_env)?;
+        let environment = Self::parse_env_entries("--env", &env, true)?;
+        let secret_environment = Self::parse_env_entries("--secret-env", &secret_env, false)?;
         Self::validate_disjoint_env_keys(&environment, &secret_environment)?;
         let group_dir = home.groups_dir().join(&group);
         let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile)?;
@@ -329,6 +329,7 @@ impl SubmitPlan {
     fn parse_env_entries(
         flag: &str,
         entries: &[String],
+        allow_guest_agent_tuning_keys: bool,
     ) -> RunnerResult<Option<HashMap<String, String>>> {
         if entries.is_empty() {
             return Ok(None);
@@ -359,9 +360,14 @@ impl SubmitPlan {
                     "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
                 )));
             }
-            if guest_contracts::env::is_runner_owned_env_key(key)
-                && !guest_contracts::env::is_guest_agent_tuning_env_key(key)
-            {
+            let is_guest_agent_tuning_key =
+                guest_contracts::env::is_guest_agent_tuning_env_key(key);
+            if is_guest_agent_tuning_key && !allow_guest_agent_tuning_keys {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} key '{key}': guest-agent tuning environment variables must be passed with --env"
+                )));
+            }
+            if guest_contracts::env::is_runner_owned_env_key(key) && !is_guest_agent_tuning_key {
                 return Err(RunnerError::Config(format!(
                     "invalid {flag} key '{key}': runner-owned environment variables are not allowed"
                 )));
@@ -961,6 +967,11 @@ mod tests {
                 Vec::new(),
                 vec!["CLI_AGENT_TYPE=codex".to_string()],
                 "runner-owned environment variables",
+            ),
+            (
+                Vec::new(),
+                vec!["VM0_STUCK_TOOL_TIMEOUT_SECS=3".to_string()],
+                "must be passed with --env",
             ),
             (
                 vec!["FOO=1".to_string(), "FOO=2".to_string()],

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -94,6 +94,7 @@ struct PublishedMarker {
 
 struct SubmitQueueEntry {
     job_id: RunId,
+    group_dir: PathBuf,
     job_dir: PathBuf,
     job: PathBuf,
     result: PathBuf,
@@ -105,6 +106,7 @@ impl SubmitQueueEntry {
     fn for_job(group_dir: &Path, profile: &str, job_id: RunId) -> RunnerResult<Self> {
         Ok(Self {
             job_id,
+            group_dir: group_dir.to_path_buf(),
             job_dir: local_queue::profile_jobs_dir(group_dir, profile)?,
             job: local_queue::job_path(group_dir, profile, job_id)?,
             result: local_queue::result_path(group_dir, job_id),
@@ -115,17 +117,20 @@ impl SubmitQueueEntry {
 
     /// Clean up queue files after a completed job has produced a result.
     fn cleanup_completed(&self) {
-        let job_removed = remove_file_if_exists(&self.job);
+        let jobs_removed = local_queue::LocalQueue::new(self.group_dir.clone())
+            .remove_job_files_if_present(self.job_id);
         let _ = remove_file_if_exists(&self.cancel);
         let _ = remove_file_if_exists(&self.claim);
-        if job_removed {
+        if jobs_removed {
             let _ = remove_file_if_exists(&self.result);
         }
     }
 
     /// Clean up submit-owned queue files after timing out while waiting for a result.
     fn cleanup_abandoned(&self, marker: Option<&PublishedMarker>) {
-        if remove_file_if_exists(&self.job) && !self.claim.exists() {
+        let jobs_removed = local_queue::LocalQueue::new(self.group_dir.clone())
+            .remove_job_files_if_present(self.job_id);
+        if jobs_removed && !self.claim.exists() {
             let _ = remove_file_if_exists(&self.cancel);
             if marker.is_some() {
                 remove_marker_if_unchanged(&self.result, marker);
@@ -528,6 +533,13 @@ mod tests {
 
     fn submit_queue_entry(group_dir: &Path, job_id: RunId) -> SubmitQueueEntry {
         SubmitQueueEntry::for_job(group_dir, crate::profile::DEFAULT_PROFILE, job_id).unwrap()
+    }
+
+    fn write_queue_job_file(group_dir: &Path, profile: &str, job_id: RunId) -> PathBuf {
+        let path = local_queue::job_path(group_dir, profile, job_id).unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"{}").unwrap();
+        path
     }
 
     #[test]
@@ -1125,6 +1137,31 @@ mod tests {
     }
 
     #[test]
+    fn completed_cleanup_removes_duplicate_job_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        let default_job = write_queue_job_file(group_dir, crate::profile::DEFAULT_PROFILE, job_id);
+        let large_job = write_queue_job_file(group_dir, "vm0/large", job_id);
+        std::fs::create_dir_all(queue.result.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(queue.claim.parent().unwrap()).unwrap();
+
+        std::fs::write(&queue.result, b"{}").unwrap();
+        std::fs::write(&queue.cancel, b"").unwrap();
+        std::fs::write(&queue.claim, b"").unwrap();
+
+        queue.cleanup_completed();
+
+        assert!(!default_job.exists());
+        assert!(!large_job.exists());
+        assert!(!queue.result.exists());
+        assert!(!queue.cancel.exists());
+        assert!(!queue.claim.exists());
+    }
+
+    #[test]
     fn completed_cleanup_keeps_result_when_job_cannot_be_removed() {
         let dir = tempfile::tempdir().unwrap();
         let group_dir = dir.path();
@@ -1144,6 +1181,35 @@ mod tests {
         assert!(
             queue.result.exists(),
             "result must remain as the terminal marker if the job path was not removed"
+        );
+        assert!(!queue.cancel.exists());
+        assert!(!queue.claim.exists());
+    }
+
+    #[test]
+    fn completed_cleanup_keeps_result_when_duplicate_job_cannot_be_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        let default_job = write_queue_job_file(group_dir, crate::profile::DEFAULT_PROFILE, job_id);
+        let blocked_job = local_queue::job_path(group_dir, "vm0/large", job_id).unwrap();
+        std::fs::create_dir_all(&blocked_job).unwrap();
+        std::fs::create_dir_all(queue.result.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(queue.claim.parent().unwrap()).unwrap();
+
+        std::fs::write(&queue.result, b"{}").unwrap();
+        std::fs::write(&queue.cancel, b"").unwrap();
+        std::fs::write(&queue.claim, b"").unwrap();
+
+        queue.cleanup_completed();
+
+        assert!(!default_job.exists());
+        assert!(blocked_job.exists());
+        assert!(
+            queue.result.exists(),
+            "result must remain as the terminal marker if any duplicate job path was not removed"
         );
         assert!(!queue.cancel.exists());
         assert!(!queue.claim.exists());
@@ -1227,6 +1293,31 @@ mod tests {
     }
 
     #[test]
+    fn abandoned_cleanup_removes_duplicate_unclaimed_jobs() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        let default_job = write_queue_job_file(group_dir, crate::profile::DEFAULT_PROFILE, job_id);
+        let large_job = write_queue_job_file(group_dir, "vm0/large", job_id);
+        std::fs::create_dir_all(queue.result.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
+
+        std::fs::write(&queue.cancel, b"").unwrap();
+
+        queue.abandon("timed out");
+
+        assert!(!default_job.exists());
+        assert!(!large_job.exists());
+        assert!(!queue.result.exists());
+        assert!(!queue.cancel.exists());
+        assert!(
+            !queue.claim.exists(),
+            "abandoned cleanup should not create a temporary claim"
+        );
+    }
+
+    #[test]
     fn abandoned_cleanup_removes_marker_when_job_already_absent() {
         let dir = tempfile::tempdir().unwrap();
         let group_dir = dir.path();
@@ -1242,6 +1333,31 @@ mod tests {
 
         assert!(!queue.result.exists());
         assert!(!queue.cancel.exists());
+        assert!(!queue.claim.exists());
+    }
+
+    #[test]
+    fn abandoned_cleanup_keeps_marker_when_duplicate_job_cannot_be_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        let default_job = write_queue_job_file(group_dir, crate::profile::DEFAULT_PROFILE, job_id);
+        let blocked_job = local_queue::job_path(group_dir, "vm0/large", job_id).unwrap();
+        std::fs::create_dir_all(&blocked_job).unwrap();
+        std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
+
+        std::fs::write(&queue.cancel, b"").unwrap();
+
+        queue.abandon("timed out");
+
+        assert!(!default_job.exists());
+        assert!(blocked_job.exists());
+        assert!(
+            queue.result.exists(),
+            "terminal marker must remain if any duplicate job path could not be removed"
+        );
+        assert!(queue.cancel.exists());
         assert!(!queue.claim.exists());
     }
 

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -4,7 +4,7 @@
 //! for a group-wide `{job_id}.result` file written by the runner that claimed
 //! the job.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -44,6 +44,12 @@ pub struct SubmitArgs {
     /// Feature flags (repeatable, format: key=value, e.g. --feature-flag myFlag=true)
     #[arg(long = "feature-flag")]
     feature_flags: Vec<String>,
+    /// Ordinary environment variables to pass to the local job (KEY=VALUE)
+    #[arg(long = "env")]
+    env: Vec<String>,
+    /// Local-only secret environment variables to pass and register for masking (KEY=VALUE)
+    #[arg(long = "secret-env")]
+    secret_env: Vec<String>,
     /// Timeout in seconds waiting for a runner to complete the job
     #[arg(long, default_value_t = 300)]
     timeout: u64,
@@ -242,6 +248,8 @@ impl SubmitPlan {
             profile,
             session_id,
             feature_flags,
+            env,
+            secret_env,
             timeout,
         } = args;
 
@@ -256,6 +264,9 @@ impl SubmitPlan {
         };
 
         let feature_flags = Self::parse_feature_flags(&feature_flags)?;
+        let environment = Self::parse_env_entries("--env", &env)?;
+        let secret_environment = Self::parse_env_entries("--secret-env", &secret_env)?;
+        Self::validate_disjoint_env_keys(&environment, &secret_environment)?;
         let group_dir = home.groups_dir().join(&group);
         let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile)?;
 
@@ -273,7 +284,8 @@ impl SubmitPlan {
             prompt,
             cli_agent_type,
             vars: None,
-            environment: None,
+            environment,
+            secret_environment,
             user_timezone: detect_system_timezone(),
             profile: Some(profile.clone()),
             session_id,
@@ -311,6 +323,62 @@ impl SubmitPlan {
             map.insert(key.to_string(), bool_val);
         }
         Ok(Some(map))
+    }
+
+    fn parse_env_entries(
+        flag: &str,
+        entries: &[String],
+    ) -> RunnerResult<Option<HashMap<String, String>>> {
+        if entries.is_empty() {
+            return Ok(None);
+        }
+
+        let mut map = HashMap::new();
+        for entry in entries {
+            if entry.contains(['\n', '\r', '\0']) {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} value: newline or NUL characters are not allowed"
+                )));
+            }
+            let Some(eq_pos) = entry.find('=') else {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} value: expected KEY=VALUE format"
+                )));
+            };
+            if eq_pos == 0 {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} value: expected KEY=VALUE format"
+                )));
+            }
+
+            let key = &entry[..eq_pos];
+            let value = &entry[eq_pos + 1..];
+            if map.insert(key.to_owned(), value.to_owned()).is_some() {
+                return Err(RunnerError::Config(format!("duplicate {flag} key '{key}'")));
+            }
+        }
+
+        Ok(Some(map))
+    }
+
+    fn validate_disjoint_env_keys(
+        environment: &Option<HashMap<String, String>>,
+        secret_environment: &Option<HashMap<String, String>>,
+    ) -> RunnerResult<()> {
+        let (Some(environment), Some(secret_environment)) = (environment, secret_environment)
+        else {
+            return Ok(());
+        };
+
+        let secret_keys: HashSet<&str> = secret_environment.keys().map(String::as_str).collect();
+        for key in environment.keys() {
+            if secret_keys.contains(key.as_str()) {
+                return Err(RunnerError::Config(format!(
+                    "duplicate env key '{key}' across --env and --secret-env"
+                )));
+            }
+        }
+        Ok(())
     }
 
     fn write_job_file(&self) -> RunnerResult<()> {
@@ -642,6 +710,20 @@ mod tests {
         wait_for_job_and_write_result(group_dir, profile, 0, None).await
     }
 
+    fn submit_args_for_test() -> SubmitArgs {
+        SubmitArgs {
+            group: "test/group".into(),
+            prompt: "hello".into(),
+            cli_agent_type: "claude-code".into(),
+            profile: None,
+            session_id: None,
+            feature_flags: vec![],
+            env: vec![],
+            secret_env: vec![],
+            timeout: 1,
+        }
+    }
+
     #[tokio::test]
     async fn submit_defaults_profile_and_writes_default_partition() {
         let dir = tempfile::tempdir().unwrap();
@@ -661,6 +743,8 @@ mod tests {
                 profile: None,
                 session_id: None,
                 feature_flags: vec![],
+                env: vec![],
+                secret_env: vec![],
                 timeout: 5,
             },
             home,
@@ -698,6 +782,8 @@ mod tests {
                 profile: Some(profile.into()),
                 session_id: None,
                 feature_flags: vec![],
+                env: vec![],
+                secret_env: vec![],
                 timeout: 5,
             },
             home,
@@ -729,6 +815,8 @@ mod tests {
                 profile: None,
                 session_id: Some("sess-123".into()),
                 feature_flags: vec!["alpha=true".into(), "beta=false".into()],
+                env: vec![],
+                secret_env: vec![],
                 timeout: 5,
             },
             home,
@@ -744,6 +832,92 @@ mod tests {
         assert_eq!(request.session_id.as_deref(), Some("sess-123"));
         assert_eq!(flags.get("alpha"), Some(&true));
         assert_eq!(flags.get("beta"), Some(&false));
+    }
+
+    #[tokio::test]
+    async fn submit_serializes_env_and_secret_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let group = "test/group";
+        let group_dir = home.groups_dir().join(group);
+        let watcher = tokio::spawn(wait_for_job_and_write_success(
+            group_dir,
+            crate::profile::DEFAULT_PROFILE.to_owned(),
+        ));
+
+        let mut args = submit_args_for_test();
+        args.group = group.into();
+        args.timeout = 5;
+        args.env = vec![
+            "FOO=bar".into(),
+            "URL=https://example.test/path?a=1&b=2".into(),
+            "EMPTY=".into(),
+        ];
+        args.secret_env = vec!["ANTHROPIC_API_KEY=sk-ant-local-secret".into()];
+
+        let code = run_submit_with_home(args, home).await.unwrap();
+        let request = watcher.await.unwrap();
+        let environment = request.environment.as_ref().unwrap();
+        let secret_environment = request.secret_environment.as_ref().unwrap();
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(environment.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(
+            environment.get("URL").map(String::as_str),
+            Some("https://example.test/path?a=1&b=2")
+        );
+        assert_eq!(environment.get("EMPTY").map(String::as_str), Some(""));
+        assert_eq!(
+            secret_environment
+                .get("ANTHROPIC_API_KEY")
+                .map(String::as_str),
+            Some("sk-ant-local-secret")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_env_entries_before_submit() {
+        let cases = vec![
+            (vec!["FOO".to_string()], Vec::new(), "expected KEY=VALUE"),
+            (vec!["=VALUE".to_string()], Vec::new(), "expected KEY=VALUE"),
+            (
+                vec!["KEY=line1\nline2".to_string()],
+                Vec::new(),
+                "newline or NUL",
+            ),
+            (
+                Vec::new(),
+                vec!["KEY=foo\rbar".to_string()],
+                "newline or NUL",
+            ),
+            (
+                Vec::new(),
+                vec!["KEY=with\0nul".to_string()],
+                "newline or NUL",
+            ),
+            (
+                vec!["FOO=1".to_string(), "FOO=2".to_string()],
+                Vec::new(),
+                "duplicate --env key 'FOO'",
+            ),
+            (
+                vec!["FOO=1".to_string()],
+                vec!["FOO=2".to_string()],
+                "across --env and --secret-env",
+            ),
+        ];
+
+        for (env, secret_env, expected) in cases {
+            let dir = tempfile::tempdir().unwrap();
+            let home = HomePaths::with_root(dir.path().to_path_buf());
+            let mut args = submit_args_for_test();
+            args.env = env;
+            args.secret_env = secret_env;
+
+            let err = run_submit_with_home(args, home).await.unwrap_err();
+
+            assert!(err.to_string().contains(expected), "got: {err}");
+        }
     }
 
     #[test]
@@ -795,6 +969,8 @@ mod tests {
                 profile: None,
                 session_id: None,
                 feature_flags: vec![],
+                env: vec![],
+                secret_env: vec![],
                 timeout: 5,
             },
             home,
@@ -1142,6 +1318,8 @@ mod tests {
             profile: Some("bad-name".into()),
             session_id: None,
             feature_flags: vec![],
+            env: vec![],
+            secret_env: vec![],
             timeout: 1,
         };
         let dir = tempfile::tempdir().unwrap();
@@ -1162,6 +1340,8 @@ mod tests {
             profile: Some("vm0/default".into()),
             session_id: None,
             feature_flags: vec![],
+            env: vec![],
+            secret_env: vec![],
             timeout: 0,
         };
         // Should pass validation and fail later (HomePaths or timeout), not on profile.
@@ -1182,6 +1362,8 @@ mod tests {
             profile: None,
             session_id: None,
             feature_flags: vec!["myFlag".into()],
+            env: vec![],
+            secret_env: vec![],
             timeout: 1,
         };
         let dir = tempfile::tempdir().unwrap();
@@ -1199,6 +1381,8 @@ mod tests {
             profile: None,
             session_id: None,
             feature_flags: vec!["myFlag=yes".into()],
+            env: vec![],
+            secret_env: vec![],
             timeout: 1,
         };
         let dir = tempfile::tempdir().unwrap();
@@ -1221,6 +1405,8 @@ mod tests {
             profile: Some("vm0/large".into()),
             session_id: None,
             feature_flags: vec![],
+            env: vec![],
+            secret_env: vec![],
             timeout: 0,
         };
 
@@ -1245,6 +1431,8 @@ mod tests {
             profile: None,
             session_id: None,
             feature_flags: vec![],
+            env: vec![],
+            secret_env: vec![],
             timeout: 0,
         };
 

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -353,12 +353,28 @@ impl SubmitPlan {
 
             let key = &entry[..eq_pos];
             let value = &entry[eq_pos + 1..];
+            if !Self::is_valid_env_key(key) {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
+                )));
+            }
             if map.insert(key.to_owned(), value.to_owned()).is_some() {
                 return Err(RunnerError::Config(format!("duplicate {flag} key '{key}'")));
             }
         }
 
         Ok(Some(map))
+    }
+
+    fn is_valid_env_key(key: &str) -> bool {
+        let mut chars = key.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+        if !(first == '_' || first.is_ascii_alphabetic()) {
+            return false;
+        }
+        chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
     }
 
     fn validate_disjoint_env_keys(
@@ -884,6 +900,26 @@ mod tests {
                 vec!["KEY=line1\nline2".to_string()],
                 Vec::new(),
                 "newline or NUL",
+            ),
+            (
+                vec!["BAD-KEY=value".to_string()],
+                Vec::new(),
+                "expected [_A-Za-z][_A-Za-z0-9]*",
+            ),
+            (
+                vec!["1KEY=value".to_string()],
+                Vec::new(),
+                "expected [_A-Za-z][_A-Za-z0-9]*",
+            ),
+            (
+                vec!["KEY SPACE=value".to_string()],
+                Vec::new(),
+                "expected [_A-Za-z][_A-Za-z0-9]*",
+            ),
+            (
+                Vec::new(),
+                vec!["ÅKEY=value".to_string()],
+                "expected [_A-Za-z][_A-Za-z0-9]*",
             ),
             (
                 Vec::new(),

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -359,6 +359,13 @@ impl SubmitPlan {
                     "invalid {flag} key: expected [_A-Za-z][_A-Za-z0-9]*"
                 )));
             }
+            if guest_contracts::env::is_runner_owned_env_key(key)
+                && !guest_contracts::env::is_guest_agent_tuning_env_key(key)
+            {
+                return Err(RunnerError::Config(format!(
+                    "invalid {flag} key '{key}': runner-owned environment variables are not allowed"
+                )));
+            }
             if map.insert(key.to_owned(), value.to_owned()).is_some() {
                 return Err(RunnerError::Config(format!("duplicate {flag} key '{key}'")));
             }
@@ -874,6 +881,7 @@ mod tests {
             "URL=https://example.test/path?a=1&b=2".into(),
             "EMPTY=".into(),
             "MULTILINE=line1\nline2".into(),
+            "VM0_STUCK_TOOL_TIMEOUT_SECS=3".into(),
         ];
         args.secret_env = vec![
             "ANTHROPIC_API_KEY=sk-ant-local-secret".into(),
@@ -895,6 +903,12 @@ mod tests {
         assert_eq!(
             environment.get("MULTILINE").map(String::as_str),
             Some("line1\nline2")
+        );
+        assert_eq!(
+            environment
+                .get("VM0_STUCK_TOOL_TIMEOUT_SECS")
+                .map(String::as_str),
+            Some("3")
         );
         assert_eq!(
             secret_environment
@@ -937,6 +951,16 @@ mod tests {
                 Vec::new(),
                 vec!["KEY=with\0nul".to_string()],
                 "NUL characters",
+            ),
+            (
+                vec!["VM0_PROMPT=value".to_string()],
+                Vec::new(),
+                "runner-owned environment variables",
+            ),
+            (
+                Vec::new(),
+                vec!["CLI_AGENT_TYPE=codex".to_string()],
+                "runner-owned environment variables",
             ),
             (
                 vec!["FOO=1".to_string(), "FOO=2".to_string()],

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -100,10 +100,34 @@ pub(super) fn validate_model_provider_env_placeholders(
 
 pub(super) fn validate_execution_context_before_sandbox(
     context: &ExecutionContext,
+    api_url: &str,
+    sandbox_id: &str,
+    reuse_result: SandboxReuseResult,
+) -> Result<(), String> {
+    let host_env = HostEnv::from_process();
+    validate_execution_context_before_sandbox_with_host_env(
+        context,
+        api_url,
+        sandbox_id,
+        reuse_result,
+        &host_env,
+    )
+}
+
+pub(super) fn validate_execution_context_before_sandbox_with_host_env(
+    context: &ExecutionContext,
+    api_url: &str,
+    sandbox_id: &str,
+    reuse_result: SandboxReuseResult,
+    host_env: &HostEnv,
 ) -> Result<(), String> {
     validate_model_provider_env_placeholders(context)?;
     validate_user_environment_for_guest(context)?;
     validate_claude_tool_lists(context)?;
+    let bootstrap_env =
+        build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, host_env)
+            .map_err(|error| error.to_string())?;
+    validate_bootstrap_environment_for_guest(&bootstrap_env)?;
     Ok(())
 }
 
@@ -122,6 +146,30 @@ fn validate_user_environment_for_guest(context: &ExecutionContext) -> Result<(),
         if value.contains('\0') {
             return Err(format!(
                 "user environment contains NUL byte for env key {:?}",
+                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_bootstrap_environment_for_guest(
+    environment: &HashMap<String, String>,
+) -> Result<(), String> {
+    let mut entries: Vec<(&String, &String)> = environment.iter().collect();
+    entries.sort_by_key(|(key, _)| *key);
+
+    for (key, value) in entries {
+        if !guest_contracts::env::is_valid_user_env_key(key) {
+            return Err(format!(
+                "bootstrap environment contains invalid env key {:?}",
+                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+            ));
+        }
+        if value.contains('\0') {
+            return Err(format!(
+                "bootstrap environment contains NUL byte for env key {:?}",
                 guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
             ));
         }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -102,7 +102,31 @@ pub(super) fn validate_execution_context_before_sandbox(
     context: &ExecutionContext,
 ) -> Result<(), String> {
     validate_model_provider_env_placeholders(context)?;
+    validate_user_environment_for_guest(context)?;
     validate_claude_tool_lists(context)?;
+    Ok(())
+}
+
+fn validate_user_environment_for_guest(context: &ExecutionContext) -> Result<(), String> {
+    let user_env = build_user_env_json(context);
+    let mut entries: Vec<(&String, &String)> = user_env.iter().collect();
+    entries.sort_by_key(|(key, _)| *key);
+
+    for (key, value) in entries {
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
+            return Err(format!(
+                "user environment contains invalid env key {:?}",
+                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+            ));
+        }
+        if value.contains('\0') {
+            return Err(format!(
+                "user environment contains NUL byte for env key {:?}",
+                guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)
+            ));
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -161,7 +161,7 @@ fn validate_bootstrap_environment_for_guest(
     entries.sort_by_key(|(key, _)| *key);
 
     for (key, value) in entries {
-        if !guest_contracts::env::is_valid_user_env_key(key) {
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
             return Err(format!(
                 "bootstrap environment contains invalid env key {:?}",
                 guest_contracts::env::sanitize_user_env_key_for_diagnostic(key)

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -529,17 +529,10 @@ pub(super) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFrame
     }
 }
 
-const NON_VM0_RUNNER_OWNED_ENV_KEYS: &[&str] = &[
-    guest_contracts::env::CLI_AGENT_TYPE_ENV,
-    guest_contracts::env::USE_MOCK_CLAUDE_ENV,
-    guest_contracts::env::USE_MOCK_CODEX_ENV,
-    guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
-];
-
 pub(super) fn is_runner_owned_env_key(key: &str) -> bool {
     // The entire VM0_ namespace is runner-owned, including retired keys such
     // as VM0_WORKING_DIR. Non-VM0 keys must stay explicit.
-    key.starts_with("VM0_") || NON_VM0_RUNNER_OWNED_ENV_KEYS.contains(&key)
+    guest_contracts::env::is_runner_owned_env_key(key)
 }
 
 pub(super) fn scrub_runner_owned_env(env: &mut HashMap<String, String>) {

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -76,6 +76,10 @@ pub(super) fn validate_model_provider_env_placeholders(
                 || protected_key
                     .placeholder
                     .is_some_and(|placeholder| value == placeholder)
+                || context
+                    .local_secret_env_keys
+                    .as_ref()
+                    .is_some_and(|keys| keys.contains(protected_key.name))
             {
                 None
             } else {

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -6,8 +6,8 @@ use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 use super::session_restore::canonical_codex_thread_id;
 use super::storage::format_guest_exec_failure;
 use super::{
-    DEFAULT_EXEC_TIMEOUT, GUEST_AGENT_TUNING_ENV_KEYS, GUEST_USER_ENV_DIR_NAME,
-    GUEST_USER_ENV_FILENAME, RunnerError, RunnerResult, guest_runtime_dir, guest_runtime_path,
+    DEFAULT_EXEC_TIMEOUT, GUEST_USER_ENV_DIR_NAME, GUEST_USER_ENV_FILENAME, RunnerError,
+    RunnerResult, guest_runtime_dir, guest_runtime_path,
 };
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, SandboxReuseResult};
@@ -489,7 +489,7 @@ pub(super) fn insert_guest_agent_tuning_env(
     let Some(user_env) = &context.environment else {
         return;
     };
-    for key in GUEST_AGENT_TUNING_ENV_KEYS {
+    for key in guest_contracts::env::GUEST_AGENT_TUNING_ENV_KEYS {
         if let Some(value) = user_env.get(*key) {
             env.insert((*key).into(), value.clone());
         }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -397,7 +397,13 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
-    let outcome = if let Err(error) = validate_execution_context_before_sandbox(&context) {
+    let sandbox_id = dispatch.id.to_string();
+    let outcome = if let Err(error) = validate_execution_context_before_sandbox(
+        &context,
+        &config.api_url,
+        &sandbox_id,
+        dispatch.reuse_result,
+    ) {
         ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(error)),
             sandbox: None,
@@ -510,7 +516,13 @@ pub async fn execute_job_reuse(
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
     // in the outcome so the caller can stop + destroy it on failure.
-    let outcome = if let Err(error) = validate_execution_context_before_sandbox(&context) {
+    let sandbox_id_string = sandbox_id.to_string();
+    let outcome = if let Err(error) = validate_execution_context_before_sandbox(
+        &context,
+        &config.api_url,
+        &sandbox_id_string,
+        SandboxReuseResult::Reused,
+    ) {
         ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(error)),
             sandbox: Some(sandbox),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -101,11 +101,6 @@ const BOOTSTRAP_SENSITIVE_ENV_KEYS: &[&str] = &[
 const USER_ENV_FILE_ENV_KEY: &str = guest_contracts::env::USER_ENV_FILE_ENV;
 const GUEST_USER_ENV_DIR_NAME: &str = "user-env";
 const GUEST_USER_ENV_FILENAME: &str = "env.json";
-const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
-    guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
-    guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
-    guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
-];
 const AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT: &str =
     include_str!("../../scripts/agent-abnormal-exit-diagnostics.sh");
 

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -23,6 +23,16 @@ use crate::host_env::{
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, ResumeSession, SandboxReuseResult};
 
+fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
+    let sandbox_id = SandboxId::new_v4().to_string();
+    validate_execution_context_before_sandbox(
+        ctx,
+        "http://localhost",
+        &sandbox_id,
+        SandboxReuseResult::Reused,
+    )
+}
+
 #[test]
 fn model_provider_env_placeholder_validation_accepts_env_without_protected_keys() {
     let ctx = context_with_env(HashMap::from([("PROJECT_ID".into(), "vm0".into())]));
@@ -79,11 +89,18 @@ fn model_provider_env_placeholder_validation_rejects_unmarked_protected_key() {
 }
 
 #[test]
+fn execution_context_validation_accepts_minimal_context() {
+    let ctx = minimal_context();
+
+    assert!(validate_context_for_test(&ctx).is_ok());
+}
+
+#[test]
 fn execution_context_validation_rejects_invalid_user_env_key_before_sandbox() {
     let secret = "secret-value";
     let ctx = context_with_env(HashMap::from([("BAD-KEY".into(), secret.into())]));
 
-    let error = validate_execution_context_before_sandbox(&ctx).unwrap_err();
+    let error = validate_context_for_test(&ctx).unwrap_err();
 
     assert!(error.contains("invalid env key"));
     assert!(error.contains("BAD-KEY"));
@@ -95,7 +112,7 @@ fn execution_context_validation_rejects_user_env_nul_value_before_sandbox() {
     let secret = "secret\0value";
     let ctx = context_with_env(HashMap::from([("CUSTOM_ENV".into(), secret.into())]));
 
-    let error = validate_execution_context_before_sandbox(&ctx).unwrap_err();
+    let error = validate_context_for_test(&ctx).unwrap_err();
 
     assert!(error.contains("NUL byte"));
     assert!(error.contains("CUSTOM_ENV"));
@@ -108,11 +125,55 @@ fn execution_context_validation_rejects_user_timezone_nul_before_sandbox() {
     let mut ctx = minimal_context();
     ctx.user_timezone = Some(secret.into());
 
-    let error = validate_execution_context_before_sandbox(&ctx).unwrap_err();
+    let error = validate_context_for_test(&ctx).unwrap_err();
 
     assert!(error.contains("NUL byte"));
     assert!(error.contains("TZ"));
     assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_tuning_env_nul_before_sandbox() {
+    let secret = "3\0";
+    let ctx = context_with_env(HashMap::from([(
+        "VM0_STUCK_TOOL_TIMEOUT_SECS".into(),
+        secret.into(),
+    )]));
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("bootstrap environment"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_STUCK_TOOL_TIMEOUT_SECS"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_bootstrap_env_nul_before_sandbox() {
+    let secret = "before\0after";
+    let mut ctx = minimal_context();
+    ctx.prompt = secret.into();
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("bootstrap environment"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_PROMPT"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_invalid_codex_resume_before_sandbox() {
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession {
+        session_id: "not-a-thread-id".into(),
+        session_history: "{}".into(),
+    });
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("invalid codex session_id"));
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
 use api_contracts::generated::types::runners::storage::{
@@ -49,6 +49,33 @@ fn model_provider_env_placeholder_validation_rejects_real_anthropic_api_key() {
 
     assert!(error.contains("ANTHROPIC_API_KEY"));
     assert!(!error.contains(secret));
+}
+
+#[test]
+fn model_provider_env_placeholder_validation_accepts_local_secret_env_key() {
+    let secret = "sk-ant-api03-real-secret-value";
+    let mut ctx = context_with_env(HashMap::from([("ANTHROPIC_API_KEY".into(), secret.into())]));
+    ctx.local_secret_env_keys = Some(HashSet::from(["ANTHROPIC_API_KEY".into()]));
+
+    assert!(validate_model_provider_env_placeholders(&ctx).is_ok());
+}
+
+#[test]
+fn model_provider_env_placeholder_validation_rejects_unmarked_protected_key() {
+    let anthropic_secret = "sk-ant-api03-real-secret-value";
+    let openai_secret = "sk-proj-real-openai-secret";
+    let mut ctx = context_with_env(HashMap::from([
+        ("ANTHROPIC_API_KEY".into(), anthropic_secret.into()),
+        ("OPENAI_API_KEY".into(), openai_secret.into()),
+    ]));
+    ctx.local_secret_env_keys = Some(HashSet::from(["ANTHROPIC_API_KEY".into()]));
+
+    let error = validate_model_provider_env_placeholders(&ctx).unwrap_err();
+
+    assert!(error.contains("OPENAI_API_KEY"));
+    assert!(!error.contains("ANTHROPIC_API_KEY"));
+    assert!(!error.contains(anthropic_secret));
+    assert!(!error.contains(openai_secret));
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -8,7 +8,7 @@ use sandbox::SandboxId;
 
 use super::super::env::{
     HostEnv, build_env_json_with_host_env, build_user_env_json, is_runner_owned_env_key,
-    validate_model_provider_env_placeholders,
+    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
@@ -76,6 +76,43 @@ fn model_provider_env_placeholder_validation_rejects_unmarked_protected_key() {
     assert!(!error.contains("ANTHROPIC_API_KEY"));
     assert!(!error.contains(anthropic_secret));
     assert!(!error.contains(openai_secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_invalid_user_env_key_before_sandbox() {
+    let secret = "secret-value";
+    let ctx = context_with_env(HashMap::from([("BAD-KEY".into(), secret.into())]));
+
+    let error = validate_execution_context_before_sandbox(&ctx).unwrap_err();
+
+    assert!(error.contains("invalid env key"));
+    assert!(error.contains("BAD-KEY"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_user_env_nul_value_before_sandbox() {
+    let secret = "secret\0value";
+    let ctx = context_with_env(HashMap::from([("CUSTOM_ENV".into(), secret.into())]));
+
+    let error = validate_execution_context_before_sandbox(&ctx).unwrap_err();
+
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("CUSTOM_ENV"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_user_timezone_nul_before_sandbox() {
+    let secret = "Asia\0Shanghai";
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some(secret.into());
+
+    let error = validate_execution_context_before_sandbox(&ctx).unwrap_err();
+
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("TZ"));
+    assert!(!error.contains(secret));
 }
 
 #[test]

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -227,6 +227,7 @@ impl LocalQueue {
             }
             return;
         }
+        let _ = self.remove_job_file_if_present(run_id);
         // Best-effort cleanup of cancel file (may have been written after the
         // last discover() scan but before the job actually finished).
         let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -39,9 +39,20 @@ pub(crate) struct LocalQueue {
 }
 
 enum JobFileLookup {
-    Found(PathBuf),
+    Found,
     NotFound,
     ScanFailed,
+}
+
+enum JobFileScan {
+    Complete(Vec<PathBuf>),
+    ScanFailed(Vec<PathBuf>),
+}
+
+#[derive(Clone, Copy)]
+enum JobFileScanMode {
+    First,
+    All,
 }
 
 impl LocalQueue {
@@ -149,7 +160,6 @@ impl LocalQueue {
                 self.fail_claimed_job_sync_with_claim(
                     run_id,
                     &claim_file,
-                    job_file,
                     format!("failed to read job file: {e}"),
                 );
                 return LocalClaimResult::NotClaimed;
@@ -169,7 +179,6 @@ impl LocalQueue {
                 self.fail_claimed_job_sync_with_claim(
                     run_id,
                     &claim_file,
-                    job_file,
                     format!("invalid job JSON: {e}"),
                 );
                 return LocalClaimResult::NotClaimed;
@@ -182,7 +191,7 @@ impl LocalQueue {
                 request.job_id
             );
             warn!(run_id = %run_id, error = %error, "local: invalid job id");
-            self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+            self.fail_claimed_job_sync_with_claim(run_id, &claim_file, error);
             return LocalClaimResult::NotClaimed;
         }
 
@@ -195,7 +204,7 @@ impl LocalQueue {
                 let error =
                     format!("missing job profile in non-default partition: {partition_profile}");
                 warn!(run_id = %run_id, error = %error, "local: invalid job profile");
-                self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+                self.fail_claimed_job_sync_with_claim(run_id, &claim_file, error);
                 return LocalClaimResult::NotClaimed;
             }
         };
@@ -204,7 +213,7 @@ impl LocalQueue {
                 "job profile mismatch: request={request_profile}, partition={partition_profile}"
             );
             warn!(run_id = %run_id, error = %error, "local: invalid job profile");
-            self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+            self.fail_claimed_job_sync_with_claim(run_id, &claim_file, error);
             return LocalClaimResult::NotClaimed;
         }
 
@@ -214,20 +223,20 @@ impl LocalQueue {
         }
     }
 
-    pub(crate) fn fail_claimed_job_sync(&self, run_id: RunId, job_file: &Path, error: String) {
+    pub(crate) fn fail_claimed_job_sync(&self, run_id: RunId, error: String) {
         let claim_file = super::claim_path(&self.group_dir, run_id);
-        self.fail_claimed_job_sync_with_claim(run_id, &claim_file, job_file, error);
+        self.fail_claimed_job_sync_with_claim(run_id, &claim_file, error);
     }
 
     pub(crate) fn complete_job_sync(&self, run_id: RunId, exit_code: i32, error: Option<String>) {
         if !self.write_result_sync(run_id, exit_code, error.as_deref()) {
-            if self.remove_job_file_if_present(run_id) {
+            if self.remove_job_files_if_present(run_id) {
                 let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
                 let _ = std::fs::remove_file(super::claim_path(&self.group_dir, run_id));
             }
             return;
         }
-        let _ = self.remove_job_file_if_present(run_id);
+        let _ = self.remove_job_files_if_present(run_id);
         // Best-effort cleanup of cancel file (may have been written after the
         // last discover() scan but before the job actually finished).
         let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
@@ -281,7 +290,7 @@ impl LocalQueue {
             return CancelTargetState::Pending;
         }
         match self.lookup_job_file(run_id) {
-            JobFileLookup::Found(_) => CancelTargetState::Pending,
+            JobFileLookup::Found => CancelTargetState::Pending,
             JobFileLookup::NotFound => CancelTargetState::NotPending,
             JobFileLookup::ScanFailed => CancelTargetState::Unknown,
         }
@@ -294,19 +303,25 @@ impl LocalQueue {
             .unwrap_or(false)
     }
 
-    pub(crate) fn remove_job_file_if_present(&self, run_id: RunId) -> bool {
-        match self.lookup_job_file(run_id) {
-            JobFileLookup::Found(path) => match std::fs::remove_file(&path) {
-                Ok(()) => true,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+    pub(crate) fn remove_job_files_if_present(&self, run_id: RunId) -> bool {
+        let (paths, mut removed_all) =
+            match self.collect_job_file_paths(run_id, JobFileScanMode::All) {
+                JobFileScan::Complete(paths) => (paths, true),
+                JobFileScan::ScanFailed(paths) => (paths, false),
+            };
+
+        for path in paths {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => {
-                    warn!(run_id = %run_id, path = %path.display(), error = %e, "local: failed to remove job file after result failure");
-                    false
+                    warn!(run_id = %run_id, path = %path.display(), error = %e, "local: failed to remove job file after terminal result");
+                    removed_all = false;
                 }
-            },
-            JobFileLookup::NotFound => true,
-            JobFileLookup::ScanFailed => false,
+            };
         }
+
+        removed_all
     }
 
     pub(crate) fn write_result_sync(
@@ -350,32 +365,62 @@ impl LocalQueue {
         true
     }
 
-    fn fail_claimed_job_sync_with_claim(
-        &self,
-        run_id: RunId,
-        claim_file: &Path,
-        job_file: &Path,
-        error: String,
-    ) {
+    fn fail_claimed_job_sync_with_claim(&self, run_id: RunId, claim_file: &Path, error: String) {
         if self.write_result_sync(run_id, 1, Some(&error)) {
-            let _ = std::fs::remove_file(job_file);
+            let _ = self.remove_job_files_if_present(run_id);
         }
         let _ = std::fs::remove_file(claim_file);
     }
 
     fn lookup_job_file(&self, run_id: RunId) -> JobFileLookup {
+        match self.collect_job_file_paths(run_id, JobFileScanMode::First) {
+            JobFileScan::Complete(paths) => {
+                if paths.is_empty() {
+                    JobFileLookup::NotFound
+                } else {
+                    JobFileLookup::Found
+                }
+            }
+            JobFileScan::ScanFailed(paths) => {
+                if paths.is_empty() {
+                    JobFileLookup::ScanFailed
+                } else {
+                    JobFileLookup::Found
+                }
+            }
+        }
+    }
+
+    fn collect_job_file_paths(&self, run_id: RunId, mode: JobFileScanMode) -> JobFileScan {
         let jobs_dir = super::jobs_dir(&self.group_dir);
+        let mut paths = Vec::new();
         let orgs = match std::fs::read_dir(&jobs_dir) {
             Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return JobFileLookup::NotFound,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return JobFileScan::Complete(paths);
+            }
             Err(e) => {
                 warn!(path = %jobs_dir.display(), error = %e, "local: cannot scan jobs dir for job file");
-                return JobFileLookup::ScanFailed;
+                return JobFileScan::ScanFailed(paths);
             }
         };
 
-        for org in orgs.filter_map(Result::ok) {
-            if !org.file_type().map(|ty| ty.is_dir()).unwrap_or(false) {
+        for org in orgs {
+            let org = match org {
+                Ok(entry) => entry,
+                Err(e) => {
+                    warn!(path = %jobs_dir.display(), error = %e, "local: cannot scan jobs dir entry for job file");
+                    return JobFileScan::ScanFailed(paths);
+                }
+            };
+            let org_file_type = match org.file_type() {
+                Ok(file_type) => file_type,
+                Err(e) => {
+                    warn!(path = %org.path().display(), error = %e, "local: cannot stat profile org dir entry for job file");
+                    return JobFileScan::ScanFailed(paths);
+                }
+            };
+            if !org_file_type.is_dir() {
                 continue;
             }
             let org_path = org.path();
@@ -384,25 +429,44 @@ impl LocalQueue {
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
                 Err(e) => {
                     warn!(path = %org_path.display(), error = %e, "local: cannot scan profile org dir for job file");
-                    return JobFileLookup::ScanFailed;
+                    return JobFileScan::ScanFailed(paths);
                 }
             };
-            for profile in profiles.filter_map(Result::ok) {
-                if !profile.file_type().map(|ty| ty.is_dir()).unwrap_or(false) {
+            for profile in profiles {
+                let profile = match profile {
+                    Ok(entry) => entry,
+                    Err(e) => {
+                        warn!(path = %org_path.display(), error = %e, "local: cannot scan profile dir entry for job file");
+                        return JobFileScan::ScanFailed(paths);
+                    }
+                };
+                let profile_file_type = match profile.file_type() {
+                    Ok(file_type) => file_type,
+                    Err(e) => {
+                        warn!(path = %profile.path().display(), error = %e, "local: cannot stat profile dir entry for job file");
+                        return JobFileScan::ScanFailed(paths);
+                    }
+                };
+                if !profile_file_type.is_dir() {
                     continue;
                 }
                 let path = profile.path().join(format!("{run_id}.job"));
                 match std::fs::metadata(&path) {
-                    Ok(_) => return JobFileLookup::Found(path),
+                    Ok(_) => {
+                        paths.push(path);
+                        if matches!(mode, JobFileScanMode::First) {
+                            return JobFileScan::Complete(paths);
+                        }
+                    }
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                     Err(e) => {
                         warn!(run_id = %run_id, path = %path.display(), error = %e, "local: cannot stat job file");
-                        return JobFileLookup::ScanFailed;
+                        return JobFileScan::ScanFailed(paths);
                     }
                 }
             }
         }
 
-        JobFileLookup::NotFound
+        JobFileScan::Complete(paths)
     }
 }

--- a/crates/runner/src/local_queue/types.rs
+++ b/crates/runner/src/local_queue/types.rs
@@ -13,6 +13,8 @@ pub(crate) struct JobRequest {
     #[serde(default)]
     pub(crate) environment: Option<HashMap<String, String>>,
     #[serde(default)]
+    pub(crate) secret_environment: Option<HashMap<String, String>>,
+    #[serde(default)]
     pub(crate) user_timezone: Option<String>,
     #[serde(default)]
     pub(crate) profile: Option<String>,

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -248,7 +248,7 @@ impl JobProvider for LocalProvider {
                 warn!(run_id = %run_id, error = %error, "local: claimed job invariant violation");
                 let queue = self.queue.clone();
                 if let Err(e) = tokio::task::spawn_blocking(move || {
-                    queue.fail_claimed_job_sync(run_id, &job_file, error);
+                    queue.fail_claimed_job_sync(run_id, error);
                 })
                 .await
                 {
@@ -969,6 +969,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn complete_removes_duplicate_job_files_across_profiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = default_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        write_job_in_partition(
+            dir.path(),
+            crate::profile::DEFAULT_PROFILE,
+            run_id,
+            "default",
+            Some(crate::profile::DEFAULT_PROFILE),
+        );
+        write_job_in_partition(dir.path(), "vm0/large", run_id, "large", Some("vm0/large"));
+        let default_job_path =
+            local_queue::job_path(dir.path(), crate::profile::DEFAULT_PROFILE, run_id).unwrap();
+        let large_job_path = local_queue::job_path(dir.path(), "vm0/large", run_id).unwrap();
+
+        provider
+            .complete(run_id, 0, None, None, None, CompletionAuth::local())
+            .await;
+
+        assert!(
+            !default_job_path.exists(),
+            "complete() should remove the default profile duplicate"
+        );
+        assert!(
+            !large_job_path.exists(),
+            "complete() should remove the large profile duplicate"
+        );
+    }
+
+    #[tokio::test]
     async fn complete_result_failure_removes_job_before_claim() {
         let dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
@@ -1000,6 +1033,52 @@ mod tests {
         assert!(
             !claim_path.exists(),
             "claim can be released after the job is no longer retryable"
+        );
+        assert!(
+            !cancel_path.exists(),
+            "cancel file should not be stranded after terminal cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_result_failure_removes_duplicate_jobs_before_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = default_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let run_id = RunId::new_v4();
+        write_job_in_partition(
+            dir.path(),
+            crate::profile::DEFAULT_PROFILE,
+            run_id,
+            "default",
+            Some(crate::profile::DEFAULT_PROFILE),
+        );
+        write_job_in_partition(dir.path(), "vm0/large", run_id, "large", Some("vm0/large"));
+        let default_job_path =
+            local_queue::job_path(dir.path(), crate::profile::DEFAULT_PROFILE, run_id).unwrap();
+        let large_job_path = local_queue::job_path(dir.path(), "vm0/large", run_id).unwrap();
+        let claim_path = local_queue::claim_path(dir.path(), run_id);
+        let cancel_path = local_queue::cancel_path(dir.path(), run_id);
+        let result_dir = local_queue::results_dir(dir.path());
+        std::fs::create_dir_all(claim_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(cancel_path.parent().unwrap()).unwrap();
+        std::fs::write(&claim_path, b"").unwrap();
+        std::fs::write(&cancel_path, b"").unwrap();
+        std::fs::write(&result_dir, b"not a directory").unwrap();
+
+        provider
+            .complete(run_id, 0, None, None, None, CompletionAuth::local())
+            .await;
+
+        assert!(
+            !default_job_path.exists(),
+            "default duplicate must be removed"
+        );
+        assert!(!large_job_path.exists(), "large duplicate must be removed");
+        assert!(
+            !claim_path.exists(),
+            "claim can be released after all duplicate jobs are no longer retryable"
         );
         assert!(
             !cancel_path.exists(),
@@ -1147,6 +1226,47 @@ mod tests {
 
         // Next discover() scan must not re-surface the job.
         assert!(provider.find_unclaimed_job().is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_failure_removes_duplicate_job_files_across_profiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = provider_with_profiles(
+            dir.path(),
+            &[crate::profile::DEFAULT_PROFILE, "vm0/large"],
+            CancellationToken::new(),
+            empty_cancel_tokens(),
+        );
+
+        let run_id = RunId::new_v4();
+        let default_job_path =
+            local_queue::job_path(dir.path(), crate::profile::DEFAULT_PROFILE, run_id).unwrap();
+        std::fs::create_dir_all(default_job_path.parent().unwrap()).unwrap();
+        std::fs::write(&default_job_path, b"not json").unwrap();
+        write_job_in_partition(
+            dir.path(),
+            "vm0/large",
+            run_id,
+            "large duplicate",
+            Some("vm0/large"),
+        );
+        let large_job_path = local_queue::job_path(dir.path(), "vm0/large", run_id).unwrap();
+
+        let candidate = provider.discover().await.unwrap();
+        assert!(provider.claim(candidate).await.is_none());
+
+        assert!(
+            !default_job_path.exists(),
+            "claim failure should remove the poisoned job"
+        );
+        assert!(
+            !large_job_path.exists(),
+            "claim failure should remove duplicate jobs for the same run id"
+        );
+        assert!(
+            provider.find_unclaimed_job().is_none(),
+            "terminal result should stop duplicate rediscovery"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -6,7 +6,7 @@
 //! The winning runner executes the job and writes a group-wide
 //! `{job_id}.result` file that `submit` polls for.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -191,6 +191,8 @@ impl JobProvider for LocalProvider {
             }
         };
 
+        let environment_merge = merge_local_environments(req.environment, req.secret_environment);
+
         let context = ExecutionContext {
             run_id,
             prompt: req.prompt,
@@ -200,7 +202,7 @@ impl JobProvider for LocalProvider {
             checkpoint_id: None,
             sandbox_token: String::new(),
             storage_manifest: None,
-            environment: req.environment,
+            environment: environment_merge.environment,
             resume_session: req
                 .session_id
                 .as_ref()
@@ -208,7 +210,8 @@ impl JobProvider for LocalProvider {
                     session_id: id.clone(),
                     session_history: String::new(),
                 }),
-            secret_values: None,
+            secret_values: environment_merge.secret_values,
+            local_secret_env_keys: environment_merge.local_secret_env_keys,
             encrypted_secrets: None,
             secret_connector_map: None,
             secret_connector_metadata_map: None,
@@ -280,6 +283,47 @@ impl JobProvider for LocalProvider {
 
     async fn shutdown(&self) {
         self.cancel_watcher.shutdown().await;
+    }
+}
+
+struct LocalEnvironmentMerge {
+    environment: Option<HashMap<String, String>>,
+    secret_values: Option<Vec<String>>,
+    local_secret_env_keys: Option<HashSet<String>>,
+}
+
+fn merge_local_environments(
+    environment: Option<HashMap<String, String>>,
+    secret_environment: Option<HashMap<String, String>>,
+) -> LocalEnvironmentMerge {
+    let Some(secret_environment) = secret_environment else {
+        return LocalEnvironmentMerge {
+            environment,
+            secret_values: None,
+            local_secret_env_keys: None,
+        };
+    };
+    if secret_environment.is_empty() {
+        return LocalEnvironmentMerge {
+            environment,
+            secret_values: None,
+            local_secret_env_keys: None,
+        };
+    }
+
+    let mut merged = environment.unwrap_or_default();
+    let mut secret_values = Vec::with_capacity(secret_environment.len());
+    let mut local_secret_env_keys = HashSet::with_capacity(secret_environment.len());
+    for (key, value) in secret_environment {
+        local_secret_env_keys.insert(key.clone());
+        secret_values.push(value.clone());
+        merged.insert(key, value);
+    }
+
+    LocalEnvironmentMerge {
+        environment: Some(merged),
+        secret_values: Some(secret_values),
+        local_secret_env_keys: Some(local_secret_env_keys),
     }
 }
 
@@ -374,6 +418,7 @@ mod tests {
             cli_agent_type: "claude-code".into(),
             vars: None,
             environment: None,
+            secret_environment: None,
             user_timezone: None,
             profile: json_profile.map(String::from),
             session_id: None,
@@ -384,6 +429,34 @@ mod tests {
         std::fs::create_dir_all(&job_dir).unwrap();
         std::fs::write(
             local_queue::job_path(dir, partition_profile, job_id).unwrap(),
+            &json,
+        )
+        .unwrap();
+    }
+
+    fn write_job_with_environments(
+        dir: &std::path::Path,
+        job_id: RunId,
+        environment: Option<std::collections::HashMap<String, String>>,
+        secret_environment: Option<std::collections::HashMap<String, String>>,
+    ) {
+        let req = JobRequest {
+            job_id,
+            prompt: "hello with env".into(),
+            cli_agent_type: "claude-code".into(),
+            vars: None,
+            environment,
+            secret_environment,
+            user_timezone: None,
+            profile: Some(crate::profile::DEFAULT_PROFILE.into()),
+            session_id: None,
+            feature_flags: None,
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let job_dir = local_queue::profile_jobs_dir(dir, crate::profile::DEFAULT_PROFILE).unwrap();
+        std::fs::create_dir_all(&job_dir).unwrap();
+        std::fs::write(
+            local_queue::job_path(dir, crate::profile::DEFAULT_PROFILE, job_id).unwrap(),
             &json,
         )
         .unwrap();
@@ -421,6 +494,45 @@ mod tests {
         let resp = read_result(dir.path(), job_id);
         assert_eq!(resp.exit_code, 0);
         assert!(resp.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_maps_secret_environment_into_context_and_masking() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = default_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let job_id = RunId::new_v4();
+        write_job_with_environments(
+            dir.path(),
+            job_id,
+            Some(std::collections::HashMap::from([(
+                "ANTHROPIC_MODEL".into(),
+                "claude-haiku-4-5".into(),
+            )])),
+            Some(std::collections::HashMap::from([(
+                "ANTHROPIC_API_KEY".into(),
+                "sk-ant-local-secret".into(),
+            )])),
+        );
+
+        let candidate = provider.discover().await.unwrap();
+        let claimed = provider.claim(candidate).await.unwrap();
+        let ctx = claimed.context();
+        let environment = ctx.environment.as_ref().unwrap();
+        let secret_values = ctx.secret_values.as_ref().unwrap();
+        let local_secret_env_keys = ctx.local_secret_env_keys.as_ref().unwrap();
+
+        assert_eq!(
+            environment.get("ANTHROPIC_MODEL").map(String::as_str),
+            Some("claude-haiku-4-5")
+        );
+        assert_eq!(
+            environment.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("sk-ant-local-secret")
+        );
+        assert_eq!(secret_values, &["sk-ant-local-secret".to_string()]);
+        assert!(local_secret_env_keys.contains("ANTHROPIC_API_KEY"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -477,6 +477,8 @@ mod tests {
 
         let job_id = RunId::new_v4();
         write_job(dir.path(), job_id, "hello world");
+        let job_path =
+            local_queue::job_path(dir.path(), crate::profile::DEFAULT_PROFILE, job_id).unwrap();
 
         let candidate = provider.discover().await.unwrap();
         assert_eq!(candidate.run_id(), job_id);
@@ -494,6 +496,10 @@ mod tests {
         let resp = read_result(dir.path(), job_id);
         assert_eq!(resp.exit_code, 0);
         assert!(resp.error.is_none());
+        assert!(
+            !job_path.exists(),
+            "complete() should remove the completed local job file"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -14,6 +14,7 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         environment: None,
         resume_session: None,
         secret_values: None,
+        local_secret_env_keys: None,
         encrypted_secrets: None,
         secret_connector_map: None,
         secret_connector_metadata_map: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
@@ -63,6 +63,10 @@ pub struct ExecutionContext {
     // Plain secret values used only for redaction. These are values, not names.
     #[serde(default)]
     pub secret_values: Option<Vec<String>>,
+    // Local submit may explicitly allow raw provider secrets for local-only
+    // runner testing. This marker is internal and must not be claimable via API JSON.
+    #[serde(default, skip_deserializing)]
+    pub local_secret_env_keys: Option<HashSet<String>>,
     // Encrypted runtime secret namespace forwarded to mitm-addon for auth
     // resolution. Decrypted keys match `${{ secrets.NAME }}` names; connector
     // and model-provider keys are env aliases, not storage secret names.
@@ -441,6 +445,7 @@ mod tests {
         assert!(ctx.vars.is_none());
         assert!(ctx.firewalls.is_none());
         assert!(ctx.secret_values.is_none());
+        assert!(ctx.local_secret_env_keys.is_none());
         assert!(ctx.billable_firewalls.is_empty());
         assert!(ctx.model_usage_provider.is_none());
     }
@@ -475,6 +480,7 @@ mod tests {
             "environment": {"NODE_ENV": "production"},
             "resumeSession": {"sessionId": "sess-1", "sessionHistory": "/tmp/history"},
             "secretValues": ["s1", "s2"],
+            "localSecretEnvKeys": ["ANTHROPIC_API_KEY"],
             "encryptedSecrets": "enc-blob",
             "secretConnectorMap": {"GITHUB_TOKEN": "github"},
             "secretConnectorMetadataMap": {
@@ -506,6 +512,7 @@ mod tests {
         assert_eq!(ctx.environment.as_ref().unwrap()["NODE_ENV"], "production");
         assert_eq!(ctx.resume_session.as_ref().unwrap().session_id, "sess-1");
         assert_eq!(ctx.secret_values.as_ref().unwrap().len(), 2);
+        assert!(ctx.local_secret_env_keys.is_none());
         assert_eq!(ctx.encrypted_secrets.as_deref(), Some("enc-blob"));
         let metadata = ctx.secret_connector_metadata_map.as_ref().unwrap();
         assert_eq!(

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -65,7 +65,7 @@ pub struct ExecutionContext {
     pub secret_values: Option<Vec<String>>,
     // Local submit may explicitly allow raw provider secrets for local-only
     // runner testing. This marker is internal and must not be claimable via API JSON.
-    #[serde(default, skip_deserializing)]
+    #[serde(default, skip)]
     pub local_secret_env_keys: Option<HashSet<String>>,
     // Encrypted runtime secret namespace forwarded to mitm-addon for auth
     // resolution. Decrypted keys match `${{ secrets.NAME }}` names; connector


### PR DESCRIPTION
## Summary
- add repeatable `runner local submit --env KEY=VALUE` for ordinary local job environment overrides
- add local-only `--secret-env KEY=VALUE` that is merged by the local provider, registered for masking, and narrowly allowed through model-provider secret validation
- keep the bypass marker internal to local execution so API-claimed JSON cannot set it, and add coverage for CLI validation/provider merge/ExecutionContext deserialization

Closes #17914

## Test Plan
- `cargo fmt --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit hooks: cargo-fmt, cargo-doc, cargo-clippy