### PR TITLE
fix: rename playful launch presentation template

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -52,7 +52,7 @@ describe("buildGenerationTemplatePrompt", () => {
     if (result.status !== "resolved") {
       return;
     }
-    expect(result.prompt).toContain("Playful Editorial");
+    expect(result.prompt).toContain("Playful Launch Presentation");
     expect(result.prompt).toContain(`(${item.designSystemId})`);
     expect(result.prompt).toContain(`(${item.templateId})`);
     expect(result.prompt).toContain(

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -146,20 +146,20 @@ describe("zero generate presentation command", () => {
       "--design-system",
       "playful-editorial",
       "--template",
-      "html-ppt-playful-editorial",
+      "html-ppt-playful-launch",
       "--title",
       "Launch",
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(
-      "Selected design system: design-system:playful-editorial (Playful Editorial)",
+      "Selected design system: design-system:playful-editorial (Playful Launch)",
     );
     expect(stdout).toContain(
-      "Selected template: template:html-ppt-playful-editorial (Playful Editorial Presentation)",
+      "Selected template: template:html-ppt-playful-launch (Playful Launch Presentation)",
     );
     expect(stdout).toContain("vm0-ai/vm0-skills@main");
-    expect(stdout).toContain('"id": "template:html-ppt-playful-editorial"');
+    expect(stdout).toContain('"id": "template:html-ppt-playful-launch"');
     expect(stdout).toContain('"path": "presentation-template/aplocoto"');
     expect(stdout).toContain('"id": "design-system:playful-editorial"');
     expect(stdout).toContain(

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -68,17 +68,17 @@ describe("presentation template items", () => {
   it("keeps the picker catalog separate from the legacy catalog", () => {
     expect(
       PRESENTATION_TEMPLATE_ITEMS.some((candidate) => {
-        return candidate.slug === "playful-editorial-deck";
+        return candidate.slug === "playful-launch-presentation";
       }),
     ).toBe(false);
 
     const item = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((candidate) => {
-      return candidate.slug === "playful-editorial-deck";
+      return candidate.slug === "playful-launch-presentation";
     });
 
     expect(item).toBeDefined();
     expect(item?.designSystemId).toBe("design-system:playful-editorial");
-    expect(item?.templateId).toBe("template:html-ppt-playful-editorial");
+    expect(item?.templateId).toBe("template:html-ppt-playful-launch");
     expect(item?.previewImages.length).toBe(15);
     expect(item?.previewImage).toBe(item?.previewImages[0]);
     expect(

--- a/turbo/packages/core/src/presentation-template-items.ts
+++ b/turbo/packages/core/src/presentation-template-items.ts
@@ -1774,7 +1774,7 @@ export const PRESENTATION_TEMPLATE_ITEMS: readonly PresentationTemplateItem[] =
     },
   ];
 
-const APLOCOTO_CDN_PREVIEW_IMAGES = [
+const PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES = [
   "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e0e4eee8-78f5-4630-9133-5c1771268833/slide-01.png",
   "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6b283082-35a6-466e-b44e-d1f03b7538b7/slide-02.png",
   "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/27522a10-0cf6-46aa-a25d-7c3fa5f125a3/slide-03.png",
@@ -1795,15 +1795,15 @@ const APLOCOTO_CDN_PREVIEW_IMAGES = [
 export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateItem[] =
   [
     {
-      slug: "playful-editorial-deck",
-      title: "Playful editorial deck",
+      slug: "playful-launch-presentation",
+      title: "Playful launch presentation",
       prompt:
-        "/gen presentation with design system `playful-editorial` and template `html-ppt-playful-editorial`, create a 15-slide presentation for a product or service launch. Include cover, agenda, about, vision, team, offerings, process, gallery, metrics, testimonials, pricing, and contact. Make it saturated, editorial, joyful, and structured.",
+        "/gen presentation with design system `playful-editorial` and template `html-ppt-playful-launch`, create a 15-slide presentation for a product or service launch. Include cover, agenda, about, vision, team, offerings, process, gallery, metrics, testimonials, pricing, and contact. Make it saturated, joyful, idea-led, and structured.",
       embedUrl:
         "https://playful-editorial-presentation-preview-715f6d07-adec3994.sites.vm0.io",
-      previewImage: APLOCOTO_CDN_PREVIEW_IMAGES[0],
-      previewImages: APLOCOTO_CDN_PREVIEW_IMAGES,
+      previewImage: PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES[0],
+      previewImages: PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES,
       designSystemId: "design-system:playful-editorial",
-      templateId: "template:html-ppt-playful-editorial",
+      templateId: "template:html-ppt-playful-launch",
     },
   ];

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -766,11 +766,11 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     targets: ["presentation"],
   },
   {
-    id: "template:html-ppt-playful-editorial",
+    id: "template:html-ppt-playful-launch",
     kind: "template",
-    name: "Playful Editorial Presentation",
+    name: "Playful Launch Presentation",
     description:
-      "15-slot HTML presentation structure with oversized headlines, color-field rhythm, recurring motifs, and required media slots.",
+      "15-slot HTML presentation structure for product and service launches with oversized headlines, color-field rhythm, recurring motifs, and required media slots.",
     source: {
       repo: VM0_SKILLS_REPO,
       ref: VM0_SKILLS_REF,
@@ -2512,9 +2512,9 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
   {
     id: "design-system:playful-editorial",
     kind: "design-system",
-    name: "Playful Editorial",
+    name: "Playful Launch",
     description:
-      "Carnival editorial look with saturated color fields, scalloped burst badges, pill chips, Archivo headlines, and Manrope body.",
+      "Joyful launch-deck look with saturated color fields, scalloped burst badges, pill chips, Archivo headlines, and Manrope body.",
     source: {
       repo: VM0_SKILLS_REPO,
       ref: VM0_SKILLS_REF,


### PR DESCRIPTION
## Summary
- Rename the new picker presentation template to Playful Launch Presentation
- Update the picker slug/template id to use playful-launch naming
- Sync CLI/API/core test expectations with the new display name

## Validation
- git diff --check
- npx --yes prettier@3.6.2 --check turbo/packages/core/src/resource-registry.ts turbo/packages/core/src/presentation-template-items.ts turbo/packages/core/src/__tests__/presentation-template-items.spec.ts turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts

Targeted vitest was attempted but local turbo node_modules are missing, so PR CI should run those checks.