### PR TITLE
feat: redesign chat automation sidebar cards as flat-divider rows

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3478,8 +3478,9 @@ describe("chat lifecycle", () => {
     expect(
       within(sidebar).getByText("Manual launch reminder"),
     ).toBeInTheDocument();
+    expect(within(sidebar).getAllByText("Status")).toHaveLength(3);
+    expect(within(sidebar).getAllByText("Schedule")).toHaveLength(3);
     expect(within(sidebar).getAllByText("Next run")).toHaveLength(3);
-    expect(within(sidebar).getAllByText("Rule")).toHaveLength(3);
     expect(within(sidebar).getAllByText("Run now")).toHaveLength(3);
     expect(within(sidebar).getAllByText("Edit")).toHaveLength(3);
     expect(within(sidebar).getAllByText("No upcoming run")).toHaveLength(2);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2135,7 +2135,14 @@ function HeaderAutomationSidebarCard({
         </div>
       </dl>
 
-      <div className="mt-3 flex min-w-0 items-center gap-2">
+      <div className="mt-3 flex min-w-0 items-center justify-between gap-2">
+        <Link
+          pathname="/automations/:automationId"
+          options={{ pathParams: { automationId: automation.id } }}
+          className="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Edit
+        </Link>
         <Button
           type="button"
           variant="outline"
@@ -2151,13 +2158,6 @@ function HeaderAutomationSidebarCard({
           )}
           {running ? "Starting…" : "Run now"}
         </Button>
-        <Link
-          pathname="/automations/:automationId"
-          options={{ pathParams: { automationId: automation.id } }}
-          className="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-        >
-          Edit
-        </Link>
       </div>
     </article>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2090,60 +2090,74 @@ function HeaderAutomationSidebarCard({
         !automation.enabled && "opacity-75",
       )}
     >
-      <p className="line-clamp-2 text-sm font-medium leading-snug text-foreground">
+      <p
+        className={cn(
+          "line-clamp-2 text-sm font-medium leading-snug",
+          automation.enabled ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
         {automationDescription(automation)}
       </p>
 
-      <div className="mt-3 grid gap-1.5">
-        <div className="rounded-lg bg-muted/45 px-3 py-2">
-          <div className="text-xs text-muted-foreground">Next run</div>
-          <div className="mt-1 truncate text-xs font-medium text-foreground">
-            {formatAutomationNextRun(automation)}
-          </div>
+      <dl className="mt-2 text-xs">
+        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2">
+          <dt className="shrink-0 text-muted-foreground">Status</dt>
+          <dd className="flex shrink-0 items-center gap-2">
+            <span
+              className={cn(
+                "font-medium",
+                automation.enabled
+                  ? "text-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
+              {automation.enabled ? "Active" : "Paused"}
+            </span>
+            <LoadingSwitch
+              checked={automation.enabled}
+              loading={toggling}
+              onCheckedChange={toggleEnabled}
+              ariaLabel={`${automation.enabled ? "Disable" : "Enable"} automation`}
+            />
+          </dd>
         </div>
-        <div className="rounded-lg bg-muted/45 px-3 py-2">
-          <div className="text-xs text-muted-foreground">Rule</div>
-          <div className="mt-1 truncate text-xs font-medium text-foreground">
+        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2">
+          <dt className="shrink-0 text-muted-foreground">Schedule</dt>
+          <dd className="min-w-0 truncate text-right font-medium text-foreground">
             {automation.rule}
-          </div>
+          </dd>
         </div>
-      </div>
-
-      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="zero-btn-morandi h-8 shrink-0 gap-1.5 rounded-lg px-3 text-xs font-medium transition-colors hover:bg-accent"
-            disabled={running}
-            onClick={runNow}
-          >
-            {running ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : (
-              <IconPlayerPlay size={14} stroke={1.5} />
-            )}
-            {running ? "Starting…" : "Run now"}
-          </Button>
-          <Link
-            pathname="/automations/:automationId"
-            options={{ pathParams: { automationId: automation.id } }}
-            className="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >
-            Edit
-          </Link>
+        <div className="flex items-center justify-between gap-3 py-2">
+          <dt className="shrink-0 text-muted-foreground">Next run</dt>
+          <dd className="min-w-0 truncate text-right font-medium text-foreground">
+            {formatAutomationNextRun(automation)}
+          </dd>
         </div>
+      </dl>
 
-        <span className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-          Active
-          <LoadingSwitch
-            checked={automation.enabled}
-            loading={toggling}
-            onCheckedChange={toggleEnabled}
-            ariaLabel={`${automation.enabled ? "Disable" : "Enable"} automation`}
-          />
-        </span>
+      <div className="mt-3 flex min-w-0 items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="zero-btn-morandi h-8 shrink-0 gap-1.5 rounded-lg px-3 text-xs font-medium transition-colors hover:bg-accent"
+          disabled={running}
+          onClick={runNow}
+        >
+          {running ? (
+            <IconLoader2 size={14} className="animate-spin" />
+          ) : (
+            <IconPlayerPlay size={14} stroke={1.5} />
+          )}
+          {running ? "Starting…" : "Run now"}
+        </Button>
+        <Link
+          pathname="/automations/:automationId"
+          options={{ pathParams: { automationId: automation.id } }}
+          className="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Edit
+        </Link>
       </div>
     </article>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2086,7 +2086,7 @@ function HeaderAutomationSidebarCard({
   return (
     <article
       className={cn(
-        "rounded-lg border border-border bg-background p-3 transition-colors",
+        "rounded-lg border border-border bg-background p-4 transition-colors",
         !automation.enabled && "opacity-75",
       )}
     >
@@ -2099,8 +2099,8 @@ function HeaderAutomationSidebarCard({
         {automationDescription(automation)}
       </p>
 
-      <dl className="mt-2 text-xs">
-        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2">
+      <dl className="mt-3 text-xs">
+        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2.5">
           <dt className="shrink-0 text-muted-foreground">Status</dt>
           <dd className="flex shrink-0 items-center gap-2">
             <span
@@ -2121,13 +2121,13 @@ function HeaderAutomationSidebarCard({
             />
           </dd>
         </div>
-        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2">
+        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2.5">
           <dt className="shrink-0 text-muted-foreground">Schedule</dt>
           <dd className="min-w-0 truncate text-right font-medium text-foreground">
             {automation.rule}
           </dd>
         </div>
-        <div className="flex items-center justify-between gap-3 py-2">
+        <div className="flex items-center justify-between gap-3 py-2.5">
           <dt className="shrink-0 text-muted-foreground">Next run</dt>
           <dd className="min-w-0 truncate text-right font-medium text-foreground">
             {formatAutomationNextRun(automation)}
@@ -2135,7 +2135,7 @@ function HeaderAutomationSidebarCard({
         </div>
       </dl>
 
-      <div className="mt-3 flex min-w-0 items-center justify-between gap-2">
+      <div className="mt-4 flex min-w-0 items-center justify-between gap-2">
         <Link
           pathname="/automations/:automationId"
           options={{ pathParams: { automationId: automation.id } }}


### PR DESCRIPTION
## What

Restyles each card in the chat **Automations** side panel (`HeaderAutomationSidebarCard`) to the flat-divider layout Ming picked.

Before, every card stacked a prose summary on top of two filled `bg-muted/45` boxes (Next run, Rule), with the enable toggle stranded at the far right of the action row. That read as heavy and lopsided in the panel.

After:
- The two heavy boxes become hairline key/value rows — no fills.
- The enable toggle moves into a leading **Status** row (`Active` / `Paused` + switch).
- The rule row is relabeled **Schedule**.
- `Run now` / `Edit` stay as the action row; the toggle no longer floats beside them.

The panel already renders one card per automation, so multi-automation threads now show a clean stack of identical flat cards.

## Scope

- `zero-chat-thread-page.tsx` — `HeaderAutomationSidebarCard` markup only; no logic/data changes.
- `chat-lifecycle.test.tsx` — updated the sidebar assertions (`Rule` → `Schedule`, added `Status`).

## Notes

- Reuses existing primitives (`Button` outline/morandi, `LoadingSwitch`, `Link`); no new components or one-off tokens.
- Local `prettier --check` and repo-pinned `oxlint` pass on the changed files. Full lint/type/test left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)