### PR TITLE
fix(runner): redact session ids from diagnostics

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::config::RunnerConfig;
 use crate::error::RunnerResult;
 use crate::live_runner_instances::LiveRunnerInstance;
-use crate::paths::HomePaths;
+use crate::paths::{HomePaths, diagnostic_session_fingerprint};
 use crate::process;
 use chrono::{DateTime, Utc};
 use clap::Args;
@@ -1304,10 +1304,7 @@ fn print_report(
         {
             println!("    Idle:    {} VMs", st.idle_vms.len());
             for vm in &st.idle_vms {
-                println!(
-                    "      - session {} -> sandbox {}",
-                    vm.session_id, vm.sandbox_id
-                );
+                println!("{}", format_idle_vm_diagnostic_line(vm));
             }
         }
 
@@ -1342,6 +1339,14 @@ fn print_report(
         reports.iter().map(|r| r.warnings.len()).sum::<usize>() + global_warnings.len();
     println!("{total_warnings} warning(s) found");
     total_warnings
+}
+
+fn format_idle_vm_diagnostic_line(vm: &IdleVm) -> String {
+    format!(
+        "      - session fingerprint {} -> sandbox {}",
+        diagnostic_session_fingerprint(&vm.session_id),
+        vm.sandbox_id
+    )
 }
 
 /// Format an ISO 8601 timestamp as a human-readable relative duration.
@@ -2342,6 +2347,25 @@ mod tests {
         assert!(!is_inactive_mode("running"));
         assert!(!is_inactive_mode("starting"));
         assert!(!is_inactive_mode(""));
+    }
+
+    #[test]
+    fn idle_vm_diagnostic_line_redacts_session_id() {
+        let raw_session_id = "sess-sensitive-doctor-17975";
+        let line = format_idle_vm_diagnostic_line(&IdleVm {
+            session_id: raw_session_id.into(),
+            sandbox_id: "sandbox-123".into(),
+        });
+
+        assert!(
+            !line.contains(raw_session_id),
+            "doctor idle VM output must not expose raw session id: {line}"
+        );
+        assert!(
+            line.contains(&diagnostic_session_fingerprint(raw_session_id)),
+            "doctor idle VM output should retain session-level correlation: {line}"
+        );
+        assert!(line.contains("sandbox-123"));
     }
 
     struct DoctorReportFixture {

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(state.running_count, 2);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn send_heartbeat_logs_held_session_count_without_raw_session_state() {
         let session_id = "sess-sensitive-heartbeat-17975";
         let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -87,7 +87,10 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
         sessions = state.held_session_states.len(),
         "heartbeat"
     );
-    debug!(held_session_states = ?state.held_session_states);
+    debug!(
+        sessions = state.held_session_states.len(),
+        "heartbeat held session states"
+    );
     hb.provider
         .set_held_session_states(state.held_session_states.clone())
         .await;
@@ -198,12 +201,15 @@ mod tests {
         IdlePoolConfig, ParkResult, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts,
     };
     use crate::paths::RunnerPaths;
+    use crate::provider::mock::MockJobProvider;
     use crate::workspace_image_cache::{
         WorkspaceCacheTerminalStatus, WorkspaceImagePrepareRequest,
     };
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{SandboxFactory, SandboxId};
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::{CapturedEvent, CapturedEvents};
 
     fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
         let mut m = BTreeMap::new();
@@ -275,6 +281,31 @@ mod tests {
         drop(lease);
     }
 
+    async fn capture_heartbeat_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+    where
+        F: std::future::Future,
+    {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        let output = future.await;
+        drop(guard);
+        (output, captured.entries())
+    }
+
+    fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+        events
+            .iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|actual| actual == message)
+            })
+            .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+    }
+
     #[test]
     fn heartbeat_running_count_no_idle() {
         let budget = Arc::new(ResourceBudget::new(8, 32768, 1.0, 4));
@@ -298,6 +329,55 @@ mod tests {
             RunnerMode::Running,
         );
         assert_eq!(state.running_count, 2);
+    }
+
+    #[tokio::test]
+    async fn send_heartbeat_logs_held_session_count_without_raw_session_state() {
+        let session_id = "sess-sensitive-heartbeat-17975";
+        let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+            default_timeout: Duration::from_secs(300),
+            max_idle: 1,
+        })));
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        seed_workspace_cache_state(&cache, &paths, session_id, "2026-06-01T00:00:00.000Z").await;
+        let profiles = test_profiles();
+        let budget = ResourceBudget::new(8, 32768, 1.0, 4);
+        let active_sessions = super::super::active_sessions::new_active_sessions();
+        let (provider, provider_handle) =
+            MockJobProvider::new(tokio_util::sync::CancellationToken::new());
+        let hb = HeartbeatContext::new(HeartbeatContextInit {
+            idle_pool: &idle_pool,
+            runner_id: "runner-1",
+            name: "test-runner",
+            group: "vm0/test",
+            profiles: &profiles,
+            budget: &budget,
+            provider: provider.as_ref(),
+            workspace_cache: Some(cache),
+            active_sessions: &active_sessions,
+        });
+
+        let ((), events) = capture_heartbeat_events(send_heartbeat(&hb, RunnerMode::Running)).await;
+
+        let debug_event = captured_event(&events, "heartbeat held session states");
+        assert_eq!(
+            debug_event.fields.get("sessions").map(String::as_str),
+            Some("1")
+        );
+        for event in &events {
+            for (field, value) in &event.fields {
+                assert!(
+                    !value.contains(session_id),
+                    "captured field {field} leaked raw session id {session_id:?}: {event:#?}"
+                );
+            }
+        }
+        let updates = provider_handle.held_session_state_updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0][0].session_id, session_id);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -20,6 +20,7 @@ use super::idle_lifecycle::{
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
+use crate::executor::validate_resume_session_id;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::paths::diagnostic_session_fingerprint;
@@ -106,9 +107,14 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         budget_lease: job_lease,
         cancel: job_cancel,
     } = admission;
+    let resume_session_valid = validate_resume_session_id(claimed.context()).is_ok();
     let active_session_guard = ActiveSessionGuard::new(
         ctx.spawn_ctx.active_sessions.clone(),
-        claimed.context().session_id().map(str::to_owned),
+        if resume_session_valid {
+            claimed.context().session_id().map(str::to_owned)
+        } else {
+            None
+        },
     );
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
@@ -121,6 +127,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         &profile_name,
         &device_rate_limits,
         claimed.context(),
+        resume_session_valid,
         job_lease,
         &mut ctx,
     )
