### PR TITLE
fix: compact computer use app state output

### DIFF
--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -141,6 +141,17 @@ export const ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS =
   });
 
 const GENERIC_WRAPPER_ROLES = new Set(["AXGroup", "AXUnknown"]);
+const REDUNDANT_LABEL_CHILD_ROLES = new Set(["AXImage", "AXStaticText"]);
+const PARENT_TEXT_COVERED_ROLES = new Set([
+  "AXButton",
+  "AXGroup",
+  "AXHeading",
+  "AXImage",
+  "AXLink",
+  "AXStaticText",
+  "AXUnknown",
+]);
+const TEXT_COVERING_PARENT_ROLES = new Set(["AXButton", "AXHeading", "AXLink"]);
 
 interface ComputerUseAppStateScreenshot {
   readonly dataUrl: string;
@@ -396,6 +407,14 @@ function normalizeDisplayText(value: string): string {
   return value.trim().replaceAll(/\s+/g, " ");
 }
 
+function normalizeCoverageText(value: string): string {
+  return normalizeDisplayText(value)
+    .replaceAll(/[•·]/g, " ")
+    .replaceAll(/\s+/g, " ")
+    .trim()
+    .toLocaleLowerCase();
+}
+
 function stringArrayHasValue(value: readonly string[] | undefined): boolean {
   return (
     value !== undefined &&
@@ -405,11 +424,8 @@ function stringArrayHasValue(value: readonly string[] | undefined): boolean {
   );
 }
 
-function elementIsWebArea(element: AccessibilityElementSnapshot): boolean {
-  return (
-    element.role === "AXWebArea" ||
-    element.roleDescription?.toLowerCase().includes("html") === true
-  );
+function stringValues(value: readonly string[] | undefined): readonly string[] {
+  return value ?? [];
 }
 
 function elementHasMeaningfulContent(
@@ -430,31 +446,272 @@ function elementHasMeaningfulContent(
     element.focused === true ||
     element.enabled === false ||
     element.selected === true ||
-    element.expanded !== undefined ||
+    element.expanded === true ||
     element.pressable === true ||
     element.pickable === true ||
     element.selectable === true ||
-    element.mouseClickable === true ||
-    element.clickableKind !== undefined ||
-    (element.actions !== undefined && element.actions.length > 0)
+    element.clickableKind === "press" ||
+    element.clickableKind === "pick" ||
+    element.clickableKind === "select" ||
+    hasMeaningfulSecondaryAction(element)
   );
 }
 
-function shouldElideElement(
+function hasMeaningfulSecondaryAction(
   element: AccessibilityElementSnapshot,
-  childCount: number,
-  inWebArea: boolean,
 ): boolean {
+  return (
+    element.actions?.some((action) => {
+      return (
+        action !== "AXShowMenu" &&
+        action !== "AXScrollToVisible" &&
+        action !== "AXPress" &&
+        !(action === "AXPick" && element.clickableKind === "pick")
+      );
+    }) === true
+  );
+}
+
+function shouldElideElement(element: AccessibilityElementSnapshot): boolean {
   if (!element.role || !GENERIC_WRAPPER_ROLES.has(element.role)) {
     return false;
   }
   if (elementHasMeaningfulContent(element)) {
     return false;
   }
-  if (inWebArea && childCount > 1) {
+  return true;
+}
+
+function elementHasDefaultPress(
+  element: AccessibilityElementSnapshot,
+): boolean {
+  return (
+    element.pressable === true ||
+    element.clickableKind === "press" ||
+    element.actions?.includes("AXPress") === true
+  );
+}
+
+function elementHasIndependentStateOrAction(
+  element: AccessibilityElementSnapshot,
+): boolean {
+  return (
+    element.focused === true ||
+    element.selected === true ||
+    element.enabled === false ||
+    element.expanded === true ||
+    element.valueSettable === true ||
+    element.pickable === true ||
+    element.selectable === true ||
+    element.clickableKind === "pick" ||
+    element.clickableKind === "select" ||
+    hasMeaningfulSecondaryAction(element)
+  );
+}
+
+function normalizedElementLabelValues(
+  element: AccessibilityElementSnapshot,
+): readonly string[] {
+  return [
+    element.name,
+    element.value,
+    element.description,
+    element.help,
+    element.placeholderValue,
+    element.visibleText,
+    element.text,
+    element.titleElementText,
+    ...stringValues(element.columnTitles),
+  ]
+    .filter((value): value is string => {
+      return value !== undefined;
+    })
+    .map(normalizeCoverageText)
+    .filter((value) => {
+      return value.length > 0;
+    });
+}
+
+function normalizedElementTextValues(
+  element: AccessibilityElementSnapshot,
+): ReadonlySet<string> {
+  const values = [
+    element.name,
+    element.value,
+    element.description,
+    element.help,
+    element.placeholderValue,
+    element.visibleText,
+    element.text,
+    element.titleElementText,
+    ...stringValues(element.columnTitles),
+    element.identifier,
+    element.url,
+  ]
+    .filter((value): value is string => {
+      return value !== undefined;
+    })
+    .map(normalizeDisplayText)
+    .filter((value) => {
+      return value.length > 0;
+    });
+  return new Set(values);
+}
+
+function normalizedSubtreeLabelValues(
+  element: AccessibilityElementSnapshot,
+): readonly string[] {
+  const values = [...normalizedElementLabelValues(element)];
+  for (const child of element.children ?? []) {
+    values.push(...normalizedSubtreeLabelValues(child));
+  }
+  return values;
+}
+
+function textValuesCover(
+  parentTexts: readonly string[],
+  childTexts: readonly string[],
+): boolean {
+  const meaningfulChildTexts = childTexts.filter((text) => {
+    return text.length > 0;
+  });
+  return (
+    meaningfulChildTexts.length > 0 &&
+    meaningfulChildTexts.every((childText) => {
+      return parentTexts.some((parentText) => {
+        return parentText === childText || parentText.includes(childText);
+      });
+    })
+  );
+}
+
+function childHasIndependentSemantics(
+  parent: AccessibilityElementSnapshot,
+  child: AccessibilityElementSnapshot,
+): boolean {
+  if (!child.role || !PARENT_TEXT_COVERED_ROLES.has(child.role)) {
+    return true;
+  }
+  if (elementHasIndependentStateOrAction(child)) {
+    return true;
+  }
+  if (
+    (child.role === "AXLink" || child.role === "AXButton") &&
+    child.role !== parent.role
+  ) {
+    return true;
+  }
+  if (
+    child.role === "AXLink" &&
+    parent.role === "AXLink" &&
+    child.url !== undefined &&
+    parent.url !== undefined &&
+    child.url !== parent.url
+  ) {
+    return true;
+  }
+  return (child.children ?? []).some((grandchild) => {
+    return childHasIndependentSemantics(parent, grandchild);
+  });
+}
+
+function childIsCoveredByParentText(
+  parent: AccessibilityElementSnapshot,
+  child: AccessibilityElementSnapshot,
+): boolean {
+  if (!parent.role || !TEXT_COVERING_PARENT_ROLES.has(parent.role)) {
+    return false;
+  }
+  if (childHasIndependentSemantics(parent, child)) {
+    return false;
+  }
+  return textValuesCover(
+    normalizedElementLabelValues(parent),
+    normalizedSubtreeLabelValues(child),
+  );
+}
+
+function childIsRedundantLabel(
+  parent: AccessibilityElementSnapshot,
+  child: AccessibilityElementSnapshot,
+): boolean {
+  if (
+    child.role === "AXStaticText" &&
+    (child.children ?? []).length === 0 &&
+    normalizedElementTextValues(child).size === 0 &&
+    !elementHasIndependentStateOrAction(child)
+  ) {
+    return true;
+  }
+  if (!child.role || !REDUNDANT_LABEL_CHILD_ROLES.has(child.role)) {
+    return false;
+  }
+  if (child.children && child.children.length > 0) {
+    return false;
+  }
+  const parentTexts = normalizedElementTextValues(parent);
+  if (parentTexts.size === 0) {
+    return false;
+  }
+  const duplicatesParentText = [...normalizedElementTextValues(child)].some(
+    (text) => {
+      return parentTexts.has(text);
+    },
+  );
+  if (!duplicatesParentText) {
+    return false;
+  }
+  if (
+    child.focused === true ||
+    child.selected === true ||
+    child.enabled === false ||
+    child.expanded === true ||
+    child.pickable === true ||
+    child.selectable === true ||
+    child.clickableKind === "pick" ||
+    child.clickableKind === "select" ||
+    hasMeaningfulSecondaryAction(child)
+  ) {
+    return false;
+  }
+  if (elementHasDefaultPress(child) && !elementHasDefaultPress(parent)) {
     return false;
   }
   return true;
+}
+
+function shouldCompactChild(
+  parent: AccessibilityElementSnapshot,
+  child: AccessibilityElementSnapshot,
+): boolean {
+  return (
+    childIsRedundantLabel(parent, child) ||
+    childIsCoveredByParentText(parent, child)
+  );
+}
+
+function shallowMenuBarChild(
+  element: AccessibilityElementSnapshot,
+): AccessibilityElementSnapshot {
+  return {
+    ...element,
+    actions: undefined,
+    children: undefined,
+  };
+}
+
+function compactRawChildren(
+  element: AccessibilityElementSnapshot,
+): readonly AccessibilityElementSnapshot[] {
+  const rawChildren = element.children ?? [];
+  if (element.role === "AXMenuBar") {
+    return rawChildren.map((child) => {
+      return shallowMenuBarChild(child);
+    });
+  }
+  return rawChildren.filter((child) => {
+    return !shouldCompactChild(element, child);
+  });
 }
 
 function pushUniqueReason(reasons: string[], reason: string): void {
@@ -473,7 +730,6 @@ export function normalizeAccessibilitySnapshot(
   const normalizeElement = (
     element: AccessibilityElementSnapshot,
     depth: number,
-    inWebArea: boolean,
   ): AccessibilityElementSnapshot[] => {
     if (depth > limits.maxDepth) {
       pushUniqueReason(truncationReasons, "max_depth");
@@ -488,14 +744,13 @@ export function normalizeAccessibilitySnapshot(
       return [];
     }
 
-    const nextInWebArea = inWebArea || elementIsWebArea(element);
-    const rawChildren = element.children ?? [];
-    const childEntries = rawChildren.slice(0, limits.maxChildrenPerNode);
-    if (rawChildren.length > childEntries.length) {
+    const semanticChildren = compactRawChildren(element);
+    const childEntries = semanticChildren.slice(0, limits.maxChildrenPerNode);
+    if (semanticChildren.length > childEntries.length) {
       pushUniqueReason(truncationReasons, "max_children_per_node");
     }
 
-    const elide = shouldElideElement(element, rawChildren.length, inWebArea);
+    const elide = shouldElideElement(element);
     if (!elide) {
       if (nodeCount >= limits.maxNodes) {
         pushUniqueReason(truncationReasons, "max_nodes");
@@ -510,23 +765,27 @@ export function normalizeAccessibilitySnapshot(
         pushUniqueReason(truncationReasons, "max_nodes");
         break;
       }
-      children.push(...normalizeElement(child, depth + 1, nextInWebArea));
+      children.push(...normalizeElement(child, depth + 1));
     }
 
     if (elide) {
       return children;
     }
 
+    const compactedChildren = children.filter((child) => {
+      return !shouldCompactChild(element, child);
+    });
+
     return [
       {
         ...element,
-        children: children.length > 0 ? children : undefined,
+        children: compactedChildren.length > 0 ? compactedChildren : undefined,
       },
     ];
   };
 
   const elements = snapshot.elements.flatMap((element) => {
-    return normalizeElement(element, 0, false);
+    return normalizeElement(element, 0);
   });
 
   const combinedReasons = [
@@ -844,6 +1103,14 @@ const ROLE_LABELS: Readonly<Record<string, string>> = Object.freeze({
 });
 
 const DEFAULT_ACTION_NAMES = new Set(["AXPress"]);
+const GENERIC_WEB_ACTION_NAMES = new Set(["AXShowMenu", "AXScrollToVisible"]);
+const MENU_ACTION_NOISE_NAMES = new Set(["AXCancel", "AXPick"]);
+const MENU_ROLE_NAMES = new Set([
+  "AXMenu",
+  "AXMenuBar",
+  "AXMenuBarItem",
+  "AXMenuItem",
+]);
 const PRIMARY_CLICK_ROLE_NAMES = new Set([
   "AXButton",
   "AXCheckBox",
@@ -946,7 +1213,10 @@ function elementAnnotations(element: AccessibilityElementSnapshot): string[] {
     element.mouseClickable === true &&
     element.clickableKind === "mouse" &&
     element.selectable !== true &&
-    (element.role === undefined || !PRIMARY_CLICK_ROLE_NAMES.has(element.role))
+    (element.role === undefined ||
+      !PRIMARY_CLICK_ROLE_NAMES.has(element.role)) &&
+    element.role !== "AXStaticText" &&
+    (element.role === undefined || !GENERIC_WRAPPER_ROLES.has(element.role))
   ) {
     annotations.push("clickable");
   }
@@ -979,7 +1249,17 @@ function secondaryActions(element: AccessibilityElementSnapshot): string[] {
       if (action === "AXPick" && element.clickableKind === "pick") {
         return false;
       }
-      return !DEFAULT_ACTION_NAMES.has(action);
+      if (
+        element.role !== undefined &&
+        MENU_ROLE_NAMES.has(element.role) &&
+        MENU_ACTION_NOISE_NAMES.has(action)
+      ) {
+        return false;
+      }
+      return (
+        !DEFAULT_ACTION_NAMES.has(action) &&
+        !GENERIC_WEB_ACTION_NAMES.has(action)
+      );
     })
     .map((action) => {
       return actionLabel(action);

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -827,7 +827,12 @@ describe("computer use desktop runtime", () => {
                   id: "w0.e0.e1",
                   role: "AXButton",
                   description: "Invite people",
-                  actions: ["AXPress", "AXRaise"],
+                  actions: [
+                    "AXPress",
+                    "AXRaise",
+                    "AXShowMenu",
+                    "AXScrollToVisible",
+                  ],
                 },
               ],
             },
@@ -850,6 +855,8 @@ describe("computer use desktop runtime", () => {
     expect(text).toContain(
       "\t\t3 button Invite people, Secondary Actions: Raise",
     );
+    expect(text).not.toContain("Show Menu");
+    expect(text).not.toContain("ScrollToVisible");
     expect(text).toContain(
       "The focused UI element is 2 text entry area (settable, string) Ask me to automate workflows.",
     );
@@ -1003,7 +1010,7 @@ describe("computer use desktop runtime", () => {
     ]);
   });
 
-  it("compacts generic wrappers while preserving WebArea branching context", () => {
+  it("compacts structural web wrappers while preserving child controls", () => {
     const snapshot = {
       app: "Slack",
       snapshotId: "snap_1",
@@ -1025,10 +1032,12 @@ describe("computer use desktop runtime", () => {
                     {
                       id: "w0.e0.e0.e0",
                       role: "AXGroup",
+                      expanded: false,
                       children: [
                         {
                           id: "w0.e0.e0.e0.e0",
                           role: "AXGroup",
+                          expanded: false,
                           children: [
                             {
                               id: "w0.e0.e0.e0.e0.e0",
@@ -1060,9 +1069,276 @@ describe("computer use desktop runtime", () => {
 
     expect(text).not.toContain("w0.e0");
     expect(text).toContain("\t1 HTML content");
-    expect(text).toContain("\t\t2 container");
-    expect(text).toContain("\t\t\t3 button Send message");
-    expect(text).toContain("\t\t\t4 text release-notify");
+    expect(text).toContain("\t\t2 button Send message");
+    expect(text).toContain("\t\t3 text release-notify");
+    expect(text).not.toContain("\t\t2 container");
+  });
+
+  it("applies structural wrapper compaction before the output node budget", () => {
+    const noisyProfileLinks = Array.from({ length: 20 }, (_value, index) => {
+      const label = `Profile ${index}`;
+      return {
+        id: `w0.e0.row${index}`,
+        role: "AXGroup",
+        actions: ["AXShowMenu", "AXScrollToVisible"],
+        expanded: false,
+        mouseClickable: true,
+        children: [
+          {
+            id: `w0.e0.row${index}.link`,
+            role: "AXLink",
+            name: label,
+            actions: ["AXPress", "AXShowMenu", "AXScrollToVisible"],
+            pressable: true,
+            children: [
+              {
+                id: `w0.e0.row${index}.label`,
+                role: "AXStaticText",
+                value: label,
+                actions: ["AXPress", "AXShowMenu", "AXScrollToVisible"],
+                expanded: false,
+                pressable: true,
+                mouseClickable: true,
+              },
+            ],
+          },
+        ],
+      };
+    });
+    const snapshot = {
+      app: "Google Chrome",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "LinkedIn",
+          children: [
+            {
+              id: "w0.e0",
+              role: "AXWebArea",
+              roleDescription: "HTML content",
+              children: [
+                ...noisyProfileLinks,
+                {
+                  id: "w0.e0.messaging",
+                  role: "AXGroup",
+                  actions: ["AXShowMenu", "AXScrollToVisible"],
+                  children: [
+                    {
+                      id: "w0.e0.messaging.title",
+                      role: "AXStaticText",
+                      value: "New message",
+                    },
+                    {
+                      id: "w0.e0.messaging.input",
+                      role: "AXTextArea",
+                      description: "Write a message...",
+                      placeholderValue: "Write a message...",
+                      valueSettable: true,
+                      valueType: "string",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const normalized = normalizeAccessibilitySnapshot(snapshot, {
+      ...ACCESSIBILITY_SNAPSHOT_OUTPUT_LIMITS,
+      maxNodes: 24,
+    });
+    const text = renderAccessibilityTree(normalized);
+
+    expect(normalized.truncated).toBeUndefined();
+    expect(text).toContain("text New message");
+    expect(text).toContain(
+      "text entry area (settable, string) Write a message...",
+    );
+    expect(text).toContain("\t\t2 link Profile 0");
+    expect(text).not.toContain("text Profile 0");
+    expect(text).not.toContain("Secondary Actions: Show Menu");
+    expect(text).not.toContain("ScrollToVisible");
+  });
+
+  it("keeps menu bars shallow for app state output", () => {
+    const snapshot = {
+      app: "Google Chrome",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "LinkedIn",
+          children: [
+            {
+              id: "w0.menu",
+              role: "AXMenuBar",
+              actions: ["AXCancel"],
+              children: [
+                {
+                  id: "w0.menu.chrome",
+                  role: "AXMenuBarItem",
+                  name: "Chrome",
+                  actions: ["AXCancel", "AXPick"],
+                  children: [
+                    {
+                      id: "w0.menu.chrome.menu",
+                      role: "AXMenu",
+                      name: "Chrome",
+                      actions: ["AXCancel"],
+                      children: [
+                        {
+                          id: "w0.menu.chrome.about",
+                          role: "AXMenuItem",
+                          name: "About Google Chrome",
+                          actions: ["AXPick"],
+                        },
+                        {
+                          id: "w0.menu.chrome.settings",
+                          role: "AXMenuItem",
+                          name: "Settings...",
+                          actions: ["AXPick"],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  id: "w0.menu.file",
+                  role: "AXMenuBarItem",
+                  name: "File",
+                  actions: ["AXCancel", "AXPick"],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const text = renderAccessibilityTree(
+      normalizeAccessibilitySnapshot(snapshot),
+    );
+
+    expect(text).toContain("\t1 menu bar");
+    expect(text).toContain("\t\t2 menu bar item Chrome");
+    expect(text).toContain("\t\t3 menu bar item File");
+    expect(text).not.toContain("About Google Chrome");
+    expect(text).not.toContain("Settings...");
+    expect(text).not.toContain("Secondary Actions: Cancel");
+    expect(text).not.toContain("Secondary Actions: Pick");
+  });
+
+  it("compacts child labels already covered by parent action text", () => {
+    const snapshot = {
+      app: "Google Chrome",
+      snapshotId: "snap_1",
+      elements: [
+        {
+          id: "w0",
+          role: "AXWindow",
+          name: "LinkedIn",
+          children: [
+            {
+              id: "w0.e0",
+              role: "AXWebArea",
+              roleDescription: "HTML content",
+              children: [
+                {
+                  id: "w0.e0.card",
+                  role: "AXLink",
+                  name: "Stephan B. Premium · 2nd Director Software Development & Product",
+                  url: "https://www.linkedin.com/in/stephangbetz/",
+                  actions: ["AXPress"],
+                  pressable: true,
+                  children: [
+                    {
+                      id: "w0.e0.card.name",
+                      role: "AXLink",
+                      name: "Stephan B. Premium",
+                      url: "https://www.linkedin.com/in/stephangbetz/",
+                      actions: ["AXPress"],
+                      pressable: true,
+                      children: [
+                        {
+                          id: "w0.e0.card.name.text",
+                          role: "AXStaticText",
+                          value: "Stephan B.",
+                        },
+                        {
+                          id: "w0.e0.card.name.empty",
+                          role: "AXStaticText",
+                          value: "",
+                        },
+                        {
+                          id: "w0.e0.card.name.badge",
+                          role: "AXImage",
+                          description: "Premium",
+                          mouseClickable: true,
+                        },
+                      ],
+                    },
+                    {
+                      id: "w0.e0.card.degree",
+                      role: "AXStaticText",
+                      value: "· 2nd",
+                    },
+                    {
+                      id: "w0.e0.card.headline",
+                      role: "AXStaticText",
+                      value: "Director Software Development & Product",
+                    },
+                  ],
+                },
+                {
+                  id: "w0.e0.invite",
+                  role: "AXButton",
+                  name: "Invite Stephan B. to connect",
+                  actions: ["AXPress"],
+                },
+                {
+                  id: "w0.e0.post",
+                  role: "AXLink",
+                  name: "Starting a new position at OpenAI",
+                  url: "https://www.linkedin.com/feed/update/1/",
+                  actions: ["AXPress"],
+                  pressable: true,
+                  children: [
+                    {
+                      id: "w0.e0.post.company",
+                      role: "AXLink",
+                      name: "OpenAI",
+                      url: "https://www.linkedin.com/company/openai/",
+                      actions: ["AXPress"],
+                      pressable: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const text = renderAccessibilityTree(
+      normalizeAccessibilitySnapshot(snapshot),
+    );
+
+    expect(text).toContain(
+      "\t\t2 link Stephan B. Premium · 2nd Director Software Development & Product",
+    );
+    expect(text).toContain("\t\t3 button Invite Stephan B. to connect");
+    expect(text).toContain("\t\t4 link Starting a new position at OpenAI");
+    expect(text).toContain("\t\t\t5 link OpenAI");
+    expect(text).not.toContain("text Stephan B.");
+    expect(text).not.toContain("image Premium");
+    expect(text).not.toContain("text · 2nd");
+    expect(text).not.toContain("text Director Software Development & Product");
   });
 
   it("renders browser table row and cell content for model targeting", () => {


### PR DESCRIPTION
## Summary
- compact structural accessibility wrappers and duplicate labels before app-state budgeting
- keep macOS menu bars shallow and filter default menu action noise
- collapse child label subtrees already covered by parent link/button/heading text

## Testing
- pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop build:cli
- local vm0-computer Chrome/LinkedIn app-state smoke test