### PR TITLE
test(mitm-addon): expose responseheaders lifecycle in helpers

### DIFF
--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -7,7 +7,6 @@ from mitmproxy import http
 from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
-import mitm_addon
 from tests.flow_helpers import header_map
 
 RealFlowFactory = Callable[..., http.HTTPFlow]
@@ -69,7 +68,6 @@ def make_openai_responses_websocket_flow(
         status_code=101,
         headers=http.Headers(upgrade="websocket"),
     )
-    mitm_addon.responseheaders(flow)
     return flow
 
 
@@ -94,7 +92,6 @@ def make_model_provider_sse_flow(
         status_code=200,
         headers=header_map({"content-type": "text/event-stream"}),
     )
-    mitm_addon.responseheaders(flow)
     return flow
 
 

--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -9,6 +9,7 @@ from mitmproxy import http, websocket
 from wsproto.frame_protocol import Opcode
 
 import mitm_addon
+import response_streaming
 from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_flow,
     model_provider_usage_sources,
@@ -99,12 +100,18 @@ def _set_websocket_message(
     _append_websocket_message(flow, from_client=from_client, content=content)
 
 
+def _assert_model_websocket_usage_started(flow: http.HTTPFlow) -> None:
+    assert response_streaming.is_model_websocket_usage_enabled(flow)
+
+
 def _feed_websocket_server_message(flow: http.HTTPFlow, content: bytes) -> None:
+    _assert_model_websocket_usage_started(flow)
     _set_websocket_message(flow, from_client=False, content=content)
     mitm_addon.websocket_message(flow)
 
 
 def _feed_websocket_server_text_message(flow: http.HTTPFlow, content: str) -> None:
+    _assert_model_websocket_usage_started(flow)
     _set_websocket_message(flow, from_client=False, content=content.encode())
     assert flow.websocket is not None
     object.__setattr__(flow.websocket.messages[-1], "content", content)

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -100,6 +100,7 @@ class TestModelProviderSseUsage:
     def test_full_pipeline_model_sse_finalizes_trailing_event(self, tmp_path, real_flow):
         """response() must flush a trailing SSE usage event before reporting."""
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
@@ -119,6 +120,7 @@ class TestModelProviderSseUsage:
 
     def test_full_pipeline_model_sse_reports_response_incomplete_usage(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: response.incomplete\n"
             b'data: {"response":{"id":"resp_incomplete","model":"gpt-5.5",'
@@ -145,6 +147,7 @@ class TestModelProviderSseUsage:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
@@ -168,6 +171,7 @@ class TestModelProviderSseUsage:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","mod'
         )
@@ -190,6 +194,7 @@ class TestModelProviderSseUsage:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(b"event: message_start\ndata: {invalid json}\n\n")
 
         webhook = self._run_response(flow)
@@ -211,6 +216,7 @@ class TestModelProviderSseUsage:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: message_start\n"
             b'data: {"type":"message_start","message":{"id":"msg_1",'
@@ -233,6 +239,7 @@ class TestModelProviderSseUsage:
 
     def test_full_pipeline_openai_sse_logs_truncated_terminal_event(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
@@ -249,6 +256,7 @@ class TestModelProviderSseUsage:
 
     def test_full_pipeline_openai_sse_logs_truncated_late_event_name(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt\n'
             b"event: response.completed\n\n"
@@ -273,6 +281,7 @@ class TestModelProviderSseUsage:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b'data: {"type":"message_start","message":{"id":"msg_1","model":"claude'
         )
@@ -296,6 +305,7 @@ class TestModelProviderSseUsage:
             original_url="https://api.anthropic.com/v1/messages",
             firewall_name="model-provider:anthropic-api-key",
         )
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: content_block_delta\n"
             b'data: {"type":"content_block_delta","delta":{"text":"hello'
@@ -308,6 +318,7 @@ class TestModelProviderSseUsage:
 
     def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
@@ -321,6 +332,7 @@ class TestModelProviderSseUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: response.in_progress\n"
             b'data: {"type":"response.in_progress","response":{"id":"resp_1","model":"gpt'
@@ -335,6 +347,7 @@ class TestModelProviderSseUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"response":{"id":"resp_sse_1","model":"gpt-5.5",'

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
@@ -8,6 +8,7 @@ import pytest
 from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
+import mitm_addon
 from tests.model_provider_websocket_helpers import (
     _capture_deferred_websocket_trims,
     _feed_websocket_server_message,
@@ -38,6 +39,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
     def test_model_websocket_zero_frame_preserves_prior_positive_usage(self, tmp_path, real_flow):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         _feed_websocket_server_message(
             flow,
@@ -84,6 +86,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
     def test_model_websocket_positive_frame_updates_prior_zero_usage(self, tmp_path, real_flow):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         _feed_websocket_server_message(
             flow,
@@ -121,6 +124,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
     def test_model_websocket_partial_frame_preserves_existing_categories(self, tmp_path, real_flow):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         _feed_websocket_server_message(
             flow,
@@ -163,6 +167,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
     def test_model_websocket_accepts_text_frame_content(self, tmp_path, real_flow):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         _feed_websocket_server_text_message(
             flow,
@@ -187,6 +192,7 @@ class TestModelProviderWebSocketUsageMetadata:
 
     def test_model_websocket_malformed_frame_preserves_prior_usage(self, tmp_path, real_flow):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "message_id": "resp_ws_1",
             "model": "gpt-5.5",
@@ -207,6 +213,7 @@ class TestModelProviderWebSocketUsageMetadata:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = "invalid"
 
         _feed_websocket_server_message(
@@ -237,6 +244,7 @@ class TestModelProviderWebSocketUsageMetadata:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_metadata_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = "invalid"
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = "invalid"
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -124,6 +124,7 @@ class TestModelProviderWebSocketUsage:
     def test_full_pipeline_model_websocket_reports_usage(self, tmp_path, real_flow):
         """Codex Responses WebSocket frames should bill like SSE events."""
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         assert flow.metadata["model_websocket_usage_enabled"] is True
         assert "model_json_usage_finish" not in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
@@ -161,6 +162,7 @@ class TestModelProviderWebSocketUsage:
 
     def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -190,6 +192,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -219,6 +222,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -258,6 +262,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -300,6 +305,7 @@ class TestModelProviderWebSocketUsage:
 
     def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -341,6 +347,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -540,6 +547,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
 
         webhook = self._run_websocket_messages_and_end(
             flow,
@@ -587,6 +595,7 @@ class TestModelProviderWebSocketUsage:
 
     def test_model_websocket_ignores_client_messages(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         _set_websocket_message(
             flow,
             from_client=True,
@@ -615,6 +624,7 @@ class TestModelProviderWebSocketUsage:
         deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         old_client = _append_websocket_message(flow, from_client=True, content=b"client-old")
         old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
         latest_server = _append_websocket_message(
@@ -650,6 +660,7 @@ class TestModelProviderWebSocketUsage:
         deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         old_server = _append_websocket_message(flow, from_client=False, content=b"server-old")
         latest_client = _append_websocket_message(
             flow,
@@ -676,6 +687,7 @@ class TestModelProviderWebSocketUsage:
         deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         first_server = _append_websocket_message(
             flow,
             from_client=False,
@@ -734,6 +746,7 @@ class TestModelProviderWebSocketUsage:
         deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         _append_websocket_message(
             flow,
             from_client=False,
@@ -762,6 +775,7 @@ class TestModelProviderWebSocketUsage:
         deferred_websocket_trim_scheduler: list[_ScheduledWebSocketTrim],
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         flow.error = Error("connection reset by peer")
         _append_websocket_message(
             flow,


### PR DESCRIPTION
## Summary

- Make model-provider SSE/WebSocket flow helpers construct response shapes without running `responseheaders()`.
- Update SSE and WebSocket usage tests to call `mitm_addon.responseheaders(flow)` at the visible lifecycle boundary before feeding chunks or frames.
- Add a narrow WebSocket feed-helper assertion so missing model WebSocket setup fails clearly instead of silently no-oping.

Closes #18021

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_model_provider_sse_usage.py tests/test_model_provider_websocket_usage.py tests/test_model_provider_websocket_metadata.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_response_streaming.py tests/test_model_provider_response_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/python -m basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/ -v`
