### PR TITLE
refactor: remove cron trigger internal callback route

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
@@ -13,10 +13,10 @@ describe("internalApiBaseUrl", () => {
     expect(internalApiBaseUrl()).toBe("https://api.vm0.ai");
     expect(
       new URL(
-        "/api/internal/callbacks/trigger/cron",
+        "/api/internal/callbacks/trigger/loop",
         internalApiBaseUrl(),
       ).toString(),
-    ).toBe("https://api.vm0.ai/api/internal/callbacks/trigger/cron");
+    ).toBe("https://api.vm0.ai/api/internal/callbacks/trigger/loop");
   });
 
   it("defaults to the API backend origin in production when VM0_API_BACKEND_URL is unset", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-trigger.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-trigger.test.ts
@@ -12,7 +12,6 @@ import { testContext } from "../../../__tests__/test-helpers";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
-import { calculateNextRun } from "../../services/automations/time-trigger";
 import { seedAgentRunCallback$ } from "./helpers/agent-run-callback";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 import {
@@ -26,7 +25,6 @@ import {
 const context = testContext();
 const store = createStore();
 
-const CRON_PATH = "/api/internal/callbacks/trigger/cron";
 const LOOP_PATH = "/api/internal/callbacks/trigger/loop";
 const TEST_CALLBACK_SECRET = "test-callback-secret";
 
@@ -34,14 +32,12 @@ interface TriggerCallbackFixture extends UsageInsightFixture {
   readonly composeId: string;
 }
 
-type TriggerKind = "cron" | "loop";
+type TriggerKind = "loop";
 
 interface TriggerSeedOptions {
   readonly kind: TriggerKind;
-  readonly enabled?: boolean;
   readonly consecutiveFailures?: number;
   readonly intervalSeconds?: number;
-  readonly cronExpression?: string;
 }
 
 interface CallbackSeedOptions {
@@ -80,7 +76,6 @@ async function seedTrigger(
   options: TriggerSeedOptions,
 ): Promise<string> {
   const writeDb = store.set(writeDb$);
-  const isCron = options.kind === "cron";
   const [thread] = await writeDb
     .insert(chatThreads)
     .values({ userId: fixture.userId, agentComposeId: fixture.composeId })
@@ -108,11 +103,11 @@ async function seedTrigger(
     .values({
       automationId: automation.id,
       kind: options.kind,
-      cronExpression: isCron ? (options.cronExpression ?? "0 9 * * *") : null,
-      intervalSeconds: isCron ? null : (options.intervalSeconds ?? 300),
+      cronExpression: null,
+      intervalSeconds: options.intervalSeconds ?? 300,
       timezone: "UTC",
       nextRunAt: null,
-      enabled: options.enabled ?? true,
+      enabled: true,
       consecutiveFailures: options.consecutiveFailures ?? 0,
     })
     .returning({ id: automationTriggers.id });
@@ -202,13 +197,6 @@ async function updateTrigger(
     .where(eq(automationTriggers.id, triggerId));
 }
 
-async function deleteTrigger(triggerId: string): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb
-    .delete(automationTriggers)
-    .where(eq(automationTriggers.id, triggerId));
-}
-
 async function runSummary(runId: string): Promise<string | null> {
   const writeDb = store.set(writeDb$);
   const [row] = await writeDb
@@ -223,53 +211,9 @@ afterEach(() => {
   clearMockNow();
 });
 
-describe("POST /api/internal/callbacks/trigger/*", () => {
+describe("POST /api/internal/callbacks/trigger/loop", () => {
   const track = createFixtureTracker<TriggerCallbackFixture>((fixture) => {
     return deleteFixture(fixture);
-  });
-
-  it("rejects cron callbacks with invalid signatures", async () => {
-    const fixture = await track(seedFixture());
-    const triggerId = await seedTrigger(fixture, { kind: "cron" });
-    const { runId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    const response = await postSignedCallback(
-      CRON_PATH,
-      {
-        runId,
-        status: "completed",
-        payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-      },
-      true,
-    );
-
-    expect(response.status).toBe(401);
-  });
-
-  it("rejects invalid cron payloads", async () => {
-    const fixture = await track(seedFixture());
-    const triggerId = await seedTrigger(fixture, { kind: "cron" });
-    const { runId, callbackId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    const response = await postSignedCallback(CRON_PATH, {
-      callbackId,
-      runId,
-      status: "completed",
-      payload: { triggerId },
-    });
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toStrictEqual({
-      error: "Invalid or missing payload",
-    });
   });
 
   it("rejects invalid loop payloads", async () => {
@@ -410,149 +354,5 @@ describe("POST /api/internal/callbacks/trigger/*", () => {
     expect(updated?.consecutiveFailures).toBe(3);
     expect(updated?.enabled).toBeFalsy();
     expect(updated?.nextRunAt).toBeNull();
-  });
-
-  it("advances cron callbacks from the dispatched expression on completion", async () => {
-    const completedAt = new Date("2026-05-13T04:00:00.000Z");
-    mockNow(completedAt);
-    const fixture = await track(seedFixture());
-    const triggerId = await seedTrigger(fixture, {
-      kind: "cron",
-      consecutiveFailures: 2,
-    });
-    const { runId, callbackId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    const response = await postSignedCallback(CRON_PATH, {
-      callbackId,
-      runId,
-      status: "completed",
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toStrictEqual({ success: true });
-    const updated = await triggerById(triggerId);
-    expect(updated?.consecutiveFailures).toBe(0);
-    expect(updated?.enabled).toBeTruthy();
-    expect(updated?.nextRunAt?.toISOString()).toBe(
-      calculateNextRun("0 9 * * *", "UTC", completedAt)?.toISOString(),
-    );
-    await expect(runSummary(runId)).resolves.toBeNull();
-  });
-
-  it("increments cron failure counters before the auto-disable threshold", async () => {
-    const failedAt = new Date("2026-05-13T04:00:00.000Z");
-    mockNow(failedAt);
-    const fixture = await track(seedFixture());
-    const triggerId = await seedTrigger(fixture, { kind: "cron" });
-    const { runId, callbackId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    const response = await postSignedCallback(CRON_PATH, {
-      callbackId,
-      runId,
-      status: "failed",
-      error: "Agent crashed",
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toStrictEqual({ success: true });
-    const updated = await triggerById(triggerId);
-    expect(updated?.consecutiveFailures).toBe(1);
-    expect(updated?.enabled).toBeTruthy();
-    expect(updated?.nextRunAt?.toISOString()).toBe(
-      calculateNextRun("0 9 * * *", "UTC", failedAt)?.toISOString(),
-    );
-  });
-
-  it("auto-disables cron triggers after the third consecutive failure", async () => {
-    const fixture = await track(seedFixture());
-    const triggerId = await seedTrigger(fixture, {
-      kind: "cron",
-      consecutiveFailures: 2,
-    });
-    const { runId, callbackId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    const response = await postSignedCallback(CRON_PATH, {
-      callbackId,
-      runId,
-      status: "failed",
-      error: "Agent crashed",
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toStrictEqual({ success: true });
-    const updated = await triggerById(triggerId);
-    expect(updated?.consecutiveFailures).toBe(3);
-    expect(updated?.enabled).toBeFalsy();
-    expect(updated?.nextRunAt).toBeNull();
-  });
-
-  it("skips completed callbacks for deleted triggers", async () => {
-    const fixture = await track(seedFixture());
-    const triggerId = await seedTrigger(fixture, { kind: "cron" });
-    const { runId, callbackId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-    await deleteTrigger(triggerId);
-
-    const response = await postSignedCallback(CRON_PATH, {
-      callbackId,
-      runId,
-      status: "completed",
-      payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
-  });
-
-  it("skips completed callbacks for disabled triggers (once after claim)", async () => {
-    const fixture = await track(seedFixture());
-    // A once trigger is disabled at claim time, so its completion callback must
-    // land in the disabled-skip branch — live schedule parity.
-    const triggerId = await seedTrigger(fixture, {
-      kind: "cron",
-      enabled: false,
-    });
-    const { runId, callbackId } = await seedRunAndCallback(fixture, {
-      path: CRON_PATH,
-      triggerId,
-      payload: { triggerId, timezone: "UTC" },
-    });
-
-    const response = await postSignedCallback(CRON_PATH, {
-      callbackId,
-      runId,
-      status: "completed",
-      payload: { triggerId, timezone: "UTC" },
-    });
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toStrictEqual({
-      success: true,
-      skipped: true,
-    });
-    const updated = await triggerById(triggerId);
-    expect(updated?.enabled).toBeFalsy();
-    expect(updated?.consecutiveFailures).toBe(0);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2211,9 +2211,6 @@ function captureScheduleRunCallbacks(): void {
   webhooks.captureInternalCallbackDeliveries(
     "/api/internal/callbacks/trigger/loop",
   );
-  webhooks.captureInternalCallbackDeliveries(
-    "/api/internal/callbacks/trigger/cron",
-  );
 }
 
 describe("RUN-04/OPS-01: zero run logs", () => {

--- a/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
+++ b/turbo/apps/api/src/signals/routes/internal-callbacks-trigger.ts
@@ -11,7 +11,7 @@ import type { InternalRunCallbackKind } from "../services/internal-run-callback"
 
 type TriggerInternalRunCallbackKind = Extract<
   InternalRunCallbackKind,
-  "trigger:cron" | "trigger:loop"
+  "trigger:loop"
 >;
 
 function successResponse(skipped?: true): {
@@ -56,14 +56,9 @@ function createTriggerCallbackHandler(kind: TriggerInternalRunCallbackKind) {
   });
 }
 
-const handleCronTriggerCallback$ = createTriggerCallbackHandler("trigger:cron");
 const handleLoopTriggerCallback$ = createTriggerCallbackHandler("trigger:loop");
 
 export const internalCallbacksTriggerRoutes: readonly RouteEntry[] = [
-  {
-    route: internalCallbacksTriggerContract.cron,
-    handler: callbackRoute(handleCronTriggerCallback$),
-  },
   {
     route: internalCallbacksTriggerContract.loop,
     handler: callbackRoute(handleLoopTriggerCallback$),

--- a/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
@@ -1934,6 +1934,49 @@ describe("dispatchRunCallbacks$ trigger internal dispatch", () => {
     });
   });
 
+  it("dispatches typed cron trigger callbacks through ccstate without fetching the route", async () => {
+    const completedAt = new Date("2026-05-13T04:00:00.000Z");
+    mockNow(completedAt);
+    const fixture = await seedAgentCallbackRun();
+    const triggerId = await seedAutomationTrigger(fixture, {
+      kind: "cron",
+      consecutiveFailures: 2,
+    });
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "trigger:cron",
+        payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+      },
+      context.signal,
+    );
+    const routeRequests = failIfCallbackRouteIsFetched(
+      TRIGGER_CRON_CALLBACK_URL,
+    );
+    const db = store.set(writeDb$);
+
+    const results = await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "completed" },
+      context.signal,
+    );
+
+    expect(results).toStrictEqual([{ callbackId, success: true }]);
+    expect(routeRequests()).toBe(0);
+    await expect(readTrigger(triggerId)).resolves.toMatchObject({
+      consecutiveFailures: 0,
+      enabled: true,
+    });
+    await expect(readCallback(callbackId)).resolves.toMatchObject({
+      url: null,
+      internalKind: "trigger:cron",
+      status: "delivered",
+      attempts: 1,
+      lastError: null,
+    });
+  });
+
   it("dispatches legacy cron trigger URLs through the same ccstate path", async () => {
     const fixture = await seedAgentCallbackRun();
     const triggerId = await seedAutomationTrigger(fixture, {

--- a/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
+++ b/turbo/apps/api/src/signals/services/automations/default-interpreter.ts
@@ -1,11 +1,9 @@
 import { randomBytes } from "node:crypto";
 
-import type {
-  TriggerCronCallbackPayload,
-  TriggerLoopCallbackPayload,
-} from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
+import type { TriggerLoopCallbackPayload } from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
 
 import type { InternalRunCallbackKind } from "../internal-run-callback";
+import type { TriggerCronCallbackPayload } from "../trigger-callback-payload";
 
 /**
  * Identifies how an Automation should be interpreted into an agent run. The

--- a/turbo/apps/api/src/signals/services/internal-trigger-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-trigger-run-callback.service.ts
@@ -1,8 +1,6 @@
 import { command } from "ccstate";
 import {
-  triggerCronCallbackPayloadSchema,
   triggerLoopCallbackPayloadSchema,
-  type TriggerCronCallbackPayload,
   type TriggerLoopCallbackPayload,
 } from "@vm0/api-contracts/contracts/internal-callbacks-trigger";
 import { automationTriggers } from "@vm0/db/schema/automation";
@@ -16,6 +14,10 @@ import type {
   InternalRunCallbackEnvelope,
   InternalRunCallbackKind,
 } from "./internal-run-callback";
+import {
+  triggerCronCallbackPayloadSchema,
+  type TriggerCronCallbackPayload,
+} from "./trigger-callback-payload";
 
 const MAX_CONSECUTIVE_FAILURES = 3;
 

--- a/turbo/apps/api/src/signals/services/trigger-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/trigger-callback-payload.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const triggerCronCallbackPayloadSchema = z
+  .object({
+    triggerId: z.string(),
+    timezone: z.string(),
+    cronExpression: z.string().optional(),
+  })
+  .passthrough();
+
+export type TriggerCronCallbackPayload = z.infer<
+  typeof triggerCronCallbackPayloadSchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1375,10 +1375,8 @@ export {
 } from "./automations";
 export {
   internalCallbacksTriggerContract,
-  triggerCronCallbackPayloadSchema,
   triggerLoopCallbackPayloadSchema,
   type InternalCallbacksTriggerContract,
-  type TriggerCronCallbackPayload,
   type TriggerLoopCallbackPayload,
 } from "./internal-callbacks-trigger";
 export {

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-trigger.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-trigger.ts
@@ -16,13 +16,6 @@ export const triggerLoopCallbackPayloadSchema = z
   })
   .passthrough();
 
-export const triggerCronCallbackPayloadSchema = triggerLoopCallbackPayloadSchema
-  .extend({
-    timezone: z.string(),
-    cronExpression: z.string().optional(),
-  })
-  .passthrough();
-
 /**
  * Completion callbacks for `automation_triggers` time rows. The poller
  * claims a due trigger by
@@ -31,21 +24,6 @@ export const triggerCronCallbackPayloadSchema = triggerLoopCallbackPayloadSchema
  * increment on failure, auto-disable at the threshold).
  */
 export const internalCallbacksTriggerContract = c.router({
-  cron: {
-    method: "POST",
-    path: "/api/internal/callbacks/trigger/cron",
-    headers: internalCallbackHeadersSchema,
-    body: internalCallbackBodySchema.extend({
-      payload: triggerCronCallbackPayloadSchema,
-    }),
-    responses: {
-      200: internalCallbackSuccessWithSkippedSchema,
-      400: internalCallbackErrorSchema,
-      401: internalCallbackErrorSchema,
-      404: internalCallbackErrorSchema,
-    },
-    summary: "Handle terminal callbacks for cron/once automation triggers",
-  },
   loop: {
     method: "POST",
     path: "/api/internal/callbacks/trigger/loop",
@@ -65,9 +43,6 @@ export const internalCallbacksTriggerContract = c.router({
 
 export type InternalCallbacksTriggerContract =
   typeof internalCallbacksTriggerContract;
-export type TriggerCronCallbackPayload = z.infer<
-  typeof triggerCronCallbackPayloadSchema
->;
 export type TriggerLoopCallbackPayload = z.infer<
   typeof triggerLoopCallbackPayloadSchema
 >;


### PR DESCRIPTION
Closes #17960.
Part of #17809.

## Summary
- removed the POST /api/internal/callbacks/trigger/cron route registration and ts-rest contract surface
- kept POST /api/internal/callbacks/trigger/loop registered and covered for the next separate route cleanup
- moved the cron trigger callback payload type/schema into the API internal service layer
- preserved legacy /api/internal/callbacks/trigger/cron URL-to-kind dispatch compatibility for pending rows
- updated tests so cron trigger behavior is verified through typed dispatch and legacy URL dispatch without fetching the deleted HTTP route

## Verification
- pnpm format
- pnpm -F api exec vitest run src/signals/services/__tests__/agent-run-callback.service.test.ts src/signals/routes/__tests__/internal-callbacks-trigger.test.ts src/lib/__tests__/internal-api-url.test.ts -t "trigger internal dispatch|POST /api/internal/callbacks/trigger/loop|internalApiBaseUrl"
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "zero run logs"
- git diff --check
- pnpm -F api lint
- pnpm check-types
- pnpm knip
- pnpm turbo run lint