### PR TITLE
fix: use CDN previews for aplocoto deck

### DIFF
--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -80,6 +80,12 @@ describe("presentation template items", () => {
     expect(item?.designSystemId).toBe("design-system:playful-editorial");
     expect(item?.templateId).toBe("template:html-ppt-playful-editorial");
     expect(item?.previewImages.length).toBe(15);
+    expect(item?.previewImage).toBe(item?.previewImages[0]);
+    expect(
+      item?.previewImages.every((url) => {
+        return url.startsWith("https://cdn.vm0.io/artifacts/");
+      }),
+    ).toBe(true);
     expect(findDesignSystem(item?.designSystemId ?? "")).toBeDefined();
     expect(findTemplate(item?.templateId ?? "")?.targets).toContain(
       "presentation",

--- a/turbo/packages/core/src/presentation-template-items.ts
+++ b/turbo/packages/core/src/presentation-template-items.ts
@@ -1774,6 +1774,24 @@ export const PRESENTATION_TEMPLATE_ITEMS: readonly PresentationTemplateItem[] =
     },
   ];
 
+const APLOCOTO_CDN_PREVIEW_IMAGES = [
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e0e4eee8-78f5-4630-9133-5c1771268833/slide-01.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6b283082-35a6-466e-b44e-d1f03b7538b7/slide-02.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/27522a10-0cf6-46aa-a25d-7c3fa5f125a3/slide-03.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/307dfb24-884e-437c-9a2d-7693fbee518c/slide-04.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b6e088b9-5dbf-4e31-b7fc-28f12098e458/slide-05.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/025efa81-1335-40a9-a23e-f5fd99514487/slide-06.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/df433d75-a07b-4f09-b5b8-0781f4be8b45/slide-07.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/fdeb3e55-5386-474d-a7b6-52c54c049369/slide-08.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/353a2ed5-3025-40c3-86c4-7262ded58aab/slide-09.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/5a698210-b1a2-43ca-a6b2-723b4905da72/slide-10.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/db852f11-b0a7-4653-b733-c25a538882e1/slide-11.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/092dc4b8-105b-4419-8369-9cfccf60ed58/slide-12.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6d1c5ddf-fe8b-4d27-9a25-531fabf71cad/slide-13.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d5643224-c343-4588-bfa4-ab9ccf4e13af/slide-14.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/968f9b6a-3ac9-4933-9902-df630f41e5b2/slide-15.png",
+] as const satisfies readonly [string, ...string[]];
+
 export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateItem[] =
   [
     {
@@ -1783,25 +1801,8 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "/gen presentation with design system `playful-editorial` and template `html-ppt-playful-editorial`, create a 15-slide presentation for a product or service launch. Include cover, agenda, about, vision, team, offerings, process, gallery, metrics, testimonials, pricing, and contact. Make it saturated, editorial, joyful, and structured.",
       embedUrl:
         "https://playful-editorial-presentation-preview-715f6d07-adec3994.sites.vm0.io",
-      previewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/47dd22b0-f4d5-4f22-a2c1-eacfd9b76422/slide-01.png",
-      previewImages: [
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/47dd22b0-f4d5-4f22-a2c1-eacfd9b76422/slide-01.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/469e122c-2e41-49a2-b505-aee2d5513533/slide-02.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d6363611-391c-4307-84e5-46b7d8bc4d90/slide-03.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/40b6e3c4-89c7-4e8e-ad77-5074e268aec3/slide-04.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/865ffc08-40d5-4673-94a9-75e82262ef18/slide-05.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/678a9c07-5893-4422-baef-b10bdb119ba1/slide-06.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e1e0435d-f2d0-4a10-85b8-ceaad79ba800/slide-07.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f3bef1d9-98b6-4f9a-b80f-656170f4cdd1/slide-08.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/7b48d9f6-49db-4934-9e53-fcb09cee5e12/slide-09.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/607f88f7-1386-4e78-b8ca-c8c5e58ba27b/slide-10.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8f226d1f-4665-4c6e-9500-edf8b0ad4e1c/slide-11.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8bfa2a1c-3d7d-408b-bb13-8cde538882b8/slide-12.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/2d3a5385-a650-467c-8f71-b6f1206d0745/slide-13.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a168bd42-ad4c-4b5a-aa2f-91682aeb7f1a/slide-14.png",
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/7f81a84b-8c63-45d8-a46f-3d558cde7faf/slide-15.png",
-      ],
+      previewImage: APLOCOTO_CDN_PREVIEW_IMAGES[0],
+      previewImages: APLOCOTO_CDN_PREVIEW_IMAGES,
       designSystemId: "design-system:playful-editorial",
       templateId: "template:html-ppt-playful-editorial",
     },


### PR DESCRIPTION
## Summary
- Upload the aplocoto slide previews to vm0 CDN.
- Replace the playful editorial picker preview image URLs with cdn.vm0.io artifact URLs.
- Keep the 15-slide preview array explicit and add a regression assertion for CDN-hosted previews.

## Validation
- pnpm exec prettier --check packages/core/src/presentation-template-items.ts packages/core/src/__tests__/presentation-template-items.spec.ts
- pnpm --filter @vm0/core lint
- pnpm --filter @vm0/core check-types
- pnpm --filter @vm0/core exec vitest run src/__tests__/presentation-template-items.spec.ts
- Verified all 15 CDN image URLs return 200 image/png