### PR TITLE
fix: keep typed composer text when quoting into inline feedback

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -8,6 +8,7 @@ import {
   feedbackItemsValue$,
   feedbackThreadIdValue$,
 } from "../zero-page/chat-feedback.ts";
+import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 import { testContext } from "./test-helpers.ts";
 
 // Render a minimal assistant bubble inside a thread container, matching the DOM
@@ -62,6 +63,44 @@ describe("inline feedback thread scoping", () => {
     expect(ctx.store.get(feedbackThreadIdValue$)).toBe("thread-b");
     expect(items).toHaveLength(1);
     expect(items[0]?.quote).toBe("Reply from thread B");
+  });
+
+  it("carries pending composer text into the first comment's note", () => {
+    // Text the user already typed before quoting must survive: the feedback
+    // rows replace the textarea, so it moves into the new comment's note.
+    const { draft } = ctx.store.set(ensureDraft$, "thread-a");
+    ctx.store.set(draft.setInput$, "please fix this");
+
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    const items = ctx.store.get(feedbackItemsValue$);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.note).toBe("please fix this");
+    // The text left the composer so it is not also re-sent as a draft.
+    expect(ctx.store.get(draft.input$)).toBe("");
+  });
+
+  it("only carries pending text into the first comment of a stack", () => {
+    const { draft } = ctx.store.set(ensureDraft$, "thread-a");
+    ctx.store.set(draft.setInput$, "please fix this");
+
+    const bubble = mountThreadBubble("thread-a", "First passage");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    const second = mountThreadBubble("thread-a", "Second passage");
+    selectContents(second);
+    ctx.store.set(captureFeedbackSelection$);
+    ctx.store.set(startFeedback$);
+
+    const items = ctx.store.get(feedbackItemsValue$);
+    expect(items).toHaveLength(2);
+    expect(items[0]?.note).toBe("please fix this");
+    expect(items[1]?.note).toBe("");
   });
 
   it("clears the owning thread when feedback is dismissed", () => {

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -1,5 +1,6 @@
 import { state, computed, command } from "ccstate";
 import { writeToClipboard } from "./clipboard.ts";
+import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 
 // Assistant message bubbles carry this class in the chat thread. Text selected
 // inside one of them is what we offer feedback on.
@@ -186,9 +187,8 @@ export const captureFeedbackSelection$ = command(({ get, set }) => {
   });
 });
 
-// "Provide feedback" on a passage: append it as a new fragment with an empty
-// note. The newest fragment is the one the user just picked, so the view
-// focuses its note input.
+// "Provide feedback" on a passage: append it as a new fragment. The newest
+// fragment is the one the user just picked, so the view focuses its note input.
 export const startFeedback$ = command(({ get, set }) => {
   const selection = get(feedbackSelection$);
   if (!selection) {
@@ -201,10 +201,24 @@ export const startFeedback$ = command(({ get, set }) => {
   const crossesThreads =
     activeThreadId !== null && activeThreadId !== selection.threadId;
   const existing = crossesThreads ? [] : get(feedbackItems$);
+  // When this is the first comment in a stack, carry any text already typed in
+  // the composer into its note — otherwise the textarea (and the text in it)
+  // vanishes the moment the feedback rows replace it, and the pending text is
+  // lost when the turn sends. Only non-blank text is moved, and it leaves the
+  // draft so it is not also re-sent. Later comments find the draft empty.
+  let note = "";
+  if (existing.length === 0 && selection.threadId !== null) {
+    const { draft } = set(ensureDraft$, selection.threadId);
+    const pending = get(draft.input$);
+    if (pending.trim().length > 0) {
+      note = pending;
+      set(draft.setInput$, "");
+    }
+  }
   const id = get(feedbackNextId$);
   set(feedbackNextId$, id + 1);
   set(feedbackThreadId$, selection.threadId);
-  set(feedbackItems$, [...existing, { id, quote: selection.text, note: "" }]);
+  set(feedbackItems$, [...existing, { id, quote: selection.text, note }]);
 
   // A fresh stack on a thread switch starts the highlights over too.
   const ranges = new Map<number, Range>(


### PR DESCRIPTION
## Problem

Reported by bingjie: 先输入文字，然后再 quote，之前输入的文本会丢失.

When you type text in the chat composer and then quote an assistant passage, the composer switches into "feedback mode" where `ComposerFeedbackRows` **replaces** the textarea (`zero-chat-composer.tsx:3922`). The text you'd already typed still lives in `thread.draft.input$` but is now:
- invisible (the textarea is gone),
- never part of the composed feedback prompt (`submitFeedback$` only reads `feedbackItems$`), and
- wiped by `set(draft.clear$)` when the feedback turn sends.

So it's silently lost.

## Fix

When the **first** comment in a feedback stack is added, carry any non-blank text already in the composer into that comment's note, and clear it from the draft. The text now stays visible, editable, and part of the message — matching the natural "type a comment, then quote what it's about" workflow. Later comments in the same stack find the draft already empty.

The carry reads the exact same per-thread draft (`ensureDraft$`) the composer renders from, keyed by the selection's thread id.

## Tests

Added two cases to `chat-feedback.test.ts`:
- pending composer text moves into the first comment's note and leaves the draft empty
- only the first comment of a stack receives carried text

All 6 tests in the file pass locally; `prettier --check` and `oxlint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)