### PR TITLE
feat: enable chat double-click rename for staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -53,6 +53,11 @@ describe("isFeatureEnabled", () => {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ChatThreadDoubleClickRename, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).toBe(true);
   });
 
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
@@ -73,6 +78,11 @@ describe("isFeatureEnabled", () => {
     ).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.ChatAutomationSidebar, {
+        orgId: "org_nonexistent",
+      }),
+    ).toBe(false);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ChatThreadDoubleClickRename, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
@@ -127,6 +137,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatAutomationSidebar]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatThreadDoubleClickRename]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
 
@@ -137,6 +150,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.SkillsViewer]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatAutomationSidebar]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatThreadDoubleClickRename]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -275,6 +275,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Open the existing chat rename dialog when a sidebar chat thread is double-clicked.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatTemplatePicker]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary
- enable `chatThreadDoubleClickRename` by default for staff orgs via `STAFF_ORG_ID_HASHES`
- keep the feature disabled by default for non-staff orgs
- extend feature switch tests for staff and non-staff rollout behavior

## Verification
- pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts --reporter verbose