### PR TITLE
refactor: remove axiom event consumer route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -39,7 +39,6 @@ import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalEventConsumerAgentPhoneTypingRoutes } from "./routes/internal-event-consumers-agentphone-typing";
-import { internalEventConsumerAxiomRoutes } from "./routes/internal-event-consumers-axiom";
 import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
 import { legacyFileRoutes } from "./routes/legacy-file";
@@ -201,7 +200,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalEventConsumerAgentPhoneTypingRoutes,
-  ...internalEventConsumerAxiomRoutes,
   ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
   ...legacyFileRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/github-integration.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-integration.bdd.test.ts
@@ -1615,6 +1615,7 @@ describe("HOOK-01/INT-03 G6: issue-label runs and typed internal callbacks", () 
       sandboxHeaders,
       [200],
     );
+    await flushWaitUntilForTest();
     const completed = await api.readRun(actor, runId);
     expect(completed.status).toBe("completed");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -1,7 +1,6 @@
 import { createHmac, randomUUID } from "node:crypto";
 
 import {
-  internalEventConsumerAxiomContract,
   internalEventConsumerChatAssistantContract,
   type eventConsumerPayloadSchema,
 } from "@vm0/api-contracts/contracts/internal-event-consumers";
@@ -522,20 +521,6 @@ export function createWebhookCallbackApi(context: TestContext) {
       const signature = delivery.headers["x-vm0-signature"] ?? "";
       const flipped = signature.startsWith("a") ? "b" : "a";
       return `${flipped}${signature.slice(1)}`;
-    },
-
-    async requestAxiomEventConsumer(
-      body: EventConsumerPayload,
-      headers: Partial<Vm0SignatureHeaders>,
-      statuses: readonly (200 | 401 | 503)[],
-    ) {
-      return await accept(
-        setupApp({ context })(internalEventConsumerAxiomContract).ingest({
-          headers,
-          body,
-        }),
-        statuses,
-      );
     },
 
     async requestChatAssistantEventConsumer(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1020,30 +1020,50 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     expect(invalidBody.body).toStrictEqual({ error: "Invalid JSON body" });
   });
 
-  it("ingests signed axiom event batches and surfaces axiom outages as 503", async () => {
+  it("dispatches agent event batches to Axiom in-process", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsAutomationsApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD Axiom Event Consumer Agent",
+      visibility: "private",
+    });
+    const run = await runs.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "emit events to Axiom",
+      modelProvider: "anthropic-api-key",
+    });
+    const headers = {
+      authorization: `Bearer ${runs.sandboxTokenForRun(actor, run.runId)}`,
+    };
     const body = {
-      runId: "run_bdd_axiom",
+      runId: run.runId,
       events: [
         { type: "assistant", sequenceNumber: 1, message: { content: [] } },
         { type: "tool_result", sequenceNumber: 2, result: "ok" },
       ],
-      context: { userId: "user_bdd_axiom", orgId: "org_bdd_axiom" },
     };
     context.mocks.axiom.ingest.mockReturnValue(true);
     context.mocks.axiom.flush.mockResolvedValue(undefined);
 
-    const ingested = await api.requestAxiomEventConsumer(
-      body,
-      api.signedEventConsumerHeaders(body),
-      [200],
-    );
-    expect(ingested.body).toStrictEqual({ received: 2 });
+    const ingested = await api.requestAgentEvents(body, headers, [200]);
+    expect(ingested.body).toStrictEqual({
+      received: 2,
+      firstSequence: 1,
+      lastSequence: 2,
+    });
     expect(context.mocks.axiom.ingest).toHaveBeenCalledWith(
       "agent-run-events",
       [
         {
-          runId: "run_bdd_axiom",
-          userId: "user_bdd_axiom",
+          runId: run.runId,
+          userId: actor.userId,
           sequenceNumber: 1,
           eventType: "assistant",
           eventData: {
@@ -1053,8 +1073,8 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
           },
         },
         {
-          runId: "run_bdd_axiom",
-          userId: "user_bdd_axiom",
+          runId: run.runId,
+          userId: actor.userId,
           sequenceNumber: 2,
           eventType: "tool_result",
           eventData: { type: "tool_result", sequenceNumber: 2, result: "ok" },
@@ -1067,24 +1087,18 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     });
 
     context.mocks.axiom.ingest.mockReturnValueOnce(false);
-    const unconfigured = await api.requestAxiomEventConsumer(
-      body,
-      api.signedEventConsumerHeaders(body),
-      [503],
+    const unconfigured = await api.requestAgentEvents(body, headers, [500]);
+    expectApiError(unconfigured.body);
+    expect(unconfigured.body.error.message).toBe(
+      "Required event consumer dispatch failed: axiom",
     );
-    expect(unconfigured.body).toStrictEqual({
-      error: "Axiom agent-run-events dataset is not configured",
-    });
 
     context.mocks.axiom.flush.mockRejectedValueOnce(new Error("axiom down"));
-    const flushFailed = await api.requestAxiomEventConsumer(
-      body,
-      api.signedEventConsumerHeaders(body),
-      [503],
+    const flushFailed = await api.requestAgentEvents(body, headers, [500]);
+    expectApiError(flushFailed.body);
+    expect(flushFailed.body.error.message).toBe(
+      "Required event consumer dispatch failed: axiom",
     );
-    expect(flushFailed.body).toStrictEqual({
-      error: "Axiom agent-run-events flush failed",
-    });
   });
 });
 

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -1,12 +1,7 @@
 import { command } from "ccstate";
-import { internalEventConsumerAxiomContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
 
-import {
-  eventConsumerPayload$,
-  eventConsumerRoute,
-} from "../../lib/event-consumer/route";
+import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
 import { flushAxiom, getDatasetName, ingestToAxiom } from "../external/axiom";
-import type { RouteEntry } from "../route";
 import { settle } from "../utils";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
@@ -56,10 +51,3 @@ export const ingestAxiomEvents$ = command(
     };
   },
 );
-
-export const internalEventConsumerAxiomRoutes: readonly RouteEntry[] = [
-  {
-    route: internalEventConsumerAxiomContract.ingest,
-    handler: eventConsumerRoute(ingestAxiomEvents$),
-  },
-];

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -14,7 +14,7 @@ import { now } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import { db$ } from "../external/db";
 import { publishRunChangedForUserSafely } from "../external/realtime";
-import { ingestAxiomEvents$ } from "../routes/internal-event-consumers-axiom";
+import { ingestAxiomEvents$ } from "./agent-event-consumer-axiom.service";
 import { processChatAssistantEvents$ } from "../routes/internal-event-consumers-chat-assistant";
 import { settle } from "../utils";
 

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2028,10 +2028,10 @@ describe("API backend rewrite proxy behavior", () => {
     );
   });
 
-  it("matches the internal event consumer axiom rewrite path exactly", () => {
+  it("rejects the removed internal event consumer axiom rewrite path", () => {
     expect(
       matchesApiBackendRewritePath("/api/internal/event-consumers/axiom"),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       matchesApiBackendRewritePath("/api/internal/event-consumers/axiom/extra"),
     ).toBe(false);

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -2319,11 +2319,6 @@ describe("API backend rewrites", () => {
             "https://api.example.test/api/internal/event-consumers/agentphone-typing",
         },
         {
-          source: "/api/internal/event-consumers/axiom",
-          destination:
-            "https://api.example.test/api/internal/event-consumers/axiom",
-        },
-        {
           source: "/api/internal/event-consumers/chat-assistant",
           destination:
             "https://api.example.test/api/internal/event-consumers/chat-assistant",

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -661,10 +661,6 @@ export const API_BACKEND_REWRITES = [
     "/api/internal/event-consumers/agentphone-typing",
   ],
   [
-    "/api/internal/event-consumers/axiom",
-    "/api/internal/event-consumers/axiom",
-  ],
-  [
     "/api/internal/event-consumers/chat-assistant",
     "/api/internal/event-consumers/chat-assistant",
   ],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -351,12 +351,10 @@ export {
   type TestTelegramStateResponse,
 } from "./test-telegram-state";
 export {
-  internalEventConsumerAxiomContract,
   internalEventConsumerAgentPhoneTypingContract,
   internalEventConsumerChatAssistantContract,
   internalEventConsumerTelegramTypingContract,
   type InternalEventConsumerAgentPhoneTypingContract,
-  type InternalEventConsumerAxiomContract,
   type InternalEventConsumerChatAssistantContract,
   type InternalEventConsumerTelegramTypingContract,
 } from "./internal-event-consumers";

--- a/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
@@ -76,21 +76,6 @@ export const internalEventConsumerAgentPhoneTypingContract = c.router({
   },
 });
 
-export const internalEventConsumerAxiomContract = c.router({
-  ingest: {
-    method: "POST",
-    path: "/api/internal/event-consumers/axiom",
-    headers: eventConsumerHeadersSchema,
-    body: eventConsumerPayloadSchema,
-    responses: {
-      200: z.object({ received: z.number() }),
-      401: eventConsumerUnauthorizedSchema,
-      503: z.object({ error: z.string() }),
-    },
-    summary: "Ingest agent run events into Axiom",
-  },
-});
-
 export const internalEventConsumerChatAssistantContract = c.router({
   process: {
     method: "POST",
@@ -104,9 +89,6 @@ export const internalEventConsumerChatAssistantContract = c.router({
     summary: "Persist assistant-visible run events into chat threads",
   },
 });
-
-export type InternalEventConsumerAxiomContract =
-  typeof internalEventConsumerAxiomContract;
 
 export type InternalEventConsumerChatAssistantContract =
   typeof internalEventConsumerChatAssistantContract;


### PR DESCRIPTION
## Summary
- move the Axiom event consumer command behind an in-process service boundary
- remove the `/api/internal/event-consumers/axiom` route, API contract, and web rewrite
- update webhook BDD coverage to exercise Axiom ingestion through agent event dispatch

Closes #17983

## Verification
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/security-headers.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`