### PR TITLE
fix: bound desktop computer use command log memory growth

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -422,6 +422,70 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("caps the local command log so long sessions stay bounded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T08:00:00.000Z"));
+    // The cap mirrors LOCAL_COMMAND_LOG_LIMIT in computer-use-host.ts.
+    const logLimit = 50;
+    const totalCommands = logLimit + 10;
+    let claimed = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        if (claimed >= totalCommands) {
+          return jsonResponse({ status: "idle" });
+        }
+        claimed += 1;
+        return jsonResponse({
+          status: "claimed",
+          command: {
+            id: `cmd-${claimed}`,
+            kind: "app.state",
+            payload: { app: "Things" },
+          },
+        });
+      }
+      if (url.includes("/api/zero/computer-use/host/commands/")) {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ status: "idle" });
+    });
+    const executeCommand = vi.fn<
+      (
+        command: ComputerUseCommand,
+        permissions: ComputerUsePermissionState,
+      ) => Promise<ComputerUseCommandExecutionResult>
+    >(async () => {
+      return {
+        status: "succeeded",
+        result: {
+          appState: "0 standard window Inbox",
+          screenshot: "data:image/png;base64,abc123",
+          screenshotWidth: 800,
+          screenshotHeight: 600,
+          screenshotSourceName: "Inbox",
+        },
+      };
+    });
+    const { runtime } = createRuntime({ hostFetch, executeCommand });
+
+    await runtime.start();
+    for (let poll = 0; poll < totalCommands + 5; poll += 1) {
+      await vi.advanceTimersByTimeAsync(2_000);
+    }
+
+    const log = runtime.getState().localCommandLog;
+    expect(claimed).toBe(totalCommands);
+    expect(log).toHaveLength(logLimit);
+    // Newest command is kept at the front and the oldest entries are evicted.
+    expect(log[0]?.commandId).toBe(`cmd-${totalCommands}`);
+    expect(log.some((entry) => entry.commandId === "cmd-1")).toBe(false);
+
+    await runtime.stop();
+  });
+
   it("keeps heartbeats running while a command is executing", async () => {
     vi.useFakeTimers();
     const command: ComputerUseCommand = {

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -26,6 +26,10 @@ const COMMAND_COMPLETION_RETRY_DELAY_MS = 2_000;
 const COMMAND_COMPLETION_MAX_ATTEMPTS = 3;
 const AUTH_ME_PATH = "/api/auth/me";
 const ERROR_LOG_LIMIT = 20;
+// Completed entries retain the full command result, which for Computer Use
+// includes screenshot-heavy app state. Cap retained entries so a long session
+// (e.g. repetitive browser automation) cannot grow runtime memory without bound.
+const LOCAL_COMMAND_LOG_LIMIT = 50;
 
 export type ComputerUseHostFetch = (
   input: string,
@@ -401,7 +405,7 @@ export class ComputerUseHostRuntime {
         ...this.state.localCommandLog.filter((candidate) => {
           return candidate.commandId !== command.id;
         }),
-      ],
+      ].slice(0, LOCAL_COMMAND_LOG_LIMIT),
     });
   }
 


### PR DESCRIPTION
## Problem

Closes #17951.

A long Zero Desktop Computer Use run can grow memory until the app freezes (the reported case: asking Zero to add ~80 Stripe card fingerprints). `ComputerUseHostRuntime` keeps every local native command in `state.localCommandLog` with **no size limit**:

- `startLocalCommandLogEntry()` prepends every command and only de-dupes by `commandId`.
- `finishLocalCommandLogEntry()` stores the full `completed.result`, which for Computer Use includes a base64 `screenshot`, `appState`, `elements`, and `visibleElements` (`buildComputerUseAppStateResult()` in `computer-use-accessibility.ts`).
- `getComputerUseBridgeState()` clones the whole log across IPC into the renderer, where `CommandLogPanel` keeps it in React state and decodes the screenshots.

So a single screenshot-heavy result is retained in several places, and the log grows roughly with command count — especially in repetitive browser automation where every action produces a post-action screenshot.

The sibling `errorLog` already guards against exactly this by capping at `ERROR_LOG_LIMIT` (`computer-use-host.ts:313`); `localCommandLog` simply lacked the equivalent cap.

## Solution

Add `LOCAL_COMMAND_LOG_LIMIT` next to `ERROR_LOG_LIMIT` and apply `.slice(0, LOCAL_COMMAND_LOG_LIMIT)` in `startLocalCommandLogEntry`, mirroring the existing `errorLog` pattern. The newest entries (which the UI cares about) are kept at the front; the oldest are evicted, so runtime and IPC-cloned renderer memory stay bounded regardless of session length. Serial command execution means the in-flight command is always within the retained window, so `finishLocalCommandLogEntry` still resolves its entry.

This is the focused "strict cap on entries" fix from the issue's suggested direction. Per-entry redaction / a separate short-lived screenshot preview store (also listed there) is a larger UI design change and is left as a follow-up.

## Testing

Added an integration test that drives the runtime poll loop through `logLimit + 10` screenshot-heavy commands and asserts the log stays at the cap, the newest command stays at the front, and the oldest entries are evicted. Verified it fails without the cap (length 60 vs 50) and passes with it.

- `pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts` — 22 passed
- `pnpm -F @vm0/desktop check-types` — clean
- `pnpm -F @vm0/desktop lint` — 0 warnings, 0 errors