### PR TITLE
fix(mitm-addon): preserve underbilling fallback context

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -62,7 +62,7 @@ def log_network_entry(log_path: str, entry: dict) -> None:
     _write_jsonl_entry(log_path, log_entry, "network")
 
 
-def _proxy_log_extra_value(key: str, value: object) -> object:
+def sanitize_proxy_log_extra_value(key: str, value: object) -> object:
     if key == "url" and isinstance(value, str):
         return network_log_sanitization.sanitize_url_for_network_log(value)
     return value
@@ -83,7 +83,7 @@ def log_proxy_entry(
     }
     for key, value in extra.items():
         if key not in _PROXY_LOG_RESERVED_FIELDS:
-            entry[key] = _proxy_log_extra_value(key, value)
+            entry[key] = sanitize_proxy_log_extra_value(key, value)
     _write_jsonl_entry(proxy_log_path, entry, "proxy")
 
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -217,14 +217,14 @@ def log_usage_underbilling(
         parts = [
             (
                 f"type={USAGE_UNDERBILLING_LOG_TYPE} "
-                f"reason={_single_token_stderr_value(reason)} "
-                f"underbilling_class={_single_token_stderr_value(underbilling_class)} "
+                f"reason={_single_token_stderr_value(str(reason))} "
+                f"underbilling_class={_single_token_stderr_value(str(underbilling_class))} "
                 f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON}"
             )
         ]
         if rendered_fields := _render_stderr_extra_fields(fields):
             parts.append(rendered_fields)
-        parts.append(_render_stderr_message(message))
+        parts.append(_render_stderr_message(str(message)))
         ctx.log.error(" ".join(parts))
         return
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -13,15 +13,56 @@ UnderbillingClass = Literal["confirmed", "risk"]
 USAGE_UNDERBILLING_LOG_TYPE = "usage_underbilling"
 USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
 _UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
+_SECRET_FIELD_WORDS = frozenset(
+    (
+        "authorization",
+        "credential",
+        "password",
+        "secret",
+    )
+)
+_SECRET_KEY_WORD_PAIRS = frozenset(
+    (
+        ("access", "key"),
+        ("api", "key"),
+        ("private", "key"),
+    )
+)
+_SECRET_TOKEN_KEYS = frozenset(
+    (
+        "accesstoken",
+        "refreshtoken",
+        "sandboxtoken",
+        "token",
+    )
+)
+_SECRET_COMPACT_KEYS = frozenset(("accesskey", "apikey", "privatekey"))
+
+
+def _stderr_field_key_words(key: str) -> tuple[str, ...]:
+    words: list[str] = []
+    current = ""
+    for ch in key:
+        if ch.isalnum():
+            if current and ch.isupper() and not current[-1].isupper():
+                words.append(current.lower())
+                current = ch
+            else:
+                current += ch
+            continue
+        if current:
+            words.append(current.lower())
+            current = ""
+    if current:
+        words.append(current.lower())
+    return tuple(words)
+
+
 _SECRET_FIELD_MARKERS = (
-    "accesskey",
-    "apikey",
     "authorization",
     "credential",
     "password",
-    "privatekey",
     "secret",
-    "token",
 )
 _STDERR_FIELD_KEY_MAX_CHARS = 80
 _STDERR_FIELD_VALUE_MAX_CHARS = 256
@@ -29,9 +70,20 @@ _TRUNCATION_SUFFIX = "..."
 
 
 def _stderr_field_is_secret_like(key: str, value: object) -> bool:
-    if value is None or isinstance(value, bool | int | float):
+    if value is None or isinstance(value, bool):
         return False
-    normalized_key = "".join(ch for ch in key.lower() if ch.isalnum())
+    words = _stderr_field_key_words(key)
+    normalized_key = "".join(words)
+    if any(pair[0] in words and pair[1] in words for pair in _SECRET_KEY_WORD_PAIRS):
+        return True
+    if any(word in _SECRET_FIELD_WORDS for word in words):
+        return True
+    if normalized_key in _SECRET_COMPACT_KEYS:
+        return True
+    if "token" in words:
+        return True
+    if normalized_key in _SECRET_TOKEN_KEYS:
+        return True
     return any(marker in normalized_key for marker in _SECRET_FIELD_MARKERS)
 
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -14,6 +14,7 @@ USAGE_UNDERBILLING_LOG_TYPE = "usage_underbilling"
 USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
 _UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
 _SECRET_FIELD_MARKERS = ("token", "secret", "password", "authorization")
+_STDERR_FIELD_KEY_MAX_CHARS = 80
 _STDERR_FIELD_VALUE_MAX_CHARS = 256
 _TRUNCATION_SUFFIX = "..."
 
@@ -22,17 +23,32 @@ def _stderr_field_is_secret_like(key: str, value: object) -> bool:
     return isinstance(value, str) and any(marker in key.lower() for marker in _SECRET_FIELD_MARKERS)
 
 
-def _single_line_stderr_value(value: str) -> str:
+def _truncate_stderr_text(value: str, max_chars: int) -> str:
+    if len(value) <= max_chars:
+        return value
+    limit = max_chars - len(_TRUNCATION_SUFFIX)
+    return value[:limit] + _TRUNCATION_SUFFIX
+
+
+def _render_stderr_field_key(key: str) -> str:
+    rendered = "".join(
+        ch if ch.isascii() and (ch.isalnum() or ch in ("_", "-", ".")) else "_" for ch in key
+    )
+    return _truncate_stderr_text(rendered or "_", _STDERR_FIELD_KEY_MAX_CHARS)
+
+
+def _single_token_stderr_value(value: str) -> str:
     return (
-        value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+        value.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace(" ", "\\s")
     )
 
 
 def _truncate_stderr_value(value: str) -> str:
-    if len(value) <= _STDERR_FIELD_VALUE_MAX_CHARS:
-        return value
-    limit = _STDERR_FIELD_VALUE_MAX_CHARS - len(_TRUNCATION_SUFFIX)
-    return value[:limit] + _TRUNCATION_SUFFIX
+    return _truncate_stderr_text(value, _STDERR_FIELD_VALUE_MAX_CHARS)
 
 
 def _render_stderr_field_value(key: str, value: object) -> str:
@@ -45,12 +61,12 @@ def _render_stderr_field_value(key: str, value: object) -> str:
         rendered = "null"
     else:
         rendered = str(sanitized)
-    return _truncate_stderr_value(_single_line_stderr_value(rendered))
+    return _truncate_stderr_value(_single_token_stderr_value(rendered))
 
 
 def _render_stderr_extra_fields(fields: dict[str, object]) -> str:
     return " ".join(
-        f"{key}={_render_stderr_field_value(key, fields[key])}"
+        f"{_render_stderr_field_key(key)}={_render_stderr_field_value(key, fields[key])}"
         for key in sorted(fields)
         if key not in _UNDERBILLING_PROTECTED_FIELDS
     )

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -38,13 +38,23 @@ def _render_stderr_field_key(key: str) -> str:
 
 
 def _single_token_stderr_value(value: str) -> str:
-    return (
-        value.replace("\\", "\\\\")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-        .replace(" ", "\\s")
-    )
+    rendered: list[str] = []
+    for ch in value:
+        if ch == "\\":
+            rendered.append("\\\\")
+        elif ch == "\n":
+            rendered.append("\\n")
+        elif ch == "\r":
+            rendered.append("\\r")
+        elif ch == "\t":
+            rendered.append("\\t")
+        elif ch.isspace():
+            rendered.append("\\s")
+        elif not ch.isprintable():
+            rendered.append(f"\\u{ord(ch):04x}")
+        else:
+            rendered.append(ch)
+    return "".join(rendered)
 
 
 def _truncate_stderr_value(value: str) -> str:

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -24,18 +24,25 @@ _SECRET_FIELD_WORDS = frozenset(
         "secret",
     )
 )
