### PR TITLE
refactor: dispatch telegram typing in process

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/internal-api-url.test.ts
@@ -13,10 +13,10 @@ describe("internalApiBaseUrl", () => {
     expect(internalApiBaseUrl()).toBe("https://api.vm0.ai");
     expect(
       new URL(
-        "/api/internal/event-consumers/telegram-typing",
+        "/api/internal/cron/aggregate-model-stats",
         internalApiBaseUrl(),
       ).toString(),
-    ).toBe("https://api.vm0.ai/api/internal/event-consumers/telegram-typing");
+    ).toBe("https://api.vm0.ai/api/internal/cron/aggregate-model-stats");
   });
 
   it("defaults to the API backend origin in production when VM0_API_BACKEND_URL is unset", () => {

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -39,7 +39,6 @@ import { apiHealth$ } from "./routes/health";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { internalEventConsumerAgentPhoneTypingRoutes } from "./routes/internal-event-consumers-agentphone-typing";
-import { internalEventConsumerTelegramTypingRoutes } from "./routes/internal-event-consumers-telegram-typing";
 import { legacyFileRoutes } from "./routes/legacy-file";
 import { logsSearchRoutes } from "./routes/logs-search";
 import { modelStatsRoutes } from "./routes/model-stats";
@@ -199,7 +198,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...healthAuthProbeRoutes,
   ...githubOauthRoutes,
   ...internalEventConsumerAgentPhoneTypingRoutes,
-  ...internalEventConsumerTelegramTypingRoutes,
   ...legacyFileRoutes,
   ...logsSearchRoutes,
   ...usageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -43,7 +43,6 @@ import { orgDefaultAgentContract } from "@vm0/api-contracts/contracts/orgs";
 import { testSlackStateContract } from "@vm0/api-contracts/contracts/test-slack-state";
 import { zeroIntegrationsAgentPhoneContract } from "@vm0/api-contracts/contracts/zero-integrations-agentphone";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
-import { internalEventConsumerTelegramTypingContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
 import { zeroIntegrationsTelegramContract } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import {
   zeroSlackBrowserConnectContract,
@@ -1720,20 +1719,6 @@ export function createBddIntegrationApi(context: TestContext) {
         }),
         statuses,
       );
-    },
-
-    async requestTelegramTypingEventConsumer(
-      body: { readonly runId: string } & Record<string, unknown>,
-      headers: {
-        readonly "x-vm0-signature"?: string;
-        readonly "x-vm0-timestamp"?: string;
-      },
-      statuses: readonly (200 | 401)[],
-    ) {
-      const client = setupApp({ context })(
-        internalEventConsumerTelegramTypingContract,
-      );
-      return await accept(client.refresh({ headers, body }), statuses);
     },
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3312,22 +3312,24 @@ describe("INT-02: Telegram integration", () => {
         status: "pending",
         attempts: 0,
       });
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped actor");
-    }
-
     const typingBody = {
       runId,
       events: [{ type: "assistant", sequenceNumber: 1 }],
-      context: { userId: actor.userId, orgId: actor.orgId },
+    };
+    const sandboxHeaders = {
+      authorization: `Bearer ${runs.sandboxTokenForRun(actor, runId)}`,
     };
     const actionsBeforeTyping = chatActions.length;
