### PR TITLE
refactor: remove chat assistant event consumer route

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -39,7 +39,6 @@ import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalEventConsumerAgentPhoneTypingRoutes } from "./routes/internal-event-consumers-agentphone-typing";
-import { internalEventConsumerChatAssistantRoutes } from "./routes/internal-event-consumers-chat-assistant";
 import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
 import { legacyFileRoutes } from "./routes/legacy-file";
 import { logsSearchRoutes } from "./routes/logs-search";
@@ -200,7 +199,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalEventConsumerAgentPhoneTypingRoutes,
-  ...internalEventConsumerChatAssistantRoutes,
   ...internalEventConsumerTelegramTypingRoutes,
   ...legacyFileRoutes,
   ...logsSearchRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -1,10 +1,6 @@
 import { createHmac, randomUUID } from "node:crypto";
 
 import {
-  internalEventConsumerChatAssistantContract,
-  type eventConsumerPayloadSchema,
-} from "@vm0/api-contracts/contracts/internal-event-consumers";
-import {
   zeroEmailInboundContract,
   zeroEmailTriggerCallbackContract,
 } from "@vm0/api-contracts/contracts/zero-email";
@@ -41,7 +37,6 @@ import {
   type TestContext,
 } from "../../../../__tests__/test-helpers";
 
-type EventConsumerPayload = z.input<typeof eventConsumerPayloadSchema>;
 type AgentEventsBody = z.infer<(typeof webhookEventsContract.send)["body"]>;
 type AgentCompleteBody = z.infer<
   (typeof webhookCompleteContract.complete)["body"]
