### PR TITLE
perf(runner): avoid cloned idle eviction keys

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -65,14 +65,17 @@ pub(super) async fn cleanup_expired_idle_entries(
     status: &StatusTracker,
 ) -> Vec<IdleDestroyJob> {
     let mut pool = idle_pool.lock().await;
-    let (expired, snapshot) = pool.evict_expired_with_snapshot();
+    let (expired, mut snapshot) = pool.evict_expired_with_snapshot();
+    drop(pool);
+    if snapshot.idle_vms.len() < snapshot.idle_vms.capacity() / 2 {
+        snapshot.idle_vms.shrink_to_fit();
+    }
     for entry in &expired {
         info!(
             profile = %entry.profile_name(),
             "idle VM expired, destroying"
         );
     }
-    drop(pool);
     set_idle_status_snapshot(status, snapshot).await;
     expired
 }

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -65,14 +65,13 @@ pub(super) async fn cleanup_expired_idle_entries(
     status: &StatusTracker,
 ) -> Vec<IdleDestroyJob> {
     let mut pool = idle_pool.lock().await;
-    let expired = pool.evict_expired();
+    let (expired, snapshot) = pool.evict_expired_with_snapshot();
     for entry in &expired {
         info!(
             profile = %entry.profile_name(),
             "idle VM expired, destroying"
         );
     }
-    let snapshot = pool.status_snapshot();
     drop(pool);
     set_idle_status_snapshot(status, snapshot).await;
     expired

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -877,6 +877,9 @@ impl IdlePool {
             self.bump_revision();
         }
         idle_vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+        if idle_vms.len() < idle_vms.capacity() / 2 {
+            idle_vms.shrink_to_fit();
+        }
         (
             expired,
             IdlePoolSnapshot {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -681,6 +681,10 @@ impl IdleEntry {
         self.budget_lease.memory_mb()
     }
 
+    fn is_expired_at(&self, now: Instant) -> bool {
+        now.duration_since(self.parked_at) >= self.idle_timeout
+    }
+
     /// Unpark and consume this idle entry. On failure the entry becomes an
     /// idle-owned destroy job so callers cannot keep using a partially
     /// unparked sandbox.
@@ -842,22 +846,44 @@ impl IdlePool {
     /// Remove and return all entries that have exceeded their idle timeout.
     pub fn evict_expired(&mut self) -> Vec<IdleDestroyJob> {
         let now = Instant::now();
-        let expired_keys: Vec<String> = self
+        let expired: Vec<IdleDestroyJob> = self
             .entries
-            .iter()
-            .filter(|(_, e)| now.duration_since(e.parked_at) >= e.idle_timeout)
-            .map(|(k, _)| k.clone())
-            .collect();
-
-        let expired: Vec<IdleDestroyJob> = expired_keys
-            .into_iter()
-            .filter_map(|k| self.entries.remove(&k))
-            .map(IdleEntry::into_destroy_job)
+            .extract_if(|_, entry| entry.is_expired_at(now))
+            .map(|(_, entry)| entry.into_destroy_job())
             .collect();
         if !expired.is_empty() {
             self.bump_revision();
         }
         expired
+    }
+
+    /// Remove expired entries and return the post-eviction idle status snapshot.
+    pub fn evict_expired_with_snapshot(&mut self) -> (Vec<IdleDestroyJob>, IdlePoolSnapshot) {
+        let now = Instant::now();
+        let mut idle_vms = Vec::with_capacity(self.entries.len());
+        let expired: Vec<IdleDestroyJob> = self
+            .entries
+            .extract_if(|session_id, entry| {
+                if entry.is_expired_at(now) {
+                    true
+                } else {
+                    idle_vms.push(idle_vm_for_entry(session_id, entry));
+                    false
+                }
+            })
+            .map(|(_, entry)| entry.into_destroy_job())
+            .collect();
+        if !expired.is_empty() {
+            self.bump_revision();
+        }
+        idle_vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+        (
+            expired,
+            IdlePoolSnapshot {
+                revision: self.revision,
+                idle_vms,
+            },
+        )
     }
 
     /// Evict the oldest idle entry (by park time). Used for resource
@@ -886,10 +912,7 @@ impl IdlePool {
         let mut vms: Vec<IdleVm> = self
             .entries
             .iter()
-            .map(|(session_id, entry)| IdleVm {
-                session_id: session_id.clone(),
-                sandbox_id: entry.metadata.sandbox_id,
-            })
+            .map(|(session_id, entry)| idle_vm_for_entry(session_id, entry))
             .collect();
         vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
         IdlePoolSnapshot {
@@ -978,6 +1001,13 @@ impl IdlePool {
 
     fn bump_revision(&mut self) {
         self.revision = self.revision.saturating_add(1);
+    }
+}
+
+fn idle_vm_for_entry(session_id: &str, entry: &IdleEntry) -> IdleVm {
+    IdleVm {
+        session_id: session_id.to_owned(),
+        sandbox_id: entry.metadata.sandbox_id,
     }
 }
 
@@ -1368,6 +1398,99 @@ mod tests {
     }
 
     #[test]
+    fn evict_expired_with_snapshot_none_expired_keeps_revision() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+        let fresh = make_candidate_for("fresh", 2, 2048);
+        let fresh_sandbox_id = fresh.sandbox_id();
+        let _ = park_at(&mut pool, "fresh", fresh, now, Duration::from_secs(300));
+        let before_revision = pool.status_snapshot().revision;
+
+        let (evicted, snapshot) = pool.evict_expired_with_snapshot();
+
+        assert!(evicted.is_empty());
+        assert_eq!(pool.len(), 1);
+        assert_eq!(snapshot.revision, before_revision);
+        assert_eq!(snapshot.idle_vms.len(), 1);
+        assert_eq!(snapshot.idle_vms[0].session_id, "fresh");
+        assert_eq!(snapshot.idle_vms[0].sandbox_id, fresh_sandbox_id);
+    }
+
+    #[test]
+    fn evict_expired_with_snapshot_returns_retained_entries_sorted() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+
+        let expired = make_candidate_for("expired", 2, 2048);
+        let _ = park_at(
+            &mut pool,
+            "expired",
+            expired,
+            now - Duration::from_secs(310),
+            Duration::from_secs(300),
+        );
+        let retained_b = make_candidate_for("sess-b", 4, 4096);
+        let retained_b_sandbox_id = retained_b.sandbox_id();
+        let _ = park_at(
+            &mut pool,
+            "sess-b",
+            retained_b,
+            now,
+            Duration::from_secs(300),
+        );
+        let retained_a = make_candidate_for("sess-a", 1, 1024);
+        let retained_a_sandbox_id = retained_a.sandbox_id();
+        let _ = park_at(
+            &mut pool,
+            "sess-a",
+            retained_a,
+            now,
+            Duration::from_secs(300),
+        );
+        let before_revision = pool.status_snapshot().revision;
+
+        let (evicted, snapshot) = pool.evict_expired_with_snapshot();
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(pool.len(), 2);
+        assert_eq!(snapshot.revision, before_revision + 1);
+        assert_eq!(snapshot.idle_vms.len(), 2);
+        assert_eq!(snapshot.idle_vms[0].session_id, "sess-a");
+        assert_eq!(snapshot.idle_vms[0].sandbox_id, retained_a_sandbox_id);
+        assert_eq!(snapshot.idle_vms[1].session_id, "sess-b");
+        assert_eq!(snapshot.idle_vms[1].sandbox_id, retained_b_sandbox_id);
+    }
+
+    #[test]
+    fn evict_expired_with_snapshot_all_expired_returns_empty_snapshot() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+
+        let _ = park_at(
+            &mut pool,
+            "s1",
+            make_candidate_for("s1", 2, 2048),
+            now - Duration::from_secs(400),
+            Duration::from_secs(300),
+        );
+        let _ = park_at(
+            &mut pool,
+            "s2",
+            make_candidate_for("s2", 4, 4096),
+            now - Duration::from_secs(310),
+            Duration::from_secs(300),
+        );
+        let before_revision = pool.status_snapshot().revision;
+
+        let (evicted, snapshot) = pool.evict_expired_with_snapshot();
+
+        assert_eq!(evicted.len(), 2);
+        assert_eq!(pool.len(), 0);
+        assert_eq!(snapshot.revision, before_revision + 1);
+        assert!(snapshot.idle_vms.is_empty());
+    }
+
+    #[test]
     fn evict_oldest() {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
@@ -1569,6 +1692,7 @@ mod tests {
         let evicted = pool.evict_expired();
         assert!(evicted.is_empty());
         assert_eq!(pool.len(), 1);
+        assert_eq!(pool.status_snapshot().revision, 1);
     }
 
     #[test]
@@ -1603,6 +1727,7 @@ mod tests {
         let evicted = pool.evict_expired();
         assert_eq!(evicted.len(), 2);
         assert_eq!(pool.len(), 0);
+        assert_eq!(pool.status_snapshot().revision, 3);
     }
 
     #[test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -877,9 +877,6 @@ impl IdlePool {
             self.bump_revision();
         }
         idle_vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
-        if idle_vms.len() < idle_vms.capacity() / 2 {
-            idle_vms.shrink_to_fit();
-        }
         (
             expired,
             IdlePoolSnapshot {


### PR DESCRIPTION
## Summary

- Replace expired idle-pool key collection/removal with `HashMap::extract_if` so expired entries move directly into destroy jobs.
- Add a cleanup-specific eviction helper that returns expired destroy jobs plus the post-eviction idle snapshot in one locked map traversal.
- Preserve idle-pool revision semantics, deterministic idle status ordering, and lock-free sandbox teardown.

Closes #17972

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner idle_pool`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::idle_lifecycle`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
