### PR TITLE
feat: add sidebar chat double-click rename

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -155,17 +155,22 @@ function sidebar(): HTMLElement {
 }
 
 function threadRowByTitle(title: string): HTMLElement {
+  const link = threadLinkByTitle(title);
+  const row = link.parentElement;
+  if (!row) {
+    throw new Error(`${title} thread row not found`);
+  }
+  return row;
+}
+
+function threadLinkByTitle(title: string): HTMLElement {
   const link = queryAllByRoleFast("link", sidebar()).find((candidate) => {
     return candidate.textContent?.replace(/\s+/g, " ").trim() === title;
   });
   if (!link) {
     throw new Error(`${title} thread link not found`);
   }
-  const row = link.parentElement;
-  if (!row) {
-    throw new Error(`${title} thread row not found`);
-  }
-  return row;
+  return link;
 }
 
 function openThreadMenu(title: string): void {
@@ -405,6 +410,63 @@ describe("zero sidebar", () => {
 
     openThreadMenu("Release plan");
     click(menuItemByText("Rename chat"));
+
+    const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    const titleInput = within(dialog).getByPlaceholderText("Chat title");
+    expect(titleInput).toHaveValue("Release plan");
+
+    await fill(titleInput, "Launch plan");
+    click(buttonByText("Rename", dialog));
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Launch plan")).toBeInTheDocument();
+      expect(
+        within(sidebar()).queryByText("Release plan"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps sidebar double-click rename disabled by default", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(INCIDENT_THREAD_ID, "Incident notes"),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+    });
+
+    fireEvent.doubleClick(threadLinkByTitle("Release plan"));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Rename chat" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renames a chat thread by double-clicking from the sidebar when enabled", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(INCIDENT_THREAD_ID, "Incident notes"),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatThreadDoubleClickRename]: true },
+    });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+    });
+
+    fireEvent.doubleClick(threadLinkByTitle("Release plan"));
 
     const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
     const titleInput = within(dialog).getByPlaceholderText("Chat title");

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -16,6 +16,7 @@ import {
   IconPinnedOff,
 } from "@tabler/icons-react";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { useChatThreadsTitleLabels } from "./zero-sidebar-shared.tsx";
 import {
   Tooltip,
@@ -85,6 +86,7 @@ import {
 } from "../../signals/chat-page/header-automation-menu.ts";
 import { sidebarDraftThreadIds$ } from "../../signals/chat-page/sidebar-draft-threads.ts";
 import { sidebarUnreadThreadIds$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   openRenameChatThreadDialog$,
   pendingDeleteThreadId$,
@@ -444,6 +446,7 @@ function useChatThreadItemState(session: ChatThreadListItem) {
   const pageSignal = useGet(pageSignal$);
   const draftThreadIds = useLastResolved(sidebarDraftThreadIds$);
   const unreadThreadIds = useLastResolved(sidebarUnreadThreadIds$);
+  const features = useLastResolved(featureSwitch$);
 
   const isPinned = session.pinnedAt !== null && session.pinnedAt !== undefined;
   const onChatPage = urlMainThreadId !== null;
@@ -477,6 +480,8 @@ function useChatThreadItemState(session: ChatThreadListItem) {
     setSidebarExpanded,
     unloadRightThread,
     indicatorState,
+    doubleClickRenameEnabled:
+      features?.[FeatureSwitchKey.ChatThreadDoubleClickRename] ?? false,
   } as const;
 }
 
@@ -487,6 +492,7 @@ function ChatThreadItemLink({
   session: ChatThreadListItem;
   state: ReturnType<typeof useChatThreadItemState>;
 }) {
+  const openRenameChatThreadDialog = useSet(openRenameChatThreadDialog$);
   const closeSidebarOnSelect = () => {
     state.setSidebarExpanded(false);
   };
@@ -510,6 +516,17 @@ function ChatThreadItemLink({
           unloadRightThread: state.unloadRightThread,
         });
       }}
+      onDoubleClick={
+        state.doubleClickRenameEnabled
+          ? (e) => {
+              e.preventDefault();
+              openRenameChatThreadDialog({
+                threadId: session.id,
+                title: session.title,
+              });
+            }
+          : undefined
+      }
       className={`flex h-8 items-center gap-2 rounded-lg py-2 pl-2 pr-8 text-left text-sm leading-5 transition-colors ${
         state.isHighlighted
           ? "bg-gray-200 text-gray-900 font-medium"

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -49,6 +49,7 @@ export enum FeatureSwitchKey {
   ZapierConnector = "zapierConnector",
   SandboxIoLimiters = "sandboxIoLimiters",
   ChatGithubPrTracking = "chatGithubPrTracking",
+  ChatThreadDoubleClickRename = "chatThreadDoubleClickRename",
   ChatTemplatePicker = "chatTemplatePicker",
   ChatNewPresentationTemplates = "chatNewPresentationTemplates",
   VideoTemplatePicker = "videoTemplatePicker",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -270,6 +270,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show GitHub PR tracking in chat thread headers when the current agent is connected to and authorized for GitHub. Individuals opt in via feature-switch overrides.",
     enabled: false,
   },
+  [FeatureSwitchKey.ChatThreadDoubleClickRename]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Open the existing chat rename dialog when a sidebar chat thread is double-clicked.",
+    enabled: false,
+  },
   [FeatureSwitchKey.ChatTemplatePicker]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- add a feature switch for sidebar chat thread double-click rename
- reuse the existing rename chat dialog from the sidebar menu
- cover default-disabled and enabled double-click behavior in sidebar tests

## Verification
- pnpm exec prettier --check apps/platform/src/views/zero-page/sidebar-threads.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/app exec oxlint src/views/zero-page/sidebar-threads.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app exec eslint src/views/zero-page/sidebar-threads.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --reporter verbose
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "keeps sidebar double-click rename disabled by default" --reporter verbose --testTimeout 10000 --hookTimeout 10000
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "renames a chat thread by double-clicking from the sidebar when enabled" --reporter verbose --testTimeout 10000 --hookTimeout 10000

Note: full @vm0/app check-types was attempted locally but was killed by the environment with exit 137 before reporting TypeScript diagnostics.