### PR TITLE
fix: normalize presentation HTML slide exports

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePresentationEditDraft } from "../presentation-html-edit-protocol.ts";
+
+describe("presentation HTML edit protocol", () => {
+  it("selects a unique inner slide canvas inside legacy viewport wrappers", () => {
+    const draft = parsePresentationEditDraft(`<!doctype html>
+<html>
+  <body>
+    <section class="slide" data-slide-id="outer-slide">
+      <div class="stage">
+        <h1 data-vm0-editable="text" data-vm0-edit-id="title">Quarterly results</h1>
+      </div>
+    </section>
+  </body>
+</html>`);
+
+    expect(draft.slides).toStrictEqual([
+      {
+        id: "outer-slide",
+        notes: "",
+        title: "Quarterly results",
+      },
+    ]);
+    expect(draft.blocks).toStrictEqual([
+      {
+        editId: "title",
+        slideId: "outer-slide",
+        tagName: "h1",
+        text: "Quarterly results",
+      },
+    ]);
+    expect(draft.html).toContain(
+      '<div class="stage" data-slide-id="outer-slide">',
+    );
+  });
+
+  it("falls back to the wrapper when there is no unique inner slide canvas", () => {
+    const draft = parsePresentationEditDraft(`<!doctype html>
+<html>
+  <body>
+    <section class="slide" data-slide-id="outer-slide">
+      <div class="stage">First candidate</div>
+      <div class="stage">Second candidate</div>
+    </section>
+  </body>
+</html>`);
+
+    expect(draft.slides[0]?.id).toBe("outer-slide");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -242,6 +242,32 @@ function presentationHtmlWithDeckBackground(): string {
 </html>`;
 }
 
+function presentationHtmlWithNestedStage(): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <title>Nested stage deck</title>
+    <style>
+      .slide {
+        width: 100vw;
+        height: 100vh;
+      }
+      .stage {
+        width: min(100vw, 177.7778vh);
+        height: min(56.25vw, 100vh);
+      }
+    </style>
+  </head>
+  <body>
+    <section class="slide" data-slide-id="slide-intro">
+      <div class="stage">
+        <h1>Nested stage deck</h1>
+      </div>
+    </section>
+  </body>
+</html>`;
+}
+
 function presentationPptxBlob(): Promise<Blob> {
   const zip = new JSZip();
   zip.file(
@@ -881,6 +907,44 @@ describe("zero artifact sidebar", () => {
 
     await waitFor(() => {
       expect(downloads).toContain("dog-world.pptx");
+      expect(
+        document.querySelector('iframe[title="Presentation PPTX export"]'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("includes nested slide canvas normalization for PPTX export", async () => {
+    const presentationUrl = "https://deck.sites.vm7.io/nested-stage.html";
+    setupPresentationArtifactThread(
+      presentationUrl,
+      presentationHtmlWithNestedStage(),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+      expect(screen.getByLabelText("Download artifact")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      expect(menuItemByText("Download (.pptx)")).toBeInTheDocument();
+    });
+    click(menuItemByText("Download (.pptx)"));
+
+    const exportFrame = await waitFor(() => {
+      const frame = document.querySelector(
+        'iframe[title="Presentation PPTX export"]',
+      );
+      expect(frame).toBeInstanceOf(HTMLIFrameElement);
+      return frame as HTMLIFrameElement;
+    });
+
+    expect(exportFrame.srcdoc).toContain("normalizeSlideNode");
+    expect(exportFrame.srcdoc).toContain("innerSlideCandidateSelectors");
+    expect(exportFrame.srcdoc).toContain(".stage");
+
+    completePresentationPptxExport(exportFrame, await presentationPptxBlob());
+    await waitFor(() => {
       expect(
         document.querySelector('iframe[title="Presentation PPTX export"]'),
       ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -3,6 +3,7 @@ import type { PresentationSpeakerNotesPatch } from "@vm0/api-contracts/contracts
 const EDITABLE_SELECTOR = '[data-vm0-editable="text"]';
 const METADATA_SCRIPT_ID = "vm0-deck-metadata";
 const SLIDE_SELECTORS = [
+  "[data-vm0-slide]",
   "[data-slide]",
   "[data-slide-index]",
   "[data-page]",
@@ -12,6 +13,21 @@ const SLIDE_SELECTORS = [
   ".slide-page",
   ".slide",
   "section",
+] as const;
+const WEAK_SLIDE_SELECTORS = [".slide", "section"] as const;
+const INNER_SLIDE_CANDIDATE_SELECTORS = [
+  "[data-vm0-slide]",
+  "[data-slide]",
+  "[data-slide-index]",
+  "[data-page]",
+  ".ppt-slide",
+  ".presentation-slide",
+  ".deck-slide",
+  ".slide-page",
+  ".stage",
+  ".slide-stage",
+  ".slide-canvas",
+  ".presentation-stage",
 ] as const;
 const FALLBACK_EDITABLE_SELECTOR =
   "h1,h2,h3,h4,h5,h6,p,li,blockquote,figcaption,td,th,span,div";
@@ -135,10 +151,60 @@ function selectSlideElements(doc: Document): Element[] {
   for (const selector of SLIDE_SELECTORS) {
     const slides = Array.from(doc.querySelectorAll(selector));
     if (slides.length > 0) {
-      return slides;
+      return slides.map((slide) => {
+        return normalizeSlideElement(slide, selector);
+      });
     }
   }
   return doc.body ? [doc.body] : [];
+}
+
+function matchesAnySelector(
+  element: Element,
+  selectors: readonly string[],
+): boolean {
+  return selectors.some((selector) => {
+    return element.matches(selector);
+  });
+}
+
+function isWeakSlideSelector(selector: string): boolean {
+  return WEAK_SLIDE_SELECTORS.some((candidate) => {
+    return candidate === selector;
+  });
+}
+
+function normalizeSlideElement(slide: Element, selector: string): Element {
+  if (!isWeakSlideSelector(selector)) {
+    return slide;
+  }
+  const directCandidates = Array.from(slide.children).filter((child) => {
+    return matchesAnySelector(child, INNER_SLIDE_CANDIDATE_SELECTORS);
+  });
+  const candidate =
+    directCandidates.length === 1
+      ? directCandidates[0]
+      : uniqueInnerSlideCandidate(slide);
+  if (!candidate) {
+    return slide;
+  }
+  inheritSlideId(slide, candidate);
+  return candidate;
+}
+
+function uniqueInnerSlideCandidate(slide: Element): Element | null {
+  const selector = INNER_SLIDE_CANDIDATE_SELECTORS.join(",");
+  const candidates = Array.from(slide.querySelectorAll(selector));
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function inheritSlideId(source: Element, target: Element): void {
+  if (!(source instanceof HTMLElement) || !(target instanceof HTMLElement)) {
+    return;
+  }
+  if (!target.dataset.slideId && source.dataset.slideId) {
+    target.dataset.slideId = source.dataset.slideId;
+  }
 }
 
 function hasUsefulText(element: Element): boolean {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -44,6 +44,23 @@ const SLIDE_SELECTORS = [
   ".slide",
   "section",
 ] as const;
+const WEAK_SLIDE_SELECTORS = [".slide", "section"] as const;
+const INNER_SLIDE_CANDIDATE_SELECTORS = [
+  "[data-vm0-slide]",
+  "[data-slide]",
+  "[data-slide-index]",
+  "[data-page]",
+  ".ppt-slide",
+  ".presentation-slide",
+  ".deck-slide",
+  ".slide-page",
+  ".stage",
+  ".slide-stage",
+  ".slide-canvas",
+  ".presentation-stage",
+] as const;
+const WIDE_SLIDE_ASPECT_RATIO = 16 / 9;
+const WIDE_SLIDE_ASPECT_TOLERANCE = 0.03;
 
 type DomToPptxOptions = {
   readonly fileName: string;
@@ -339,6 +356,10 @@ function createExportBootstrapScript(options: DomToPptxOptions): string {
   const options = ${JSON.stringify(options)};
   const scriptUrl = ${JSON.stringify(domToPptxScriptUrl())};
   const slideSelectors = ${JSON.stringify(SLIDE_SELECTORS)};
+  const weakSlideSelectors = ${JSON.stringify(WEAK_SLIDE_SELECTORS)};
+  const innerSlideCandidateSelectors = ${JSON.stringify(INNER_SLIDE_CANDIDATE_SELECTORS)};
+  const wideSlideAspectRatio = ${JSON.stringify(WIDE_SLIDE_ASPECT_RATIO)};
+  const wideSlideAspectTolerance = ${JSON.stringify(WIDE_SLIDE_ASPECT_TOLERANCE)};
   const fontReadyTimeoutMs = ${JSON.stringify(EXPORT_FONT_READY_TIMEOUT_MS)};
 
   const post = (message) => {
@@ -390,13 +411,84 @@ function createExportBootstrapScript(options: DomToPptxOptions): string {
 `;
 }
 
+function createExportSlideNormalizationScript(): string {
+  return `
+  const matchesAnySelector = (element, selectors) => {
+    return selectors.some((selector) => element.matches(selector));
+  };
+
+  const isWeakSlideSelector = (selector) => {
+    return weakSlideSelectors.includes(selector);
+  };
+
+  const isWideSlideNode = (node) => {
+    if (!(node instanceof HTMLElement)) {
+      return false;
+    }
+    const rect = node.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return false;
+    }
+    return Math.abs(rect.width / rect.height - wideSlideAspectRatio) <= wideSlideAspectTolerance;
+  };
+
+  const innerSlideCandidates = (node) => {
+    if (!(node instanceof HTMLElement)) {
+      return [];
+    }
+    const directCandidates = Array.from(node.children).filter((child) => {
+      return matchesAnySelector(child, innerSlideCandidateSelectors);
+    });
+    if (directCandidates.length > 0) {
+      return directCandidates;
+    }
+    return Array.from(
+      node.querySelectorAll(innerSlideCandidateSelectors.join(",")),
+    );
+  };
+
+  const normalizeSlideNode = (node, selector) => {
+    if (!(node instanceof HTMLElement) || !isWeakSlideSelector(selector)) {
+      return node;
+    }
+    if (isWideSlideNode(node)) {
+      return node;
+    }
+    const candidates = innerSlideCandidates(node);
+    const wideCandidates = candidates.filter(isWideSlideNode);
+    if (wideCandidates.length === 1) {
+      return wideCandidates[0];
+    }
+    if (candidates.length === 1) {
+      return candidates[0];
+    }
+    console.warn(
+      "Presentation PPTX export kept the original slide node because no unique 16:9 inner slide canvas was found.",
+      node,
+    );
+    return node;
+  };
+
+  const uniqueNodes = (nodes) => {
+    const seen = new Set();
+    return nodes.filter((node) => {
+      if (seen.has(node)) {
+        return false;
+      }
+      seen.add(node);
+      return true;
+    });
+  };
+`;
+}
+
 function createExportSlideScript(): string {
   return `
   const selectSlideNodes = () => {
     for (const selector of slideSelectors) {
       const nodes = Array.from(document.querySelectorAll(selector));
       if (nodes.length > 0) {
-        return nodes;
+        return uniqueNodes(nodes.map((node) => normalizeSlideNode(node, selector)));
       }
     }
     return document.body ? [document.body] : [];
@@ -637,6 +729,7 @@ function createExportRunnerScript(): string {
 function createExportScript(options: DomToPptxOptions): string {
   return [
     createExportBootstrapScript(options),
+    createExportSlideNormalizationScript(),
     createExportSlideScript(),
     createExportReadinessScript(),
     createExportRunnerScript(),
@@ -747,10 +840,60 @@ function selectSlideElements(doc: Document): Element[] {
   for (const selector of SLIDE_SELECTORS) {
     const slides = Array.from(doc.querySelectorAll(selector));
     if (slides.length > 0) {
-      return slides;
+      return slides.map((slide) => {
+        return normalizeSlideElement(slide, selector);
+      });
     }
   }
   return doc.body ? [doc.body] : [];
+}
+
+function matchesAnySelector(
+  element: Element,
+  selectors: readonly string[],
+): boolean {
+  return selectors.some((selector) => {
+    return element.matches(selector);
+  });
+}
+
+function isWeakSlideSelector(selector: string): boolean {
+  return WEAK_SLIDE_SELECTORS.some((candidate) => {
+    return candidate === selector;
+  });
+}
+
+function normalizeSlideElement(slide: Element, selector: string): Element {
+  if (!isWeakSlideSelector(selector)) {
+    return slide;
+  }
+  const directCandidates = Array.from(slide.children).filter((child) => {
+    return matchesAnySelector(child, INNER_SLIDE_CANDIDATE_SELECTORS);
+  });
+  const candidate =
+    directCandidates.length === 1
+      ? directCandidates[0]
+      : uniqueInnerSlideCandidate(slide);
+  if (!candidate) {
+    return slide;
+  }
+  inheritSlideId(slide, candidate);
+  return candidate;
+}
+
+function uniqueInnerSlideCandidate(slide: Element): Element | null {
+  const selector = INNER_SLIDE_CANDIDATE_SELECTORS.join(",");
+  const candidates = Array.from(slide.querySelectorAll(selector));
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function inheritSlideId(source: Element, target: Element): void {
+  if (!(source instanceof HTMLElement) || !(target instanceof HTMLElement)) {
+    return;
+  }
+  if (!target.dataset.slideId && source.dataset.slideId) {
+    target.dataset.slideId = source.dataset.slideId;
+  }
 }
 
 function slideIdForElement(slide: Element, index: number): string {


### PR DESCRIPTION
## Summary
- prefer protocol-marked presentation slide nodes in the edit parser
- normalize weak .slide/section matches to a unique inner slide canvas when present
- apply the same fallback behavior to PPTX export and speaker notes extraction
- add targeted coverage for legacy viewport wrappers with nested 16:9 stage canvases

## Testing
- pnpm exec prettier --write apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts apps/platform/src/views/zero-page/presentation-html-pptx-download.ts apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "presentation HTML edit protocol|includes nested slide canvas normalization"
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint

Note: running the full zero-artifact-sidebar test file locally exposed unrelated existing environment failures around Invalid URL / inbox artifact tabs; the new targeted test passes.