-_SECRET_KEY_WORD_PAIRS = frozenset(
+_SECRET_FIELD_WORD_PAIRS = frozenset(
     (
         ("access", "key"),
         ("api", "key"),
+        ("auth", "header"),
+        ("authentication", "header"),
         ("private", "key"),
     )
 )
-_SECRET_TOKEN_KEYS = frozenset(
+_SECRET_COMPACT_TOKEN_KEYS = frozenset(
     (
         "accesstoken",
         "refreshtoken",
         "sandboxtoken",
+    )
+)
+_SECRET_TOKEN_KEYS = frozenset(
+    (
+        *_SECRET_COMPACT_TOKEN_KEYS,
         "token",
     )
 )
@@ -78,15 +85,18 @@ def _stderr_field_is_secret_like(key: str, value: object) -> bool:
         return False
     words = _stderr_field_key_words(key)
     normalized_key = "".join(words)
-    if any(pair[0] in words and pair[1] in words for pair in _SECRET_KEY_WORD_PAIRS):
+    if any(pair[0] in words and pair[1] in words for pair in _SECRET_FIELD_WORD_PAIRS):
         return True
     if any(word in _SECRET_FIELD_WORDS for word in words):
         return True
-    if normalized_key in _SECRET_COMPACT_KEYS:
+    if any(word in _SECRET_COMPACT_KEYS for word in words):
         return True
     if "token" in words:
         return True
-    if normalized_key in _SECRET_TOKEN_KEYS:
+    if any(word in _SECRET_TOKEN_KEYS for word in words):
+        return True
+    compact_secret_markers = _SECRET_COMPACT_KEYS | _SECRET_COMPACT_TOKEN_KEYS
+    if any(marker in normalized_key for marker in compact_secret_markers):
         return True
     return any(marker in normalized_key for marker in _SECRET_FIELD_MARKERS)
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -6,12 +6,54 @@ from typing import Literal
 
 from mitmproxy import ctx
 
-from logging_utils import log_proxy_entry
+from logging_utils import log_proxy_entry, sanitize_proxy_log_extra_value
 
 UnderbillingClass = Literal["confirmed", "risk"]
 
 USAGE_UNDERBILLING_LOG_TYPE = "usage_underbilling"
 USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
+_UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
+_SECRET_FIELD_MARKERS = ("token", "secret", "password", "authorization")
+_STDERR_FIELD_VALUE_MAX_CHARS = 256
+_TRUNCATION_SUFFIX = "..."
+
+
+def _stderr_field_is_secret_like(key: str, value: object) -> bool:
+    return isinstance(value, str) and any(marker in key.lower() for marker in _SECRET_FIELD_MARKERS)
+
+
+def _single_line_stderr_value(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    )
+
+
+def _truncate_stderr_value(value: str) -> str:
+    if len(value) <= _STDERR_FIELD_VALUE_MAX_CHARS:
+        return value
+    limit = _STDERR_FIELD_VALUE_MAX_CHARS - len(_TRUNCATION_SUFFIX)
+    return value[:limit] + _TRUNCATION_SUFFIX
+
+
+def _render_stderr_field_value(key: str, value: object) -> str:
+    if _stderr_field_is_secret_like(key, value):
+        return "[redacted]"
+    sanitized = sanitize_proxy_log_extra_value(key, value)
+    if isinstance(sanitized, bool):
+        rendered = "true" if sanitized else "false"
+    elif sanitized is None:
+        rendered = "null"
+    else:
+        rendered = str(sanitized)
+    return _truncate_stderr_value(_single_line_stderr_value(rendered))
+
+
+def _render_stderr_extra_fields(fields: dict[str, object]) -> str:
+    return " ".join(
+        f"{key}={_render_stderr_field_value(key, fields[key])}"
+        for key in sorted(fields)
+        if key not in _UNDERBILLING_PROTECTED_FIELDS
+    )
 
 
 def underbilling_fields(
@@ -39,11 +81,17 @@ def log_usage_underbilling(
 ) -> None:
     fields = underbilling_fields(reason, underbilling_class, **extra)
     if not proxy_log_path:
-        ctx.log.error(
-            f"type={USAGE_UNDERBILLING_LOG_TYPE} reason={reason} "
-            f"underbilling_class={underbilling_class} "
-            f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON} {message}"
-        )
+        parts = [
+            (
+                f"type={USAGE_UNDERBILLING_LOG_TYPE} reason={reason} "
+                f"underbilling_class={underbilling_class} "
+                f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON}"
+            )
+        ]
+        if rendered_fields := _render_stderr_extra_fields(fields):
+            parts.append(rendered_fields)
+        parts.append(message)
+        ctx.log.error(" ".join(parts))
         return
 
     log_proxy_entry(

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -51,26 +51,33 @@ def _render_stderr_field_key(key: str) -> str:
 
 def _single_token_stderr_value(value: str) -> str:
     rendered: list[str] = []
+    truncated_prefix: list[str] = []
+    rendered_len = 0
+    truncated_prefix_len = 0
+    truncated_prefix_limit = _STDERR_FIELD_VALUE_MAX_CHARS - len(_TRUNCATION_SUFFIX)
     for ch in value:
         if ch == "\\":
-            rendered.append("\\\\")
+            chunk = "\\\\"
         elif ch == "\n":
-            rendered.append("\\n")
+            chunk = "\\n"
         elif ch == "\r":
-            rendered.append("\\r")
+            chunk = "\\r"
         elif ch == "\t":
-            rendered.append("\\t")
+            chunk = "\\t"
         elif ch.isspace():
-            rendered.append("\\s")
+            chunk = "\\s"
         elif not ch.isprintable():
-            rendered.append(f"\\u{ord(ch):04x}")
+            chunk = f"\\u{ord(ch):04x}"
         else:
-            rendered.append(ch)
+            chunk = ch
+        if rendered_len + len(chunk) > _STDERR_FIELD_VALUE_MAX_CHARS:
+            return "".join(truncated_prefix) + _TRUNCATION_SUFFIX
+        rendered.append(chunk)
+        rendered_len += len(chunk)
+        if truncated_prefix_len + len(chunk) <= truncated_prefix_limit:
+            truncated_prefix.append(chunk)
+            truncated_prefix_len += len(chunk)
     return "".join(rendered)
-
-
-def _truncate_stderr_value(value: str) -> str:
-    return _truncate_stderr_text(value, _STDERR_FIELD_VALUE_MAX_CHARS)
 
 
 def _render_stderr_field_value(key: str, value: object) -> str:
@@ -83,7 +90,7 @@ def _render_stderr_field_value(key: str, value: object) -> str:
         rendered = "null"
     else:
         rendered = str(sanitized)
-    return _truncate_stderr_value(_single_token_stderr_value(rendered))
+    return _single_token_stderr_value(rendered)
 
 
 def _render_stderr_extra_fields(fields: dict[str, object]) -> str:

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -14,16 +14,11 @@ USAGE_UNDERBILLING_LOG_TYPE = "usage_underbilling"
 USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
 _UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
 _SECRET_FIELD_MARKERS = (
-    "access_key",
     "accesskey",
-    "api_key",
-    "api-key",
     "apikey",
     "authorization",
     "credential",
     "password",
-    "private_key",
-    "private-key",
     "privatekey",
     "secret",
     "token",
@@ -34,7 +29,10 @@ _TRUNCATION_SUFFIX = "..."
 
 
 def _stderr_field_is_secret_like(key: str, value: object) -> bool:
-    return isinstance(value, str) and any(marker in key.lower() for marker in _SECRET_FIELD_MARKERS)
+    if value is None or isinstance(value, bool | int | float):
+        return False
+    normalized_key = "".join(ch for ch in key.lower() if ch.isalnum())
+    return any(marker in normalized_key for marker in _SECRET_FIELD_MARKERS)
 
 
 def _truncate_stderr_text(value: str, max_chars: int) -> str:

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -45,9 +45,10 @@ _SECRET_COMPACT_KEYS = frozenset(("accesskey", "apikey", "privatekey"))
 def _stderr_field_key_words(key: str) -> tuple[str, ...]:
     words: list[str] = []
     current = ""
-    for ch in key:
+    for index, ch in enumerate(key):
         if ch.isalnum():
-            if current and ch.isupper() and not current[-1].isupper():
+            next_ch = key[index + 1] if index + 1 < len(key) else ""
+            if current and ch.isupper() and (not current[-1].isupper() or next_ch.islower()):
                 words.append(current.lower())
                 current = ch
             else:

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -13,7 +13,17 @@ UnderbillingClass = Literal["confirmed", "risk"]
 USAGE_UNDERBILLING_LOG_TYPE = "usage_underbilling"
 USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
 _UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
-_SECRET_FIELD_MARKERS = ("token", "secret", "password", "authorization")
+_SECRET_FIELD_MARKERS = (
+    "access_key",
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+    "password",
+    "private_key",
+    "secret",
+    "token",
+)
 _STDERR_FIELD_KEY_MAX_CHARS = 80
 _STDERR_FIELD_VALUE_MAX_CHARS = 256
 _TRUNCATION_SUFFIX = "..."

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import reprlib
 from typing import Literal
 
 from mitmproxy import ctx
@@ -140,8 +141,10 @@ def _render_stderr_field_value(key: str, value: object) -> str:
         rendered = "true" if sanitized else "false"
     elif sanitized is None:
         rendered = "null"
-    else:
+    elif isinstance(sanitized, str | int | float):
         rendered = str(sanitized)
+    else:
+        rendered = reprlib.repr(sanitized)
     return _single_token_stderr_value(rendered)
 
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -13,7 +13,9 @@ UnderbillingClass = Literal["confirmed", "risk"]
 
 USAGE_UNDERBILLING_LOG_TYPE = "usage_underbilling"
 USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
-_UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
+_UNDERBILLING_PROTECTED_FIELDS = frozenset(
+    ("type", "reason", "underbilling_class", "component", "timestamp", "level", "message")
+)
 _SECRET_FIELD_WORDS = frozenset(
     (
         "authorization",

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -19,8 +19,13 @@ _UNDERBILLING_PROTECTED_FIELDS = frozenset(
 _SECRET_FIELD_WORDS = frozenset(
     (
         "authorization",
+        "bearer",
+        "cookie",
         "credential",
+        "jwt",
         "password",
+        "passwd",
+        "pwd",
         "secret",
     )
 )
@@ -47,6 +52,11 @@ _SECRET_TOKEN_KEYS = frozenset(
     )
 )
 _SECRET_COMPACT_KEYS = frozenset(("accesskey", "apikey", "privatekey"))
+_SECRET_COMPACT_FIELD_MARKERS = (
+    _SECRET_COMPACT_KEYS
+    | _SECRET_COMPACT_TOKEN_KEYS
+    | frozenset(("bearer", "cookie", "jwt", "passwd"))
+)
 
 
 def _stderr_field_key_words(key: str) -> tuple[str, ...]:
@@ -95,8 +105,7 @@ def _stderr_field_is_secret_like(key: str, value: object) -> bool:
         return True
     if any(word in _SECRET_TOKEN_KEYS for word in words):
         return True
-    compact_secret_markers = _SECRET_COMPACT_KEYS | _SECRET_COMPACT_TOKEN_KEYS
-    if any(marker in normalized_key for marker in compact_secret_markers):
+    if any(marker in normalized_key for marker in _SECRET_COMPACT_FIELD_MARKERS):
         return True
     return any(marker in normalized_key for marker in _SECRET_FIELD_MARKERS)
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -87,6 +87,7 @@ _SECRET_FIELD_MARKERS = (
 )
 _STDERR_FIELD_KEY_MAX_CHARS = 80
 _STDERR_FIELD_VALUE_MAX_CHARS = 256
+_STDERR_MESSAGE_MAX_CHARS = 512
 _TRUNCATION_SUFFIX = "..."
 
 
@@ -124,12 +125,12 @@ def _render_stderr_field_key(key: str) -> str:
     return _truncate_stderr_text(rendered or "_", _STDERR_FIELD_KEY_MAX_CHARS)
 
 
-def _single_token_stderr_value(value: str) -> str:
+def _render_stderr_text(value: str, max_chars: int, *, preserve_spaces: bool) -> str:
     rendered: list[str] = []
     truncated_prefix: list[str] = []
     rendered_len = 0
     truncated_prefix_len = 0
-    truncated_prefix_limit = _STDERR_FIELD_VALUE_MAX_CHARS - len(_TRUNCATION_SUFFIX)
+    truncated_prefix_limit = max_chars - len(_TRUNCATION_SUFFIX)
     for ch in value:
         if ch == "\\":
             chunk = "\\\\"
@@ -139,13 +140,15 @@ def _single_token_stderr_value(value: str) -> str:
             chunk = "\\r"
         elif ch == "\t":
             chunk = "\\t"
+        elif ch == " " and preserve_spaces:
+            chunk = ch
         elif ch.isspace():
             chunk = "\\s"
         elif not ch.isprintable():
             chunk = f"\\u{ord(ch):04x}"
         else:
             chunk = ch
-        if rendered_len + len(chunk) > _STDERR_FIELD_VALUE_MAX_CHARS:
+        if rendered_len + len(chunk) > max_chars:
             return "".join(truncated_prefix) + _TRUNCATION_SUFFIX
         rendered.append(chunk)
         rendered_len += len(chunk)
@@ -153,6 +156,14 @@ def _single_token_stderr_value(value: str) -> str:
             truncated_prefix.append(chunk)
             truncated_prefix_len += len(chunk)
     return "".join(rendered)
+
+
+def _single_token_stderr_value(value: str) -> str:
+    return _render_stderr_text(value, _STDERR_FIELD_VALUE_MAX_CHARS, preserve_spaces=False)
+
+
+def _render_stderr_message(value: str) -> str:
+    return _render_stderr_text(value, _STDERR_MESSAGE_MAX_CHARS, preserve_spaces=True)
 
 
 def _render_stderr_field_value(key: str, value: object) -> str:
@@ -205,14 +216,15 @@ def log_usage_underbilling(
     if not proxy_log_path:
         parts = [
             (
-                f"type={USAGE_UNDERBILLING_LOG_TYPE} reason={reason} "
-                f"underbilling_class={underbilling_class} "
+                f"type={USAGE_UNDERBILLING_LOG_TYPE} "
+                f"reason={_single_token_stderr_value(reason)} "
+                f"underbilling_class={_single_token_stderr_value(underbilling_class)} "
                 f"component={USAGE_UNDERBILLING_COMPONENT_MITM_ADDON}"
             )
         ]
         if rendered_fields := _render_stderr_extra_fields(fields):
             parts.append(rendered_fields)
-        parts.append(message)
+        parts.append(_render_stderr_message(message))
         ctx.log.error(" ".join(parts))
         return
 

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -15,12 +15,16 @@ USAGE_UNDERBILLING_COMPONENT_MITM_ADDON = "mitm_addon"
 _UNDERBILLING_PROTECTED_FIELDS = frozenset(("type", "reason", "underbilling_class", "component"))
 _SECRET_FIELD_MARKERS = (
     "access_key",
+    "accesskey",
     "api_key",
+    "api-key",
     "apikey",
     "authorization",
     "credential",
     "password",
     "private_key",
+    "private-key",
+    "privatekey",
     "secret",
     "token",
 )

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -332,3 +332,24 @@ def test_underbilling_stderr_fallback_escapes_nonstandard_whitespace_and_control
     assert "\u00a0" not in message
     assert "\f" not in message
     assert "\x1b" not in message
+
+
+def test_underbilling_stderr_fallback_escapes_reason_and_message_controls(
+    mitm_ctx,
+):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Usage underbilling\nsignal\twith\x1bcontrols",
+            "expected reason\nwith\tcontrols",
+            "risk",
+            run_id="run-1",
+        )
+
+    message = log.error.call_args.args[0]
+    assert "reason=expected\\sreason\\nwith\\tcontrols" in message
+    assert "run_id=run-1" in message
+    assert message.endswith("Usage underbilling\\nsignal\\twith\\u001bcontrols")
+    assert "\n" not in message
+    assert "\t" not in message
+    assert "\x1b" not in message

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -17,6 +17,9 @@ def test_underbilling_log_fields_cannot_be_overridden_by_context(tmp_path):
         component="wrong_component",
         underbilling_class="confirmed",
         run_id="run-1",
+        level="debug",
+        message="wrong_message",
+        timestamp="wrong_timestamp",
     )
 
     [entry] = read_jsonl_entries_after_flush(proxy_log_path)
@@ -25,6 +28,9 @@ def test_underbilling_log_fields_cannot_be_overridden_by_context(tmp_path):
     assert entry["underbilling_class"] == "risk"
     assert entry["component"] == "mitm_addon"
     assert entry["run_id"] == "run-1"
+    assert entry["level"] == "error"
+    assert entry["message"] == "Usage underbilling signal"
+    assert entry["timestamp"] != "wrong_timestamp"
 
 
 def test_underbilling_log_without_proxy_path_uses_stderr(mitm_ctx):
@@ -66,6 +72,9 @@ def test_underbilling_stderr_fallback_preserves_context(mitm_ctx):
             missing_sandbox_token=True,
             missing_api_url=False,
             dropped_webhook_batch_count=2,
+            level="debug",
+            message="wrong_message",
+            timestamp="wrong_timestamp",
         )
 
     log.error.assert_called_once()
@@ -83,6 +92,9 @@ def test_underbilling_stderr_fallback_preserves_context(mitm_ctx):
     assert "type=usage_event" not in message
     assert "wrong_reason" not in message
     assert "wrong_component" not in message
+    assert "level=debug" not in message
+    assert "message=wrong_message" not in message
+    assert "timestamp=wrong_timestamp" not in message
     assert message.endswith("Cannot report usage event")
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -1,7 +1,9 @@
 """Tests for usage underbilling log contracts."""
 
+from typing import cast
+
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
-from usage.underbilling import log_usage_underbilling
+from usage.underbilling import UnderbillingClass, log_usage_underbilling
 
 
 def test_underbilling_log_fields_cannot_be_overridden_by_context(tmp_path):
@@ -353,3 +355,20 @@ def test_underbilling_stderr_fallback_escapes_reason_and_message_controls(
     assert "\n" not in message
     assert "\t" not in message
     assert "\x1b" not in message
+
+
+def test_underbilling_stderr_fallback_stringifies_prefix_values(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            cast(str, 123),
+            cast(str, None),
+            cast(UnderbillingClass, True),
+            run_id="run-1",
+        )
+
+    message = log.error.call_args.args[0]
+    assert "reason=None" in message
+    assert "underbilling_class=True" in message
+    assert "run_id=run-1" in message
+    assert message.endswith("123")

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -224,6 +224,22 @@ def test_underbilling_stderr_fallback_truncates_on_escape_boundaries(mitm_ctx):
     assert len(message) < 420
 
 
+def test_underbilling_stderr_fallback_bounds_non_scalar_values(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Usage underbilling signal",
+            "expected_reason",
+            "risk",
+            debug_payload={"items": ["x" * 400] * 20},
+        )
+
+    message = log.error.call_args.args[0]
+    assert "debug_payload=" in message
+    assert "x" * 300 not in message
+    assert len(message) < 420
+
+
 def test_underbilling_stderr_fallback_sanitizes_field_keys(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -162,6 +162,8 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
                 "access key number": 456789,
                 "accessKeyId": "camel-access-key-value",
                 "oauth_token": "oauth-token-value",
+                "APIToken": "upper-api-token-value",
+                "XApiKey": "prefixed-api-key-value",
                 "private.key": "dotted-private-key-value",
                 "privateKey": "camel-private-key-value",
             },
@@ -181,6 +183,8 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "accessKeyId=[redacted]" in message
     assert "private.key=[redacted]" in message
     assert "privateKey=[redacted]" in message
+    assert "APIToken=[redacted]" in message
+    assert "XApiKey=[redacted]" in message
     assert "idempotency_key=diagnostic-key" in message
     assert "input_tokens=42" in message
     assert "tokenizer_name=usage-tokenizer" in message
@@ -191,6 +195,8 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "private-key-value" not in message
     assert "credential-value" not in message
     assert "oauth-token-value" not in message
+    assert "upper-api-token-value" not in message
+    assert "prefixed-api-key-value" not in message
     assert "bytes-token-value" not in message
     assert "hyphen-api-key-value" not in message
     assert "spaced-api-key-value" not in message

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -161,3 +161,22 @@ def test_underbilling_stderr_fallback_sanitizes_field_keys(mitm_ctx):
     message = log.error.call_args.args[0]
     assert "bad_key_name=value\\swith\\sspaces" in message
     assert "bad key" not in message
+
+
+def test_underbilling_stderr_fallback_escapes_nonstandard_whitespace_and_controls(
+    mitm_ctx,
+):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Usage underbilling signal",
+            "expected_reason",
+            "risk",
+            parse_error="left\u00a0middle\f\x1b[31mright",
+        )
+
+    message = log.error.call_args.args[0]
+    assert "parse_error=left\\smiddle\\s\\u001b[31mright" in message
+    assert "\u00a0" not in message
+    assert "\f" not in message
+    assert "\x1b" not in message

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -151,6 +151,8 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
             access_key_id="access-key-value",
             private_key="private-key-value",
             credential_value="credential-value",
+            bearer="bearer-value",
+            jwt="jwt-value",
             sandbox_token_bytes=b"bytes-token-value",
             auth_header="short-auth-header-value",
             authentication_header="authentication-header-value",
@@ -164,11 +166,17 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
                 "access key number": 456789,
                 "accessKeyId": "camel-access-key-value",
                 "oauth_token": "oauth-token-value",
+                "passwd": "passwd-value",
+                "pwd": "pwd-value",
                 "APIToken": "upper-api-token-value",
                 "XApiKey": "prefixed-api-key-value",
                 "AWSACCESSKEYID": "upper-compact-access-key-value",
                 "github_accesstoken": "compact-access-token-value",
                 "openai_apikey": "compact-api-key-value",
+                "sessioncookie": "compact-cookie-value",
+                "signedjwt": "compact-jwt-value",
+                "dbpasswd": "compact-passwd-value",
+                "bearerCredential": "compact-bearer-value",
                 "private.key": "dotted-private-key-value",
                 "privateKey": "camel-private-key-value",
                 "ssh_privatekey": "compact-private-key-value",
@@ -180,6 +188,10 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "access_key_id=[redacted]" in message
     assert "private_key=[redacted]" in message
     assert "credential_value=[redacted]" in message
+    assert "bearer=[redacted]" in message
+    assert "jwt=[redacted]" in message
+    assert "passwd=[redacted]" in message
+    assert "pwd=[redacted]" in message
     assert "auth_header=[redacted]" in message
     assert "authentication_header=[redacted]" in message
     assert "oauth_token=[redacted]" in message
@@ -196,6 +208,10 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "AWSACCESSKEYID=[redacted]" in message
     assert "github_accesstoken=[redacted]" in message
     assert "openai_apikey=[redacted]" in message
+    assert "sessioncookie=[redacted]" in message
+    assert "signedjwt=[redacted]" in message
+    assert "dbpasswd=[redacted]" in message
+    assert "bearerCredential=[redacted]" in message
     assert "ssh_privatekey=[redacted]" in message
     assert "idempotency_key=diagnostic-key" in message
     assert "input_tokens=42" in message
@@ -206,6 +222,10 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "456789" not in message
     assert "private-key-value" not in message
     assert "credential-value" not in message
+    assert "bearer-value" not in message
+    assert "jwt-value" not in message
+    assert "passwd-value" not in message
+    assert "pwd-value" not in message
     assert "short-auth-header-value" not in message
     assert "authentication-header-value" not in message
     assert "oauth-token-value" not in message
@@ -214,6 +234,10 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "upper-compact-access-key-value" not in message
     assert "compact-access-token-value" not in message
     assert "compact-api-key-value" not in message
+    assert "compact-cookie-value" not in message
+    assert "compact-jwt-value" not in message
+    assert "compact-passwd-value" not in message
+    assert "compact-bearer-value" not in message
     assert "bytes-token-value" not in message
     assert "hyphen-api-key-value" not in message
     assert "spaced-api-key-value" not in message

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -47,3 +47,102 @@ def test_underbilling_log_without_proxy_path_uses_stderr(mitm_ctx):
         "underbilling_class=risk component=mitm_addon "
     )
     assert message.endswith("Usage underbilling signal")
+
+
+def test_underbilling_stderr_fallback_preserves_context(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Cannot report usage event",
+            "missing_reporting_context",
+            "confirmed",
+            type="usage_event",
+            reason="wrong_reason",
+            component="wrong_component",
+            underbilling_class="risk",
+            run_id="run-1",
+            firewall_name="model-provider:anthropic",
+            permission="messages:create",
+            missing_sandbox_token=True,
+            missing_api_url=False,
+            dropped_webhook_batch_count=2,
+        )
+
+    log.error.assert_called_once()
+    message = log.error.call_args.args[0]
+    assert message.startswith(
+        "type=usage_underbilling reason=missing_reporting_context "
+        "underbilling_class=confirmed component=mitm_addon "
+    )
+    assert "run_id=run-1" in message
+    assert "firewall_name=model-provider:anthropic" in message
+    assert "permission=messages:create" in message
+    assert "missing_sandbox_token=true" in message
+    assert "missing_api_url=false" in message
+    assert "dropped_webhook_batch_count=2" in message
+    assert "type=usage_event" not in message
+    assert "wrong_reason" not in message
+    assert "wrong_component" not in message
+    assert message.endswith("Cannot report usage event")
+
+
+def test_underbilling_stderr_fallback_sanitizes_url(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "X response unparseable",
+            "unparseable_usage_response",
+            "confirmed",
+            url="https://user:pass@example.com/v1/search?token=secret#fragment",
+        )
+
+    message = log.error.call_args.args[0]
+    assert "url=https://example.com/v1/search" in message
+    assert "user:pass" not in message
+    assert "token=secret" not in message
+    assert "#fragment" not in message
+
+
+def test_underbilling_stderr_fallback_redacts_secret_strings_not_boolean_flags(mitm_ctx):
+    sensitive_context = {
+        "sandbox_token": "secret-token",
+        "missing_sandbox_token": True,
+        "authorization_header": "Bearer secret-token",
+        "retained_retry_count": 3,
+    }
+
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Cannot report usage event",
+            "missing_reporting_context",
+            "confirmed",
+            **sensitive_context,
+        )
+
+    message = log.error.call_args.args[0]
+    assert "sandbox_token=[redacted]" in message
+    assert "authorization_header=[redacted]" in message
+    assert "missing_sandbox_token=true" in message
+    assert "retained_retry_count=3" in message
+    assert "secret-token" not in message
+
+
+def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):
+    long_value = f"first line\n{'x' * 400}\nlast line"
+
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Usage underbilling signal",
+            "expected_reason",
+            "risk",
+            parse_error=long_value,
+        )
+
+    message = log.error.call_args.args[0]
+    assert log.error.call_count == 1
+    assert "\n" not in message
+    assert "parse_error=first line\\n" in message
+    assert "last line" not in message
+    assert len(message) < 420

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -140,6 +140,11 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
             private_key="private-key-value",
             credential_value="credential-value",
             idempotency_key="diagnostic-key",
+            **{
+                "api-key": "hyphen-api-key-value",
+                "accessKeyId": "camel-access-key-value",
+                "privateKey": "camel-private-key-value",
+            },
         )
 
     message = log.error.call_args.args[0]
@@ -147,11 +152,17 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "access_key_id=[redacted]" in message
     assert "private_key=[redacted]" in message
     assert "credential_value=[redacted]" in message
+    assert "api-key=[redacted]" in message
+    assert "accessKeyId=[redacted]" in message
+    assert "privateKey=[redacted]" in message
     assert "idempotency_key=diagnostic-key" in message
     assert "api-key-value" not in message
     assert "access-key-value" not in message
     assert "private-key-value" not in message
     assert "credential-value" not in message
+    assert "hyphen-api-key-value" not in message
+    assert "camel-access-key-value" not in message
+    assert "camel-private-key-value" not in message
 
 
 def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -196,6 +196,23 @@ def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):
     assert len(message) < 420
 
 
+def test_underbilling_stderr_fallback_truncates_on_escape_boundaries(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Usage underbilling signal",
+            "expected_reason",
+            "risk",
+            parse_error="\t" * 129,
+        )
+
+    message = log.error.call_args.args[0]
+    assert "parse_error=" in message
+    assert "\\..." not in message
+    assert "\\t... Usage underbilling signal" in message
+    assert len(message) < 420
+
+
 def test_underbilling_stderr_fallback_sanitizes_field_keys(mitm_ctx):
     with mitm_ctx() as log:
         log_usage_underbilling(

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -128,6 +128,32 @@ def test_underbilling_stderr_fallback_redacts_secret_strings_not_boolean_flags(m
     assert "secret-token" not in message
 
 
+def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Cannot report usage event",
+            "missing_reporting_context",
+            "confirmed",
+            api_key="api-key-value",
+            access_key_id="access-key-value",
+            private_key="private-key-value",
+            credential_value="credential-value",
+            idempotency_key="diagnostic-key",
+        )
+
+    message = log.error.call_args.args[0]
+    assert "api_key=[redacted]" in message
+    assert "access_key_id=[redacted]" in message
+    assert "private_key=[redacted]" in message
+    assert "credential_value=[redacted]" in message
+    assert "idempotency_key=diagnostic-key" in message
+    assert "api-key-value" not in message
+    assert "access-key-value" not in message
+    assert "private-key-value" not in message
+    assert "credential-value" not in message
+
+
 def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):
     long_value = f"first line\n{'x' * 400}\nlast line"
 

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -139,10 +139,14 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
             access_key_id="access-key-value",
             private_key="private-key-value",
             credential_value="credential-value",
