### PR TITLE
fix: bound desktop command log memory

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -366,10 +366,19 @@ describe("ComputerUseHostRuntime", () => {
         status: "succeeded",
         result: {
           appState: "0 standard window Inbox",
+          elements: [{ id: "element-1", role: "AXWindow" }],
           screenshot: "data:image/png;base64,abc123",
           screenshotWidth: 800,
           screenshotHeight: 600,
           screenshotSourceName: "Inbox",
+          visibleElements: [
+            {
+              elementId: "element-1",
+              text: "Inbox",
+              source: "accessibility",
+              sourceAttributes: ["AXTitle"],
+            },
+          ],
         },
       };
     });
@@ -386,11 +395,15 @@ describe("ComputerUseHostRuntime", () => {
       status: "succeeded",
       payload: { app: "Things" },
       result: {
-        appState: "0 standard window Inbox",
-        screenshot: "data:image/png;base64,abc123",
         screenshotWidth: 800,
         screenshotHeight: 600,
         screenshotSourceName: "Inbox",
+        omittedResultFields: [
+          "appState",
+          "elements",
+          "screenshot",
+          "visibleElements",
+        ],
       },
       error: null,
       durationMs: 0,
@@ -415,9 +428,56 @@ describe("ComputerUseHostRuntime", () => {
       status: "succeeded",
       result: {
         appState: "0 standard window Inbox",
+        elements: [{ id: "element-1", role: "AXWindow" }],
         screenshot: "data:image/png;base64,abc123",
+        visibleElements: [
+          {
+            elementId: "element-1",
+            text: "Inbox",
+            source: "accessibility",
+            sourceAttributes: ["AXTitle"],
+          },
+        ],
       },
     });
+
+    await runtime.stop();
+  });
+
+  it("limits the local native command log to recent entries", async () => {
+    vi.useFakeTimers();
+    let nextCommandId = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCommandId++;
+        return jsonResponse({
+          status: "command",
+          command: {
+            id: `cmd-${nextCommandId.toString()}`,
+            kind: "keyboard.press_key",
+            payload: { app: "Terminal", key: "Enter" },
+          },
+        });
+      }
+      if (url.includes("/api/zero/computer-use/host/commands/cmd-")) {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    for (let index = 0; index < 25; index++) {
+      await vi.advanceTimersByTimeAsync(2_000);
+    }
+
+    const entries = runtime.getState().localCommandLog;
+    expect(entries).toHaveLength(20);
+    expect(entries[0]?.commandId).toBe("cmd-25");
+    expect(entries.at(-1)?.commandId).toBe("cmd-6");
 
     await runtime.stop();
   });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -26,6 +26,13 @@ const COMMAND_COMPLETION_RETRY_DELAY_MS = 2_000;
 const COMMAND_COMPLETION_MAX_ATTEMPTS = 3;
 const AUTH_ME_PATH = "/api/auth/me";
 const ERROR_LOG_LIMIT = 20;
+const LOCAL_COMMAND_LOG_LIMIT = 20;
+const LOCAL_COMMAND_LOG_OMITTED_RESULT_KEYS = new Set([
+  "appState",
+  "elements",
+  "screenshot",
+  "visibleElements",
+]);
 
 export type ComputerUseHostFetch = (
   input: string,
@@ -162,6 +169,24 @@ function commandFailureFromError(
       message: errorMessage(error),
     },
   };
+}
+
+function localCommandLogResult(
+  result: Record<string, unknown>,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  const omittedResultFields: string[] = [];
+  for (const [key, value] of Object.entries(result)) {
+    if (LOCAL_COMMAND_LOG_OMITTED_RESULT_KEYS.has(key)) {
+      omittedResultFields.push(key);
+      continue;
+    }
+    next[key] = value;
+  }
+  if (omittedResultFields.length > 0) {
+    next.omittedResultFields = omittedResultFields;
+  }
+  return next;
 }
 
 function replaceHostPrefix(hostname: string, target: string): string {
@@ -401,7 +426,7 @@ export class ComputerUseHostRuntime {
         ...this.state.localCommandLog.filter((candidate) => {
           return candidate.commandId !== command.id;
         }),
-      ],
+      ].slice(0, LOCAL_COMMAND_LOG_LIMIT),
     });
   }
 
@@ -421,7 +446,7 @@ export class ComputerUseHostRuntime {
         return {
           ...entry,
           status: args.status,
-          result: args.result,
+          result: args.result ? localCommandLogResult(args.result) : null,
           error: args.error,
           completedAt: args.completedAt,
           durationMs: args.durationMs,


### PR DESCRIPTION
## Summary
- Bound the local Desktop Computer Use command log to recent entries.
- Store log-safe command results by omitting long-lived screenshot, appState, elements, and visibleElements payloads from runtime state.
- Preserve full command completion payloads sent back to the API and cover the behavior with host runtime tests.

## Testing
- pnpm -F @vm0/desktop exec vitest run src/computer-use-host.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop test
- pnpm exec prettier --write apps/desktop/src/computer-use-host.ts apps/desktop/src/computer-use-host.test.ts
- git diff --check

Fixes #17951