### PR TITLE
fix: validate builtin firewall base URL variables

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -35,6 +35,7 @@ _PERCENT_DECODED_BOUNDARY_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
 _BASE_URL_VAR_PARAMETER_CHARS = frozenset(("{", "}"))
 _PATH_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "\\"))
 _PORT_VAR_PATTERN = re.compile(r"^[0-9]+$")
+_MAX_PATH_VAR_PERCENT_DECODE_PASSES = 5
 
 
 class _RegistryFormatError(ValueError):
@@ -234,6 +235,31 @@ def _validate_base_url_variable_percent_encoding(
     return decoded.value
 
 
+def _path_variable_value_has_encoded_structure(value: str) -> bool:
+    current = value
+    for _ in range(_MAX_PATH_VAR_PERCENT_DECODE_PASSES):
+        decoded = percent_decode_host(current, syntax_chars=_PATH_VAR_STRUCTURE_CHARS)
+        if (
+            decoded.invalid_encoding
+            or decoded.decoded_syntax
+            or any(char.isspace() for char in decoded.value)
+            or has_unsafe_url_codepoint(decoded.value)
+        ):
+            return True
+        if decoded.value == current:
+            return False
+        current = decoded.value
+
+    decoded = percent_decode_host(current, syntax_chars=_PATH_VAR_STRUCTURE_CHARS)
+    return (
+        decoded.invalid_encoding
+        or decoded.decoded_syntax
+        or decoded.value != current
+        or any(char.isspace() for char in decoded.value)
+        or has_unsafe_url_codepoint(decoded.value)
+    )
+
+
 def _validate_base_url_prefix_variable(
     *,
     firewall_name: str,
@@ -348,7 +374,7 @@ def _validate_base_url_path_variable(
             name=name,
             detail="must not introduce path structure",
         )
-    _validate_base_url_variable_percent_encoding(
+    decoded = _validate_base_url_variable_percent_encoding(
         firewall_name=firewall_name,
         base=base,
         name=name,
@@ -358,7 +384,9 @@ def _validate_base_url_path_variable(
     prefix_segment = prefix[prefix.rfind("/") + 1 :]
     suffix_delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
     suffix_segment = suffix if suffix_delimiter is None else suffix[: suffix_delimiter.start()]
-    if has_unsafe_path(f"/{prefix_segment}{value}{suffix_segment}"):
+    if _path_variable_value_has_encoded_structure(decoded) or has_unsafe_path(
+        f"/{prefix_segment}{decoded}{suffix_segment}"
+    ):
         raise _base_url_variable_error(
             firewall_name=firewall_name,
             base=base,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -16,6 +16,7 @@ from firewall_auth_cache import evict_all_cache_keys, evict_stale_cache_keys
 from firewall_auth_config import auth_config_injects_credentials
 from authority_utils import percent_decode_host
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
+from path_security import has_unsafe_path
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 VmContext = tuple[
@@ -177,7 +178,7 @@ def _validate_base_url_variable_common_syntax(
     name: str,
     value: str,
 ) -> None:
-    if has_raw_whitespace(value):
+    if has_raw_whitespace(value) or any(char.isspace() for char in value):
         raise _base_url_variable_error(
             firewall_name=firewall_name,
             base=base,
@@ -254,6 +255,13 @@ def _validate_base_url_prefix_variable(
             base=base,
             name=name,
             detail="must not contain query or fragment before a fixed path suffix",
+        )
+    if has_unsafe_path(parts.path):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain unsafe path segments before a fixed path suffix",
         )
 
 
@@ -340,7 +348,7 @@ def _validate_base_url_path_variable(
             name=name,
             detail="must not introduce path structure",
         )
-    decoded = _validate_base_url_variable_percent_encoding(
+    _validate_base_url_variable_percent_encoding(
         firewall_name=firewall_name,
         base=base,
         name=name,
@@ -350,13 +358,12 @@ def _validate_base_url_path_variable(
     prefix_segment = prefix[prefix.rfind("/") + 1 :]
     suffix_delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
     suffix_segment = suffix if suffix_delimiter is None else suffix[: suffix_delimiter.start()]
-    decoded_segment = f"{prefix_segment}{decoded}{suffix_segment}"
-    if decoded_segment in (".", ".."):
+    if has_unsafe_path(f"/{prefix_segment}{value}{suffix_segment}"):
         raise _base_url_variable_error(
             firewall_name=firewall_name,
             base=base,
             name=name,
-            detail="must not be a path dot segment",
+            detail="must not contain unsafe path segments",
         )
 
 
@@ -488,6 +495,10 @@ def _resolve_base_url_template(
     if not matching.firewall_base_config_is_valid(resolved):
         raise _FirewallEntryResolutionError(
             f'builtin firewall "{firewall_name}" resolved base URL is invalid'
+        )
+    if has_unsafe_path(urllib.parse.urlsplit(resolved).path):
+        raise _FirewallEntryResolutionError(
+            f'builtin firewall "{firewall_name}" resolved base URL has unsafe path segments'
         )
     return resolved
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -14,7 +14,9 @@ from mitmproxy import ctx
 import matching
 from firewall_auth_cache import evict_all_cache_keys, evict_stale_cache_keys
 from firewall_auth_config import auth_config_injects_credentials
+from authority_utils import percent_decode_host
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
+from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 VmContext = tuple[
     dict,
@@ -25,6 +27,11 @@ _RegistryCacheKey = tuple[str, int, int, int, int]
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
 _READ_CHUNK_BYTES = 1024 * 1024
 _BASE_URL_VAR_PATTERN = re.compile(r"\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+_URL_COMPONENT_DELIMITER_PATTERN = re.compile(r"[/?#]")
+_AUTHORITY_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "@", "\\"))
+_AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
+_PERCENT_DECODED_BOUNDARY_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
+_BASE_URL_VAR_PARAMETER_CHARS = frozenset(("{", "}"))
 
 
 class _RegistryFormatError(ValueError):
@@ -149,22 +156,247 @@ def _base_url_vars_for_entry(entry: dict) -> dict[str, str]:
     return {}
 
 
+def _base_url_variable_error(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    detail: str,
+) -> _FirewallEntryResolutionError:
+    return _FirewallEntryResolutionError(
+        f'builtin firewall "{firewall_name}" base URL variable "{name}" {detail}: {base}'
+    )
+
+
+def _validate_base_url_variable_common_syntax(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if has_raw_whitespace(value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain whitespace",
+        )
+    if has_unsafe_url_codepoint(value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain control characters or invalid Unicode",
+        )
+    if any(char in _BASE_URL_VAR_PARAMETER_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain firewall parameter syntax",
+        )
+
+
+def _validate_base_url_variable_percent_encoding(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    decoded = percent_decode_host(value, syntax_chars=_PERCENT_DECODED_BOUNDARY_CHARS)
+    if decoded.invalid_encoding:
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="has invalid percent encoding",
+        )
+    if decoded.decoded_syntax or any(char.isspace() for char in decoded.value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain encoded URL structure",
+        )
+    if has_unsafe_url_codepoint(decoded.value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain encoded control characters or invalid Unicode",
+        )
+
+
+def _validate_base_url_prefix_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if not matching.firewall_base_config_is_valid(value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must be a valid base URL before a fixed path suffix",
+        )
+    parts = urllib.parse.urlsplit(value)
+    if parts.query or parts.fragment:
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain query or fragment before a fixed path suffix",
+        )
+
+
+def _validate_base_url_authority_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if any(char in _AUTHORITY_VAR_STRUCTURE_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not introduce URL structure",
+        )
+    _validate_base_url_variable_percent_encoding(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+    )
+    if not matching.firewall_base_config_is_valid(f"https://{value}"):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must be a valid URL authority",
+        )
+
+
+def _validate_base_url_authority_fragment_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if any(char in _AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not introduce URL structure",
+        )
+    _validate_base_url_variable_percent_encoding(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+    )
+
+
+def _prefix_is_inside_authority(prefix: str) -> bool:
+    scheme_end = prefix.find("://")
+    if scheme_end == -1:
+        return False
+    after_scheme = prefix[scheme_end + 3 :]
+    return _URL_COMPONENT_DELIMITER_PATTERN.search(after_scheme) is None
+
+
+def _suffix_authority_prefix(suffix: str) -> str:
+    delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
+    if delimiter is None:
+        return suffix
+    return suffix[: delimiter.start()]
+
+
+def _validate_base_url_template_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    _validate_base_url_variable_common_syntax(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+    )
+    if prefix == "" and suffix == "":
+        return
+    if prefix == "" and suffix.startswith("/"):
+        _validate_base_url_prefix_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    if prefix.endswith("://") and (suffix == "" or suffix.startswith("/")):
+        _validate_base_url_authority_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    if _prefix_is_inside_authority(prefix) and _suffix_authority_prefix(suffix) != "":
+        _validate_base_url_authority_fragment_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    raise _base_url_variable_error(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        detail="is used in an unsupported base URL template position",
+    )
+
+
 def _resolve_base_url_template(
     *,
     firewall_name: str,
     base: str,
     vars_map: dict[str, str],
 ) -> str:
-    def replace_var(match: re.Match[str]) -> str:
+    resolved_parts: list[str] = []
+    last_index = 0
+    for match in _BASE_URL_VAR_PATTERN.finditer(base):
         name = match.group(1)
         value = vars_map.get(name)
         if not value:
             raise _FirewallEntryResolutionError(
                 f'builtin firewall "{firewall_name}" base URL requires variable "{name}"'
             )
-        return value
+        _validate_base_url_template_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+            prefix=base[: match.start()],
+            suffix=base[match.end() :],
+        )
+        resolved_parts.append(base[last_index : match.start()])
+        resolved_parts.append(value)
+        last_index = match.end()
 
-    resolved = _BASE_URL_VAR_PATTERN.sub(replace_var, base)
+    resolved_parts.append(base[last_index:])
+    resolved = "".join(resolved_parts)
     if not matching.firewall_base_config_is_valid(resolved):
         raise _FirewallEntryResolutionError(
             f'builtin firewall "{firewall_name}" resolved base URL is invalid'

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -32,6 +32,8 @@ _AUTHORITY_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "@", "\\"))
 _AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
 _PERCENT_DECODED_BOUNDARY_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
 _BASE_URL_VAR_PARAMETER_CHARS = frozenset(("{", "}"))
+_PATH_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "\\"))
+_PORT_VAR_PATTERN = re.compile(r"^[0-9]+$")
 
 
 class _RegistryFormatError(ValueError):
@@ -204,8 +206,9 @@ def _validate_base_url_variable_percent_encoding(
     base: str,
     name: str,
     value: str,
-) -> None:
-    decoded = percent_decode_host(value, syntax_chars=_PERCENT_DECODED_BOUNDARY_CHARS)
+    structure_chars: frozenset[str] = _PERCENT_DECODED_BOUNDARY_CHARS,
+) -> str:
+    decoded = percent_decode_host(value, syntax_chars=structure_chars)
     if decoded.invalid_encoding:
         raise _base_url_variable_error(
             firewall_name=firewall_name,
@@ -227,6 +230,7 @@ def _validate_base_url_variable_percent_encoding(
             name=name,
             detail="must not contain encoded control characters or invalid Unicode",
         )
+    return decoded.value
 
 
 def _validate_base_url_prefix_variable(
@@ -304,12 +308,74 @@ def _validate_base_url_authority_fragment_variable(
     )
 
 
+def _validate_base_url_port_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if _PORT_VAR_PATTERN.fullmatch(value) is None:
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must be a numeric URL port",
+        )
+
+
+def _validate_base_url_path_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    if any(char in _PATH_VAR_STRUCTURE_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not introduce path structure",
+        )
+    decoded = _validate_base_url_variable_percent_encoding(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+        structure_chars=_PATH_VAR_STRUCTURE_CHARS,
+    )
+    prefix_segment = prefix[prefix.rfind("/") + 1 :]
+    suffix_delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
+    suffix_segment = suffix if suffix_delimiter is None else suffix[: suffix_delimiter.start()]
+    decoded_segment = f"{prefix_segment}{decoded}{suffix_segment}"
+    if decoded_segment in (".", ".."):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not be a path dot segment",
+        )
+
+
 def _prefix_is_inside_authority(prefix: str) -> bool:
     scheme_end = prefix.find("://")
     if scheme_end == -1:
         return False
     after_scheme = prefix[scheme_end + 3 :]
     return _URL_COMPONENT_DELIMITER_PATTERN.search(after_scheme) is None
+
+
+def _prefix_is_inside_path(prefix: str) -> bool:
+    scheme_end = prefix.find("://")
+    if scheme_end == -1:
+        return False
+    after_scheme = prefix[scheme_end + 3 :]
+    if "?" in after_scheme or "#" in after_scheme:
+        return False
+    return "/" in after_scheme
 
 
 def _suffix_authority_prefix(suffix: str) -> str:
@@ -352,12 +418,34 @@ def _validate_base_url_template_variable(
             value=value,
         )
         return
+    if (
+        _prefix_is_inside_authority(prefix)
+        and prefix.endswith(":")
+        and (suffix == "" or suffix.startswith("/"))
+    ):
+        _validate_base_url_port_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
     if _prefix_is_inside_authority(prefix) and _suffix_authority_prefix(suffix) != "":
         _validate_base_url_authority_fragment_variable(
             firewall_name=firewall_name,
             base=base,
             name=name,
             value=value,
+        )
+        return
+    if _prefix_is_inside_path(prefix):
+        _validate_base_url_path_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+            prefix=prefix,
+            suffix=suffix,
         )
         return
     raise _base_url_variable_error(

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from mitmproxy import ctx
 
 import matching
+from authority_utils import percent_decode_host
 from firewall_auth_cache import evict_all_cache_keys, evict_stale_cache_keys
 from firewall_auth_config import auth_config_injects_credentials
-from authority_utils import percent_decode_host
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from path_security import has_unsafe_path
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -329,6 +329,25 @@ class TestGetVmContext:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "STRAPI_BASE_URL"' in invalid_vm.message
 
+    def test_builtin_base_url_var_rejects_unicode_whitespace(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-strapi",
+            name="strapi",
+            base_url_vars={"STRAPI_BASE_URL": "https://strapi.example.test/work\u00a0flows"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "STRAPI_BASE_URL"' in invalid_vm.message
+
     def test_builtin_base_url_prefix_preserves_fixed_path_suffix(self, tmp_path):
         path = tmp_path / "registry.json"
         _write_builtin_firewall_registry(
@@ -346,6 +365,44 @@ class TestGetVmContext:
         assert vm_info["firewalls"][0]["apis"][0]["base"] == (
             "https://n8n.example.test/workflows/api/v1"
         )
+
+    def test_builtin_base_url_prefix_rejects_path_dot_segments(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-n8n",
+            name="n8n",
+            base_url_vars={"N8N_BASE_URL": "https://n8n.example.test/workflows/.."},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "N8N_BASE_URL"' in invalid_vm.message
+
+    def test_builtin_base_url_prefix_rejects_encoded_path_dot_segments(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-n8n",
+            name="n8n",
+            base_url_vars={"N8N_BASE_URL": "https://n8n.example.test/workflows/%2e%2e"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "N8N_BASE_URL"' in invalid_vm.message
 
     def test_builtin_path_segment_var_accepts_fixed_suffix(self, tmp_path, monkeypatch):
         _install_test_builtin_firewall(
@@ -418,6 +475,84 @@ class TestGetVmContext:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
+    def test_builtin_path_segment_var_rejects_path_parameter_dot_segment(
+        self, tmp_path, monkeypatch
+    ):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "..;type=folder"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "TENANT"' in invalid_vm.message
+
+    def test_builtin_path_segment_var_rejects_nested_encoded_dot_segment(
+        self, tmp_path, monkeypatch
+    ):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "%252e%252e"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "TENANT"' in invalid_vm.message
+
+    def test_builtin_path_segment_var_rejects_compatibility_dot_segment(
+        self, tmp_path, monkeypatch
+    ):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "\uff0e\uff0e"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "TENANT"' in invalid_vm.message
+
     def test_builtin_path_var_allows_dot_outside_dot_segment(self, tmp_path, monkeypatch):
         _install_test_builtin_firewall(
             monkeypatch,
@@ -438,6 +573,53 @@ class TestGetVmContext:
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://api.example.test/v%2e1")
+
+    def test_builtin_path_vars_reject_combined_dot_segment(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="multi-path-segment",
+            base="https://api.example.test/accounts/${{ vars.A }}${{ vars.B }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-multi-path-segment",
+            name="multi-path-segment",
+            base_url_vars={"A": ".", "B": "."},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert "resolved base URL has unsafe path segments" in invalid_vm.message
+
+    def test_builtin_path_vars_accept_combined_safe_segment(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="multi-path-segment",
+            base="https://api.example.test/accounts/${{ vars.A }}${{ vars.B }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-multi-path-segment",
+            name="multi-path-segment",
+            base_url_vars={"A": "v", "B": "1"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == (
+            "https://api.example.test/accounts/v1/v1"
+        )
 
     def test_builtin_port_var_accepts_numeric_port(self, tmp_path, monkeypatch):
         _install_test_builtin_firewall(

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -366,6 +366,24 @@ class TestGetVmContext:
             "https://n8n.example.test/workflows/api/v1"
         )
 
+    def test_builtin_base_url_prefix_accepts_encoded_path_separator(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-n8n",
+            name="n8n",
+            base_url_vars={"N8N_BASE_URL": "https://n8n.example.test/work%2fflows"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == (
+            "https://n8n.example.test/work%2fflows/api/v1"
+        )
+
     def test_builtin_base_url_prefix_rejects_path_dot_segments(self, tmp_path):
         path = tmp_path / "registry.json"
         _write_builtin_firewall_registry(
@@ -439,6 +457,30 @@ class TestGetVmContext:
             run_id="run-tenant-path",
             name="tenant-path",
             base_url_vars={"TENANT": "acme/../admin"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "TENANT"' in invalid_vm.message
+
+    def test_builtin_path_segment_var_rejects_encoded_path_separator(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "acme%252fprod"},
         )
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -10,6 +10,34 @@ import registry
 from tests.registry_helpers import pin_mtime, write_firewall_registry
 
 
+def _write_builtin_firewall_registry(
+    path,
+    *,
+    run_id: str,
+    name: str,
+    base_url_vars: dict[str, str],
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "vms": {
+                    "10.200.0.1": {
+                        "runId": run_id,
+                        "firewalls": [
+                            {
+                                "kind": "builtin",
+                                "name": name,
+                                "baseUrlVars": base_url_vars,
+                            }
+                        ],
+                    }
+                },
+                "updatedAt": 0,
+            }
+        )
+    )
+
+
 class TestGetVmInfo:
     def test_known_ip(self, registry_file):
         info = registry.get_vm_info("10.200.0.1", str(registry_file))
@@ -152,6 +180,153 @@ class TestGetVmContext:
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.zendesk.com"
+
+    def test_builtin_fixed_provider_suffix_rejects_authority_escape(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-shopify",
+            name="shopify",
+            base_url_vars={"SHOPIFY_SHOP": "attacker.example:443/capture"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "SHOPIFY_SHOP"' in invalid_vm.message
+
+    def test_builtin_fixed_provider_suffix_rejects_encoded_structure(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-shopify",
+            name="shopify",
+            base_url_vars={"SHOPIFY_SHOP": "attacker.example%3A443%2Fcapture"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "SHOPIFY_SHOP"' in invalid_vm.message
+
+    def test_builtin_fixed_provider_suffix_accepts_multi_label_fragment(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-snowflake",
+            name="snowflake",
+            base_url_vars={"SNOWFLAKE_ACCOUNT": "xy12345.us-east-1.aws"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == (
+            "https://xy12345.us-east-1.aws.snowflakecomputing.com/api"
+        )
+
+    def test_builtin_fixed_provider_suffix_rejects_path_injection(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-snowflake",
+            name="snowflake",
+            base_url_vars={"SNOWFLAKE_ACCOUNT": "xy12345.us-east-1.aws/capture"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "SNOWFLAKE_ACCOUNT"' in invalid_vm.message
+
+    def test_builtin_whole_authority_accepts_host_value(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-jira",
+            name="jira",
+            base_url_vars={"JIRA_DOMAIN": "acme.atlassian.net"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.atlassian.net"
+
+    def test_builtin_whole_authority_rejects_path_injection(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-jira",
+            name="jira",
+            base_url_vars={"JIRA_DOMAIN": "attacker.example/capture"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "JIRA_DOMAIN"' in invalid_vm.message
+
+    def test_builtin_base_url_var_rejects_firewall_parameter_syntax(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-strapi",
+            name="strapi",
+            base_url_vars={"STRAPI_BASE_URL": "https://{host}.example.test"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "STRAPI_BASE_URL"' in invalid_vm.message
+
+    def test_builtin_base_url_prefix_preserves_fixed_path_suffix(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-n8n",
+            name="n8n",
+            base_url_vars={"N8N_BASE_URL": "https://n8n.example.test/workflows"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == (
+            "https://n8n.example.test/workflows/api/v1"
+        )
 
     def test_credentialed_builtin_firewall_entry_rejects_http_dynamic_base(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -38,6 +38,25 @@ def _write_builtin_firewall_registry(
     )
 
 
+def _install_test_builtin_firewall(monkeypatch, *, name: str, base: str) -> None:
+    monkeypatch.setattr(
+        registry,
+        "BUILTIN_FIREWALLS",
+        {
+            name: {
+                "name": name,
+                "apis": [
+                    {
+                        "base": base,
+                        "auth": {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+                        "permissions": [],
+                    }
+                ],
+            }
+        },
+    )
+
+
 class TestGetVmInfo:
     def test_known_ip(self, registry_file):
         info = registry.get_vm_info("10.200.0.1", str(registry_file))
@@ -327,6 +346,143 @@ class TestGetVmContext:
         assert vm_info["firewalls"][0]["apis"][0]["base"] == (
             "https://n8n.example.test/workflows/api/v1"
         )
+
+    def test_builtin_path_segment_var_accepts_fixed_suffix(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "acme:prod"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == (
+            "https://api.example.test/accounts/acme:prod/v1"
+        )
+
+    def test_builtin_path_segment_var_rejects_path_injection(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "acme/../admin"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "TENANT"' in invalid_vm.message
+
+    def test_builtin_path_segment_var_rejects_dot_segment(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="tenant-path",
+            base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-tenant-path",
+            name="tenant-path",
+            base_url_vars={"TENANT": "%2e%2e"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "TENANT"' in invalid_vm.message
+
+    def test_builtin_path_var_allows_dot_outside_dot_segment(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="path-fragment",
+            base="https://api.example.test/v${{ vars.VERSION }}",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-path-fragment",
+            name="path-fragment",
+            base_url_vars={"VERSION": "%2e1"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://api.example.test/v%2e1")
+
+    def test_builtin_port_var_accepts_numeric_port(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="port-api",
+            base="https://api.example.test:${{ vars.API_PORT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-port-api",
+            name="port-api",
+            base_url_vars={"API_PORT": "8443"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://api.example.test:8443/v1")
+
+    def test_builtin_port_var_rejects_non_numeric_port(self, tmp_path, monkeypatch):
+        _install_test_builtin_firewall(
+            monkeypatch,
+            name="port-api",
+            base="https://api.example.test:${{ vars.API_PORT }}/v1",
+        )
+        path = tmp_path / "registry.json"
+        _write_builtin_firewall_registry(
+            path,
+            run_id="run-port-api",
+            name="port-api",
+            base_url_vars={"API_PORT": "443/path"},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'base URL variable "API_PORT"' in invalid_vm.message
 
     def test_credentialed_builtin_firewall_entry_rejects_http_dynamic_base(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -1306,6 +1306,48 @@ describe("resolveFirewallBaseUrlVars", () => {
     ],
   };
 
+  const tenantPathFirewall = {
+    name: "tenant-path",
+    apis: [
+      {
+        base: "https://api.example.test/accounts/${{ vars.TENANT }}/v1",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+          },
+        },
+      },
+    ],
+  };
+
+  const portFirewall = {
+    name: "port-api",
+    apis: [
+      {
+        base: "https://api.example.test:${{ vars.API_PORT }}/v1",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+          },
+        },
+      },
+    ],
+  };
+
+  const pathFragmentFirewall = {
+    name: "path-fragment",
+    apis: [
+      {
+        base: "https://api.example.test/v${{ vars.VERSION }}",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+          },
+        },
+      },
+    ],
+  };
+
   const nonCredentialFirewall = {
     name: "diagnostic",
     apis: [
@@ -1386,6 +1428,53 @@ describe("resolveFirewallBaseUrlVars", () => {
     expect(result[0]!.apis[0]!.base).toBe(
       "https://n8n.example.test/workflows/api/v1",
     );
+  });
+
+  it("accepts path segment variables without crossing path boundaries", () => {
+    const result = resolveFirewallBaseUrlVars([tenantPathFirewall], {
+      TENANT: "acme:prod",
+    });
+    expect(result[0]!.apis[0]!.base).toBe(
+      "https://api.example.test/accounts/acme:prod/v1",
+    );
+  });
+
+  it("rejects path segment variables that inject path structure", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "acme/../admin",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects path segment variables that normalize as dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "%2e%2e",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("accepts path variable dots that do not form dot segments", () => {
+    const result = resolveFirewallBaseUrlVars([pathFragmentFirewall], {
+      VERSION: "%2e1",
+    });
+    expect(result[0]!.apis[0]!.base).toBe("https://api.example.test/v%2e1");
+  });
+
+  it("accepts authority port variables", () => {
+    const result = resolveFirewallBaseUrlVars([portFirewall], {
+      API_PORT: "8443",
+    });
+    expect(result[0]!.apis[0]!.base).toBe("https://api.example.test:8443/v1");
+  });
+
+  it("rejects authority port variables that are not numeric", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([portFirewall], {
+        API_PORT: "443/path",
+      });
+    }).toThrow("base URL variable");
   });
 
   it("leaves static base URLs unchanged", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -1348,6 +1348,20 @@ describe("resolveFirewallBaseUrlVars", () => {
     ],
   };
 
+  const multiPathSegmentFirewall = {
+    name: "multi-path-segment",
+    apis: [
+      {
+        base: "https://api.example.test/accounts/${{ vars.A }}${{ vars.B }}/v1",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+          },
+        },
+      },
+    ],
+  };
+
   const nonCredentialFirewall = {
     name: "diagnostic",
     apis: [
@@ -1421,6 +1435,14 @@ describe("resolveFirewallBaseUrlVars", () => {
     }).toThrow("base URL variable");
   });
 
+  it("rejects base URL variables with Unicode whitespace", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([strapiFirewall], {
+        STRAPI_BASE_URL: "https://strapi.example.test/work\u00a0flows",
+      });
+    }).toThrow("base URL variable");
+  });
+
   it("preserves fixed path suffixes for whole base URL prefix templates", () => {
     const result = resolveFirewallBaseUrlVars([n8nFirewall], {
       N8N_BASE_URL: "https://n8n.example.test/workflows",
@@ -1428,6 +1450,22 @@ describe("resolveFirewallBaseUrlVars", () => {
     expect(result[0]!.apis[0]!.base).toBe(
       "https://n8n.example.test/workflows/api/v1",
     );
+  });
+
+  it("rejects whole base URL prefix variables with path dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([n8nFirewall], {
+        N8N_BASE_URL: "https://n8n.example.test/workflows/..",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects whole base URL prefix variables with encoded path dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([n8nFirewall], {
+        N8N_BASE_URL: "https://n8n.example.test/workflows/%2e%2e",
+      });
+    }).toThrow("base URL variable");
   });
 
   it("accepts path segment variables without crossing path boundaries", () => {
@@ -1455,11 +1493,54 @@ describe("resolveFirewallBaseUrlVars", () => {
     }).toThrow("base URL variable");
   });
 
+  it("rejects path segment variables with path-parameter dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "..;type=folder",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects path segment variables with nested encoded dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "%252e%252e",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects path segment variables with compatibility dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "\uff0e\uff0e",
+      });
+    }).toThrow("base URL variable");
+  });
+
   it("accepts path variable dots that do not form dot segments", () => {
     const result = resolveFirewallBaseUrlVars([pathFragmentFirewall], {
       VERSION: "%2e1",
     });
     expect(result[0]!.apis[0]!.base).toBe("https://api.example.test/v%2e1");
+  });
+
+  it("rejects path variables that combine into dot segments", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([multiPathSegmentFirewall], {
+        A: ".",
+        B: ".",
+      });
+    }).toThrow("resolved base URL must not contain unsafe path segments");
+  });
+
+  it("accepts path variables that combine into safe segments", () => {
+    const result = resolveFirewallBaseUrlVars([multiPathSegmentFirewall], {
+      A: "v",
+      B: "1",
+    });
+    expect(result[0]!.apis[0]!.base).toBe(
+      "https://api.example.test/accounts/v1/v1",
+    );
   });
 
   it("accepts authority port variables", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -1452,6 +1452,15 @@ describe("resolveFirewallBaseUrlVars", () => {
     );
   });
 
+  it("accepts encoded path separators in whole base URL prefix paths", () => {
+    const result = resolveFirewallBaseUrlVars([n8nFirewall], {
+      N8N_BASE_URL: "https://n8n.example.test/work%2fflows",
+    });
+    expect(result[0]!.apis[0]!.base).toBe(
+      "https://n8n.example.test/work%2fflows/api/v1",
+    );
+  });
+
   it("rejects whole base URL prefix variables with path dot segments", () => {
     expect(() => {
       return resolveFirewallBaseUrlVars([n8nFirewall], {
@@ -1481,6 +1490,19 @@ describe("resolveFirewallBaseUrlVars", () => {
     expect(() => {
       return resolveFirewallBaseUrlVars([tenantPathFirewall], {
         TENANT: "acme/../admin",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects path segment variables with encoded path separators", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "acme%2fprod",
+      });
+    }).toThrow("base URL variable");
+    expect(() => {
+      return resolveFirewallBaseUrlVars([tenantPathFirewall], {
+        TENANT: "acme%252fprod",
       });
     }).toThrow("base URL variable");
   });

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -1249,6 +1249,63 @@ describe("resolveFirewallBaseUrlVars", () => {
     ],
   };
 
+  const shopifyFirewall = {
+    name: "shopify",
+    apis: [
+      {
+        base: "https://${{ vars.SHOPIFY_SHOP }}.myshopify.com",
+        auth: {
+          headers: {
+            "X-Shopify-Access-Token": "${{ secrets.SHOPIFY_TOKEN }}",
+          },
+        },
+      },
+    ],
+  };
+
+  const snowflakeFirewall = {
+    name: "snowflake",
+    apis: [
+      {
+        base: "https://${{ vars.SNOWFLAKE_ACCOUNT }}.snowflakecomputing.com/api",
+        auth: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.SNOWFLAKE_PAT }}",
+          },
+        },
+      },
+    ],
+  };
+
+  const jiraFirewall = {
+    name: "jira",
+    apis: [
+      {
+        base: "https://${{ vars.JIRA_DOMAIN }}",
+        auth: {
+          headers: {
+            Authorization:
+              "${{ basic(vars.JIRA_EMAIL, secrets.JIRA_API_TOKEN) }}",
+          },
+        },
+      },
+    ],
+  };
+
+  const n8nFirewall = {
+    name: "n8n",
+    apis: [
+      {
+        base: "${{ vars.N8N_BASE_URL }}/api/v1",
+        auth: {
+          headers: {
+            "X-N8N-API-KEY": "${{ secrets.N8N_TOKEN }}",
+          },
+        },
+      },
+    ],
+  };
+
   const nonCredentialFirewall = {
     name: "diagnostic",
     apis: [
@@ -1264,6 +1321,71 @@ describe("resolveFirewallBaseUrlVars", () => {
       ZENDESK_SUBDOMAIN: "mycompany",
     });
     expect(result[0]!.apis[0]!.base).toBe("https://mycompany.zendesk.com");
+  });
+
+  it("rejects fixed provider suffix variables that escape the authority", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([shopifyFirewall], {
+        SHOPIFY_SHOP: "attacker.example:443/capture",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects fixed provider suffix variables with encoded URL structure", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([shopifyFirewall], {
+        SHOPIFY_SHOP: "attacker.example%3A443%2Fcapture",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("accepts multi-label fixed provider suffix values without URL structure", () => {
+    const result = resolveFirewallBaseUrlVars([snowflakeFirewall], {
+      SNOWFLAKE_ACCOUNT: "xy12345.us-east-1.aws",
+    });
+    expect(result[0]!.apis[0]!.base).toBe(
+      "https://xy12345.us-east-1.aws.snowflakecomputing.com/api",
+    );
+  });
+
+  it("rejects fixed provider suffix values that inject path syntax", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([snowflakeFirewall], {
+        SNOWFLAKE_ACCOUNT: "xy12345.us-east-1.aws/capture",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("accepts whole authority template values", () => {
+    const result = resolveFirewallBaseUrlVars([jiraFirewall], {
+      JIRA_DOMAIN: "acme.atlassian.net",
+    });
+    expect(result[0]!.apis[0]!.base).toBe("https://acme.atlassian.net");
+  });
+
+  it("rejects whole authority template values with paths", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([jiraFirewall], {
+        JIRA_DOMAIN: "attacker.example/capture",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("rejects base URL variables that introduce firewall parameters", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlVars([strapiFirewall], {
+        STRAPI_BASE_URL: "https://{host}.example.test",
+      });
+    }).toThrow("base URL variable");
+  });
+
+  it("preserves fixed path suffixes for whole base URL prefix templates", () => {
+    const result = resolveFirewallBaseUrlVars([n8nFirewall], {
+      N8N_BASE_URL: "https://n8n.example.test/workflows",
+    });
+    expect(result[0]!.apis[0]!.base).toBe(
+      "https://n8n.example.test/workflows/api/v1",
+    );
   });
 
   it("leaves static base URLs unchanged", () => {

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -663,6 +663,7 @@ const PERCENT_DECODED_BOUNDARY_CHARS = new Set(["/", ":", "?", "#", "@", "\\"]);
 const BASE_URL_VAR_PARAMETER_CHARS = new Set(["{", "}"]);
 const PATH_VAR_STRUCTURE_CHARS = new Set(["/", "?", "#", "\\"]);
 const PORT_VAR_PATTERN = /^[0-9]+$/;
+const MAX_PATH_PERCENT_DECODE_PASSES = 5;
 
 /**
  * Check if a base URL contains `${{ vars.X }}` template references.
@@ -693,7 +694,7 @@ function validateBaseUrlVariableCommonSyntax({
   readonly name: string;
   readonly value: string;
 }): void {
-  if (hasRawWhitespace(value)) {
+  if (WHITESPACE_PATTERN.test(value)) {
     throw baseUrlVariableError(
       base,
       serviceName,
@@ -719,6 +720,83 @@ function validateBaseUrlVariableCommonSyntax({
       );
     }
   }
+}
+
+function pathSegmentDotPrefix(segment: string): string {
+  return segment.split(";", 1)[0]!;
+}
+
+function pathSegmentIsDotSegment(segment: string): boolean {
+  const dotPrefix = pathSegmentDotPrefix(segment);
+  return dotPrefix === "." || dotPrefix === "..";
+}
+
+function normalizedPathSegmentHasUnsafeSyntax(segment: string): boolean {
+  const normalized = segment.normalize("NFKC");
+  if (normalized === segment) return false;
+  if (normalized.includes("%")) return true;
+  for (const char of normalized) {
+    if (PATH_VAR_STRUCTURE_CHARS.has(char)) return true;
+  }
+  return (
+    pathSegmentIsDotSegment(normalized) || hasUnsafeUrlCodepoint(normalized)
+  );
+}
+
+function percentDecodePathSegment(segment: string): string | null {
+  if (!segment.includes("%")) return segment;
+  for (let i = 0; i < segment.length; i += 1) {
+    if (segment[i] !== "%") continue;
+    if (
+      i + 2 >= segment.length ||
+      !isHexDigit(segment[i + 1]!) ||
+      !isHexDigit(segment[i + 2]!)
+    ) {
+      return null;
+    }
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
+  for (const char of decoded) {
+    if (
+      PATH_VAR_STRUCTURE_CHARS.has(char) ||
+      WHITESPACE_PATTERN.test(char) ||
+      UNICODE_CONTROL_PATTERN.test(char)
+    ) {
+      return null;
+    }
+  }
+  return decoded;
+}
+
+function pathSegmentHasUnsafeSyntax(segment: string): boolean {
+  let current = segment;
+  for (let pass = 0; pass < MAX_PATH_PERCENT_DECODE_PASSES; pass += 1) {
+    if (
+      pathSegmentIsDotSegment(current) ||
+      normalizedPathSegmentHasUnsafeSyntax(current)
+    ) {
+      return true;
+    }
+    const decoded = percentDecodePathSegment(current);
+    if (decoded === null) return true;
+    if (decoded === current) return false;
+    current = decoded;
+  }
+
+  if (
+    pathSegmentIsDotSegment(current) ||
+    normalizedPathSegmentHasUnsafeSyntax(current)
+  ) {
+    return true;
+  }
+  const decoded = percentDecodePathSegment(current);
+  return decoded === null || decoded !== current;
 }
 
 function validateBaseUrlVariablePercentEncoding({
@@ -803,6 +881,38 @@ function validateBaseUrlVariablePercentEncoding({
   }
 }
 
+function validateBaseUrlPathSegment({
+  base,
+  serviceName,
+  name,
+  segment,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly segment: string;
+}): void {
+  if (pathSegmentHasUnsafeSyntax(segment)) {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must not contain unsafe path segments",
+    );
+  }
+}
+
+function rawPathFromBaseUrl(value: string): string {
+  const schemeEnd = value.indexOf("://");
+  if (schemeEnd === -1) return "";
+  const afterScheme = value.slice(schemeEnd + 3);
+  const pathStart = afterScheme.indexOf("/");
+  if (pathStart === -1) return "";
+  const pathAndAfter = afterScheme.slice(pathStart);
+  const pathEnd = pathAndAfter.search(/[?#]/);
+  return pathEnd === -1 ? pathAndAfter : pathAndAfter.slice(0, pathEnd);
+}
+
 function validateBaseUrlPrefixVariable({
   base,
   serviceName,
@@ -823,6 +933,29 @@ function validateBaseUrlPrefixVariable({
       name,
       "must not contain query or fragment before a fixed path suffix",
     );
+  }
+  const rawPath = rawPathFromBaseUrl(value);
+  for (const segment of rawPath.split("/")) {
+    validateBaseUrlPathSegment({ base, serviceName, name, segment });
+  }
+}
+
+function validateResolvedBaseUrlPathSafety(
+  templateBase: string,
+  serviceName: string,
+  resolved: string,
+): void {
+  const rawPath = rawPathFromBaseUrl(resolved);
+  for (const segment of rawPath.split("/")) {
+    if (pathSegmentHasUnsafeSyntax(segment)) {
+      throw new Error(
+        errMsg(
+          templateBase,
+          serviceName,
+          "resolved base URL must not contain unsafe path segments",
+        ),
+      );
+    }
   }
 }
 
@@ -944,15 +1077,12 @@ function validateBaseUrlPathVariable({
   const suffixSegmentEnd = suffix.search(URL_COMPONENT_DELIMITER_PATTERN);
   const suffixSegment =
     suffixSegmentEnd === -1 ? suffix : suffix.slice(0, suffixSegmentEnd);
-  const decodedSegment = `${prefixSegment}${decoded}${suffixSegment}`;
-  if (decodedSegment === "." || decodedSegment === "..") {
-    throw baseUrlVariableError(
-      base,
-      serviceName,
-      name,
-      "must not be a path dot segment",
-    );
-  }
+  validateBaseUrlPathSegment({
+    base,
+    serviceName,
+    name,
+    segment: `${prefixSegment}${decoded}${suffixSegment}`,
+  });
 }
 
 function prefixIsInsideAuthority(prefix: string): boolean {
@@ -1103,6 +1233,7 @@ export function resolveFirewallBaseUrlVars(
           lastIndex = matchIndex + fullMatch.length;
         }
         resolved += api.base.slice(lastIndex);
+        validateResolvedBaseUrlPathSafety(api.base, fw.name, resolved);
         validateBaseUrl(resolved, fw.name);
         validateCredentialedBaseUrlTransport(resolved, fw.name, api.auth);
         return { ...api, base: resolved };

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -649,12 +649,267 @@ export function extractFirewallTemplateReferences(
  */
 const BASE_URL_VARS_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/;
 const BASE_URL_VARS_PATTERN_G = new RegExp(BASE_URL_VARS_PATTERN.source, "g");
+const URL_COMPONENT_DELIMITER_PATTERN = /[/?#]/;
+const AUTHORITY_VAR_STRUCTURE_CHARS = new Set(["/", "?", "#", "@", "\\"]);
+const AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS = new Set([
+  "/",
+  ":",
+  "?",
+  "#",
+  "@",
+  "\\",
+]);
+const PERCENT_DECODED_BOUNDARY_CHARS = new Set(["/", ":", "?", "#", "@", "\\"]);
+const BASE_URL_VAR_PARAMETER_CHARS = new Set(["{", "}"]);
 
 /**
  * Check if a base URL contains `${{ vars.X }}` template references.
  */
 export function hasBaseUrlVars(base: string): boolean {
   return BASE_URL_VARS_PATTERN.test(base);
+}
+
+function baseUrlVariableError(
+  base: string,
+  serviceName: string,
+  name: string,
+  detail: string,
+): Error {
+  return new Error(
+    errMsg(base, serviceName, `base URL variable "${name}" ${detail}`),
+  );
+}
+
+function validateBaseUrlVariableCommonSyntax({
+  base,
+  serviceName,
+  name,
+  value,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+}): void {
+  if (hasRawWhitespace(value)) {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must not contain whitespace",
+    );
+  }
+  if (hasUnsafeUrlCodepoint(value)) {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must not contain control characters or invalid Unicode",
+    );
+  }
+  for (const char of value) {
+    if (BASE_URL_VAR_PARAMETER_CHARS.has(char)) {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "must not contain firewall parameter syntax",
+      );
+    }
+  }
+}
+
+function validateBaseUrlVariablePercentEncoding({
+  base,
+  serviceName,
+  name,
+  value,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+}): void {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] !== "%") continue;
+    if (
+      i + 2 >= value.length ||
+      !isHexDigit(value[i + 1]!) ||
+      !isHexDigit(value[i + 2]!)
+    ) {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "has invalid percent encoding",
+      );
+    }
+
+    let end = i;
+    while (
+      end + 2 < value.length &&
+      value[end] === "%" &&
+      isHexDigit(value[end + 1]!) &&
+      isHexDigit(value[end + 2]!)
+    ) {
+      end += 3;
+    }
+
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(value.slice(i, end));
+    } catch {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "has invalid percent encoding",
+      );
+    }
+    for (const char of decoded) {
+      if (
+        PERCENT_DECODED_BOUNDARY_CHARS.has(char) ||
+        WHITESPACE_PATTERN.test(char) ||
+        UNICODE_CONTROL_PATTERN.test(char)
+      ) {
+        throw baseUrlVariableError(
+          base,
+          serviceName,
+          name,
+          "must not contain encoded URL structure",
+        );
+      }
+    }
+    i = end - 1;
+  }
+}
+
+function validateBaseUrlPrefixVariable({
+  base,
+  serviceName,
+  name,
+  value,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+}): void {
+  validateBaseUrl(value, serviceName);
+  const url = new URL(value);
+  if (url.search || url.hash) {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must not contain query or fragment before a fixed path suffix",
+    );
+  }
+}
+
+function validateBaseUrlAuthorityVariable({
+  base,
+  serviceName,
+  name,
+  value,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+}): void {
+  for (const char of value) {
+    if (AUTHORITY_VAR_STRUCTURE_CHARS.has(char)) {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "must not introduce URL structure",
+      );
+    }
+  }
+  validateBaseUrlVariablePercentEncoding({ base, serviceName, name, value });
+  validateBaseUrl(`https://${value}`, serviceName);
+}
+
+function validateBaseUrlAuthorityFragmentVariable({
+  base,
+  serviceName,
+  name,
+  value,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+}): void {
+  for (const char of value) {
+    if (AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS.has(char)) {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "must not introduce URL structure",
+      );
+    }
+  }
+  validateBaseUrlVariablePercentEncoding({ base, serviceName, name, value });
+}
+
+function prefixIsInsideAuthority(prefix: string): boolean {
+  const schemeEnd = prefix.indexOf("://");
+  if (schemeEnd === -1) return false;
+  const afterScheme = prefix.slice(schemeEnd + 3);
+  return !URL_COMPONENT_DELIMITER_PATTERN.test(afterScheme);
+}
+
+function suffixAuthorityPrefix(suffix: string): string {
+  const delimiterIndex = suffix.search(URL_COMPONENT_DELIMITER_PATTERN);
+  return delimiterIndex === -1 ? suffix : suffix.slice(0, delimiterIndex);
+}
+
+function validateBaseUrlTemplateVariable({
+  base,
+  serviceName,
+  name,
+  value,
+  prefix,
+  suffix,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+  readonly prefix: string;
+  readonly suffix: string;
+}): void {
+  validateBaseUrlVariableCommonSyntax({ base, serviceName, name, value });
+  if (prefix === "" && suffix === "") {
+    return;
+  }
+  if (prefix === "" && suffix.startsWith("/")) {
+    validateBaseUrlPrefixVariable({ base, serviceName, name, value });
+    return;
+  }
+  if (prefix.endsWith("://") && (suffix === "" || suffix.startsWith("/"))) {
+    validateBaseUrlAuthorityVariable({ base, serviceName, name, value });
+    return;
+  }
+  if (prefixIsInsideAuthority(prefix) && suffixAuthorityPrefix(suffix) !== "") {
+    validateBaseUrlAuthorityFragmentVariable({
+      base,
+      serviceName,
+      name,
+      value,
+    });
+    return;
+  }
+  throw baseUrlVariableError(
+    base,
+    serviceName,
+    name,
+    "is used in an unsupported base URL template position",
+  );
 }
 
 function firewallAuthInjectsCredentials(auth: FirewallApi["auth"]): boolean {
@@ -698,18 +953,30 @@ export function resolveFirewallBaseUrlVars(
       ...fw,
       apis: fw.apis.map((api) => {
         if (!hasBaseUrlVars(api.base)) return api;
-        const resolved = api.base.replace(
-          BASE_URL_VARS_PATTERN_G,
-          (_match, name: string) => {
-            const value = vars?.[name];
-            if (!value) {
-              throw new Error(
-                `Firewall "${fw.name}" base URL requires variable "${name}" but it was not provided`,
-              );
-            }
-            return value;
-          },
-        );
+        let resolved = "";
+        let lastIndex = 0;
+        for (const match of api.base.matchAll(BASE_URL_VARS_PATTERN_G)) {
+          const fullMatch = match[0];
+          const name = match[1]!;
+          const matchIndex = match.index!;
+          const value = vars?.[name];
+          if (!value) {
+            throw new Error(
+              `Firewall "${fw.name}" base URL requires variable "${name}" but it was not provided`,
+            );
+          }
+          validateBaseUrlTemplateVariable({
+            base: api.base,
+            serviceName: fw.name,
+            name,
+            value,
+            prefix: api.base.slice(0, matchIndex),
+            suffix: api.base.slice(matchIndex + fullMatch.length),
+          });
+          resolved += api.base.slice(lastIndex, matchIndex) + value;
+          lastIndex = matchIndex + fullMatch.length;
+        }
+        resolved += api.base.slice(lastIndex);
         validateBaseUrl(resolved, fw.name);
         validateCredentialedBaseUrlTransport(resolved, fw.name, api.auth);
         return { ...api, base: resolved };

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -661,6 +661,8 @@ const AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS = new Set([
 ]);
 const PERCENT_DECODED_BOUNDARY_CHARS = new Set(["/", ":", "?", "#", "@", "\\"]);
 const BASE_URL_VAR_PARAMETER_CHARS = new Set(["{", "}"]);
+const PATH_VAR_STRUCTURE_CHARS = new Set(["/", "?", "#", "\\"]);
+const PORT_VAR_PATTERN = /^[0-9]+$/;
 
 /**
  * Check if a base URL contains `${{ vars.X }}` template references.
@@ -724,14 +726,18 @@ function validateBaseUrlVariablePercentEncoding({
   serviceName,
   name,
   value,
+  structureChars,
 }: {
   readonly base: string;
   readonly serviceName: string;
   readonly name: string;
   readonly value: string;
-}): void {
+  readonly structureChars: ReadonlySet<string>;
+}): string {
   for (let i = 0; i < value.length; i += 1) {
-    if (value[i] !== "%") continue;
+    if (value[i] !== "%") {
+      continue;
+    }
     if (
       i + 2 >= value.length ||
       !isHexDigit(value[i + 1]!) ||
@@ -768,7 +774,7 @@ function validateBaseUrlVariablePercentEncoding({
     }
     for (const char of decoded) {
       if (
-        PERCENT_DECODED_BOUNDARY_CHARS.has(char) ||
+        structureChars.has(char) ||
         WHITESPACE_PATTERN.test(char) ||
         UNICODE_CONTROL_PATTERN.test(char)
       ) {
@@ -781,6 +787,19 @@ function validateBaseUrlVariablePercentEncoding({
       }
     }
     i = end - 1;
+  }
+  if (!value.includes("%")) {
+    return value;
+  }
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "has invalid percent encoding",
+    );
   }
 }
 
@@ -828,7 +847,13 @@ function validateBaseUrlAuthorityVariable({
       );
     }
   }
-  validateBaseUrlVariablePercentEncoding({ base, serviceName, name, value });
+  validateBaseUrlVariablePercentEncoding({
+    base,
+    serviceName,
+    name,
+    value,
+    structureChars: PERCENT_DECODED_BOUNDARY_CHARS,
+  });
   validateBaseUrl(`https://${value}`, serviceName);
 }
 
@@ -853,7 +878,81 @@ function validateBaseUrlAuthorityFragmentVariable({
       );
     }
   }
-  validateBaseUrlVariablePercentEncoding({ base, serviceName, name, value });
+  validateBaseUrlVariablePercentEncoding({
+    base,
+    serviceName,
+    name,
+    value,
+    structureChars: PERCENT_DECODED_BOUNDARY_CHARS,
+  });
+}
+
+function validateBaseUrlPortVariable({
+  base,
+  serviceName,
+  name,
+  value,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+}): void {
+  if (!PORT_VAR_PATTERN.test(value)) {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must be a numeric URL port",
+    );
+  }
+}
+
+function validateBaseUrlPathVariable({
+  base,
+  serviceName,
+  name,
+  value,
+  prefix,
+  suffix,
+}: {
+  readonly base: string;
+  readonly serviceName: string;
+  readonly name: string;
+  readonly value: string;
+  readonly prefix: string;
+  readonly suffix: string;
+}): void {
+  for (const char of value) {
+    if (PATH_VAR_STRUCTURE_CHARS.has(char)) {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "must not introduce path structure",
+      );
+    }
+  }
+  const decoded = validateBaseUrlVariablePercentEncoding({
+    base,
+    serviceName,
+    name,
+    value,
+    structureChars: PATH_VAR_STRUCTURE_CHARS,
+  });
+  const prefixSegment = prefix.slice(prefix.lastIndexOf("/") + 1);
+  const suffixSegmentEnd = suffix.search(URL_COMPONENT_DELIMITER_PATTERN);
+  const suffixSegment =
+    suffixSegmentEnd === -1 ? suffix : suffix.slice(0, suffixSegmentEnd);
+  const decodedSegment = `${prefixSegment}${decoded}${suffixSegment}`;
+  if (decodedSegment === "." || decodedSegment === "..") {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must not be a path dot segment",
+    );
+  }
 }
 
 function prefixIsInsideAuthority(prefix: string): boolean {
@@ -861,6 +960,14 @@ function prefixIsInsideAuthority(prefix: string): boolean {
   if (schemeEnd === -1) return false;
   const afterScheme = prefix.slice(schemeEnd + 3);
   return !URL_COMPONENT_DELIMITER_PATTERN.test(afterScheme);
+}
+
+function prefixIsInsidePath(prefix: string): boolean {
+  const schemeEnd = prefix.indexOf("://");
+  if (schemeEnd === -1) return false;
+  const afterScheme = prefix.slice(schemeEnd + 3);
+  if (afterScheme.includes("?") || afterScheme.includes("#")) return false;
+  return afterScheme.includes("/");
 }
 
 function suffixAuthorityPrefix(suffix: string): string {
@@ -895,12 +1002,31 @@ function validateBaseUrlTemplateVariable({
     validateBaseUrlAuthorityVariable({ base, serviceName, name, value });
     return;
   }
+  if (
+    prefixIsInsideAuthority(prefix) &&
+    prefix.endsWith(":") &&
+    (suffix === "" || suffix.startsWith("/"))
+  ) {
+    validateBaseUrlPortVariable({ base, serviceName, name, value });
+    return;
+  }
   if (prefixIsInsideAuthority(prefix) && suffixAuthorityPrefix(suffix) !== "") {
     validateBaseUrlAuthorityFragmentVariable({
       base,
       serviceName,
       name,
       value,
+    });
+    return;
+  }
+  if (prefixIsInsidePath(prefix)) {
+    validateBaseUrlPathVariable({
+      base,
+      serviceName,
+      name,
+      value,
+      prefix,
+      suffix,
     });
     return;
   }

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -722,28 +722,50 @@ function validateBaseUrlVariableCommonSyntax({
   }
 }
 
-function pathSegmentDotPrefix(segment: string): string {
-  return segment.split(";", 1)[0]!;
+function pathPartDotPrefix(part: string): string {
+  return part.split(";", 1)[0]!;
 }
 
-function pathSegmentIsDotSegment(segment: string): boolean {
-  const dotPrefix = pathSegmentDotPrefix(segment);
+function pathPartIsDotSegment(part: string): boolean {
+  const dotPrefix = pathPartDotPrefix(part);
   return dotPrefix === "." || dotPrefix === "..";
 }
 
-function normalizedPathSegmentHasUnsafeSyntax(segment: string): boolean {
+function pathSegmentContainsDotPathPart(segment: string): boolean {
+  if (pathPartIsDotSegment(segment)) return true;
+  return segment.split("/").some((part) => {
+    return pathPartIsDotSegment(part);
+  });
+}
+
+function pathSegmentHasUnsafeSyntaxParts(
+  segment: string,
+  rejectPathStructure: boolean,
+): boolean {
+  if (hasUnsafeUrlCodepoint(segment)) return true;
+  if (segment.includes("\\")) return true;
+  if (pathSegmentContainsDotPathPart(segment)) return true;
+  if (!rejectPathStructure) return false;
+  for (const char of segment) {
+    if (PATH_VAR_STRUCTURE_CHARS.has(char)) return true;
+  }
+  return false;
+}
+
+function normalizedPathSegmentHasUnsafeSyntax(
+  segment: string,
+  rejectPathStructure: boolean,
+): boolean {
   const normalized = segment.normalize("NFKC");
   if (normalized === segment) return false;
   if (normalized.includes("%")) return true;
-  for (const char of normalized) {
-    if (PATH_VAR_STRUCTURE_CHARS.has(char)) return true;
-  }
-  return (
-    pathSegmentIsDotSegment(normalized) || hasUnsafeUrlCodepoint(normalized)
-  );
+  return pathSegmentHasUnsafeSyntaxParts(normalized, rejectPathStructure);
 }
 
-function percentDecodePathSegment(segment: string): string | null {
+function percentDecodePathSegment(
+  segment: string,
+  rejectPathStructure: boolean,
+): string | null {
   if (!segment.includes("%")) return segment;
   for (let i = 0; i < segment.length; i += 1) {
     if (segment[i] !== "%") continue;
@@ -762,40 +784,45 @@ function percentDecodePathSegment(segment: string): string | null {
   } catch {
     return null;
   }
-  for (const char of decoded) {
-    if (
-      PATH_VAR_STRUCTURE_CHARS.has(char) ||
-      WHITESPACE_PATTERN.test(char) ||
-      UNICODE_CONTROL_PATTERN.test(char)
-    ) {
-      return null;
+  if (rejectPathStructure) {
+    for (const char of decoded) {
+      if (
+        PATH_VAR_STRUCTURE_CHARS.has(char) ||
+        WHITESPACE_PATTERN.test(char) ||
+        UNICODE_CONTROL_PATTERN.test(char)
+      ) {
+        return null;
+      }
     }
   }
   return decoded;
 }
 
-function pathSegmentHasUnsafeSyntax(segment: string): boolean {
+function pathSegmentHasUnsafeSyntax(
+  segment: string,
+  rejectPathStructure: boolean,
+): boolean {
   let current = segment;
   for (let pass = 0; pass < MAX_PATH_PERCENT_DECODE_PASSES; pass += 1) {
     if (
-      pathSegmentIsDotSegment(current) ||
-      normalizedPathSegmentHasUnsafeSyntax(current)
+      pathSegmentHasUnsafeSyntaxParts(current, rejectPathStructure) ||
+      normalizedPathSegmentHasUnsafeSyntax(current, rejectPathStructure)
     ) {
       return true;
     }
-    const decoded = percentDecodePathSegment(current);
+    const decoded = percentDecodePathSegment(current, rejectPathStructure);
     if (decoded === null) return true;
     if (decoded === current) return false;
     current = decoded;
   }
 
   if (
-    pathSegmentIsDotSegment(current) ||
-    normalizedPathSegmentHasUnsafeSyntax(current)
+    pathSegmentHasUnsafeSyntaxParts(current, rejectPathStructure) ||
+    normalizedPathSegmentHasUnsafeSyntax(current, rejectPathStructure)
   ) {
     return true;
   }
-  const decoded = percentDecodePathSegment(current);
+  const decoded = percentDecodePathSegment(current, rejectPathStructure);
   return decoded === null || decoded !== current;
 }
 
@@ -892,7 +919,7 @@ function validateBaseUrlPathSegment({
   readonly name: string;
   readonly segment: string;
 }): void {
-  if (pathSegmentHasUnsafeSyntax(segment)) {
+  if (pathSegmentHasUnsafeSyntax(segment, true)) {
     throw baseUrlVariableError(
       base,
       serviceName,
@@ -936,7 +963,14 @@ function validateBaseUrlPrefixVariable({
   }
   const rawPath = rawPathFromBaseUrl(value);
   for (const segment of rawPath.split("/")) {
-    validateBaseUrlPathSegment({ base, serviceName, name, segment });
+    if (pathSegmentHasUnsafeSyntax(segment, false)) {
+      throw baseUrlVariableError(
+        base,
+        serviceName,
+        name,
+        "must not contain unsafe path segments before a fixed path suffix",
+      );
+    }
   }
 }
 
@@ -947,7 +981,7 @@ function validateResolvedBaseUrlPathSafety(
 ): void {
   const rawPath = rawPathFromBaseUrl(resolved);
   for (const segment of rawPath.split("/")) {
-    if (pathSegmentHasUnsafeSyntax(segment)) {
+    if (pathSegmentHasUnsafeSyntax(segment, false)) {
       throw new Error(
         errMsg(
           templateBase,


### PR DESCRIPTION
Closes #17978

## Summary
- Validate base URL template variable values before substitution so runtime vars cannot cross URL component boundaries.
- Apply the same validation in the TypeScript connector resolver and Python mitm registry resolver.
- Preserve supported connector shapes: fixed provider suffixes, whole authority values, whole base URL values with fixed path suffixes, path segment values, and authority port values.
- Reject encoded URL structure, firewall parameter syntax, path boundary injection, unsafe path segments, nested path encodings, compatibility dot segments, resolved cross-variable dot segments, and non-numeric port variables in runtime base URL vars.
- Keep full base URL prefix paths compatible with encoded path data such as `%2f`, while still rejecting encoded dot traversal and encoded backslashes.

## Tests
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-expander.test.ts` (141 tests)
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `PYTHONPATH=src:/tmp/mitm-addon-test-deps /tmp/mitm-addon-test-deps/bin/ruff check src/registry.py tests/test_registry_context.py`
- `python3 -m py_compile src/registry.py tests/test_registry_context.py`
- `PYTHONPATH=src:/tmp/mitm-addon-test-deps python3 -m pytest tests/test_registry_context.py` (62 tests)
- pre-commit: ruff format/check, prettier, knip, full `pnpm check-types`