### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.136.0"
+version = "1.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd03e531a7d981fba45114c5813a7565dd470a1bd3ef1188ca98c98ebdfc668"
+checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -3177,9 +3177,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3921,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Summary

Updated the Rust workspace lockfile under `crates/` with `cargo update --verbose` from current `main`.

Updated dependencies:
- `aws-sdk-s3` `1.136.0` -> `1.137.0`
- `syn` `2.0.117` -> `2.0.118`
- `which` `8.0.3` -> `8.0.4`

## Dependencies Not Updated

- `generic-array` stayed at `0.14.7` even though `0.14.9` is available. A targeted `cargo update -p generic-array --precise 0.14.9` fails because transitive dependency `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`. The dependency path is through `digest v0.10.7` and `aws-smithy-checksums`/`aws-sdk-s3`; this is not pinned by a vm0 `Cargo.toml` version specifier.

## Manual Version Bumps

None. No `Cargo.toml` version specifiers were changed.

## Test Status

Final status: pass.

Verification command:

```bash
umask 077 && TMPDIR=/home/user/workspace/secure-tmp CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test --workspace
```

Notes from this automation runtime:
- The first `cargo test --workspace` attempt used the default target directory under `/tmp` and failed before tests completed because the 7.8 GB root filesystem ran out of space while writing build archives.
- After moving `CARGO_TARGET_DIR` to `/home/user/workspace`, the default automation `umask 0002` caused broad `runner` failures because its path-safety checks reject group-writable temp directories without the sticky bit.
- A targeted previously failing `runner` test passed under `umask 077`, and the final full workspace run also passed under `umask 077` with a private `TMPDIR`.
- No tests were skipped or disabled for this update.