### PR TITLE
feat: pull presentation resources from private r2 archives

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -41,6 +41,7 @@ import { githubOauthRoutes } from "./routes/github-oauth";
 import { legacyFileRoutes } from "./routes/legacy-file";
 import { logsSearchRoutes } from "./routes/logs-search";
 import { modelStatsRoutes } from "./routes/model-stats";
+import { registryResourceDownloadRoutes } from "./routes/registry-resources-download";
 import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
 import { userExportRoutes } from "./routes/user-export";
@@ -331,6 +332,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroTeamRoutes,
   ...zeroUploadsCompleteRoutes,
   ...zeroUploadsPrepareRoutes,
+  ...registryResourceDownloadRoutes,
   ...storagesCommitRoutes,
   ...storagesDownloadRoutes,
   ...storagesListRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from "node:crypto";
+
+import { registryResourceDownloadContract } from "@vm0/api-contracts/contracts/registry-resources";
+import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { writeDb$ } from "../../external/db";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+const routeMocks = createZeroRouteMocks(context);
+
+const STORAGE_NAME = "registry-resource@template:html-ppt-business-data";
+const VERSION_ID =
+  "5d981ea6d44248fdfffb7b467e40177a394f234d5f8ba9b3ff0c33e39d1c7081";
+const ARCHIVE_SHA256 =
+  "a5e0777b924534404a7be2e0a8b34feb546b70ec1f9b91058673e12c39772d86";
+
+function client() {
+  return setupApp({ context })(registryResourceDownloadContract);
+}
+
+function authHeaders() {
+  routeMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+  return { authorization: "Bearer clerk-session" };
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (
+    typeof command === "object" &&
+    command !== null &&
+    "input" in command &&
+    typeof command.input === "object" &&
+    command.input !== null
+  ) {
+    return command.input as Record<string, unknown>;
+  }
+  return {};
+}
+
+async function deleteStorageFixture(): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.delete(storages).where(eq(storages.name, STORAGE_NAME));
+}
+
+async function seedPrivateArchiveStorage(): Promise<string> {
+  const writeDb = store.set(writeDb$);
+  await deleteStorageFixture();
+
+  const orgId = `org_${randomUUID()}`;
+  const s3Prefix = `${orgId}/volume/${STORAGE_NAME}`;
+  const s3Key = `${s3Prefix}/${VERSION_ID}`;
+  const [storage] = await writeDb
+    .insert(storages)
+    .values({
+      orgId,
+      userId: VOLUME_ORG_USER_ID,
+      name: STORAGE_NAME,
+      type: "volume",
+      s3Prefix,
+      size: 1_433_248,
+      fileCount: 19,
+    })
+    .returning({ id: storages.id });
+
+  if (!storage) {
+    throw new Error("Failed to seed registry resource storage");
+  }
+
+  await writeDb.insert(storageVersions).values({
+    id: VERSION_ID,
+    storageId: storage.id,
+    s3Key,
+    size: 1_433_248,
+    fileCount: 19,
+    message: "test private registry archive",
+    createdBy: "test",
+  });
+  await writeDb
+    .update(storages)
+    .set({ headVersionId: VERSION_ID })
+    .where(eq(storages.id, storage.id));
+
+  return s3Key;
+}
+
+afterEach(async () => {
+  await deleteStorageFixture();
+});
+
+describe("registry resource download", () => {
+  it("returns a presigned URL for an allowlisted private registry archive", async () => {
+    const s3Key = await seedPrivateArchiveStorage();
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", "test-user-storages");
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.test/private-resource.tar.gz?sig=test",
+    );
+
+    const response = await accept(
+      client().download({
+        headers: authHeaders(),
+        query: { id: "template:html-ppt-business-data" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      id: "template:html-ppt-business-data",
+      type: "tar.gz",
+      sha256: ARCHIVE_SHA256,
+      versionId: VERSION_ID,
+      fileCount: 19,
+      size: 1_433_248,
+      expiresInSeconds: 900,
+      url: "https://r2.example.test/private-resource.tar.gz?sig=test",
+    });
+
+    const [, command] = context.mocks.s3.getSignedUrl.mock.calls.at(-1) ?? [];
+    expect(commandInput(command)).toMatchObject({
+      Bucket: "test-user-storages",
+      Key: `${s3Key}/archive.tar.gz`,
+    });
+  });
+
+  it("rejects registry resources that are not in the private archive allowlist", async () => {
+    const response = await accept(
+      client().download({
+        headers: authHeaders(),
+        query: { id: "template:dashboard" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -1,0 +1,181 @@
+import { computed } from "ccstate";
+import { registryResourceDownloadContract } from "@vm0/api-contracts/contracts/registry-resources";
+import {
+  findDesignSystem,
+  findImageStyle,
+  findTemplate,
+  findVideoTemplate,
+  type RegistryEntry,
+  type VideoTemplateRegistryEntry,
+} from "@vm0/core/resource-registry";
+import { storages, storageVersions } from "@vm0/db/schema/storage";
+import { and, eq } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { notFound } from "../../lib/error";
+import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
+import { db$ } from "../external/db";
+import { generatePresignedGetUrl } from "../external/s3";
+import type { RouteEntry } from "../route";
+
+type PullableRegistryEntry = RegistryEntry | VideoTemplateRegistryEntry;
+
+interface PrivateRegistryResourceArchive {
+  readonly storageName: string;
+  readonly versionId: string;
+}
+
+const DOWNLOAD_URL_TTL_SECONDS = 900;
+
+function storageServiceNotConfigured() {
+  return {
+    status: 500 as const,
+    body: {
+      error: {
+        message: "Storage service is not properly configured",
+        code: "INTERNAL_ERROR" as const,
+      },
+    },
+  };
+}
+
+function privateRegistryResourceArchive(
+  id: string,
+): PrivateRegistryResourceArchive | undefined {
+  switch (id) {
+    case "design-system:berry-pop": {
+      return {
+        storageName: "registry-resource@design-system:berry-pop",
+        versionId:
+          "8a7b9e507e793d31f5d97a126a2eb1e65d7faf299dbdc802ecf1a7e3b88ec4df",
+      };
+    }
+    case "design-system:mauve-dusk": {
+      return {
+        storageName: "registry-resource@design-system:mauve-dusk",
+        versionId:
+          "83f12acbb4e377f92f13bc37a203d9111a537237900913233dd7f6ce6bfffa0b",
+      };
+    }
+    case "design-system:playful-editorial": {
+      return {
+        storageName: "registry-resource@design-system:playful-editorial",
+        versionId:
+          "4e521d00ce64504386ed6b90fb8631224bc7975152085fa968a70a456ae8de02",
+      };
+    }
+    case "template:html-ppt-botane-organic": {
+      return {
+        storageName: "registry-resource@template:html-ppt-botane-organic",
+        versionId:
+          "dd38f6ead8da5be5121d285de1f61cde522b3c2eda4d8c3917bea65bf9e852cc",
+      };
+    }
+    case "template:html-ppt-playful-launch": {
+      return {
+        storageName: "registry-resource@template:html-ppt-playful-launch",
+        versionId:
+          "debf60cf13d32df7b31fd9078576512257b1a2e1e17b2464cdd17efd6f3638c5",
+      };
+    }
+    case "template:html-ppt-business-data": {
+      return {
+        storageName: "registry-resource@template:html-ppt-business-data",
+        versionId:
+          "5d981ea6d44248fdfffb7b467e40177a394f234d5f8ba9b3ff0c33e39d1c7081",
+      };
+    }
+    default: {
+      return undefined;
+    }
+  }
+}
+
+function findRegistryResource(id: string): PullableRegistryEntry | undefined {
+  return (
+    findTemplate(id) ??
+    findDesignSystem(id) ??
+    findImageStyle(id) ??
+    findVideoTemplate(id)
+  );
+}
+
+function archiveFilename(id: string): string {
+  return `${id.replace(/[^a-zA-Z0-9._-]/g, "-")}.tar.gz`;
+}
+
+const downloadRegistryResourceInner$ = computed(async (get) => {
+  const query = get(queryOf(registryResourceDownloadContract.download));
+  const privateArchive = privateRegistryResourceArchive(query.id);
+  if (!privateArchive) {
+    return notFound(`Registry resource "${query.id}" is not private-pullable`);
+  }
+
+  const entry = findRegistryResource(query.id);
+  const archive = entry?.source.archive;
+  if (!entry || !archive) {
+    return notFound(`Registry resource "${query.id}" has no archive source`);
+  }
+
+  const db = get(db$);
+  const [version] = await db
+    .select({
+      s3Key: storageVersions.s3Key,
+      fileCount: storageVersions.fileCount,
+      size: storageVersions.size,
+    })
+    .from(storageVersions)
+    .innerJoin(storages, eq(storages.id, storageVersions.storageId))
+    .where(
+      and(
+        eq(storages.name, privateArchive.storageName),
+        eq(storages.type, "volume"),
+        eq(storageVersions.id, privateArchive.versionId),
+      ),
+    )
+    .limit(1);
+
+  if (!version) {
+    return notFound(`Private archive for "${query.id}" was not found`);
+  }
+
+  const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+  if (!bucket) {
+    return storageServiceNotConfigured();
+  }
+
+  const url = await get(
+    generatePresignedGetUrl(
+      bucket,
+      `${version.s3Key}/archive.tar.gz`,
+      DOWNLOAD_URL_TTL_SECONDS,
+      archiveFilename(query.id),
+      true,
+    ),
+  );
+
+  return {
+    status: 200 as const,
+    body: {
+      url,
+      id: entry.id,
+      type: archive.type,
+      sha256: archive.sha256,
+      expiresInSeconds: DOWNLOAD_URL_TTL_SECONDS,
+      versionId: privateArchive.versionId,
+      fileCount: version.fileCount,
+      size: Number(version.size),
+    },
+  };
+});
+
+export const registryResourceDownloadRoutes: readonly RouteEntry[] = [
+  {
+    route: registryResourceDownloadContract.download,
+    handler: authRoute(
+      { requiredCapability: "file:read" },
+      downloadRegistryResourceInner$,
+    ),
+  },
+];

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -20,6 +20,7 @@ function buildCommands(): Command[] {
     new Command("connector"),
     new Command("credit"),
     new Command("logs"),
+    new Command("resource"),
     new Command("preference"),
     new Command("schedule"),
     new Command("secret"),
@@ -144,6 +145,7 @@ describe("registerZeroCommands", () => {
       "model",
       "model-provider",
       "agent",
+      "resource",
       "whoami",
       "generate",
       "web",
@@ -199,6 +201,7 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toEqual([
       "model",
       "model-provider",
+      "resource",
       "whoami",
       "generate",
       "web",
@@ -654,6 +657,7 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toEqual([
       "model",
       "model-provider",
+      "resource",
       "whoami",
       "generate",
       "web",

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -22,6 +22,7 @@ describe("zero CLI program", () => {
       "doctor",
       "logs",
       "search",
+      "resource",
       "preference",
       "schedule",
       "automation",
@@ -64,7 +65,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 28 commands", () => {
-    expect(commandNames).toHaveLength(28);
+  it("should have exactly 29 commands", () => {
+    expect(commandNames).toHaveLength(29);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -158,9 +158,14 @@ describe("zero generate presentation command", () => {
     expect(stdout).toContain(
       "Selected template: template:html-ppt-playful-launch (Playful Launch Presentation)",
     );
-    expect(stdout).toContain("vm0-ai/vm0-skills@main");
+    expect(stdout).toContain(
+      "zero resource pull <resource-id> --dir ./generated/resources",
+    );
     expect(stdout).toContain('"id": "template:html-ppt-playful-launch"');
     expect(stdout).toContain('"path": "presentation-template/aplocoto"');
+    expect(stdout).toContain('"archive"');
+    expect(stdout).toContain('"type": "tar.gz"');
+    expect(stdout).toContain('"sha256"');
     expect(stdout).toContain('"id": "design-system:playful-editorial"');
     expect(stdout).toContain(
       '"path": "presentation-design-system/playful-editorial"',

--- a/turbo/apps/cli/src/commands/zero/resource/index.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/index.ts
@@ -1,0 +1,147 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Command } from "commander";
+import chalk from "chalk";
+import * as tar from "tar";
+import {
+  findDesignSystem,
+  findImageStyle,
+  findTemplate,
+  findVideoTemplate,
+  type RegistryEntry,
+  type VideoTemplateRegistryEntry,
+} from "@vm0/core/resource-registry";
+
+import { getRegistryResourceDownload } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+type PullableRegistryEntry = RegistryEntry | VideoTemplateRegistryEntry;
+
+interface PullOptions {
+  readonly dir: string;
+}
+
+function candidateIds(id: string): readonly string[] {
+  if (id.includes(":")) {
+    return [id];
+  }
+  return [
+    `template:${id}`,
+    `design-system:${id}`,
+    `image-style:${id}`,
+    `video-template:${id}`,
+  ];
+}
+
+function findRegistryResource(id: string): PullableRegistryEntry | undefined {
+  for (const candidate of candidateIds(id)) {
+    const entry =
+      findTemplate(candidate) ??
+      findDesignSystem(candidate) ??
+      findImageStyle(candidate) ??
+      findVideoTemplate(candidate);
+    if (entry) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function isSafeTarPath(entryPath: string): boolean {
+  const normalized = entryPath.replace(/\\/gu, "/");
+  return (
+    !path.isAbsolute(normalized) &&
+    !normalized.split("/").some((segment) => {
+      return segment === "..";
+    })
+  );
+}
+
+async function downloadArchive(url: string): Promise<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Resource archive download failed: ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+function verifyArchive(buffer: Buffer, expectedSha256: string): void {
+  const actual = createHash("sha256").update(buffer).digest("hex");
+  if (actual !== expectedSha256) {
+    throw new Error(
+      `Resource archive digest mismatch: expected ${expectedSha256}, got ${actual}`,
+    );
+  }
+}
+
+export const zeroResourceCommand = new Command()
+  .name("resource")
+  .description("Pull registry resources from private R2-backed archives")
+  .addCommand(
+    new Command()
+      .name("pull")
+      .description("Download and extract a private registry resource archive")
+      .argument(
+        "<id>",
+        "Registry resource id, such as template:html-ppt-playful-launch",
+      )
+      .option(
+        "--dir <path>",
+        "Directory to extract into",
+        "./generated/resources",
+      )
+      .action(
+        withErrorHandler(async (id: string, options: PullOptions) => {
+          const entry = findRegistryResource(id);
+          if (!entry) {
+            throw new Error(`Unknown registry resource: ${id}`);
+          }
+
+          const archive = entry.source.archive;
+          if (!archive) {
+            throw new Error(
+              `Registry resource ${entry.id} does not provide an R2 archive source`,
+            );
+          }
+
+          console.log(chalk.dim(`Pulling ${entry.id}...`));
+          const download = await getRegistryResourceDownload({ id: entry.id });
+          if (download.sha256 !== archive.sha256) {
+            throw new Error(
+              `Resource archive digest metadata mismatch: expected ${archive.sha256}, got ${download.sha256}`,
+            );
+          }
+
+          const buffer = await downloadArchive(download.url);
+          verifyArchive(buffer, archive.sha256);
+
+          const outputDir = path.resolve(options.dir);
+          const tmpDir = await mkdtemp(path.join(tmpdir(), "zero-resource-"));
+          const archivePath = path.join(tmpDir, "resource.tar.gz");
+          await mkdir(outputDir, { recursive: true });
+          await writeFile(archivePath, buffer);
+
+          try {
+            await tar.extract({
+              file: archivePath,
+              cwd: outputDir,
+              gzip: true,
+              filter: isSafeTarPath,
+            });
+          } finally {
+            await rm(tmpDir, { recursive: true, force: true });
+          }
+
+          console.log(chalk.green(`✓ Pulled ${entry.id}`));
+          console.log(chalk.dim(`  Extracted to: ${outputDir}`));
+          console.log(
+            chalk.dim(
+              `  Source path:  ${path.join(outputDir, entry.source.path)}`,
+            ),
+          );
+        }),
+      ),
+  );

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -89,6 +89,15 @@ function outputDirForSite(site: string): string {
   return `./generated/mockups/${site}`;
 }
 
+function formatCandidateSource(
+  source: ResourceCandidateSlice["sources"][number],
+): string {
+  if ("repo" in source) {
+    return `- \`${source.repo}@${source.ref}\``;
+  }
+  return `- ${source.description}`;
+}
+
 export function createHtmlArtifactAuthoringPacket(
   options: HtmlArtifactAuthoringOptions,
 ): HtmlArtifactAuthoringPacket {
@@ -167,9 +176,7 @@ export function createHtmlArtifactAuthoringPacket(
     "## Candidate Registry Slice",
     `Registry: \`${candidateSlice.registryVersion}\``,
     "Sources:",
-    ...candidateSlice.sources.map((src) => {
-      return `- \`${src.repo}@${src.ref}\``;
-    }),
+    ...candidateSlice.sources.map(formatCandidateSource),
     "",
     "```json",
     JSON.stringify(candidateSlice.candidates, null, 2),
@@ -178,6 +185,7 @@ export function createHtmlArtifactAuthoringPacket(
     "## Stage 2: Resolve Selected Resources",
     "- For every selected resource, fetch or read the referenced source before authoring.",
     "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
+    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
     "- For directory refs, inspect the most relevant files such as `SKILL.md`, `DESIGN.md`, `README.md`, tokens, examples, and templates.",
     "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
     "",

--- a/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
@@ -46,6 +46,15 @@ interface StyledImageAuthoringPacket {
   readonly instructions: string;
 }
 
+function formatCandidateSource(
+  source: ResourceCandidateSlice["sources"][number],
+): string {
+  if ("repo" in source) {
+    return `- \`${source.repo}@${source.ref}\``;
+  }
+  return `- ${source.description}`;
+}
+
 const outputDir = "./generated/images";
 const artifactRules = [
   "Resolve the selected style source before generating the image.",
@@ -110,9 +119,7 @@ export function createStyledImageAuthoringPacket(
     "## Candidate Registry Slice",
     `Registry: \`${candidateSlice.registryVersion}\``,
     "Sources:",
-    ...candidateSlice.sources.map((src) => {
-      return `- \`${src.repo}@${src.ref}\``;
-    }),
+    ...candidateSlice.sources.map(formatCandidateSource),
     "",
     "```json",
     JSON.stringify(candidateSlice.candidates, null, 2),
@@ -121,6 +128,7 @@ export function createStyledImageAuthoringPacket(
     "## Stage 2: Resolve Selected Resources",
     "- Fetch or read the selected resource source before generation.",
     "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
+    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
     "- For directory refs, inspect the most relevant files such as `SKILL.md`, references, examples, and templates.",
     "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
     "",

--- a/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
@@ -46,6 +46,15 @@ interface VideoTemplateAuthoringPacket {
   readonly instructions: string;
 }
 
+function formatCandidateSource(
+  source: ResourceCandidateSlice["sources"][number],
+): string {
+  if ("repo" in source) {
+    return `- \`${source.repo}@${source.ref}\``;
+  }
+  return `- ${source.description}`;
+}
+
 const outputDir = "./generated/videos";
 const artifactRules = [
   "Resolve the selected video template source before generating the video.",
@@ -112,9 +121,7 @@ export function createVideoTemplateAuthoringPacket(
     "## Candidate Registry Slice",
     `Registry: \`${candidateSlice.registryVersion}\``,
     "Sources:",
-    ...candidateSlice.sources.map((src) => {
-      return `- \`${src.repo}@${src.ref}\``;
-    }),
+    ...candidateSlice.sources.map(formatCandidateSource),
     "",
     "```json",
     JSON.stringify(candidateSlice.candidates, null, 2),
@@ -123,6 +130,7 @@ export function createVideoTemplateAuthoringPacket(
     "## Stage 2: Resolve Selected Resources",
     "- Fetch or read the selected resource source before generation.",
     "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
+    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
     "- For directory refs, inspect the most relevant files such as `SKILL.md`, references, examples, and templates.",
     "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
     "",

--- a/turbo/apps/cli/src/lib/api/domains/registry-resources.ts
+++ b/turbo/apps/cli/src/lib/api/domains/registry-resources.ts
@@ -1,0 +1,27 @@
+import { initClient } from "@ts-rest/core";
+import { registryResourceDownloadContract } from "@vm0/api-contracts/contracts/registry-resources";
+
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function getRegistryResourceDownload(query: {
+  id: string;
+}): Promise<{
+  url: string;
+  id: string;
+  type: "tar.gz";
+  sha256: string;
+  expiresInSeconds: number;
+  versionId: string;
+  fileCount: number;
+  size: number;
+}> {
+  const config = await getClientConfig();
+  const client = initClient(registryResourceDownloadContract, config);
+
+  const result = await client.download({ query });
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Registry resource "${query.id}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -35,6 +35,9 @@ export {
   listStorages,
 } from "./domains/storages";
 
+// Domain modules - Registry Resources
+export { getRegistryResourceDownload } from "./domains/registry-resources";
+
 // Domain modules - Zero User Preferences
 export {
   getZeroUserPreferences,

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -31,6 +31,7 @@ import { zeroBankingCommand } from "./commands/zero/banking";
 import { zeroModelCommand } from "./commands/zero/model";
 import { zeroModelProviderCommand } from "./commands/zero/model-provider";
 import { zeroVideoCommand } from "./commands/zero/video";
+import { zeroResourceCommand } from "./commands/zero/resource";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -59,6 +60,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   "model-provider": null,
   logs: "agent-run:read",
   search: "chat-message:read",
+  resource: null,
   github: ["github:read", "github:write"],
   slack: "slack:write",
   telegram: ["telegram:read", "telegram:write"],
@@ -93,6 +95,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroVariableCommand,
   zeroLogsCommand,
   zeroSearchCommand,
+  zeroResourceCommand,
   zeroWhoamiCommand,
   zeroSkillCommand,
   zeroDeveloperSupportCommand,

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -1773,6 +1773,19 @@ describe("API backend rewrite proxy behavior", () => {
     expect(matchesApiBackendRewritePath("/api/storages/commits")).toBe(false);
   });
 
+  it("matches the registry resource download rewrite path exactly", () => {
+    expect(
+      matchesApiBackendRewritePath("/api/registry/resources/download"),
+    ).toBe(true);
+    expect(
+      matchesApiBackendRewritePath("/api/registry/resources/download/extra"),
+    ).toBe(false);
+    expect(matchesApiBackendRewritePath("/api/registry/resources")).toBe(false);
+    expect(
+      matchesApiBackendRewritePath("/api/registry/resources/downloads"),
+    ).toBe(false);
+  });
+
   it("matches the storages download rewrite path exactly", () => {
     expect(matchesApiBackendRewritePath("/api/storages/download")).toBe(true);
     expect(matchesApiBackendRewritePath("/api/storages/download/extra")).toBe(

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -635,6 +635,7 @@ export const API_BACKEND_REWRITES = [
     ZERO_LOGS_BY_ID_PATH_RE,
   ],
   ["/api/zero/logs/search", "/api/zero/logs/search"],
+  ["/api/registry/resources/download", "/api/registry/resources/download"],
   ["/api/storages/commit", "/api/storages/commit"],
   ["/api/storages/download", "/api/storages/download"],
   ["/api/storages/list", "/api/storages/list"],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -184,6 +184,10 @@ export {
   type StoragesListContract,
 } from "./storages";
 export {
+  registryResourceDownloadContract,
+  type RegistryResourceDownloadContract,
+} from "./registry-resources";
+export {
   testTelegramDispatchProbeContract,
   type TestTelegramDispatchProbeContract,
 } from "./test-telegram-dispatch-probe";

--- a/turbo/packages/api-contracts/src/contracts/registry-resources.ts
+++ b/turbo/packages/api-contracts/src/contracts/registry-resources.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const registryResourceDownloadContract = c.router({
+  download: {
+    method: "GET",
+    path: "/api/registry/resources/download",
+    headers: authHeadersSchema,
+    query: z.object({
+      id: z.string().min(1, "Resource id is required"),
+    }),
+    responses: {
+      200: z.object({
+        url: z.url(),
+        id: z.string(),
+        type: z.literal("tar.gz"),
+        sha256: z.string().regex(/^[a-f0-9]{64}$/),
+        expiresInSeconds: z.number().int().positive(),
+        versionId: z.string(),
+        fileCount: z.number().int().nonnegative(),
+        size: z.number().nonnegative(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get a presigned URL for a private registry resource archive",
+  },
+});
+
+export type RegistryResourceDownloadContract =
+  typeof registryResourceDownloadContract;

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -5,9 +5,33 @@ import {
 } from "../presentation-template-items";
 import { findDesignSystem, findTemplate } from "../resource-registry";
 
+const FORBIDDEN_ASSET_URL_PARTS = [
+  "drive.google.com",
+  "googleusercontent.com",
+  "raw.githubusercontent.com",
+  "file://",
+] as const;
+
 function stripRegistryPrefix(id: string, prefix: string): string {
   expect(id.startsWith(prefix)).toBe(true);
   return id.slice(prefix.length);
+}
+
+function expectCdnPreviewImages(
+  item: (typeof PRESENTATION_TEMPLATE_PICKER_ITEMS)[number],
+): void {
+  expect(item.previewImages.length).toBeGreaterThan(0);
+  expect(item.previewImage).toBe(item.previewImages[0]);
+
+  for (const url of item.previewImages) {
+    expect(url).toMatch(/^https:\/\/cdn\.vm0\.io\/artifacts\/.+\.png$/);
+  }
+
+  for (const url of [item.previewImage, item.embedUrl, ...item.previewImages]) {
+    for (const forbidden of FORBIDDEN_ASSET_URL_PARTS) {
+      expect(url).not.toContain(forbidden);
+    }
+  }
 }
 
 describe("presentation template items", () => {
@@ -77,20 +101,47 @@ describe("presentation template items", () => {
     });
 
     expect(item).toBeDefined();
-    expect(item?.designSystemId).toBe("design-system:playful-editorial");
-    expect(item?.templateId).toBe("template:html-ppt-playful-launch");
-    expect(item?.previewImages.length).toBe(15);
-    expect(item?.previewImage).toBe(item?.previewImages[0]);
-    expect(
-      item?.previewImages.every((url) => {
-        return url.startsWith("https://cdn.vm0.io/artifacts/");
-      }),
-    ).toBe(true);
-    expect(findDesignSystem(item?.designSystemId ?? "")).toBeDefined();
-    expect(findTemplate(item?.templateId ?? "")?.targets).toContain(
-      "presentation",
-    );
+    if (!item) {
+      throw new Error("missing playful-launch-presentation picker item");
+    }
 
+    expect(item.designSystemId).toBe("design-system:playful-editorial");
+    expect(item.templateId).toBe("template:html-ppt-playful-launch");
+    expect(item.previewImages.length).toBe(15);
+    expect(item.previewImage).toBe(item.previewImages[0]);
+    expectCdnPreviewImages(item);
+    expect(findDesignSystem(item.designSystemId)).toBeDefined();
+    expect(findTemplate(item.templateId)?.targets).toContain("presentation");
+  });
+
+  it("keeps the business data picker item aligned with CDN assets", () => {
+    expect(
+      PRESENTATION_TEMPLATE_ITEMS.some((candidate) => {
+        return candidate.slug === "business-data-presentation";
+      }),
+    ).toBe(false);
+
+    const item = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((candidate) => {
+      return candidate.slug === "business-data-presentation";
+    });
+
+    expect(item).toBeDefined();
+    if (!item) {
+      throw new Error("missing business-data-presentation picker item");
+    }
+
+    expect(item.designSystemId).toBe("design-system:berry-pop");
+    expect(item.templateId).toBe("template:html-ppt-business-data");
+    expect(item.previewImages.length).toBe(15);
+    expect(item.embedUrl).toMatch(
+      /^https:\/\/cdn\.vm0\.io\/artifacts\/.+\/example\.html$/,
+    );
+    expectCdnPreviewImages(item);
+    expect(findDesignSystem(item.designSystemId)).toBeDefined();
+    expect(findTemplate(item.templateId)?.targets).toContain("presentation");
+  });
+
+  it("keeps the botane picker item aligned with CDN assets", () => {
     const botaneItem = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((candidate) => {
       return candidate.slug === "botane-organic-deck";
     });
@@ -104,12 +155,7 @@ describe("presentation template items", () => {
     expect(botaneItem.previewImages.length).toBe(15);
     expect(botaneItem.previewImage).toBe(botaneItem.previewImages[0]);
     expect(botaneItem.embedUrl).toMatch(/^https:\/\/cdn\.vm0\.io\/.+\.html$/);
-    for (const previewUrl of botaneItem.previewImages) {
-      expect(previewUrl).toMatch(/^https:\/\/cdn\.vm0\.io\//);
-      expect(previewUrl).not.toMatch(
-        /drive\.google\.com|googleusercontent\.com|raw\.githubusercontent\.com|file:\/\//,
-      );
-    }
+    expectCdnPreviewImages(botaneItem);
     expect(findDesignSystem(botaneItem.designSystemId)).toBeDefined();
     expect(findTemplate(botaneItem.templateId)?.targets).toContain(
       "presentation",

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -34,6 +34,43 @@ function expectCdnPreviewImages(
   }
 }
 
+function expectR2ArchiveSource(id: string, sourcePath: string): void {
+  const entry = id.startsWith("template:")
+    ? findTemplate(id)
+    : findDesignSystem(id);
+
+  expect(entry, id).toBeDefined();
+  if (!entry) {
+    throw new Error(`missing registry entry ${id}`);
+  }
+
+  expect(entry.source.path).toBe(sourcePath);
+  expect(entry.source.repo).toBeUndefined();
+  expect(entry.source.ref).toBeUndefined();
+  expect(entry.source.archive?.type).toBe("tar.gz");
+  expect(entry.source.archive?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  expect(entry.source.archive).not.toHaveProperty("url");
+}
+
+function expectOpenDesignSource(
+  id: string,
+  sourcePathPrefix: "design-systems/" | "design-templates/",
+): void {
+  const entry = id.startsWith("template:")
+    ? findTemplate(id)
+    : findDesignSystem(id);
+
+  expect(entry, id).toBeDefined();
+  if (!entry) {
+    throw new Error(`missing registry entry ${id}`);
+  }
+
+  expect(entry.source.path).toMatch(new RegExp(`^${sourcePathPrefix}`));
+  expect(entry.source.repo).toBeUndefined();
+  expect(entry.source.ref).toBeUndefined();
+  expect(entry.source.archive).toBeUndefined();
+}
+
 describe("presentation template items", () => {
   const allPresentationItems = [
     ...PRESENTATION_TEMPLATE_ITEMS,
@@ -89,6 +126,13 @@ describe("presentation template items", () => {
     );
   });
 
+  it("keeps legacy presentation templates on the Open Design source path", () => {
+    for (const item of PRESENTATION_TEMPLATE_ITEMS) {
+      expectOpenDesignSource(item.designSystemId, "design-systems/");
+      expectOpenDesignSource(item.templateId, "design-templates/");
+    }
+  });
+
   it("keeps the picker catalog separate from the legacy catalog", () => {
     expect(
       PRESENTATION_TEMPLATE_ITEMS.some((candidate) => {
@@ -112,6 +156,11 @@ describe("presentation template items", () => {
     expectCdnPreviewImages(item);
     expect(findDesignSystem(item.designSystemId)).toBeDefined();
     expect(findTemplate(item.templateId)?.targets).toContain("presentation");
+    expectR2ArchiveSource(
+      item.designSystemId,
+      "presentation-design-system/playful-editorial",
+    );
+    expectR2ArchiveSource(item.templateId, "presentation-template/aplocoto");
   });
 
   it("keeps the business data picker item aligned with CDN assets", () => {
@@ -139,6 +188,14 @@ describe("presentation template items", () => {
     expectCdnPreviewImages(item);
     expect(findDesignSystem(item.designSystemId)).toBeDefined();
     expect(findTemplate(item.templateId)?.targets).toContain("presentation");
+    expectR2ArchiveSource(
+      item.designSystemId,
+      "presentation-design-system/berry-pop",
+    );
+    expectR2ArchiveSource(
+      item.templateId,
+      "presentation-template/business-data",
+    );
   });
 
   it("keeps the botane picker item aligned with CDN assets", () => {
@@ -159,6 +216,14 @@ describe("presentation template items", () => {
     expect(findDesignSystem(botaneItem.designSystemId)).toBeDefined();
     expect(findTemplate(botaneItem.templateId)?.targets).toContain(
       "presentation",
+    );
+    expectR2ArchiveSource(
+      botaneItem.designSystemId,
+      "presentation-design-system/mauve-dusk",
+    );
+    expectR2ArchiveSource(
+      botaneItem.templateId,
+      "presentation-template/botane-organic",
     );
   });
 });

--- a/turbo/packages/core/src/presentation-template-items.ts
+++ b/turbo/packages/core/src/presentation-template-items.ts
@@ -1810,6 +1810,24 @@ const PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES = [
   "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/968f9b6a-3ac9-4933-9902-df630f41e5b2/slide-15.png",
 ] as const satisfies readonly [string, ...string[]];
 
+const BUSINESS_DATA_CDN_PREVIEW_IMAGES = [
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a918a437-969d-4c2b-99b6-873b87ff010c/slide-01.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/9ae2de1d-9375-4ac9-8790-a89dd8c005aa/slide-02.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c748158b-2762-45e4-af7b-1518990c3d99/slide-03.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/0bf8ec9a-87bc-4cb6-ac4d-0632025e05f0/slide-04.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/59d39d34-823a-49a3-bb68-60b52609ea31/slide-05.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/56cf6793-4e43-4d41-98d3-69fe56587794/slide-06.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/14071bf1-4f38-4777-a86c-ed4b9e215162/slide-07.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b592f0fa-5989-4c31-95da-f7b2c12e232f/slide-08.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/e2c94257-3cfd-41f6-bf80-fe0ae52b7c1e/slide-09.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/19aa9c33-08e6-48ea-ad5d-00101e91987e/slide-10.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d867953f-d22d-44c9-952b-546832f3d3cc/slide-11.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b4fc1a75-d67d-436d-871e-59247b181f47/slide-12.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/9de2074d-c006-4de1-89de-f300a2edf8d7/slide-13.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3d4b209c-72ae-4567-a74b-d7b94bcbe048/slide-14.png",
+  "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f19a05ae-bf5d-4662-bcf0-42edd46cf03e/slide-15.png",
+] as const satisfies readonly [string, ...string[]];
+
 export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateItem[] =
   [
     {
@@ -1836,5 +1854,17 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
       previewImages: BOTANE_ORGANIC_PREVIEW_IMAGES,
       designSystemId: "design-system:mauve-dusk",
       templateId: "template:html-ppt-botane-organic",
+    },
+    {
+      slug: "business-data-presentation",
+      title: "Business data presentation",
+      prompt:
+        "/gen presentation with design system `berry-pop` and template `html-ppt-business-data`, create a 15-slide presentation for a business data report, annual review, market analysis, growth story, or metric-led service pitch. Include cover, agenda, company context, commitments, team, services, process, project gallery, proof metrics, testimonials, pricing, and contact. Make it number-first, chart-led, confident, modern, and readable.",
+      embedUrl:
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d3ff9478-a282-4946-9b1b-431c4cdb1788/example.html",
+      previewImage: BUSINESS_DATA_CDN_PREVIEW_IMAGES[0],
+      previewImages: BUSINESS_DATA_CDN_PREVIEW_IMAGES,
+      designSystemId: "design-system:berry-pop",
+      templateId: "template:html-ppt-business-data",
     },
   ];

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -35,6 +35,10 @@ interface ResourceSourceRef {
   readonly path: string;
   readonly repo?: string;
   readonly ref?: string;
+  readonly archive?: {
+    readonly type: "tar.gz";
+    readonly sha256: string;
+  };
 }
 
 export interface RegistryEntry {
@@ -70,10 +74,17 @@ export interface ResourceCandidateSlice {
     readonly repo: string;
     readonly ref: string;
   };
-  readonly sources: readonly {
-    readonly repo: string;
-    readonly ref: string;
-  }[];
+  readonly sources: readonly (
+    | {
+        readonly type?: "git";
+        readonly repo: string;
+        readonly ref: string;
+      }
+    | {
+        readonly type: "r2-archive";
+        readonly description: string;
+      }
+  )[];
   readonly candidates: {
     readonly skills: readonly RegistryEntry[];
     readonly templates: readonly RegistryEntry[];
@@ -95,6 +106,31 @@ const VIDEO_TEMPLATE_REGISTRY_SOURCE = {
 } as const;
 
 const RESOURCE_REGISTRY_VERSION = "v1";
+
+function privateR2ArchiveSource(
+  path: string,
+  sha256: string,
+): ResourceSourceRef {
+  return {
+    path,
+    archive: {
+      type: "tar.gz",
+      sha256,
+    },
+  };
+}
+
+const PRESENTATION_RESOURCE_ARCHIVE_SHA256 = {
+  berryPop: "dd0424e32f8534f23b46e02338ea11cc79d5fc2106e9be2c25343632b667a728",
+  mauveDusk: "a83c3d566c133234db5c31e4c93d06b403c9c651dcc62fce9d597a226712c61b",
+  playfulEditorial:
+    "c97ad47460cc43ca0a172c4ac7ccc471c4801d3e98b3f1f202b0f46eaee1eaaf",
+  aplocoto: "f5fd07c53c3f5f047975895d4a4d0af25345389a22d193c1020f032419f54c49",
+  botaneOrganic:
+    "6b4015b5e81692586af89ba03f58eb0ccf966dfb0caa712d5414971824f83429",
+  businessData:
+    "a5e0777b924534404a7be2e0a8b34feb546b70ec1f9b91058673e12c39772d86",
+} as const;
 
 function videoTemplateSource(
   path: string,
@@ -869,11 +905,10 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     name: "Botane Organic Presentation",
     description:
       "15-slot organic wellness deck with colour-block panels, circular media, side titles, icon cycles, and donut stats.",
-    source: {
-      repo: VM0_SKILLS_REPO,
-      ref: VM0_SKILLS_REF,
-      path: "presentation-template/botane-organic",
-    },
+    source: privateR2ArchiveSource(
+      "presentation-template/botane-organic",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.botaneOrganic,
+    ),
     targets: ["presentation"],
   },
   {
@@ -891,11 +926,10 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     name: "Playful Launch Presentation",
     description:
       "15-slot HTML presentation structure for product and service launches with oversized headlines, color-field rhythm, recurring motifs, and required media slots.",
-    source: {
-      repo: VM0_SKILLS_REPO,
-      ref: VM0_SKILLS_REF,
-      path: "presentation-template/aplocoto",
-    },
+    source: privateR2ArchiveSource(
+      "presentation-template/aplocoto",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.aplocoto,
+    ),
     targets: ["presentation"],
   },
   {
@@ -904,11 +938,10 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     name: "Business Data Presentation",
     description:
       "15-slot HTML presentation structure for metric-led business reports with big numbers, stat strips, bars, rings, photo squares, and dark/accent proof slides.",
-    source: {
-      repo: VM0_SKILLS_REPO,
-      ref: VM0_SKILLS_REF,
-      path: "presentation-template/business-data",
-    },
+    source: privateR2ArchiveSource(
+      "presentation-template/business-data",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.businessData,
+    ),
     targets: ["presentation"],
   },
   {
@@ -2491,11 +2524,10 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     name: "Mauve Dusk",
     description:
       "Soft lavender editorial look with muted mauve accents, Fraunces display type, Work Sans body, and rounded organic motifs.",
-    source: {
-      repo: VM0_SKILLS_REPO,
-      ref: VM0_SKILLS_REF,
-      path: "presentation-design-system/mauve-dusk",
-    },
+    source: privateR2ArchiveSource(
+      "presentation-design-system/mauve-dusk",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.mauveDusk,
+    ),
   },
   {
     id: "design-system:meta",
@@ -2660,11 +2692,10 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     name: "Playful Launch",
     description:
       "Joyful launch-deck look with saturated color fields, scalloped burst badges, pill chips, Archivo headlines, and Manrope body.",
-    source: {
-      repo: VM0_SKILLS_REPO,
-      ref: VM0_SKILLS_REF,
-      path: "presentation-design-system/playful-editorial",
-    },
+    source: privateR2ArchiveSource(
+      "presentation-design-system/playful-editorial",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.playfulEditorial,
+    ),
   },
   {
     id: "design-system:berry-pop",
@@ -2672,11 +2703,10 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     name: "Berry Pop",
     description:
       "Magenta/plum data-deck look with Space Grotesk display, Lexend body, soft corners, plus marks, stat blocks, photo squares, bars, and rings.",
-    source: {
-      repo: VM0_SKILLS_REPO,
-      ref: VM0_SKILLS_REF,
-      path: "presentation-design-system/berry-pop",
-    },
+    source: privateR2ArchiveSource(
+      "presentation-design-system/berry-pop",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.berryPop,
+    ),
   },
   {
     id: "design-system:perplexity",
@@ -3635,6 +3665,11 @@ export function selectResourceCandidates(
       {
         repo: VM0_SKILLS_REPO,
         ref: VM0_SKILLS_REF,
+      },
+      {
+        type: "r2-archive",
+        description:
+          "Private R2-backed resource archives resolved through authenticated `zero resource pull` requests",
       },
     ],
     candidates: {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -53,10 +53,8 @@ export interface RegistryEntry {
   readonly targets?: readonly GenerationTarget[];
 }
 
-export interface VideoTemplateRegistryEntry extends Omit<
-  RegistryEntry,
-  "kind" | "source"
-> {
+export interface VideoTemplateRegistryEntry
+  extends Omit<RegistryEntry, "kind" | "source"> {
   readonly kind: "video-template";
   readonly source: ResourceSourceRef & {
     readonly repo: string;
@@ -895,6 +893,19 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
       repo: VM0_SKILLS_REPO,
       ref: VM0_SKILLS_REF,
       path: "presentation-template/aplocoto",
+    },
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-business-data",
+    kind: "template",
+    name: "Business Data Presentation",
+    description:
+      "15-slot HTML presentation structure for metric-led business reports with big numbers, stat strips, bars, rings, photo squares, and dark/accent proof slides.",
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "presentation-template/business-data",
     },
     targets: ["presentation"],
   },
@@ -2651,6 +2662,18 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
       repo: VM0_SKILLS_REPO,
       ref: VM0_SKILLS_REF,
       path: "presentation-design-system/playful-editorial",
+    },
+  },
+  {
+    id: "design-system:berry-pop",
+    kind: "design-system",
+    name: "Berry Pop",
+    description:
+      "Magenta/plum data-deck look with Space Grotesk display, Lexend body, soft corners, plus marks, stat blocks, photo squares, bars, and rings.",
+    source: {
+      repo: VM0_SKILLS_REPO,
+      ref: VM0_SKILLS_REF,
+      path: "presentation-design-system/berry-pop",
     },
   },
   {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -53,8 +53,10 @@ export interface RegistryEntry {
   readonly targets?: readonly GenerationTarget[];
 }
 
-export interface VideoTemplateRegistryEntry
-  extends Omit<RegistryEntry, "kind" | "source"> {
+export interface VideoTemplateRegistryEntry extends Omit<
+  RegistryEntry,
+  "kind" | "source"
+> {
   readonly kind: "video-template";
   readonly source: ResourceSourceRef & {
     readonly repo: string;


### PR DESCRIPTION
## Summary
- Keep presentation picker previews public on `cdn.vm0.io` for UI display.
- Remove public archive URLs from the registry source model; `source.archive` now stores only `type` and `sha256`.
- Add authenticated `GET /api/registry/resources/download?id=...`, which validates an allowlisted registry id and returns a short-lived presigned R2 GET URL for the private archive.
- Update `zero resource pull <resource-id> --dir ./generated/resources` so the CLI asks the API for the presigned URL, verifies the sha256 digest, and extracts the selected resource locally.
- Update source-selection packets to explain the private archive pull flow while preserving GitHub `repo/ref/path` support for existing resources.

## Public vs Private Boundary
- Public: picker `previewImage`, `previewImages`, and `embedUrl` remain CDN assets for template browsing.
- Private: template/design-system source archives are no longer stored as public CDN URLs in code or registry metadata.
- Registry metadata exposes only resource id, source path, archive type, and digest.
- Runtime access to source archives requires CLI/API auth and a 15-minute presigned R2 URL.

## Migrated Private Registry Sources
- `template:html-ppt-playful-launch` -> `presentation-template/aplocoto`
- `template:html-ppt-botane-organic` -> `presentation-template/botane-organic`
- `template:html-ppt-business-data` -> `presentation-template/business-data`
- `design-system:playful-editorial` -> `presentation-design-system/playful-editorial`
- `design-system:mauve-dusk` -> `presentation-design-system/mauve-dusk`
- `design-system:berry-pop` -> `presentation-design-system/berry-pop`

## Paired PR / Research
- Paired vm0-skills cleanup PR: https://github.com/vm0-ai/vm0-skills/pull/265
- Deep-dive research note: https://drive.google.com/file/d/1YJZ97XPp6fNM0cA2STnZnIIOjnjLPrDh/view?usp=drivesdk

## Validation
- Uploaded 6 archives into private R2-backed storage, downloaded them through authenticated storage download, and recomputed sha256 successfully.
- Verified each template archive contains `SKILL.md` plus `presentation-template/canonical-page-set.md`.
- Verified each design-system archive contains its `SKILL.md` under the original source path.
- `npx prettier@3.8.1 --check` on changed files.
- `npx oxlint@1.57.0` on changed files.
- `git diff --check`.
- Static scans confirm no public `.tar.gz` CDN URLs and no `archive.url` field remain in the changed registry/CLI/API paths.

Note: package-level local `vitest`/`tsc` could not run in this workspace because those binaries are not installed in the package context. I did not run full local vitest or start a dev server; PR CI should cover those checks.