### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.178"
+CLAUDE_CODE_VERSION="2.1.179"
 CODEX_CLI_VERSION="0.140.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.27.3"
+AGENT_BROWSER_VERSION="0.28.0"
 PNPM_VERSION="11.7.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Update pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.178` -> `2.1.179`
- agent-browser: `0.27.3` -> `0.28.0`

Checked the remaining pinned versions and package channels; no other updates were available or appropriate for the current LTS/stable lines. Ubuntu was intentionally left unchanged.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`