### PR TITLE
fix(runner): validate benchmark env keys before startup

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2821,6 +2821,7 @@ name = "sandbox-mock"
 version = "0.7.8"
 dependencies = [
  "async-trait",
+ "guest-contracts",
  "sandbox",
  "tokio",
  "uuid",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2794,6 +2794,7 @@ dependencies = [
  "base64",
  "clap",
  "futures-util",
+ "guest-contracts",
  "hex",
  "libc",
  "nbd-cow",
@@ -3713,6 +3714,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 name = "vsock-guest"
 version = "0.18.34"
 dependencies = [
+ "guest-contracts",
  "libc",
  "process-control-ipc",
  "vsock-proto",

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -34,6 +34,22 @@ pub const MOCK_CODEX_PATH_ENV: &str = "VM0_MOCK_CODEX_PATH";
 /// boundary.
 pub const WORKING_DIR_ENV: &str = "VM0_WORKING_DIR";
 
+/// Returns whether `key` is supported by vm0 guest shell exec env injection.
+///
+/// This is the shell identifier format accepted by the guest env script's
+/// `export KEY=VALUE` lines. It is intentionally not a general definition of
+/// every environment variable name an operating system can carry.
+pub fn is_shell_identifier_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,5 +60,32 @@ mod tests {
         assert_eq!(RUN_ID_ENV, "VM0_RUN_ID");
         assert_eq!(CLI_AGENT_TYPE_ENV, "CLI_AGENT_TYPE");
         assert_eq!(USER_ENV_FILE_ENV, "VM0_USER_ENV_FILE");
+    }
+
+    #[test]
+    fn shell_identifier_env_key_accepts_supported_keys() {
+        for key in ["FOO", "_FOO", "FOO_1", "_", "A1_B2"] {
+            assert!(
+                is_shell_identifier_env_key(key),
+                "{key} should be a supported shell exec env key"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_identifier_env_key_rejects_unsupported_keys() {
+        for key in [
+            "",
+            "1BAD",
+            "BAD-NAME",
+            "BAD.NAME",
+            "BAD NAME",
+            "\u{00e9}clair",
+        ] {
+            assert!(
+                !is_shell_identifier_env_key(key),
+                "{key} should not be a supported shell exec env key"
+            );
+        }
     }
 }

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -471,13 +471,18 @@ mod tests {
 
     #[test]
     fn parse_env_args_rejects_invalid_shell_identifier_keys() {
-        for value in ["=value", "1BAD=value", "BAD-NAME=value"] {
+        for value in [
+            "=secret-value",
+            "1BAD=secret-value",
+            "BAD-NAME=secret-value",
+        ] {
             let input = vec![value.to_string()];
             let err = parse_env_args(&input).unwrap_err();
             assert!(
                 err.to_string().contains("expected shell identifier"),
                 "got: {err}"
             );
+            assert!(!err.to_string().contains("secret-value"), "got: {err}");
         }
     }
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -30,10 +30,12 @@ struct Timing {
 /// Reject malformed entries so typos fail loud before benchmark startup.
 fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
     env.iter()
-        .map(|s| {
+        .enumerate()
+        .map(|(index, s)| {
             let (key, value) = s.split_once('=').ok_or_else(|| {
                 RunnerError::Config(format!(
-                    "invalid --env value '{s}': expected KEY=VALUE format"
+                    "invalid --env entry {}: expected KEY=VALUE format",
+                    index + 1
                 ))
             })?;
             if !guest_contracts::env::is_shell_identifier_env_key(key) {
@@ -445,14 +447,26 @@ mod tests {
     fn parse_env_args_rejects_missing_equals() {
         let input = vec!["FOO".to_string()];
         let err = parse_env_args(&input).unwrap_err();
-        assert!(err.to_string().contains("expected KEY=VALUE"), "got: {err}");
+        assert!(
+            err.to_string()
+                .contains("invalid --env entry 1: expected KEY=VALUE format"),
+            "got: {err}"
+        );
     }
 
     #[test]
     fn parse_env_args_rejects_when_any_entry_is_missing_equals() {
-        let input = vec!["GOOD=ok".to_string(), "BAD".to_string()];
+        let input = vec!["GOOD=ok".to_string(), "secret-without-equals".to_string()];
         let err = parse_env_args(&input).unwrap_err();
-        assert!(err.to_string().contains("'BAD'"), "got: {err}");
+        assert!(
+            err.to_string()
+                .contains("invalid --env entry 2: expected KEY=VALUE format"),
+            "got: {err}"
+        );
+        assert!(
+            !err.to_string().contains("secret-without-equals"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -27,18 +27,22 @@ struct Timing {
     exec_ms: Option<u128>,
 }
 
-/// Reject entries missing `=` so typos like `--env FOO` fail loud instead of
-/// being silently dropped.
+/// Reject malformed entries so typos fail loud before benchmark startup.
 fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
     env.iter()
         .map(|s| {
-            s.split_once('=')
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .ok_or_else(|| {
-                    RunnerError::Config(format!(
-                        "invalid --env value '{s}': expected KEY=VALUE format"
-                    ))
-                })
+            let (key, value) = s.split_once('=').ok_or_else(|| {
+                RunnerError::Config(format!(
+                    "invalid --env value '{s}': expected KEY=VALUE format"
+                ))
+            })?;
+            if !guest_contracts::env::is_shell_identifier_env_key(key) {
+                return Err(RunnerError::Config(format!(
+                    "invalid --env key '{}': expected shell identifier",
+                    key.escape_debug()
+                )));
+            }
+            Ok((key.to_string(), value.to_string()))
         })
         .collect()
 }
@@ -409,12 +413,19 @@ mod tests {
 
     #[test]
     fn parse_env_args_accepts_key_value_pairs() {
-        let input = vec!["FOO=bar".to_string(), "EMPTY=".to_string()];
+        let input = vec![
+            "FOO=bar".to_string(),
+            "_FOO=bar".to_string(),
+            "FOO_1=bar".to_string(),
+            "EMPTY=".to_string(),
+        ];
         let parsed = parse_env_args(&input).unwrap();
         assert_eq!(
             parsed,
             vec![
                 ("FOO".to_string(), "bar".to_string()),
+                ("_FOO".to_string(), "bar".to_string()),
+                ("FOO_1".to_string(), "bar".to_string()),
                 ("EMPTY".to_string(), String::new()),
             ]
         );
@@ -438,10 +449,22 @@ mod tests {
     }
 
     #[test]
-    fn parse_env_args_rejects_when_any_entry_is_invalid() {
+    fn parse_env_args_rejects_when_any_entry_is_missing_equals() {
         let input = vec!["GOOD=ok".to_string(), "BAD".to_string()];
         let err = parse_env_args(&input).unwrap_err();
         assert!(err.to_string().contains("'BAD'"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_env_args_rejects_invalid_shell_identifier_keys() {
+        for value in ["=value", "1BAD=value", "BAD-NAME=value"] {
+            let input = vec![value.to_string()];
+            let err = parse_env_args(&input).unwrap_err();
+            assert!(
+                err.to_string().contains("expected shell identifier"),
+                "got: {err}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -40,8 +40,8 @@ fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
             })?;
             if !guest_contracts::env::is_shell_identifier_env_key(key) {
                 return Err(RunnerError::Config(format!(
-                    "invalid --env key '{}': expected shell identifier",
-                    key.escape_debug()
+                    "invalid --env key in entry {}: expected shell identifier",
+                    index + 1
                 )));
             }
             Ok((key.to_string(), value.to_string()))
@@ -479,10 +479,12 @@ mod tests {
             let input = vec![value.to_string()];
             let err = parse_env_args(&input).unwrap_err();
             assert!(
-                err.to_string().contains("expected shell identifier"),
+                err.to_string()
+                    .contains("invalid --env key in entry 1: expected shell identifier"),
                 "got: {err}"
             );
             assert!(!err.to_string().contains("secret-value"), "got: {err}");
+            assert!(!err.to_string().contains(value), "got: {err}");
         }
     }
 

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 futures-util.workspace = true
+guest-contracts.workspace = true
 nbd-cow.workspace = true
 libc.workspace = true
 nix = { workspace = true, features = ["user", "inotify", "fs", "signal"] }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -848,6 +848,26 @@ impl FirecrackerSandbox {
         }
     }
 
+    fn invalid_env_key_error(operation: SandboxOperation, key: &str) -> SandboxError {
+        SandboxError::Operation {
+            operation,
+            reason: SandboxOperationReason::Other,
+            message: format!("invalid environment variable name: {}", key.escape_debug()),
+        }
+    }
+
+    fn validate_exec_env_keys(
+        operation: SandboxOperation,
+        env: &[(&str, &str)],
+    ) -> sandbox::Result<()> {
+        for (key, _) in env {
+            if !guest_contracts::env::is_shell_identifier_env_key(key) {
+                return Err(Self::invalid_env_key_error(operation, key));
+            }
+        }
+        Ok(())
+    }
+
     fn operation_gate_closed_error(
         operation: SandboxOperation,
         state: crate::park_coordinator::CoordinatorState,
@@ -906,12 +926,26 @@ impl FirecrackerSandbox {
     where
         Fut: Future<Output = io::Result<T>>,
     {
+        self.run_bounded_guest_operation_with_validation(operation, || Ok(()), call)
+            .await
+    }
+
+    async fn run_bounded_guest_operation_with_validation<T, Fut>(
+        &self,
+        operation: SandboxOperation,
+        validate: impl FnOnce() -> sandbox::Result<()>,
+        call: impl FnOnce(Arc<VsockHost>) -> Fut,
+    ) -> sandbox::Result<T>
+    where
+        Fut: Future<Output = io::Result<T>>,
+    {
         enum GuestCallOutcome<T> {
             Returned(io::Result<T>),
             BackendCrashed,
         }
 
         let vsock = self.begin_guest_operation(operation).await?;
+        validate()?;
 
         let outcome = tokio::select! {
             result = call(vsock) => {
@@ -2052,29 +2086,33 @@ impl Sandbox for FirecrackerSandbox {
         let limits = request.output_limits;
         let timeout_ms = request.timeout_ms();
 
-        self.run_bounded_guest_operation(operation, |guest| async move {
-            guest
-                .exec_capture(vsock_host::ExecCaptureRequest {
-                    command: request.cmd,
-                    timeout_ms,
-                    env: request.env,
-                    sudo: request.sudo,
-                    label: "sandbox-exec",
-                    stdout_limit_bytes: limits.stdout_limit_bytes,
-                    stderr_limit_bytes: limits.stderr_limit_bytes,
-                    expected_exit_codes: &[],
-                    stdin_bytes: request.stdin_bytes,
-                    wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-                })
-                .await
-                .map(|result| ExecResult {
-                    exit_code: result.exit_code,
-                    stdout: result.stdout,
-                    stderr: result.stderr,
-                    stdout_truncated: result.stdout_truncated,
-                    stderr_truncated: result.stderr_truncated,
-                })
-        })
+        self.run_bounded_guest_operation_with_validation(
+            operation,
+            || Self::validate_exec_env_keys(operation, request.env),
+            |guest| async move {
+                guest
+                    .exec_capture(vsock_host::ExecCaptureRequest {
+                        command: request.cmd,
+                        timeout_ms,
+                        env: request.env,
+                        sudo: request.sudo,
+                        label: "sandbox-exec",
+                        stdout_limit_bytes: limits.stdout_limit_bytes,
+                        stderr_limit_bytes: limits.stderr_limit_bytes,
+                        expected_exit_codes: &[],
+                        stdin_bytes: request.stdin_bytes,
+                        wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+                    })
+                    .await
+                    .map(|result| ExecResult {
+                        exit_code: result.exit_code,
+                        stdout: result.stdout,
+                        stderr: result.stderr,
+                        stdout_truncated: result.stdout_truncated,
+                        stderr_truncated: result.stderr_truncated,
+                    })
+            },
+        )
         .await
     }
 
@@ -2130,6 +2168,7 @@ impl Sandbox for FirecrackerSandbox {
     ) -> sandbox::Result<GuestProcessHandle> {
         let operation = SandboxOperation::StartProcess;
         let vsock = self.begin_guest_operation(operation).await?;
+        Self::validate_exec_env_keys(operation, request.env)?;
 
         let start_future = async move {
             vsock
@@ -5039,6 +5078,50 @@ mod tests {
         );
 
         assert_operation_error(err, SandboxOperation::Exec, SandboxOperationReason::Guest);
+    }
+
+    #[test]
+    fn invalid_exec_env_key_returns_operation_error() {
+        let err = FirecrackerSandbox::validate_exec_env_keys(
+            SandboxOperation::Exec,
+            &[("BAD-NAME", "x")],
+        )
+        .unwrap_err();
+
+        match err {
+            SandboxError::Operation {
+                operation,
+                reason,
+                message,
+            } => {
+                assert_eq!(operation, SandboxOperation::Exec);
+                assert_eq!(reason, SandboxOperationReason::Other);
+                assert!(message.contains("BAD-NAME"), "got: {message}");
+            }
+            other => panic!("expected operation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_start_process_env_key_returns_operation_error() {
+        let err = FirecrackerSandbox::validate_exec_env_keys(
+            SandboxOperation::StartProcess,
+            &[("1BAD", "x")],
+        )
+        .unwrap_err();
+
+        match err {
+            SandboxError::Operation {
+                operation,
+                reason,
+                message,
+            } => {
+                assert_eq!(operation, SandboxOperation::StartProcess);
+                assert_eq!(reason, SandboxOperationReason::Other);
+                assert!(message.contains("1BAD"), "got: {message}");
+            }
+            other => panic!("expected operation error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/sandbox-mock/Cargo.toml
+++ b/crates/sandbox-mock/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+guest-contracts.workspace = true
 sandbox = { workspace = true }
 tokio = { workspace = true, features = ["sync", "time"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -3298,7 +3298,8 @@ mod tests {
 
     #[tokio::test]
     async fn start_process_rejects_invalid_env_key() {
-        let sandbox = MockSandbox::new("test-1");
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let sandbox = MockSandbox::with_overrides("test-1", Arc::clone(&overrides));
         let result = sandbox
             .start_process(&StartProcessRequest {
                 cmd: "agent",
@@ -3320,6 +3321,7 @@ mod tests {
             SandboxOperationReason::Other,
             "invalid environment variable name",
         );
+        assert!(overrides.start_process_calls().is_empty());
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -56,6 +56,23 @@ fn mock_copy_file_error(message: impl Into<String>) -> SandboxError {
     mock_file_operation_error(SandboxOperation::CopyFile, message)
 }
 
+fn mock_exec_env_error(operation: SandboxOperation, key: &str) -> SandboxError {
+    SandboxError::Operation {
+        operation,
+        reason: SandboxOperationReason::Other,
+        message: format!("invalid environment variable name: {}", key.escape_debug()),
+    }
+}
+
+fn validate_mock_exec_env_keys(operation: SandboxOperation, env: &[(&str, &str)]) -> Result<()> {
+    for (key, _) in env {
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
+            return Err(mock_exec_env_error(operation, key));
+        }
+    }
+    Ok(())
+}
+
 fn validate_mock_guest_file_path(
     operation: SandboxOperation,
     operation_name: &str,
@@ -1152,6 +1169,7 @@ impl Sandbox for MockSandbox {
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {
+        validate_mock_exec_env_keys(SandboxOperation::Exec, request.env)?;
         let call = ExecCall {
             cmd: request.cmd.to_string(),
             timeout: request.timeout,
@@ -1339,6 +1357,7 @@ impl Sandbox for MockSandbox {
     }
 
     async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle> {
+        validate_mock_exec_env_keys(SandboxOperation::StartProcess, request.env)?;
         validate_start_process_output(request.output)?;
         if let Some(overrides) = &self.overrides {
             overrides
@@ -1914,6 +1933,33 @@ mod tests {
         let exec = result.unwrap();
         assert_eq!(exec.exit_code, 0);
         assert!(exec.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sandbox_exec_rejects_invalid_env_key_without_recording_call() {
+        let sandbox = MockSandbox::new("test-1");
+        let result = sandbox
+            .exec(&ExecRequest {
+                cmd: "echo hello",
+                timeout: Duration::from_secs(5),
+                env: &[("BAD-NAME", "x")],
+                sudo: false,
+                stdin_bytes: None,
+                output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
+            })
+            .await;
+        let err = match result {
+            Ok(_) => panic!("invalid env key should be rejected"),
+            Err(err) => err,
+        };
+
+        assert_operation_error(
+            err,
+            SandboxOperation::Exec,
+            SandboxOperationReason::Other,
+            "invalid environment variable name",
+        );
+        assert!(sandbox.exec_calls().is_empty());
     }
 
     #[tokio::test]
@@ -3248,6 +3294,32 @@ mod tests {
                 Err(other) => panic!("expected start_process operation error, got {other:?}"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn start_process_rejects_invalid_env_key() {
+        let sandbox = MockSandbox::new("test-1");
+        let result = sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[("1BAD", "x")],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::None,
+            })
+            .await;
+        let err = match result {
+            Ok(_) => panic!("invalid env key should be rejected"),
+            Err(err) => err,
+        };
+
+        assert_operation_error(
+            err,
+            SandboxOperation::StartProcess,
+            SandboxOperationReason::Other,
+            "invalid environment variable name",
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -43,7 +43,8 @@ pub struct ExecRequest<'a> {
     pub cmd: &'a str,
     /// Guest-side command timeout.
     pub timeout: Duration,
-    /// Environment variables passed to the command.
+    /// Environment variables passed to the command. Keys must satisfy the vm0
+    /// guest shell exec env key contract.
     pub env: &'a [(&'a str, &'a str)],
     /// Run the command with guest-side sudo privileges.
     pub sudo: bool,
@@ -70,7 +71,8 @@ pub struct StartProcessRequest<'a> {
     pub cmd: &'a str,
     /// Guest-side process timeout.
     pub timeout: Duration,
-    /// Environment variables passed to the command.
+    /// Environment variables passed to the command. Keys must satisfy the vm0
+    /// guest shell exec env key contract.
     pub env: &'a [(&'a str, &'a str)],
     /// Run the command with guest-side sudo privileges.
     pub sudo: bool,

--- a/crates/vsock-guest/Cargo.toml
+++ b/crates/vsock-guest/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.18.34"
 edition.workspace = true
 
 [dependencies]
+guest-contracts.workspace = true
 process-control-ipc.workspace = true
 libc.workspace = true
 vsock-proto.workspace = true

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -207,20 +207,9 @@ pub(crate) fn format_env_diagnostics(command: &str, env: &[(&str, &str)]) -> Str
     )
 }
 
-fn is_shell_identifier(key: &str) -> bool {
-    let mut chars = key.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first.is_ascii_alphabetic()) {
-        return false;
-    }
-    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
-}
-
 fn validate_env_keys(env: &[(&str, &str)]) -> io::Result<()> {
     for (key, _) in env {
-        if !is_shell_identifier(key) {
+        if !guest_contracts::env::is_shell_identifier_env_key(key) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
@@ -644,6 +633,22 @@ mod tests {
             err.to_string()
                 .contains("invalid environment variable name")
         );
+    }
+
+    #[test]
+    fn env_script_content_rejects_non_shell_identifier_env_keys() {
+        let dir = Path::new("/run/vm0-exec/vm0-env-test");
+        let path = dir.join("run.sh");
+
+        for key in ["", "1BAD", "BAD-NAME"] {
+            let err = build_env_script_content(dir, &path, "echo hi", &[(key, "x")]).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+            assert!(
+                err.to_string()
+                    .contains("invalid environment variable name"),
+                "got: {err}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a shared `guest-contracts` helper for vm0 guest shell exec env key validation.
- Reuse the helper in `vsock-guest` env script generation and `runner benchmark --env` parsing.
- Reject invalid sandbox exec/start_process env keys at the `sandbox-fc` host boundary before vsock requests are sent.
- Document the env key contract on sandbox request types.

Closes #17971

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner parse_env_args`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest env_script_content_rejects`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc invalid_`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p vsock-guest -p sandbox-fc --all-targets -- -D warnings`
