### PR TITLE
style: update template picker icon

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -40,6 +40,7 @@
     "jszip": "^3.10.1",
     "katex": "^0.17.0",
     "lowlight": "^3.3.0",
+    "lucide-react": "1.20.0",
     "path-to-regexp": "^8.4.0",
     "posthog-js": "^1.372.1",
     "react": "^19.2.6",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -36,6 +36,7 @@ import {
   IconVideo,
   IconX,
 } from "@tabler/icons-react";
+import { LayoutGrid, Sparkle } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -2503,6 +2504,23 @@ function SelectedTemplateChipSlot({
   return null;
 }
 
+function TemplatePickerIcon() {
+  return (
+    <span aria-hidden="true" className="relative inline-flex h-[18px] w-[18px]">
+      <LayoutGrid
+        className="absolute bottom-0 left-0"
+        size={16}
+        strokeWidth={1.7}
+      />
+      <Sparkle
+        className="absolute -right-1.5 -top-1"
+        size={8}
+        strokeWidth={1.8}
+      />
+    </span>
+  );
+}
+
 function TemplatePickerButton({
   picker,
   hasPptTab,
@@ -2545,7 +2563,7 @@ function TemplatePickerButton({
                 setOpen(true);
               }}
             >
-              <IconTemplate size={18} stroke={1.5} />
+              <TemplatePickerIcon />
             </button>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -583,6 +583,9 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      lucide-react:
+        specifier: 1.20.0
+        version: 1.20.0(react@19.2.6)
       path-to-regexp:
         specifier: ^8.4.0
         version: 8.4.0
@@ -7749,6 +7752,11 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lucide-react@1.20.0:
+    resolution: {integrity: sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -17379,6 +17387,10 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  lucide-react@1.20.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary
- Add `lucide-react` so the composer template picker can use Lucide's square `LayoutGrid` icon
- Replace the composer template picker icon with a monochrome `LayoutGrid` plus a separated small `Sparkle` accent
- Keep the existing template button hover/pressed behavior and leave larger template preview icons unchanged

## Tests
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/package.json pnpm-lock.yaml
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx