### PR TITLE
fix: avoid presentation template preview flicker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -362,6 +362,7 @@ async function openTemplatePicker(
   await waitFor(() => {
     expect(screen.getByText(template.title)).toBeInTheDocument();
   });
+  expect(document.querySelector("[data-template-preview-error]")).toBeNull();
 
   if (slideCount > 1) {
     const previewImage = screen.getByTestId(
@@ -383,7 +384,7 @@ async function openTemplatePicker(
         screen.getByTestId(
           `${template.title} card preview slide ${slideCount}`,
         ),
-      ).toBeInTheDocument();
+      ).toHaveAttribute("data-loaded", "true");
     });
     fireEvent.mouseLeave(preview);
   }
@@ -392,19 +393,29 @@ async function openTemplatePicker(
   await waitFor(() => {
     expect(screen.getByText(`1 of ${slideCount}`)).toBeInTheDocument();
   });
+  expect(document.querySelector("[data-template-preview-error]")).toBeNull();
 
   if (slideCount > 1) {
     click(screen.getByLabelText("Next slide"));
     await waitFor(() => {
       expect(screen.getByText(`2 of ${slideCount}`)).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${template.title} preview slide 2`),
+      ).toHaveAttribute("data-loaded", "true");
     });
     click(screen.getByLabelText("Previous slide"));
     await waitFor(() => {
       expect(screen.getByText(`1 of ${slideCount}`)).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${template.title} preview slide 1`),
+      ).toHaveAttribute("data-loaded", "true");
     });
     click(screen.getByLabelText("Show slide 2"));
     await waitFor(() => {
       expect(screen.getByText(`2 of ${slideCount}`)).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`${template.title} preview slide 2`),
+      ).toHaveAttribute("data-loaded", "true");
     });
   }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1095,6 +1095,63 @@ async function selectDecodedTemplatePreviewImage({
   }
 }
 