-    const typing = await integrations.requestTelegramTypingEventConsumer(
+    const typing = await webhooks.requestAgentEvents(
       typingBody,
-      webhooks.signedEventConsumerHeaders(typingBody),
+      sandboxHeaders,
       [200],
     );
-    expect(typing.body).toStrictEqual({ scheduled: true });
+    expect(typing.body).toStrictEqual({
+      received: 1,
+      firstSequence: 1,
+      lastSequence: 1,
+    });
     await waitForExpectation(() => {
       expect(chatActions.slice(actionsBeforeTyping)).toStrictEqual([
         { chat_id: String(dmChatId), action: "typing" },
@@ -3344,12 +3346,16 @@ describe("INT-02: Telegram integration", () => {
       })
       .toBe("cancelled");
     const actionsAfterCancel = chatActions.length;
-    const idleTyping = await integrations.requestTelegramTypingEventConsumer(
+    const idleTyping = await webhooks.requestAgentEvents(
       typingBody,
-      webhooks.signedEventConsumerHeaders(typingBody),
+      sandboxHeaders,
       [200],
     );
-    expect(idleTyping.body).toStrictEqual({ scheduled: true });
+    expect(idleTyping.body).toStrictEqual({
+      received: 1,
+      firstSequence: 1,
+      lastSequence: 1,
+    });
     expect(chatActions).toHaveLength(actionsAfterCancel);
   });
 });

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-telegram-typing.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-telegram-typing.service.ts
@@ -2,12 +2,8 @@ import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
-import { internalEventConsumerTelegramTypingContract } from "@vm0/api-contracts/contracts/internal-event-consumers";
 
-import {
-  eventConsumerPayload$,
-  eventConsumerRoute,
-} from "../../lib/event-consumer/route";
+import { eventConsumerPayload$ } from "../../lib/event-consumer/route";
 import { logger } from "../../lib/log";
 import { waitUntil } from "../context/wait-until";
 import { db$ } from "../external/db";
@@ -19,7 +15,6 @@ import {
 import { decryptPersistentSecretValue } from "../services/crypto.utils";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import { internalRunCallbackKindForRecord } from "../services/internal-run-callback";
-import type { RouteEntry } from "../route";
 import { tapError } from "../utils";
 
 const L = logger("event-consumer:telegram-typing");
@@ -113,7 +108,7 @@ const refreshTelegramTypingForRun$ = command(
   },
 );
 
-const refreshInner$ = command(
+export const refreshTelegramTypingEvents$ = command(
   ({ get, set }, signal: AbortSignal): RefreshResponse => {
     const payload = get(eventConsumerPayload$);
     signal.throwIfAborted();
@@ -138,11 +133,3 @@ interface RefreshResponse {
   readonly status: 200;
   readonly body: { readonly scheduled: true };
 }
-
-export const internalEventConsumerTelegramTypingRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: internalEventConsumerTelegramTypingContract.refresh,
-      handler: eventConsumerRoute(refreshInner$),
-    },
-  ];

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -16,6 +16,7 @@ import { db$ } from "../external/db";
 import { publishRunChangedForUserSafely } from "../external/realtime";
 import { ingestAxiomEvents$ } from "./agent-event-consumer-axiom.service";
 import { processChatAssistantEvents$ } from "./agent-event-consumer-chat-assistant.service";
+import { refreshTelegramTypingEvents$ } from "./agent-event-consumer-telegram-typing.service";
 import { settle } from "../utils";
 
 const L = logger("webhook:events");
@@ -29,7 +30,8 @@ interface ConsumerResult {
   readonly status: number;
 }
 
-type ConsumerCommand = Command<Promise<ConsumerResult>, [AbortSignal]>;
+type ConsumerCommandResult = ConsumerResult | Promise<ConsumerResult>;
+type ConsumerCommand = Command<ConsumerCommandResult, [AbortSignal]>;
 
 interface AgentEventsBody {
   readonly runId: string;
@@ -71,6 +73,10 @@ const EVENT_CONSUMERS: readonly DispatchableConsumer[] = [
     name: "chat-assistant",
     command$: processChatAssistantEvents$,
     eventTypes: ["assistant", "item.completed"],
+  },
+  {
+    name: "telegram-typing",
+    command$: refreshTelegramTypingEvents$,
   },
 ];
 
@@ -122,7 +128,10 @@ const runEventConsumer$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     set(eventConsumerPayloadState$, params.payload);
-    const result = await settle(set(params.consumer.command$, signal), signal);
+    const result = await settle(
+      Promise.resolve(set(params.consumer.command$, signal)),
+      signal,
+    );
 
     if (!result.ok) {
       L.error(`Event consumer "${params.consumer.name}" failed`, {

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2102,12 +2102,12 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(false);
   });
 
-  it("matches the internal event consumer telegram typing rewrite path exactly", () => {
+  it("does not match the removed internal event consumer telegram typing rewrite path", () => {
     expect(
       matchesApiBackendRewritePath(
         "/api/internal/event-consumers/telegram-typing",
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       matchesApiBackendRewritePath(
         "/api/internal/event-consumers/telegram-typing/extra",

--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -2319,11 +2319,6 @@ describe("API backend rewrites", () => {
             "https://api.example.test/api/internal/event-consumers/agentphone-typing",
         },
         {
-          source: "/api/internal/event-consumers/telegram-typing",
-          destination:
-            "https://api.example.test/api/internal/event-consumers/telegram-typing",
-        },
-        {
           source: "/api/user/export",
           destination: "https://api.example.test/api/user/export",
         },

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -660,10 +660,6 @@ export const API_BACKEND_REWRITES = [
     "/api/internal/event-consumers/agentphone-typing",
     "/api/internal/event-consumers/agentphone-typing",
   ],
-  [
-    "/api/internal/event-consumers/telegram-typing",
-    "/api/internal/event-consumers/telegram-typing",
-  ],
   ["/api/test/oauth-provider/authorize", "/api/test/oauth-provider/authorize"],
   [
     "/api/test/oauth-provider/device/code",

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -352,9 +352,7 @@ export {
 } from "./test-telegram-state";
 export {
   internalEventConsumerAgentPhoneTypingContract,
-  internalEventConsumerTelegramTypingContract,
   type InternalEventConsumerAgentPhoneTypingContract,
-  type InternalEventConsumerTelegramTypingContract,
 } from "./internal-event-consumers";
 export {
   cronAggregateInsightsContract,

--- a/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-event-consumers.ts
@@ -14,51 +14,8 @@ export const eventConsumerHeadersSchema = z.object({
   "x-vm0-timestamp": z.string().optional(),
 });
 
-export const eventConsumerEventSchema = z
-  .object({
-    type: z.string(),
-    sequenceNumber: z.number(),
-  })
-  .passthrough();
-
-export const eventConsumerPayloadSchema = z
-  .object({
-    runId: z.string(),
-    events: z.array(eventConsumerEventSchema),
-    context: z
-      .object({
-        userId: z.string(),
-        orgId: z.string(),
-      })
-      .passthrough(),
-  })
-  .passthrough();
-
 export const eventConsumerUnauthorizedSchema = z.object({
   error: z.string(),
-});
-
-/**
- * Refresh Telegram typing indicators for all pending Telegram callbacks
- * attached to a run. Triggered by the events webhook on every batch.
- *
- * The body schema only requires `runId`; everything else is forwarded
- * verbatim to the background refresh task without validation, matching
- * web's permissive behaviour.
- */
-export const internalEventConsumerTelegramTypingContract = c.router({
-  refresh: {
-    method: "POST",
-    path: "/api/internal/event-consumers/telegram-typing",
-    headers: eventConsumerHeadersSchema,
-    body: z.object({ runId: z.string() }).passthrough(),
-    responses: {
-      200: z.object({ scheduled: z.literal(true) }),
-      401: eventConsumerUnauthorizedSchema,
-    },
-    summary:
-      "Refresh Telegram typing indicators for all pending callbacks of a run",
-  },
 });
 
 export const internalEventConsumerAgentPhoneTypingContract = c.router({
@@ -75,9 +32,6 @@ export const internalEventConsumerAgentPhoneTypingContract = c.router({
       "Refresh AgentPhone typing indicators for all pending iMessage callbacks of a run",
   },
 });
-
-export type InternalEventConsumerTelegramTypingContract =
-  typeof internalEventConsumerTelegramTypingContract;
 
 export type InternalEventConsumerAgentPhoneTypingContract =
   typeof internalEventConsumerAgentPhoneTypingContract;


### PR DESCRIPTION
## Summary
- move the Telegram typing event consumer command behind an in-process service boundary
- dispatch Telegram typing refreshes from sandbox agent event batches
- remove the `/api/internal/event-consumers/telegram-typing` route, API contract, and web rewrite

Closes #17985

## Verification
- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t "refreshes telegram typing for pending webhook-dispatched runs"`
- `pnpm -F api exec vitest run src/lib/__tests__/internal-api-url.test.ts`
- `pnpm -F web exec vitest run __tests__/api-backend-rewrite-proxy.test.ts __tests__/security-headers.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F web lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F web check-types`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`