@@ -264,6 +271,7 @@ async fn try_reuse_from_pool(
     profile_name: &str,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     context: &ExecutionContext,
+    resume_session_valid: bool,
     job_lease: BudgetLease,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> (
@@ -272,6 +280,9 @@ async fn try_reuse_from_pool(
     SandboxReuseResult,
     Option<IdlePoolSnapshot>,
 ) {
+    if !resume_session_valid {
+        return (None, job_lease, SandboxReuseResult::NoSessionId, None);
+    }
     let Some(session_id) = context.session_id() else {
         return (None, job_lease, SandboxReuseResult::NoSessionId, None);
     };

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -22,6 +22,7 @@ use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
 use crate::ids::RunId;
+use crate::paths::diagnostic_session_fingerprint;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
@@ -274,6 +275,7 @@ async fn try_reuse_from_pool(
     let Some(session_id) = context.session_id() else {
         return (None, job_lease, SandboxReuseResult::NoSessionId, None);
     };
+    let session_fingerprint = diagnostic_session_fingerprint(session_id);
 
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.
@@ -307,7 +309,7 @@ async fn try_reuse_from_pool(
                 } => {
                     info!(
                         run_id = %run_id,
-                        session_id,
+                        session_fingerprint = %session_fingerprint,
                         "reusing idle VM for session"
                     );
                     // Idle entry already holds budget. Drop the speculative
@@ -324,7 +326,7 @@ async fn try_reuse_from_pool(
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
                         run_id = %run_id,
-                        session_id,
+                        session_fingerprint = %session_fingerprint,
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
@@ -336,7 +338,7 @@ async fn try_reuse_from_pool(
         Some(stale) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
-                session_id,
+                session_fingerprint = %session_fingerprint,
                 profile = %profile_name,
                 "idle VM device rate limiter mismatch, destroying"
             );
@@ -355,7 +357,7 @@ async fn try_reuse_from_pool(
         Some(stale) => {
             info!(
                 run_id = %run_id,
-                session_id,
+                session_fingerprint = %session_fingerprint,
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
@@ -375,7 +377,7 @@ async fn try_reuse_from_pool(
         None => {
             info!(
                 run_id = %run_id,
-                session_id,
+                session_fingerprint = %session_fingerprint,
                 "no idle VM found for session"
             );
             (None, job_lease, SandboxReuseResult::PoolMiss, None)

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -432,7 +432,11 @@ pub(super) fn spawn_job(
     } = request;
     let (context, completion_auth) = claimed.into_parts();
     let run_id = context.run_id;
-    let session_id = context.session_id().map(String::from);
+    let session_id = if executor::validate_resume_session_id(&context).is_ok() {
+        context.session_id().map(String::from)
+    } else {
+        None
+    };
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
     let active_lease = job_profile.budget_lease;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -761,8 +761,16 @@ enum SignalSource {
 #[derive(Debug, PartialEq, Eq)]
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
-    IdleCleanupProcessed { expired_count: usize },
-    BeforeIdlePoolOwnershipTransfer { run_id: RunId },
+    IdleCleanupProcessed {
+        expired_count: usize,
+    },
+    BeforeIdlePoolOwnershipTransfer {
+        run_id: RunId,
+    },
+    VmParkedForReuse {
+        run_id: RunId,
+        session_fingerprint: String,
+    },
     UsageFlushRequested,
 }
 
@@ -868,6 +876,13 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
     }
 
+    fn notify_vm_parked_for_reuse(&self, run_id: RunId, session_fingerprint: String) {
+        self.record(StartLoopEvent::VmParkedForReuse {
+            run_id,
+            session_fingerprint,
+        });
+    }
+
     fn notify_usage_flush_requested(&self) {
         self.record(StartLoopEvent::UsageFlushRequested);
     }
@@ -904,6 +919,17 @@ impl StartLoopTestObserver {
                 _ => None,
             },
         )
+        .await
+    }
+
+    async fn wait_vm_parked_for_reuse(&self, run_id: RunId, timeout: Duration) -> String {
+        self.wait_for(timeout, "VM parked for reuse", |event| match event {
+            StartLoopEvent::VmParkedForReuse {
+                run_id: observed_run_id,
+                session_fingerprint,
+            } if *observed_run_id == run_id => Some(session_fingerprint.clone()),
+            _ => None,
+        })
         .await
     }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -53,7 +53,7 @@ use crate::kmsg_log;
 use crate::lock;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
-use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
+use crate::paths::{HomePaths, LogPaths, RunnerPaths, diagnostic_session_fingerprint, touch_mtime};
 use crate::prefetch;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
@@ -1269,8 +1269,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 if let Some(evicted) =
                     evict_oldest_idle_entry(&shared.idle_pool, &shared.status).await
                 {
+                    let session_fingerprint = diagnostic_session_fingerprint(evicted.session_id());
                     info!(
-                        session_id = %evicted.session_id(),
+                        session_fingerprint = %session_fingerprint,
                         profile = %evicted.profile_name(),
                         vcpu = evicted.budget_vcpu(),
                         memory_mb = evicted.budget_memory_mb(),

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -28,6 +28,7 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogSession;
+use crate::paths::diagnostic_session_fingerprint;
 #[cfg(test)]
 use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
@@ -157,6 +158,7 @@ pub(super) async fn finalize_sandbox_for_completion(
     let mut session_affinity_changed = false;
     let mut session_affinity_refresh_sent = false;
     let budget = if let Some(session_id) = parkable_session {
+        let session_fingerprint = diagnostic_session_fingerprint(&session_id);
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
@@ -184,7 +186,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 } = failure.active;
                 warn!(
                     run_id = %run_id,
-                    session_id,
+                    session_fingerprint = %session_fingerprint,
                     error = %failure.error,
                     "sandbox park failed, destroying instead of parking"
                 );
@@ -226,7 +228,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
-                session_id,
+                session_fingerprint = %session_fingerprint,
                 "job cancelled while parking, destroying VM"
             );
             let destroy_result = destroy_active_owned_idle_payload(
@@ -254,7 +256,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     if cancel.is_cancelled() {
                         info!(
                             run_id = %run_id,
-                            session_id,
+                            session_fingerprint = %session_fingerprint,
                             "job cancelled before idle pool ownership transfer, destroying VM"
                         );
                         drop(transfer_guard);
@@ -278,7 +280,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 if cancel.is_cancelled() {
                     info!(
                         run_id = %run_id,
-                        session_id,
+                        session_fingerprint = %session_fingerprint,
                         "job cancelled before idle pool ownership transfer, destroying VM"
                     );
                     drop(transfer_guard);
@@ -300,7 +302,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 let candidate = candidate.with_last_completed_at(completed_at.clone());
                 break match pool.park(candidate) {
                     ParkResult::Parked => {
-                        info!(run_id = %run_id, session_id, "VM parked for reuse");
+                        info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "VM parked for reuse");
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
                         maybe_panic_outer_job(
@@ -328,7 +330,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         BudgetOwnership::idle_owned()
                     }
                     ParkResult::Replaced(evicted) => {
-                        info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                        info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "VM parked, evicting previous");
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
                         maybe_panic_outer_job(
@@ -356,7 +358,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         BudgetOwnership::idle_owned()
                     }
                     ParkResult::Rejected(rejected) => {
-                        info!(run_id = %run_id, session_id, "idle parking rejected, destroying VM");
+                        info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "idle parking rejected, destroying VM");
                         drop(transfer_guard);
                         drop(pool);
                         // Pool unchanged (park rejected) — no status
@@ -520,13 +522,14 @@ async fn stop_and_destroy_sandbox(
     mut context: ActiveCleanupContext<'_>,
 ) -> DestroyOutcome {
     let mut uncertain = false;
+    let session_fingerprint = context.session_id.map(diagnostic_session_fingerprint);
     match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => warn!(
             run_id = %context.run_id,
             sandbox_id = %context.sandbox_id,
             profile_name = context.profile_name,
-            session_id = context.session_id.unwrap_or("<none>"),
+            session_fingerprint = ?session_fingerprint,
             reason = context.reason,
             error = %e,
             "sandbox stop failed during active cleanup"
@@ -536,7 +539,7 @@ async fn stop_and_destroy_sandbox(
                 run_id = %context.run_id,
                 sandbox_id = %context.sandbox_id,
                 profile_name = context.profile_name,
-                session_id = context.session_id.unwrap_or("<none>"),
+                session_fingerprint = ?session_fingerprint,
                 reason = context.reason,
                 "sandbox stop panicked during active cleanup"
             );
@@ -558,7 +561,7 @@ async fn stop_and_destroy_sandbox(
             run_id = %context.run_id,
             sandbox_id = %context.sandbox_id,
             profile_name = context.profile_name,
-            session_id = context.session_id.unwrap_or("<none>"),
+            session_fingerprint = ?session_fingerprint,
             reason = context.reason,
             "sandbox destroy panicked during active cleanup"
         );
@@ -580,6 +583,8 @@ mod tests {
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::{CapturedEvent, CapturedEvents};
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::{
@@ -686,6 +691,42 @@ mod tests {
                 cleanup_state: RunCleanupState::new(),
                 outer_job_panic: None,
                 test_observer: StartLoopTestObserver::default(),
+            }
+        }
+    }
+
+    async fn capture_finalizer_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+    where
+        F: std::future::Future,
+    {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        let output = future.await;
+        drop(guard);
+        (output, captured.entries())
+    }
+
+    fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+        events
+            .iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|actual| actual == message)
+            })
+            .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+    }
+
+    fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
+        for event in events {
+            for (field, value) in &event.fields {
+                assert!(
+                    !value.contains(raw),
+                    "captured field {field} leaked raw session id {raw:?}: {event:#?}"
+                );
             }
         }
     }
@@ -798,6 +839,49 @@ mod tests {
                 )
                 .await,
             "parked sandbox must not retain the previous run's network-log attribution",
+        );
+    }
+
+    #[tokio::test]
+    async fn finalizer_parking_log_uses_session_fingerprint() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let raw_session_id = "sess-sensitive-finalizer-17975";
+
+        let (_completion_ready, events) =
+            capture_finalizer_events(finalize_sandbox_for_completion(
+                Some(Box::new(MockSandbox::new("finalizer-redaction"))),
+                ActiveBudgetLease::new(lease),
+                CompletionPayload::new(
+                    run_id,
+                    0,
+                    None,
+                    sandbox_id,
+                    SandboxReuseResult::PoolMiss,
+                    CompletionAuth::local(),
+                ),
+                fixture.finalize_context(
+                    run_id,
+                    sandbox_id,
+                    raw_session_id,
+                    network_log_session,
+                    RunCancellationHandle::new(),
+                ),
+            ))
+            .await;
+
+        assert_captured_events_do_not_contain(&events, raw_session_id);
+        let event = captured_event(&events, "VM parked for reuse");
+        assert_eq!(
+            event.fields.get("session_fingerprint").map(String::as_str),
+            Some(diagnostic_session_fingerprint(raw_session_id).as_str())
+        );
+        assert!(
+            !event.fields.contains_key("session_id"),
+            "parking diagnostic must not include raw session_id field: {event:#?}"
         );
     }
 

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -303,6 +303,9 @@ pub(super) async fn finalize_sandbox_for_completion(
                 break match pool.park(candidate) {
                     ParkResult::Parked => {
                         info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "VM parked for reuse");
+                        #[cfg(test)]
+                        test_observer
+                            .notify_vm_parked_for_reuse(run_id, session_fingerprint.clone());
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
                         maybe_panic_outer_job(
@@ -583,8 +586,6 @@ mod tests {
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
-    use tracing_subscriber::prelude::*;
-    use tracing_test_support::{CapturedEvent, CapturedEvents};
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::{
@@ -691,42 +692,6 @@ mod tests {
                 cleanup_state: RunCleanupState::new(),
                 outer_job_panic: None,
                 test_observer: StartLoopTestObserver::default(),
-            }
-        }
-    }
-
-    async fn capture_finalizer_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
-    where
-        F: std::future::Future,
-    {
-        let captured = CapturedEvents::default();
-        let subscriber = tracing_subscriber::registry().with(captured.clone());
-        let guard = tracing::subscriber::set_default(subscriber);
-        tracing::callsite::rebuild_interest_cache();
-        let output = future.await;
-        drop(guard);
-        (output, captured.entries())
-    }
-
-    fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
-        events
-            .iter()
-            .find(|event| {
-                event
-                    .fields
-                    .get("message")
-                    .is_some_and(|actual| actual == message)
-            })
-            .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
-    }
-
-    fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
-        for event in events {
-            for (field, value) in &event.fields {
-                assert!(
-                    !value.contains(raw),
-                    "captured field {field} leaked raw session id {raw:?}: {event:#?}"
-                );
             }
         }
     }
@@ -850,38 +815,38 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let raw_session_id = "sess-sensitive-finalizer-17975";
+        let observer = StartLoopTestObserver::default();
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            raw_session_id,
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.test_observer = observer.clone();
 
-        let (_completion_ready, events) =
-            capture_finalizer_events(finalize_sandbox_for_completion(
-                Some(Box::new(MockSandbox::new("finalizer-redaction"))),
-                ActiveBudgetLease::new(lease),
-                CompletionPayload::new(
-                    run_id,
-                    0,
-                    None,
-                    sandbox_id,
-                    SandboxReuseResult::PoolMiss,
-                    CompletionAuth::local(),
-                ),
-                fixture.finalize_context(
-                    run_id,
-                    sandbox_id,
-                    raw_session_id,
-                    network_log_session,
-                    RunCancellationHandle::new(),
-                ),
-            ))
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("finalizer-redaction"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+        let field = observer
+            .wait_vm_parked_for_reuse(run_id, Duration::from_secs(1))
             .await;
 
-        assert_captured_events_do_not_contain(&events, raw_session_id);
-        let event = captured_event(&events, "VM parked for reuse");
-        assert_eq!(
-            event.fields.get("session_fingerprint").map(String::as_str),
-            Some(diagnostic_session_fingerprint(raw_session_id).as_str())
-        );
+        assert_eq!(field, diagnostic_session_fingerprint(raw_session_id));
         assert!(
-            !event.fields.contains_key("session_id"),
-            "parking diagnostic must not include raw session_id field: {event:#?}"
+            !field.contains(raw_session_id),
+            "parking diagnostic field must not include raw session id: {field}"
         );
     }
 

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -740,6 +740,50 @@ async fn job_without_session_reports_no_session_id() {
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn invalid_resume_session_does_not_reuse_idle_vm() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let invalid_session_id = "../invalid-session";
+    seed_idle_pool(
+        &idle_pool,
+        &budget,
+        invalid_session_id,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, invalid_session_id)),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+    assert_eq!(completion.exit_code, 1);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::NoSessionId),
+    );
+    let error = completion.error.as_deref().expect("error should be set");
+    assert!(error.contains("invalid session_id"));
+    assert!(!error.contains(invalid_session_id));
+    wait_idle_pool_sessions(&idle_pool, &[invalid_session_id], Duration::from_secs(5)).await;
+
+    shutdown(&env, run_handle).await;
+}
+
 // -----------------------------------------------------------------------
 // Test 14: Profile mismatch destroys stale and creates new
 // -----------------------------------------------------------------------

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -11,6 +11,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tracing::{info, warn};
 
 use super::env::is_runner_owned_env_key;
+use super::session_restore::is_valid_session_id;
 use super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT, AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT,
     AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, AGENT_ENV_KEY_MAX_CHARS, BOOTSTRAP_SENSITIVE_ENV_KEYS,
@@ -19,7 +20,7 @@ use super::{
     STDOUT_STREAM_OVERFLOW_MARKER, SandboxReuseResult, guest_runtime_path,
 };
 use crate::ids::RunId;
-use crate::paths::LogPaths;
+use crate::paths::{LogPaths, diagnostic_session_fingerprint};
 use crate::types::ExecutionContext;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -446,7 +447,18 @@ pub(super) async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: RunId) 
     match sandbox.read_file(&path, SMALL_GUEST_FILE_MAX_BYTES).await {
         Ok(Some(bytes)) if !bytes.is_empty() => {
             let id = String::from_utf8_lossy(&bytes).trim().to_string();
-            Some(id).filter(|s| !s.is_empty())
+            if id.is_empty() {
+                return None;
+            }
+            if !is_valid_session_id(&id) {
+                warn!(
+                    run_id = %run_id,
+                    session_fingerprint = %diagnostic_session_fingerprint(&id),
+                    "ignoring invalid guest session ID"
+                );
+                return None;
+            }
+            Some(id)
         }
         _ => None,
     }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
-use super::session_restore::canonical_codex_thread_id;
+use super::session_restore::{canonical_codex_thread_id, is_valid_session_id};
 use super::storage::format_guest_exec_failure;
 use super::{
     DEFAULT_EXEC_TIMEOUT, GUEST_AGENT_TUNING_ENV_KEYS, GUEST_USER_ENV_DIR_NAME,
@@ -97,9 +97,28 @@ pub(super) fn validate_model_provider_env_placeholders(
 pub(super) fn validate_execution_context_before_sandbox(
     context: &ExecutionContext,
 ) -> Result<(), String> {
+    validate_resume_session_id(context)?;
     validate_model_provider_env_placeholders(context)?;
     validate_claude_tool_lists(context)?;
     Ok(())
+}
+
+pub(super) fn validate_resume_session_id(context: &ExecutionContext) -> Result<(), String> {
+    let Some(session) = &context.resume_session else {
+        return Ok(());
+    };
+    match effective_cli_framework(&context.cli_agent_type) {
+        EffectiveCliFramework::Codex => canonical_codex_thread_id(&session.session_id)
+            .map(|_| ())
+            .ok_or_else(|| "invalid codex session_id".to_string()),
+        EffectiveCliFramework::ClaudeCode => {
+            if is_valid_session_id(&session.session_id) {
+                Ok(())
+            } else {
+                Err("invalid session_id".to_string())
+            }
+        }
+    }
 }
 
 pub(super) fn validate_claude_tool_lists(context: &ExecutionContext) -> Result<(), String> {

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -329,15 +329,13 @@ pub(super) fn build_env_json_with_host_env(
 
     // Resume session ID
     if let Some(session) = &context.resume_session {
-        let session_id = if effective_cli_framework(&context.cli_agent_type)
-            == EffectiveCliFramework::Codex
-        {
-            canonical_codex_thread_id(&session.session_id).ok_or_else(|| {
-                RunnerError::Internal(format!("invalid codex session_id: {}", session.session_id))
-            })?
-        } else {
-            session.session_id.clone()
-        };
+        let session_id =
+            if effective_cli_framework(&context.cli_agent_type) == EffectiveCliFramework::Codex {
+                canonical_codex_thread_id(&session.session_id)
+                    .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?
+            } else {
+                session.session_id.clone()
+            };
         env.insert(
             guest_contracts::env::RESUME_SESSION_ID_ENV.into(),
             session_id,

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -103,7 +103,7 @@ pub(super) fn validate_execution_context_before_sandbox(
     Ok(())
 }
 
-pub(super) fn validate_resume_session_id(context: &ExecutionContext) -> Result<(), String> {
+pub(crate) fn validate_resume_session_id(context: &ExecutionContext) -> Result<(), String> {
     let Some(session) = &context.resume_session else {
         return Ok(());
     };

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -35,7 +35,8 @@ mod telemetry;
 pub(crate) use guest_state::{fix_guest_clock, reseed_guest_entropy};
 
 use agent_run::ProcessCancelTimeouts;
-use env::{validate_execution_context_before_sandbox, validate_resume_session_id};
+use env::validate_execution_context_before_sandbox;
+pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
     workspace_image_promotable,
@@ -461,20 +462,61 @@ pub async fn execute_job_reuse(
 
     let sandbox_id = idle_sandbox.sandbox_id();
     let idle_parts = idle_sandbox.into_parts();
+    let idle_session_id = idle_parts.session_id;
     let source_ip = idle_parts.source_ip;
     let prev_storage = idle_parts.storage_fingerprints;
     let workspace_promotion = idle_parts.workspace_promotion;
     let sandbox = idle_parts.sandbox;
 
     if let Err(error) = validate_resume_session_id(&context) {
+        let workspace_image = match config.workspace_cache.as_ref() {
+            Some(_) => workspace_promotion.map(|promotion| {
+                promotion.into_active_lease(WorkspaceImageActiveLeaseRequest {
+                    run_id,
+                    sandbox_id,
+                    profile_name: &params.profile_name,
+                    session_id: Some(idle_session_id.as_str()),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                    workspace_drive_available: true,
+                })
+            }),
+            None => {
+                if let Some(promotion) = workspace_promotion
+                    && let Err(error) = promotion
+                        .invalidate_current("reused sandbox ran without workspace image cache")
+                        .await
+                {
+                    let failure = ExecutionFailure::from_error(format!(
+                        "failed to invalidate workspace image cache before unconfigured-cache reuse: {error}"
+                    ));
+                    return (
+                        ExecuteOutcome {
+                            failure: Some(failure),
+                            sandbox: Some(sandbox),
+                            source_ip,
+                            network_log_session: None,
+                            workspace_image: None,
+                            workspace_promotable: false,
+                            guest_session_id: None,
+                        },
+                        telemetry,
+                    );
+                }
+                None
+            }
+        };
+        let workspace_promotable = workspace_image
+            .as_ref()
+            .is_some_and(|image| image.can_attempt_promotion(Some(idle_session_id.as_str())));
         return (
             ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(error)),
                 sandbox: Some(sandbox),
                 source_ip,
                 network_log_session: None,
-                workspace_image: None,
-                workspace_promotable: false,
+                workspace_image,
+                workspace_promotable,
                 guest_session_id: None,
             },
             telemetry,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -35,7 +35,7 @@ mod telemetry;
 pub(crate) use guest_state::{fix_guest_clock, reseed_guest_entropy};
 
 use agent_run::ProcessCancelTimeouts;
-use env::validate_execution_context_before_sandbox;
+use env::{validate_execution_context_before_sandbox, validate_resume_session_id};
 use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
     workspace_image_promotable,
@@ -465,6 +465,21 @@ pub async fn execute_job_reuse(
     let prev_storage = idle_parts.storage_fingerprints;
     let workspace_promotion = idle_parts.workspace_promotion;
     let sandbox = idle_parts.sandbox;
+
+    if let Err(error) = validate_resume_session_id(&context) {
+        return (
+            ExecuteOutcome {
+                failure: Some(ExecutionFailure::from_error(error)),
+                sandbox: Some(sandbox),
+                source_ip,
+                network_log_session: None,
+                workspace_image: None,
+                workspace_promotable: false,
+                guest_session_id: None,
+            },
+            telemetry,
+        );
+    }
 
     let workspace_image = match config.workspace_cache.as_ref() {
         Some(cache) => {

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -21,6 +21,7 @@ use super::{
 };
 use crate::ids::RunId;
 use crate::network_log_manager::NetworkLogSession;
+use crate::paths::diagnostic_session_fingerprint;
 use crate::proxy;
 use crate::telemetry::JobTelemetry;
 use crate::types::ExecutionContext;
@@ -519,7 +520,11 @@ pub(super) async fn execute_prepared_sandbox_run(
     let guest_session_id = if agent_result.exit_code() == 0 && context.session_id().is_none() {
         let id = read_guest_session_id(sandbox.as_ref(), context.run_id).await;
         if let Some(ref sid) = id {
-            info!(run_id = %context.run_id, session_id = %sid, "read guest session ID for parking");
+            info!(
+                run_id = %context.run_id,
+                session_fingerprint = %diagnostic_session_fingerprint(sid),
+                "read guest session ID for parking"
+            );
         }
         id
     } else {

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -13,7 +13,8 @@ use super::diagnostics::{
     AgentStdoutStreamDiagnostics, append_stdout_stream_diagnostics_to_stream_log, copy_guest_logs,
     read_guest_session_id,
 };
-use super::env::normalized_cli_agent_type;
+use super::env::{EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type};
+use super::session_restore::{canonical_codex_thread_id, is_valid_session_id};
 use super::telemetry::record_workspace_cache_result;
 use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,
@@ -518,7 +519,9 @@ pub(super) async fn execute_prepared_sandbox_run(
 
     // Read CLI-generated session ID for first-run parking.
     let guest_session_id = if agent_result.exit_code() == 0 && context.session_id().is_none() {
-        let id = read_guest_session_id(sandbox.as_ref(), context.run_id).await;
+        let id = read_guest_session_id(sandbox.as_ref(), context.run_id)
+            .await
+            .and_then(|id| normalize_guest_session_id_for_parking(context, id));
         if let Some(ref sid) = id {
             info!(
                 run_id = %context.run_id,
@@ -539,6 +542,36 @@ pub(super) async fn execute_prepared_sandbox_run(
         workspace_image: None,
         workspace_promotable: false,
         guest_session_id,
+    }
+}
+
+fn normalize_guest_session_id_for_parking(
+    context: &ExecutionContext,
+    session_id: String,
+) -> Option<String> {
+    match effective_cli_framework(&context.cli_agent_type) {
+        EffectiveCliFramework::Codex => canonical_codex_thread_id(&session_id).or_else(|| {
+            warn!(
+                run_id = %context.run_id,
+                framework = "codex",
+                session_fingerprint = %diagnostic_session_fingerprint(&session_id),
+                "ignoring invalid guest session ID for framework"
+            );
+            None
+        }),
+        EffectiveCliFramework::ClaudeCode => {
+            if is_valid_session_id(&session_id) {
+                Some(session_id)
+            } else {
+                warn!(
+                    run_id = %context.run_id,
+                    framework = "claude-code",
+                    session_fingerprint = %diagnostic_session_fingerprint(&session_id),
+                    "ignoring invalid guest session ID for framework"
+                );
+                None
+            }
+        }
     }
 }
 

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -235,9 +235,10 @@ fi"#;
         })
         .await?;
     if result.exit_code != 0 {
-        return Err(RunnerError::Internal(format_guest_exec_failure(
-            "codex session cleanup",
-            &result,
+        return Err(RunnerError::Internal(redact_codex_session_diagnostic(
+            format_guest_exec_failure("codex session cleanup", &result),
+            session_id,
+            session_path,
         )));
     }
     info!(
@@ -246,6 +247,20 @@ fi"#;
         "cleaned up existing codex session files before restore",
     );
     Ok(())
+}
+
+fn redact_codex_session_diagnostic(
+    message: String,
+    session_id: &str,
+    session_path: &str,
+) -> String {
+    let no_dashes = session_id.replace('-', "");
+    let mut redacted = message.replace(session_path, "[redacted-codex-session-path]");
+    redacted = redacted.replace(session_id, "[redacted-codex-session-id]");
+    if !no_dashes.is_empty() {
+        redacted = redacted.replace(&no_dashes, "[redacted-codex-session-id]");
+    }
+    redacted
 }
 
 /// Returns true if the session ID contains only safe characters (alphanumeric, dash, underscore).

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -325,11 +325,18 @@ fn redact_session_restore_diagnostic(
     session_id: &str,
     session_path: &str,
 ) -> String {
-    let mut redacted = message.replace(session_path, "[redacted-session-path]");
+    const SESSION_PATH_SENTINEL: &str = "\u{0}\u{1}";
+    const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
+    const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
+    const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
+
+    let mut redacted = message.replace(session_path, SESSION_PATH_SENTINEL);
     for sensitive in session_redaction_variants(session_id) {
-        redacted = redacted.replace(&sensitive, "[redacted-session-id]");
+        redacted = redacted.replace(&sensitive, SESSION_ID_SENTINEL);
     }
     redacted
+        .replace(SESSION_PATH_SENTINEL, REDACTED_SESSION_PATH)
+        .replace(SESSION_ID_SENTINEL, REDACTED_SESSION_ID)
 }
 
 fn session_redaction_variants(session_id: &str) -> Vec<String> {

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -294,7 +294,7 @@ fn redact_session_restore_sandbox_error(
             message,
         } => SandboxError::InvalidState {
             context,
-            state,
+            state: redact_session_restore_diagnostic(state, session_id, session_path),
             message: redact_session_restore_diagnostic(message, session_id, session_path),
         },
         SandboxError::Operation {
@@ -325,13 +325,26 @@ fn redact_session_restore_diagnostic(
     session_id: &str,
     session_path: &str,
 ) -> String {
-    let no_dashes = session_id.replace('-', "");
     let mut redacted = message.replace(session_path, "[redacted-session-path]");
-    redacted = redacted.replace(session_id, "[redacted-session-id]");
-    if !no_dashes.is_empty() {
-        redacted = redacted.replace(&no_dashes, "[redacted-session-id]");
+    for sensitive in session_redaction_variants(session_id) {
+        redacted = redacted.replace(&sensitive, "[redacted-session-id]");
     }
     redacted
+}
+
+fn session_redaction_variants(session_id: &str) -> Vec<String> {
+    let no_dashes = session_id.replace('-', "");
+    [
+        session_id.to_string(),
+        session_id.to_ascii_lowercase(),
+        session_id.to_ascii_uppercase(),
+        no_dashes.clone(),
+        no_dashes.to_ascii_lowercase(),
+        no_dashes.to_ascii_uppercase(),
+    ]
+    .into_iter()
+    .filter(|variant| !variant.is_empty())
+    .collect()
 }
 
 /// Returns true if the session ID contains only safe characters (alphanumeric, dash, underscore).

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -56,7 +56,7 @@ pub(super) async fn restore_claude_session(
     write_session_history_file(
         sandbox,
         &session_path,
-        &session.session_id,
+        &[&session.session_id],
         &session.session_history,
     )
     .await?;
@@ -159,7 +159,7 @@ pub(super) async fn restore_codex_session(
     write_session_history_file(
         sandbox,
         &session_path,
-        &session_id,
+        &[&session_id, &session.session_id],
         &session.session_history,
     )
     .await?;
@@ -251,7 +251,7 @@ fi"#;
     if result.exit_code != 0 {
         return Err(RunnerError::Internal(redact_session_restore_diagnostic(
             format_guest_exec_failure("codex session cleanup", &result),
-            session_id,
+            &[session_id],
             session_path,
         )));
     }
@@ -266,33 +266,33 @@ fi"#;
 async fn write_session_history_file(
     sandbox: &dyn Sandbox,
     session_path: &str,
-    session_id: &str,
+    session_ids: &[&str],
     session_history: &str,
 ) -> RunnerResult<()> {
     sandbox
         .write_file(session_path, session_history.as_bytes())
         .await
-        .map_err(|error| redact_session_restore_sandbox_error(error, session_id, session_path))
+        .map_err(|error| redact_session_restore_sandbox_error(error, session_ids, session_path))
 }
 
 fn redact_session_restore_sandbox_error(
     error: SandboxError,
-    session_id: &str,
+    session_ids: &[&str],
     session_path: &str,
 ) -> RunnerError {
     RunnerError::Sandbox(match error {
         SandboxError::BackendUnavailable { message } => SandboxError::BackendUnavailable {
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::Configuration { message } => SandboxError::Configuration {
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::Initialization { phase, message } => SandboxError::Initialization {
             phase,
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::Start { message } => SandboxError::Start {
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::InvalidState {
             context,
@@ -300,8 +300,8 @@ fn redact_session_restore_sandbox_error(
             message,
         } => SandboxError::InvalidState {
             context,
-            state: redact_session_restore_diagnostic(state, session_id, session_path),
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            state: redact_session_restore_diagnostic(state, session_ids, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::Operation {
             operation,
@@ -310,30 +310,32 @@ fn redact_session_restore_sandbox_error(
         } => SandboxError::Operation {
             operation,
             reason,
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::IdleTransition {
             transition,
             message,
         } => SandboxError::IdleTransition {
             transition,
-            message: redact_session_restore_diagnostic(message, session_id, session_path),
+            message: redact_session_restore_diagnostic(message, session_ids, session_path),
         },
         SandboxError::Io(error) => SandboxError::Io(std::io::Error::new(
             error.kind(),
-            redact_session_restore_diagnostic(error.to_string(), session_id, session_path),
+            redact_session_restore_diagnostic(error.to_string(), session_ids, session_path),
         )),
     })
 }
 
 fn redact_session_restore_diagnostic(
     message: String,
-    session_id: &str,
+    session_ids: &[&str],
     session_path: &str,
 ) -> String {
     let mut redacted = message.replace(session_path, SESSION_PATH_SENTINEL);
-    for sensitive in session_redaction_variants(session_id) {
-        redacted = redact_session_id_variant(redacted, &sensitive);
+    for session_id in session_ids {
+        for sensitive in session_redaction_variants(session_id) {
+            redacted = redact_session_id_variant(redacted, &sensitive);
+        }
     }
     redacted
         .replace(SESSION_PATH_SENTINEL, REDACTED_SESSION_PATH)

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -5,6 +5,7 @@ use tracing::{info, warn};
 
 use super::storage::format_guest_exec_failure;
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
+use crate::paths::diagnostic_session_fingerprint;
 use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
@@ -17,10 +18,7 @@ pub(super) async fn restore_session(
     // Applied up-front so unknown frameworks still reject malformed IDs in case the
     // skip branch is ever upgraded to a write.
     if !is_valid_session_id(&session.session_id) {
-        return Err(RunnerError::Internal(format!(
-            "invalid session_id: {}",
-            session.session_id
-        )));
+        return Err(RunnerError::Internal("invalid session_id".into()));
     }
 
     match context.cli_agent_type.as_str() {
@@ -52,7 +50,13 @@ pub(super) async fn restore_claude_session(
     sandbox
         .write_file(&session_path, session.session_history.as_bytes())
         .await?;
-    info!(run_id = %context.run_id, path = %session_path, "restored claude session history");
+    info!(
+        run_id = %context.run_id,
+        framework = "claude-code",
+        session_fingerprint = %diagnostic_session_fingerprint(&session.session_id),
+        bytes_in = session.session_history.len(),
+        "restored session history"
+    );
     Ok(())
 }
 
@@ -134,9 +138,8 @@ pub(super) async fn restore_codex_session(
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<()> {
-    let session_id = canonical_codex_thread_id(&session.session_id).ok_or_else(|| {
-        RunnerError::Internal(format!("invalid codex session_id: {}", session.session_id))
-    })?;
+    let session_id = canonical_codex_thread_id(&session.session_id)
+        .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
 
     let session_path =
         codex_restore_rollout_path(&session_id, &session.session_history, chrono::Utc::now());
@@ -149,9 +152,10 @@ pub(super) async fn restore_codex_session(
 
     info!(
         run_id = %context.run_id,
-        path = %session_path,
+        framework = "codex",
+        session_fingerprint = %diagnostic_session_fingerprint(&session_id),
         bytes_in = session.session_history.len(),
-        "restored codex session history",
+        "restored session history",
     );
     Ok(())
 }
@@ -238,7 +242,7 @@ fi"#;
     }
     info!(
         run_id = %context.run_id,
-        session_id = %session_id,
+        session_fingerprint = %diagnostic_session_fingerprint(session_id),
         "cleaned up existing codex session files before restore",
     );
     Ok(())

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -1,6 +1,6 @@
 //! CLI session restore helpers for guest agent frameworks.
 
-use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox, SandboxError};
 use tracing::{info, warn};
 
 use super::storage::format_guest_exec_failure;
@@ -47,9 +47,13 @@ pub(super) async fn restore_claude_session(
     let session_dir = format!("/home/user/.claude/projects/-{project_name}");
     let session_path = format!("{session_dir}/{}.jsonl", session.session_id);
 
-    sandbox
-        .write_file(&session_path, session.session_history.as_bytes())
-        .await?;
+    write_session_history_file(
+        sandbox,
+        &session_path,
+        &session.session_id,
+        &session.session_history,
+    )
+    .await?;
     info!(
         run_id = %context.run_id,
         framework = "claude-code",
@@ -146,9 +150,13 @@ pub(super) async fn restore_codex_session(
 
     cleanup_existing_codex_session_files(sandbox, context, &session_id, &session_path).await?;
 
-    sandbox
-        .write_file(&session_path, session.session_history.as_bytes())
-        .await?;
+    write_session_history_file(
+        sandbox,
+        &session_path,
+        &session_id,
+        &session.session_history,
+    )
+    .await?;
 
     info!(
         run_id = %context.run_id,
@@ -235,7 +243,7 @@ fi"#;
         })
         .await?;
     if result.exit_code != 0 {
-        return Err(RunnerError::Internal(redact_codex_session_diagnostic(
+        return Err(RunnerError::Internal(redact_session_restore_diagnostic(
             format_guest_exec_failure("codex session cleanup", &result),
             session_id,
             session_path,
@@ -249,16 +257,79 @@ fi"#;
     Ok(())
 }
 
-fn redact_codex_session_diagnostic(
+async fn write_session_history_file(
+    sandbox: &dyn Sandbox,
+    session_path: &str,
+    session_id: &str,
+    session_history: &str,
+) -> RunnerResult<()> {
+    sandbox
+        .write_file(session_path, session_history.as_bytes())
+        .await
+        .map_err(|error| redact_session_restore_sandbox_error(error, session_id, session_path))
+}
+
+fn redact_session_restore_sandbox_error(
+    error: SandboxError,
+    session_id: &str,
+    session_path: &str,
+) -> RunnerError {
+    RunnerError::Sandbox(match error {
+        SandboxError::BackendUnavailable { message } => SandboxError::BackendUnavailable {
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::Configuration { message } => SandboxError::Configuration {
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::Initialization { phase, message } => SandboxError::Initialization {
+            phase,
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::Start { message } => SandboxError::Start {
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::InvalidState {
+            context,
+            state,
+            message,
+        } => SandboxError::InvalidState {
+            context,
+            state,
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::Operation {
+            operation,
+            reason,
+            message,
+        } => SandboxError::Operation {
+            operation,
+            reason,
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::IdleTransition {
+            transition,
+            message,
+        } => SandboxError::IdleTransition {
+            transition,
+            message: redact_session_restore_diagnostic(message, session_id, session_path),
+        },
+        SandboxError::Io(error) => SandboxError::Io(std::io::Error::new(
+            error.kind(),
+            redact_session_restore_diagnostic(error.to_string(), session_id, session_path),
+        )),
+    })
+}
+
+fn redact_session_restore_diagnostic(
     message: String,
     session_id: &str,
     session_path: &str,
 ) -> String {
     let no_dashes = session_id.replace('-', "");
-    let mut redacted = message.replace(session_path, "[redacted-codex-session-path]");
-    redacted = redacted.replace(session_id, "[redacted-codex-session-id]");
+    let mut redacted = message.replace(session_path, "[redacted-session-path]");
+    redacted = redacted.replace(session_id, "[redacted-session-id]");
     if !no_dashes.is_empty() {
-        redacted = redacted.replace(&no_dashes, "[redacted-codex-session-id]");
+        redacted = redacted.replace(&no_dashes, "[redacted-session-id]");
     }
     redacted
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -14,6 +14,7 @@ const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
 const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
 const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
 const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
+const MAX_SESSION_ID_LEN: usize = 128;
 
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
@@ -386,9 +387,11 @@ fn session_redaction_variants(session_id: &str) -> Vec<String> {
     .collect()
 }
 
-/// Returns true if the session ID contains only safe characters (alphanumeric, dash, underscore).
+/// Returns true if the session ID is short enough for guest filenames and
+/// contains only safe characters (alphanumeric, dash, underscore).
 pub(super) fn is_valid_session_id(id: &str) -> bool {
     !id.is_empty()
+        && id.len() <= MAX_SESSION_ID_LEN
         && id
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -9,6 +9,12 @@ use crate::paths::diagnostic_session_fingerprint;
 use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
+const SESSION_PATH_SENTINEL: &str = "\u{0}\u{1}";
+const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
+const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
+const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
+const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
+
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
@@ -325,18 +331,42 @@ fn redact_session_restore_diagnostic(
     session_id: &str,
     session_path: &str,
 ) -> String {
-    const SESSION_PATH_SENTINEL: &str = "\u{0}\u{1}";
-    const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
-    const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
-    const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
-
     let mut redacted = message.replace(session_path, SESSION_PATH_SENTINEL);
     for sensitive in session_redaction_variants(session_id) {
-        redacted = redacted.replace(&sensitive, SESSION_ID_SENTINEL);
+        redacted = redact_session_id_variant(redacted, &sensitive);
     }
     redacted
         .replace(SESSION_PATH_SENTINEL, REDACTED_SESSION_PATH)
         .replace(SESSION_ID_SENTINEL, REDACTED_SESSION_ID)
+}
+
+fn redact_session_id_variant(message: String, sensitive: &str) -> String {
+    if sensitive.len() >= SUBSTRING_SESSION_ID_REDACTION_MIN_LEN {
+        return message.replace(sensitive, SESSION_ID_SENTINEL);
+    }
+
+    let mut redacted = String::with_capacity(message.len());
+    let mut last = 0;
+    for (start, _) in message.match_indices(sensitive) {
+        let end = start + sensitive.len();
+        let previous = message[..start].chars().next_back();
+        let next = message[end..].chars().next();
+        if is_session_token_boundary(previous) && is_session_token_boundary(next) {
+            redacted.push_str(&message[last..start]);
+            redacted.push_str(SESSION_ID_SENTINEL);
+            last = end;
+        }
+    }
+    if last == 0 {
+        message
+    } else {
+        redacted.push_str(&message[last..]);
+        redacted
+    }
+}
+
+fn is_session_token_boundary(ch: Option<char>) -> bool {
+    !ch.is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 fn session_redaction_variants(session_id: &str) -> Vec<String> {

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -333,6 +333,16 @@ async fn read_guest_session_id_returns_none_on_missing_or_empty_file() {
 }
 
 #[tokio::test]
+async fn read_guest_session_id_rejects_invalid_content() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_read_file_result(Ok(Some(b" ../session \n".to_vec())));
+
+    let session_id = read_guest_session_id(&sandbox, RunId::nil()).await;
+
+    assert!(session_id.is_none());
+}
+
+#[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
     let sandbox = MockSandbox::new("test");
     let diagnostic = FailureDiagnostic::new(

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -343,6 +343,16 @@ async fn read_guest_session_id_rejects_invalid_content() {
 }
 
 #[tokio::test]
+async fn read_guest_session_id_rejects_overlong_content() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_read_file_result(Ok(Some("a".repeat(129).into_bytes())));
+
+    let session_id = read_guest_session_id(&sandbox, RunId::nil()).await;
+
+    assert!(session_id.is_none());
+}
+
+#[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
     let sandbox = MockSandbox::new("test");
     let diagnostic = FailureDiagnostic::new(

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -585,10 +585,12 @@ fn build_env_json_rejects_invalid_codex_resume_session_id() {
         });
 
         let error = build_env_for_test_result(&ctx, "http://localhost").unwrap_err();
+        let message = error.to_string();
 
+        assert!(message.contains("invalid codex session_id"), "got: {error}");
         assert!(
-            error.to_string().contains("invalid codex session_id"),
-            "got: {error}"
+            !message.contains(session_id),
+            "invalid codex error must not echo raw session id: {message}"
         );
     }
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -149,7 +149,7 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
     assert_eq!(system_stream_log, b"bootstrap diagnostic\n");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw_id() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -150,6 +150,52 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
 }
 
 #[tokio::test]
+async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let raw_session_id = "sess-sensitive-first-run-17975";
+    overrides.push_wait_process_exit(ProcessExit::new(1, 0, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let source_ip = sandbox.source_ip().to_string();
+    let network_log_session = register_proxy(&config, &ctx, &source_ip).await.unwrap();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let (outcome, events) = capture_async_events(execute_prepared_sandbox_run(
+        PreparedSandboxRun {
+            sandbox,
+            source_ip,
+            network_log_session,
+        },
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(outcome.guest_session_id.as_deref(), Some(raw_session_id));
+    assert_captured_events_do_not_contain(&events, raw_session_id);
+    let event = captured_event(&events, "read guest session ID for parking");
+    assert_eq!(
+        event.fields.get("session_fingerprint").map(String::as_str),
+        Some(crate::paths::diagnostic_session_fingerprint(raw_session_id).as_str())
+    );
+    assert!(
+        !event.fields.contains_key("session_id"),
+        "guest session read diagnostic must not include raw session_id field: {event:#?}"
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_aborts_drain_task_on_wait_process_error() {
     // Simulate wait_process timeout: stdout channel stays open (sender held
     // alive by MockSandbox), wait_process returns error.
@@ -203,6 +249,42 @@ async fn execute_inner_aborts_drain_task_on_wait_process_error() {
         "network log session must be returned on post-start execution failure"
     );
     assert_proxy_registry_empty(dir.path()).await;
+}
+
+async fn capture_async_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+where
+    F: std::future::Future,
+{
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let output = future.await;
+    drop(guard);
+    (output, captured.entries())
+}
+
+fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+    events
+        .iter()
+        .find(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|actual| actual == message)
+        })
+        .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+}
+
+fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
+    for event in events {
+        for (field, value) in &event.fields {
+            assert!(
+                !value.contains(raw),
+                "captured field {field} leaked raw session id {raw:?}: {event:#?}"
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -195,6 +195,100 @@ async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn execute_prepared_sandbox_run_canonicalizes_codex_guest_session_id_for_parking() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let raw_session_id = "019E9154C30470F0ADDE36EFB1BE1701";
+    let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    overrides.push_wait_process_exit(ProcessExit::new(1, 0, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let source_ip = sandbox.source_ip().to_string();
+    let network_log_session = register_proxy(&config, &ctx, &source_ip).await.unwrap();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let (outcome, events) = capture_async_events(execute_prepared_sandbox_run(
+        PreparedSandboxRun {
+            sandbox,
+            source_ip,
+            network_log_session,
+        },
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(
+        outcome.guest_session_id.as_deref(),
+        Some(canonical_session_id)
+    );
+    assert_captured_events_do_not_contain(&events, raw_session_id);
+    let event = captured_event(&events, "read guest session ID for parking");
+    assert_eq!(
+        event.fields.get("session_fingerprint").map(String::as_str),
+        Some(crate::paths::diagnostic_session_fingerprint(canonical_session_id).as_str())
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn execute_prepared_sandbox_run_ignores_non_uuid_codex_guest_session_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let raw_session_id = "codex-safe-but-not-uuid";
+    overrides.push_wait_process_exit(ProcessExit::new(1, 0, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let source_ip = sandbox.source_ip().to_string();
+    let network_log_session = register_proxy(&config, &ctx, &source_ip).await.unwrap();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let (outcome, events) = capture_async_events(execute_prepared_sandbox_run(
+        PreparedSandboxRun {
+            sandbox,
+            source_ip,
+            network_log_session,
+        },
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    ))
+    .await;
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert!(outcome.guest_session_id.is_none());
+    assert_captured_events_do_not_contain(&events, raw_session_id);
+    let event = captured_event(&events, "ignoring invalid guest session ID for framework");
+    assert_eq!(
+        event.fields.get("framework").map(String::as_str),
+        Some("codex")
+    );
+    assert_eq!(
+        event.fields.get("session_fingerprint").map(String::as_str),
+        Some(crate::paths::diagnostic_session_fingerprint(raw_session_id).as_str())
+    );
+}
+
 #[tokio::test]
 async fn execute_inner_aborts_drain_task_on_wait_process_error() {
     // Simulate wait_process timeout: stdout channel stays open (sender held

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -102,6 +102,46 @@ async fn execute_job_reuse_claude_tool_validation_failure_returns_sandbox() {
 }
 
 #[tokio::test]
+async fn execute_job_reuse_invalid_resume_session_does_not_lease_workspace_image() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = SessionWorkspaceCache::new(RunnerPaths::new(dir.path().join("runner")));
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache);
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let source_ip = sandbox.source_ip().to_string();
+    let (idle_sandbox, _lease) =
+        make_reusable_idle_sandbox(sandbox, source_ip, "bad-session").await;
+    let raw_session_id = "../bad-session";
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        session_id: raw_session_id.into(),
+        session_history: "{}".into(),
+    });
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (reuse_outcome, _telemetry) =
+        execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+
+    assert_eq!(reuse_outcome.exit_code(), 1);
+    let error = reuse_outcome.error().unwrap();
+    assert!(error.contains("invalid session_id"));
+    assert!(!error.contains(raw_session_id));
+    assert!(reuse_outcome.sandbox.is_some());
+    assert!(reuse_outcome.network_log_session.is_none());
+    assert!(reuse_outcome.workspace_image.is_none());
+    assert!(!reuse_outcome.workspace_promotable);
+    assert!(
+        overrides.start_process_calls().is_empty(),
+        "reused sandbox must not start a process after resume session validation failure"
+    );
+}
+
+#[tokio::test]
 async fn execute_job_reuse_appends_stream_limit_marker() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -455,6 +455,63 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
     );
 }
 
+#[tokio::test]
+async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidden() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let session_id = "sess-cache-reuse-invalid-resume";
+    let (idle_sandbox, _current_image, overrides) =
+        reusable_idle_sandbox_with_workspace_promotion(&cache, &runner_paths, &params, session_id)
+            .await;
+
+    let raw_session_id = "../invalid-resume";
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        session_id: raw_session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    });
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (reuse_outcome, _telemetry) =
+        execute_job_reuse(idle_sandbox, ctx, &config, &params, cancel).await;
+
+    assert_eq!(reuse_outcome.exit_code(), 1);
+    let error = reuse_outcome.error().unwrap();
+    assert!(error.contains("invalid session_id"));
+    assert!(!error.contains(raw_session_id));
+    assert!(reuse_outcome.sandbox.is_some());
+    assert!(reuse_outcome.workspace_promotable);
+    assert!(reuse_outcome.workspace_image.is_some());
+    assert!(
+        overrides.start_process_calls().is_empty(),
+        "reused sandbox must not start a process after resume session validation failure"
+    );
+
+    let checkout = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            run_id: RunId::new_v4(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: &params.profile_name,
+            session_id: Some(session_id),
+            working_dir: CANONICAL_WORKING_DIR,
+            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(
+        checkout.result(),
+        WorkspaceCacheCheckoutResult::LockBusy,
+        "invalid resume sessions must not release the hidden cache baseline before finalization can promote or invalidate the live workspace"
+    );
+}
+
 async fn reusable_idle_sandbox_with_workspace_promotion(
     cache: &SessionWorkspaceCache,
     runner_paths: &RunnerPaths,

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -341,6 +341,55 @@ async fn restore_session_fails_when_codex_cleanup_fails() {
 }
 
 #[tokio::test]
+async fn restore_session_redacts_codex_cleanup_failure_output() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let session_id_no_dashes = session_id.replace('-', "");
+    let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
+    let session = ResumeSession {
+        session_id: session_id.into(),
+        session_history: format!(
+            "{}\n",
+            serde_json::json!({
+                "timestamp": "2026-06-04T07:18:08.001Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "timestamp": "2026-06-04T07:18:08.000Z",
+                },
+            }),
+        ),
+    };
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        format!("stdout includes {session_id_no_dashes}").into_bytes(),
+        format!("find: {session_path}: Permission denied").into_bytes(),
+    )));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("codex session cleanup failed"));
+    assert!(message.contains("[redacted-codex-session-path]"));
+    assert!(message.contains("[redacted-codex-session-id]"));
+    assert!(
+        !message.contains(session_id),
+        "cleanup failure must not echo raw session id: {message}"
+    );
+    assert!(
+        !message.contains(&session_id_no_dashes),
+        "cleanup failure must not echo no-dash session id: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "cleanup failure must not echo raw session path: {message}"
+    );
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
 async fn restore_session_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -544,6 +544,38 @@ async fn restore_session_redacts_write_file_invalid_state() {
 }
 
 #[tokio::test]
+async fn restore_session_redaction_does_not_rewrite_markers() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    let session_id = "session";
+    let session_path = "/home/user/.claude/projects/-home-user-workspace/session.jsonl";
+    let session = ResumeSession {
+        session_id: session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    };
+    sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
+        "failed to write {session_path} for {session_id}"
+    ))));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("failed to write [redacted-session-path] for [redacted-session-id]"),
+        "redaction markers should stay readable: {message}"
+    );
+    assert!(
+        !message.contains("[redacted-[redacted-session-id]"),
+        "redaction markers must not be recursively rewritten: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "write failure must not echo raw session path: {message}"
+    );
+}
+
+#[tokio::test]
 async fn restore_session_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -1,4 +1,4 @@
-use sandbox::ExecResult;
+use sandbox::{ExecResult, SandboxError, SandboxInvalidStateContext, SandboxOperation};
 use sandbox_mock::MockSandbox;
 use tracing_subscriber::prelude::*;
 
@@ -462,6 +462,84 @@ async fn restore_session_redacts_codex_write_file_error() {
     assert!(
         !message.contains(session_path),
         "write failure must not echo raw session path: {message}"
+    );
+}
+
+#[tokio::test]
+async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let raw_session_id = "019E9154C30470F0ADDE36EFB1BE1701";
+    let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
+    let session = ResumeSession {
+        session_id: raw_session_id.into(),
+        session_history: format!(
+            "{}\n",
+            serde_json::json!({
+                "timestamp": "2026-06-04T07:18:08.001Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": canonical_session_id,
+                    "timestamp": "2026-06-04T07:18:08.000Z",
+                },
+            }),
+        ),
+    };
+    sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
+        "failed to write original thread {raw_session_id} at {session_path}"
+    ))));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("[redacted-session-path]"));
+    assert!(message.contains("[redacted-session-id]"));
+    assert!(
+        !message.contains(raw_session_id),
+        "write failure must not echo raw no-dash session id: {message}"
+    );
+    assert!(
+        !message.contains(canonical_session_id),
+        "write failure must not echo canonical session id: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "write failure must not echo raw session path: {message}"
+    );
+}
+
+#[tokio::test]
+async fn restore_session_redacts_write_file_invalid_state() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    let session_id = "sess-invalid-state-17975";
+    let session_path =
+        "/home/user/.claude/projects/-home-user-workspace/sess-invalid-state-17975.jsonl";
+    let session = ResumeSession {
+        session_id: session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    };
+    sandbox.push_write_file_result(Err(SandboxError::InvalidState {
+        context: SandboxInvalidStateContext::Operation(SandboxOperation::WriteFile),
+        state: format!("blocked for {session_path}"),
+        message: format!("cannot write session {session_id}"),
+    }));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("[redacted-session-path]"));
+    assert!(message.contains("[redacted-session-id]"));
+    assert!(
+        !message.contains(session_id),
+        "invalid-state failure must not echo raw session id: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "invalid-state failure must not echo raw session path: {message}"
     );
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -65,7 +65,7 @@ async fn restore_session_rejects_invalid_session_id() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
@@ -171,7 +171,7 @@ async fn restore_session_writes_codex_session() {
     assert_eq!(writes[0].content, session.session_history.as_bytes());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
@@ -372,8 +372,8 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
 
     let message = err.to_string();
     assert!(message.contains("codex session cleanup failed"));
-    assert!(message.contains("[redacted-codex-session-path]"));
-    assert!(message.contains("[redacted-codex-session-id]"));
+    assert!(message.contains("[redacted-session-path]"));
+    assert!(message.contains("[redacted-session-id]"));
     assert!(
         !message.contains(session_id),
         "cleanup failure must not echo raw session id: {message}"
@@ -387,6 +387,82 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
         "cleanup failure must not echo raw session path: {message}"
     );
     assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
+async fn restore_session_redacts_claude_write_file_error() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    let session_id = "sess-sensitive-write-17975";
+    let session_path =
+        "/home/user/.claude/projects/-home-user-workspace/sess-sensitive-write-17975.jsonl";
+    let session = ResumeSession {
+        session_id: session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    };
+    sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
+        "failed to write {session_path} for {session_id}"
+    ))));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("[redacted-session-path]"));
+    assert!(message.contains("[redacted-session-id]"));
+    assert!(
+        !message.contains(session_id),
+        "write failure must not echo raw session id: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "write failure must not echo raw session path: {message}"
+    );
+}
+
+#[tokio::test]
+async fn restore_session_redacts_codex_write_file_error() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let session_id_no_dashes = session_id.replace('-', "");
+    let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
+    let session = ResumeSession {
+        session_id: session_id.into(),
+        session_history: format!(
+            "{}\n",
+            serde_json::json!({
+                "timestamp": "2026-06-04T07:18:08.001Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "timestamp": "2026-06-04T07:18:08.000Z",
+                },
+            }),
+        ),
+    };
+    sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
+        "failed to rename temp file to {session_path}: thread {session_id_no_dashes}"
+    ))));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("[redacted-session-path]"));
+    assert!(message.contains("[redacted-session-id]"));
+    assert!(
+        !message.contains(session_id),
+        "write failure must not echo raw session id: {message}"
+    );
+    assert!(
+        !message.contains(&session_id_no_dashes),
+        "write failure must not echo no-dash session id: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "write failure must not echo raw session path: {message}"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -1,8 +1,10 @@
 use sandbox::ExecResult;
 use sandbox_mock::MockSandbox;
+use tracing_subscriber::prelude::*;
 
 use super::super::session_restore::{is_valid_session_id, restore_session};
-use super::support::{minimal_context, sandbox_write_file_error};
+use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
+use crate::paths::diagnostic_session_fingerprint;
 use crate::types::ResumeSession;
 
 #[test]
@@ -49,12 +51,48 @@ async fn restore_session_writes_history() {
 async fn restore_session_rejects_invalid_session_id() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
+    let raw_session_id = "../../etc/passwd";
     let session = ResumeSession {
-        session_id: "../../etc/passwd".into(),
+        session_id: raw_session_id.into(),
         session_history: "data".into(),
     };
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
-    assert!(err.to_string().contains("invalid session_id"));
+    let message = err.to_string();
+    assert!(message.contains("invalid session_id"));
+    assert!(
+        !message.contains(raw_session_id),
+        "invalid-session error must not echo raw session id: {message}"
+    );
+}
+
+#[tokio::test]
+async fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    let raw_session_id = "sess-sensitive-restore-17975";
+    let session = ResumeSession {
+        session_id: raw_session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    };
+
+    let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session)).await;
+
+    result.unwrap();
+    assert_captured_events_do_not_contain(&events, raw_session_id);
+    let event = captured_event(&events, "restored session history");
+    assert_eq!(
+        event.fields.get("framework").map(String::as_str),
+        Some("claude-code")
+    );
+    assert_eq!(
+        event.fields.get("session_fingerprint").map(String::as_str),
+        Some(diagnostic_session_fingerprint(raw_session_id).as_str())
+    );
+    assert!(
+        !event.fields.contains_key("path"),
+        "restore diagnostic must not include a path embedding the session id: {event:#?}"
+    );
 }
 
 #[tokio::test]
@@ -131,6 +169,50 @@ async fn restore_session_writes_codex_session() {
         writes[0].path
     );
     assert_eq!(writes[0].content, session.session_history.as_bytes());
+}
+
+#[tokio::test]
+async fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let raw_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let session = ResumeSession {
+        session_id: raw_session_id.into(),
+        session_history: "{}\n".into(),
+    };
+
+    let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session)).await;
+
+    result.unwrap();
+    assert_captured_events_do_not_contain(&events, raw_session_id);
+    let restore_event = captured_event(&events, "restored session history");
+    assert_eq!(
+        restore_event.fields.get("framework").map(String::as_str),
+        Some("codex")
+    );
+    assert_eq!(
+        restore_event
+            .fields
+            .get("session_fingerprint")
+            .map(String::as_str),
+        Some(diagnostic_session_fingerprint(raw_session_id).as_str())
+    );
+    assert!(
+        !restore_event.fields.contains_key("path"),
+        "restore diagnostic must not include a path embedding the session id: {restore_event:#?}"
+    );
+    let cleanup_event = captured_event(
+        &events,
+        "cleaned up existing codex session files before restore",
+    );
+    assert_eq!(
+        cleanup_event
+            .fields
+            .get("session_fingerprint")
+            .map(String::as_str),
+        Some(diagnostic_session_fingerprint(raw_session_id).as_str())
+    );
 }
 
 #[tokio::test]
@@ -222,9 +304,11 @@ async fn restore_session_rejects_short_codex_session_id_without_cleanup() {
 
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
+    let message = err.to_string();
+    assert!(message.contains("invalid codex session_id"), "got: {err}");
     assert!(
-        err.to_string().contains("invalid codex session_id"),
-        "got: {err}"
+        !message.contains("abc"),
+        "invalid codex error must not echo raw session id: {message}"
     );
     assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
@@ -304,4 +388,40 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(exec_calls[0].cmd.contains(".jsonl.vm0tmp-*"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
     assert!(exec_calls[0].cmd.contains("-delete"));
+}
+
+async fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+where
+    F: std::future::Future,
+{
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let output = future.await;
+    drop(guard);
+    (output, captured.entries())
+}
+
+fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+    events
+        .iter()
+        .find(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|actual| actual == message)
+        })
+        .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+}
+
+fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
+    for event in events {
+        for (field, value) in &event.fields {
+            assert!(
+                !value.contains(raw),
+                "captured field {field} leaked raw session id {raw:?}: {event:#?}"
+            );
+        }
+    }
 }

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -20,6 +20,12 @@ fn session_id_validation_rejects_path_traversal() {
     for id in invalid_ids {
         assert!(!is_valid_session_id(id), "expected rejection for: {id:?}");
     }
+
+    let overlong_id = "a".repeat(129);
+    assert!(
+        !is_valid_session_id(&overlong_id),
+        "expected overlong session id rejection"
+    );
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -511,6 +511,45 @@ async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
 }
 
 #[tokio::test]
+async fn restore_session_redacts_codex_mixed_case_original_write_file_error() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let raw_session_id = "019e9154C30470f0ADDE36efB1be1701";
+    let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let session = ResumeSession {
+        session_id: raw_session_id.into(),
+        session_history: format!(
+            "{}\n",
+            serde_json::json!({
+                "timestamp": "2026-06-04T07:18:08.001Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": canonical_session_id,
+                    "timestamp": "2026-06-04T07:18:08.000Z",
+                },
+            }),
+        ),
+    };
+    sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
+        "failed to write original thread {raw_session_id} with canonical {canonical_session_id}"
+    ))));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("[redacted-session-id]"));
+    assert!(
+        !message.contains(raw_session_id),
+        "write failure must not echo mixed-case raw session id: {message}"
+    );
+    assert!(
+        !message.contains(canonical_session_id),
+        "write failure must not echo canonical session id: {message}"
+    );
+}
+
+#[tokio::test]
 async fn restore_session_redacts_write_file_invalid_state() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -576,6 +576,38 @@ async fn restore_session_redaction_does_not_rewrite_markers() {
 }
 
 #[tokio::test]
+async fn restore_session_redaction_preserves_words_for_short_ids() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    let session_id = "a";
+    let session_path = "/home/user/.claude/projects/-home-user-workspace/a.jsonl";
+    let session = ResumeSession {
+        session_id: session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    };
+    sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
+        "failed to write {session_path} for {session_id}"
+    ))));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("failed to write [redacted-session-path] for [redacted-session-id]"),
+        "short session id redaction should preserve surrounding words: {message}"
+    );
+    assert!(
+        !message.contains("f[redacted-session-id]iled"),
+        "short session id redaction must not rewrite ordinary words: {message}"
+    );
+    assert!(
+        !message.contains(session_path),
+        "write failure must not echo raw session path: {message}"
+    );
+}
+
+#[tokio::test]
 async fn restore_session_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -486,6 +486,7 @@ pub struct ReusableIdleSandbox {
 
 pub struct ReusableIdleSandboxParts {
     pub sandbox: Box<dyn Sandbox>,
+    pub session_id: String,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
     pub workspace_promotion: Option<WorkspaceImagePromotionContext>,
@@ -503,7 +504,7 @@ impl ReusableIdleSandbox {
             workspace_promotion,
         } = self;
         let IdleSandboxMetadata {
-            session_id: _,
+            session_id,
             sandbox_id: _,
             profile_name: _,
             device_rate_limits: _,
@@ -514,6 +515,7 @@ impl ReusableIdleSandbox {
 
         ReusableIdleSandboxParts {
             sandbox,
+            session_id,
             source_ip,
             storage_fingerprints,
             workspace_promotion,
@@ -1176,6 +1178,7 @@ mod tests {
         let sandbox = *sandbox;
         assert_eq!(sandbox.sandbox_id(), sandbox_id);
         let reused_parts = sandbox.into_parts();
+        assert_eq!(reused_parts.session_id, session_id);
         assert_eq!(reused_parts.source_ip, source_ip);
         assert_eq!(
             reused_parts.storage_fingerprints.storages,

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -48,6 +48,15 @@ pub(crate) fn short_digest(s: &str) -> String {
     hex::encode(prefix)
 }
 
+/// Stable non-reversible label for diagnostics that need to correlate one CLI
+/// session across logs without exposing the resumable session ID.
+///
+/// Do not use this value for resume, parking, cache metadata, or API payloads;
+/// it is diagnostic-only.
+pub(crate) fn diagnostic_session_fingerprint(session_id: &str) -> String {
+    short_digest(session_id)
+}
+
 /// Versioned digest key for host-shared session workspace image baselines.
 ///
 /// The raw CLI session id is untrusted and must not be embedded directly in
@@ -561,6 +570,20 @@ mod tests {
         assert_eq!(home.ca_dir(), PathBuf::from("/test/ca"));
         assert_eq!(home.debootstrap_dir(), PathBuf::from("/test/debootstrap"));
         assert_eq!(home.locks_dir(), PathBuf::from("/test/locks"));
+    }
+
+    #[test]
+    fn diagnostic_session_fingerprint_is_stable_short_hex() {
+        let raw_session_id = "sess-sensitive-paths-17975";
+        let fingerprint = diagnostic_session_fingerprint(raw_session_id);
+
+        assert_eq!(fingerprint, diagnostic_session_fingerprint(raw_session_id));
+        assert_ne!(fingerprint, raw_session_id);
+        assert_eq!(fingerprint.len(), 16);
+        assert!(
+            fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "fingerprint should be hex: {fingerprint}"
+        );
     }
 
     #[test]

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -4,6 +4,7 @@ use futures_util::FutureExt;
 use sandbox::Sandbox;
 use tracing::warn;
 
+use crate::paths::diagnostic_session_fingerprint;
 use crate::workspace_image_cache::WorkspaceImagePromotionContext;
 use crate::workspace_mount::flush_and_unmount_workspace_drive;
 
@@ -24,11 +25,12 @@ pub(crate) async fn promote_workspace_image_from_active_sandbox(
     {
         Ok(promoted) => promoted,
         Err(_) => {
+            let session_fingerprint = diagnostic_session_fingerprint(promotion.session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_id = promotion.session_id(),
+                session_fingerprint = %session_fingerprint,
                 reason,
                 "workspace image cache promotion panicked"
             );
@@ -45,11 +47,12 @@ async fn promote_workspace_image_from_active_sandbox_inner(
     match flush_and_unmount_workspace_drive(sandbox, promotion.run_id()).await {
         Ok(()) => {}
         Err(e) => {
+            let session_fingerprint = diagnostic_session_fingerprint(promotion.session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_id = promotion.session_id(),
+                session_fingerprint = %session_fingerprint,
                 reason,
                 error = %e,
                 "workspace image cache promotion skipped because guest unmount failed"
@@ -61,11 +64,12 @@ async fn promote_workspace_image_from_active_sandbox_inner(
     match promotion.promote().await {
         Ok(promoted) => promoted,
         Err(e) => {
+            let session_fingerprint = diagnostic_session_fingerprint(promotion.session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_id = promotion.session_id(),
+                session_fingerprint = %session_fingerprint,
                 reason,
                 error = %e,
                 "workspace image cache promotion failed"
@@ -87,11 +91,12 @@ pub(crate) async fn promote_workspace_image_from_parked_sandbox(
     match AssertUnwindSafe(sandbox.unpark()).catch_unwind().await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
+            let session_fingerprint = diagnostic_session_fingerprint(promotion.session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_id = promotion.session_id(),
+                session_fingerprint = %session_fingerprint,
                 reason,
                 error = %e,
                 "workspace image cache promotion skipped because idle sandbox unpark failed"
@@ -99,11 +104,12 @@ pub(crate) async fn promote_workspace_image_from_parked_sandbox(
             return false;
         }
         Err(_) => {
+            let session_fingerprint = diagnostic_session_fingerprint(promotion.session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_id = promotion.session_id(),
+                session_fingerprint = %session_fingerprint,
                 reason,
                 "workspace image cache promotion skipped because idle sandbox unpark panicked"
             );

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -10,6 +10,8 @@ use sandbox::{
     Sandbox, SandboxFactory, SandboxId, StartProcessRequest,
 };
 use sandbox_mock::{ExecMatcher, MockSandboxFactory, MockSandboxOverrides};
+use tracing_subscriber::prelude::*;
+use tracing_test_support::{CapturedEvent, CapturedEvents};
 
 async fn mock_sandbox_with_overrides(
     sandbox_id: SandboxId,
@@ -157,6 +159,40 @@ async fn parked_workspace_promotion_unpark_error_skips_cache() {
 }
 
 #[tokio::test]
+async fn parked_workspace_promotion_warning_uses_session_fingerprint() {
+    let raw_session_id = "sess-sensitive-promotion-17975";
+    let fixture = WorkspacePromotionFixture::new(raw_session_id).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated unpark failure".into(),
+    }));
+    let mut sandbox = mock_sandbox_with_overrides(fixture.sandbox_id, Arc::clone(&overrides)).await;
+
+    let (promoted, events) = capture_promotion_events(promote_workspace_image_from_parked_sandbox(
+        sandbox.as_mut(),
+        Some(&fixture.promotion),
+        "test",
+    ))
+    .await;
+
+    assert!(!promoted);
+    assert_captured_events_do_not_contain(&events, raw_session_id);
+    let event = captured_event(
+        &events,
+        "workspace image cache promotion skipped because idle sandbox unpark failed",
+    );
+    assert_eq!(
+        event.fields.get("session_fingerprint").map(String::as_str),
+        Some(crate::paths::diagnostic_session_fingerprint(raw_session_id).as_str())
+    );
+    assert!(
+        !event.fields.contains_key("session_id"),
+        "promotion diagnostic must not include raw session_id field: {event:#?}"
+    );
+}
+
+#[tokio::test]
 async fn parked_workspace_promotion_unpark_panic_skips_cache() {
     let fixture = WorkspacePromotionFixture::new("sess-parked-unpark-panic").await;
     let overrides = Arc::new(MockSandboxOverrides::new());
@@ -215,4 +251,40 @@ async fn parked_workspace_promotion_guest_exec_panic_skips_cache() {
     assert!(!promoted);
     drop(fixture.promotion);
     assert!(fixture.cache.held_session_states().await.is_empty());
+}
+
+async fn capture_promotion_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+where
+    F: std::future::Future,
+{
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let output = future.await;
+    drop(guard);
+    (output, captured.entries())
+}
+
+fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+    events
+        .iter()
+        .find(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|actual| actual == message)
+        })
+        .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
+}
+
+fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
+    for event in events {
+        for (field, value) in &event.fields {
+            assert!(
+                !value.contains(raw),
+                "captured field {field} leaked raw session id {raw:?}: {event:#?}"
+            );
+        }
+    }
 }

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -158,7 +158,7 @@ async fn parked_workspace_promotion_unpark_error_skips_cache() {
     assert!(fixture.cache.held_session_states().await.is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn parked_workspace_promotion_warning_uses_session_fingerprint() {
     let raw_session_id = "sess-sensitive-promotion-17975";
     let fixture = WorkspacePromotionFixture::new(raw_session_id).await;


### PR DESCRIPTION
## Summary
- add a diagnostic-only session fingerprint helper for runner logs
- replace raw session IDs and session-history paths in runner diagnostics with fingerprints or counts
- keep functional session affinity state unchanged for resume, idle pool, status, workspace cache, and provider payloads

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check
- cargo test --manifest-path crates/Cargo.toml -p runner diagnostic_session_fingerprint
- cargo test --manifest-path crates/Cargo.toml -p runner session_restore
- cargo test --manifest-path crates/Cargo.toml -p runner sandbox_run
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_promotion
- cargo test --manifest-path crates/Cargo.toml -p runner doctor
- cargo test --manifest-path crates/Cargo.toml -p runner heartbeat
- cargo test --manifest-path crates/Cargo.toml -p runner sandbox_finalization
- cargo test --manifest-path crates/Cargo.toml -p runner job_discovery
- cargo test --manifest-path crates/Cargo.toml -p runner env_tests

Closes #17975