### PR TITLE
fix: render bare image urls as markdown previews

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -415,6 +415,59 @@ export function previewAttachmentFromUrl(
   return { filename, url };
 }
 
+function markdownImageLine(url: string, alt: string): string {
+  const escapedAlt = alt
+    .replace(/\\/g, String.raw`\\`)
+    .replace(/\]/g, String.raw`\]`);
+  return `![${escapedAlt}](${url})`;
+}
+
+type ExtractedPreviewLineRender =
+  | {
+      renderKind: "markdown";
+      line: string;
+    }
+  | {
+      renderKind: "preview";
+      preview: {
+        filename: string;
+        url: string;
+        kind: BodyPreviewKind;
+      };
+    };
+
+function renderExtractedPreviewLine(
+  extracted: ExtractedPreviewUrl,
+  line: string,
+): ExtractedPreviewLineRender {
+  const { title, url } = extracted;
+  const attachment = previewAttachmentFromUrl(url, title);
+  const kind = classifyChatAttachment(attachment);
+
+  if (
+    extracted.source === "markdown-link" &&
+    (kind === "image" || kind === "video")
+  ) {
+    return { renderKind: "markdown", line };
+  }
+
+  if (kind === "image" && isPreviewableChatUrl(url)) {
+    return {
+      renderKind: "markdown",
+      line: markdownImageLine(url, attachment.filename),
+    };
+  }
+
+  if (isBodyPreviewKind(kind) && isPreviewableChatUrl(url)) {
+    return {
+      renderKind: "preview",
+      preview: { filename: attachment.filename, url, kind },
+    };
+  }
+
+  return { renderKind: "markdown", line };
+}
+
 function stripMarkdownLineDecorations(value: string): string {
   let candidate = value
     .trim()
@@ -717,38 +770,19 @@ export function parseBodyRenderBlocks(
       continue;
     }
 
-    const { title, url } = extracted;
-    const attachment = previewAttachmentFromUrl(url, title);
-    const kind = classifyChatAttachment(attachment);
-
-    if (
-      extracted.source === "markdown-link" &&
-      (kind === "image" || kind === "video")
-    ) {
-      markdownBuffer.push(line);
-      keptLines.push(line);
+    const renderedLine = renderExtractedPreviewLine(extracted, line);
+    if (renderedLine.renderKind === "markdown") {
+      markdownBuffer.push(renderedLine.line);
+      keptLines.push(renderedLine.line);
       continue;
     }
 
-    if (isBodyPreviewKind(kind)) {
-      // Only render platform-managed files and hosted sites as inline previews.
-      // Other external URLs stay as plain markdown links.
-      if (!isPreviewableChatUrl(url)) {
-        markdownBuffer.push(line);
-        keptLines.push(line);
-        continue;
-      }
-      flushMarkdownBuffer();
-      blocks.push({
-        type: "preview",
-        id: nextBlockId("preview"),
-        preview: { filename: attachment.filename, url, kind },
-      });
-      continue;
-    }
-
-    markdownBuffer.push(line);
-    keptLines.push(line);
+    flushMarkdownBuffer();
+    blocks.push({
+      type: "preview",
+      id: nextBlockId("preview"),
+      preview: renderedLine.preview,
+    });
   }
 
   flushMarkdownBuffer();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -920,7 +920,7 @@ Download the archive here: ${fileUrl}.`,
 
     await waitFor(() => {
       expect(screen.getByText("Table keeps URLs as text")).toBeInTheDocument();
-      expect(screen.getByLabelText("Preview chart.png")).toBeInTheDocument();
+      expect(screen.getByAltText("chart.png")).toBeInTheDocument();
       expect(screen.getByLabelText("Preview demo.mp4")).toBeInTheDocument();
       expect(screen.getByTestId("attachment-preview-markdown")).toHaveAttribute(
         "aria-label",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -637,7 +637,7 @@ describe("zero attachment chips", () => {
         screen.getByLabelText("Open audio preview for briefing.mp3"),
       ).toBeInTheDocument();
       expect(screen.getByLabelText("Preview demo.mp4")).toBeInTheDocument();
-      expect(screen.getByLabelText("Preview chart.png")).toBeInTheDocument();
+      expect(screen.getByAltText("chart.png")).toBeInTheDocument();
       expect(
         screen.getByLabelText("Open markdown preview for release-notes.md"),
       ).toBeInTheDocument();
@@ -683,8 +683,13 @@ describe("zero attachment chips", () => {
       ).not.toBeInTheDocument();
     });
 
-    fireEvent.load(screen.getByAltText("chart.png"));
-    click(screen.getByLabelText("Preview chart.png"));
+    const chartImage = screen.getByAltText("chart.png");
+    const chartPreview = chartImage.closest("button");
+    if (!chartPreview) {
+      throw new Error("Chart markdown image preview button not found");
+    }
+    fireEvent.load(chartImage);
+    click(chartPreview);
 
     await waitFor(() => {
       expect(
@@ -779,7 +784,7 @@ describe("zero attachment chips", () => {
     });
   });
 
-  it("keeps chat image preview dimensions stable while the image loads", async () => {
+  it("renders bare image URLs through markdown image preview", async () => {
     const imageUrl = "https://cdn.vm7.io/artifacts/test/body-image/chart.png";
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
@@ -796,28 +801,31 @@ describe("zero attachment chips", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    const preview = await screen.findByLabelText("Preview chart.png");
+    const image = await screen.findByAltText("chart.png");
+    const preview = image.closest("button");
+    if (!preview) {
+      throw new Error("Markdown image preview button not found");
+    }
     expect(preview).toHaveClass(
       "aspect-[10/9]",
-      "w-[50px]",
+      "w-[200px]",
       "max-w-full",
       "cursor-pointer",
     );
     expect(
-      within(preview).getByTestId("chat-image-preview-loading"),
+      within(preview).getByTestId("markdown-image-preview-loading"),
     ).toHaveClass("h-full", "w-full");
 
-    const image = within(preview).getByAltText("chart.png");
     fireEvent.load(image);
 
     await waitFor(() => {
       expect(
-        within(preview).queryByTestId("chat-image-preview-loading"),
+        within(preview).queryByTestId("markdown-image-preview-loading"),
       ).not.toBeInTheDocument();
     });
     expect(preview).toHaveClass(
       "aspect-[10/9]",
-      "w-[50px]",
+      "w-[200px]",
       "max-w-full",
       "cursor-pointer",
     );


### PR DESCRIPTION
## Summary
- render assistant bare image URLs through the Markdown image renderer instead of chat body preview blocks
- keep non-image body previews, including video/audio/doc previews, on the existing preview block path
- update attachment and artifact sidebar coverage for the new bare image behavior

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "bare image|markdown image|media and file previews"
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "renders inline previews"
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pre-commit: prettier, knip, check-types