### PR TITLE
fix: keep credit usage focus ring visible

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -163,4 +163,19 @@ describe("personal usage settings", () => {
       expect(requestedRanges).toContain("7d");
     });
   });
+
+  it("keeps keyboard focus styling on the usage title instead of the row", async () => {
+    mockPersonalUsageStory();
+    await openUsageSettings();
+
+    const titleLink = await screen.findByText("Quarterly planning chat");
+
+    titleLink.focus();
+    expect(titleLink).toHaveFocus();
+    expect(titleLink.parentElement?.closest("a")).toBeNull();
+    expect(titleLink).toHaveClass(
+      "focus-visible:outline-none",
+      "focus-visible:ring-inset",
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -112,9 +112,10 @@ const ROW_CLASS =
 // overflow-hidden. inline-block + max-w-full keeps the hover fill hugging the
 // title text (not the whole row), truncating long titles; the chip padding /
 // negative margin are right-only (-mr-1.5/pr-1.5) so the hover chip's left edge
-// stays flush with the title text and the breakdown bar below.
+// stays flush with the title text and the breakdown bar below. The keyboard
+// focus ring is inset so the list card's overflow-hidden cannot clip it.
 const TITLE_LINK_CLASS =
-  "inline-block max-w-full -mr-1.5 truncate rounded-md pr-1.5 py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground";
+  "inline-block max-w-full -mr-1.5 truncate rounded-md pr-1.5 py-1 text-sm leading-6 font-medium text-foreground decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:bg-foreground/5 hover:decoration-foreground focus-visible:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring";
 
 type UsageRecordLoadable =
   | { readonly state: "loading" }


### PR DESCRIPTION
## Summary
- keep the Credit balance usage title focus ring inset so the list card cannot clip it
- add a regression test that keeps keyboard focus styling on the title link instead of a row-wide target

Fixes #17666

## Testing
- `cd turbo/apps/platform && ./node_modules/.bin/vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx`
- `cd turbo/apps/platform && ./node_modules/.bin/tsc --noEmit`
- `cd turbo/apps/platform && pnpm exec eslint src/views/zero-page/components/preferences/personal-usage-record.tsx src/views/zero-page/__tests__/personal-usage-tab.test.tsx --max-warnings 0`
- `cd turbo/apps/platform && pnpm exec oxlint src/views/zero-page/components/preferences/personal-usage-record.tsx src/views/zero-page/__tests__/personal-usage-tab.test.tsx`
- `cd turbo && ./node_modules/.bin/prettier --check --ignore-unknown apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx`