### PR TITLE
fix: stream safe request body capture

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -306,11 +306,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     # Request body
     request_stream_body = request_streaming.captured_request_stream_body(flow)
     if flow.metadata.get(metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE):
-        if request_stream_body is not None:
-            if request_stream_body.buffer or request_stream_body.truncated:
-                log_entry["request_body_truncated"] = True
-        elif flow.request.raw_content:
-            log_entry["request_body_truncated"] = True
+        log_entry["request_body_truncated"] = True
     elif request_stream_body is not None:
         req_ct = flow.request.headers.get("content-type", "")
         request_body = body_decoding.decode_body_bounded(

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -10,6 +10,7 @@ from mitmproxy import http
 
 import body_decoding
 import flow_metadata_keys as metadata_keys
+import request_streaming
 import response_streaming
 from body_limits import STREAM_BUFFER_LIMIT
 
@@ -290,6 +291,9 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     #         request_body_truncated, response_headers, response_body,
     #         response_body_encoding, response_body_truncated
 
+    Request bodies prefer request streaming metadata when requestheaders()
+    installed a safe capped stream before mitmproxy buffered the body.
+
     Response bodies prefer streaming metadata from
     ``response_streaming.configure_response_stream()`` because that path keeps a
     bounded raw wire-byte buffer and records whether it was truncated. The
@@ -300,9 +304,33 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     log_entry["request_headers"] = _sanitize_headers_for_capture(flow.request.headers)
 
     # Request body
+    request_stream_body = request_streaming.captured_request_stream_body(flow)
     if flow.metadata.get(metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE):
-        if flow.request.raw_content:
+        if request_stream_body is not None:
+            if request_stream_body.buffer or request_stream_body.truncated:
+                log_entry["request_body_truncated"] = True
+        elif flow.request.raw_content:
             log_entry["request_body_truncated"] = True
+    elif request_stream_body is not None:
+        req_ct = flow.request.headers.get("content-type", "")
+        request_body = body_decoding.decode_body_bounded(
+            bytes(request_stream_body.buffer),
+            flow.request.headers,
+            max_output=STREAM_BUFFER_LIMIT + 1,
+            fail_on_unsupported_encoding=True,
+        )
+        if request_body.failed:
+            if request_stream_body.truncated:
+                log_entry["request_body_truncated"] = True
+            log_entry["request_body_encoding"] = "binary"
+        else:
+            _set_body_fields(
+                log_entry,
+                "request",
+                request_body.body,
+                req_ct,
+                already_truncated=request_stream_body.truncated,
+            )
     elif flow.request.raw_content:
         req_ct = flow.request.headers.get("content-type", "")
         request_body = body_decoding.decode_body_bounded(

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -304,41 +304,42 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     log_entry["request_headers"] = _sanitize_headers_for_capture(flow.request.headers)
 
     # Request body
-    request_stream_body = request_streaming.captured_request_stream_body(flow)
     if flow.metadata.get(metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE):
         log_entry["request_body_truncated"] = True
-    elif request_stream_body is not None:
-        req_ct = flow.request.headers.get("content-type", "")
-        request_body = body_decoding.decode_body_bounded(
-            bytes(request_stream_body.buffer),
-            flow.request.headers,
-            max_output=STREAM_BUFFER_LIMIT + 1,
-            fail_on_unsupported_encoding=True,
-        )
-        if request_body.failed:
-            if request_stream_body.truncated:
-                log_entry["request_body_truncated"] = True
-            log_entry["request_body_encoding"] = "binary"
-        else:
-            _set_body_fields(
-                log_entry,
-                "request",
-                request_body.body,
-                req_ct,
-                already_truncated=request_stream_body.truncated,
+    else:
+        request_stream_body = request_streaming.captured_request_stream_body(flow)
+        if request_stream_body is not None:
+            req_ct = flow.request.headers.get("content-type", "")
+            request_body = body_decoding.decode_body_bounded(
+                bytes(request_stream_body.buffer),
+                flow.request.headers,
+                max_output=STREAM_BUFFER_LIMIT + 1,
+                fail_on_unsupported_encoding=True,
             )
-    elif flow.request.raw_content:
-        req_ct = flow.request.headers.get("content-type", "")
-        request_body = body_decoding.decode_body_bounded(
-            flow.request.raw_content,
-            flow.request.headers,
-            max_output=STREAM_BUFFER_LIMIT + 1,
-            fail_on_unsupported_encoding=True,
-        )
-        if request_body.failed:
-            log_entry["request_body_encoding"] = "binary"
-        else:
-            _set_body_fields(log_entry, "request", request_body.body, req_ct)
+            if request_body.failed:
+                if request_stream_body.truncated:
+                    log_entry["request_body_truncated"] = True
+                log_entry["request_body_encoding"] = "binary"
+            else:
+                _set_body_fields(
+                    log_entry,
+                    "request",
+                    request_body.body,
+                    req_ct,
+                    already_truncated=request_stream_body.truncated,
+                )
+        elif flow.request.raw_content:
+            req_ct = flow.request.headers.get("content-type", "")
+            request_body = body_decoding.decode_body_bounded(
+                flow.request.raw_content,
+                flow.request.headers,
+                max_output=STREAM_BUFFER_LIMIT + 1,
+                fail_on_unsupported_encoding=True,
+            )
+            if request_body.failed:
+                log_entry["request_body_encoding"] = "binary"
+            else:
+                _set_body_fields(log_entry, "request", request_body.body, req_ct)
 
     # Response headers
     if flow.response:

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -69,9 +69,10 @@ Firewall and auth context
   registry failures. It is orthogonal to ``FIREWALL_ACTION``: an ``ALLOW``
   decision can still have an auth or forwarding error.
 - ``CONNECTOR_DIAGNOSTIC_TYPE``: optional ``str`` connector type for a generic
-  connector availability diagnostic. The request hook records this for an
-  inactive built-in connector candidate; network logs expose it only after the
-  response/error hook turns the candidate into an agent-visible diagnostic.
+  connector availability diagnostic. HTTP request classification records this
+  for an inactive built-in connector candidate from the request-header stream
+  path or the request hook; network logs expose it only after the response/error
+  hook turns the candidate into an agent-visible diagnostic.
 - ``CONNECTOR_DIAGNOSTIC_REASON``: optional ``str`` generic diagnostic reason.
   First-version diagnostics use ``not_configured_for_run``.
 - ``CONNECTOR_DIAGNOSTIC_ENV_NAMES``: optional ``list[str]`` env aliases that

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -97,6 +97,16 @@ Response streaming
   ``total_bytes``. Written with ``STREAM_BUFFER`` and read for response size,
   capture truncation, and connector parsing. Removed by stream cleanup.
 
+Request streaming
+-----------------
+- ``REQUEST_STREAM_BUFFER``: capped ``bytearray`` written by
+  ``requestheaders()`` via request streaming setup for stream-safe body
+  capture paths. Read by request body capture. Removed by stream cleanup after
+  terminal hooks.
+- ``REQUEST_STREAM_BUFFER_STATE``: ``dict`` with at least ``truncated`` and
+  ``total_bytes``. Written with ``REQUEST_STREAM_BUFFER`` and read for request
+  size and capture truncation. Removed by stream cleanup.
+
 Model-provider usage
 --------------------
 - ``MODEL_PROVIDER_USAGE``: ``dict`` of normalized token usage for one
@@ -169,5 +179,7 @@ MODEL_USAGE_PROVIDER: Final = "model_usage_provider"
 MODEL_JSON_USAGE_FINALIZED: Final = "_model_json_usage_finalized"
 STREAM_BUFFER: Final = "stream_buffer"
 STREAM_BUFFER_STATE: Final = "stream_buffer_state"
+REQUEST_STREAM_BUFFER: Final = "request_stream_buffer"
+REQUEST_STREAM_BUFFER_STATE: Final = "request_stream_buffer_state"
 X_NDJSON_STATE: Final = "x_ndjson_state"
 X_JSON_STATE: Final = "x_json_state"

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -7,22 +7,25 @@ When adding a shared metadata key, add its ownership and lifecycle notes here.
 
 Request context
 ---------------
-- ``VM_RUN_ID``: ``str`` copied from registry VM info by ``request()`` and
-  ``tcp_start()``. Read by HTTP, TCP, proxy logging, and usage reporting.
+- ``VM_RUN_ID``: ``str`` copied from registry VM info by HTTP request
+  classification and ``tcp_start()``. Header-phase HTTP probes restore this key
+  unless they intentionally keep the classification for a streaming or local
+  response path. Read by HTTP, TCP, proxy logging, and usage reporting.
 - ``VM_NETWORK_LOG_PATH``: ``str`` copied from registry VM info. Read by HTTP
   and TCP log writers; empty strings skip network-log writes.
 - ``VM_PROXY_LOG_PATH``: ``str`` copied from registry VM info. Read by proxy
   warnings, usage reporting, and auth/streaming diagnostics.
 - ``VM_SANDBOX_AUTH_KEY``: ``str`` sandbox token copied from registry VM info.
   Read by usage webhook reporters.
-- ``ORIGINAL_URL``: absolute URL written by ``request()`` from trusted
-  authority, or from the authority-validation fallback URL on local denial.
-  Read by response/error logging and connector billing.
+- ``ORIGINAL_URL``: absolute URL written by HTTP request classification from
+  trusted authority, or from the authority-validation fallback URL on local
+  denial. Read by response/error logging and connector billing.
 - ``NETWORK_LOG_TARGET``: ``dict`` with ``url``, ``host``, and ``port`` from
   trusted authority or authority-validation fallback URL. Read by network-log
   entry construction.
-- ``CAPTURE_BODY``: ``bool`` copied from registry VM info. Read by
-  ``response()`` to decide whether to add request/response bodies.
+- ``CAPTURE_BODY``: ``bool`` copied from registry VM info by HTTP request
+  classification. Read by ``response()`` to decide whether to add
+  request/response bodies.
 - ``SUPPRESS_REQUEST_BODY_CAPTURE``: ``bool`` written by auth.base request-size
   handling. Read by body capture to mark oversized request bodies truncated.
 - ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
@@ -34,8 +37,10 @@ Request context
 Timing context
 --------------
 - ``HTTP_REQUEST_START_MONOTONIC``: ``float`` from ``time.monotonic()``,
-  written by ``request()`` after registered-VM lookup. Popped by ``response()``
-  or ``error()`` when computing HTTP latency, and removed on request failures.
+  written when a request first reaches a registered-VM HTTP path, including
+  header-phase streaming and local auth.base rejection paths. Popped by
+  ``response()`` or ``error()`` when computing HTTP latency, and removed on
+  request failures.
 - ``TCP_START_MONOTONIC``: ``float`` from ``time.monotonic()``, written by
   ``tcp_start()``. Read by TCP end/error logging; it is not popped.
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1673,7 +1673,6 @@ def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) ->
         _clear_model_websocket_messages(flow)
         if response_streaming.is_model_websocket_usage_enabled(flow):
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
-    flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
     request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     if release_tracking:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -666,14 +666,11 @@ def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
     return _RequestClassification(kind="allow", vm_info=vm_info)
 
 
-def _request_classification(flow: http.HTTPFlow, *, cache: bool = False) -> _RequestClassification:
+def _request_classification(flow: http.HTTPFlow) -> _RequestClassification:
     classification = flow.metadata.get(_REQUEST_CLASSIFICATION)
     if isinstance(classification, _RequestClassification):
         return classification
-    classification = _classify_request(flow)
-    if cache:
-        flow.metadata[_REQUEST_CLASSIFICATION] = classification
-    return classification
+    return _classify_request(flow)
 
 
 def _classification_needs_request_timing(classification: _RequestClassification) -> bool:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -49,6 +49,7 @@ import flow_metadata_keys as metadata_keys
 import matching
 import network_log_sanitization
 import registry
+import request_streaming
 import response_streaming
 import usage
 from auth import (
@@ -60,6 +61,7 @@ from auth import (
     prepare_firewall_metadata,
 )
 from firewall_auth_cache import clear_cached_firewall_headers, request_force_refresh
+from body_limits import STREAM_BUFFER_LIMIT
 from logging_utils import (
     add_firewall_metadata,
     flush_log_path,
@@ -156,6 +158,7 @@ _RequestClassificationKind = Literal[
 ]
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
+_REQUEST_CLASSIFICATION = "_request_classification"
 
 
 @dataclass(frozen=True)
@@ -651,6 +654,15 @@ def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
     return _RequestClassification(kind="allow", vm_info=vm_info)
 
 
+def _request_classification(flow: http.HTTPFlow) -> _RequestClassification:
+    classification = flow.metadata.get(_REQUEST_CLASSIFICATION)
+    if isinstance(classification, _RequestClassification):
+        return classification
+    classification = _classify_request(flow)
+    flow.metadata[_REQUEST_CLASSIFICATION] = classification
+    return classification
+
+
 def _classification_needs_request_timing(classification: _RequestClassification) -> bool:
     return classification.kind in (
         "authority_denied",
@@ -660,6 +672,13 @@ def _classification_needs_request_timing(classification: _RequestClassification)
         "firewall_allow",
         "allow",
     )
+
+
+def _should_stream_capture_request(classification: _RequestClassification) -> bool:
+    if classification.kind not in ("api_allow", "browser_allow", "allow"):
+        return False
+    vm_info = classification.vm_info
+    return isinstance(vm_info, dict) and bool(vm_info.get("captureNetworkBodies", False))
 
 
 def _start_request_timing(flow: http.HTTPFlow) -> None:
@@ -704,16 +723,45 @@ def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
 
 
 def _parse_auth_base_content_length_part(value: str) -> int | None:
+    return _parse_limited_content_length_part(
+        value,
+        max_value=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+    )
+
+
+def _parse_limited_content_length_part(value: str, *, max_value: int) -> int | None:
     value = value.strip(" \t")
     if not value:
         return None
     if not value.isascii() or not value.isdecimal():
         return None
     normalized = value.lstrip("0") or "0"
-    limit_text = str(auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES)
+    limit_text = str(max_value)
     if len(normalized) > len(limit_text):
-        return auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1
+        return max_value + 1
     return int(normalized)
+
+
+def _request_body_fits_stream_buffer(flow: http.HTTPFlow) -> bool:
+    if flow.request.headers.get_all("Transfer-Encoding"):
+        return False
+
+    raw_content_lengths = flow.request.headers.get_all("Content-Length")
+    if not raw_content_lengths:
+        return flow.request.method.upper() in _AUTH_BASE_BODYLESS_METHODS
+
+    parsed_length: int | None = None
+    for raw_content_length in raw_content_lengths:
+        for part in raw_content_length.split(","):
+            candidate = _parse_limited_content_length_part(part, max_value=STREAM_BUFFER_LIMIT)
+            if candidate is None:
+                return False
+            if parsed_length is None:
+                parsed_length = candidate
+            elif parsed_length != candidate:
+                return False
+
+    return (parsed_length or 0) <= STREAM_BUFFER_LIMIT
 
 
 def _record_connector_diagnostic_candidate(
@@ -1221,39 +1269,45 @@ def client_disconnected(client: connection.Client) -> None:
 
 
 def requestheaders(flow: http.HTTPFlow) -> None:
-    """Terminate unsafe auth.base request bodies before mitmproxy buffers them."""
+    """Handle request-header-only decisions before mitmproxy buffers bodies."""
     body_check = _auth_base_body_header_check(flow)
-    if body_check.kind == "ok":
+    if body_check.kind == "ok" and _request_body_fits_stream_buffer(flow):
         return
 
-    classification = _classify_request(flow)
+    classification = _request_classification(flow)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
-    if classification.kind != "firewall_allow" or allow is None or vm_info is None:
-        return
-    if not _firewall_allow_auth_base(allow):
+    if (
+        classification.kind == "firewall_allow"
+        and allow is not None
+        and vm_info is not None
+        and body_check.kind != "ok"
+        and _firewall_allow_auth_base(allow)
+    ):
+        _start_request_timing(flow)
+        prepare_firewall_metadata(flow, allow, vm_info)
+        proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+        firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+        if body_check.kind == "too_large":
+            mark_auth_base_request_too_large(
+                flow,
+                proxy_log_path=proxy_log_path,
+                firewall_base=firewall_base,
+                observed_size=body_check.observed_size,
+            )
+        else:
+            mark_auth_base_request_length_required(
+                flow,
+                proxy_log_path=proxy_log_path,
+                firewall_base=firewall_base,
+                reason=body_check.reason,
+            )
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        flow.kill()
         return
 
-    _start_request_timing(flow)
-    prepare_firewall_metadata(flow, allow, vm_info)
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-    firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
-    if body_check.kind == "too_large":
-        mark_auth_base_request_too_large(
-            flow,
-            proxy_log_path=proxy_log_path,
-            firewall_base=firewall_base,
-            observed_size=body_check.observed_size,
-        )
-    else:
-        mark_auth_base_request_length_required(
-            flow,
-            proxy_log_path=proxy_log_path,
-            firewall_base=firewall_base,
-            reason=body_check.reason,
-        )
-    flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-    flow.kill()
+    if _should_stream_capture_request(classification):
+        request_streaming.configure_request_stream(flow)
 
 
 def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:
@@ -1309,7 +1363,7 @@ async def request(flow: http.HTTPFlow) -> None:
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         return
 
-    classification = _classify_request(flow)
+    classification = _request_classification(flow)
 
     if _classification_needs_request_timing(classification):
         _start_request_timing(flow)
@@ -1502,6 +1556,13 @@ def _response_size(flow: http.HTTPFlow) -> int:
     return _content_length_response_size(flow.response.headers.get("content-length"))
 
 
+def _request_size(flow: http.HTTPFlow) -> int:
+    streamed_size = request_streaming.streamed_request_size(flow)
+    if streamed_size is not None:
+        return streamed_size
+    return len(flow.request.raw_content or b"")
+
+
 def _content_length_response_size(content_length: str | None) -> int:
     if content_length is None:
         return 0
@@ -1557,6 +1618,7 @@ def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) ->
         _clear_model_websocket_messages(flow)
         if response_streaming.is_model_websocket_usage_enabled(flow):
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
+    request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     if release_tracking:
         _release_tracked_usage_flow(flow)
@@ -1623,7 +1685,7 @@ def response(flow: http.HTTPFlow) -> None:
 
     _maybe_replace_connector_diagnostic_response(flow, original_url=original_url)
 
-    request_size = len(flow.request.raw_content or b"")
+    request_size = _request_size(flow)
     stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
     status_code = flow.response.status_code if flow.response else 0
 
@@ -1744,7 +1806,7 @@ def error(flow: http.HTTPFlow) -> None:
 
     _maybe_make_connector_diagnostic_error_response(flow, original_url=original_url)
 
-    request_size = len(flow.request.raw_content or b"")
+    request_size = _request_size(flow)
     error_msg = flow.error.msg if flow.error else "unknown error"
 
     # [NETWORK_LOG_FIELDS] — HTTP error fields; api-contracts is the shared schema boundary.

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -831,6 +831,31 @@ def _connector_diagnostic_candidate_from_flow(
     )
 
 
+def _maybe_record_allow_connector_diagnostic_candidate(
+    flow: http.HTTPFlow,
+    classification: _RequestClassification,
+) -> None:
+    if classification.kind != "allow":
+        return
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+        return
+    if metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE in flow.metadata:
+        return
+
+    vm_info = classification.vm_info
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if vm_info is None or not isinstance(original_url, str):
+        return
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        original_url,
+        flow.request.method,
+        active_firewall_names=_active_firewall_names(vm_info),
+    )
+    if candidate is not None:
+        _record_connector_diagnostic_candidate(flow, candidate)
+
+
 def _metadata_str_tuple(value: object) -> tuple[str, ...]:
     if not isinstance(value, (list, tuple)):
         return ()
@@ -1336,6 +1361,7 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         return
 
     if _should_stream_capture_request(classification):
+        _maybe_record_allow_connector_diagnostic_candidate(flow, classification)
         flow.metadata[_REQUEST_CLASSIFICATION] = classification
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
@@ -1464,15 +1490,7 @@ async def request(flow: http.HTTPFlow) -> None:
         vm_info = classification.vm_info
         if vm_info is None:
             return
-        original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-        if not flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-            candidate = builtin_connector_diagnostics.find_candidate(
-                original_url,
-                flow.request.method,
-                active_firewall_names=_active_firewall_names(vm_info),
-            )
-            if candidate is not None:
-                _record_connector_diagnostic_candidate(flow, candidate)
+        _maybe_record_allow_connector_diagnostic_candidate(flow, classification)
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -60,8 +60,8 @@ from auth import (
     mark_auth_base_request_too_large,
     prepare_firewall_metadata,
 )
-from firewall_auth_cache import clear_cached_firewall_headers, request_force_refresh
 from body_limits import STREAM_BUFFER_LIMIT
+from firewall_auth_cache import clear_cached_firewall_headers, request_force_refresh
 from logging_utils import (
     add_firewall_metadata,
     flush_log_path,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -654,12 +654,13 @@ def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
     return _RequestClassification(kind="allow", vm_info=vm_info)
 
 
-def _request_classification(flow: http.HTTPFlow) -> _RequestClassification:
+def _request_classification(flow: http.HTTPFlow, *, cache: bool = False) -> _RequestClassification:
     classification = flow.metadata.get(_REQUEST_CLASSIFICATION)
     if isinstance(classification, _RequestClassification):
         return classification
     classification = _classify_request(flow)
-    flow.metadata[_REQUEST_CLASSIFICATION] = classification
+    if cache:
+        flow.metadata[_REQUEST_CLASSIFICATION] = classification
     return classification
 
 
@@ -1274,7 +1275,7 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     if body_check.kind == "ok" and _request_body_fits_stream_buffer(flow):
         return
 
-    classification = _request_classification(flow)
+    classification = _request_classification(flow, cache=True)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
     if (
@@ -1441,6 +1442,7 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
+        flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         _release_tracked_usage_flow(flow)
         raise
 
@@ -1618,6 +1620,7 @@ def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) ->
         _clear_model_websocket_messages(flow)
         if response_streaming.is_model_websocket_usage_enabled(flow):
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
+    flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
     request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     if release_tracking:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1303,6 +1303,7 @@ def requestheaders(flow: http.HTTPFlow) -> None:
                 firewall_base=firewall_base,
                 reason=body_check.reason,
             )
+        flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         flow.kill()
         return
@@ -1362,14 +1363,15 @@ async def request(flow: http.HTTPFlow) -> None:
     3. Firewall match (inject auth headers for allowed requests)
     """
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
+        flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 
-    classification = _request_classification(flow)
-
-    if _classification_needs_request_timing(classification):
-        _start_request_timing(flow)
-
     try:
+        classification = _request_classification(flow)
+
+        if _classification_needs_request_timing(classification):
+            _start_request_timing(flow)
+
         if classification.kind == "no_client_ip":
             ctx.log.warn("No client IP available, passing through")
             return
@@ -1442,9 +1444,10 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
-        flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         _release_tracked_usage_flow(flow)
         raise
+    finally:
+        flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
 
 
 def _is_model_provider_usage_observable(firewall_name: str, vm_info: dict) -> bool:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1309,6 +1309,7 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         return
 
     if _should_stream_capture_request(classification):
+        _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -758,7 +758,10 @@ def _request_body_fits_stream_buffer(flow: http.HTTPFlow) -> bool:
 
     raw_content_lengths = flow.request.headers.get_all("Content-Length")
     if not raw_content_lengths:
-        return flow.request.method.upper() in _AUTH_BASE_BODYLESS_METHODS
+        # requestheaders() does not expose mitmproxy's end_stream flag. Treat
+        # missing Content-Length as unknown length even for GET/HEAD because
+        # HTTP/2 can carry DATA frames after headers without a length header.
+        return False
 
     parsed_length: int | None = None
     for raw_content_length in raw_content_lengths:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -159,6 +159,18 @@ _RequestClassificationKind = Literal[
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _REQUEST_CLASSIFICATION = "_request_classification"
+_REQUEST_HEADERS_PROBE_METADATA_KEYS = (
+    metadata_keys.VM_RUN_ID,
+    metadata_keys.VM_NETWORK_LOG_PATH,
+    metadata_keys.VM_PROXY_LOG_PATH,
+    metadata_keys.CAPTURE_BODY,
+    metadata_keys.VM_SANDBOX_AUTH_KEY,
+    metadata_keys.CLI_AGENT_TYPE,
+    metadata_keys.BROWSER_USER_AGENT,
+    metadata_keys.ORIGINAL_URL,
+    metadata_keys.TRUSTED_AUTHORITY_HOST,
+    metadata_keys.NETWORK_LOG_TARGET,
+)
 
 
 @dataclass(frozen=True)
@@ -765,6 +777,16 @@ def _request_body_fits_stream_buffer(flow: http.HTTPFlow) -> bool:
     return (parsed_length or 0) <= STREAM_BUFFER_LIMIT
 
 
+def _restore_request_headers_probe_metadata(
+    flow: http.HTTPFlow, snapshot: dict[str, object]
+) -> None:
+    for key in _REQUEST_HEADERS_PROBE_METADATA_KEYS:
+        if key in snapshot:
+            flow.metadata[key] = snapshot[key]
+        else:
+            flow.metadata.pop(key, None)
+
+
 def _record_connector_diagnostic_candidate(
     flow: http.HTTPFlow,
     candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
@@ -1275,7 +1297,12 @@ def requestheaders(flow: http.HTTPFlow) -> None:
     if body_check.kind == "ok" and _request_body_fits_stream_buffer(flow):
         return
 
-    classification = _request_classification(flow, cache=True)
+    metadata_snapshot = {
+        key: flow.metadata[key]
+        for key in _REQUEST_HEADERS_PROBE_METADATA_KEYS
+        if key in flow.metadata
+    }
+    classification = _classify_request(flow)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
     if (
@@ -1309,8 +1336,12 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         return
 
     if _should_stream_capture_request(classification):
+        flow.metadata[_REQUEST_CLASSIFICATION] = classification
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
+        return
+
+    _restore_request_headers_probe_metadata(flow, metadata_snapshot)
 
 
 def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1424,6 +1424,10 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 
+    if flow.response is not None or flow.error is not None:
+        flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
+        return
+
     try:
         classification = _request_classification(flow)
 
@@ -1668,11 +1672,16 @@ def _single_content_length_response_size(content_length: str, start: int, end: i
     return response_size
 
 
-def _release_usage_hook_state(flow: http.HTTPFlow, *, release_tracking: bool) -> None:
+def _release_usage_hook_state(
+    flow: http.HTTPFlow,
+    *,
+    release_tracking: bool,
+) -> None:
     if release_tracking:
         _clear_model_websocket_messages(flow)
         if response_streaming.is_model_websocket_usage_enabled(flow):
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
+    flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
     request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     if release_tracking:

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -17,7 +17,7 @@ class CapturedRequestStreamBody(NamedTuple):
 
 def configure_request_stream(flow: http.HTTPFlow) -> None:
     """Enable capped request body capture without modifying forwarded chunks."""
-    if flow.request.stream:
+    if callable(flow.request.stream):
         return
 
     buf = bytearray()

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -1,0 +1,94 @@
+"""Request streaming setup for stream-safe body capture paths."""
+
+from typing import NamedTuple
+
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+from body_limits import STREAM_BUFFER_LIMIT
+
+_REQUEST_STREAM_CALLBACK = "_vm0_request_stream_callback"
+
+
+class CapturedRequestStreamBody(NamedTuple):
+    buffer: bytearray
+    truncated: bool
+
+
+def configure_request_stream(flow: http.HTTPFlow) -> None:
+    """Enable capped request body capture without modifying forwarded chunks."""
+    if flow.request.stream:
+        return
+
+    buf = bytearray()
+    state = {"truncated": False, "total_bytes": 0}
+    buf_limit = STREAM_BUFFER_LIMIT
+
+    def stream_and_buffer(chunk: bytes) -> bytes:
+        state["total_bytes"] += len(chunk)
+        if not state["truncated"]:
+            remaining = buf_limit - len(buf)
+            if len(chunk) <= remaining:
+                buf.extend(chunk)
+            else:
+                buf.extend(chunk[:remaining])
+                state["truncated"] = True
+        return chunk
+
+    flow.request.stream = stream_and_buffer
+    flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = buf
+    flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = state
+    flow.metadata[_REQUEST_STREAM_CALLBACK] = stream_and_buffer
+
+
+def streamed_request_size(flow: http.HTTPFlow) -> int | None:
+    """Return total request bytes observed by the request stream callback."""
+    state = flow.metadata.get(metadata_keys.REQUEST_STREAM_BUFFER_STATE)
+    if state is None:
+        return None
+    return int(state["total_bytes"])
+
+
+def captured_request_stream_body(flow: http.HTTPFlow) -> CapturedRequestStreamBody | None:
+    """Return buffered request body bytes and truncation state for capture logging."""
+    stream_buf = flow.metadata.get(metadata_keys.REQUEST_STREAM_BUFFER)
+    stream_state = flow.metadata.get(metadata_keys.REQUEST_STREAM_BUFFER_STATE)
+    stream_truncated = False
+    if stream_buf is None:
+        return None
+
+    if stream_buf:
+        if not isinstance(stream_state, dict) or "truncated" not in stream_state:
+            state_description = (
+                f"keys={sorted(str(key) for key in stream_state)}"
+                if isinstance(stream_state, dict)
+                else f"type={type(stream_state).__name__}"
+            )
+            raise RuntimeError(
+                "Invalid request body capture metadata: request_stream_buffer is "
+                f"present and non-empty (len={len(stream_buf)}) but "
+                "request_stream_buffer_state is missing the truncated flag. "
+                "request_streaming.configure_request_stream() must set "
+                "request_stream_buffer and request_stream_buffer_state together "
+                f"(request_stream_buffer_state {state_description})."
+            )
+        stream_truncated = bool(stream_state["truncated"])
+    elif stream_state is not None and not isinstance(stream_state, dict):
+        raise RuntimeError(
+            "Invalid request body capture metadata: request_stream_buffer is "
+            "empty but request_stream_buffer_state is not a dict "
+            f"(request_stream_buffer_state type={type(stream_state).__name__})."
+        )
+    elif stream_state:
+        stream_truncated = bool(stream_state.get("truncated", False))
+
+    return CapturedRequestStreamBody(stream_buf, stream_truncated)
+
+
+def release_request_stream_state(flow: http.HTTPFlow) -> None:
+    """Release request stream callback and buffered capture metadata."""
+    stream_callback = flow.metadata.pop(_REQUEST_STREAM_CALLBACK, None)
+    flow.metadata.pop(metadata_keys.REQUEST_STREAM_BUFFER, None)
+    flow.metadata.pop(metadata_keys.REQUEST_STREAM_BUFFER_STATE, None)
+    if stream_callback is not None and flow.request.stream is stream_callback:
+        flow.request.stream = False

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -77,6 +77,40 @@ class TestBodyCaptureStreamBuffer:
         ):
             add_capture_fields(flow, entry)
 
+    def test_empty_request_stream_buffer_skips_body(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            request_body=b"should-be-ignored",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray()
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": False}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert "request_body_truncated" not in entry
+
+    def test_empty_request_stream_buffer_requires_dict_state_when_present(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray()
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = ["truncated"]
+        entry = {}
+        with pytest.raises(
+            RuntimeError,
+            match=r"request_stream_buffer.*empty.*request_stream_buffer_state.*type=list",
+        ):
+            add_capture_fields(flow, entry)
+
     def test_captures_response_body_from_stream_buffer(self, real_flow):
         """When stream_buffer is present, response body should be read from it."""
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -94,6 +94,21 @@ class TestBodyCaptureStreamBuffer:
         assert "request_body_encoding" not in entry
         assert "request_body_truncated" not in entry
 
+    def test_suppressed_request_body_marks_truncated_without_buffer(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert entry["request_body_truncated"] is True
+
     def test_empty_request_stream_buffer_requires_dict_state_when_present(self, real_flow):
         flow = real_flow(
             method="POST",

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -109,6 +109,23 @@ class TestBodyCaptureStreamBuffer:
         assert "request_body_encoding" not in entry
         assert entry["request_body_truncated"] is True
 
+    def test_suppressed_request_body_ignores_invalid_stream_state(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(b"hidden")
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = ["truncated"]
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert entry["request_body_truncated"] is True
+
     def test_empty_request_stream_buffer_requires_dict_state_when_present(self, real_flow):
         flow = real_flow(
             method="POST",

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -4,11 +4,79 @@ import gzip
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 from body_capture import add_capture_fields
 from body_limits import STREAM_BUFFER_LIMIT
 
 
 class TestBodyCaptureStreamBuffer:
+    def test_captures_request_body_from_stream_buffer(self, real_flow):
+        """When request_stream_buffer is present, request body should be read from it."""
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            request_body=b"should-be-ignored",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        body = b'{"streamed": true}'
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": False}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body"] == '{"streamed": true}'
+        assert entry["request_body_encoding"] == "utf-8"
+        assert "request_body_truncated" not in entry
+
+    def test_request_stream_buffer_truncated_marks_truncation(self, real_flow):
+        body = b"x" * STREAM_BUFFER_LIMIT
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": True}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body"] == "x" * STREAM_BUFFER_LIMIT
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
+
+    def test_binary_request_stream_buffer_truncated_marks_truncation(self, real_flow):
+        body = b"\x00" * STREAM_BUFFER_LIMIT
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/octet-stream",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": True}
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+        assert entry["request_body_truncated"] is True
+
+    def test_non_empty_request_stream_buffer_requires_state(self, real_flow):
+        body = b'{"ok": true}'
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+        )
+        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
+        entry = {}
+        with pytest.raises(
+            RuntimeError,
+            match=r"request_stream_buffer.*request_stream_buffer_state.*truncated",
+        ):
+            add_capture_fields(flow, entry)
+
     def test_captures_response_body_from_stream_buffer(self, real_flow):
         """When stream_buffer is present, response body should be read from it."""
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -190,6 +190,22 @@ class TestErrorHandler:
         assert "stream_buffer_state" not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
+    def test_error_without_run_id_releases_request_stream_state(self, real_flow, mitm_ctx):
+        """Early-returning error flows should still drop request stream closures."""
+        flow = real_flow(with_response=False, host="api.example.com", method="POST")
+        request_streaming.configure_request_stream(flow)
+        stream = flow.request.stream
+        assert callable(stream)
+        stream(b"request-prefix")
+        flow.error = Error("connection reset")
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        assert flow.request.stream is False
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     def test_error_does_not_bill_partial_x_json_response(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, usage_webhook_api
     ):

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -10,6 +10,7 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_streaming
 import usage
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import (
@@ -305,6 +306,40 @@ class TestErrorHandler:
         assert entry["port"] == 9443
         assert entry["url"] == "https://invalid.example.com:bad/path"
         assert entry["error"] == "connection reset by peer"
+
+    def test_error_request_size_tracks_streamed_bytes_and_releases_request_stream_state(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.example.com",
+            method="POST",
+            request_body=b"should-be-ignored",
+        )
+        log_path = str(tmp_path / "network.jsonl")
+        body = b"abcdef"
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.error = Error("connection reset by peer")
+
+        request_streaming.configure_request_stream(flow)
+        stream = flow.request.stream
+        assert callable(stream)
+        assert stream(body[:2]) == body[:2]
+        assert stream(body[2:]) == body[2:]
+
+        with mitm_ctx():
+            mitm_addon.error(flow)
+
+        [entry] = read_jsonl_entries_after_flush(Path(log_path))
+        assert entry["request_size"] == len(body)
+        assert entry["error"] == "connection reset by peer"
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.request.stream is False
 
     def test_error_includes_firewall_context(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="slack.com")

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -63,6 +63,47 @@ class TestErrorHandler:
         assert proxy_entries[0]["upstream_status"] == 0
         assert proxy_entries[1]["type"] == "connection_error"
 
+    def test_streamed_connector_candidate_error_before_request_gets_diagnostic(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            stream = flow.request.stream
+            assert callable(stream)
+            assert stream(b"partial request") == b"partial request"
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        content = flow.response.content
+        assert content is not None
+        body = json.loads(content)
+        assert body["error"] == "connector_not_configured_for_run"
+        assert body["connector"] == "fal"
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 0
+        assert entry["request_size"] == len(b"partial request")
+        assert entry["error"] == "connection reset by peer"
+        assert entry["firewall_error"] == "connector_not_configured_for_run"
+        assert entry["connector_diagnostic_type"] == "fal"
+        assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_browser_connector_candidate_error_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -104,6 +104,43 @@ class TestErrorHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
+    def test_streamed_authenticated_connector_candidate_error_keeps_original_error(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+            request_headers=headers(
+                ("Host", "fal.run"),
+                ("Authorization", "Key user-provided"),
+            ),
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            stream = flow.request.stream
+            assert callable(stream)
+            assert stream(b"partial request") == b"partial request"
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        assert flow.response is None
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 0
+        assert entry["request_size"] == len(b"partial request")
+        assert entry["error"] == "connection reset by peer"
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_browser_connector_candidate_error_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -103,6 +103,7 @@ class TestErrorHandler:
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
 
     def test_streamed_authenticated_connector_candidate_error_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx, headers
@@ -140,6 +141,7 @@ class TestErrorHandler:
         assert "firewall_error" not in entry
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
 
     async def test_browser_connector_candidate_error_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx, headers

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -73,6 +73,7 @@ def test_capture_enabled_browser_allow_installs_request_stream(
 
     assert callable(flow.request.stream)
     assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC in flow.metadata
 
 
 def test_capture_enabled_final_allow_installs_request_stream(tmp_path, real_flow, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -143,6 +143,52 @@ def test_capture_enabled_body_at_stream_limit_does_not_install_request_stream(
     assert metadata_keys.VM_RUN_ID not in flow.metadata
 
 
+def test_capture_enabled_explicit_zero_length_body_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="GET",
+        request_headers=headers(("Host", "example.com"), ("Content-Length", "0")),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+
+
+def test_capture_enabled_bodyless_method_without_content_length_installs_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    for method in ("GET", "HEAD"):
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="example.com",
+            method=method,
+            request_headers=headers(("Host", "example.com")),
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+
+        callback = _request_stream(flow)
+        assert callback(b"body over http2") == b"body over http2"
+        assert flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] == bytearray(b"body over http2")
+
+
 def test_capture_enabled_body_over_stream_limit_installs_request_stream(
     tmp_path, real_flow, mitm_ctx, headers
 ):

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -166,6 +166,28 @@ def test_capture_enabled_body_over_stream_limit_installs_request_stream(
     assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
 
 
+async def test_request_releases_cached_classification_after_stream_setup(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        assert mitm_addon._REQUEST_CLASSIFICATION in flow.metadata
+        await mitm_addon.request(flow)
+
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
+
+
 def test_capture_enabled_chunked_body_installs_request_stream(
     tmp_path, real_flow, mitm_ctx, headers
 ):
@@ -313,3 +335,4 @@ def test_auth_base_requestheaders_rejection_does_not_install_request_stream(
     _assert_no_request_stream(flow)
     assert flow.live is False
     assert flow.error is not None
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -26,6 +26,7 @@ def _assert_no_request_stream(flow) -> None:
     assert flow.request.stream is False
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
 
 
 def test_capture_enabled_api_allow_installs_request_stream(tmp_path, real_flow, mitm_ctx):
@@ -226,6 +227,25 @@ def test_capture_disabled_final_allow_does_not_install_request_stream(
         mitm_addon.requestheaders(flow)
 
     _assert_no_request_stream(flow)
+
+
+def test_non_stream_requestheaders_probe_restores_request_metadata(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
+    assert metadata_keys.NETWORK_LOG_TARGET not in flow.metadata
+    assert metadata_keys.CAPTURE_BODY not in flow.metadata
 
 
 def test_capture_enabled_firewall_allow_does_not_install_request_stream(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -116,6 +116,78 @@ def test_capture_enabled_small_bounded_body_does_not_install_request_stream(
     assert metadata_keys.VM_RUN_ID not in flow.metadata
 
 
+def test_capture_enabled_body_at_stream_limit_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+        request_headers=headers(
+            ("Host", "example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT)),
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+
+
+def test_capture_enabled_body_over_stream_limit_installs_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+        request_headers=headers(
+            ("Host", "example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert callable(flow.request.stream)
+    assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
+
+
+def test_capture_enabled_chunked_body_installs_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+        request_headers=headers(("Host", "example.com"), ("Transfer-Encoding", "chunked")),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert callable(flow.request.stream)
+    assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
+
+
 def test_capture_disabled_final_allow_does_not_install_request_stream(
     tmp_path, real_flow, mitm_ctx
 ):

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -280,6 +280,8 @@ def test_capture_enabled_firewall_allow_does_not_install_request_stream(
         mitm_addon.requestheaders(flow)
 
     _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
 
 
 def test_capture_enabled_firewall_block_does_not_install_request_stream(
@@ -314,6 +316,8 @@ def test_capture_enabled_firewall_block_does_not_install_request_stream(
         mitm_addon.requestheaders(flow)
 
     _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
 
 
 def test_auth_base_requestheaders_rejection_does_not_install_request_stream(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -1,0 +1,243 @@
+"""Tests for requestheaders() request-stream setup."""
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from auth import MAX_AUTH_BASE_REQUEST_BODY_BYTES
+from body_limits import STREAM_BUFFER_LIMIT
+from tests.request_handler_helpers import (
+    _single_firewall_vm,
+    _vm_without_firewalls,
+    _write_registry,
+)
+
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
+)
+
+
+def _request_stream(flow):
+    stream = flow.request.stream
+    assert callable(stream)
+    return stream
+
+
+def _assert_no_request_stream(flow) -> None:
+    assert flow.request.stream is False
+    assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+    assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
+
+def test_capture_enabled_api_allow_installs_request_stream(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.vm0.ai",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    callback = _request_stream(flow)
+    body = b"x" * (STREAM_BUFFER_LIMIT + 10)
+    assert callback(body) == body
+    assert len(flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+    assert flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] == {
+        "truncated": True,
+        "total_bytes": STREAM_BUFFER_LIMIT + 10,
+    }
+
+
+def test_capture_enabled_browser_allow_installs_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+        request_headers=headers(("Host", "example.com"), ("User-Agent", _BROWSER_USER_AGENT)),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert callable(flow.request.stream)
+    assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
+
+
+def test_capture_enabled_final_allow_installs_request_stream(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    assert callable(flow.request.stream)
+    assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
+
+
+def test_capture_enabled_small_bounded_body_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+        request_headers=headers(("Host", "example.com"), ("Content-Length", "4")),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+
+
+def test_capture_disabled_final_allow_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+
+
+def test_capture_enabled_firewall_allow_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/octocat/hello",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+
+
+def test_capture_enabled_firewall_block_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": [],
+                "deny": ["full-access"],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos/octocat/hello",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+
+
+def test_auth_base_requestheaders_rejection_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="webhook",
+            api_entry={
+                "base": "https://placeholder.example.com",
+                "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
+                "permissions": [{"name": "send", "rules": ["ANY /"]}],
+            },
+            network_policy={
+                "allow": ["send"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1)),
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    _assert_no_request_stream(flow)
+    assert flow.live is False
+    assert flow.error is not None

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -168,6 +168,36 @@ def test_capture_enabled_body_over_stream_limit_installs_request_stream(
     assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
 
 
+def test_capture_enabled_replaces_boolean_stream_with_capture_callback(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="example.com",
+        method="POST",
+        request_headers=headers(
+            ("Host", "example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    flow.request.stream = True
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+
+    callback = _request_stream(flow)
+    assert callback(b"partial request") == b"partial request"
+    assert flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] == bytearray(b"partial request")
+    assert flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE]["total_bytes"] == len(
+        b"partial request"
+    )
+
+
 async def test_request_releases_cached_classification_after_stream_setup(
     tmp_path, real_flow, mitm_ctx
 ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -257,6 +257,48 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
+    def test_streamed_authenticated_connector_401_before_request_keeps_upstream_response(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+            request_headers=headers(
+                ("Host", "fal.run"),
+                ("Authorization", "Key user-provided"),
+            ),
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert response_stream(flow)(b"upstream auth error") == b"upstream auth error"
+            mitm_addon.response(flow)
+
+        assert flow.response.content == b"upstream auth error"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 401
+        assert entry["request_size"] == len(b"partial request")
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -11,6 +11,7 @@ from mitmproxy.test import tutils
 import firewall_auth_cache as auth_cache
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_streaming
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_state_helpers import (
     cached_headers,
@@ -640,6 +641,47 @@ class TestResponseHandler:
 
         entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == len(body)
+
+    def test_request_size_tracks_streamed_bytes_and_captures_stream_body(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.example.com",
+            method="POST",
+            request_body=b"should-be-ignored",
+            request_content_type="text/plain",
+        )
+        log_path = str(tmp_path / "network.jsonl")
+        body = b"x" * (STREAM_BUFFER_LIMIT + 17)
+
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.CAPTURE_BODY] = True
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-length": "0", "content-type": "application/json"}),
+        )
+
+        request_streaming.configure_request_stream(flow)
+        stream = flow.request.stream
+        assert callable(stream)
+        assert stream(body[:123]) == body[:123]
+        assert stream(body[123:]) == body[123:]
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        entry = read_jsonl_entries_after_flush(Path(log_path))[0]
+        assert entry["request_size"] == len(body)
+        assert entry["request_body"] == "x" * STREAM_BUFFER_LIMIT
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.request.stream is False
 
     @pytest.mark.parametrize(
         ("content_length", "expected_size"),

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -215,6 +215,48 @@ class TestResponseHandler:
         assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
 
+    def test_streamed_connector_401_before_request_gets_diagnostic(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert flow.response.stream is False
+            mitm_addon.response(flow)
+
+        content = flow.response.content
+        assert content is not None
+        body = json.loads(content)
+        assert body["error"] == "connector_not_configured_for_run"
+        assert body["connector"] == "fal"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 401
+        assert entry["request_size"] == len(b"partial request")
+        assert entry["firewall_error"] == "connector_not_configured_for_run"
+        assert entry["connector_diagnostic_type"] == "fal"
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1008,9 +1008,7 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert flow.request.stream is False
 
-    async def test_early_response_keeps_request_classification_for_late_request_hook(
-        self, tmp_path, real_flow, mitm_ctx
-    ):
+    async def test_early_response_makes_late_request_hook_noop(self, tmp_path, real_flow, mitm_ctx):
         reg_path = _write_registry(
             tmp_path,
             vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
@@ -1034,6 +1032,7 @@ class TestResponseHandler:
                 content=b"ok",
             )
             mitm_addon.response(flow)
+            assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
             reg_path.write_text("{ broken registry")
             await mitm_addon.request(flow)
 

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -299,6 +299,46 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
+    def test_streamed_query_authenticated_connector_401_before_request_keeps_upstream_response(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro?api_key=user-token",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream query auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert (
+                response_stream(flow)(b"upstream query auth error") == b"upstream query auth error"
+            )
+            mitm_addon.response(flow)
+
+        assert flow.response.content == b"upstream query auth error"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 401
+        assert entry["request_size"] == len(b"partial request")
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1129,6 +1129,20 @@ class TestResponseHandler:
         assert "stream_buffer_state" not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
+    def test_response_without_run_id_releases_request_stream_state(self, real_flow):
+        """Even early-returning flows should not retain request stream closures."""
+        flow = real_flow(with_response=False, host="api.example.com", method="POST")
+        request_streaming.configure_request_stream(flow)
+        stream = flow.request.stream
+        assert callable(stream)
+        stream(b"request-prefix")
+
+        mitm_addon.response(flow)
+
+        assert flow.request.stream is False
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
         """Early-returning SSE flows should not retain parser closures."""
         flow = real_flow(with_response=False, host="api.openai.com")

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1143,6 +1143,25 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
+    def test_response_does_not_clear_replaced_request_stream_callback(self, real_flow):
+        """Cleanup should not clear a request callback that replaced ours."""
+        flow = real_flow(with_response=False, host="api.example.com", method="POST")
+
+        def external_stream(chunk):
+            return chunk
+
+        request_streaming.configure_request_stream(flow)
+        stream = flow.request.stream
+        assert callable(stream)
+        stream(b"request-prefix")
+        flow.request.stream = external_stream
+
+        mitm_addon.response(flow)
+
+        assert flow.request.stream is external_stream
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
         """Early-returning SSE flows should not retain parser closures."""
         flow = real_flow(with_response=False, host="api.openai.com")

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -176,6 +176,45 @@ class TestResponseHandler:
         assert "connector_diagnostic_type" not in entry
         assert "firewall_error" not in entry
 
+    async def test_streamed_connector_401_with_query_auth_keeps_upstream_response(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro?auth=token",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            await mitm_addon.request(flow)
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream query auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert (
+                response_stream(flow)(b"upstream query auth error") == b"upstream query auth error"
+            )
+            mitm_addon.response(flow)
+
+        assert flow.response.content == b"upstream query auth error"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 401
+        assert entry["request_size"] == len(b"partial request")
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -974,6 +974,40 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert flow.request.stream is False
 
+    async def test_unknown_length_get_without_body_logs_zero_request_size(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="example.com",
+            method="GET",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            assert callable(flow.request.stream)
+            await mitm_addon.request(flow)
+            flow.response = tutils.tresp(
+                status_code=200,
+                headers=header_map({"content-length": "2", "content-type": "text/plain"}),
+                content=b"ok",
+            )
+            mitm_addon.response(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["request_size"] == 0
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert "request_body_truncated" not in entry
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.request.stream is False
+
     @pytest.mark.parametrize(
         ("content_length", "expected_size"),
         [

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -135,6 +135,47 @@ class TestResponseHandler:
 
         assert flow.response.content == b"upstream auth error"
 
+    async def test_streamed_connector_401_with_user_auth_keeps_upstream_response(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+            request_headers=headers(
+                ("Host", "fal.run"),
+                ("Authorization", "Key user-provided"),
+            ),
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            await mitm_addon.request(flow)
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert response_stream(flow)(b"upstream auth error") == b"upstream auth error"
+            mitm_addon.response(flow)
+
+        assert flow.response.content == b"upstream auth error"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 401
+        assert entry["request_size"] == len(b"partial request")
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1008,6 +1008,40 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert flow.request.stream is False
 
+    async def test_early_response_keeps_request_classification_for_late_request_hook(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.vm0.ai",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            assert mitm_addon._REQUEST_CLASSIFICATION in flow.metadata
+            stream = flow.request.stream
+            assert callable(stream)
+            assert stream(b"partial request") == b"partial request"
+            flow.response = tutils.tresp(
+                status_code=200,
+                headers=header_map({"content-length": "2", "content-type": "text/plain"}),
+                content=b"ok",
+            )
+            mitm_addon.response(flow)
+            reg_path.write_text("{ broken registry")
+            await mitm_addon.request(flow)
+
+        assert flow.response.status_code == 200
+        assert flow.response.content == b"ok"
+        assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+        assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
+
     @pytest.mark.parametrize(
         ("content_length", "expected_size"),
         [

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -385,6 +385,47 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
+    def test_streamed_api_allow_response_before_request_logs_without_firewall_context(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.vm0.ai",
+            path="/api/runs",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"api auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert response_stream(flow)(b"api auth error") == b"api auth error"
+            mitm_addon.response(flow)
+
+        assert flow.response.content == b"api auth error"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["action"] == "ALLOW"
+        assert entry["status"] == 401
+        assert entry["request_size"] == len(b"partial request")
+        assert entry["response_size"] == len(b"api auth error")
+        assert "firewall_base" not in entry
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -339,6 +339,52 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
+    def test_streamed_browser_connector_403_before_request_keeps_upstream_response(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+            request_headers=headers(
+                ("Host", "fal.run"),
+                (
+                    "User-Agent",
+                    "Mozilla/5.0 AppleWebKit/537.36 Chrome/126.0 Safari/537.36",
+                ),
+            ),
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            request_stream = flow.request.stream
+            assert callable(request_stream)
+            assert request_stream(b"partial request") == b"partial request"
+            flow.response = tutils.tresp(
+                status_code=403,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"browser upstream body",
+            )
+            mitm_addon.responseheaders(flow)
+            assert response_stream(flow)(b"browser upstream body") == b"browser upstream body"
+            mitm_addon.response(flow)
+
+        assert flow.response.content == b"browser upstream body"
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 403
+        assert entry["request_size"] == len(b"partial request")
+        assert entry["browser_user_agent"] is True
+        assert "connector_diagnostic_type" not in entry
+        assert "firewall_error" not in entry
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):


### PR DESCRIPTION
## Summary
- add request-side stream buffering for safe non-firewall capture paths with large or unknown request bodies
- use streamed request metadata for request size and request body capture, then release stream state in terminal hooks
- keep small bounded request bodies on the existing raw_content path and avoid streaming firewall/auth mutation paths
- cache request-header classification only for actual request streaming paths and restore probe metadata for non-stream paths
- cover empty request stream buffers and non-stream firewall probe metadata restoration edge cases
- clarify shared request metadata lifecycle docs for header-phase classification paths

Fixes #17974

## Tests
- `ruff check src/flow_metadata_keys.py src/request_streaming.py src/body_capture.py src/mitm_addon.py tests/test_request_headers_handler.py tests/test_body_capture_stream_buffer.py tests/test_response_handler.py tests/test_error_handler.py`
- `ruff format --check src/flow_metadata_keys.py src/request_streaming.py src/body_capture.py src/mitm_addon.py tests/test_request_headers_handler.py tests/test_body_capture_stream_buffer.py tests/test_response_handler.py tests/test_error_handler.py`
- `pytest tests/test_request_headers_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_response_handler.py tests/test_error_handler.py tests/test_body_capture_stream_buffer.py` (`181 passed`)
- `pytest` from `crates/runner/mitm-addon` (`2796 passed` before the final test/doc-only commits)
