### PR TITLE
fix(mitm-addon): release unreportable websocket usage sources

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -124,7 +124,8 @@ Model-provider usage
   with normalized token usage dict values. Written by WebSocket model-provider
   usage extraction and read by model usage-event and observation reporters.
   Entries may be removed before ``websocket_end()`` once a terminal WebSocket
-  usage frame is accepted into the source-preserving usage buffer.
+  usage frame is accepted into the source-preserving usage buffer or the source
+  has no future reporting path.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` model id from registry VM info.
   Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -362,17 +362,16 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
             usage_sources[message_id] = usage_target
         usage.merge_openai_responses_usage_result(usage_target, usage_result)
         run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
-        release_source = usage.report_model_provider_usage_source(
+        source_disposition = usage.report_model_provider_usage_source(
             flow,
             run_id,
             message_id,
             usage_target,
         )
-        # The accepted OpenAI Responses WebSocket events are final for a logical
-        # response id. Once that source reaches the source-preserving buffer,
-        # later same-id frames are duplicates under source/category idempotency
-        # and terminal end/error hooks do not need to retain it on the flow.
-        if release_source:
+        # Retain only sources that may still become reportable on a later
+        # same-response-id frame. Buffered or permanently unreportable sources
+        # do not need to stay in per-flow metadata until websocket_end/error.
+        if source_disposition == "release":
             usage_sources.pop(message_id, None)
         return
 

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -18,7 +18,7 @@ field existed can still report usage.
 
 import uuid
 from collections.abc import Iterator
-from typing import TypeGuard
+from typing import Literal, TypeGuard
 
 from mitmproxy import http
 
@@ -43,6 +43,7 @@ from ..model_tokens import MODEL_USAGE_CATEGORIES
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
+ModelProviderUsageSourceDisposition = Literal["release", "keep"]
 
 
 def is_model_provider_usage_observable(flow: http.HTTPFlow) -> bool:
@@ -174,13 +175,14 @@ def report_model_provider_usage_source(
     run_id: str,
     message_id: str,
     source_usage: dict,
-) -> bool:
+) -> ModelProviderUsageSourceDisposition:
     """Buffer one finalized WebSocket response usage source.
 
     Unlike flow-terminal reporting, this preserves the source idempotency keys
     in the webhook payload so the platform can dedupe one response source even
-    when a later lifecycle hook sees the same source again. Returns whether the
-    source can be released from flow metadata.
+    when a later lifecycle hook sees the same source again. Returns ``release``
+    when the caller can drop the source from flow metadata and ``keep`` only
+    when a later same-response-id frame may still make the source reportable.
     """
     usage_events: list[UsageEvent] = []
     observation_events: list[UsageEvent] = []
@@ -205,19 +207,28 @@ def report_model_provider_usage_source(
             USAGE_OBSERVATION_NAMESPACE_MODEL,
         )
 
-    if not usage_events and not observation_events:
-        return not (can_report_usage or can_report_observation)
-
     sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
     api_url = get_api_url() if sandbox_token else ""
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    if not usage_events and not observation_events:
+        if not (can_report_usage or can_report_observation):
+            return "release"
+        if not sandbox_token or not api_url:
+            return "release"
+        return "keep"
+
     if not sandbox_token or not api_url:
         if usage_events:
-            log_proxy_entry(
+            firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+            log_usage_underbilling(
                 proxy_log_path,
-                "warn",
                 "Cannot report usage event: missing sandbox_token or api_url",
-                type="usage_event",
+                "missing_reporting_context",
+                "confirmed",
+                run_id=run_id,
+                firewall_name=firewall_name,
+                missing_sandbox_token=not bool(sandbox_token),
+                missing_api_url=not bool(api_url),
             )
         if observation_events:
             log_proxy_entry(
@@ -226,7 +237,7 @@ def report_model_provider_usage_source(
                 "Cannot report model usage observation: missing sandbox_token or api_url",
                 type="model_usage_observation",
             )
-        return False
+        return "release"
 
     if usage_events:
         buffer_source_usage_events(
@@ -244,7 +255,7 @@ def report_model_provider_usage_source(
             observation_events,
             proxy_log_path,
         )
-    return True
+    return "release"
 
 
 def _build_model_provider_usage_events(

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_metadata.py
@@ -3,12 +3,14 @@
 import json
 from collections.abc import Callable
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import usage
 from tests.model_provider_websocket_helpers import (
     _capture_deferred_websocket_trims,
     _feed_websocket_server_message,
@@ -26,12 +28,23 @@ def deferred_websocket_trim_scheduler(
     return _capture_deferred_websocket_trims(monkeypatch)
 
 
+@pytest.fixture(autouse=True)
+def keep_websocket_usage_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    def keep_source(
+        _flow: http.HTTPFlow,
+        _run_id: str,
+        _message_id: str,
+        _source_usage: dict,
+    ) -> Literal["keep"]:
+        return "keep"
+
+    monkeypatch.setattr(usage, "report_model_provider_usage_source", keep_source)
+
+
 def _openai_model_websocket_metadata_flow(
     tmp_path: Path, real_flow: Callable[..., http.HTTPFlow]
 ) -> http.HTTPFlow:
-    flow = _openai_model_websocket_flow(tmp_path, real_flow)
-    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
-    return flow
+    return _openai_model_websocket_flow(tmp_path, real_flow)
 
 
 class TestModelProviderWebSocketUsageMetadata:

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -179,7 +179,7 @@ class TestModelProviderWebSocketUsage:
         [entry] = [
             entry
             for entry in read_jsonl_entries_after_flush(proxy_log)
-            if entry["type"] == "usage_underbilling"
+            if entry.get("type") == "usage_underbilling"
         ]
         assert entry["type"] == "usage_underbilling"
         assert entry["reason"] == "missing_reporting_context"
@@ -187,6 +187,32 @@ class TestModelProviderWebSocketUsage:
         assert entry["run_id"] == "run-abc-123"
         assert entry["firewall_name"] == "model-provider:openai-api-key"
         assert entry["missing_sandbox_token"] is True
+
+    def test_model_websocket_missing_api_url_releases_positive_source(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+
+        with mitm_ctx(api_url=""):
+            _feed_websocket_server_message(
+                flow,
+                _openai_websocket_usage_frame(
+                    "resp_ws_missing_api_url",
+                    input_tokens=10,
+                    output_tokens=4,
+                ),
+            )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        [entry] = [
+            entry
+            for entry in read_jsonl_entries_after_flush(proxy_log)
+            if entry.get("type") == "usage_underbilling"
+        ]
+        assert entry["reason"] == "missing_reporting_context"
+        assert entry["missing_sandbox_token"] is False
+        assert entry["missing_api_url"] is True
 
     def test_model_websocket_missing_context_releases_zero_only_source(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
@@ -201,6 +227,25 @@ class TestModelProviderWebSocketUsage:
                 output_tokens=0,
             ),
         )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        assert not jsonl_exists_after_flush(proxy_log)
+
+    def test_model_websocket_missing_api_url_releases_zero_only_source(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+
+        with mitm_ctx(api_url=""):
+            _feed_websocket_server_message(
+                flow,
+                _openai_websocket_usage_frame(
+                    "resp_ws_zero_missing_api_url",
+                    input_tokens=0,
+                    output_tokens=0,
+                ),
+            )
 
         assert _model_websocket_usage_sources(flow) == {}
         assert not jsonl_exists_after_flush(proxy_log)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -13,6 +13,7 @@ from mitmproxy.test import tutils
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
+from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_websocket_helpers import (
     _append_websocket_message,
     _capture_deferred_websocket_trims,
@@ -159,6 +160,50 @@ class TestModelProviderWebSocketUsage:
             "tokens.output": 20,
             "tokens.cache_read": 10,
         }
+
+    def test_model_websocket_missing_context_releases_positive_source(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_missing_context",
+                input_tokens=10,
+                output_tokens=4,
+            ),
+        )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        [entry] = [
+            entry
+            for entry in read_jsonl_entries_after_flush(proxy_log)
+            if entry["type"] == "usage_underbilling"
+        ]
+        assert entry["type"] == "usage_underbilling"
+        assert entry["reason"] == "missing_reporting_context"
+        assert entry["underbilling_class"] == "confirmed"
+        assert entry["run_id"] == "run-abc-123"
+        assert entry["firewall_name"] == "model-provider:openai-api-key"
+        assert entry["missing_sandbox_token"] is True
+
+    def test_model_websocket_missing_context_releases_zero_only_source(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+
+        _feed_websocket_server_message(
+            flow,
+            _openai_websocket_usage_frame(
+                "resp_ws_zero_missing_context",
+                input_tokens=0,
+                output_tokens=0,
+            ),
+        )
+
+        assert _model_websocket_usage_sources(flow) == {}
+        assert not jsonl_exists_after_flush(proxy_log)
 
     def test_full_pipeline_model_websocket_reports_multiple_response_ids(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -163,6 +163,7 @@ class TestModelProviderWebSocketUsage:
 
     def test_model_websocket_missing_context_releases_positive_source(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
@@ -192,6 +193,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow, mitm_ctx
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
         with mitm_ctx(api_url=""):
@@ -216,6 +218,7 @@ class TestModelProviderWebSocketUsage:
 
     def test_model_websocket_missing_context_releases_zero_only_source(self, tmp_path, real_flow):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
@@ -235,6 +238,7 @@ class TestModelProviderWebSocketUsage:
         self, tmp_path, real_flow, mitm_ctx
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
         with mitm_ctx(api_url=""):


### PR DESCRIPTION
## Summary

- replace model-provider WebSocket source reporting bool with an explicit `release` / `keep` disposition
- release per-response usage sources when reporting context is missing, including zero-only sources that cannot become reportable in the same flow
- keep valid-context zero-only sources so later same-response-id positive frames still preserve model attribution
- emit structured underbilling logs for positive billable sources released due to missing reporting context

Closes #18026

## Tests

- `pytest tests/test_model_provider_websocket_usage.py tests/test_model_provider_websocket_metadata.py tests/test_model_provider_usage.py`
- `ruff check .`
- `ruff format --check .`
- `npx --yes basedpyright@latest -p .`