### PR TITLE
feat: make connector and computer-use rows fully clickable to toggle

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2749,8 +2749,11 @@ function ComputerUseConnectorMenuSection({
             return (
               <div
                 key={host.id}
+                onClick={() => {
+                  computerUse.onChange(checked ? null : host.id);
+                }}
                 className={cn(
-                  "flex items-center gap-2 px-3 py-2 transition-colors",
+                  "flex items-center gap-2 px-3 py-2 transition-colors cursor-pointer",
                   checked ? "bg-primary/5" : "hover:bg-muted/50",
                 )}
               >
@@ -2767,15 +2770,22 @@ function ComputerUseConnectorMenuSection({
                     </span>
                   )}
                 </span>
-                <LoadingSwitch
-                  checked={checked}
-                  onCheckedChange={onDomEventFn((nextChecked) => {
-                    computerUse.onChange(nextChecked ? host.id : null);
-                  })}
-                  loading={false}
-                  ariaLabel={`${checked ? "Disconnect" : "Connect"} ${host.displayName}`}
-                  size="sm"
-                />
+                <span
+                  className="flex shrink-0 items-center"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <LoadingSwitch
+                    checked={checked}
+                    onCheckedChange={onDomEventFn((nextChecked) => {
+                      computerUse.onChange(nextChecked ? host.id : null);
+                    })}
+                    loading={false}
+                    ariaLabel={`${checked ? "Disconnect" : "Connect"} ${host.displayName}`}
+                    size="sm"
+                  />
+                </span>
               </div>
             );
           })}
@@ -2904,7 +2914,13 @@ function ConnectorsPopoverButton({
                   return (
                     <div
                       key={item.type}
-                      className="flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors"
+                      onClick={onDomEventFn(async () => {
+                        if (savingType === item.type) {
+                          return;
+                        }
+                        await onToggle(item.type, !item.authorized);
+                      })}
+                      className="flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors cursor-pointer"
                     >
                       <span className="flex h-4 w-4 shrink-0 items-center justify-center">
                         <ConnectorIcon type={item.type} size={16} />
@@ -2912,15 +2928,22 @@ function ConnectorsPopoverButton({
                       <span className="text-sm flex-1 truncate text-foreground">
                         {item.label}
                       </span>
-                      <LoadingSwitch
-                        checked={item.authorized}
-                        onCheckedChange={onDomEventFn(async (checked) => {
-                          await onToggle(item.type, checked);
-                        })}
-                        loading={savingType === item.type}
-                        ariaLabel={`${item.authorized ? "Remove" : "Add"} ${item.label}`}
-                        size="sm"
-                      />
+                      <span
+                        className="flex shrink-0 items-center"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        <LoadingSwitch
+                          checked={item.authorized}
+                          onCheckedChange={onDomEventFn(async (checked) => {
+                            await onToggle(item.type, checked);
+                          })}
+                          loading={savingType === item.type}
+                          ariaLabel={`${item.authorized ? "Remove" : "Add"} ${item.label}`}
+                          size="sm"
+                        />
+                      </span>
                     </div>
                   );
                 })}


### PR DESCRIPTION
## What

In the chat composer connectors popover, only the small switch on the right was clickable to toggle a connector (or a Computer Use host) on/off. This makes the **entire row** clickable, so a click anywhere on the row flips the toggle.

Addresses Ethan's question in Slack about whether the whole row should be clickable — yes.

## How

- Connector rows and Computer Use host rows now have an `onClick` on the row container that toggles the switch state.
- The switch stays independently interactive (wrapped in a `stopPropagation` span) so keyboard users can still tab to it, and clicking directly on the switch doesn't double-fire the toggle.
- Connector rows guard against clicking while a save is in flight (`savingType`).

## Test

- `pnpm -F @vm0/app lint` — 0 warnings, 0 errors
- `pnpm -F @vm0/app check-types` — clean
- Connector/chat tests pass (99 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)