+async function selectDecodedPresentationPreviewSlide({
+  container,
+  imageUrl,
+  index,
+  onSlideChange,
+}: {
+  container: HTMLElement;
+  imageUrl: string;
+  index: number;
+  onSlideChange: (index: number) => void;
+}): Promise<void> {
+  await decodePresentationPreviewImage(imageUrl);
+  if (
+    container.dataset.targetSlideIndex === String(index) &&
+    presentationPreviewImageDecoded(imageUrl)
+  ) {
+    delete container.dataset.targetSlideIndex;
+    onSlideChange(index);
+  }
+}
+
+function selectPresentationPreviewSlide({
+  container,
+  imageUrl,
+  index,
+  onSlideChange,
+}: {
+  container: HTMLElement | null;
+  imageUrl: string;
+  index: number;
+  onSlideChange: (index: number) => void;
+}): void {
+  if (presentationPreviewImageDecoded(imageUrl)) {
+    if (container !== null) {
+      delete container.dataset.targetSlideIndex;
+    }
+    onSlideChange(index);
+    return;
+  }
+
+  if (container === null) {
+    detach(decodePresentationPreviewImage(imageUrl), Reason.DomCallback);
+    return;
+  }
+
+  container.dataset.targetSlideIndex = String(index);
+  detach(
+    selectDecodedPresentationPreviewSlide({
+      container,
+      imageUrl,
+      index,
+      onSlideChange,
+    }),
+    Reason.DomCallback,
+  );
+}
+
 async function markPresentationPreviewImageLoaded(
   url: string,
   image: HTMLImageElement,
@@ -1107,9 +1164,6 @@ async function markPresentationPreviewImageLoaded(
     cache.decoded.add(url);
   }
   image.dataset.loaded = "true";
-  image.parentElement
-    ?.querySelector<HTMLElement>("[data-template-preview-error]")
-    ?.setAttribute("hidden", "");
 }
 
 function TemplatePreview({
@@ -1196,18 +1250,22 @@ function TemplatePreview({
             src={previewImage}
             alt=""
             data-testid={`${item.title} card preview slide 1`}
+            data-loaded={
+              presentationPreviewImageDecoded(previewImage) ? "true" : undefined
+            }
             title={`${item.title} card preview slide 1`}
             className="absolute inset-0 h-full w-full object-contain"
             loading="lazy"
+            decoding="async"
+            fetchPriority="low"
             onLoad={(event) => {
-              event.currentTarget.parentElement
-                ?.querySelector<HTMLElement>("[data-template-preview-error]")
-                ?.setAttribute("hidden", "");
-            }}
-            onError={(event) => {
-              event.currentTarget.parentElement
-                ?.querySelector<HTMLElement>("[data-template-preview-error]")
-                ?.removeAttribute("hidden");
+              detach(
+                markPresentationPreviewImageLoaded(
+                  previewImage,
+                  event.currentTarget,
+                ),
+                Reason.DomCallback,
+              );
             }}
           />
           {isHovering &&
@@ -1221,11 +1279,18 @@ function TemplatePreview({
                   data-testid={`${item.title} card preview slide ${
                     isHovering ? imageIndex + 1 : 1
                   }`}
+                  data-loaded={
+                    presentationPreviewImageDecoded(imageUrl)
+                      ? "true"
+                      : undefined
+                  }
                   className={cn(
                     "absolute inset-0 h-full w-full object-contain opacity-0 transition-opacity duration-75",
                     active && "data-[loaded=true]:opacity-100",
                   )}
                   loading={isHovering ? "eager" : "lazy"}
+                  decoding="async"
+                  fetchPriority={active ? "high" : "low"}
                   onLoad={(event) => {
                     detach(
                       markPresentationPreviewImageLoaded(
@@ -1235,23 +1300,9 @@ function TemplatePreview({
                       Reason.DomCallback,
                     );
                   }}
-                  onError={(event) => {
-                    event.currentTarget.parentElement
-                      ?.querySelector<HTMLElement>(
-                        "[data-template-preview-error]",
-                      )
-                      ?.removeAttribute("hidden");
-                  }}
                 />
               );
             })}
-          <div
-            data-template-preview-error=""
-            hidden
-            className="absolute inset-0 flex items-center justify-center bg-muted text-muted-foreground"
-          >
-            <IconTemplate size={28} stroke={1.5} />
-          </div>
         </>
       ) : (
         <div className="flex h-full items-center justify-center text-muted-foreground">
@@ -1291,18 +1342,38 @@ function TemplatePreviewPage({
     0,
     Math.min(selectedSlideIndex, slideImages.length - 1),
   );
-  const selectedSlideImage = slideImages[safeSlideIndex];
-  const selectedSlidePreviewImage = selectedSlideImage
-    ? r2ImageTransformUrl(selectedSlideImage, TEMPLATE_DETAIL_PREVIEW_SIZE)
-    : selectedSlideImage;
+  const detailPreviewImage = (index: number): string | undefined => {
+    const slideImage = slideImages[index];
+    return slideImage
+      ? r2ImageTransformUrl(slideImage, TEMPLATE_DETAIL_PREVIEW_SIZE)
+      : undefined;
+  };
+  const selectedSlidePreviewImage = detailPreviewImage(safeSlideIndex);
   const hasMultipleSlides = slideImages.length > 1;
 
-  const changeSlide = (direction: -1 | 1) => {
+  const requestSlideChange = (
+    index: number,
+    container: HTMLElement | null,
+  ): void => {
+    const imageUrl = detailPreviewImage(index);
+    if (imageUrl === undefined) {
+      return;
+    }
+    selectPresentationPreviewSlide({
+      container,
+      imageUrl,
+      index,
+      onSlideChange,
+    });
+  };
+
+  const changeSlide = (direction: -1 | 1, container: HTMLElement | null) => {
     if (!hasMultipleSlides) {
       return;
     }
-    onSlideChange(
+    requestSlideChange(
       (safeSlideIndex + direction + slideImages.length) % slideImages.length,
+      container,
     );
   };
 
@@ -1324,26 +1395,68 @@ function TemplatePreviewPage({
         </DialogTitle>
       </DialogHeader>
       <div className="grid max-h-[72vh] gap-5 overflow-y-auto bg-muted/20 p-5 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="rounded-lg border border-border bg-background p-4">
+        <div
+          data-template-preview-page=""
+          className="rounded-lg border border-border bg-background p-4"
+        >
           <div className="relative overflow-hidden rounded-lg bg-muted">
             <div className="absolute left-3 top-3 z-10 rounded-md bg-black/80 px-2 py-1 text-xs font-semibold text-white">
               {safeSlideIndex + 1} of {slideImages.length}
             </div>
-            <img
-              key={selectedSlideImage}
-              src={selectedSlidePreviewImage}
-              title={`${item.title} preview slide ${safeSlideIndex + 1}`}
-              alt=""
-              className="aspect-[16/9] w-full object-contain"
-              loading="lazy"
-            />
+            {selectedSlidePreviewImage ? (
+              <img
+                key={selectedSlidePreviewImage}
+                src={selectedSlidePreviewImage}
+                data-loaded={
+                  presentationPreviewImageDecoded(selectedSlidePreviewImage)
+                    ? "true"
+                    : undefined
+                }
+                title={`${item.title} preview slide ${safeSlideIndex + 1}`}
+                alt=""
+                className="aspect-[16/9] w-full object-contain"
+                loading="eager"
+                decoding="async"
+                fetchPriority="high"
+                onLoad={(event) => {
+                  detach(
+                    markPresentationPreviewImageLoaded(
+                      selectedSlidePreviewImage,
+                      event.currentTarget,
+                    ),
+                    Reason.DomCallback,
+                  );
+                }}
+              />
+            ) : (
+              <div className="flex aspect-[16/9] items-center justify-center text-muted-foreground">
+                <IconTemplate size={28} stroke={1.5} />
+              </div>
+            )}
             <button
               type="button"
               aria-label="Previous slide"
               className="absolute left-3 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-background/95 text-foreground shadow-sm transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               disabled={!hasMultipleSlides}
-              onClick={() => {
-                changeSlide(-1);
+              onMouseEnter={() => {
+                const previousImage = detailPreviewImage(
+                  (safeSlideIndex - 1 + slideImages.length) %
+                    slideImages.length,
+                );
+                if (previousImage) {
+                  detach(
+                    decodePresentationPreviewImage(previousImage),
+                    Reason.DomCallback,
+                  );
+                }
+              }}
+              onClick={(event) => {
+                changeSlide(
+                  -1,
+                  event.currentTarget.closest<HTMLElement>(
+                    "[data-template-preview-page]",
+                  ),
+                );
               }}
             >
               <IconChevronLeft size={22} stroke={1.8} />
@@ -1353,8 +1466,24 @@ function TemplatePreviewPage({
               aria-label="Next slide"
               className="absolute right-3 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-background/95 text-foreground shadow-sm transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               disabled={!hasMultipleSlides}
-              onClick={() => {
-                changeSlide(1);
+              onMouseEnter={() => {
+                const nextImage = detailPreviewImage(
+                  (safeSlideIndex + 1) % slideImages.length,
+                );
+                if (nextImage) {
+                  detach(
+                    decodePresentationPreviewImage(nextImage),
+                    Reason.DomCallback,
+                  );
+                }
+              }}
+              onClick={(event) => {
+                changeSlide(
+                  1,
+                  event.currentTarget.closest<HTMLElement>(
+                    "[data-template-preview-page]",
+                  ),
+                );
               }}
             >
               <IconChevronRight size={22} stroke={1.8} />
@@ -1377,8 +1506,22 @@ function TemplatePreviewPage({
                     "relative overflow-hidden rounded-md border bg-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                     selected ? "border-primary" : "border-border",
                   )}
-                  onClick={() => {
-                    onSlideChange(index);
+                  onMouseEnter={() => {
+                    const detailImage = detailPreviewImage(index);
+                    if (detailImage) {
+                      detach(
+                        decodePresentationPreviewImage(detailImage),
+                        Reason.DomCallback,
+                      );
+                    }
+                  }}
+                  onClick={(event) => {
+                    requestSlideChange(
+                      index,
+                      event.currentTarget.closest<HTMLElement>(
+                        "[data-template-preview-page]",
+                      ),
+                    );
                   }}
                 >
                   <img


### PR DESCRIPTION
## Summary
- remove the presentation template preview fallback/error overlay so it no longer flashes over the current slide
- keep the current preview visible while the requested hover/next/previous/thumbnail slide decodes, then switch only after the target image is ready
- mark cached/decoded presentation preview images as loaded immediately so already-loaded slides appear without another blank frame
- cover the no-fallback DOM and loaded-state behavior in the presentation template picker test helper

## Verification
- pnpm exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --testNamePattern "selects a presentation template from the picker"
- pnpm --filter @vm0/app check-types
- pnpm exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --max-warnings 0
- pnpm exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm exec prettier --check src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx

## Notes
- Started the local Vite server and opened `http://localhost:3002/`, but the app could not become interactive because local env vars such as `VITE_API_URL` and `VITE_CLERK_PUBLISHABLE_KEY` were missing.