+            sandbox_token_bytes=b"bytes-token-value",
             idempotency_key="diagnostic-key",
+            input_tokens=42,
             **{
                 "api-key": "hyphen-api-key-value",
+                "spaced api key": "spaced-api-key-value",
                 "accessKeyId": "camel-access-key-value",
+                "private.key": "dotted-private-key-value",
                 "privateKey": "camel-private-key-value",
             },
         )
@@ -152,16 +156,23 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "access_key_id=[redacted]" in message
     assert "private_key=[redacted]" in message
     assert "credential_value=[redacted]" in message
+    assert "sandbox_token_bytes=[redacted]" in message
     assert "api-key=[redacted]" in message
+    assert "spaced_api_key=[redacted]" in message
     assert "accessKeyId=[redacted]" in message
+    assert "private.key=[redacted]" in message
     assert "privateKey=[redacted]" in message
     assert "idempotency_key=diagnostic-key" in message
+    assert "input_tokens=42" in message
     assert "api-key-value" not in message
     assert "access-key-value" not in message
     assert "private-key-value" not in message
     assert "credential-value" not in message
+    assert "bytes-token-value" not in message
     assert "hyphen-api-key-value" not in message
+    assert "spaced-api-key-value" not in message
     assert "camel-access-key-value" not in message
