### PR TITLE
Prefill chat draft from root prompt links

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -12,18 +12,21 @@ export const setupHomePage$ = command(
 
     await set(checkUnifiedSettingsParam$, signal);
 
-    // Redirect bare / to /agents/:id/chat. Use-case "Try It" deep links go
-    // through /onboarding directly (see buildPromptHref in use-cases/data.ts),
-    // so we no longer intercept ?prompt= here. ?queue= is forwarded so the
-    // queue drawer opens on arrival.
+    // Redirect bare / to /agents/:id/chat. Keep prompt deep links intact so
+    // paid-onboarding handoffs can prefill the chat composer on arrival.
+    // ?queue= is also forwarded so the queue drawer opens on arrival.
     const homeAgentId = await get(homeAgentId$);
     signal.throwIfAborted();
     if (!homeAgentId) {
       return;
     }
     const params = get(searchParams$);
+    const prompt = params.get("prompt");
     const queue = params.get("queue");
     const forwardParams = new URLSearchParams();
+    if (prompt) {
+      forwardParams.set("prompt", prompt);
+    }
     if (queue) {
       forwardParams.set("queue", queue);
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -7,6 +7,19 @@ import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
 const context = testContext();
 
 describe("prompt query parameter injection", () => {
+  it("prefills the chat draft from the app root prompt URL", async () => {
+    detachedSetupPage({
+      context,
+      path: "/?prompt=Start%20my%20first%20task",
+    });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    expect(textarea).toHaveValue("Start my first task");
+  });
+
   it("starts a chat draft from a prompt URL", async () => {
     detachedSetupPage({
       context,


### PR DESCRIPTION
## Summary
- Preserve `prompt` when the app root redirects to the default agent chat.
- Let `https://app.vm0.ai/?prompt=...` land on `/agents/:agentId/chat?prompt=...`, where the existing chat setup pre-fills the composer.
- Add a regression test for root prompt deep links.

## Verification
- `pnpm test apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx`
- `pnpm -F @vm0/app check-types`