### PR TITLE
docs(mitm-addon): clarify browser passthrough heuristic

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -27,9 +27,10 @@ Request context
   handling. Read by body capture to mark oversized request bodies truncated.
 - ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
   ``"claude-code"``. Read by model-provider usage protocol selection.
-- ``BROWSER_USER_AGENT``: ``bool`` written during request classification for
-  browser-looking user agents. Read by request dispatch to skip firewall
-  matching and credential mutation, and by network-log entry construction.
+- ``BROWSER_USER_AGENT``: ``bool`` written during request classification when
+  the request matches the short-term browser passthrough User-Agent heuristic.
+  Read by request dispatch to skip connector firewall handling and managed
+  credential mutation, and by network-log entry construction.
 
 Timing context
 --------------

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -485,9 +485,10 @@ def _is_browser_user_agent(user_agent: str | None) -> bool:
     )
 
 
-def _is_browser_request(flow: http.HTTPFlow) -> bool:
-    # This is only a browser-looking User-Agent heuristic. It is not trusted
-    # browser provenance: any sandbox client can set this header.
+def _is_browser_passthrough_heuristic(flow: http.HTTPFlow) -> bool:
+    # Short-term business passthrough heuristic for browser-originated traffic.
+    # This is not trusted browser provenance: any sandbox client can set this
+    # header. Issue #18024 tracks replacing it with a runner-owned signal.
     return _is_browser_user_agent(flow.request.headers.get("User-Agent"))
 
 
@@ -591,7 +592,7 @@ def _classify_request(flow: http.HTTPFlow) -> _RequestClassification:
 
     _store_registered_request_metadata(flow, vm_info=vm_info, run_id=run_id)
 
-    if _is_browser_request(flow):
+    if _is_browser_passthrough_heuristic(flow):
         flow.metadata[metadata_keys.BROWSER_USER_AGENT] = True
 
     try:
@@ -930,7 +931,9 @@ def _maybe_replace_connector_diagnostic_response(
         _HTTP_STATUS_FORBIDDEN,
     ):
         return
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_request(flow):
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_passthrough_heuristic(
+        flow
+    ):
         return
 
     candidate = _connector_diagnostic_candidate_from_flow(flow)
@@ -958,7 +961,9 @@ def _maybe_make_connector_diagnostic_error_response(
     *,
     original_url: str,
 ) -> None:
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_request(flow):
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_passthrough_heuristic(
+        flow
+    ):
         return
     candidate = _connector_diagnostic_candidate_from_flow(flow)
     if candidate is None:
@@ -986,7 +991,9 @@ def _should_buffer_connector_diagnostic_response(flow: http.HTTPFlow) -> bool:
         _HTTP_STATUS_FORBIDDEN,
     ):
         return False
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_request(flow):
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_passthrough_heuristic(
+        flow
+    ):
         return False
 
     candidate = _connector_diagnostic_candidate_from_flow(flow)
@@ -1342,10 +1349,9 @@ async def request(flow: http.HTTPFlow) -> None:
             flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
             return
         if classification.kind == "browser_allow":
-            # User-Agent is client-controlled. This is a business passthrough
-            # for browser-looking traffic, not proof of trusted browser
-            # provenance. Registry and authority validation have already run,
-            # but firewall matching, credential fetch, and auth injection do not.
+            # Browser-originated traffic intentionally bypasses connector
+            # firewall handling. User-Agent is the short-term heuristic for that
+            # business passthrough, not trusted provenance.
             flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
             flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
             return

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1039,10 +1039,10 @@ async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
-async def test_browser_firewall_match_skips_auth_injection(
+async def test_browser_passthrough_skips_firewall_auth_injection(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs pass through without entering the credential flow."""
+    """Browser-looking UAs use the short-term passthrough heuristic."""
     pending_path = tmp_path / "usage-pending"
     usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
     reg_path = _write_registry(
@@ -1163,10 +1163,10 @@ async def test_non_browser_firewall_match_still_injects_auth(
     assert flow.metadata["firewall_name"] == "stripe"
 
 
-async def test_browser_firewall_match_bypasses_denied_unknown_policy(
+async def test_browser_passthrough_skips_denied_unknown_policy_match(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs skip the firewall matcher for unknown endpoints."""
+    """Browser passthrough intentionally skips unknown-policy firewall matching."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1214,10 +1214,10 @@ async def test_browser_firewall_match_bypasses_denied_unknown_policy(
     assert "firewall_name" not in flow.metadata
 
 
-async def test_browser_firewall_match_bypasses_explicit_denied_permission(
+async def test_browser_passthrough_skips_denied_permission_match(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs pass through even when a matched permission is denied."""
+    """Browser passthrough intentionally skips denied-permission matching."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -1366,10 +1366,10 @@ async def test_firewall_unsafe_path_blocks_before_auth_injection(
     assert proxy_log_entry["reason"] == "unsafe_path"
 
 
-async def test_browser_firewall_unsafe_path_bypasses_firewall_match(
+async def test_browser_passthrough_skips_unsafe_path_firewall_match(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    """Browser-looking UAs skip firewall matching, including unsafe-path blocks."""
+    """Browser passthrough intentionally skips unsafe-path firewall matching."""
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(


### PR DESCRIPTION
## Summary

- clarify that browser-looking User-Agent handling is an intentional short-term browser passthrough heuristic
- document that the heuristic is not trusted browser provenance because sandbox clients can spoof User-Agent
- rename firewall dispatch tests to describe browser passthrough behavior instead of implying accidental firewall enforcement bugs

Refs #18024. This PR documents and sharpens the current short-term behavior; #18024 remains the tracking issue for a runner-owned, non-spoofable browser provenance signal.

## Tests

- `/tmp/vm5-mitm-addon-venv/bin/ruff check src/mitm_addon.py src/flow_metadata_keys.py tests/test_request_handler_firewall_dispatch.py`
- `/tmp/vm5-mitm-addon-venv/bin/ruff format --check src/mitm_addon.py src/flow_metadata_keys.py tests/test_request_handler_firewall_dispatch.py`
- `/tmp/vm5-mitm-addon-venv/bin/python -m pytest tests/test_request_handler_firewall_dispatch.py`
- `/tmp/vm5-mitm-addon-venv/bin/basedpyright -p .`
- `git diff --check`