+    assert "dotted-private-key-value" not in message
     assert "camel-private-key-value" not in message
 
 

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -141,11 +141,15 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
             credential_value="credential-value",
             sandbox_token_bytes=b"bytes-token-value",
             idempotency_key="diagnostic-key",
-            input_tokens=42,
+            input_tokens="42",
+            tokenizer_name="usage-tokenizer",
             **{
                 "api-key": "hyphen-api-key-value",
+                "api key number": 123456,
                 "spaced api key": "spaced-api-key-value",
+                "access key number": 456789,
                 "accessKeyId": "camel-access-key-value",
+                "oauth_token": "oauth-token-value",
                 "private.key": "dotted-private-key-value",
                 "privateKey": "camel-private-key-value",
             },
@@ -156,18 +160,25 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "access_key_id=[redacted]" in message
     assert "private_key=[redacted]" in message
     assert "credential_value=[redacted]" in message
+    assert "oauth_token=[redacted]" in message
     assert "sandbox_token_bytes=[redacted]" in message
     assert "api-key=[redacted]" in message
+    assert "api_key_number=[redacted]" in message
     assert "spaced_api_key=[redacted]" in message
+    assert "access_key_number=[redacted]" in message
     assert "accessKeyId=[redacted]" in message
     assert "private.key=[redacted]" in message
     assert "privateKey=[redacted]" in message
     assert "idempotency_key=diagnostic-key" in message
     assert "input_tokens=42" in message
