### PR TITLE
fix(desktop): align tray command labels

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -493,10 +493,14 @@ describe("desktop tray menu", () => {
 
     expect(findItem(menu, "Recent Commands").enabled).toBe(false);
     expect(commandItems).toHaveLength(5);
-    expect(commandItems[0]?.label).toContain("command-0 - App 0");
+    expect(commandItems[0]?.label).toMatch(
+      /^\d{2}:\d{2} - App 0 - command-0 - Succeeded$/,
+    );
     expect(commandItems[0]?.label).toMatch(/ - Succeeded$/);
     expect(commandItems[1]?.label).toMatch(/ - Running$/);
-    expect(commandItems[4]?.label).toContain("command-4 - App 4");
+    expect(commandItems[4]?.label).toMatch(
+      /^\d{2}:\d{2} - App 4 - command-4 - Succeeded$/,
+    );
     expect(commandItems[4]?.label).toMatch(/ - Succeeded$/);
     expect(
       commandItems.some((item) => {

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -296,10 +296,10 @@ function truncateMenuLabel(value: string): string {
 function formatRecentCommandLabel(
   entry: ComputerUseLocalCommandLogEntry,
 ): string {
-  const target = entry.app ? ` - ${entry.app}` : "";
+  const target = entry.app ? `${entry.app} - ` : "";
   const timestamp = formatTrayTime(entry.completedAt ?? entry.startedAt);
   return truncateMenuLabel(
-    `${entry.kind}${target} - ${timestamp} - ${COMMAND_STATUS_LABELS[entry.status]}`,
+    `${timestamp} - ${target}${entry.kind} - ${COMMAND_STATUS_LABELS[entry.status]}`,
   );
 }
 


### PR DESCRIPTION
## Summary
- Move the timestamp to the front of desktop tray recent command rows
- Order recent command rows as `time - app - kind - status` when an app is present
- Tighten tray menu tests around the displayed label order

## Validation
- `pnpm -F @vm0/desktop exec vitest run src/desktop-tray-menu.test.ts`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`

## Notes
- `scripts/prepare.sh` installed dependencies but could not complete env/database setup because `DATABASE_URL` and 1Password CLI were unavailable in this worktree.