@@ -521,38 +516,6 @@ export function createWebhookCallbackApi(context: TestContext) {
       const signature = delivery.headers["x-vm0-signature"] ?? "";
       const flipped = signature.startsWith("a") ? "b" : "a";
       return `${flipped}${signature.slice(1)}`;
-    },
-
-    async requestChatAssistantEventConsumer(
-      body: EventConsumerPayload,
-      headers: Partial<Vm0SignatureHeaders>,
-      statuses: readonly (200 | 401)[],
-    ) {
-      return await accept(
-        setupApp({ context })(
-          internalEventConsumerChatAssistantContract,
-        ).process({
-          headers,
-          body,
-        }),
-        statuses,
-      );
-    },
-
-    async requestInvalidChatAssistantEventConsumerBody(
-      body: string,
-      headers: Vm0SignatureHeaders,
-      statuses: readonly 401[],
-    ) {
-      return await accept(
-        setupApp({ context })(
-          internalEventConsumerChatAssistantContract,
-        ).process({
-          headers,
-          body: body as unknown as EventConsumerPayload,
-        }),
-        statuses,
-      );
     },
 
     sandboxWebhookHeaders,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -993,33 +993,6 @@ describe("WHCB-03: email inbound webhook boundaries", () => {
 });
 
 describe("WHCB-04: internal callback and event-consumer boundaries", () => {
-  it("rejects event consumers with missing auth or invalid bodies", async () => {
-    const body = {
-      runId: randomUUID(),
-      events: [],
-      context: {
-        userId: "user_bdd_event_consumer",
-        orgId: "org_bdd_event_consumer",
-      },
-    };
-
-    const missingSignature = await api.requestChatAssistantEventConsumer(
-      body,
-      {},
-      [401],
-    );
-    expect(missingSignature.body).toStrictEqual({
-      error: "Missing X-VM0-Signature header",
-    });
-
-    const invalidBody = await api.requestInvalidChatAssistantEventConsumerBody(
-      "not-json",
-      api.signedEventConsumerHeaders("not-json"),
-      [401],
-    );
-    expect(invalidBody.body).toStrictEqual({ error: "Invalid JSON body" });
-  });
-
   it("dispatches agent event batches to Axiom in-process", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsAutomationsApi(context);

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-chat-assistant.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-chat-assistant.service.ts
@@ -1,12 +1,7 @@
 import { command } from "ccstate";
-import { internalEventConsumerChatAssistantContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
 
-import {
-  eventConsumerPayload$,
-  eventConsumerRoute,
-} from "../../lib/event-consumer/route";
+import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
 import type { AgentEvent } from "../../lib/event-consumer/verify";
-import type { RouteEntry } from "../route";
 import {
   chatThreadForRun,
   insertAssistantEventMessages$,
@@ -123,10 +118,3 @@ export const processChatAssistantEvents$ = command(
     return { status: 200 as const, body: { processed: written } };
   },
 );
-
-export const internalEventConsumerChatAssistantRoutes: readonly RouteEntry[] = [
-  {
-    route: internalEventConsumerChatAssistantContract.process,
-    handler: eventConsumerRoute(processChatAssistantEvents$),
-  },
-];

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -15,7 +15,7 @@ import type { SandboxAuth } from "../../types/auth";
 import { db$ } from "../external/db";
 import { publishRunChangedForUserSafely } from "../external/realtime";
 import { ingestAxiomEvents$ } from "./agent-event-consumer-axiom.service";
-import { processChatAssistantEvents$ } from "../routes/internal-event-consumers-chat-assistant";
+import { processChatAssistantEvents$ } from "./agent-event-consumer-chat-assistant.service";
 import { settle } from "../utils";
 
 const L = logger("webhook:events");

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2084,12 +2084,12 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
-  it("matches the internal event consumer chat assistant rewrite path exactly", () => {
+  it("does not match the removed internal event consumer chat assistant rewrite path", () => {
     expect(
       matchesApiBackendRewritePath(
         "/api/internal/event-consumers/chat-assistant",
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       matchesApiBackendRewritePath(
         "/api/internal/event-consumers/chat-assistant/extra",

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -2319,11 +2319,6 @@ describe("API backend rewrites", () => {
             "https://api.example.test/api/internal/event-consumers/agentphone-typing",
         },
         {
-          source: "/api/internal/event-consumers/chat-assistant",
-          destination:
-            "https://api.example.test/api/internal/event-consumers/chat-assistant",
-        },
-        {
           source: "/api/internal/event-consumers/telegram-typing",
           destination:
             "https://api.example.test/api/internal/event-consumers/telegram-typing",

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -661,10 +661,6 @@ export const API_BACKEND_REWRITES = [
     "/api/internal/event-consumers/agentphone-typing",
   ],
   [
-    "/api/internal/event-consumers/chat-assistant",
-    "/api/internal/event-consumers/chat-assistant",
-  ],
-  [
     "/api/internal/event-consumers/telegram-typing",
     "/api/internal/event-consumers/telegram-typing",
   ],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -352,10 +352,8 @@ export {
 } from "./test-telegram-state";
 export {
   internalEventConsumerAgentPhoneTypingContract,
-  internalEventConsumerChatAssistantContract,
   internalEventConsumerTelegramTypingContract,
   type InternalEventConsumerAgentPhoneTypingContract,
-  type InternalEventConsumerChatAssistantContract,
   type InternalEventConsumerTelegramTypingContract,
 } from "./internal-event-consumers";
 export {

--- a/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
@@ -76,23 +76,6 @@ export const internalEventConsumerAgentPhoneTypingContract = c.router({
   },
 });
 
-export const internalEventConsumerChatAssistantContract = c.router({
-  process: {
-    method: "POST",
-    path: "/api/internal/event-consumers/chat-assistant",
-    headers: eventConsumerHeadersSchema,
-    body: eventConsumerPayloadSchema,
-    responses: {
-      200: z.object({ processed: z.number() }),
-      401: eventConsumerUnauthorizedSchema,
-    },
-    summary: "Persist assistant-visible run events into chat threads",
-  },
-});
-
-export type InternalEventConsumerChatAssistantContract =
-  typeof internalEventConsumerChatAssistantContract;
-
 export type InternalEventConsumerTelegramTypingContract =
   typeof internalEventConsumerTelegramTypingContract;
 


### PR DESCRIPTION
## Summary
- move the chat assistant event consumer command behind an in-process service boundary
- remove the `/api/internal/event-consumers/chat-assistant` route, API contract, and web rewrite
- keep coverage on the existing agent events path that persists assistant messages into chat threads

Closes #17984

## Verification
- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "persists assistant events into the linked thread and swallows optional consumer failures"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/security-headers.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`