+    assert "tokenizer_name=usage-tokenizer" in message
     assert "api-key-value" not in message
+    assert "123456" not in message
     assert "access-key-value" not in message
+    assert "456789" not in message
     assert "private-key-value" not in message
     assert "credential-value" not in message
+    assert "oauth-token-value" not in message
     assert "bytes-token-value" not in message
     assert "hyphen-api-key-value" not in message
     assert "spaced-api-key-value" not in message

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -152,6 +152,8 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
             private_key="private-key-value",
             credential_value="credential-value",
             sandbox_token_bytes=b"bytes-token-value",
+            auth_header="short-auth-header-value",
+            authentication_header="authentication-header-value",
             idempotency_key="diagnostic-key",
             input_tokens="42",
             tokenizer_name="usage-tokenizer",
@@ -164,8 +166,12 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
                 "oauth_token": "oauth-token-value",
                 "APIToken": "upper-api-token-value",
                 "XApiKey": "prefixed-api-key-value",
+                "AWSACCESSKEYID": "upper-compact-access-key-value",
+                "github_accesstoken": "compact-access-token-value",
+                "openai_apikey": "compact-api-key-value",
                 "private.key": "dotted-private-key-value",
                 "privateKey": "camel-private-key-value",
+                "ssh_privatekey": "compact-private-key-value",
             },
         )
 
@@ -174,6 +180,8 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "access_key_id=[redacted]" in message
     assert "private_key=[redacted]" in message
     assert "credential_value=[redacted]" in message
+    assert "auth_header=[redacted]" in message
+    assert "authentication_header=[redacted]" in message
     assert "oauth_token=[redacted]" in message
     assert "sandbox_token_bytes=[redacted]" in message
     assert "api-key=[redacted]" in message
@@ -185,6 +193,10 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "privateKey=[redacted]" in message
     assert "APIToken=[redacted]" in message
     assert "XApiKey=[redacted]" in message
+    assert "AWSACCESSKEYID=[redacted]" in message
+    assert "github_accesstoken=[redacted]" in message
+    assert "openai_apikey=[redacted]" in message
+    assert "ssh_privatekey=[redacted]" in message
     assert "idempotency_key=diagnostic-key" in message
     assert "input_tokens=42" in message
     assert "tokenizer_name=usage-tokenizer" in message
@@ -194,15 +206,21 @@ def test_underbilling_stderr_fallback_redacts_common_key_fields(mitm_ctx):
     assert "456789" not in message
     assert "private-key-value" not in message
     assert "credential-value" not in message
+    assert "short-auth-header-value" not in message
+    assert "authentication-header-value" not in message
     assert "oauth-token-value" not in message
     assert "upper-api-token-value" not in message
     assert "prefixed-api-key-value" not in message
+    assert "upper-compact-access-key-value" not in message
+    assert "compact-access-token-value" not in message
+    assert "compact-api-key-value" not in message
     assert "bytes-token-value" not in message
     assert "hyphen-api-key-value" not in message
     assert "spaced-api-key-value" not in message
     assert "camel-access-key-value" not in message
     assert "dotted-private-key-value" not in message
     assert "camel-private-key-value" not in message
+    assert "compact-private-key-value" not in message
 
 
 def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):

--- a/crates/runner/mitm-addon/tests/test_usage_underbilling.py
+++ b/crates/runner/mitm-addon/tests/test_usage_underbilling.py
@@ -143,6 +143,21 @@ def test_underbilling_stderr_fallback_bounds_multiline_values(mitm_ctx):
     message = log.error.call_args.args[0]
     assert log.error.call_count == 1
     assert "\n" not in message
-    assert "parse_error=first line\\n" in message
+    assert "parse_error=first\\sline\\n" in message
     assert "last line" not in message
     assert len(message) < 420
+
+
+def test_underbilling_stderr_fallback_sanitizes_field_keys(mitm_ctx):
+    with mitm_ctx() as log:
+        log_usage_underbilling(
+            "",
+            "Usage underbilling signal",
+            "expected_reason",
+            "risk",
+            **{"bad key\nname": "value with spaces"},
+        )
+
+    message = log.error.call_args.args[0]
+    assert "bad_key_name=value\\swith\\sspaces" in message
+    assert "bad key" not in message


### PR DESCRIPTION
## Summary

- Preserve sanitized diagnostic context in `log_usage_underbilling()` when `VM_PROXY_LOG_PATH` is unavailable.
- Reuse the proxy-log `url` sanitizer for stderr fallback fields.
- Redact obvious secret-like string fields and bound multiline fallback values.

## Tests

- `pytest tests/test_usage_underbilling.py`
- `pytest tests/test_logging_utils.py`
- `pytest tests/test_usage_buffer_timer_shutdown.py::test_shutdown_retry_exhaustion_logs_underbilling_without_proxy_log_path`
- `pytest tests/x_connector_usage/test_unparseable.py::test_unparseable_no_hints_without_proxy_log_path_logs_stderr`
- `ruff check src/logging_utils.py src/usage/underbilling.py tests/test_usage_underbilling.py`
- `ruff format --check src/logging_utils.py src/usage/underbilling.py tests/test_usage_underbilling.py`
- `basedpyright src/logging_utils.py src/usage/underbilling.py tests/test_usage_underbilling.py`
- `git diff --check`

Closes #18025