### PR TITLE
docs: align model comparison pages

### DIFF
--- a/turbo/apps/web/__tests__/security-headers.test.ts
+++ b/turbo/apps/web/__tests__/security-headers.test.ts
@@ -1831,7 +1831,9 @@ describe("Model page redirects", () => {
     const modelSlugs = new Set(MODEL_SLUGS);
     const expectedRedirects = [
       ["kimi-k2.6", "kimi-k2-7-code"],
+      ["kimi-k2-6", "kimi-k2-7-code"],
       ["kimi-k2.5", "kimi-k2-7-code"],
+      ["kimi-k2-5", "kimi-k2-7-code"],
       ["glm-5.2", "glm-5-2"],
       ["glm-5.1", "glm-5-1"],
       ["claude-haiku-4-5", "claude-sonnet-4-6"],

--- a/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/models/__tests__/data.test.ts
@@ -3,12 +3,16 @@ import { describe, expect, it } from "vitest";
 import { VM0_MODEL_CREDIT_MULTIPLIER } from "@vm0/api-contracts/contracts/model-credit-multipliers";
 import { VM0_MODEL_TO_PROVIDER } from "@vm0/api-contracts/contracts/model-providers";
 
-import { MODELS, isReasoningModel } from "../data";
+import { MODEL_SLUGS, MODELS, isReasoningModel } from "../data";
 
 const MODEL_CONTENT_LOCALES = ["en", "de", "es", "ja"] as const;
 type ModelContent = Record<
   string,
   {
+    readonly comparisons?: readonly {
+      readonly body?: string;
+      readonly vs?: string;
+    }[];
     readonly alternatives?: readonly {
       readonly reason?: string;
       readonly slug?: string;
@@ -153,6 +157,34 @@ describe("models page data", () => {
         return slugs.has(slug);
       }),
     ).toBe(true);
+  });
+
+  it("keeps localized model content scoped to documented pages", () => {
+    const expectedSlugs = [...MODEL_SLUGS].sort();
+    for (const locale of MODEL_CONTENT_LOCALES) {
+      expect(Object.keys(readModelContent(locale)).sort()).toEqual(
+        expectedSlugs,
+      );
+    }
+  });
+
+  it("keeps localized comparison and alternative targets aligned with model data", () => {
+    for (const locale of MODEL_CONTENT_LOCALES) {
+      const content = readModelContent(locale);
+      for (const model of MODELS) {
+        const localized = content[model.slug];
+        expect(
+          localized?.comparisons?.map((comparison) => {
+            return comparison.vs;
+          }),
+        ).toEqual(model.comparisonSlugs);
+        expect(
+          localized?.alternatives?.map((alternative) => {
+            return alternative.slug;
+          }),
+        ).toEqual(model.alternativeSlugs);
+      }
+    }
   });
 
   it("omits removed model names from localized model content", () => {

--- a/turbo/apps/web/app/[locale]/models/data.ts
+++ b/turbo/apps/web/app/[locale]/models/data.ts
@@ -414,7 +414,7 @@ export const MODELS: ModelEntry[] = [
     vm0TimeoutMin: 50,
     byoKeyLabel: "MiniMax API key",
     defaultFor: ["MiniMax"],
-    comparisonSlugs: ["Kimi K2.7 Code", "Claude Sonnet 4.6", "GLM-5.1"],
+    comparisonSlugs: ["Kimi K2.7 Code", "Claude Sonnet 4.6", "GLM-5.2"],
     alternativeSlugs: ["kimi-k2-7-code", "claude-sonnet-4-6"],
   }),
 

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -2380,7 +2380,7 @@
           },
           {
             "name": "Zero",
-            "text": "**Kostenoptimierungs-Audit - Diese Woche**\n\n🟢 **Bereits optimal** (beibehalten):\n• morning-brief (Sonnet) - Multi-Quellen-Aggregation, gerechtfertigt\n• pr-review-merge (Sonnet) - Code-Review bei Auslösung, gerechtfertigt\n\n🟡 **Überdimensioniert** (sicher downgraden):\n| Aufgabe | Aktuelles Modell | Empfehlung | Gesch. Einsparung |\n|------|--------------|-------------|-------------|\n| tech-debt-scan | Opus | GLM-5.1 | ~5-10x |\n| merge-queue-monitor | Sonnet | GLM-5.1 | ~3x |\n| standup-summary | Sonnet | GPT-4o mini | ~4x |\n| daily-email-check | Sonnet | GPT-4o mini | ~4x |\n\n🔴 **Manuelle Prüfung erforderlich**:\n• auto-test-coverage - schreibt echten Code, Grenzbereich.\n\n**Geschätzte monatliche Einsparung: 2.400–3.800 $**"
+            "text": "**Kostenoptimierungs-Audit - Diese Woche**\n\n🟢 **Bereits optimal** (beibehalten):\n• morning-brief (Sonnet) - Multi-Quellen-Aggregation, gerechtfertigt\n• pr-review-merge (Sonnet) - Code-Review bei Auslösung, gerechtfertigt\n\n🟡 **Überdimensioniert** (sicher downgraden):\n| Aufgabe | Aktuelles Modell | Empfehlung | Gesch. Einsparung |\n|------|--------------|-------------|-------------|\n| tech-debt-scan | Opus | GLM-5.2 | ~5-10x |\n| merge-queue-monitor | Sonnet | GLM-5.2 | ~3x |\n| standup-summary | Sonnet | GPT-4o mini | ~4x |\n| daily-email-check | Sonnet | GPT-4o mini | ~4x |\n\n🔴 **Manuelle Prüfung erforderlich**:\n• auto-test-coverage - schreibt echten Code, Grenzbereich.\n\n**Geschätzte monatliche Einsparung: 2.400–3.800 $**"
           }
         ],
         "steps": [
@@ -2401,12 +2401,12 @@
           {
             "title": "Eine Niedrig-Risiko-Aufgabe auf ein günstigeres Modell umstellen",
             "description": "Mit der sichersten Empfehlung starten.",
-            "examplePrompt": "@Zero den merge-queue-monitor-Schedule von Sonnet auf GLM-5.1 umstellen"
+            "examplePrompt": "@Zero den merge-queue-monitor-Schedule von Sonnet auf GLM-5.2 umstellen"
           },
           {
             "title": "Einen Vergleichstest durchführen",
             "description": "Dasselbe Task auf beiden Modellen ausführen und Outputs vergleichen.",
-            "examplePrompt": "@Zero den tech-debt-scan-Prompt sowohl auf Opus als auch GLM-5.1 ausführen und die Ergebnisse nebeneinander vergleichen"
+            "examplePrompt": "@Zero den tech-debt-scan-Prompt sowohl auf Opus als auch GLM-5.2 ausführen und die Ergebnisse nebeneinander vergleichen"
           },
           {
             "title": "Zur Routine machen",
@@ -4343,7 +4343,7 @@
             "body": "Fast Mode bei 2,5× Geschwindigkeit kostete früher dreimal so viel wie heute ($10/$50 pro 1M gegenüber der vorherigen Stufe). Für interaktive Copilots, On-Call-Summarizer oder jeden Schritt, bei dem Wall-Clock-Latenz das Erlebnis dominiert, ist Fast-Mode 4.8 jetzt die Standardwahl in der Claude-Familie."
           }
         ],
-        "avoidFor": "Verzichte auf Opus 4.8 bei Hochvolumen-Routinearbeit, bei der Sonnet 4.6 die gleiche Qualitätsschwelle zu einem Bruchteil der Kosten erreicht, bei latenzkritischen Chat-Antworten, bei denen Kimi K2.6 deutlich schneller ist, bei agentischem Terminal-Coding, wo GPT-5.5 weiterhin Terminal-Bench 2.1 anführt (78,2% vs 74,6% bei 4.8), sowie bei Pipelines, die untrusted Input ohne Sandboxing aufnehmen — die Prompt-Injection-Robustheit von 4.8 ist leicht schwächer als die von 4.7.",
+        "avoidFor": "Verzichte auf Opus 4.8 bei Hochvolumen-Routinearbeit, bei der Sonnet 4.6 die gleiche Qualitätsschwelle zu einem Bruchteil der Kosten erreicht, bei latenzkritischen Chat-Antworten, bei denen Kimi K2.7 Code deutlich schneller ist, bei agentischem Terminal-Coding, wo GPT-5.5 weiterhin Terminal-Bench 2.1 anführt (78,2% vs 74,6% bei 4.8), sowie bei Pipelines, die untrusted Input ohne Sandboxing aufnehmen — die Prompt-Injection-Robustheit von 4.8 ist leicht schwächer als die von 4.7.",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -4351,7 +4351,7 @@
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 (×1) bleibt das Arbeitspferd-Default für die meisten Agent-Schleifen. Eskaliere zu Opus 4.8, wenn Sonnet bei hartem Reasoning, Langkontext-Recall oder Code-Änderungen im ersten Versuch sichtbar scheitert — meist als Planer, der an Subagenten auf Sonnet- oder Kimi K2.6-Niveau delegiert. Mit dynamischen Workflows ist Opus 4.8 als Orchestrator + Sonnet 4.6 als Worker das neue empfohlene Muster."
+            "body": "Sonnet 4.6 (×1) bleibt das Arbeitspferd-Default für die meisten Agent-Schleifen. Eskaliere zu Opus 4.8, wenn Sonnet bei hartem Reasoning, Langkontext-Recall oder Code-Änderungen im ersten Versuch sichtbar scheitert — meist als Planer, der an Subagenten auf Sonnet- oder Kimi K2.7 Code-Niveau delegiert. Mit dynamischen Workflows ist Opus 4.8 als Orchestrator + Sonnet 4.6 als Worker das neue empfohlene Muster."
           },
           {
             "vs": "GPT-5.5",
@@ -4529,7 +4529,7 @@
           },
           {
             "title": "Überdimensioniert für kurze Single-Shot-Aufgaben",
-            "body": "Opus 4.7 bei einfachen Aufgaben einzusetzen verursacht unnötige Latenz und Kosten. Für Klassifikation, kurze Zusammenfassungen oder Q&A liefern Sonnet/Kimi K2.6 praktisch identische Qualität zu einem Bruchteil der Kosten."
+            "body": "Opus 4.7 bei einfachen Aufgaben einzusetzen verursacht unnötige Latenz und Kosten. Für Klassifikation, kurze Zusammenfassungen oder Q&A liefern Sonnet/Kimi K2.7 Code praktisch identische Qualität zu einem Bruchteil der Kosten."
           },
           {
             "title": "Breiteste Tool-Routing-Fähigkeiten",
@@ -4554,8 +4554,12 @@
             "body": "1M Token Kontext + starkes Langkontext-Recall: Opus kann eine ganze Repository-Größe an Code in einer Runde lesen und referenzieren."
           }
         ],
-        "avoidFor": "Opus 4.7 standardmäßig für alle Agent-Aktionen zu verwenden. Bei den meisten täglichen Arbeiten (Zusammenfassungen, Klassifikation, Q&A, leichte Reviews) liefern Sonnet 4.6 oder Kimi K2.6 praktisch identische Qualität zu 3–50× niedrigeren Kosten.",
+        "avoidFor": "Opus 4.7 standardmäßig für alle Agent-Aktionen zu verwenden. Bei den meisten täglichen Arbeiten (Zusammenfassungen, Klassifikation, Q&A, leichte Reviews) liefern Sonnet 4.6 oder Kimi K2.7 Code praktisch identische Qualität zu 3–50× niedrigeren Kosten.",
         "comparisons": [
+          {
+            "vs": "Claude Opus 4.8",
+            "body": "Opus 4.8 ist das neuere Flaggschiff beim gleichen VM0-Multiplikator. Nutze 4.8 für neue High-Stakes-Agenten; behalte 4.7 nur, wenn ein bestehender Workflow dagegen validiert ist und Stabilität wichtiger ist als die neuesten Benchmark-Gewinne."
+          },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Opus 4.7 bietet konsistentere Langschleifen-Kohärenz und höhere Code-Patch-Qualität im ersten Versuch. Sonnet 4.6 ist ~2× günstiger (×1 vs. ×2 Credits) mit höherem Durchsatz. Standardmuster: Sonnet als Default, Opus für Orchestrator-Rolle und kritische Schritte."
@@ -4565,16 +4569,12 @@
             "body": "Opus 4.7 übertrifft Opus 4.6 bei SWE-bench Verified (80,6% vs. 73,8%), Terminal-Bench (48,3% vs. 37,1%) und GPQA Diamond (93,1% vs. 90,2%). Gleicher Preis, gleiches API — kein Grund zum Bleiben."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Opus 4.7 übertrifft K2.6 bei Hard-Reasoning und Langkontext, aber K2.6 kostet nur ×0,3 Credits. Für Bulk-Code-Reviews und Klassifikation ist K2.6 kosteneffizienter."
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 Code ist Moonshots aktuelles kostensparendes Coding-Modell. Opus 4.7 bleibt bei Tool-Routing-Zuverlässigkeit, Sicherheitsprofil und englischem High-Stakes-Reasoning stärker; Kimi ist die günstigere Wahl für Bulk-Code-Arbeit."
           },
           {
             "vs": "DeepSeek V4 Pro",
             "body": "Opus 4.7 hat die höhere Reasoning-Decke; V4 Pro (×0,1 Credits) bietet besseres Preis-Leistungs-Verhältnis für Frontend-Stacks, Migrationen und Routine-Patches."
-          },
-          {
-            "vs": "GPT-5.2 / Gemini 3 Pro",
-            "body": "Opus 4.7 konkurriert direkt mit OpenAI- und Google-Flaggschiffen. Die Rangfolge variiert je nach Benchmark — Opus führt bei GPQA Diamond und Terminal-Bench."
           }
         ],
         "verdict": "Wenn Budget für Opus 4.7 vorhanden ist und Aufgaben tiefes Reasoning erfordern, ist es die beste Wahl im VM0-Katalog. Starte mit Sonnet 4.6 als Standard und eskaliere die härtesten 10–20% der Schritte auf Opus 4.7.",
@@ -4602,16 +4602,16 @@
         ],
         "alternatives": [
           {
+            "slug": "claude-opus-4-8",
+            "reason": "Neueres Flaggschiff für High-Stakes-Agenten"
+          },
+          {
             "slug": "claude-sonnet-4-6",
-            "reason": "Gleiche Familie, 2× günstiger, schnellere Inferenz. Standardmodell für die meisten Agent-Aufgaben."
+            "reason": "Günstigerer Standard für die meisten Agent-Schleifen"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Gute Reasoning-Qualität zu ×0,3 Credits. Ideal zur Kostenoptimierung."
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Open-Source-Flaggschiff mit starken Code-Benchmarks bei ×0,1 Credits."
+            "slug": "kimi-k2-7-code",
+            "reason": "Kostensparende Open-Weight-Coding-Alternative"
           }
         ],
         "routingNotes": "On VM0, Opus 4.7 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code.",
@@ -4710,7 +4710,7 @@
           },
           {
             "title": "Speed",
-            "body": "Slower than Sonnet 4.6 and Kimi K2.6; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
+            "body": "Slower than Sonnet 4.6 and Kimi K2.7 Code; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
           }
         ],
         "bestForExamples": [
@@ -4734,8 +4734,8 @@
             "body": "Sonnet 4.6 is ×1 and handles most agent loops. Reach for Opus only when Sonnet visibly fails. Usually for orchestration or hard code edits."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Kimi K2.6 (×0.3) edges Opus 4.6 on SWE-bench Pro (58.6 vs 53.4 vendor-reported) and is much cheaper. Opus 4.6 retains the safety-profile advantage and is the default Western enterprise pick."
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 Code (×0,3) ist bei agentischem Coding deutlich günstiger als Opus 4.6. Opus 4.6 behält den Vorteil beim Sicherheitsprofil und bleibt die konservativere Wahl für westliche Enterprise-Workflows."
           }
         ],
         "verdict": "Opus 4.6 ist weiterhin nutzbar, aber Opus 4.7 ist ein striktes Upgrade zum gleichen Preis. Migriere, sobald du deine Workflows validiert hast.",
@@ -4754,7 +4754,7 @@
           },
           {
             "q": "Why is Opus 4.6 the default on the Anthropic API key provider?",
-            "a": "Historical default from before Opus 4.7 launched. You can switch any agent to Opus 4.7, Sonnet 4.6, or Kimi K2.6 in VM0 Settings → Model Providers without changing the API key."
+            "a": "Historischer Default aus der Zeit vor Opus 4.7. Du kannst jeden Agenten in den VM0-Einstellungen unter Modellanbieter auf Opus 4.7, Sonnet 4.6 oder Kimi K2.7 Code umstellen, ohne den API-Schlüssel zu ändern."
           },
           {
             "q": "What's adaptive thinking?",
@@ -4764,15 +4764,15 @@
         "alternatives": [
           {
             "slug": "claude-opus-4-7",
-            "reason": "Direkter Nachfolger mit besseren Benchmarks zum gleichen Preis."
+            "reason": "Neuer und niedrigere Anbieterpreise"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Günstigere Alternative innerhalb der Claude 4-Familie."
+            "reason": "Sonnet-Basislinie zu deutlich niedrigeren Kosten"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Deutlich günstiger (×0,3 Credits) mit guter Reasoning-Qualität."
+            "slug": "kimi-k2-7-code",
+            "reason": "Günstigere Open-Weight-Alternative für agentische Benchmarks"
           }
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and as the default model on the Anthropic API-key and Claude Code OAuth providers.",
@@ -4972,9 +4972,9 @@
         "releaseDate": "Verfügbar seit VM0-Launch",
         "familyPosition": "Arbeitstier der Claude 4-Familie. Das Standardmodell für VM0 Managed.",
         "background": [
-          "Claude Sonnet 4.6 ist das Mittelklasse-Modell der Claude 4-Familie — positioniert zwischen dem Flaggschiff Opus und dem leichten Kimi K2.6. Es teilt das 1M-Token-Kontextfenster und Prompt Caching mit Opus, verzichtet aber auf Adaptive-Thinking-Effort-Levels zugunsten eines einfacheren, schnelleren Inferenzprofils.",
+          "Claude Sonnet 4.6 ist das Mittelklasse-Modell der Claude 4-Familie — positioniert zwischen dem Flaggschiff Opus und dem leichten Kimi K2.7 Code. Es teilt das 1M-Token-Kontextfenster und Prompt Caching mit Opus, verzichtet aber auf Adaptive-Thinking-Effort-Levels zugunsten eines einfacheren, schnelleren Inferenzprofils.",
           "Auf VM0 ist Sonnet 4.6 das Standardmodell für VM0 Managed Routing. Es ist die ×1 Credit-Basislinie — jedes andere Built-in-Modell wird als Vielfaches des Sonnet-4.6-Preises bepreist. Das macht Sonnet zur natürlichen Einheit für Kostenvergleiche.",
-          "Sonnet 4.6 ist das Schweizer Taschenmesser: gut genug für fast alles, ohne der Beste in einer Kategorie zu sein. Opus 4.7 übertrifft es bei Hard-Reasoning; Kimi K2.6 ist günstiger und schneller für High-Volume-Arbeit. Aber Sonnet ist das Modell, zu dem du zurückkehrst, wenn du nicht sicher bist, welches du wählen sollst."
+          "Sonnet 4.6 ist das Schweizer Taschenmesser: gut genug für fast alles, ohne der Beste in einer Kategorie zu sein. Opus 4.7 übertrifft es bei Hard-Reasoning; Kimi K2.7 Code ist günstiger und schneller für High-Volume-Arbeit. Aber Sonnet ist das Modell, zu dem du zurückkehrst, wenn du nicht sicher bist, welches du wählen sollst."
         ],
         "architecture": "Sonnet 4.6 teilt die Claude 4-Architektur mit 1M-Token-Kontextfenster und nativer Tool-Use-Unterstützung. Es verwendet keine Adaptive-Thinking-Effort-Levels — der Inferenz-Pfad ist auf konstanten Durchsatz und konsistente Qualität bei Single-Shot- und kurzen Multi-Turn-Aufgaben optimiert.",
         "specs": [
@@ -5028,7 +5028,7 @@
         "performance": [
           {
             "title": "Ausgeglichene Geschwindigkeit und Qualität",
-            "body": "Sonnet 4.6 bietet das beste Verhältnis von Inferenzgeschwindigkeit zu Reasoning-Qualität in der Claude-Familie. Schneller als Opus, leistungsfähiger als Kimi K2.6."
+            "body": "Sonnet 4.6 bietet das beste Verhältnis von Inferenzgeschwindigkeit zu Reasoning-Qualität in der Claude-Familie. Schneller als Opus, leistungsfähiger als Kimi K2.7 Code."
           },
           {
             "title": "Das Standard-Orchestrator-Modell",
@@ -5053,7 +5053,7 @@
             "body": "Entwickler, die im Chat-Modus Code iterieren, profitieren von Sonnets schnellerer Inferenz im Vergleich zu Opus."
           }
         ],
-        "avoidFor": "Sonnet 4.6 für absolut jeden Schritt zu verwenden. Bei High-Volume-Hintergrundarbeit (Klassifikation, Vorfilter) nutze Kimi K2.6 oder GPT-5.4 Mini. Wenn ein Schritt teuer ist, wenn er falsch ist (komplexer Refactor, Sicherheits-Patch), eskaliere an Opus 4.7.",
+        "avoidFor": "Sonnet 4.6 für absolut jeden Schritt zu verwenden. Bei High-Volume-Hintergrundarbeit (Klassifikation, Vorfilter) nutze Kimi K2.7 Code oder GPT-5.4 Mini. Wenn ein Schritt teuer ist, wenn er falsch ist (komplexer Refactor, Sicherheits-Patch), eskaliere an Opus 4.7.",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -5062,6 +5062,10 @@
           {
             "vs": "DeepSeek V4 Pro",
             "body": "V4 Pro bietet ähnliche Reasoning-Qualität zu ×0,1 Credits. Sonnet 4.6s Vorteil ist tiefere Anthropic-Ökosystem-Integration und konsistentere Tool-Use-Zuverlässigkeit."
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "GPT-5.4 Mini ist die günstigere OpenAI-seitige Option für Bulk-Arbeit. Nutze Sonnet, wenn Tool-Routing-Zuverlässigkeit wichtiger ist; nutze Mini für hohes Volumen, Vorfilterung und einfache Schritte ohne Sonnet-Klasse beim Routing."
           }
         ],
         "verdict": "Sonnet 4.6 ist das richtige Standardmodell für VM0. Es ist nicht das Beste in einer Kategorie, aber es ist gut genug für 80%+ der Agent-Schritte. Starte hier und routen nur dann an andere Modelle, wenn du einen spezifischen Grund hast.",
@@ -5080,7 +5084,7 @@
           },
           {
             "q": "Wann sollte ich von Sonnet 4.6 wechseln?",
-            "a": "Wechsle zu Opus 4.7 bei Hard-Reasoning oder langen Schleifen. Wechsle zu Kimi K2.6 oder GPT-5.4 Mini bei High-Volume-, latenzkritischen oder kostensensitiven Aufgaben."
+            "a": "Wechsle zu Opus 4.7 bei Hard-Reasoning oder langen Schleifen. Wechsle zu Kimi K2.7 Code oder GPT-5.4 Mini bei High-Volume-, latenzkritischen oder kostensensitiven Aufgaben."
           },
           {
             "q": "Ist Sonnet 4.6 dasselbe wie Sonnet 4.5?",
@@ -5361,15 +5365,19 @@
         "comparisons": [
           {
             "vs": "GLM-5.1",
-            "body": "GLM-5.1 remains available for compatibility. GLM-5.2 is the default choice for new Z.AI routes on VM0."
+            "body": "GLM-5.1 bleibt aus Kompatibilitätsgründen verfügbar. GLM-5.2 ist auf VM0 die Standardwahl für neue Z.AI-Routen."
           },
           {
             "vs": "Kimi K2.7 Code",
-            "body": "Both sit in cost-saving territory. Kimi is the Moonshot default and a strong code-focused alternative; GLM-5.2 is the preferred Z.AI long-context route."
+            "body": "Beide liegen im kostensparenden Bereich. Kimi ist der Moonshot-Default und eine starke codeorientierte Alternative; GLM-5.2 ist die bevorzugte Z.AI-Route für Langkontext."
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 remains the stronger default for premium tool-routing quality. GLM-5.2 is cheaper and better suited when context size dominates."
+            "body": "Sonnet 4.6 bleibt der stärkere Standard, wenn Premium-Tool-Routing zählt. GLM-5.2 ist günstiger und besser geeignet, wenn die Kontextgröße dominiert."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro liegt beim VM0-Credit-Multiplikator niedriger und ist die stärkere Kosten-zuerst-Reasoning-Wahl. Nutze es, wenn der Preis dominiert; nutze GLM-5.2, wenn Z.AI-Fit oder Langkontext wichtiger sind."
           }
         ],
         "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
@@ -5390,15 +5398,15 @@
         "alternatives": [
           {
             "slug": "glm-5-1",
-            "reason": "Compatibility with existing GLM-5.1 workflows"
+            "reason": "Kompatibilität mit bestehenden GLM-5.1-Workflows"
           },
           {
             "slug": "kimi-k2-7-code",
-            "reason": "Moonshot's cost-saving code model"
+            "reason": "Moonshots kostensparendes Code-Modell"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Cheaper standard-context alternative"
+            "reason": "Günstigere Alternative für Standardkontext"
           }
         ],
         "routingNotes": "On VM0 Managed, GLM-5.2 routes through OpenRouter with the upstream id `z-ai/glm-5.2`. With a Z.AI API key it talks directly to `api.z.ai` as `glm-5.2`. It is the default model on the Z.AI provider.",
@@ -5415,9 +5423,9 @@
         "releaseDate": "April 2026",
         "familyPosition": "Flaggschiff der GLM-Familie von Z.AI.",
         "background": [
-          "GLM-5.1 is the flagship of Zhipu AI's GLM series, distributed via Z.AI. It's a reasoning model with strong general capability and an unusually large context window. Up to 1M tokens, several times larger than the Anthropic and Moonshot defaults at the same price tier.",
-          "On VM0, GLM-5.1 is exposed two ways: through VM0 Managed (routed via OpenRouter with the upstream id `z-ai/glm-5.1`), and via a direct Z.AI API key. GLM-5.2 is now the Z.AI default, while GLM-5.1 remains available for compatibility.",
-          "GLM-5.1 became broadly available on VM0 in April 2026 when its feature flag was retired (PR #10497). It's the cost-efficient long-context option in the lineup, sitting at ×0.4 credits. Less than half of Sonnet 4.6."
+          "GLM-5.1 ist das Flaggschiff der GLM-Serie von Zhipu AI, vertrieben über Z.AI. Es ist ein Reasoning-Modell mit starker allgemeiner Leistungsfähigkeit und einem ungewöhnlich großen Kontextfenster von bis zu 1M Tokens, also deutlich größer als die Anthropic- und Moonshot-Defaults in derselben Preisstufe.",
+          "Auf VM0 wird GLM-5.1 auf zwei Wegen bereitgestellt: über VM0 Managed (geroutet über OpenRouter mit der Upstream-ID `z-ai/glm-5.1`) und über einen direkten Z.AI-API-Schlüssel. GLM-5.2 ist inzwischen der Z.AI-Default, während GLM-5.1 aus Kompatibilitätsgründen verfügbar bleibt.",
+          "GLM-5.1 wurde im April 2026 breit auf VM0 verfügbar, als sein Feature Flag entfernt wurde (PR #10497). Es ist die kosteneffiziente Langkontext-Option im Katalog, liegt bei ×0,4 Credits und kostet weniger als die Hälfte von Sonnet 4.6."
         ],
         "architecture": "",
         "specs": [
@@ -5487,11 +5495,11 @@
             "body": "Some agent steps genuinely take five to thirty minutes — deep research, multi-document analysis, long planning passes. VM0 sets a 50-minute API timeout for the Z.AI provider so those long thinking steps don't get cut off mid-thought, which makes GLM-5.1 the safe pick over models routed through providers with shorter default timeouts."
           }
         ],
-        "avoidFor": "Skip GLM-5.1 on the hardest English-language reasoning where Sonnet 4.6 or Opus 4.7 still leads, and on latency-critical chat replies where Kimi K2.6 is much faster.",
+        "avoidFor": "Verzichte auf GLM-5.1 bei schwierigstem englischsprachigem Reasoning, wo Sonnet 4.6 oder Opus 4.7 weiterhin führen, und bei latenzkritischen Chat-Antworten, bei denen Kimi K2.7 Code deutlich schneller ist.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
-            "body": "Both are long-context options at similar credit cost (×0.4 vs ×0.3). Kimi has stronger long-context recall in our internal evaluation; GLM-5.1 wins on raw context size (1M vs 256K). Pick Kimi for very long transcripts; pick GLM-5.1 when you need to stuff a whole codebase into one prompt."
+            "vs": "Kimi K2.7 Code",
+            "body": "Beide sind Langkontext-Optionen mit ähnlichen Credit-Kosten (×0,4 vs. ×0,3). Kimi hat in unserer internen Bewertung stärkeren Langkontext-Recall; GLM-5.1 gewinnt bei der reinen Kontextgröße (1M vs. 256K). Nutze Kimi für sehr lange Transkripte; nutze GLM-5.1, wenn ein ganzer Codebestand in einen Prompt passen muss."
           },
           {
             "vs": "Claude Sonnet 4.6",
@@ -5518,21 +5526,25 @@
           },
           {
             "q": "Does GLM-5.1 support image input?",
-            "a": "GLM-5.1 on VM0 is exposed for text and code. For multimodal (image/video) input, choose Claude Sonnet 4.6 or Kimi K2.6."
+            "a": "GLM-5.1 wird auf VM0 für Text und Code bereitgestellt. Für multimodale Eingaben (Bild/Video) wähle Claude Sonnet 4.6 oder Kimi K2.7 Code."
           }
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "Ähnlicher Preis mit Bildunterstützung und starken Benchmarks."
+            "slug": "glm-5-2",
+            "reason": "Aktuelle Z.AI-Standardroute"
+          },
+          {
+            "slug": "kimi-k2-7-code",
+            "reason": "Stärkerer Langkontext-Recall"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Open-Source-Alternative mit ähnlichen Kosten (×0,1 Credits)."
+            "reason": "Günstigere Alternative mit kürzerem Kontext"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Bessere Allround-Qualität zu höheren Kosten (×1,0 Credits)."
+            "reason": "Stärkeres Reasoning, wenn Kosten nicht die Einschränkung sind"
           }
         ],
         "routingNotes": "On VM0 Managed, GLM-5.1 is routed through OpenRouter with the upstream id `z-ai/glm-5.1`. With a Z.AI API key it talks to `api.z.ai`'s Anthropic-compatible endpoint directly. GLM-5.2 is now the default model on the Z.AI provider.",
@@ -5544,14 +5556,14 @@
         "tagline": "OpenAIs kostenoptimiertes Mitglied der GPT-5-Familie. ×0,3 Credits, multimodale Vision und schnell genug für volumenstarkes Routing, Klassifikation und Pre-Filter-Arbeit.",
         "cardIntro": "OpenAIs kostensparendes GPT-5. ×0,3 Credits, schnell und multimodal — die richtige Wahl für Bulk-Pre-Filter-Arbeit auf dem Codex-Framework.",
         "metaTitle": "GPT-5.4 Mini auf VM0: Benchmarks, Preise & Vergleich",
-        "metaDescription": "GPT-5.4 Mini im Test auf VM0. Das kostensparende OpenAI-GPT-5-Modell zu $0,75/$4,5 Anbieterpreisen, ×0,3 Credits, 400K Kontext und multimodaler Vision. Spezifikationen, Verhalten und Vergleich zu Kimi K2.6.",
-        "summary": "GPT-5.4 Mini ist das kostensparende Mitglied der GPT-5-Familie von OpenAI — das Modell, zu dem du greifst, wenn Stückkosten mehr zählen als Spitzen-Reasoning-Qualität. Es behält das 400K-Kontextfenster und die multimodalen Eingaben der Familie, kürzt aber Compute pro Token, was sich in niedrigerem Preis ($0,75 / $4,5 pro 1M) und merklich höherer Geschwindigkeit niederschlägt.\n\nAuf VM0 liegt es bei ×0,3 Credits, demselben Multiplikator wie Kimi K2.6, was es zur natürlichen OpenAI-seitigen Wahl für Bulk-Klassifikation, Fan-Out-Routing, Pre-Filter und jeden Agent-Schritt macht, bei dem das Drücken auf ein Drittel der GPT-5.4-Kosten der entscheidende Faktor ist.",
+        "metaDescription": "GPT-5.4 Mini im Test auf VM0. Das kostensparende OpenAI-GPT-5-Modell zu $0,75/$4,5 Anbieterpreisen, ×0,3 Credits, 400K Kontext und multimodaler Vision. Spezifikationen, Verhalten und Vergleich zu Kimi K2.7 Code.",
+        "summary": "GPT-5.4 Mini ist das kostensparende Mitglied der GPT-5-Familie von OpenAI — das Modell, zu dem du greifst, wenn Stückkosten mehr zählen als Spitzen-Reasoning-Qualität. Es behält das 400K-Kontextfenster und die multimodalen Eingaben der Familie, kürzt aber Compute pro Token, was sich in niedrigerem Preis ($0,75 / $4,5 pro 1M) und merklich höherer Geschwindigkeit niederschlägt.\n\nAuf VM0 liegt es bei ×0,3 Credits, demselben Multiplikator wie Kimi K2.7 Code, was es zur natürlichen OpenAI-seitigen Wahl für Bulk-Klassifikation, Fan-Out-Routing, Pre-Filter und jeden Agent-Schritt macht, bei dem das Drücken auf ein Drittel der GPT-5.4-Kosten der entscheidende Faktor ist.",
         "releaseDate": "April 2026",
-        "familyPosition": "Kostensparende Variante der GPT-5-Familie. Das OpenAI-seitige Pendant zu Kimi K2.6.",
+        "familyPosition": "Kostensparende Variante der GPT-5-Familie. Das OpenAI-seitige Pendant zu Kimi K2.7 Code.",
         "background": [
           "GPT-5.4 Mini ist das kostenoptimierte Mitglied der GPT-5-Generation von OpenAI, veröffentlicht im April 2026 neben GPT-5.5 und GPT-5.4. OpenAI positioniert es als Hochdurchsatz-Stufe — das Modell, das du auf Klassifikations-, Routing- und Pre-Filter-Schritten laufen lässt, wo das größere 5.4 oder 5.5 für Routine-Entscheidungen verschwendet wäre.",
           "Architektonisch teilt es das 400K-Token-Kontextfenster der GPT-5-Familie, den `reasoning_effort`-Parameter, Prompt Caching und die Responses-API-Oberfläche, die codex CLI standardmäßig nutzt. Der Trade-off gegenüber 5.4 ist Reasoning-Tiefe: Mini handhabt Standard-Tool-Calls, kurze Zusammenfassungen und Structured-Output-Workloads gut, fängt aber bei den schwereren mehrstufigen Plänen an zu driften, wo 5.4 noch hält. Der Trade-off gegenüber Konkurrenten im selben Preispunkt ist Ökosystem — wenn du bereits auf Codex bist, hält das Bleiben in der OpenAI-Oberfläche Tool-Definitionen und Structured-Output-Schemas konsistent.",
-          "Auf VM0 liegt Mini beim ×0,3 Credit-Multiplikator, gleich wie Kimi K2.6. DeepSeek V4 Pro liegt niedriger bei ×0,1. Innerhalb der kostensparenden Stufe hängt die Wahl meist von Framework und Verhaltens-Fit auf deiner spezifischen Workload ab."
+          "Auf VM0 liegt Mini beim ×0,3 Credit-Multiplikator, gleich wie Kimi K2.7 Code. DeepSeek V4 Pro liegt niedriger bei ×0,1. Innerhalb der kostensparenden Stufe hängt die Wahl meist von Framework und Verhaltens-Fit auf deiner spezifischen Workload ab."
         ],
         "architecture": "GPT-5.4 Mini nutzt dieselbe Architektur wie der Rest der GPT-5-Familie: 400K-Token-Kontextfenster, `reasoning_effort`-Parameter auf vier Stufen, Prompt Caching, wobei gecachter Input zu einem Zehntel des Input-Preises berechnet wird, und die Responses-API-Oberfläche. Tool-Use, Structured Outputs und multimodale Vision-Eingaben werden unterstützt. Das Modell ist ein kleinerer, schnellerer Verwandter — weniger Parameter pro Token, mehr Durchsatz pro Dollar.",
         "specs": [
@@ -5588,7 +5600,7 @@
             "value": "$0,75 Input / $4,5 Output pro 1M"
           }
         ],
-        "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5 Mini Release-Materialien. Unabhängige Reviews platzieren 5.4 Mini bei den meisten Agent-Benchmarks im selben kostensparenden Band wie Kimi K2.6. Behandle absolute Prozente als richtungsweisend.",
+        "benchmarksNote": "Vom Anbieter gemeldete Werte aus OpenAIs GPT-5 Mini Release-Materialien. Unabhängige Reviews platzieren 5.4 Mini bei den meisten Agent-Benchmarks im selben kostensparenden Band wie Kimi K2.7 Code. Behandle absolute Prozente als richtungsweisend.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -5631,7 +5643,7 @@
           },
           {
             "title": "Kosteneffizienz",
-            "body": "×0,3 Credits inklusive multimodaler Vision. Mini und Kimi K2.6 liegen im selben Band, während DeepSeek V4 Pro niedriger bei ×0,1 liegt — die Wahl kommt meist auf Framework-Fit und Verhalten auf deiner spezifischen Workload an."
+            "body": "×0,3 Credits inklusive multimodaler Vision. Mini und Kimi K2.7 Code liegen im selben Band, während DeepSeek V4 Pro niedriger bei ×0,1 liegt — die Wahl kommt meist auf Framework-Fit und Verhalten auf deiner spezifischen Workload an."
           },
           {
             "title": "Wann eskalieren",
@@ -5657,6 +5669,14 @@
           {
             "vs": "GPT-5.4",
             "body": "Gleiche Familie, andere Positionierung. 5.4 Mini (×0,3) gewinnt bei Kosten und Geschwindigkeit; 5.4 (×1) gewinnt bei Reasoning-Qualität und Tool-Routing-Genauigkeit in harten Fällen. Das Standardmuster: mit Mini vorfiltern und verbleibende Fälle auf 5.4 eskalieren."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Claude Sonnet 4.6 ist der zuverlässigere Vergleichspunkt, wenn Tool-Routing-Qualität wichtiger ist als reiner Durchsatz. Mini ist günstiger und schneller für Vorfilterung und einfache Schritte."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro liegt beim VM0-Credit-Multiplikator niedriger und ist die stärkere Kosten-zuerst-Reasoning-Wahl. Nutze DeepSeek, wenn Preis und Reasoning-Tiefe dominieren; nutze Mini, wenn OpenAI-Framework-Fit und hoher Durchsatz wichtiger sind."
           }
         ],
         "verdict": "GPT-5.4 Mini ist der kostensparende Standard auf der OpenAI-Seite. Vorfiltern mit Mini, eskalieren auf GPT-5.4 für Routine-Schritte, eskalieren auf GPT-5.5 nur für das schwerste Reasoning.",
@@ -5670,7 +5690,7 @@
             "a": "Ja. Wie der Rest der GPT-5-Familie akzeptiert es Bildeingaben neben Text und Code."
           },
           {
-            "q": "Wann GPT-5.4 Mini statt Kimi K2.6 wählen?",
+            "q": "Wann GPT-5.4 Mini statt Kimi K2.7 Code wählen?",
             "a": "Wenn dein Agent bereits auf dem Codex-Framework gebaut ist oder du das OpenAI Structured-Output- / Tool-Call-Ökosystem brauchst. Beide liegen bei ×0,3 Credits, also sind die Kosten identisch und die Wahl hängt von Framework und Verhalten ab."
           },
           {
@@ -5689,178 +5709,7 @@
           }
         ],
         "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
-        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Kimi K2.6, above DeepSeek V4 Pro's ×0.1 tier. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
-      },
-      "kimi-k2-6": {
-        "name": "Kimi K2.6",
-        "pageTitle": "Kimi K2.6 on VM0. Long-context agents",
-        "tagline": "Moonshots Open-Source-Flaggschiff. Starke SWE-bench-Ergebnisse, Bildunterstützung und AWS-Fehlerbehebungsfähigkeiten zu ×0,3 Credits.",
-        "cardIntro": "Moonshots leistungsstärkstes Modell mit Bild- und Code-Fähigkeiten. Open-Source-Lizenz, 256K-Kontext und ×0,3 Credits auf VM0.",
-        "metaTitle": "Kimi K2.6: Benchmarks, Preise & Fähigkeiten",
-        "metaDescription": "Kimi K2.6 im Test. Moonshots Open-Source-Flaggschiff mit 256K-Kontext, $0,60/$3,00 Preisen und ×0,3 Credits. Starke SWE-bench-Ergebnisse.",
-        "summary": "Kimi K2.6 ist Moonshots leistungsstärkstes öffentliches Modell, veröffentlicht im April 2026. Es bietet starke SWE-bench-Ergebnisse, multimodale Eingabe (Text, Bild, Code) und prompt caching — alles unter einer Open-Source-Lizenz.\n\nListenpreis $0,60/$3,00 pro 1M Tokens mit gecachtem Input bei $0,10/1M. Auf VM0 bei ×0,3 Credits positioniert es sich als kosteneffiziente Alternative zu Claude Sonnet 4.6.",
-        "releaseDate": "April 2026",
-        "familyPosition": "Moonshots Flaggschiff-Modell. Nachfolger von K2.5.",
-        "background": [
-          "Kimi K2.6 is Moonshot AI's open-weight agentic model released April 20, 2026. It's a 1-trillion-parameter Mixture-of-Experts (MoE) model with 32B active parameters per token. The same architecture family as K2.5 and K2 Thinking, with substantial gains on agentic coding and long-horizon reasoning.",
-          "K2.6 made a real splash on independent leaderboards. Vendor-reported scores put it ahead of GPT-5.4 (xhigh) and Claude Opus 4.6 (max effort) on SWE-bench Pro, with a hallucination rate of 39% (down from K2.5's 65%). Artificial Analysis ranks it #4 on its Intelligence Index. The leading open-weight option.",
-          "On VM0 it's exposed via the Moonshot API key as the default model, through VM0 Managed at the same ×0.3 multiplier, and via OpenRouter. The API is Anthropic-compatible, so VM0 agents written for Claude work without code changes."
-        ],
-        "architecture": "",
-        "specs": [
-          {
-            "label": "Familie",
-            "value": "Kimi K2-Familie"
-          },
-          {
-            "label": "Parameter",
-            "value": "Nicht veröffentlicht"
-          },
-          {
-            "label": "Modalitäten",
-            "value": "Text, Bild, Code"
-          },
-          {
-            "label": "Sprachen",
-            "value": "Mehrsprachig"
-          },
-          {
-            "label": "Kontextfenster",
-            "value": "256K Token"
-          },
-          {
-            "label": "Lizenz",
-            "value": "Open Source"
-          },
-          {
-            "label": "Verfügbar auf VM0",
-            "value": "April 2026"
-          }
-        ],
-        "benchmarksNote": "Vendor-reported scores from Moonshot's K2.6 release blog. Independent third parties (Artificial Analysis, TokenMix) corroborate the relative ordering. K2.6's hallucination rate dropped to 39% from K2.5's 65%. A significant safety/reliability improvement.",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "58.6",
-            "note": "vendor-reported; beats GPT-5.4, Opus 4.6"
-          },
-          {
-            "name": "SWE-bench Verified",
-            "score": "80.2",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "Terminal-Bench 2.0",
-            "score": "66.7",
-            "note": "Terminus-2 framework"
-          },
-          {
-            "name": "LiveCodeBench (v6)",
-            "score": "89.6",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "HLE (with tools)",
-            "score": "54.0",
-            "note": "leads GPT-5.4 and Opus 4.6"
-          },
-          {
-            "name": "BrowseComp (Agent Swarm)",
-            "score": "86.3",
-            "note": "up from K2.5's 78.4"
-          },
-          {
-            "name": "Artificial Analysis Intelligence Index",
-            "score": "54",
-            "note": "#4 overall, leading open-weight"
-          }
-        ],
-        "performance": [
-          {
-            "title": "Long-context recall",
-            "body": "Strongest long-context recall in our internal evaluation across the Built-in lineup. Maintains coherence across long agent transcripts where Anthropic Sonnet starts to drift."
-          },
-          {
-            "title": "Agentic benchmarks",
-            "body": "Vendor-reported SWE-bench Pro 58.6 is the highest in the lineup at the time of writing. Beats GPT-5.4 and Opus 4.6."
-          },
-          {
-            "title": "Long-horizon coding",
-            "body": "Documented 12+ hour autonomous sessions completing 4,000+ tool calls. The model genuinely sustains performance across very long runs."
-          },
-          {
-            "title": "Tool use",
-            "body": "Reliable across common VM0 tool flows. The Anthropic-compatible API means tool schemas designed for Claude work directly."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "The investigation that has to read every old thread",
-            "body": "Dig through six months of Slack conversations to find why a customer churned, comb the support-ticket backlog for a recurring bug pattern, or stitch together insights across a hundred RFCs. K2.6's long-context recall holds up across transcripts where Anthropic Sonnet starts dropping earlier turns, which is exactly what \"reading the whole pile\" workflows need."
-          },
-          {
-            "title": "The autonomous refactor that runs overnight",
-            "body": "Moonshot has documented a 13-hour autonomous refactor of an eight-year-old matching engine, with K2.6 sustaining 4,000+ tool calls without drifting off task. That's the kind of run where most models lose the goal somewhere around hour two; K2.6's long-horizon stability is what makes \"start it Friday evening, check Monday morning\" actually work."
-          },
-          {
-            "title": "The multimodal agent that handles screenshots and clips",
-            "body": "K2.6 accepts both image and video input through MoonViT, which is unusual outside the Claude family. Useful for screenshot-driven QA agents, document-vision pipelines, and any deployment where you'd otherwise have to splice in a separate vision model just to read images."
-          }
-        ],
-        "avoidFor": "Verzichte auf K2.6 bei den schwierigsten Tool-Routing-Edge-Cases, in denen Sonnet 4.6 bei Produktionszuverlässigkeit noch führt, sowie bei gepinnten Legacy-Workflows, in denen K2.5s niedrigerer Multiplikator bereits ausreicht.",
-        "comparisons": [
-          {
-            "vs": "GLM-5.1",
-            "body": "Both are long-context options. K2.6 wins on raw long-context recall in our internal evaluation; GLM-5.1 wins on context size (1M vs 256K). Default to K2.6 for long transcripts; reach for GLM-5.1 only when you need >256K tokens in a single prompt."
-          },
-          {
-            "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet (×1) leads on multi-tool English-language routing reliability. K2.6 (×0.3) wins on cost and on agentic benchmarks (SWE-bench Pro). Pair them: Sonnet for complex tool-routing, K2.6 for cost-sensitive agent work."
-          },
-          {
-            "vs": "Kimi K2.5",
-            "body": "K2.6 is the newer generation with stronger tool-use, lower hallucination rate (39% vs 65%), and better reasoning. K2.5 (×0.2) is slightly cheaper. Prefer K2.6 for new work."
-          }
-        ],
-        "verdict": "Kimi K2.6 ist die beste kosteneffiziente Wahl für SWE-bench-intensive Workloads. Seine Kombination aus Open-Source-Lizenz, Bildunterstützung und niedrigen Kosten macht es zu einem starken Kandidaten für selbst gehostete Setups.",
-        "faqs": [
-          {
-            "q": "When was Kimi K2.6 released?",
-            "a": "Moonshot AI released Kimi K2.6 on April 20, 2026. Open weights are published on Hugging Face under a Modified MIT License."
-          },
-          {
-            "q": "What's the context window?",
-            "a": "256K tokens. K2.6 differentiates on recall quality at that size, not raw window size. Recall starts to degrade past ~180K (similar to other 256K models)."
-          },
-          {
-            "q": "Do I need to rewrite my agent to use Kimi?",
-            "a": "No. Kimi K2.6 exposes an Anthropic-compatible API, so VM0 agents tuned for Claude work without code changes."
-          },
-          {
-            "q": "How does Kimi K2.6 compare to Claude Opus 4.6?",
-            "a": "On agentic benchmarks (vendor-reported), K2.6 leads. SWE-bench Pro 58.6 vs Opus 4.6's 53.4, HLE with tools 54.0 vs 53.0. Opus 4.6 retains an edge on safety profile and English-language tool-routing reliability in production."
-          },
-          {
-            "q": "Does K2.6 support image input?",
-            "a": "Yes. K2.6 accepts image and video input. Text-only output. Multimodal agents work natively."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-5",
-            "reason": "Vorherige Generation, noch günstiger (×0,2 Credits) mit ähnlichen Fähigkeiten."
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Ähnlicher Preis, 1M-Kontext, aber ohne Bildunterstützung."
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Stärkere Code-Benchmarks mit ähnlichem Preis (×0,1 Credits)."
-          }
-        ],
-        "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Default model on the Moonshot provider; also available on VM0 Managed and via OpenRouter.",
-        "vm0Notes": "K2.6 has the strongest long-context recall in the Built-in lineup based on our internal evaluation, and at ×0.3 credits it's cheap enough to act as a viable Sonnet substitute for cost-sensitive work."
+        "vm0Notes": "GPT-5.4 Mini liegt beim kostensparenden ×0,3-Multiplikator neben Kimi K2.7 Code und über DeepSeek V4 Pros ×0,1-Stufe. Prompt Caching ist standardmäßig aktiv, und der hohe Durchsatz macht Mini zu einem natürlichen Vorfilter in gestapelten Agent-Designs, die nur Restfälle an 5.4 oder 5.5 eskalieren."
       },
       "kimi-k2-7-code": {
         "name": "Kimi K2.7 Code",
@@ -5981,16 +5830,16 @@
         "avoidFor": "Verzichte auf K2.7 bei den schwierigsten Tool-Routing-Edge-Cases, in denen Sonnet 4.6 bei Produktionszuverlässigkeit noch führt, sowie bei gepinnten Legacy-Workflows, in denen K2.6s niedrigerer Multiplikator bereits ausreicht.",
         "comparisons": [
           {
-            "vs": "GLM-5.1",
-            "body": "Both are long-context options. K2.7 wins on raw long-context recall in our internal evaluation; GLM-5.1 wins on context size (1M vs 256K). Default to K2.7 for long transcripts; reach for GLM-5.1 only when you need >256K tokens in a single prompt."
+            "vs": "GLM-5.2",
+            "body": "Beide sind aktuelle kostensparende Langkontext-Optionen. K2.7 Code ist der Moonshot-Default mit stärkerem multimodalem Coding-Fit; GLM-5.2 ist der aktuelle Z.AI-Default mit größerem 1M-Token-Kontextfenster."
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet (×1) leads on multi-tool English-language routing reliability. K2.7 (×0.3) wins on cost and on agentic benchmarks (SWE-bench Pro). Pair them: Sonnet for complex tool-routing, K2.7 for cost-sensitive agent work."
+            "body": "Sonnet (×1) führt bei zuverlässigem englischem Multi-Tool-Routing. K2.7 (×0,3) gewinnt bei Kosten und agentischen Benchmarks. Kombiniere sie: Sonnet für komplexes Tool-Routing, K2.7 für kostensensitive Agent-Arbeit."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "K2.7 is the newer generation with stronger tool-use, lower hallucination rate (39% vs 65%), and better reasoning. K2.6 (×0.2) is slightly cheaper. Prefer K2.7 for new work."
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro ist günstiger und hat ein größeres 1M-Token-Kontextfenster. Kimi K2.7 Code ist die stärkere Moonshot-native Coding-Route und unterstützt Bildeingaben. Wähle nach Provider-Fit und Workload-Form."
           }
         ],
         "verdict": "Kimi K2.7 Code ist die beste kosteneffiziente Wahl für SWE-bench-intensive Workloads. Seine Kombination aus Open-Source-Lizenz, Bildunterstützung und niedrigen Kosten macht es zu einem starken Kandidaten für selbst gehostete Setups.",
@@ -6018,16 +5867,16 @@
         ],
         "alternatives": [
           {
-            "slug": "claude-sonnet-4-6",
-            "reason": "Vorherige Generation, noch günstiger (×0,2 Credits) mit ähnlichen Fähigkeiten."
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Ähnlicher Preis, 1M-Kontext, aber ohne Bildunterstützung."
+            "slug": "glm-5-2",
+            "reason": "Aktuelle Z.AI-Langkontext-Route"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Stärkere Code-Benchmarks mit ähnlichem Preis (×0,1 Credits)."
+            "reason": "Günstigere Reasoning-Alternative für kostensensitive Arbeit"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Zuverlässigere Basislinie für komplexe Tool-Nutzung"
           }
         ],
         "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Default model on the Moonshot provider; also available on VM0 Managed.",
@@ -6046,7 +5895,7 @@
         "background": [
           "DeepSeek V4 Pro ist das Flaggschiff der DeepSeek-V4-Generation, veröffentlicht am 24. April 2026 unter der MIT-Lizenz. Es ist ein Open-Weight-Mixture-of-Experts-Modell mit 1,6T Gesamtparametern und 49B aktiven Parametern pro Token.",
           "V4 Pro unterstützt ein 1M-Token-Kontextfenster, 384K maximale Ausgabe, drei Reasoning-Effort-Modi (standard, think, think-max), JSON-Ausgabe, Tool Calls und FIM-Completion im Non-Think-Modus. Das Pro-Modell ergänzt eine hybride Attention-Architektur (Compressed Sparse Attention + Heavily Compressed Attention) für deutlich effizienteren Langkontext. 27% Single-Token-Inferenz-FLOPs und 10% KV-Cache gegenüber DeepSeek V3.2 bei 1M Kontext.",
-          "DeepSeek made waves through 2025 by delivering Anthropic-grade reasoning at a fraction of the price. V4 Pro continues that pattern: vendor-reported SWE-bench Verified 80.6% sits within 0.2 points of Claude Opus 4.6, at roughly one-seventh the vendor cost. On VM0 it's exposed via the DeepSeek API-key provider and on VM0 Managed at ×0.1. Lower multiplier than Kimi K2.6, with substantially stronger reasoning behaviour."
+          "DeepSeek made waves through 2025 by delivering Anthropic-grade reasoning at a fraction of the price. V4 Pro continues that pattern: vendor-reported SWE-bench Verified 80.6% sits within 0.2 points of Claude Opus 4.6, at roughly one-seventh the vendor cost. On VM0 it's exposed via the DeepSeek API-key provider and on VM0 Managed at ×0.1. Lower multiplier than Kimi K2.7 Code, with substantially stronger reasoning behaviour."
         ],
         "architecture": "",
         "specs": [
@@ -6083,7 +5932,7 @@
             "value": "24. April 2026"
           }
         ],
-        "benchmarksNote": "Vendor-reported scores from DeepSeek's V4 Pro release. Independent reviews (Geeky Gadgets, Code Arena) place V4 Pro third on Code Arena behind GLM-5.1 and Kimi K2.6. The strongest benchmark claims come from DeepSeek's own materials. Treat directionally rather than as absolute truth.",
+        "benchmarksNote": "Vendor-reported scores from DeepSeek's V4 Pro release. Independent reviews (Geeky Gadgets, Code Arena) place V4 Pro third on Code Arena behind GLM-5.1 and Kimi K2.7 Code. The strongest benchmark claims come from DeepSeek's own materials. Treat directionally rather than as absolute truth.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -6140,7 +5989,7 @@
           },
           {
             "title": "Speed",
-            "body": "Around 36 tokens/sec at max effort per Artificial Analysis. Slower than Kimi K2.6, slightly slower than Opus 4.6."
+            "body": "Around 36 tokens/sec at max effort per Artificial Analysis. Slower than Kimi K2.7 Code, slightly slower than Opus 4.6."
           }
         ],
         "bestForExamples": [
@@ -6157,15 +6006,19 @@
             "body": "1M-token context with hybrid attention (Compressed Sparse Attention plus Heavily Compressed Attention) means a mid-sized codebase fits in one prompt and inference cost stays manageable as the window fills up. For cross-file refactors and architecture-level reviews, this is where you get the Opus-style \"see everything at once\" workflow without the Opus-style invoice."
           }
         ],
-        "avoidFor": "Verzichte auf V4 Pro bei den schwierigsten Tool-Routing-Edge-Cases, in denen Sonnet 4.6 noch führt, sowie bei Bulk-Single-Shot-Arbeit, für die GPT-5.4 Mini oder Kimi K2.6 zu niedrigeren Kosten ausreicht.",
+        "avoidFor": "Verzichte auf V4 Pro bei den schwierigsten Tool-Routing-Edge-Cases, in denen Sonnet 4.6 noch führt, sowie bei Bulk-Single-Shot-Arbeit, für die GPT-5.4 Mini oder Kimi K2.7 Code zu niedrigeren Kosten ausreicht.",
         "comparisons": [
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 (×1) wins on tool-routing edge cases and English-language reasoning. V4 Pro (×0.1) wins on cost and is competitive on coding benchmarks (vendor-reported). Worth A/B-testing on a real agent before committing."
+            "body": "Sonnet 4.6 (×1) gewinnt bei Tool-Routing-Edge-Cases und englischem Reasoning. V4 Pro (×0,1) gewinnt bei Kosten und ist bei Coding-Benchmarks wettbewerbsfähig (Anbieterangaben). Vor einer festen Umstellung lohnt ein A/B-Test mit einem echten Agenten."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Lower multiplier than Kimi (×0.1 vs ×0.3). Kimi has stronger long-context recall and a higher Intelligence Index (54 vs 52); V4 Pro has the better cache economics (free writes) and a 1M context window vs Kimi's 256K. Pick by which property matters more."
+            "vs": "Kimi K2.7 Code",
+            "body": "Niedrigerer Multiplikator als Kimi (×0,1 vs. ×0,3). Kimi hat stärkeren Langkontext-Recall und bessere multimodale Coding-Passung; V4 Pro hat bessere Cache-Ökonomie und ein 1M-Kontextfenster. Wähle nach der wichtigeren Eigenschaft."
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2 ist die aktuelle Z.AI-Standardroute auf VM0. Es ist der bessere Vergleich für neue Z.AI-gestützte Agenten; GLM-5.1 bleibt nur für getunte Workflows aus Kompatibilitätsgründen verfügbar."
           }
         ],
         "verdict": "DeepSeek V4 Pro ist die erste Wahl für Code-intensive Agenten, wenn die Gesamtbetriebskosten im Vordergrund stehen. Seine Open-Source-Lizenz und führenden Code-Benchmarks machen es zum stärksten Kosteneffizienz-Kandidaten auf VM0.",
@@ -6194,146 +6047,15 @@
         "alternatives": [
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Bessere Allround-Qualität und Anthropic-Ökosystem zu höheren Kosten."
+            "reason": "Upgrade für schwieriges Tool-Routing"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Ähnlicher Preis mit zusätzlicher Bildunterstützung."
+            "slug": "kimi-k2-7-code",
+            "reason": "Moonshot-Default mit stärkerer multimodaler Coding-Passung"
           }
         ],
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Available on VM0 Managed and the DeepSeek provider.",
         "vm0Notes": "DeepSeek bills cache reads but not cache writes, which is a real cost win whenever the system prompt is stable. VM0 sets a 10-minute API timeout for the DeepSeek provider and disables non-essential traffic to keep long-running agents responsive. The result is the strongest reasoning of any sub-Sonnet model in the Built-in lineup."
-      },
-      "kimi-k2-5": {
-        "name": "Kimi K2.5",
-        "pageTitle": "Kimi K2.5 on VM0. Moonshot's previous generation",
-        "tagline": "Moonshots vorheriges Flaggschiff. Immer noch solide mit Bildunterstützung und extrem niedrigen Kosten — ×0,2 Credits.",
-        "cardIntro": "Moonshots K2.5 mit Bild-, Text- und Code-Modalitäten. Open-Source-Lizenz und ×0,2 Credits auf VM0.",
-        "metaTitle": "Kimi K2.5: Benchmarks, Preise & Fähigkeiten",
-        "metaDescription": "Kimi K2.5 im Test. Moonshots vorheriges Flaggschiff mit Bildunterstützung, $0,60/$3,00 Preisen und ×0,2 Credits. Solide Qualität zu minimalen Kosten.",
-        "summary": "Kimi K2.5 ist Moonshots Modell der vorherigen Generation, immer noch verfügbar zu einem noch niedrigeren Multiplikator von ×0,2 Credits. Es bietet Bild-, Text- und Code-Eingabe mit derselben Preisstruktur wie K2.6 ($0,60/$3,00), aber zu einem niedrigeren VM0-Multiplikator.\n\nDer niedrigere Multiplikator spiegelt die etwas schwächeren Benchmark-Ergebnisse im Vergleich zu K2.6 wider, aber für viele Bulk-Aufgaben ist die Qualität mehr als ausreichend.",
-        "releaseDate": "Verfügbar seit VM0-Launch",
-        "familyPosition": "Vorheriges Flaggschiff der Kimi K2-Familie. Abgelöst von K2.6.",
-        "background": [
-          "Kimi K2.5 was Moonshot's flagship Kimi model before K2.6. It was the first widely-deployed Kimi to combine long-context reasoning with a Claude-compatible API surface, and it remains a capable model for long-context summarisation work.",
-          "On VM0 it sits at the same vendor list price as K2.6 but a lower credit multiplier (×0.2). The lower multiplier reflects positioning rather than raw token cost. K2.6 is the recommended default for new work; K2.5 is the legacy pin.",
-          "K2.5 has a vendor-reported SWE-bench Pro score of 50.7 and a hallucination rate of ~65%. Both meaningfully behind K2.6 (58.6 and 39%). Behaviourally it remains stable for pinned production agents."
-        ],
-        "architecture": "",
-        "specs": [
-          {
-            "label": "Familie",
-            "value": "Kimi K2-Familie"
-          },
-          {
-            "label": "Modalitäten",
-            "value": "Text, Bild, Code"
-          },
-          {
-            "label": "Sprachen",
-            "value": "Mehrsprachig"
-          },
-          {
-            "label": "Kontextfenster",
-            "value": "256K Token"
-          },
-          {
-            "label": "Lizenz",
-            "value": "Open Source"
-          },
-          {
-            "label": "Verfügbar auf VM0",
-            "value": "Seit Launch"
-          }
-        ],
-        "benchmarksNote": "K2.5's benchmarks are now most useful as the comparison baseline for K2.6. The newer model leads on every published metric at the same vendor cost.",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "50.7",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "BrowseComp",
-            "score": "78.4",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "Hallucination rate",
-            "score": "~65%",
-            "note": "down to 39% in K2.6"
-          }
-        ],
-        "performance": [
-          {
-            "title": "Long-context",
-            "body": "Strong, similar shape to K2.6 but with K2.6 having the edge on harder recall benchmarks."
-          },
-          {
-            "title": "Tool use",
-            "body": "Solid on common flows; K2.6 is meaningfully better on complex multi-tool agents."
-          },
-          {
-            "title": "Hallucinations",
-            "body": "Vendor-reported hallucination rate of ~65%. Much higher than K2.6's 39%. Expect more confident-but-wrong outputs."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "The legacy agent that already works",
-            "body": "Your team validated an agent against K2.5 a few months ago, the prompts are tuned, the eval suite passes, customers are happy. Pinning to K2.5 keeps that exact behaviour in place while you decide whether the K2.6 upgrade is worth re-running the validation. Same Moonshot endpoint, same Anthropic-compatible interface — only the model weights move when you switch."
-          },
-          {
-            "title": "The bulk-summarisation job where K2.6's edge doesn't show",
-            "body": "Hundred-thousand-token transcripts going in, three-paragraph summaries coming out. Tool-routing accuracy isn't part of the workload, hallucination resistance matters less when a human is going to skim the output anyway, and at the same vendor price as K2.6 you can run K2.5 on these jobs without touching the existing pipeline."
-          }
-        ],
-        "avoidFor": "Don't start new agents on K2.5, since K2.6 is a free upgrade in every meaningful way except the multiplier. Skip it on multi-tool English routing where Sonnet 4.6 leads, and on tasks where hallucination is costly because K2.5's rate is materially worse than K2.6's.",
-        "comparisons": [
-          {
-            "vs": "Kimi K2.6",
-            "body": "K2.6 is the newer generation with stronger tool-use, lower hallucination rate (39% vs 65%), and better reasoning. K2.5 (×0.2) is slightly cheaper. Pick K2.5 only for pinned legacy agents."
-          },
-          {
-            "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro (×0.1) has stronger reasoning. K2.5 (×0.2) wins on context size and stays within the Moonshot API surface."
-          }
-        ],
-        "verdict": "Kimi K2.5 ist eine gute Wahl, wenn du die niedrigstmöglichen Kosten bei gleichzeitiger Bildunterstützung benötigst. Für neue Projekte ist K2.6 die bessere Wahl, es sei denn, der ×0,2-Multiplikator ist entscheidend.",
-        "faqs": [
-          {
-            "q": "Why does K2.5 have a lower multiplier than K2.6 at the same vendor price?",
-            "a": "Multipliers reflect VM0's positioning of each model in the lineup, not just per-token cost. K2.6 is the recommended Kimi default at ×0.3; K2.5 is positioned as legacy at ×0.2."
-          },
-          {
-            "q": "Should I migrate from K2.5 to K2.6?",
-            "a": "Yes for new work. Same vendor price, stronger tool-use and reasoning, much lower hallucination rate. Migrate pinned agents only after running them through your regression suite."
-          },
-          {
-            "q": "What's the hallucination rate?",
-            "a": "Vendor-reported ~65%. Meaningfully higher than K2.6 (39%). If your agent reports facts to users, this matters; consider K2.6 instead."
-          },
-          {
-            "q": "What's K2.5's context window?",
-            "a": "256K tokens. Same as K2.6."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-6",
-            "reason": "Direkter Nachfolger mit besseren Benchmarks bei ×0,3 Credits."
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Ähnlicher Preisbereich mit 1M-Kontext."
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Stärkere Code-Benchmarks zu ähnlichen Kosten."
-          }
-        ],
-        "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Available on VM0 Managed, Moonshot, OpenRouter, and Vercel AI Gateway.",
-        "vm0Notes": "K2.5 carries the same per-token vendor price as K2.6 but a lower multiplier (×0.2 versus ×0.3) because the multiplier reflects positioning rather than raw cost. Long-context behaviour is solid, but K2.6 is the recommended choice for any new work on VM0."
       },
       "minimax-m3": {
         "name": "MiniMax M3",
@@ -6421,12 +6143,16 @@
         "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
-            "body": "Both target coding and agentic work at low cost. Kimi has broader existing gateway support on VM0, while M3 uses the official MiniMax route and gives MiniMax users the newer model."
+            "vs": "Kimi K2.7 Code",
+            "body": "Beide zielen auf günstige Coding- und Agent-Arbeit. Kimi hat breitere bestehende Gateway-Unterstützung auf VM0, während M3 die offizielle MiniMax-Route nutzt und MiniMax-Nutzern das neuere Modell gibt."
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 remains the baseline for reliability on complex English tool-use. M3 is much cheaper and attractive for MiniMax-native coding agents, but should be validated on critical workflows."
+            "body": "Sonnet 4.6 bleibt die Basislinie für Zuverlässigkeit bei komplexer englischer Tool-Nutzung. M3 ist deutlich günstiger und attraktiv für MiniMax-native Coding-Agenten, sollte aber für kritische Workflows validiert werden."
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2 ist die aktuelle Z.AI-Standardroute auf VM0. Es ist der bessere Vergleich für neue Z.AI-gestützte Agenten; GLM-5.1 bleibt nur für getunte Workflows aus Kompatibilitätsgründen verfügbar."
           }
         ],
         "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
@@ -6446,12 +6172,12 @@
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "Low-cost coding model with existing gateway coverage"
+            "slug": "kimi-k2-7-code",
+            "reason": "Günstiges Coding-Modell mit breiterer bestehender Gateway-Abdeckung"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Higher-reliability baseline for complex tool use"
+            "reason": "Zuverlässigere Basislinie für komplexe Tool-Nutzung"
           }
         ],
         "routingNotes": "Routed through MiniMax's official Anthropic-compatible endpoint at `api.minimax.io`. Available on VM0 Managed and MiniMax API-key providers only.",
@@ -6906,12 +6632,12 @@
         ],
         "alternatives": [
           {
-            "slug": "flux-pro-1-1-ultra",
-            "reason": "Premium hero-shot quality"
+            "slug": "gpt-image-1",
+            "reason": "Stärkere stilisierte Illustration"
           },
           {
-            "slug": "gpt-image-1",
-            "reason": "Stronger stylised illustration"
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Premium-Qualität für Hero-Shots"
           }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",

--- a/turbo/apps/web/messages/de.json
+++ b/turbo/apps/web/messages/de.json
@@ -4710,7 +4710,7 @@
           },
           {
             "title": "Speed",
-            "body": "Slower than Sonnet 4.6 and Kimi K2.7 Code; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
+            "body": "Langsamer als Sonnet 4.6 und Kimi K2.7 Code, vergleichbar mit Opus 4.7. Laut Artificial Analysis etwa 41 Token/Sekunde bei maximalem Effort."
           }
         ],
         "bestForExamples": [
@@ -5280,88 +5280,88 @@
       },
       "glm-5-2": {
         "name": "GLM-5.2",
-        "pageTitle": "GLM-5.2 on VM0. Z.AI's default long-context model",
-        "tagline": "The current Z.AI default on VM0. Up to a 1M-token context window, Anthropic-compatible routing, and cost-saving x0.4 VM0 Managed pricing.",
-        "cardIntro": "Z.AI's current default on VM0. Long-context text and code agents at x0.4 VM0 Managed pricing.",
-        "metaTitle": "GLM-5.2 on VM0: Pricing, Context & Best Agent Tasks",
-        "metaDescription": "GLM-5.2 on VM0. Z.AI's current default model with up to 1M-token context, x0.4 credit cost, OpenRouter-backed VM0 Managed routing, and direct Z.AI BYOK support.",
-        "summary": "GLM-5.2 is the current GLM default on VM0 for Z.AI API-key users and is also available through VM0 Managed via OpenRouter. It keeps the GLM series' long-context profile while becoming the preferred Z.AI route for new agents.\n\nUse it for large codebases, large document sets, and cost-sensitive long-context planning where Sonnet-class pricing is unnecessary. GLM-5.1 remains available for compatibility, but new Z.AI routes should start on GLM-5.2 unless a workflow has been tuned specifically against 5.1.",
-        "releaseDate": "June 2026",
-        "familyPosition": "Current default model in VM0's Z.AI / GLM route.",
+        "pageTitle": "GLM-5.2 auf VM0. Z.AIs Standardmodell für Langkontext",
+        "tagline": "Der aktuelle Z.AI-Default auf VM0. Bis zu 1M Token Kontext, Anthropic-kompatibles Routing und kostensparende ×0,4-Preise auf VM0 Managed.",
+        "cardIntro": "Z.AIs aktueller Default auf VM0. Langkontext-Agenten für Text und Code zu ×0,4 VM0-Managed-Kosten.",
+        "metaTitle": "GLM-5.2 auf VM0: Preise, Kontext & beste Agent-Aufgaben",
+        "metaDescription": "GLM-5.2 auf VM0. Z.AIs aktuelles Standardmodell mit bis zu 1M Token Kontext, ×0,4 Credit-Kosten, OpenRouter-gestütztem VM0-Managed-Routing und direktem Z.AI-BYOK-Support.",
+        "summary": "GLM-5.2 ist der aktuelle GLM-Default auf VM0 für Nutzer mit Z.AI-API-Schlüssel und ist über VM0 Managed auch via OpenRouter verfügbar. Es behält das Langkontext-Profil der GLM-Serie bei und wird zur bevorzugten Z.AI-Route für neue Agenten.\n\nNutze es für große Codebasen, umfangreiche Dokumentmengen und kostensensitive Langkontext-Planung, bei der Sonnet-Preise unnötig sind. GLM-5.1 bleibt aus Kompatibilitätsgründen verfügbar, aber neue Z.AI-Routen sollten auf GLM-5.2 starten, sofern kein Workflow speziell gegen 5.1 getunt wurde.",
+        "releaseDate": "Juni 2026",
+        "familyPosition": "Aktuelles Standardmodell in VM0s Z.AI-/GLM-Route.",
         "background": [
-          "GLM-5.2 extends the GLM 5 family as the current Z.AI default exposed by VM0. It is available through VM0 Managed, where VM0 routes to OpenRouter with the upstream id `z-ai/glm-5.2`, and through direct Z.AI API keys using the canonical `glm-5.2` id.",
-          "The route is Anthropic-compatible, so Claude-style agents can keep the same runtime interface. Existing GLM-5.1 agents do not need to migrate immediately, but new Z.AI-backed agents should prefer GLM-5.2.",
-          "On VM0 Managed it sits at x0.4 credits, matching GLM-5.1's cost tier while taking over the Z.AI default slot."
+          "GLM-5.2 erweitert die GLM-5-Familie als aktueller Z.AI-Default auf VM0. Es ist über VM0 Managed verfügbar, wo VM0 mit der Upstream-ID `z-ai/glm-5.2` zu OpenRouter routet, und über direkte Z.AI-API-Schlüssel mit der kanonischen ID `glm-5.2`.",
+          "Die Route ist Anthropic-kompatibel, sodass Claude-artige Agenten dieselbe Runtime-Schnittstelle behalten können. Bestehende GLM-5.1-Agenten müssen nicht sofort migrieren, neue Z.AI-gestützte Agenten sollten aber GLM-5.2 bevorzugen.",
+          "Auf VM0 Managed liegt es bei ×0,4 Credits, also in derselben Kostenstufe wie GLM-5.1, übernimmt aber den Z.AI-Default-Slot."
         ],
-        "architecture": "GLM-5.2 is exposed on VM0 through Anthropic-compatible endpoints. VM0 Managed uses OpenRouter's `z-ai/glm-5.2` id; direct Z.AI BYOK uses `glm-5.2`.",
+        "architecture": "GLM-5.2 wird auf VM0 über Anthropic-kompatible Endpunkte bereitgestellt. VM0 Managed nutzt OpenRouters ID `z-ai/glm-5.2`; direktes Z.AI BYOK nutzt `glm-5.2`.",
         "specs": [
           {
-            "label": "Family",
+            "label": "Familie",
             "value": "GLM-5 series"
           },
           {
-            "label": "Modalities",
-            "value": "Text, code"
+            "label": "Modalitäten",
+            "value": "Text, Code"
           },
           {
-            "label": "Languages",
-            "value": "Multilingual"
+            "label": "Sprachen",
+            "value": "Mehrsprachig"
           },
           {
-            "label": "Context window",
-            "value": "Up to 1M tokens"
+            "label": "Kontextfenster",
+            "value": "Bis zu 1M Token"
           },
           {
             "label": "Prompt caching",
-            "value": "Supported"
+            "value": "Unterstützt"
           },
           {
-            "label": "Available on VM0",
-            "value": "June 2026"
+            "label": "Verfügbar auf VM0",
+            "value": "Juni 2026"
           }
         ],
-        "benchmarksNote": "Treat GLM-5.2 as the preferred GLM route on VM0. Third-party rankings can move quickly, so VM0 keeps the page focused on routing, cost, and operational fit rather than frozen leaderboard percentages.",
+        "benchmarksNote": "Behandle GLM-5.2 als bevorzugte GLM-Route auf VM0. Drittanbieter-Rankings können sich schnell bewegen, daher fokussiert diese Seite auf Routing, Kosten und operativen Fit statt auf eingefrorene Leaderboard-Prozente.",
         "benchmarks": [
           {
-            "name": "Long-context tasks",
-            "score": "Strong fit",
-            "note": "VM0 routing profile"
+            "name": "Langkontext-Aufgaben",
+            "score": "Starker Fit",
+            "note": "VM0-Routingprofil"
           },
           {
-            "name": "Cost tier",
-            "score": "x0.4 credits",
+            "name": "Kostenstufe",
+            "score": "×0,4 Credits",
             "note": "VM0 Managed"
           }
         ],
         "performance": [
           {
-            "title": "Long-context work",
-            "body": "GLM-5.2 is best used when the agent needs a large working set: repositories, documentation folders, design notes, or long research material."
+            "title": "Langkontext-Arbeit",
+            "body": "GLM-5.2 passt am besten, wenn der Agent einen großen Arbeitskontext braucht: Repositories, Dokumentationsordner, Designnotizen oder umfangreiches Recherchematerial."
           },
           {
-            "title": "Cost control",
-            "body": "At x0.4 credits it is a cost-saving alternative to Sonnet-class routes for workflows where context size and price matter more than maximum English reasoning depth."
+            "title": "Kostenkontrolle",
+            "body": "Mit ×0,4 Credits ist es eine kostensparende Alternative zu Sonnet-Routen für Workflows, bei denen Kontextgröße und Preis wichtiger sind als maximale englische Reasoning-Tiefe."
           },
           {
             "title": "Routing",
-            "body": "VM0 Managed routes through OpenRouter using `z-ai/glm-5.2`; direct Z.AI API keys use `glm-5.2`. Both paths keep the Claude-compatible agent interface."
+            "body": "VM0 Managed routet über OpenRouter mit `z-ai/glm-5.2`; direkte Z.AI-API-Schlüssel nutzen `glm-5.2`. Beide Wege behalten die Claude-kompatible Agent-Schnittstelle."
           }
         ],
         "bestForExamples": [
           {
-            "title": "Whole-repo review on a budget",
-            "body": "Use GLM-5.2 when the agent needs to inspect a large codebase and produce concrete file-level recommendations without paying for a premium reasoning model on every pass."
+            "title": "Repository-weite Prüfung mit Budgetgrenze",
+            "body": "Nutze GLM-5.2, wenn der Agent eine große Codebasis prüfen und konkrete Empfehlungen auf Dateiebene liefern soll, ohne bei jedem Durchlauf ein Premium-Reasoning-Modell zu bezahlen."
           },
           {
-            "title": "Large document synthesis",
-            "body": "Load policy documents, tickets, transcripts, or internal docs together and ask for cross-document patterns. The long context and x0.4 multiplier keep repeated runs practical."
+            "title": "Synthese großer Dokumentmengen",
+            "body": "Lade Policies, Tickets, Transkripte oder interne Dokumente gemeinsam und frage nach Mustern über Dokumentgrenzen hinweg. Der lange Kontext und der ×0,4-Multiplikator halten wiederholte Läufe praktikabel."
           },
           {
-            "title": "Z.AI BYOK default route",
-            "body": "Teams using a direct Z.AI API key get GLM-5.2 as the default VM0 model while retaining GLM-5.1 for existing tuned workflows."
+            "title": "Z.AI-BYOK-Standardroute",
+            "body": "Teams mit direktem Z.AI-API-Schlüssel erhalten GLM-5.2 als VM0-Defaultmodell und behalten GLM-5.1 für bestehende getunte Workflows."
           }
         ],
-        "avoidFor": "Skip GLM-5.2 for workflows that depend on vision input, or when maximum English-language reasoning and tool routing quality matter more than context size and cost.",
+        "avoidFor": "Verzichte auf GLM-5.2 bei Workflows, die Bildeingaben benötigen, oder wenn maximale englischsprachige Reasoning- und Tool-Routing-Qualität wichtiger sind als Kontextgröße und Kosten.",
         "comparisons": [
           {
             "vs": "GLM-5.1",
@@ -5380,19 +5380,19 @@
             "body": "DeepSeek V4 Pro liegt beim VM0-Credit-Multiplikator niedriger und ist die stärkere Kosten-zuerst-Reasoning-Wahl. Nutze es, wenn der Preis dominiert; nutze GLM-5.2, wenn Z.AI-Fit oder Langkontext wichtiger sind."
           }
         ],
-        "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
+        "verdict": "Wähle GLM-5.2 als Standardroute für Z.AI auf VM0. Behalte GLM-5.1 nur für Workflows, die bereits darauf abgestimmt sind.",
         "faqs": [
           {
-            "q": "Is GLM-5.2 available through VM0 Managed?",
-            "a": "Yes. VM0 Managed routes GLM-5.2 through OpenRouter with the upstream id `z-ai/glm-5.2`."
+            "q": "Ist GLM-5.2 über VM0 Managed verfügbar?",
+            "a": "Ja. VM0 Managed routet GLM-5.2 über OpenRouter mit der Upstream-ID `z-ai/glm-5.2`."
           },
           {
-            "q": "Is GLM-5.2 the default for direct Z.AI API keys?",
-            "a": "Yes. The Z.AI provider defaults to `glm-5.2` while keeping `glm-5.1` available."
+            "q": "Ist GLM-5.2 der Default für direkte Z.AI-API-Schlüssel?",
+            "a": "Ja. Der Z.AI-Provider nutzt standardmäßig `glm-5.2`, während `glm-5.1` verfügbar bleibt."
           },
           {
-            "q": "Does GLM-5.2 support image input?",
-            "a": "No. VM0 exposes GLM-5.2 for text and code agents. Use Claude Sonnet 4.6 or Kimi K2.7 Code when vision input is required."
+            "q": "Unterstützt GLM-5.2 Bildeingaben?",
+            "a": "Nein. VM0 stellt GLM-5.2 für Text- und Code-Agenten bereit. Nutze Claude Sonnet 4.6 oder Kimi K2.7 Code, wenn Vision-Eingaben erforderlich sind."
           }
         ],
         "alternatives": [
@@ -5409,8 +5409,8 @@
             "reason": "Günstigere Alternative für Standardkontext"
           }
         ],
-        "routingNotes": "On VM0 Managed, GLM-5.2 routes through OpenRouter with the upstream id `z-ai/glm-5.2`. With a Z.AI API key it talks directly to `api.z.ai` as `glm-5.2`. It is the default model on the Z.AI provider.",
-        "vm0Notes": "VM0 sets a 50-minute API timeout for the Z.AI provider, so long-context planning and analysis runs have room to finish."
+        "routingNotes": "Auf VM0 Managed wird GLM-5.2 über OpenRouter mit der Upstream-ID `z-ai/glm-5.2` geroutet. Mit einem Z.AI-API-Schlüssel spricht es direkt als `glm-5.2` mit `api.z.ai`. Es ist das Standardmodell des Z.AI-Providers.",
+        "vm0Notes": "VM0 setzt für den Z.AI-Provider ein API-Timeout von 50 Minuten, damit Langkontext-Planung und Analyse-Läufe genug Zeit zum Abschluss haben."
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -5454,45 +5454,45 @@
             "value": "April 2026"
           }
         ],
-        "benchmarksNote": "Independent reviews place GLM-5.1 in the top tier of open-weight models for long-context tasks. Numbers shift weekly on third-party leaderboards. We deliberately don't pin exact percentages here.",
+        "benchmarksNote": "Unabhängige Reviews platzieren GLM-5.1 in der Spitzengruppe der Open-Weight-Modelle für Langkontext-Aufgaben. Zahlen auf Drittanbieter-Leaderboards verschieben sich wöchentlich, deshalb pinnen wir hier bewusst keine exakten Prozentwerte.",
         "benchmarks": [
           {
             "name": "Code Arena",
             "score": "Top-3 (open weights)",
-            "note": "third-party leaderboard"
+            "note": "Drittanbieter-Leaderboard"
           },
           {
-            "name": "Long-context recall",
-            "score": "Strong across 1M-token window",
-            "note": "vendor-reported"
+            "name": "Langkontext-Recall",
+            "score": "Stark über das 1M-Token-Fenster",
+            "note": "Anbieterangabe"
           }
         ],
         "performance": [
           {
-            "title": "Long-context recall",
-            "body": "GLM-5.1's 1M-token window is genuinely usable. It maintains coherence well past the 200K boundary that limits the Anthropic family on the older 200K models. Useful for whole-repo or whole-doc-corpus agents."
+            "title": "Langkontext-Recall",
+            "body": "Das 1M-Token-Fenster von GLM-5.1 ist wirklich nutzbar. Es hält Kohärenz weit über die 200K-Grenze hinaus, die ältere Anthropic-Modelle limitiert. Nützlich für Agenten, die ganze Repositories oder Dokumentkorpora erfassen müssen."
           },
           {
             "title": "Reasoning",
-            "body": "Solid general reasoning. Below Sonnet 4.6 on the hardest English-language multi-tool routing, but the gap is small relative to the cost difference."
+            "body": "Solides allgemeines Reasoning. Beim schwierigsten englischsprachigen Multi-Tool-Routing liegt es unter Sonnet 4.6, aber der Abstand ist im Verhältnis zum Preisunterschied klein."
           },
           {
-            "title": "Tool use",
-            "body": "Reliable across the common VM0 tool surface (Slack, GitHub, Notion, Linear). Some edge cases in deeply nested tool calls are handled less crisply than Claude Sonnet 4.6."
+            "title": "Tool-Nutzung",
+            "body": "Zuverlässig auf der üblichen VM0-Tool-Oberfläche (Slack, GitHub, Notion, Linear). Einige Randfälle mit tief verschachtelten Tool-Calls werden weniger präzise gehandhabt als bei Claude Sonnet 4.6."
           }
         ],
         "bestForExamples": [
           {
-            "title": "The whole-repo refactor that fits in one prompt",
-            "body": "Drop a 500K-token mid-sized codebase into a single GLM-5.1 call and ask for a cross-file rename, an architectural review, or a security pass. Models with smaller windows force you to chunk the repo and stitch results together, which is where bugs creep in. GLM-5.1 keeps every file in working memory and references the right paths in its output."
+            "title": "Der Whole-Repo-Refactor, der in einen Prompt passt",
+            "body": "Gib eine mittelgroße Codebasis mit 500K Token in einen einzigen GLM-5.1-Aufruf und bitte um ein dateiübergreifendes Rename, ein Architektur-Review oder einen Security-Pass. Modelle mit kleineren Fenstern zwingen dich zum Chunking und Zusammenführen, genau dort schleichen sich Bugs ein. GLM-5.1 hält jede Datei im Arbeitskontext und referenziert die richtigen Pfade in der Ausgabe."
           },
           {
-            "title": "The research run over hundreds of documents",
-            "body": "Wikis, RFCs, contracts, last year's support tickets — load the whole pile at once and ask for cross-document patterns. The cost-per-run stays manageable because of the low vendor price, which is what makes this kind of \"read everything, summarise once\" workflow actually affordable in production rather than a one-off science project."
+            "title": "Der Recherche-Lauf über Hunderte Dokumente",
+            "body": "Wikis, RFCs, Verträge, Support-Tickets aus dem letzten Jahr: Lade alles auf einmal und frage nach dokumentübergreifenden Mustern. Die Kosten pro Lauf bleiben wegen des niedrigen Anbieterpreises kontrollierbar, was diesen \"alles lesen, einmal zusammenfassen\"-Workflow produktionstauglich statt zu einem einmaligen Experiment macht."
           },
           {
-            "title": "The thinking job that needs more than ten minutes",
-            "body": "Some agent steps genuinely take five to thirty minutes — deep research, multi-document analysis, long planning passes. VM0 sets a 50-minute API timeout for the Z.AI provider so those long thinking steps don't get cut off mid-thought, which makes GLM-5.1 the safe pick over models routed through providers with shorter default timeouts."
+            "title": "Der Denkjob, der mehr als zehn Minuten braucht",
+            "body": "Manche Agent-Schritte dauern tatsächlich fünf bis dreißig Minuten: tiefe Recherche, Multi-Dokument-Analyse, lange Planungsphasen. VM0 setzt für den Z.AI-Provider ein API-Timeout von 50 Minuten, damit diese langen Denkschritte nicht mitten im Gedankengang abbrechen. Das macht GLM-5.1 zur sicheren Wahl gegenüber Modellen mit kürzeren Provider-Defaults."
           }
         ],
         "avoidFor": "Verzichte auf GLM-5.1 bei schwierigstem englischsprachigem Reasoning, wo Sonnet 4.6 oder Opus 4.7 weiterhin führen, und bei latenzkritischen Chat-Antworten, bei denen Kimi K2.7 Code deutlich schneller ist.",
@@ -5503,29 +5503,29 @@
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 (×1) leads on tool-routing accuracy and English-language reasoning. GLM-5.1 (×0.4) leads on context window and is the right pick when cost or context size dominates the decision."
+            "body": "Sonnet 4.6 (×1) führt bei Tool-Routing-Genauigkeit und englischsprachigem Reasoning. GLM-5.1 (×0,4) führt beim Kontextfenster und ist die richtige Wahl, wenn Kosten oder Kontextgröße die Entscheidung dominieren."
           },
           {
             "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro (×0.1) is cheaper and benchmarks higher on Code Arena per third-party reviews. GLM-5.1 still wins on context size. Pick DeepSeek for cost-sensitive standard-context work; pick GLM-5.1 when context size is the constraint."
+            "body": "DeepSeek V4 Pro (×0,1) ist günstiger und liegt laut Drittanbieter-Reviews auf Code Arena höher. GLM-5.1 gewinnt weiterhin bei der Kontextgröße. Wähle DeepSeek für kostensensitive Standardkontext-Arbeit; wähle GLM-5.1, wenn die Kontextgröße die Einschränkung ist."
           }
         ],
         "verdict": "GLM-5.1 ist eine solide kosteneffiziente Wahl für text- und codebasierte Aufgaben. Erwäge es, wenn du eine günstigere Alternative zu Claude Sonnet 4.6 suchst und keine Bildeingabe benötigst.",
         "faqs": [
           {
-            "q": "How big is GLM-5.1's context window on VM0?",
-            "a": "Up to 1 million tokens. The largest in our Built-in lineup. Enough to fit a mid-sized repository or several hundred documents in a single prompt."
+            "q": "Wie groß ist GLM-5.1s Kontextfenster auf VM0?",
+            "a": "Bis zu 1 Million Token. Das größte Fenster in unserem Built-in-Katalog. Groß genug, um ein mittelgroßes Repository oder mehrere Hundert Dokumente in einen einzelnen Prompt zu packen."
           },
           {
-            "q": "Which provider should I use for GLM-5.1?",
-            "a": "VM0 Managed is the simplest path. If you want vendor-direct billing, connect a Z.AI API key."
+            "q": "Welchen Provider sollte ich für GLM-5.1 verwenden?",
+            "a": "VM0 Managed ist der einfachste Weg. Wenn du direkt beim Anbieter abrechnen willst, verbinde einen Z.AI-API-Schlüssel."
           },
           {
-            "q": "Is GLM-5.1 open weights?",
-            "a": "Z.AI publishes open-weight variants of the GLM series. The version exposed on VM0 routes to the Z.AI hosted API for production reliability."
+            "q": "Ist GLM-5.1 Open Weight?",
+            "a": "Z.AI veröffentlicht Open-Weight-Varianten der GLM-Serie. Die auf VM0 bereitgestellte Version routet aus Gründen der Produktionszuverlässigkeit zur gehosteten Z.AI-API."
           },
           {
-            "q": "Does GLM-5.1 support image input?",
+            "q": "Unterstützt GLM-5.1 Bildeingaben?",
             "a": "GLM-5.1 wird auf VM0 für Text und Code bereitgestellt. Für multimodale Eingaben (Bild/Video) wähle Claude Sonnet 4.6 oder Kimi K2.7 Code."
           }
         ],
@@ -5547,8 +5547,8 @@
             "reason": "Stärkeres Reasoning, wenn Kosten nicht die Einschränkung sind"
           }
         ],
-        "routingNotes": "On VM0 Managed, GLM-5.1 is routed through OpenRouter with the upstream id `z-ai/glm-5.1`. With a Z.AI API key it talks to `api.z.ai`'s Anthropic-compatible endpoint directly. GLM-5.2 is now the default model on the Z.AI provider.",
-        "vm0Notes": "VM0 sets a 50-minute API timeout for the Z.AI provider so long thinking steps complete reliably without dropping, and pairs the model's 1M-token context with high-volume document agents that need the room."
+        "routingNotes": "Auf VM0 Managed wird GLM-5.1 über OpenRouter mit der Upstream-ID `z-ai/glm-5.1` geroutet. Mit einem Z.AI-API-Schlüssel spricht es direkt mit dem Anthropic-kompatiblen Endpunkt von `api.z.ai`. GLM-5.2 ist jetzt das Standardmodell des Z.AI-Providers.",
+        "vm0Notes": "VM0 setzt für den Z.AI-Provider ein API-Timeout von 50 Minuten, damit lange Denkschritte zuverlässig abschließen, und kombiniert das 1M-Token-Kontextfenster mit dokumentlastigen Agenten, die diesen Raum brauchen."
       },
       "gpt-5-4-mini": {
         "name": "GPT-5.4 Mini",
@@ -5895,7 +5895,7 @@
         "background": [
           "DeepSeek V4 Pro ist das Flaggschiff der DeepSeek-V4-Generation, veröffentlicht am 24. April 2026 unter der MIT-Lizenz. Es ist ein Open-Weight-Mixture-of-Experts-Modell mit 1,6T Gesamtparametern und 49B aktiven Parametern pro Token.",
           "V4 Pro unterstützt ein 1M-Token-Kontextfenster, 384K maximale Ausgabe, drei Reasoning-Effort-Modi (standard, think, think-max), JSON-Ausgabe, Tool Calls und FIM-Completion im Non-Think-Modus. Das Pro-Modell ergänzt eine hybride Attention-Architektur (Compressed Sparse Attention + Heavily Compressed Attention) für deutlich effizienteren Langkontext. 27% Single-Token-Inferenz-FLOPs und 10% KV-Cache gegenüber DeepSeek V3.2 bei 1M Kontext.",
-          "DeepSeek made waves through 2025 by delivering Anthropic-grade reasoning at a fraction of the price. V4 Pro continues that pattern: vendor-reported SWE-bench Verified 80.6% sits within 0.2 points of Claude Opus 4.6, at roughly one-seventh the vendor cost. On VM0 it's exposed via the DeepSeek API-key provider and on VM0 Managed at ×0.1. Lower multiplier than Kimi K2.7 Code, with substantially stronger reasoning behaviour."
+          "DeepSeek sorgte 2025 für Aufmerksamkeit, weil es Reasoning auf Anthropic-Niveau zu einem Bruchteil des Preises lieferte. V4 Pro setzt dieses Muster fort: Der vom Anbieter gemeldete SWE-bench Verified-Wert von 80,6% liegt nur 0,2 Punkte von Claude Opus 4.6 entfernt, bei ungefähr einem Siebtel der Anbieter-Kosten. Auf VM0 ist es über den DeepSeek-API-Key-Provider und VM0 Managed bei ×0,1 verfügbar. Der Multiplikator liegt unter Kimi K2.7 Code, bei deutlich stärkerem Reasoning-Verhalten."
         ],
         "architecture": "",
         "specs": [
@@ -5932,7 +5932,7 @@
             "value": "24. April 2026"
           }
         ],
-        "benchmarksNote": "Vendor-reported scores from DeepSeek's V4 Pro release. Independent reviews (Geeky Gadgets, Code Arena) place V4 Pro third on Code Arena behind GLM-5.1 and Kimi K2.7 Code. The strongest benchmark claims come from DeepSeek's own materials. Treat directionally rather than as absolute truth.",
+        "benchmarksNote": "Vom Anbieter gemeldete Werte aus DeepSeeks V4-Pro-Release. Unabhängige Reviews (Geeky Gadgets, Code Arena) platzieren V4 Pro auf Code Arena hinter GLM-5.1 und Kimi K2.7 Code auf Rang drei. Die stärksten Benchmark-Claims stammen aus DeepSeeks eigenen Materialien; behandle sie als Richtungssignal, nicht als absolute Wahrheit.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -5989,7 +5989,7 @@
           },
           {
             "title": "Speed",
-            "body": "Around 36 tokens/sec at max effort per Artificial Analysis. Slower than Kimi K2.7 Code, slightly slower than Opus 4.6."
+            "body": "Laut Artificial Analysis etwa 36 Token/Sekunde bei maximalem Effort. Langsamer als Kimi K2.7 Code und etwas langsamer als Opus 4.6."
           }
         ],
         "bestForExamples": [
@@ -6059,88 +6059,88 @@
       },
       "minimax-m3": {
         "name": "MiniMax M3",
-        "pageTitle": "MiniMax M3 on VM0. Official MiniMax coding model at ×0.2",
-        "tagline": "Official MiniMax M3 routing for coding agents, 1M context, and native multimodal understanding.",
-        "cardIntro": "Official MiniMax M3 routing for coding agents with 1M context, prompt cache reads, and a ×0.2 VM0 multiplier.",
-        "metaTitle": "MiniMax M3 on VM0: Pricing, Specs & Official Routing",
-        "metaDescription": "MiniMax M3 review on VM0. Official MiniMax coding model with 1M context, multimodal understanding, prompt cache reads, and ×0.2 credits.",
-        "summary": "MiniMax M3 is MiniMax's frontier coding and agentic model, exposed on VM0 through the official MiniMax Anthropic-compatible endpoint. It is the right MiniMax choice when an agent needs stronger coding, tool use, long-context reasoning, and native vision understanding than the retained M2 series.\n\nVM0 prices M3 from MiniMax's standard non-promotional pay-as-you-go tier for the base context band: $0.60 / $2.40 per 1M tokens, with prompt cache reads at $0.12 / 1M and no separate cache-write billing in the M3 table. MiniMax M2.1 remains available for lower-cost compatibility, while M3 is the default MiniMax BYOK model.",
-        "releaseDate": "June 1, 2026",
-        "familyPosition": "Official MiniMax M3 text model alongside the retained M2 series.",
+        "pageTitle": "MiniMax M3 auf VM0. Offizielles MiniMax-Coding-Modell bei ×0,2",
+        "tagline": "Offizielles MiniMax-M3-Routing für Coding-Agenten, 1M Kontext und native multimodale Verarbeitung.",
+        "cardIntro": "Offizielles MiniMax-M3-Routing für Coding-Agenten mit 1M Kontext, Prompt-Cache-Reads und ×0,2 VM0-Multiplikator.",
+        "metaTitle": "MiniMax M3 auf VM0: Preise, Spezifikationen & offizielles Routing",
+        "metaDescription": "MiniMax M3 auf VM0. Offizielles MiniMax-Coding-Modell mit 1M Kontext, multimodalem Verständnis, Prompt-Cache-Reads und ×0,2 Credits.",
+        "summary": "MiniMax M3 ist MiniMaxs Frontier-Modell für Coding und agentische Arbeit, auf VM0 über den offiziellen Anthropic-kompatiblen MiniMax-Endpunkt bereitgestellt. Es ist die richtige MiniMax-Wahl, wenn ein Agent stärkeres Coding, Tool-Use, Langkontext-Reasoning und natives Vision-Verständnis braucht als die beibehaltene M2-Serie.\n\nVM0 bepreist M3 anhand von MiniMaxs nicht-promotionaler Standard-Pay-as-you-go-Stufe für das Basiskontextband: $0.60 / $2.40 pro 1M Token, mit Prompt-Cache-Reads bei $0.12 / 1M und ohne separate Cache-Write-Abrechnung in der M3-Tabelle. MiniMax M2.1 bleibt für günstigere Kompatibilität verfügbar, während M3 das Standardmodell für MiniMax BYOK ist.",
+        "releaseDate": "1. Juni 2026",
+        "familyPosition": "Offizielles MiniMax-M3-Textmodell neben der beibehaltenen M2-Serie.",
         "background": [
-          "MiniMax M3 is the new official MiniMax text model for coding and agentic workloads. MiniMax describes it as combining frontier coding capability, a 1M-token context window, and native multimodal understanding.",
-          "On VM0, M3 is added to the existing MiniMax API-key provider instead of creating a new integration. It uses the same `api.minimax.io/anthropic` routing surface and the same `MINIMAX_API_KEY` secret as M2.",
-          "The existing M2 entries stay available, while M3 is the MiniMax provider default for new selections."
+          "MiniMax M3 ist das neue offizielle MiniMax-Textmodell für Coding- und Agent-Workloads. MiniMax beschreibt es als Kombination aus Frontier-Coding-Fähigkeit, 1M-Token-Kontextfenster und nativem multimodalem Verständnis.",
+          "Auf VM0 wird M3 dem bestehenden MiniMax-API-Key-Provider hinzugefügt, statt eine neue Integration anzulegen. Es nutzt dieselbe Routing-Oberfläche `api.minimax.io/anthropic` und dasselbe Secret `MINIMAX_API_KEY` wie M2.",
+          "Die bestehenden M2-Einträge bleiben verfügbar, während M3 für neue Auswahlen der Default des MiniMax-Providers ist."
         ],
-        "architecture": "M3 uses MiniMax Sparse Attention for ultra-long context. The official API supports up to 1M tokens with a 512K guaranteed minimum, automatic prompt cache support, and native multimodal understanding.",
+        "architecture": "M3 nutzt MiniMax Sparse Attention für Ultra-Langkontext. Die offizielle API unterstützt bis zu 1M Token mit 512K garantierter Mindestgröße, automatische Prompt-Cache-Unterstützung und natives multimodales Verständnis.",
         "specs": [
           {
-            "label": "Family",
+            "label": "Familie",
             "value": "MiniMax M3"
           },
           {
-            "label": "Modalities",
-            "value": "Text, vision, code"
+            "label": "Modalitäten",
+            "value": "Text, Vision, Code"
           },
           {
-            "label": "Languages",
-            "value": "Multilingual"
+            "label": "Sprachen",
+            "value": "Mehrsprachig"
           },
           {
-            "label": "Context window",
-            "value": "1M tokens (512K guaranteed minimum)"
+            "label": "Kontextfenster",
+            "value": "1M Token (512K garantiertes Minimum)"
           },
           {
             "label": "Prompt caching",
-            "value": "Supported with automatic cache reads"
+            "value": "Unterstützt mit automatischen Cache-Reads"
           },
           {
-            "label": "Available on VM0",
-            "value": "June 1, 2026"
+            "label": "Verfügbar auf VM0",
+            "value": "1. Juni 2026"
           }
         ],
-        "benchmarksNote": "MiniMax positions M3 around coding, agentic tasks, and long-horizon execution. Treat these as vendor-reported signals and validate against your own VM0 agent regression set.",
+        "benchmarksNote": "MiniMax positioniert M3 für Coding, agentische Aufgaben und Langhorizont-Ausführung. Behandle diese Angaben als Anbieter-Signale und validiere sie gegen dein eigenes VM0-Agent-Regression-Set.",
         "benchmarks": [
           {
             "name": "PostTrainBench Live",
-            "score": "Rank #3",
-            "note": "vendor reported"
+            "score": "Rang #3",
+            "note": "Anbieterangabe"
           },
           {
             "name": "BrowseComp",
             "score": "83.5",
-            "note": "vendor reported"
+            "note": "Anbieterangabe"
           }
         ],
         "performance": [
           {
-            "title": "Coding agents",
-            "body": "The best MiniMax option for coding assistants, long tool chains, and multi-step repository work."
+            "title": "Coding-Agenten",
+            "body": "Die beste MiniMax-Option für Coding-Assistenten, lange Tool-Ketten und mehrstufige Repository-Arbeit."
           },
           {
-            "title": "Long context",
-            "body": "A 1M context window lets agents keep large documents, code, logs, and previous work in scope without switching model families."
+            "title": "Langkontext",
+            "body": "Ein 1M-Kontextfenster hält große Dokumente, Code, Logs und frühere Arbeit im Scope, ohne die Modellfamilie zu wechseln."
           },
           {
             "title": "Multimodal",
-            "body": "Native vision understanding makes M3 a better fit than M2 when screenshots, diagrams, or visual artifacts are part of the workflow."
+            "body": "Natives Vision-Verständnis macht M3 geeigneter als M2, wenn Screenshots, Diagramme oder visuelle Artefakte Teil des Workflows sind."
           }
         ],
         "bestForExamples": [
           {
-            "title": "The coding agent that must stay on MiniMax",
-            "body": "Repository edits, debugging, and agentic coding flows where your deployment already uses MiniMax keys but needs a stronger coding model than M2.1."
+            "title": "Der Coding-Agent, der bei MiniMax bleiben muss",
+            "body": "Repository-Edits, Debugging und agentische Coding-Flows, bei denen dein Deployment bereits MiniMax-Keys nutzt, aber ein stärkeres Coding-Modell als M2.1 braucht."
           },
           {
-            "title": "The long-context review run",
-            "body": "Large pull requests, logs, notebooks, or design documents that should stay in one model context while the agent reasons and edits."
+            "title": "Der Review-Lauf mit Langkontext",
+            "body": "Große Pull Requests, Logs, Notebooks oder Designdokumente, die in einem Modellkontext bleiben sollen, während der Agent denkt und editiert."
           },
           {
-            "title": "The multimodal investigation",
-            "body": "Workflows that mix text with screenshots or diagrams. M3 is marked image-input capable on VM0, while the M2 entries stay text/code only."
+            "title": "Die multimodale Untersuchung",
+            "body": "Workflows, die Text mit Screenshots oder Diagrammen mischen. M3 ist auf VM0 als bildeingabefähig markiert, während die M2-Einträge bei Text/Code bleiben."
           }
         ],
-        "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
+        "avoidFor": "Verzichte auf M3, wenn du die absolut niedrigsten MiniMax-Kosten brauchst und textbasiertes M2.1 bereits genügt, oder wenn du OpenRouter-/Vercel-Routing brauchst, denn dieser VM0-Eintrag nutzt bewusst nur den offiziellen MiniMax-Pfad.",
         "comparisons": [
           {
             "vs": "Kimi K2.7 Code",
@@ -6155,19 +6155,19 @@
             "body": "GLM-5.2 ist die aktuelle Z.AI-Standardroute auf VM0. Es ist der bessere Vergleich für neue Z.AI-gestützte Agenten; GLM-5.1 bleibt nur für getunte Workflows aus Kompatibilitätsgründen verfügbar."
           }
         ],
-        "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
+        "verdict": "Nutze MiniMax M3, wenn du das offizielle MiniMax-Coding-Modell mit Langkontext und Vision-Support willst. Behalte M2.1, wenn Kosten und Kompatibilität wichtiger sind.",
         "faqs": [
           {
-            "q": "Is MiniMax M2.1 still available?",
-            "a": "Yes. VM0 keeps MiniMax M2.1 in the direct MiniMax provider. M3 is now the default MiniMax BYOK model."
+            "q": "Ist MiniMax M2.1 weiterhin verfügbar?",
+            "a": "Ja. VM0 behält MiniMax M2.1 im direkten MiniMax-Provider. M3 ist jetzt das Standardmodell für MiniMax BYOK."
           },
           {
-            "q": "Does VM0 route MiniMax M3 through OpenRouter or Vercel?",
-            "a": "No. This entry intentionally uses only the official MiniMax Anthropic-compatible endpoint."
+            "q": "Routet VM0 MiniMax M3 über OpenRouter oder Vercel?",
+            "a": "Nein. Dieser Eintrag nutzt bewusst nur den offiziellen Anthropic-kompatiblen MiniMax-Endpunkt."
           },
           {
-            "q": "Which M3 pricing tier does VM0 show?",
-            "a": "The VM0 model page and usage seed use MiniMax's non-promotional standard base tier. MiniMax also documents a higher standard tier for input above 512K tokens."
+            "q": "Welche M3-Preisstufe zeigt VM0?",
+            "a": "Die VM0-Modellseite und der Usage-Seed nutzen MiniMaxs nicht-promotionale Standard-Basisstufe. MiniMax dokumentiert außerdem eine höhere Standardstufe für Eingaben über 512K Token."
           }
         ],
         "alternatives": [
@@ -6180,8 +6180,8 @@
             "reason": "Zuverlässigere Basislinie für komplexe Tool-Nutzung"
           }
         ],
-        "routingNotes": "Routed through MiniMax's official Anthropic-compatible endpoint at `api.minimax.io`. Available on VM0 Managed and MiniMax API-key providers only.",
-        "vm0Notes": "VM0 maps `MiniMax-M3` to the existing MiniMax vendor key pool for Built-in routing. The direct MiniMax provider uses M3 as its default model while keeping M2.1 selectable."
+        "routingNotes": "Geroutet über MiniMaxs offiziellen Anthropic-kompatiblen Endpunkt unter `api.minimax.io`. Nur über VM0 Managed und MiniMax-API-Key-Provider verfügbar.",
+        "vm0Notes": "VM0 mappt `MiniMax-M3` für Built-in-Routing auf den bestehenden MiniMax-Vendor-Key-Pool. Der direkte MiniMax-Provider nutzt M3 als Defaultmodell und hält M2.1 auswählbar."
       },
       "gpt-image-2": {
         "name": "GPT Image 2",

--- a/turbo/apps/web/messages/en.json
+++ b/turbo/apps/web/messages/en.json
@@ -2380,7 +2380,7 @@
           },
           {
             "name": "Zero",
-            "text": "**Cost Optimization Audit - This Week**\n\n🟢 **Already optimal** (keep as-is):\n• morning-brief (Sonnet) - multi-source aggregation, justified\n• pr-review-merge (Sonnet) - code review when triggered, justified\n\n🟡 **Over-provisioned** (safe to downgrade):\n| Task | Current Model | Recommended | Est. Savings |\n|------|--------------|-------------|-------------|\n| tech-debt-scan | Opus | GLM-5.1 | ~5-10x |\n| merge-queue-monitor | Sonnet | GLM-5.1 | ~3x |\n| standup-summary | Sonnet | GPT-4o mini | ~4x |\n| daily-email-check | Sonnet | GPT-4o mini | ~4x |\n\n🔴 **Needs human review**:\n• auto-test-coverage - writes real code, borderline. Try Sonnet for a week and compare pass rates.\n\n**Estimated monthly savings: $2,400-3,800**"
+            "text": "**Cost Optimization Audit - This Week**\n\n🟢 **Already optimal** (keep as-is):\n• morning-brief (Sonnet) - multi-source aggregation, justified\n• pr-review-merge (Sonnet) - code review when triggered, justified\n\n🟡 **Over-provisioned** (safe to downgrade):\n| Task | Current Model | Recommended | Est. Savings |\n|------|--------------|-------------|-------------|\n| tech-debt-scan | Opus | GLM-5.2 | ~5-10x |\n| merge-queue-monitor | Sonnet | GLM-5.2 | ~3x |\n| standup-summary | Sonnet | GPT-4o mini | ~4x |\n| daily-email-check | Sonnet | GPT-4o mini | ~4x |\n\n🔴 **Needs human review**:\n• auto-test-coverage - writes real code, borderline. Try Sonnet for a week and compare pass rates.\n\n**Estimated monthly savings: $2,400-3,800**"
           }
         ],
         "steps": [
@@ -2401,12 +2401,12 @@
           {
             "title": "Switch a low-risk task to a cheaper model",
             "description": "Start with the safest recommendation and verify quality holds.",
-            "examplePrompt": "@Zero switch the merge-queue-monitor schedule to use GLM-5.1 instead of Sonnet"
+            "examplePrompt": "@Zero switch the merge-queue-monitor schedule to use GLM-5.2 instead of Sonnet"
           },
           {
             "title": "Run a comparison test",
             "description": "Run the same task on both models and compare outputs before committing.",
-            "examplePrompt": "@Zero run the tech-debt-scan prompt on both Opus and GLM-5.1, then compare the results side by side"
+            "examplePrompt": "@Zero run the tech-debt-scan prompt on both Opus and GLM-5.2, then compare the results side by side"
           },
           {
             "title": "Make it routine",
@@ -4343,7 +4343,7 @@
             "body": "Fast mode at 2.5× speed used to cost three times what it does now ($10/$50 per 1M vs the prior tier). For interactive copilots, on-call summarisers, or any step where wall-clock latency dominates the experience, fast-mode 4.8 is now the default choice in the Claude family."
           }
         ],
-        "avoidFor": "Skip Opus 4.8 on high-volume routine work where Sonnet 4.6 hits the same quality bar at a fraction of the cost, on latency-critical chat replies where Kimi K2.6 is much faster, on agentic terminal coding where GPT-5.5 still leads Terminal-Bench 2.1 (78.2% vs 4.8's 74.6%), and on pipelines that ingest untrusted input without sandboxing — 4.8's prompt-injection robustness is slightly weaker than 4.7's.",
+        "avoidFor": "Skip Opus 4.8 on high-volume routine work where Sonnet 4.6 hits the same quality bar at a fraction of the cost, on latency-critical chat replies where Kimi K2.7 Code is much faster, on agentic terminal coding where GPT-5.5 still leads Terminal-Bench 2.1 (78.2% vs 4.8's 74.6%), and on pipelines that ingest untrusted input without sandboxing — 4.8's prompt-injection robustness is slightly weaker than 4.7's.",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -4533,11 +4533,11 @@
           },
           {
             "title": "Speed",
-            "body": "Slower than Sonnet 4.6 and noticeably slower than Kimi K2.6. Anthropic publishes ~41 tokens/sec at max effort for Opus 4.6, and 4.7 is in a similar range. Reserve it for the steps that actually need the extra reasoning depth and run lighter tiers in parallel."
+            "body": "Slower than Sonnet 4.6 and noticeably slower than Kimi K2.7 Code. Anthropic publishes ~41 tokens/sec at max effort for Opus 4.6, and 4.7 is in a similar range. Reserve it for the steps that actually need the extra reasoning depth and run lighter tiers in parallel."
           },
           {
             "title": "Hallucination behaviour",
-            "body": "Opus 4.7 retains Anthropic's conservative refusal posture and tends to admit uncertainty rather than confabulate, which is the reason production teams keep paying the premium for high-stakes reasoning despite cheaper open-weight alternatives like Kimi K2.6 and DeepSeek V4 Pro now matching it on benchmarks."
+            "body": "Opus 4.7 retains Anthropic's conservative refusal posture and tends to admit uncertainty rather than confabulate, which is the reason production teams keep paying the premium for high-stakes reasoning despite cheaper open-weight alternatives like Kimi K2.7 Code and DeepSeek V4 Pro now matching it on benchmarks."
           }
         ],
         "bestForExamples": [
@@ -4558,8 +4558,12 @@
             "body": "Ask Opus 4.7 to migrate a 50-file codebase from one ORM to another, refactor a tangled module, or apply a security fix across the repo. The patch applies cleanly on the first attempt more often than any other model in the family, which is what vendor-reported Terminal-Bench 2.0 reflects, and what your CI bill will reflect too."
           }
         ],
-        "avoidFor": "Skip Opus 4.7 on high-volume routine work where Sonnet 4.6 hits the same quality bar at a fraction of the cost, on latency-sensitive chat replies where Kimi K2.6 is much faster, and on bulk classification or extraction jobs where GPT-5.4 Mini is the cheaper supported bulk option.",
+        "avoidFor": "Skip Opus 4.7 on high-volume routine work where Sonnet 4.6 hits the same quality bar at a fraction of the cost, on latency-sensitive chat replies where Kimi K2.7 Code is much faster, and on bulk classification or extraction jobs where GPT-5.4 Mini is the cheaper supported bulk option.",
         "comparisons": [
+          {
+            "vs": "Claude Opus 4.8",
+            "body": "Opus 4.8 is the newer flagship at the same VM0 multiplier. Use 4.8 for new high-stakes agents; keep 4.7 only when an existing workflow has been validated against it and stability matters more than the latest benchmark gains."
+          },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet 4.6 is the workhorse default in the Claude family and the right pick for most agents. Promote to Opus 4.7 only when Sonnet visibly fails on hard reasoning, long context, or first-attempt code edits, usually as the orchestrator that delegates downward to Sonnet- or cost-saving sub-agents."
@@ -4569,16 +4573,12 @@
             "body": "Same context window (1M tokens), same vendor pricing, and the same adaptive-thinking architecture. Opus 4.7 is the newer generation with vendor-reported gains across SWE-bench Verified, Terminal-Bench 2.0, ARC AGI 2, and OSWorld. Pick 4.7 for new agents; pin 4.6 only when an existing agent has been validated against that version and you need behaviour stability."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Moonshot's Kimi K2.6 leads several agentic benchmarks at the open-source frontier (vendor-reported SWE-bench Pro 58.6 versus Opus 4.6's 53.4). Opus 4.7 retains the lead on tool-routing reliability for production English-language agents and on safety profile, which is why most enterprise teams still keep it as the high-stakes tier."
+            "vs": "Kimi K2.7 Code",
+            "body": "Moonshot's Kimi K2.7 Code leads several agentic benchmarks at the open-source frontier (vendor-reported SWE-bench Pro 58.6 versus Opus 4.6's 53.4). Opus 4.7 retains the lead on tool-routing reliability for production English-language agents and on safety profile, which is why most enterprise teams still keep it as the high-stakes tier."
           },
           {
             "vs": "DeepSeek V4 Pro",
             "body": "DeepSeek V4 Pro trails Opus on most reasoning benchmarks but matches it on coding (vendor-reported SWE-bench Verified within ~0.2 points). The split is straightforward: pick DeepSeek when raw cost dominates, pick Opus 4.7 when reliability, safety profile, or tool-routing accuracy matter more than per-call price."
-          },
-          {
-            "vs": "GPT-5.2 / Gemini 3 Pro",
-            "body": "Anthropic's vendor materials position Opus 4.7 ahead of GPT-5.2 on most agentic-coding tasks (Terminal-Bench, τ2-bench Retail) and within a few points of Gemini 3 Pro on abstract reasoning (ARC AGI 2, GPQA Diamond). Independent leaderboards corroborate the rough ordering but shift weekly."
           }
         ],
         "verdict": "Opus 4.7 is the escalation tier. Default to Sonnet 4.6; promote to Opus only on the specific steps where Sonnet visibly fails.",
@@ -4606,16 +4606,16 @@
         ],
         "alternatives": [
           {
+            "slug": "claude-opus-4-8",
+            "reason": "Newer flagship for high-stakes agents"
+          },
+          {
             "slug": "claude-sonnet-4-6",
             "reason": "Cheaper default for most agent loops"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Stronger long-context recall at lower cost"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Cost-optimised reasoning if Claude is overkill"
+            "slug": "kimi-k2-7-code",
+            "reason": "Cost-saving open-weight coding alternative"
           }
         ],
         "routingNotes": "On VM0, Opus 4.7 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code.",
@@ -4714,7 +4714,7 @@
           },
           {
             "title": "Speed",
-            "body": "Slower than Sonnet 4.6 and Kimi K2.6; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
+            "body": "Slower than Sonnet 4.6 and Kimi K2.7 Code; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
           }
         ],
         "bestForExamples": [
@@ -4738,8 +4738,8 @@
             "body": "Sonnet 4.6 is ×1 and handles most agent loops. Reach for Opus only when Sonnet visibly fails. Usually for orchestration or hard code edits."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Kimi K2.6 (×0.3) edges Opus 4.6 on SWE-bench Pro (58.6 vs 53.4 vendor-reported) and is much cheaper. Opus 4.6 retains the safety-profile advantage and is the default Western enterprise pick."
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 Code (×0.3) edges Opus 4.6 on SWE-bench Pro (58.6 vs 53.4 vendor-reported) and is much cheaper. Opus 4.6 retains the safety-profile advantage and is the default Western enterprise pick."
           }
         ],
         "verdict": "Pin if you've already validated against it; otherwise start on Opus 4.7. The migration is a setting change, not a rewrite.",
@@ -4758,7 +4758,7 @@
           },
           {
             "q": "Why is Opus 4.6 the default on the Anthropic API key provider?",
-            "a": "Historical default from before Opus 4.7 launched. You can switch any agent to Opus 4.7, Sonnet 4.6, or Kimi K2.6 in VM0 Settings → Model Providers without changing the API key."
+            "a": "Historical default from before Opus 4.7 launched. You can switch any agent to Opus 4.7, Sonnet 4.6, or Kimi K2.7 Code in VM0 Settings → Model Providers without changing the API key."
           },
           {
             "q": "What's adaptive thinking?",
@@ -4775,7 +4775,7 @@
             "reason": "Sonnet baseline at much lower cost"
           },
           {
-            "slug": "kimi-k2-6",
+            "slug": "kimi-k2-7-code",
             "reason": "Cheaper open-weight alternative on agentic benchmarks"
           }
         ],
@@ -4972,7 +4972,7 @@
         "cardIntro": "The default for most VM0 agents. Strong tool-routing accuracy, good long-context behaviour, and the credit baseline. Every other model is priced relative to Sonnet 4.6.",
         "metaTitle": "Claude Sonnet 4.6 on VM0: Benchmarks, Pricing & Use Cases",
         "metaDescription": "Claude Sonnet 4.6 is the default model on VM0. ×1 credit baseline, 1M context, $3/$15 pricing, SWE-bench Verified 77%. The agent tasks it handles best.",
-        "summary": "Claude Sonnet 4.6 is the workhorse of the Claude 4 family and the default Built-in model on VM0. It picks the right tool with the right arguments more reliably than anything cheaper, stays coherent across hundred-thousand-token conversations, and most production agents — Slack triage, GitHub PR review, customer support — never need to be promoted past it.\n\nVendor list price is $3 / $15 per 1M tokens, with cached input dropping to $0.30 / 1M. Reach for Opus only when Sonnet visibly fails on the hardest reasoning, and for Kimi K2.6 or GPT-5.4 Mini when unit cost dominates.",
+        "summary": "Claude Sonnet 4.6 is the workhorse of the Claude 4 family and the default Built-in model on VM0. It picks the right tool with the right arguments more reliably than anything cheaper, stays coherent across hundred-thousand-token conversations, and most production agents — Slack triage, GitHub PR review, customer support — never need to be promoted past it.\n\nVendor list price is $3 / $15 per 1M tokens, with cached input dropping to $0.30 / 1M. Reach for Opus only when Sonnet visibly fails on the hardest reasoning, and for Kimi K2.7 Code or GPT-5.4 Mini when unit cost dominates.",
         "releaseDate": "February 2026 (Claude 4.6 generation)",
         "familyPosition": "Mid-tier of the Claude 4 family. Anthropic's workhorse model, sitting between cost-saving models and Opus.",
         "background": [
@@ -5040,7 +5040,7 @@
           },
           {
             "title": "Speed",
-            "body": "Faster than Opus and slower than Kimi K2.6. The right speed/quality balance for production agents."
+            "body": "Faster than Opus and slower than Kimi K2.7 Code. The right speed/quality balance for production agents."
           },
           {
             "title": "Cost predictability",
@@ -5065,7 +5065,7 @@
             "body": "Long conversation histories, frequent tool calls into the CRM, the same hefty system prompt and tool schema on every turn. Sonnet's prompt caching turns that fixed prefix into a fraction of the input cost after the first call, which is what keeps per-conversation cost flat as volume grows."
           }
         ],
-        "avoidFor": "Skip Sonnet 4.6 on the hardest reasoning steps where it visibly drops instructions and you should escalate to Opus 4.7, on bulk classification at high volume where GPT-5.4 Mini is the cheaper supported bulk option, and on latency-critical micro-replies where Kimi K2.6 is meaningfully faster.",
+        "avoidFor": "Skip Sonnet 4.6 on the hardest reasoning steps where it visibly drops instructions and you should escalate to Opus 4.7, on bulk classification at high volume where GPT-5.4 Mini is the cheaper supported bulk option, and on latency-critical micro-replies where Kimi K2.7 Code is meaningfully faster.",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -5074,9 +5074,13 @@
           {
             "vs": "DeepSeek V4 Pro",
             "body": "DeepSeek V4 Pro (×0.1) matches Sonnet on coding benchmarks (vendor-reported SWE-bench Verified) at much lower cost. The trade is some tool-routing reliability and a less-mature safety profile."
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "GPT-5.4 Mini is the cheaper OpenAI-side bulk option. Use Sonnet when tool-routing reliability matters more; use Mini for high-volume pre-filtering and simple steps that do not need Sonnet-class routing."
           }
         ],
-        "verdict": "Start here. Migrate up to Opus 4.7 or down to Kimi K2.6 / DeepSeek V4 Pro once you've seen real production behaviour and know which direction makes sense.",
+        "verdict": "Start here. Migrate up to Opus 4.7 or down to Kimi K2.7 Code / DeepSeek V4 Pro once you've seen real production behaviour and know which direction makes sense.",
         "faqs": [
           {
             "q": "Why is Sonnet 4.6 the default model on VM0 Managed?",
@@ -5092,7 +5096,7 @@
           },
           {
             "q": "When should I switch off Sonnet 4.6?",
-            "a": "Switch to Opus 4.7 if Sonnet visibly drops the goal on long agent loops or fails on hard code edits. Switch to Kimi K2.6 or GPT-5.4 Mini for high-volume simple flows where cost dominates."
+            "a": "Switch to Opus 4.7 if Sonnet visibly drops the goal on long agent loops or fails on hard code edits. Switch to Kimi K2.7 Code or GPT-5.4 Mini for high-volume simple flows where cost dominates."
           },
           {
             "q": "Is Sonnet 4.6 the same as Sonnet 4.5?",
@@ -5382,6 +5386,10 @@
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet 4.6 remains the stronger default for premium tool-routing quality. GLM-5.2 is cheaper and better suited when context size dominates."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro sits lower on VM0 credits and is the stronger cost-first reasoning choice. Use it when price dominates, and use the current model when its provider fit or tool-routing profile matters more."
           }
         ],
         "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
@@ -5423,7 +5431,7 @@
         "cardIntro": "Z.AI's flagship. Up to a 1M-token context window. Strong for whole-codebase or whole-knowledge-base agents at well below Sonnet pricing.",
         "metaTitle": "GLM-5.1 on VM0: 1M Context, Pricing & Best Agent Tasks",
         "metaDescription": "GLM-5.1 review on VM0. Z.AI's flagship with up to 1M-token context, ×0.4 credit cost. Specs, pricing, performance and recommended agent tasks.",
-        "summary": "GLM-5.1 is the long-context specialist in the lineup, with up to 1M tokens of input. Reach for it when the prompt is genuinely huge: a whole repository at once, several hundred documents in a single research run. Independent leaderboards consistently rank it in the top tier of open-weight models for long-context work.\n\nVendor list price is $1.40 / $4.40 per 1M tokens, well under half of Sonnet 4.6 at the vendor level, and the API is Anthropic-compatible so Claude-style agents drop in without a rewrite. Reach for Sonnet or Opus when English reasoning depth matters more than context size, and for Kimi K2.6 when latency dominates.",
+        "summary": "GLM-5.1 is the long-context specialist in the lineup, with up to 1M tokens of input. Reach for it when the prompt is genuinely huge: a whole repository at once, several hundred documents in a single research run. Independent leaderboards consistently rank it in the top tier of open-weight models for long-context work.\n\nVendor list price is $1.40 / $4.40 per 1M tokens, well under half of Sonnet 4.6 at the vendor level, and the API is Anthropic-compatible so Claude-style agents drop in without a rewrite. Reach for Sonnet or Opus when English reasoning depth matters more than context size, and for Kimi K2.7 Code when latency dominates.",
         "releaseDate": "Early 2026; full GA on VM0 April 2026",
         "familyPosition": "Z.AI / Zhipu AI's flagship general-purpose model.",
         "background": [
@@ -5499,10 +5507,10 @@
             "body": "Some agent steps genuinely take five to thirty minutes — deep research, multi-document analysis, long planning passes. VM0 sets a 50-minute API timeout for the Z.AI provider so those long thinking steps don't get cut off mid-thought, which makes GLM-5.1 the safe pick over models routed through providers with shorter default timeouts."
           }
         ],
-        "avoidFor": "Skip GLM-5.1 on the hardest English-language reasoning where Sonnet 4.6 or Opus 4.7 still leads, and on latency-critical chat replies where Kimi K2.6 is much faster.",
+        "avoidFor": "Skip GLM-5.1 on the hardest English-language reasoning where Sonnet 4.6 or Opus 4.7 still leads, and on latency-critical chat replies where Kimi K2.7 Code is much faster.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
+            "vs": "Kimi K2.7 Code",
             "body": "Both are long-context options at similar credit cost (×0.4 vs ×0.3). Kimi has stronger long-context recall in our internal evaluation; GLM-5.1 wins on raw context size (1M vs 256K). Pick Kimi for very long transcripts; pick GLM-5.1 when you need to stuff a whole codebase into one prompt."
           },
           {
@@ -5530,12 +5538,16 @@
           },
           {
             "q": "Does GLM-5.1 support image input?",
-            "a": "GLM-5.1 on VM0 is exposed for text and code. For multimodal (image/video) input, choose Claude Sonnet 4.6 or Kimi K2.6."
+            "a": "GLM-5.1 on VM0 is exposed for text and code. For multimodal (image/video) input, choose Claude Sonnet 4.6 or Kimi K2.7 Code."
           }
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
+            "slug": "glm-5-2",
+            "reason": "Current Z.AI default route"
+          },
+          {
+            "slug": "kimi-k2-7-code",
             "reason": "Stronger long-context recall"
           },
           {
@@ -5556,14 +5568,14 @@
         "tagline": "OpenAI's cost-optimised member of the GPT-5 family. ×0.3 credits, multimodal vision, and fast enough for high-volume routing, classification and pre-filter work.",
         "cardIntro": "OpenAI's cost-saving GPT-5. ×0.3 credits, fast and multimodal — the right pick for bulk pre-filter work on the Codex framework.",
         "metaTitle": "GPT-5.4 Mini on VM0: Benchmarks, Pricing & Comparison",
-        "metaDescription": "GPT-5.4 Mini review on VM0. The cost-saving OpenAI GPT-5 model at $0.75/$4.5 vendor pricing, ×0.3 credits, 400K context and multimodal vision. Specs, behaviour and comparison to Kimi K2.6.",
-        "summary": "GPT-5.4 Mini is the cost-saving member of OpenAI's GPT-5 family — the one you reach for when unit cost matters more than peak reasoning quality. It keeps the 400K context window and multimodal inputs of the rest of the family but trims compute per token, which translates to lower price ($0.75 / $4.5 per 1M) and noticeably higher speed.\n\nOn VM0 it sits at ×0.3 credits, the same multiplier as Kimi K2.6, which makes it the natural OpenAI-side pick for bulk classification, fan-out routing, pre-filters, and any agent step where dropping to a third of GPT-5.4's cost is the deciding factor.",
+        "metaDescription": "GPT-5.4 Mini review on VM0. The cost-saving OpenAI GPT-5 model at $0.75/$4.5 vendor pricing, ×0.3 credits, 400K context and multimodal vision. Specs, behaviour and comparison to Kimi K2.7 Code.",
+        "summary": "GPT-5.4 Mini is the cost-saving member of OpenAI's GPT-5 family — the one you reach for when unit cost matters more than peak reasoning quality. It keeps the 400K context window and multimodal inputs of the rest of the family but trims compute per token, which translates to lower price ($0.75 / $4.5 per 1M) and noticeably higher speed.\n\nOn VM0 it sits at ×0.3 credits, the same multiplier as Kimi K2.7 Code, which makes it the natural OpenAI-side pick for bulk classification, fan-out routing, pre-filters, and any agent step where dropping to a third of GPT-5.4's cost is the deciding factor.",
         "releaseDate": "April 2026",
-        "familyPosition": "Cost-saving variant of the GPT-5 family. The OpenAI-side peer of Kimi K2.6.",
+        "familyPosition": "Cost-saving variant of the GPT-5 family. The OpenAI-side peer of Kimi K2.7 Code.",
         "background": [
           "GPT-5.4 Mini is the cost-optimised member of OpenAI's GPT-5 generation, released in April 2026 alongside GPT-5.5 and GPT-5.4. OpenAI positions it as the high-throughput tier — the model you keep running on classification, routing and pre-filter steps where the bigger 5.4 or 5.5 would be wasted on routine decisions.",
           "Architecturally it shares the GPT-5 family's 400K-token context window, the `reasoning_effort` parameter, prompt caching, and the Responses API surface that codex CLI uses by default. The trade-off versus 5.4 is reasoning depth: Mini handles standard tool calls, short summaries and structured-output workloads well, but starts to drift on the harder multi-step plans where 5.4 still holds up. The trade-off versus competitors at the same price point is ecosystem — if you're already on Codex, staying inside the OpenAI surface keeps tool definitions and structured-output schemas consistent.",
-          "On VM0 Mini sits at the ×0.3 credit multiplier, the same as Kimi K2.6. DeepSeek V4 Pro sits lower at ×0.1, so within the cost-saving tier the choice depends mostly on framework and behaviour fit on your specific workload."
+          "On VM0 Mini sits at the ×0.3 credit multiplier, the same as Kimi K2.7 Code. DeepSeek V4 Pro sits lower at ×0.1, so within the cost-saving tier the choice depends mostly on framework and behaviour fit on your specific workload."
         ],
         "architecture": "GPT-5.4 Mini uses the same architecture as the rest of the GPT-5 family: 400K-token context window, the `reasoning_effort` parameter at four levels, prompt caching where cached input bills at one-tenth the input rate, and the Responses API surface. Tool-use, structured outputs and multimodal vision inputs are supported. The model is a smaller, faster sibling — fewer parameters per token, more throughput per dollar.",
         "specs": [
@@ -5600,7 +5612,7 @@
             "value": "$0.75 input / $4.5 output per 1M"
           }
         ],
-        "benchmarksNote": "Vendor-reported scores from OpenAI's GPT-5 Mini release materials. Independent reviews place 5.4 Mini in the same cost-saving band as Kimi K2.6 on most agent benchmarks. Treat absolute percentages as directional.",
+        "benchmarksNote": "Vendor-reported scores from OpenAI's GPT-5 Mini release materials. Independent reviews place 5.4 Mini in the same cost-saving band as Kimi K2.7 Code on most agent benchmarks. Treat absolute percentages as directional.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -5643,7 +5655,7 @@
           },
           {
             "title": "Cost efficiency",
-            "body": "×0.3 credits with multimodal vision included. Mini and Kimi K2.6 sit in the same band, while DeepSeek V4 Pro sits lower at ×0.1 — the choice usually comes down to framework fit and behaviour on your specific workload."
+            "body": "×0.3 credits with multimodal vision included. Mini and Kimi K2.7 Code sit in the same band, while DeepSeek V4 Pro sits lower at ×0.1 — the choice usually comes down to framework fit and behaviour on your specific workload."
           },
           {
             "title": "When to escalate",
@@ -5669,6 +5681,14 @@
           {
             "vs": "GPT-5.4",
             "body": "Same family, different positioning. 5.4 Mini (×0.3) wins on cost and speed; 5.4 (×1) wins on reasoning quality and tool-routing accuracy on hard cases. The standard pattern is to pre-filter with Mini and escalate residual cases to 5.4."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Claude Sonnet 4.6 is the current catalog comparison target for this model."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro sits lower on VM0 credits and is the stronger cost-first reasoning choice. Use it when price dominates, and use the current model when its provider fit or tool-routing profile matters more."
           }
         ],
         "verdict": "GPT-5.4 Mini is the cost-saving default on the OpenAI side. Pre-filter with Mini, escalate to GPT-5.4 for routine steps, escalate to GPT-5.5 only for the hardest reasoning.",
@@ -5682,7 +5702,7 @@
             "a": "Yes. Like the rest of the GPT-5 family it accepts image inputs alongside text and code."
           },
           {
-            "q": "When should I pick GPT-5.4 Mini over Kimi K2.6?",
+            "q": "When should I pick GPT-5.4 Mini over Kimi K2.7 Code?",
             "a": "When your agent is already built on the Codex framework or you need the OpenAI structured-output / tool-call ecosystem. Both sit at ×0.3 credits, so cost is identical and the choice comes down to framework and behaviour."
           },
           {
@@ -5701,178 +5721,7 @@
           }
         ],
         "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
-        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Kimi K2.6, above DeepSeek V4 Pro's ×0.1 tier. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
-      },
-      "kimi-k2-6": {
-        "name": "Kimi K2.6",
-        "pageTitle": "Kimi K2.6 on VM0. Long-context agents",
-        "tagline": "Moonshot's latest open-weight model. Best-in-class agentic benchmarks at the open-source frontier and a Claude-compatible interface.",
-        "cardIntro": "Moonshot's latest. Best-in-class long-context recall in our internal evaluation and a Claude-compatible interface.",
-        "metaTitle": "Kimi K2.6 on VM0: SWE-bench, Pricing & Long-Context Use",
-        "metaDescription": "Kimi K2.6 review on VM0. Moonshot's open-weight 1T-parameter MoE. SWE-bench Pro 58.6, ×0.3 credit cost, 256K context. Specs and recommended tasks.",
-        "summary": "Kimi K2.6 is Moonshot's open-weight flagship and currently the strongest open-source agentic model on several public benchmarks. It sustains very long runs without losing the thread (Moonshot has documented unattended sessions of 12+ hours and 4,000+ tool calls) and accepts image and video input natively. Vendor-reported SWE-bench Pro hits 58.6 (above Claude Opus 4.6 and GPT-5.4 on that benchmark), and the hallucination rate dropped from K2.5's ~65% to ~39%.\n\nVendor list price is $0.60 / $3 per 1M tokens, open weights ship under a Modified MIT license, and the API is Anthropic-compatible. Reach for Sonnet 4.6 when production tool-routing reliability matters more than benchmark scores, and for Kimi K2.6 when latency dominates.",
-        "releaseDate": "April 20, 2026",
-        "familyPosition": "Top of Moonshot's open-weight Kimi K2 series. Successor to K2.5 and K2 Thinking.",
-        "background": [
-          "Kimi K2.6 is Moonshot AI's open-weight agentic model released April 20, 2026. It's a 1-trillion-parameter Mixture-of-Experts (MoE) model with 32B active parameters per token. The same architecture family as K2.5 and K2 Thinking, with substantial gains on agentic coding and long-horizon reasoning.",
-          "K2.6 made a real splash on independent leaderboards. Vendor-reported scores put it ahead of GPT-5.4 (xhigh) and Claude Opus 4.6 (max effort) on SWE-bench Pro, with a hallucination rate of 39% (down from K2.5's 65%). Artificial Analysis ranks it #4 on its Intelligence Index. The leading open-weight option.",
-          "On VM0 it's exposed via the Moonshot API key as the default model, through VM0 Managed at the same ×0.3 multiplier, and via OpenRouter. The API is Anthropic-compatible, so VM0 agents written for Claude work without code changes."
-        ],
-        "architecture": "K2.6 is a Mixture-of-Experts model with 1T total parameters and 32B active per token, fronted by a 256K-token context window and multimodal input across image and video (text-only output). Moonshot pairs it with an Agent Swarm runtime that scales horizontally to 300 sub-agents and 4,000 coordinated steps, and has documented long-horizon coding sessions of 12 hours or more. Open weights are published on Hugging Face under a Modified MIT License.",
-        "specs": [
-          {
-            "label": "Family",
-            "value": "Kimi K2 series"
-          },
-          {
-            "label": "Parameters",
-            "value": "1T total / 32B active (MoE)"
-          },
-          {
-            "label": "Modalities",
-            "value": "Image, video, text"
-          },
-          {
-            "label": "Languages",
-            "value": "Multilingual"
-          },
-          {
-            "label": "Context window",
-            "value": "256K tokens"
-          },
-          {
-            "label": "License",
-            "value": "Modified MIT (open weights)"
-          },
-          {
-            "label": "Available on VM0",
-            "value": "April 2026"
-          }
-        ],
-        "benchmarksNote": "Vendor-reported scores from Moonshot's K2.6 release blog. Independent third parties (Artificial Analysis, TokenMix) corroborate the relative ordering. K2.6's hallucination rate dropped to 39% from K2.5's 65%. A significant safety/reliability improvement.",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "58.6",
-            "note": "vendor-reported; beats GPT-5.4, Opus 4.6"
-          },
-          {
-            "name": "SWE-bench Verified",
-            "score": "80.2",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "Terminal-Bench 2.0",
-            "score": "66.7",
-            "note": "Terminus-2 framework"
-          },
-          {
-            "name": "LiveCodeBench (v6)",
-            "score": "89.6",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "HLE (with tools)",
-            "score": "54.0",
-            "note": "leads GPT-5.4 and Opus 4.6"
-          },
-          {
-            "name": "BrowseComp (Agent Swarm)",
-            "score": "86.3",
-            "note": "up from K2.5's 78.4"
-          },
-          {
-            "name": "Artificial Analysis Intelligence Index",
-            "score": "54",
-            "note": "#4 overall, leading open-weight"
-          }
-        ],
-        "performance": [
-          {
-            "title": "Long-context recall",
-            "body": "Strongest long-context recall in our internal evaluation across the Built-in lineup. Maintains coherence across long agent transcripts where Anthropic Sonnet starts to drift."
-          },
-          {
-            "title": "Agentic benchmarks",
-            "body": "Vendor-reported SWE-bench Pro 58.6 is the highest in the lineup at the time of writing. Beats GPT-5.4 and Opus 4.6."
-          },
-          {
-            "title": "Long-horizon coding",
-            "body": "Documented 12+ hour autonomous sessions completing 4,000+ tool calls. The model genuinely sustains performance across very long runs."
-          },
-          {
-            "title": "Tool use",
-            "body": "Reliable across common VM0 tool flows. The Anthropic-compatible API means tool schemas designed for Claude work directly."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "The investigation that has to read every old thread",
-            "body": "Dig through six months of Slack conversations to find why a customer churned, comb the support-ticket backlog for a recurring bug pattern, or stitch together insights across a hundred RFCs. K2.6's long-context recall holds up across transcripts where Anthropic Sonnet starts dropping earlier turns, which is exactly what \"reading the whole pile\" workflows need."
-          },
-          {
-            "title": "The autonomous refactor that runs overnight",
-            "body": "Moonshot has documented a 13-hour autonomous refactor of an eight-year-old matching engine, with K2.6 sustaining 4,000+ tool calls without drifting off task. That's the kind of run where most models lose the goal somewhere around hour two; K2.6's long-horizon stability is what makes \"start it Friday evening, check Monday morning\" actually work."
-          },
-          {
-            "title": "The multimodal agent that handles screenshots and clips",
-            "body": "K2.6 accepts both image and video input through MoonViT, which is unusual outside the Claude family. Useful for screenshot-driven QA agents, document-vision pipelines, and any deployment where you'd otherwise have to splice in a separate vision model just to read images."
-          }
-        ],
-        "avoidFor": "Skip K2.6 on the hardest tool-routing edge cases where Sonnet 4.6 still leads on production reliability, and on pinned legacy workflows where K2.5's lower multiplier is already sufficient.",
-        "comparisons": [
-          {
-            "vs": "GLM-5.1",
-            "body": "Both are long-context options. K2.6 wins on raw long-context recall in our internal evaluation; GLM-5.1 wins on context size (1M vs 256K). Default to K2.6 for long transcripts; reach for GLM-5.1 only when you need >256K tokens in a single prompt."
-          },
-          {
-            "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet (×1) leads on multi-tool English-language routing reliability. K2.6 (×0.3) wins on cost and on agentic benchmarks (SWE-bench Pro). Pair them: Sonnet for complex tool-routing, K2.6 for cost-sensitive agent work."
-          },
-          {
-            "vs": "Kimi K2.5",
-            "body": "K2.6 is the newer generation with stronger tool-use, lower hallucination rate (39% vs 65%), and better reasoning. K2.5 (×0.2) is slightly cheaper. Prefer K2.6 for new work."
-          }
-        ],
-        "verdict": "The open-weight default for serious agent work — long-context, cost-effective. The remaining gaps versus Sonnet 4.6 are tool-routing reliability and enterprise support.",
-        "faqs": [
-          {
-            "q": "When was Kimi K2.6 released?",
-            "a": "Moonshot AI released Kimi K2.6 on April 20, 2026. Open weights are published on Hugging Face under a Modified MIT License."
-          },
-          {
-            "q": "What's the context window?",
-            "a": "256K tokens. K2.6 differentiates on recall quality at that size, not raw window size. Recall starts to degrade past ~180K (similar to other 256K models)."
-          },
-          {
-            "q": "Do I need to rewrite my agent to use Kimi?",
-            "a": "No. Kimi K2.6 exposes an Anthropic-compatible API, so VM0 agents tuned for Claude work without code changes."
-          },
-          {
-            "q": "How does Kimi K2.6 compare to Claude Opus 4.6?",
-            "a": "On agentic benchmarks (vendor-reported), K2.6 leads. SWE-bench Pro 58.6 vs Opus 4.6's 53.4, HLE with tools 54.0 vs 53.0. Opus 4.6 retains an edge on safety profile and English-language tool-routing reliability in production."
-          },
-          {
-            "q": "Does K2.6 support image input?",
-            "a": "Yes. K2.6 accepts image and video input. Text-only output. Multimodal agents work natively."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-5",
-            "reason": "Older generation, slightly cheaper multiplier"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Even longer context window (1M tokens)"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Cheaper alternative for cost-sensitive work"
-          }
-        ],
-        "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Default model on the Moonshot provider; also available on VM0 Managed and via OpenRouter.",
-        "vm0Notes": "K2.6 has the strongest long-context recall in the Built-in lineup based on our internal evaluation, and at ×0.3 credits it's cheap enough to act as a viable Sonnet substitute for cost-sensitive work."
+        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Kimi K2.7 Code, above DeepSeek V4 Pro's ×0.1 tier. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
       },
       "kimi-k2-7-code": {
         "name": "Kimi K2.7 Code",
@@ -5993,16 +5842,16 @@
         "avoidFor": "Skip K2.7 on the hardest tool-routing edge cases where Sonnet 4.6 still leads on production reliability, and on pinned legacy workflows where K2.6's lower multiplier is already sufficient.",
         "comparisons": [
           {
-            "vs": "GLM-5.1",
-            "body": "Both are long-context options. K2.7 wins on raw long-context recall in our internal evaluation; GLM-5.1 wins on context size (1M vs 256K). Default to K2.7 for long transcripts; reach for GLM-5.1 only when you need >256K tokens in a single prompt."
+            "vs": "GLM-5.2",
+            "body": "Both are current cost-saving long-context options. K2.7 Code is the Moonshot default with stronger multimodal coding fit; GLM-5.2 is the current Z.AI default with a larger 1M-token context window."
           },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet (×1) leads on multi-tool English-language routing reliability. K2.7 (×0.3) wins on cost and on agentic benchmarks (SWE-bench Pro). Pair them: Sonnet for complex tool-routing, K2.7 for cost-sensitive agent work."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "K2.7 is the newer generation with stronger tool-use, lower hallucination rate (39% vs 65%), and better reasoning. K2.6 (×0.2) is slightly cheaper. Prefer K2.7 for new work."
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro is cheaper and has a larger 1M-token context window. Kimi K2.7 Code is the stronger Moonshot-native coding route and includes vision input. Pick by provider fit and workload shape."
           }
         ],
         "verdict": "The open-weight default for serious agent work — long-context, cost-effective. The remaining gaps versus Sonnet 4.6 are tool-routing reliability and enterprise support.",
@@ -6030,16 +5879,16 @@
         ],
         "alternatives": [
           {
-            "slug": "claude-sonnet-4-6",
-            "reason": "Older generation, slightly cheaper multiplier"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Even longer context window (1M tokens)"
+            "slug": "glm-5-2",
+            "reason": "Current Z.AI long-context route"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Cheaper alternative for cost-sensitive work"
+            "reason": "Cheaper reasoning alternative for cost-sensitive work"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Higher-reliability baseline for complex tool use"
           }
         ],
         "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Default model on the Moonshot provider; also available on VM0 Managed.",
@@ -6052,13 +5901,13 @@
         "cardIntro": "DeepSeek's flagship. Strong reasoning at a low VM0 credit multiplier, Claude-compatible API.",
         "metaTitle": "DeepSeek V4 Pro on VM0: Benchmarks, Pricing & Comparison",
         "metaDescription": "DeepSeek V4 Pro review on VM0. Open-weight 1.6T MoE with SWE-bench Verified 80.6%, ×0.1 credit cost, 1M context. Pricing, specs and Claude comparison.",
-        "summary": "DeepSeek V4 Pro is the flagship of DeepSeek's V4 generation — an open-weight 1.6T-parameter MoE under the MIT license. The headline is the price-to-quality ratio: vendor-reported SWE-bench Verified is 80.6%, within a fraction of a point of Claude Opus 4.6, at roughly one-seventh of Anthropic's vendor cost. That makes reasoning-heavy agents — bulk PR review, batch document analysis, scheduled summarisation — affordable at high volume.\n\nVendor list price is $1.74 / $3.48 per 1M tokens with cache reads at $0.028 / 1M and free cache writes (unique in the lineup). 1M-token context, Anthropic-compatible API. Reach for Sonnet 4.6 when production tool-routing reliability is the deciding factor, and for GPT-5.4 Mini or Kimi K2.6 when single-shot bulk work does not need V4 Pro's reasoning depth.",
+        "summary": "DeepSeek V4 Pro is the flagship of DeepSeek's V4 generation — an open-weight 1.6T-parameter MoE under the MIT license. The headline is the price-to-quality ratio: vendor-reported SWE-bench Verified is 80.6%, within a fraction of a point of Claude Opus 4.6, at roughly one-seventh of Anthropic's vendor cost. That makes reasoning-heavy agents — bulk PR review, batch document analysis, scheduled summarisation — affordable at high volume.\n\nVendor list price is $1.74 / $3.48 per 1M tokens with cache reads at $0.028 / 1M and free cache writes (unique in the lineup). 1M-token context, Anthropic-compatible API. Reach for Sonnet 4.6 when production tool-routing reliability is the deciding factor, and for GPT-5.4 Mini or Kimi K2.7 Code when single-shot bulk work does not need V4 Pro's reasoning depth.",
         "releaseDate": "April 24, 2026",
         "familyPosition": "Reasoning variant of the DeepSeek V4 family, focused on maximum reasoning quality.",
         "background": [
           "DeepSeek V4 Pro is the flagship of DeepSeek's V4 generation, released April 24, 2026 under the MIT License. It's an open-weight Mixture-of-Experts model with 1.6T total parameters and 49B active per token.",
           "V4 Pro supports a 1M-token context window, 384K maximum output, three reasoning effort modes (standard, think, think-max), JSON output, tool calls, and FIM completion in non-think mode. The Pro model adds a hybrid attention architecture (Compressed Sparse Attention + Heavily Compressed Attention) for dramatically improved long-context efficiency. 27% of single-token inference FLOPs and 10% of KV cache vs DeepSeek V3.2 at 1M context.",
-          "DeepSeek made waves through 2025 by delivering Anthropic-grade reasoning at a fraction of the price. V4 Pro continues that pattern: vendor-reported SWE-bench Verified 80.6% sits within 0.2 points of Claude Opus 4.6, at roughly one-seventh the vendor cost. On VM0 it's exposed via the DeepSeek API-key provider and on VM0 Managed at ×0.1. Lower multiplier than Kimi K2.6, with substantially stronger reasoning behaviour."
+          "DeepSeek made waves through 2025 by delivering Anthropic-grade reasoning at a fraction of the price. V4 Pro continues that pattern: vendor-reported SWE-bench Verified 80.6% sits within 0.2 points of Claude Opus 4.6, at roughly one-seventh the vendor cost. On VM0 it's exposed via the DeepSeek API-key provider and on VM0 Managed at ×0.1. Lower multiplier than Kimi K2.7 Code, with substantially stronger reasoning behaviour."
         ],
         "architecture": "V4 Pro is a Mixture-of-Experts model with 1.6T total parameters and 49B active per token, fronted by a hybrid attention stack (Compressed Sparse Attention plus Heavily Compressed Attention) that keeps long-context inference cheap. It supports a 1M-token context window with 384K of maximum output, three reasoning effort modes (standard, think, and think-max), and uses Manifold-Constrained Hyper-Connections for stable signal propagation. The model was trained on 32T+ tokens with the Muon optimizer and is released under the MIT License with open weights.",
         "specs": [
@@ -6095,7 +5944,7 @@
             "value": "April 24, 2026"
           }
         ],
-        "benchmarksNote": "Vendor-reported scores from DeepSeek's V4 Pro release. Independent reviews (Geeky Gadgets, Code Arena) place V4 Pro third on Code Arena behind GLM-5.1 and Kimi K2.6. The strongest benchmark claims come from DeepSeek's own materials. Treat directionally rather than as absolute truth.",
+        "benchmarksNote": "Vendor-reported scores from DeepSeek's V4 Pro release. Independent reviews (Geeky Gadgets, Code Arena) place V4 Pro third on Code Arena behind GLM-5.1 and Kimi K2.7 Code. The strongest benchmark claims come from DeepSeek's own materials. Treat directionally rather than as absolute truth.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -6152,7 +6001,7 @@
           },
           {
             "title": "Speed",
-            "body": "Around 36 tokens/sec at max effort per Artificial Analysis. Slower than Kimi K2.6, slightly slower than Opus 4.6."
+            "body": "Around 36 tokens/sec at max effort per Artificial Analysis. Slower than Kimi K2.7 Code, slightly slower than Opus 4.6."
           }
         ],
         "bestForExamples": [
@@ -6169,18 +6018,22 @@
             "body": "1M-token context with hybrid attention (Compressed Sparse Attention plus Heavily Compressed Attention) means a mid-sized codebase fits in one prompt and inference cost stays manageable as the window fills up. For cross-file refactors and architecture-level reviews, this is where you get the Opus-style \"see everything at once\" workflow without the Opus-style invoice."
           }
         ],
-        "avoidFor": "Skip V4 Pro on the hardest tool-routing edge cases where Sonnet 4.6 still leads, and on bulk single-shot work where GPT-5.4 Mini or Kimi K2.6 is sufficient at lower cost.",
+        "avoidFor": "Skip V4 Pro on the hardest tool-routing edge cases where Sonnet 4.6 still leads, and on bulk single-shot work where GPT-5.4 Mini or Kimi K2.7 Code is sufficient at lower cost.",
         "comparisons": [
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet 4.6 (×1) wins on tool-routing edge cases and English-language reasoning. V4 Pro (×0.1) wins on cost and is competitive on coding benchmarks (vendor-reported). Worth A/B-testing on a real agent before committing."
           },
           {
-            "vs": "Kimi K2.6",
+            "vs": "Kimi K2.7 Code",
             "body": "Lower multiplier than Kimi (×0.1 vs ×0.3). Kimi has stronger long-context recall and a higher Intelligence Index (54 vs 52); V4 Pro has the better cache economics (free writes) and a 1M context window vs Kimi's 256K. Pick by which property matters more."
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2 is the current Z.AI default route on VM0. It is the better comparison for new Z.AI-backed agents, while GLM-5.1 remains available only for compatibility with tuned workflows."
           }
         ],
-        "verdict": "Pre-filter with GPT-5.4 Mini or Kimi K2.6, escalate to V4 Pro for reasoning, escalate to Sonnet 4.6 only when V4 Pro stalls on tool-routing edge cases.",
+        "verdict": "Pre-filter with GPT-5.4 Mini or Kimi K2.7 Code, escalate to V4 Pro for reasoning, escalate to Sonnet 4.6 only when V4 Pro stalls on tool-routing edge cases.",
         "faqs": [
           {
             "q": "When was DeepSeek V4 Pro released?",
@@ -6209,143 +6062,12 @@
             "reason": "Step up for hard tool routing"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Same price, stronger long-context recall"
+            "slug": "kimi-k2-7-code",
+            "reason": "Moonshot default with stronger multimodal coding fit"
           }
         ],
         "routingNotes": "Routed through DeepSeek's Anthropic-compatible endpoint at `api.deepseek.com`. Available on VM0 Managed and the DeepSeek provider.",
         "vm0Notes": "DeepSeek bills cache reads but not cache writes, which is a real cost win whenever the system prompt is stable. VM0 sets a 10-minute API timeout for the DeepSeek provider and disables non-essential traffic to keep long-running agents responsive. The result is the strongest reasoning of any sub-Sonnet model in the Built-in lineup."
-      },
-      "kimi-k2-5": {
-        "name": "Kimi K2.5",
-        "pageTitle": "Kimi K2.5 on VM0. Moonshot's previous generation",
-        "tagline": "The previous Kimi generation. Cheaper than K2.6 but with weaker tool-use; pin it only if a specific agent was validated on this version.",
-        "cardIntro": "The previous Kimi generation. Cheaper than K2.6 but with weaker tool-use; pin it only if a specific agent was validated on this version.",
-        "metaTitle": "Kimi K2.5 on VM0: Specs, Pricing & Migration to K2.6",
-        "metaDescription": "Kimi K2.5 review on VM0. Moonshot's previous flagship at ×0.2 credit cost. SWE-bench Pro 50.7, 256K context. When to pin K2.5 instead of K2.6.",
-        "summary": "Kimi K2.5 is Moonshot's previous flagship, the open-weight model that K2.6 superseded in April 2026. It's still capable — strong on long-context summarisation — but K2.6 leads on every published benchmark at the same vendor price, and the hallucination rate gap is wide (K2.5 ~65% on Moonshot's evaluation versus K2.6's ~39%).\n\nVendor list price is $0.60 / $3 per 1M tokens, identical to K2.6. The honest pitch: if you built on K2.5 and it works, leave it; if you're starting fresh, start on K2.6.",
-        "releaseDate": "Late 2025 (Kimi K2 series)",
-        "familyPosition": "Previous generation of Moonshot's open-weight Kimi K2 series. Superseded by K2.6.",
-        "background": [
-          "Kimi K2.5 was Moonshot's flagship Kimi model before K2.6. It was the first widely-deployed Kimi to combine long-context reasoning with a Claude-compatible API surface, and it remains a capable model for long-context summarisation work.",
-          "On VM0 it sits at the same vendor list price as K2.6 but a lower credit multiplier (×0.2). The lower multiplier reflects positioning rather than raw token cost. K2.6 is the recommended default for new work; K2.5 is the legacy pin.",
-          "K2.5 has a vendor-reported SWE-bench Pro score of 50.7 and a hallucination rate of ~65%. Both meaningfully behind K2.6 (58.6 and 39%). Behaviourally it remains stable for pinned production agents."
-        ],
-        "architecture": "K2.5 is a Mixture-of-Experts model with 1T total parameters and 32B active per token from the same family as K2.6, fronted by a 256K-token context window and an Anthropic-compatible API surface. Open weights are published on Hugging Face.",
-        "specs": [
-          {
-            "label": "Family",
-            "value": "Kimi K2 series"
-          },
-          {
-            "label": "Modalities",
-            "value": "Image, text, code"
-          },
-          {
-            "label": "Languages",
-            "value": "Multilingual"
-          },
-          {
-            "label": "Context window",
-            "value": "256K tokens"
-          },
-          {
-            "label": "License",
-            "value": "Modified MIT (open weights)"
-          },
-          {
-            "label": "Available on VM0",
-            "value": "Available since launch"
-          }
-        ],
-        "benchmarksNote": "K2.5's benchmarks are now most useful as the comparison baseline for K2.6. The newer model leads on every published metric at the same vendor cost.",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "50.7",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "BrowseComp",
-            "score": "78.4",
-            "note": "vendor-reported"
-          },
-          {
-            "name": "Hallucination rate",
-            "score": "~65%",
-            "note": "down to 39% in K2.6"
-          }
-        ],
-        "performance": [
-          {
-            "title": "Long-context",
-            "body": "Strong, similar shape to K2.6 but with K2.6 having the edge on harder recall benchmarks."
-          },
-          {
-            "title": "Tool use",
-            "body": "Solid on common flows; K2.6 is meaningfully better on complex multi-tool agents."
-          },
-          {
-            "title": "Hallucinations",
-            "body": "Vendor-reported hallucination rate of ~65%. Much higher than K2.6's 39%. Expect more confident-but-wrong outputs."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "The legacy agent that already works",
-            "body": "Your team validated an agent against K2.5 a few months ago, the prompts are tuned, the eval suite passes, customers are happy. Pinning to K2.5 keeps that exact behaviour in place while you decide whether the K2.6 upgrade is worth re-running the validation. Same Moonshot endpoint, same Anthropic-compatible interface — only the model weights move when you switch."
-          },
-          {
-            "title": "The bulk-summarisation job where K2.6's edge doesn't show",
-            "body": "Hundred-thousand-token transcripts going in, three-paragraph summaries coming out. Tool-routing accuracy isn't part of the workload, hallucination resistance matters less when a human is going to skim the output anyway, and at the same vendor price as K2.6 you can run K2.5 on these jobs without touching the existing pipeline."
-          }
-        ],
-        "avoidFor": "Don't start new agents on K2.5, since K2.6 is a free upgrade in every meaningful way except the multiplier. Skip it on multi-tool English routing where Sonnet 4.6 leads, and on tasks where hallucination is costly because K2.5's rate is materially worse than K2.6's.",
-        "comparisons": [
-          {
-            "vs": "Kimi K2.6",
-            "body": "K2.6 is the newer generation with stronger tool-use, lower hallucination rate (39% vs 65%), and better reasoning. K2.5 (×0.2) is slightly cheaper. Pick K2.5 only for pinned legacy agents."
-          },
-          {
-            "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro (×0.1) has stronger reasoning. K2.5 (×0.2) wins on context size and stays within the Moonshot API surface."
-          }
-        ],
-        "verdict": "Maintenance mode. Pin if you have an agent already validated on it; otherwise start on K2.6.",
-        "faqs": [
-          {
-            "q": "Why does K2.5 have a lower multiplier than K2.6 at the same vendor price?",
-            "a": "Multipliers reflect VM0's positioning of each model in the lineup, not just per-token cost. K2.6 is the recommended Kimi default at ×0.3; K2.5 is positioned as legacy at ×0.2."
-          },
-          {
-            "q": "Should I migrate from K2.5 to K2.6?",
-            "a": "Yes for new work. Same vendor price, stronger tool-use and reasoning, much lower hallucination rate. Migrate pinned agents only after running them through your regression suite."
-          },
-          {
-            "q": "What's the hallucination rate?",
-            "a": "Vendor-reported ~65%. Meaningfully higher than K2.6 (39%). If your agent reports facts to users, this matters; consider K2.6 instead."
-          },
-          {
-            "q": "What's K2.5's context window?",
-            "a": "256K tokens. Same as K2.6."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-6",
-            "reason": "Newer Kimi with better tool-use"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Larger context window if you need it"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Stronger reasoning at slightly higher multiplier"
-          }
-        ],
-        "routingNotes": "Routed through Moonshot's Anthropic-compatible endpoint at `api.moonshot.ai`. Available on VM0 Managed, Moonshot, OpenRouter, and Vercel AI Gateway.",
-        "vm0Notes": "K2.5 carries the same per-token vendor price as K2.6 but a lower multiplier (×0.2 versus ×0.3) because the multiplier reflects positioning rather than raw cost. Long-context behaviour is solid, but K2.6 is the recommended choice for any new work on VM0."
       },
       "minimax-m3": {
         "name": "MiniMax M3",
@@ -6433,12 +6155,16 @@
         "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
+            "vs": "Kimi K2.7 Code",
             "body": "Both target coding and agentic work at low cost. Kimi has broader existing gateway support on VM0, while M3 uses the official MiniMax route and gives MiniMax users the newer model."
           },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet 4.6 remains the baseline for reliability on complex English tool-use. M3 is much cheaper and attractive for MiniMax-native coding agents, but should be validated on critical workflows."
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2 is the current Z.AI default route on VM0. It is the better comparison for new Z.AI-backed agents, while GLM-5.1 remains available only for compatibility with tuned workflows."
           }
         ],
         "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
@@ -6458,8 +6184,8 @@
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "Low-cost coding model with existing gateway coverage"
+            "slug": "kimi-k2-7-code",
+            "reason": "Low-cost coding model with broader existing gateway coverage"
           },
           {
             "slug": "claude-sonnet-4-6",
@@ -6918,12 +6644,12 @@
         ],
         "alternatives": [
           {
-            "slug": "flux-pro-1-1-ultra",
-            "reason": "Premium hero-shot quality"
-          },
-          {
             "slug": "gpt-image-1",
             "reason": "Stronger stylised illustration"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Premium hero-shot quality"
           }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -5292,88 +5292,88 @@
       },
       "glm-5-2": {
         "name": "GLM-5.2",
-        "pageTitle": "GLM-5.2 on VM0. Z.AI's default long-context model",
-        "tagline": "The current Z.AI default on VM0. Up to a 1M-token context window, Anthropic-compatible routing, and cost-saving x0.4 VM0 Managed pricing.",
-        "cardIntro": "Z.AI's current default on VM0. Long-context text and code agents at x0.4 VM0 Managed pricing.",
-        "metaTitle": "GLM-5.2 on VM0: Pricing, Context & Best Agent Tasks",
-        "metaDescription": "GLM-5.2 on VM0. Z.AI's current default model with up to 1M-token context, x0.4 credit cost, OpenRouter-backed VM0 Managed routing, and direct Z.AI BYOK support.",
-        "summary": "GLM-5.2 is the current GLM default on VM0 for Z.AI API-key users and is also available through VM0 Managed via OpenRouter. It keeps the GLM series' long-context profile while becoming the preferred Z.AI route for new agents.\n\nUse it for large codebases, large document sets, and cost-sensitive long-context planning where Sonnet-class pricing is unnecessary. GLM-5.1 remains available for compatibility, but new Z.AI routes should start on GLM-5.2 unless a workflow has been tuned specifically against 5.1.",
-        "releaseDate": "June 2026",
-        "familyPosition": "Current default model in VM0's Z.AI / GLM route.",
+        "pageTitle": "GLM-5.2 en VM0. El modelo predeterminado de contexto largo de Z.AI",
+        "tagline": "El predeterminado actual de Z.AI en VM0. Hasta 1M tokens de contexto, enrutamiento compatible con Anthropic y precio económico de ×0,4 en VM0 Managed.",
+        "cardIntro": "El predeterminado actual de Z.AI en VM0. Agentes de texto y código de contexto largo a precio ×0,4 en VM0 Managed.",
+        "metaTitle": "GLM-5.2 en VM0: precios, contexto y mejores tareas de agente",
+        "metaDescription": "GLM-5.2 en VM0. Modelo predeterminado actual de Z.AI con hasta 1M tokens de contexto, costo de ×0,4 créditos, enrutamiento VM0 Managed mediante OpenRouter y soporte BYOK directo de Z.AI.",
+        "summary": "GLM-5.2 es el GLM predeterminado actual en VM0 para usuarios con clave API de Z.AI y también está disponible en VM0 Managed mediante OpenRouter. Mantiene el perfil de contexto largo de la serie GLM y se convierte en la ruta Z.AI preferida para nuevos agentes.\n\nÚsalo para grandes bases de código, grandes conjuntos de documentos y planificación de contexto largo sensible al costo donde el precio de clase Sonnet no es necesario. GLM-5.1 sigue disponible por compatibilidad, pero las nuevas rutas Z.AI deberían empezar en GLM-5.2 salvo que un flujo ya esté ajustado específicamente para 5.1.",
+        "releaseDate": "Junio de 2026",
+        "familyPosition": "Modelo predeterminado actual en la ruta Z.AI / GLM de VM0.",
         "background": [
-          "GLM-5.2 extends the GLM 5 family as the current Z.AI default exposed by VM0. It is available through VM0 Managed, where VM0 routes to OpenRouter with the upstream id `z-ai/glm-5.2`, and through direct Z.AI API keys using the canonical `glm-5.2` id.",
-          "The route is Anthropic-compatible, so Claude-style agents can keep the same runtime interface. Existing GLM-5.1 agents do not need to migrate immediately, but new Z.AI-backed agents should prefer GLM-5.2.",
-          "On VM0 Managed it sits at x0.4 credits, matching GLM-5.1's cost tier while taking over the Z.AI default slot."
+          "GLM-5.2 amplía la familia GLM 5 como el predeterminado actual de Z.AI expuesto por VM0. Está disponible mediante VM0 Managed, donde VM0 enruta a OpenRouter con el id upstream `z-ai/glm-5.2`, y mediante claves API directas de Z.AI usando el id canónico `glm-5.2`.",
+          "La ruta es compatible con Anthropic, así que los agentes estilo Claude pueden conservar la misma interfaz de runtime. Los agentes existentes con GLM-5.1 no necesitan migrar de inmediato, pero los agentes nuevos respaldados por Z.AI deberían preferir GLM-5.2.",
+          "En VM0 Managed está en ×0,4 créditos, igualando la capa de costo de GLM-5.1 mientras ocupa el slot predeterminado de Z.AI."
         ],
-        "architecture": "GLM-5.2 is exposed on VM0 through Anthropic-compatible endpoints. VM0 Managed uses OpenRouter's `z-ai/glm-5.2` id; direct Z.AI BYOK uses `glm-5.2`.",
+        "architecture": "GLM-5.2 se expone en VM0 mediante endpoints compatibles con Anthropic. VM0 Managed usa el id `z-ai/glm-5.2` de OpenRouter; Z.AI BYOK directo usa `glm-5.2`.",
         "specs": [
           {
-            "label": "Family",
+            "label": "Familia",
             "value": "GLM-5 series"
           },
           {
-            "label": "Modalities",
-            "value": "Text, code"
+            "label": "Modalidades",
+            "value": "Texto, código"
           },
           {
-            "label": "Languages",
-            "value": "Multilingual"
+            "label": "Idiomas",
+            "value": "Multilingüe"
           },
           {
-            "label": "Context window",
-            "value": "Up to 1M tokens"
+            "label": "Ventana de contexto",
+            "value": "Hasta 1M tokens"
           },
           {
-            "label": "Prompt caching",
-            "value": "Supported"
+            "label": "Caché de prompts",
+            "value": "Soportado"
           },
           {
-            "label": "Available on VM0",
-            "value": "June 2026"
+            "label": "Disponible en VM0",
+            "value": "Junio de 2026"
           }
         ],
-        "benchmarksNote": "Treat GLM-5.2 as the preferred GLM route on VM0. Third-party rankings can move quickly, so VM0 keeps the page focused on routing, cost, and operational fit rather than frozen leaderboard percentages.",
+        "benchmarksNote": "Trata GLM-5.2 como la ruta GLM preferida en VM0. Los rankings de terceros pueden moverse rápido, así que VM0 mantiene esta página centrada en enrutamiento, costo y encaje operativo en lugar de porcentajes congelados de leaderboard.",
         "benchmarks": [
           {
-            "name": "Long-context tasks",
-            "score": "Strong fit",
-            "note": "VM0 routing profile"
+            "name": "Tareas de contexto largo",
+            "score": "Buen encaje",
+            "note": "Perfil de enrutamiento de VM0"
           },
           {
-            "name": "Cost tier",
-            "score": "x0.4 credits",
+            "name": "Capa de costo",
+            "score": "×0,4 créditos",
             "note": "VM0 Managed"
           }
         ],
         "performance": [
           {
-            "title": "Long-context work",
-            "body": "GLM-5.2 is best used when the agent needs a large working set: repositories, documentation folders, design notes, or long research material."
+            "title": "Trabajo de contexto largo",
+            "body": "GLM-5.2 encaja mejor cuando el agente necesita un conjunto de trabajo grande: repositorios, carpetas de documentación, notas de diseño o material de investigación extenso."
           },
           {
-            "title": "Cost control",
-            "body": "At x0.4 credits it is a cost-saving alternative to Sonnet-class routes for workflows where context size and price matter more than maximum English reasoning depth."
+            "title": "Control de costos",
+            "body": "Con ×0,4 créditos es una alternativa económica a rutas de clase Sonnet para flujos donde el tamaño de contexto y el precio importan más que la máxima profundidad de razonamiento en inglés."
           },
           {
-            "title": "Routing",
-            "body": "VM0 Managed routes through OpenRouter using `z-ai/glm-5.2`; direct Z.AI API keys use `glm-5.2`. Both paths keep the Claude-compatible agent interface."
+            "title": "Enrutamiento",
+            "body": "VM0 Managed enruta mediante OpenRouter usando `z-ai/glm-5.2`; las claves API directas de Z.AI usan `glm-5.2`. Ambos caminos conservan la interfaz de agente compatible con Claude."
           }
         ],
         "bestForExamples": [
           {
-            "title": "Whole-repo review on a budget",
-            "body": "Use GLM-5.2 when the agent needs to inspect a large codebase and produce concrete file-level recommendations without paying for a premium reasoning model on every pass."
+            "title": "Revisión de repositorio completo con presupuesto",
+            "body": "Usa GLM-5.2 cuando el agente debe inspeccionar una base de código grande y producir recomendaciones concretas por archivo sin pagar por un modelo de razonamiento premium en cada pasada."
           },
           {
-            "title": "Large document synthesis",
-            "body": "Load policy documents, tickets, transcripts, or internal docs together and ask for cross-document patterns. The long context and x0.4 multiplier keep repeated runs practical."
+            "title": "Síntesis de grandes conjuntos de documentos",
+            "body": "Carga documentos de política, tickets, transcripciones o documentación interna en conjunto y pide patrones entre documentos. El contexto largo y el multiplicador ×0,4 hacen prácticos los runs repetidos."
           },
           {
-            "title": "Z.AI BYOK default route",
-            "body": "Teams using a direct Z.AI API key get GLM-5.2 as the default VM0 model while retaining GLM-5.1 for existing tuned workflows."
+            "title": "Ruta predeterminada para Z.AI BYOK",
+            "body": "Los equipos que usan una clave API directa de Z.AI reciben GLM-5.2 como modelo predeterminado en VM0 y conservan GLM-5.1 para flujos existentes ya ajustados."
           }
         ],
-        "avoidFor": "Skip GLM-5.2 for workflows that depend on vision input, or when maximum English-language reasoning and tool routing quality matter more than context size and cost.",
+        "avoidFor": "Evita GLM-5.2 en flujos que dependen de entrada visual, o cuando la máxima calidad de razonamiento en inglés y enrutamiento de herramientas importa más que el tamaño de contexto y el costo.",
         "comparisons": [
           {
             "vs": "GLM-5.1",
@@ -5392,19 +5392,19 @@
             "body": "DeepSeek V4 Pro tiene un multiplicador VM0 más bajo y es la opción de razonamiento más fuerte cuando el costo va primero. Úsalo cuando domina el precio; usa GLM-5.2 cuando importan más el ajuste con Z.AI o el contexto largo."
           }
         ],
-        "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
+        "verdict": "Elige GLM-5.2 como la ruta Z.AI predeterminada en VM0. Conserva GLM-5.1 solo por compatibilidad con flujos ya ajustados para él.",
         "faqs": [
           {
-            "q": "Is GLM-5.2 available through VM0 Managed?",
-            "a": "Yes. VM0 Managed routes GLM-5.2 through OpenRouter with the upstream id `z-ai/glm-5.2`."
+            "q": "¿GLM-5.2 está disponible mediante VM0 Managed?",
+            "a": "Sí. VM0 Managed enruta GLM-5.2 mediante OpenRouter con el id upstream `z-ai/glm-5.2`."
           },
           {
-            "q": "Is GLM-5.2 the default for direct Z.AI API keys?",
-            "a": "Yes. The Z.AI provider defaults to `glm-5.2` while keeping `glm-5.1` available."
+            "q": "¿GLM-5.2 es el predeterminado para claves API directas de Z.AI?",
+            "a": "Sí. El proveedor Z.AI usa `glm-5.2` por defecto y mantiene `glm-5.1` disponible."
           },
           {
-            "q": "Does GLM-5.2 support image input?",
-            "a": "No. VM0 exposes GLM-5.2 for text and code agents. Use Claude Sonnet 4.6 or Kimi K2.7 Code when vision input is required."
+            "q": "¿GLM-5.2 soporta entrada de imagen?",
+            "a": "No. VM0 expone GLM-5.2 para agentes de texto y código. Usa Claude Sonnet 4.6 o Kimi K2.7 Code cuando se necesite entrada visual."
           }
         ],
         "alternatives": [
@@ -5421,8 +5421,8 @@
             "reason": "Alternativa más barata para contexto estándar"
           }
         ],
-        "routingNotes": "On VM0 Managed, GLM-5.2 routes through OpenRouter with the upstream id `z-ai/glm-5.2`. With a Z.AI API key it talks directly to `api.z.ai` as `glm-5.2`. It is the default model on the Z.AI provider.",
-        "vm0Notes": "VM0 sets a 50-minute API timeout for the Z.AI provider, so long-context planning and analysis runs have room to finish."
+        "routingNotes": "En VM0 Managed, GLM-5.2 se enruta mediante OpenRouter con el id upstream `z-ai/glm-5.2`. Con una clave API de Z.AI habla directamente con `api.z.ai` como `glm-5.2`. Es el modelo predeterminado del proveedor Z.AI.",
+        "vm0Notes": "VM0 establece un timeout de API de 50 minutos para el proveedor Z.AI, de modo que las ejecuciones de planificación y análisis de contexto largo tengan margen para terminar."
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -6071,88 +6071,88 @@
       },
       "minimax-m3": {
         "name": "MiniMax M3",
-        "pageTitle": "MiniMax M3 on VM0. Official MiniMax coding model at ×0.2",
-        "tagline": "Official MiniMax M3 routing for coding agents, 1M context, and native multimodal understanding.",
-        "cardIntro": "Official MiniMax M3 routing for coding agents with 1M context, prompt cache reads, and a ×0.2 VM0 multiplier.",
-        "metaTitle": "MiniMax M3 on VM0: Pricing, Specs & Official Routing",
-        "metaDescription": "MiniMax M3 review on VM0. Official MiniMax coding model with 1M context, multimodal understanding, prompt cache reads, and ×0.2 credits.",
-        "summary": "MiniMax M3 is MiniMax's frontier coding and agentic model, exposed on VM0 through the official MiniMax Anthropic-compatible endpoint. It is the right MiniMax choice when an agent needs stronger coding, tool use, long-context reasoning, and native vision understanding than the retained M2 series.\n\nVM0 prices M3 from MiniMax's standard non-promotional pay-as-you-go tier for the base context band: $0.60 / $2.40 per 1M tokens, with prompt cache reads at $0.12 / 1M and no separate cache-write billing in the M3 table. MiniMax M2.1 remains available for lower-cost compatibility, while M3 is the default MiniMax BYOK model.",
-        "releaseDate": "June 1, 2026",
-        "familyPosition": "Official MiniMax M3 text model alongside the retained M2 series.",
+        "pageTitle": "MiniMax M3 en VM0. Modelo oficial de código de MiniMax a ×0,2",
+        "tagline": "Enrutamiento oficial de MiniMax M3 para agentes de código, contexto de 1M y comprensión multimodal nativa.",
+        "cardIntro": "Enrutamiento oficial de MiniMax M3 para agentes de código con contexto de 1M, lecturas de caché de prompt y multiplicador ×0,2 en VM0.",
+        "metaTitle": "MiniMax M3 en VM0: precios, especificaciones y enrutamiento oficial",
+        "metaDescription": "MiniMax M3 en VM0. Modelo oficial de código de MiniMax con contexto de 1M, comprensión multimodal, lecturas de caché de prompt y ×0,2 créditos.",
+        "summary": "MiniMax M3 es el modelo frontier de MiniMax para código y trabajo agéntico, expuesto en VM0 mediante el endpoint oficial de MiniMax compatible con Anthropic. Es la elección correcta dentro de MiniMax cuando un agente necesita mejor codificación, uso de herramientas, razonamiento de contexto largo y comprensión visual nativa que la serie M2 conservada.\n\nVM0 fija el precio de M3 usando la capa estándar no promocional pay-as-you-go de MiniMax para la banda base de contexto: $0.60 / $2.40 por 1M tokens, con lecturas de caché de prompt a $0.12 / 1M y sin facturación separada por escrituras de caché en la tabla de M3. MiniMax M2.1 sigue disponible por compatibilidad de menor costo, mientras M3 es el modelo MiniMax BYOK predeterminado.",
+        "releaseDate": "1 de junio de 2026",
+        "familyPosition": "Modelo de texto oficial MiniMax M3 junto a la serie M2 conservada.",
         "background": [
-          "MiniMax M3 is the new official MiniMax text model for coding and agentic workloads. MiniMax describes it as combining frontier coding capability, a 1M-token context window, and native multimodal understanding.",
-          "On VM0, M3 is added to the existing MiniMax API-key provider instead of creating a new integration. It uses the same `api.minimax.io/anthropic` routing surface and the same `MINIMAX_API_KEY` secret as M2.",
-          "The existing M2 entries stay available, while M3 is the MiniMax provider default for new selections."
+          "MiniMax M3 es el nuevo modelo de texto oficial de MiniMax para cargas de código y agentes. MiniMax lo describe como una combinación de capacidad frontier de código, una ventana de contexto de 1M tokens y comprensión multimodal nativa.",
+          "En VM0, M3 se añade al proveedor existente de claves API de MiniMax en lugar de crear una integración nueva. Usa la misma superficie de enrutamiento `api.minimax.io/anthropic` y el mismo secreto `MINIMAX_API_KEY` que M2.",
+          "Las entradas M2 existentes siguen disponibles, mientras M3 es el valor predeterminado del proveedor MiniMax para nuevas selecciones."
         ],
-        "architecture": "M3 uses MiniMax Sparse Attention for ultra-long context. The official API supports up to 1M tokens with a 512K guaranteed minimum, automatic prompt cache support, and native multimodal understanding.",
+        "architecture": "M3 usa MiniMax Sparse Attention para contexto ultralargo. La API oficial soporta hasta 1M tokens con un mínimo garantizado de 512K, soporte automático de caché de prompts y comprensión multimodal nativa.",
         "specs": [
           {
-            "label": "Family",
+            "label": "Familia",
             "value": "MiniMax M3"
           },
           {
-            "label": "Modalities",
-            "value": "Text, vision, code"
+            "label": "Modalidades",
+            "value": "Texto, visión, código"
           },
           {
-            "label": "Languages",
-            "value": "Multilingual"
+            "label": "Idiomas",
+            "value": "Multilingüe"
           },
           {
-            "label": "Context window",
-            "value": "1M tokens (512K guaranteed minimum)"
+            "label": "Ventana de contexto",
+            "value": "1M tokens (mínimo garantizado de 512K)"
           },
           {
-            "label": "Prompt caching",
-            "value": "Supported with automatic cache reads"
+            "label": "Caché de prompts",
+            "value": "Soportado con lecturas automáticas de caché"
           },
           {
-            "label": "Available on VM0",
-            "value": "June 1, 2026"
+            "label": "Disponible en VM0",
+            "value": "1 de junio de 2026"
           }
         ],
-        "benchmarksNote": "MiniMax positions M3 around coding, agentic tasks, and long-horizon execution. Treat these as vendor-reported signals and validate against your own VM0 agent regression set.",
+        "benchmarksNote": "MiniMax posiciona M3 alrededor de código, tareas agénticas y ejecución de horizonte largo. Trata estos datos como señales reportadas por el proveedor y valídalas contra tu propio conjunto de regresión de agentes en VM0.",
         "benchmarks": [
           {
             "name": "PostTrainBench Live",
-            "score": "Rank #3",
-            "note": "vendor reported"
+            "score": "Puesto #3",
+            "note": "reportado por el proveedor"
           },
           {
             "name": "BrowseComp",
             "score": "83.5",
-            "note": "vendor reported"
+            "note": "reportado por el proveedor"
           }
         ],
         "performance": [
           {
-            "title": "Coding agents",
-            "body": "The best MiniMax option for coding assistants, long tool chains, and multi-step repository work."
+            "title": "Agentes de código",
+            "body": "La mejor opción de MiniMax para asistentes de código, cadenas largas de herramientas y trabajo de repositorio en varios pasos."
           },
           {
-            "title": "Long context",
-            "body": "A 1M context window lets agents keep large documents, code, logs, and previous work in scope without switching model families."
+            "title": "Contexto largo",
+            "body": "Una ventana de contexto de 1M permite mantener documentos grandes, código, logs y trabajo previo dentro del alcance sin cambiar de familia de modelos."
           },
           {
             "title": "Multimodal",
-            "body": "Native vision understanding makes M3 a better fit than M2 when screenshots, diagrams, or visual artifacts are part of the workflow."
+            "body": "La comprensión visual nativa hace que M3 encaje mejor que M2 cuando el flujo incluye capturas de pantalla, diagramas o artefactos visuales."
           }
         ],
         "bestForExamples": [
           {
-            "title": "The coding agent that must stay on MiniMax",
-            "body": "Repository edits, debugging, and agentic coding flows where your deployment already uses MiniMax keys but needs a stronger coding model than M2.1."
+            "title": "El agente de código que debe quedarse en MiniMax",
+            "body": "Ediciones de repositorio, debugging y flujos agénticos de código donde tu despliegue ya usa claves MiniMax pero necesita un modelo de código más fuerte que M2.1."
           },
           {
-            "title": "The long-context review run",
-            "body": "Large pull requests, logs, notebooks, or design documents that should stay in one model context while the agent reasons and edits."
+            "title": "La revisión de contexto largo",
+            "body": "Pull requests grandes, logs, notebooks o documentos de diseño que deberían mantenerse en un solo contexto de modelo mientras el agente razona y edita."
           },
           {
-            "title": "The multimodal investigation",
-            "body": "Workflows that mix text with screenshots or diagrams. M3 is marked image-input capable on VM0, while the M2 entries stay text/code only."
+            "title": "La investigación multimodal",
+            "body": "Flujos que mezclan texto con capturas de pantalla o diagramas. M3 está marcado en VM0 como capaz de recibir imágenes, mientras las entradas M2 siguen siendo solo texto/código."
           }
         ],
-        "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
+        "avoidFor": "Evita M3 cuando necesitas el costo MiniMax absolutamente más bajo y M2.1 solo texto ya es suficiente, o cuando necesitas enrutamiento por OpenRouter/Vercel porque esta entrada de VM0 usa intencionalmente solo la ruta oficial de MiniMax.",
         "comparisons": [
           {
             "vs": "Kimi K2.7 Code",
@@ -6167,19 +6167,19 @@
             "body": "GLM-5.2 es la ruta Z.AI predeterminada actual en VM0. Es la mejor comparación para nuevos agentes respaldados por Z.AI, mientras GLM-5.1 queda disponible solo por compatibilidad con flujos ya ajustados."
           }
         ],
-        "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
+        "verdict": "Usa MiniMax M3 cuando quieres el modelo oficial de código de MiniMax con contexto largo y soporte visual. Conserva M2.1 cuando importan más el costo y la compatibilidad.",
         "faqs": [
           {
-            "q": "Is MiniMax M2.1 still available?",
-            "a": "Yes. VM0 keeps MiniMax M2.1 in the direct MiniMax provider. M3 is now the default MiniMax BYOK model."
+            "q": "¿MiniMax M2.1 sigue disponible?",
+            "a": "Sí. VM0 conserva MiniMax M2.1 en el proveedor directo de MiniMax. M3 es ahora el modelo MiniMax BYOK predeterminado."
           },
           {
-            "q": "Does VM0 route MiniMax M3 through OpenRouter or Vercel?",
-            "a": "No. This entry intentionally uses only the official MiniMax Anthropic-compatible endpoint."
+            "q": "¿VM0 enruta MiniMax M3 mediante OpenRouter o Vercel?",
+            "a": "No. Esta entrada usa intencionalmente solo el endpoint oficial de MiniMax compatible con Anthropic."
           },
           {
-            "q": "Which M3 pricing tier does VM0 show?",
-            "a": "The VM0 model page and usage seed use MiniMax's non-promotional standard base tier. MiniMax also documents a higher standard tier for input above 512K tokens."
+            "q": "¿Qué capa de precios de M3 muestra VM0?",
+            "a": "La página de modelo de VM0 y el seed de uso emplean la capa base estándar no promocional de MiniMax. MiniMax también documenta una capa estándar superior para entradas por encima de 512K tokens."
           }
         ],
         "alternatives": [
@@ -6192,8 +6192,8 @@
             "reason": "Base más fiable para uso complejo de herramientas"
           }
         ],
-        "routingNotes": "Routed through MiniMax's official Anthropic-compatible endpoint at `api.minimax.io`. Available on VM0 Managed and MiniMax API-key providers only.",
-        "vm0Notes": "VM0 maps `MiniMax-M3` to the existing MiniMax vendor key pool for Built-in routing. The direct MiniMax provider uses M3 as its default model while keeping M2.1 selectable."
+        "routingNotes": "Enrutado mediante el endpoint oficial de MiniMax compatible con Anthropic en `api.minimax.io`. Disponible solo en VM0 Managed y proveedores con clave API de MiniMax.",
+        "vm0Notes": "VM0 mapea `MiniMax-M3` al pool existente de claves de proveedor MiniMax para el enrutamiento Built-in. El proveedor directo MiniMax usa M3 como modelo predeterminado y mantiene M2.1 seleccionable."
       },
       "gpt-image-2": {
         "name": "GPT Image 2",

--- a/turbo/apps/web/messages/es.json
+++ b/turbo/apps/web/messages/es.json
@@ -2380,7 +2380,7 @@
           },
           {
             "name": "Zero",
-            "text": "**Auditoría de Optimización de Costes - Esta Semana**\n\n🟢 **Ya óptimas** (mantener como están):\n• morning-brief (Sonnet) - agregación multi-fuente, justificado\n• pr-review-merge (Sonnet) - revisión de código bajo demanda, justificado\n\n🟡 **Sobredimensionadas** (seguro degradar):\n| Tarea | Modelo Actual | Recomendado | Ahorro Estimado |\n|-------|---------------|-------------|-----------------|\n| tech-debt-scan | Opus | GLM-5.1 | ~5-10x |\n| merge-queue-monitor | Sonnet | GLM-5.1 | ~3x |\n| standup-summary | Sonnet | GPT-4o mini | ~4x |\n| daily-email-check | Sonnet | GPT-4o mini | ~4x |\n\n🔴 **Requiere revisión humana**:\n• auto-test-coverage - escribe código real, en el límite. Prueba con Sonnet una semana y compara tasas de aprobación.\n\n**Ahorro mensual estimado: 2.400-3.800$**"
+            "text": "**Auditoría de Optimización de Costes - Esta Semana**\n\n🟢 **Ya óptimas** (mantener como están):\n• morning-brief (Sonnet) - agregación multi-fuente, justificado\n• pr-review-merge (Sonnet) - revisión de código bajo demanda, justificado\n\n🟡 **Sobredimensionadas** (seguro degradar):\n| Tarea | Modelo Actual | Recomendado | Ahorro Estimado |\n|-------|---------------|-------------|-----------------|\n| tech-debt-scan | Opus | GLM-5.2 | ~5-10x |\n| merge-queue-monitor | Sonnet | GLM-5.2 | ~3x |\n| standup-summary | Sonnet | GPT-4o mini | ~4x |\n| daily-email-check | Sonnet | GPT-4o mini | ~4x |\n\n🔴 **Requiere revisión humana**:\n• auto-test-coverage - escribe código real, en el límite. Prueba con Sonnet una semana y compara tasas de aprobación.\n\n**Ahorro mensual estimado: 2.400-3.800$**"
           }
         ],
         "steps": [
@@ -2401,12 +2401,12 @@
           {
             "title": "Cambia una tarea de bajo riesgo a un modelo más económico",
             "description": "Empieza con la recomendación más segura y verifica que la calidad se mantiene.",
-            "examplePrompt": "@Zero cambia la programación de merge-queue-monitor para usar GLM-5.1 en vez de Sonnet"
+            "examplePrompt": "@Zero cambia la programación de merge-queue-monitor para usar GLM-5.2 en vez de Sonnet"
           },
           {
             "title": "Ejecuta una prueba comparativa",
             "description": "Ejecuta la misma tarea en ambos modelos y compara los resultados antes de comprometerte.",
-            "examplePrompt": "@Zero ejecuta el prompt de tech-debt-scan en Opus y GLM-5.1, luego compara los resultados lado a lado"
+            "examplePrompt": "@Zero ejecuta el prompt de tech-debt-scan en Opus y GLM-5.2, luego compara los resultados lado a lado"
           },
           {
             "title": "Hazlo rutina",
@@ -4343,7 +4343,7 @@
             "body": "El modo rápido a 2,5× de velocidad solía costar tres veces lo que cuesta ahora ($10/$50 por 1M frente al nivel anterior). Para copilotos interactivos, resumidores on-call o cualquier paso donde la latencia de reloj de pared domine la experiencia, el modo rápido de 4.8 ahora es la elección predeterminada en la familia Claude."
           }
         ],
-        "avoidFor": "Evita Opus 4.8 en trabajo rutinario de alto volumen donde Sonnet 4.6 alcanza la misma calidad a una fracción del costo, en respuestas de chat sensibles a la latencia donde Kimi K2.6 es mucho más rápido, en codificación agéntica de terminal donde GPT-5.5 sigue liderando Terminal-Bench 2.1 (78,2% vs 74,6% de 4.8), y en pipelines que ingieren entradas no confiables sin sandboxing — la robustez de 4.8 a la inyección de prompts es ligeramente más débil que la de 4.7.",
+        "avoidFor": "Evita Opus 4.8 en trabajo rutinario de alto volumen donde Sonnet 4.6 alcanza la misma calidad a una fracción del costo, en respuestas de chat sensibles a la latencia donde Kimi K2.7 Code es mucho más rápido, en codificación agéntica de terminal donde GPT-5.5 sigue liderando Terminal-Bench 2.1 (78,2% vs 74,6% de 4.8), y en pipelines que ingieren entradas no confiables sin sandboxing — la robustez de 4.8 a la inyección de prompts es ligeramente más débil que la de 4.7.",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -4351,7 +4351,7 @@
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 (×1) sigue siendo el caballo de batalla predeterminado para la mayoría de bucles de agente. Promueve a Opus 4.8 cuando Sonnet falla visiblemente en razonamiento difícil, recuperación de contexto largo o ediciones de código al primer intento — usualmente como el planificador que delega a subagentes de nivel Sonnet o Kimi K2.6. Con flujos de trabajo dinámicos, Opus 4.8 como orquestador + Sonnet 4.6 como trabajadores es el nuevo patrón recomendado."
+            "body": "Sonnet 4.6 (×1) sigue siendo el caballo de batalla predeterminado para la mayoría de bucles de agente. Promueve a Opus 4.8 cuando Sonnet falla visiblemente en razonamiento difícil, recuperación de contexto largo o ediciones de código al primer intento — usualmente como el planificador que delega a subagentes de nivel Sonnet o Kimi K2.7 Code. Con flujos de trabajo dinámicos, Opus 4.8 como orquestador + Sonnet 4.6 como trabajadores es el nuevo patrón recomendado."
           },
           {
             "vs": "GPT-5.5",
@@ -4533,11 +4533,11 @@
           },
           {
             "title": "Velocidad",
-            "body": "Más lento que Sonnet 4.6 y notablemente más lento que Kimi K2.6. Anthropic publica ~41 tokens/seg en esfuerzo máximo para Opus 4.6, y 4.7 está en un rango similar. Resérvalo para los pasos que realmente necesitan la profundidad de razonamiento adicional y ejecuta niveles más ligeros en paralelo."
+            "body": "Más lento que Sonnet 4.6 y notablemente más lento que Kimi K2.7 Code. Anthropic publica ~41 tokens/seg en esfuerzo máximo para Opus 4.6, y 4.7 está en un rango similar. Resérvalo para los pasos que realmente necesitan la profundidad de razonamiento adicional y ejecuta niveles más ligeros en paralelo."
           },
           {
             "title": "Comportamiento de alucinación",
-            "body": "Opus 4.7 mantiene la postura conservadora de rechazo de Anthropic y tiende a admitir incertidumbre en lugar de confabular, razón por la cual los equipos de producción siguen pagando la prima por razonamiento de alto riesgo a pesar de que alternativas de peso abierto más baratas como Kimi K2.6 y DeepSeek V4 Pro ahora lo igualan en benchmarks."
+            "body": "Opus 4.7 mantiene la postura conservadora de rechazo de Anthropic y tiende a admitir incertidumbre en lugar de confabular, razón por la cual los equipos de producción siguen pagando la prima por razonamiento de alto riesgo a pesar de que alternativas de peso abierto más baratas como Kimi K2.7 Code y DeepSeek V4 Pro ahora lo igualan en benchmarks."
           }
         ],
         "bestForExamples": [
@@ -4551,34 +4551,34 @@
           },
           {
             "title": "El orquestador ejecutando un plan multi-herramienta",
-            "body": "Usa Opus 4.7 como el planificador que divide la solicitud de un cliente en diez pasos, despacha cada paso a un sub-agente de nivel Sonnet o Kimi K2.6, y une los resultados. Ejecutar Opus solo en la capa de planificación (y los niveles más baratos en el resto) cuesta una fracción de ejecutar Opus de principio a fin, conservando la mayor parte de la calidad."
+            "body": "Usa Opus 4.7 como el planificador que divide la solicitud de un cliente en diez pasos, despacha cada paso a un sub-agente de nivel Sonnet o Kimi K2.7 Code, y une los resultados. Ejecutar Opus solo en la capa de planificación (y los niveles más baratos en el resto) cuesta una fracción de ejecutar Opus de principio a fin, conservando la mayor parte de la calidad."
           },
           {
             "title": "Las ediciones de código al primer intento que no desperdician una ejecución de CI",
             "body": "Pide a Opus 4.7 que migre un código base de 50 archivos de un ORM a otro, refactorice un módulo enredado o aplique una corrección de seguridad en todo el repositorio. El parche se aplica limpiamente al primer intento con más frecuencia que cualquier otro modelo de la familia, que es lo que refleja Terminal-Bench 2.0 reportado por el proveedor, y lo que tu factura de CI también reflejará."
           }
         ],
-        "avoidFor": "Evita Opus 4.7 en trabajo rutinario de alto volumen donde Sonnet 4.6 alcanza la misma calidad a una fracción del costo, en respuestas de chat sensibles a la latencia donde Kimi K2.6 es mucho más rápido, y en trabajos de clasificación o extracción masiva donde GPT-5.4 Mini es aproximadamente 80× más barato a nivel de proveedor.",
+        "avoidFor": "Evita Opus 4.7 en trabajo rutinario de alto volumen donde Sonnet 4.6 alcanza la misma calidad a una fracción del costo, en respuestas de chat sensibles a la latencia donde Kimi K2.7 Code es mucho más rápido, y en trabajos de clasificación o extracción masiva donde GPT-5.4 Mini es aproximadamente 80× más barato a nivel de proveedor.",
         "comparisons": [
           {
+            "vs": "Claude Opus 4.8",
+            "body": "Opus 4.8 es el buque insignia más nuevo con el mismo multiplicador de VM0. Usa 4.8 para agentes nuevos de alto riesgo; conserva 4.7 solo cuando un flujo existente ya fue validado contra él y la estabilidad pesa más que las últimas mejoras de benchmark."
+          },
+          {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 es el caballo de batalla predeterminado en la familia Claude y la opción correcta para la mayoría de agentes. Promueve a Opus 4.7 solo cuando Sonnet falla visiblemente en razonamiento difícil, contexto largo o ediciones de código al primer intento, usualmente como el orquestador que delega hacia abajo a sub-agentes de nivel Sonnet o Kimi K2.6."
+            "body": "Sonnet 4.6 es el caballo de batalla predeterminado en la familia Claude y la opción correcta para la mayoría de agentes. Promueve a Opus 4.7 solo cuando Sonnet falla visiblemente en razonamiento difícil, contexto largo o ediciones de código al primer intento, usualmente como el orquestador que delega hacia abajo a sub-agentes de nivel Sonnet o Kimi K2.7 Code."
           },
           {
             "vs": "Claude Opus 4.6",
             "body": "Misma ventana de contexto (1M tokens), mismo precio de proveedor y la misma arquitectura de pensamiento adaptativo. Opus 4.7 es la generación más reciente con mejoras reportadas por el proveedor en SWE-bench Verified, Terminal-Bench 2.0, ARC AGI 2 y OSWorld. Elige 4.7 para nuevos agentes; mantén 4.6 solo cuando un agente existente haya sido validado contra esa versión y necesites estabilidad de comportamiento."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Kimi K2.6 de Moonshot lidera varios benchmarks agénticos en la frontera de código abierto (SWE-bench Pro 58,6 reportado por el proveedor versus 53,4 de Opus 4.6). Opus 4.7 mantiene el liderazgo en fiabilidad de enrutamiento de herramientas para agentes de producción en inglés y en perfil de seguridad, razón por la cual la mayoría de equipos empresariales aún lo mantienen como el nivel de alto riesgo."
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 Code de Moonshot lidera varios benchmarks agénticos en la frontera de código abierto (SWE-bench Pro 58,6 reportado por el proveedor versus 53,4 de Opus 4.6). Opus 4.7 mantiene el liderazgo en fiabilidad de enrutamiento de herramientas para agentes de producción en inglés y en perfil de seguridad, razón por la cual la mayoría de equipos empresariales aún lo mantienen como el nivel de alto riesgo."
           },
           {
             "vs": "DeepSeek V4 Pro",
             "body": "DeepSeek V4 Pro va por detrás de Opus en la mayoría de benchmarks de razonamiento pero lo iguala en codificación (SWE-bench Verified reportado por el proveedor dentro de ~0,2 puntos). La división es clara: elige DeepSeek cuando el costo bruto domina, elige Opus 4.7 cuando la fiabilidad, el perfil de seguridad o la precisión de enrutamiento de herramientas importan más que el precio por llamada."
-          },
-          {
-            "vs": "GPT-5.2 / Gemini 3 Pro",
-            "body": "Los materiales del proveedor de Anthropic posicionan a Opus 4.7 por delante de GPT-5.2 en la mayoría de tareas de codificación agéntica (Terminal-Bench, τ2-bench Retail) y a pocos puntos de Gemini 3 Pro en razonamiento abstracto (ARC AGI 2, GPQA Diamond). Los rankings independientes corroboran el orden aproximado pero cambian semanalmente."
           }
         ],
         "verdict": "Opus 4.7 es el nivel de escalación. Usa Sonnet 4.6 por defecto; promueve a Opus solo en los pasos específicos donde Sonnet falla visiblemente.",
@@ -4606,16 +4606,16 @@
         ],
         "alternatives": [
           {
+            "slug": "claude-opus-4-8",
+            "reason": "Buque insignia más nuevo para agentes de alto riesgo"
+          },
+          {
             "slug": "claude-sonnet-4-6",
             "reason": "Predeterminado más barato para la mayoría de bucles de agente"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Mejor recuperación de contexto largo a menor costo"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Razonamiento optimizado en costo si Claude es excesivo"
+            "slug": "kimi-k2-7-code",
+            "reason": "Alternativa de código open-weight que ahorra costos"
           }
         ],
         "routingNotes": "En VM0, Opus 4.7 se enruta directamente a la API Messages de Anthropic y se expone de tres formas: a través del pool de créditos VM0 Managed, a través de una clave API directa de Anthropic, y a través del proveedor OAuth de Claude Code para equipos ya autenticados con Claude Code.",
@@ -4714,7 +4714,7 @@
           },
           {
             "title": "Velocidad",
-            "body": "Más lento que Sonnet 4.6 y Kimi K2.6; comparable a Opus 4.7. Alrededor de 41 tokens/seg en esfuerzo máximo según Artificial Analysis."
+            "body": "Más lento que Sonnet 4.6 y Kimi K2.7 Code; comparable a Opus 4.7. Alrededor de 41 tokens/seg en esfuerzo máximo según Artificial Analysis."
           }
         ],
         "bestForExamples": [
@@ -4738,8 +4738,8 @@
             "body": "Sonnet 4.6 es ×1 y maneja la mayoría de bucles de agente. Recurre a Opus solo cuando Sonnet falla visiblemente. Usualmente para orquestación o ediciones de código difíciles."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Kimi K2.6 (×0,3) supera ligeramente a Opus 4.6 en SWE-bench Pro (58,6 vs 53,4 reportado por el proveedor) y es mucho más barato. Opus 4.6 mantiene la ventaja del perfil de seguridad y es la opción empresarial occidental predeterminada."
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 Code (×0,3) supera ligeramente a Opus 4.6 en SWE-bench Pro (58,6 vs 53,4 reportado por el proveedor) y es mucho más barato. Opus 4.6 mantiene la ventaja del perfil de seguridad y es la opción empresarial occidental predeterminada."
           }
         ],
         "verdict": "Mantenlo fijado si ya lo has validado; de lo contrario, comienza en Opus 4.7. La migración es un cambio de configuración, no una reescritura.",
@@ -4758,7 +4758,7 @@
           },
           {
             "q": "¿Por qué Opus 4.6 es el predeterminado en el proveedor de clave API de Anthropic?",
-            "a": "Predeterminado histórico de antes del lanzamiento de Opus 4.7. Puedes cambiar cualquier agente a Opus 4.7, Sonnet 4.6 o Kimi K2.6 en Configuración de VM0 → Proveedores de Modelos sin cambiar la clave API."
+            "a": "Predeterminado histórico de antes del lanzamiento de Opus 4.7. Puedes cambiar cualquier agente a Opus 4.7, Sonnet 4.6 o Kimi K2.7 Code en Configuración de VM0 → Proveedores de Modelos sin cambiar la clave API."
           },
           {
             "q": "¿Qué es el pensamiento adaptativo?",
@@ -4768,15 +4768,15 @@
         "alternatives": [
           {
             "slug": "claude-opus-4-7",
-            "reason": "Más nuevo, menor costo de proveedor"
+            "reason": "Más nuevo y con menor costo de proveedor"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Línea base Sonnet a mucho menor costo"
+            "reason": "Base Sonnet a costo mucho menor"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Alternativa de peso abierto más barata en benchmarks agénticos"
+            "slug": "kimi-k2-7-code",
+            "reason": "Alternativa open-weight más barata en benchmarks agénticos"
           }
         ],
         "routingNotes": "Enrutado directamente a la API Messages de Anthropic. Disponible en VM0 Managed y como el modelo predeterminado en los proveedores de clave API de Anthropic y OAuth de Claude Code.",
@@ -4972,9 +4972,9 @@
         "cardIntro": "El predeterminado para la mayoría de agentes VM0. Alta precisión de enrutamiento de herramientas, buen comportamiento en contexto largo y la línea base de crédito. Todos los demás modelos tienen precios relativos a Sonnet 4.6.",
         "metaTitle": "Claude Sonnet 4.6 en VM0: Benchmarks, Precios y Casos de Uso",
         "metaDescription": "Claude Sonnet 4.6 es el modelo predeterminado en VM0. Línea base de crédito ×1, contexto 1M, precios $3/$15, SWE-bench Verified 77%. Las tareas de agente que mejor maneja.",
-        "summary": "Claude Sonnet 4.6 es el caballo de batalla de la familia Claude 4 y el modelo Built-in predeterminado en VM0. Elige la herramienta correcta con los argumentos correctos de manera más fiable que cualquier cosa más barata, se mantiene coherente en conversaciones de cientos de miles de tokens, y la mayoría de agentes de producción — triaje de Slack, revisión de PR en GitHub, soporte al cliente — nunca necesitan ser promovidos más allá de él.\n\nEl precio de lista del proveedor es $3 / $15 por 1M tokens, con entrada cacheada a $0,30 / 1M. Recurre a Opus solo cuando Sonnet falla visiblemente en el razonamiento más difícil, y a Kimi K2.6 o GPT-5.4 Mini cuando el costo unitario domina.",
+        "summary": "Claude Sonnet 4.6 es el caballo de batalla de la familia Claude 4 y el modelo Built-in predeterminado en VM0. Elige la herramienta correcta con los argumentos correctos de manera más fiable que cualquier cosa más barata, se mantiene coherente en conversaciones de cientos de miles de tokens, y la mayoría de agentes de producción — triaje de Slack, revisión de PR en GitHub, soporte al cliente — nunca necesitan ser promovidos más allá de él.\n\nEl precio de lista del proveedor es $3 / $15 por 1M tokens, con entrada cacheada a $0,30 / 1M. Recurre a Opus solo cuando Sonnet falla visiblemente en el razonamiento más difícil, y a Kimi K2.7 Code o GPT-5.4 Mini cuando el costo unitario domina.",
         "releaseDate": "Febrero 2026 (generación Claude 4.6)",
-        "familyPosition": "Nivel medio de la familia Claude 4. El modelo caballo de batalla de Anthropic, situado entre Kimi K2.6 y Opus.",
+        "familyPosition": "Nivel medio de la familia Claude 4. El modelo caballo de batalla de Anthropic, situado entre Kimi K2.7 Code y Opus.",
         "background": [
           "Claude Sonnet 4.6 se sitúa en el medio de la familia Claude 4 de Anthropic. Es el modelo caballo de batalla diseñado para manejar toda la amplitud del trabajo típico de agente: enrutamiento multi-herramienta, ediciones de código, conversaciones de larga duración y tareas de salida estructurada. Sin el sobrecosto de Opus.",
           "En el catálogo Built-in de VM0, el multiplicador de crédito de todos los demás modelos está normalizado contra Sonnet 4.6 (×1). Esto hace que Sonnet sea la opción correcta cuando quieres conversaciones de presupuesto predecibles: \"este agente ejecuta aproximadamente a 2× un paso de Sonnet\" es una frase más útil que cotizaciones absolutas en dólares que cambian cada trimestre.",
@@ -5040,7 +5040,7 @@
           },
           {
             "title": "Velocidad",
-            "body": "Más rápido que Opus y más lento que Kimi K2.6. El equilibrio correcto velocidad/calidad para agentes de producción."
+            "body": "Más rápido que Opus y más lento que Kimi K2.7 Code. El equilibrio correcto velocidad/calidad para agentes de producción."
           },
           {
             "title": "Previsibilidad de costos",
@@ -5065,7 +5065,7 @@
             "body": "Historiales de conversación largos, llamadas frecuentes a herramientas del CRM, el mismo prompt de sistema pesado y esquema de herramientas en cada turno. El caché de prompts de Sonnet convierte ese prefijo fijo en una fracción del costo de entrada después de la primera llamada, lo que mantiene el costo por conversación plano a medida que crece el volumen."
           }
         ],
-        "avoidFor": "Evita Sonnet 4.6 en los pasos de razonamiento más difíciles donde visiblemente pierde instrucciones y deberías escalar a Opus 4.7, en clasificación masiva a alto volumen donde GPT-5.4 Mini es aproximadamente 50× más barato, y en micro-respuestas críticas en latencia donde Kimi K2.6 es significativamente más rápido.",
+        "avoidFor": "Evita Sonnet 4.6 en los pasos de razonamiento más difíciles donde visiblemente pierde instrucciones y deberías escalar a Opus 4.7, en clasificación masiva a alto volumen donde GPT-5.4 Mini es aproximadamente 50× más barato, y en micro-respuestas críticas en latencia donde Kimi K2.7 Code es significativamente más rápido.",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -5074,9 +5074,13 @@
           {
             "vs": "DeepSeek V4 Pro",
             "body": "DeepSeek V4 Pro (×0,1) iguala a Sonnet en benchmarks de codificación (SWE-bench Verified reportado por el proveedor) a un costo mucho menor. El compromiso es algo de fiabilidad de enrutamiento de herramientas y un perfil de seguridad menos maduro."
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "GPT-5.4 Mini es la opción OpenAI más barata para trabajo masivo. Usa Sonnet cuando la fiabilidad de enrutamiento de herramientas importa más; usa Mini para prefiltrado de alto volumen y pasos simples que no necesitan enrutamiento de nivel Sonnet."
           }
         ],
-        "verdict": "Comienza aquí. Migra hacia arriba a Opus 4.7 o hacia abajo a Kimi K2.6 / DeepSeek V4 Pro una vez que hayas visto el comportamiento real en producción y sepas qué dirección tiene sentido.",
+        "verdict": "Comienza aquí. Migra hacia arriba a Opus 4.7 o hacia abajo a Kimi K2.7 Code / DeepSeek V4 Pro una vez que hayas visto el comportamiento real en producción y sepas qué dirección tiene sentido.",
         "faqs": [
           {
             "q": "¿Por qué Sonnet 4.6 es el modelo predeterminado en VM0 Managed?",
@@ -5092,7 +5096,7 @@
           },
           {
             "q": "¿Cuándo debería dejar de usar Sonnet 4.6?",
-            "a": "Cambia a Opus 4.7 si Sonnet visiblemente pierde el objetivo en bucles de agente largos o falla en ediciones de código difíciles. Cambia a Kimi K2.6 o GPT-5.4 Mini para flujos simples de alto volumen donde el costo domina."
+            "a": "Cambia a Opus 4.7 si Sonnet visiblemente pierde el objetivo en bucles de agente largos o falla en ediciones de código difíciles. Cambia a Kimi K2.7 Code o GPT-5.4 Mini para flujos simples de alto volumen donde el costo domina."
           },
           {
             "q": "¿Es Sonnet 4.6 lo mismo que Sonnet 4.5?",
@@ -5373,15 +5377,19 @@
         "comparisons": [
           {
             "vs": "GLM-5.1",
-            "body": "GLM-5.1 remains available for compatibility. GLM-5.2 is the default choice for new Z.AI routes on VM0."
+            "body": "GLM-5.1 sigue disponible por compatibilidad. GLM-5.2 es la opción predeterminada para nuevas rutas Z.AI en VM0."
           },
           {
             "vs": "Kimi K2.7 Code",
-            "body": "Both sit in cost-saving territory. Kimi is the Moonshot default and a strong code-focused alternative; GLM-5.2 is the preferred Z.AI long-context route."
+            "body": "Ambos están en territorio de ahorro de costos. Kimi es el predeterminado de Moonshot y una alternativa fuerte enfocada en código; GLM-5.2 es la ruta Z.AI preferida para contexto largo."
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 remains the stronger default for premium tool-routing quality. GLM-5.2 is cheaper and better suited when context size dominates."
+            "body": "Sonnet 4.6 sigue siendo el predeterminado más fuerte para calidad premium de enrutamiento de herramientas. GLM-5.2 es más barato y encaja mejor cuando domina el tamaño de contexto."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro tiene un multiplicador VM0 más bajo y es la opción de razonamiento más fuerte cuando el costo va primero. Úsalo cuando domina el precio; usa GLM-5.2 cuando importan más el ajuste con Z.AI o el contexto largo."
           }
         ],
         "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
@@ -5402,15 +5410,15 @@
         "alternatives": [
           {
             "slug": "glm-5-1",
-            "reason": "Compatibility with existing GLM-5.1 workflows"
+            "reason": "Compatibilidad con flujos existentes de GLM-5.1"
           },
           {
             "slug": "kimi-k2-7-code",
-            "reason": "Moonshot's cost-saving code model"
+            "reason": "Modelo de código Moonshot que ahorra costos"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Cheaper standard-context alternative"
+            "reason": "Alternativa más barata para contexto estándar"
           }
         ],
         "routingNotes": "On VM0 Managed, GLM-5.2 routes through OpenRouter with the upstream id `z-ai/glm-5.2`. With a Z.AI API key it talks directly to `api.z.ai` as `glm-5.2`. It is the default model on the Z.AI provider.",
@@ -5423,7 +5431,7 @@
         "cardIntro": "El buque insignia de Z.AI. Hasta 1M tokens de ventana de contexto. Potente para agentes de código base completo o base de conocimiento completa a un precio muy por debajo de Sonnet.",
         "metaTitle": "GLM-5.1 en VM0: Contexto 1M, Precios y Mejores Tareas de Agente",
         "metaDescription": "Reseña de GLM-5.1 en VM0. El buque insignia de Z.AI con hasta 1M tokens de contexto, costo de crédito ×0,4. Especificaciones, precios, rendimiento y tareas de agente recomendadas.",
-        "summary": "GLM-5.1 es el especialista en contexto largo del catálogo, con hasta 1M tokens de entrada. Úsalo cuando el prompt es genuinamente enorme: un repositorio completo de una vez, varios cientos de documentos en una sola ejecución de investigación. Los rankings independientes lo sitúan consistentemente en el nivel superior de modelos de peso abierto para trabajo de contexto largo.\n\nEl precio de lista del proveedor es $1,40 / $4,40 por 1M tokens, muy por debajo de la mitad de Sonnet 4.6 a nivel de proveedor, y la API es compatible con Anthropic, por lo que los agentes estilo Claude funcionan sin reescritura. Recurre a Sonnet u Opus cuando la profundidad de razonamiento en inglés importa más que el tamaño del contexto, y a Kimi K2.6 cuando la latencia domina.",
+        "summary": "GLM-5.1 es el especialista en contexto largo del catálogo, con hasta 1M tokens de entrada. Úsalo cuando el prompt es genuinamente enorme: un repositorio completo de una vez, varios cientos de documentos en una sola ejecución de investigación. Los rankings independientes lo sitúan consistentemente en el nivel superior de modelos de peso abierto para trabajo de contexto largo.\n\nEl precio de lista del proveedor es $1,40 / $4,40 por 1M tokens, muy por debajo de la mitad de Sonnet 4.6 a nivel de proveedor, y la API es compatible con Anthropic, por lo que los agentes estilo Claude funcionan sin reescritura. Recurre a Sonnet u Opus cuando la profundidad de razonamiento en inglés importa más que el tamaño del contexto, y a Kimi K2.7 Code cuando la latencia domina.",
         "releaseDate": "Principios de 2026; GA completa en VM0 abril 2026",
         "familyPosition": "El modelo insignia de propósito general de Z.AI / Zhipu AI.",
         "background": [
@@ -5499,10 +5507,10 @@
             "body": "Algunos pasos de agente genuinamente toman de cinco a treinta minutos — investigación profunda, análisis multi-documento, pases largos de planificación. VM0 establece un timeout de API de 50 minutos para el proveedor Z.AI para que esos pasos de pensamiento largos no se corten a mitad del razonamiento, lo que hace de GLM-5.1 la opción segura sobre modelos enrutados a través de proveedores con timeouts predeterminados más cortos."
           }
         ],
-        "avoidFor": "Evita GLM-5.1 en el razonamiento en inglés más difícil donde Sonnet 4.6 u Opus 4.7 aún lideran, y en respuestas de chat críticas en latencia donde Kimi K2.6 es mucho más rápido.",
+        "avoidFor": "Evita GLM-5.1 en el razonamiento en inglés más difícil donde Sonnet 4.6 u Opus 4.7 aún lideran, y en respuestas de chat críticas en latencia donde Kimi K2.7 Code es mucho más rápido.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
+            "vs": "Kimi K2.7 Code",
             "body": "Ambos son opciones de contexto largo a costo de crédito similar (×0,4 vs ×0,3). Kimi tiene mejor recuperación de contexto largo en nuestra evaluación interna; GLM-5.1 gana en tamaño bruto de contexto (1M vs 256K). Elige Kimi para transcripciones muy largas; elige GLM-5.1 cuando necesitas meter un código base completo en un solo prompt."
           },
           {
@@ -5530,13 +5538,17 @@
           },
           {
             "q": "¿GLM-5.1 soporta entrada de imágenes?",
-            "a": "GLM-5.1 en VM0 está expuesto para texto y código. Para entrada multimodal (imagen/video), elige Claude Sonnet 4.6 o Kimi K2.6."
+            "a": "GLM-5.1 en VM0 está expuesto para texto y código. Para entrada multimodal (imagen/video), elige Claude Sonnet 4.6 o Kimi K2.7 Code."
           }
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "Mejor recuperación de contexto largo"
+            "slug": "glm-5-2",
+            "reason": "Ruta Z.AI predeterminada actual"
+          },
+          {
+            "slug": "kimi-k2-7-code",
+            "reason": "Recuperación de contexto largo más fuerte"
           },
           {
             "slug": "deepseek-v4-pro",
@@ -5556,14 +5568,14 @@
         "tagline": "El miembro optimizado en costo de OpenAI de la familia GPT-5. ×0,3 créditos, visión multimodal, y lo suficientemente rápido para enrutamiento, clasificación y prefiltrado de alto volumen.",
         "cardIntro": "El GPT-5 de OpenAI que ahorra costos. ×0,3 créditos, rápido y multimodal — la opción correcta para trabajo de prefiltrado masivo en el framework Codex.",
         "metaTitle": "GPT-5.4 Mini en VM0: Benchmarks, Precios y Comparación",
-        "metaDescription": "Reseña de GPT-5.4 Mini en VM0. El modelo OpenAI GPT-5 que ahorra costos a precios de proveedor de $0,75/$4,5, ×0,3 créditos, contexto de 400K y visión multimodal. Especificaciones, comportamiento y comparación con Kimi K2.6.",
-        "summary": "GPT-5.4 Mini es el miembro que ahorra costos de la familia GPT-5 de OpenAI — al que recurres cuando el costo unitario importa más que la calidad de razonamiento máxima. Mantiene la ventana de contexto de 400K y las entradas multimodales del resto de la familia pero recorta el cómputo por token, lo que se traduce en menor precio ($0,75 / $4,5 por 1M) y velocidad notablemente mayor.\n\nEn VM0 se sitúa en ×0,3 créditos, el mismo multiplicador que Kimi K2.6, lo que lo convierte en la opción natural del lado OpenAI para clasificación masiva, enrutamiento fan-out, prefiltrado, y cualquier paso de agente donde bajar a un tercio del costo de GPT-5.4 es el factor decisivo.",
+        "metaDescription": "Reseña de GPT-5.4 Mini en VM0. El modelo OpenAI GPT-5 que ahorra costos a precios de proveedor de $0,75/$4,5, ×0,3 créditos, contexto de 400K y visión multimodal. Especificaciones, comportamiento y comparación con Kimi K2.7 Code.",
+        "summary": "GPT-5.4 Mini es el miembro que ahorra costos de la familia GPT-5 de OpenAI — al que recurres cuando el costo unitario importa más que la calidad de razonamiento máxima. Mantiene la ventana de contexto de 400K y las entradas multimodales del resto de la familia pero recorta el cómputo por token, lo que se traduce en menor precio ($0,75 / $4,5 por 1M) y velocidad notablemente mayor.\n\nEn VM0 se sitúa en ×0,3 créditos, el mismo multiplicador que Kimi K2.7 Code, lo que lo convierte en la opción natural del lado OpenAI para clasificación masiva, enrutamiento fan-out, prefiltrado, y cualquier paso de agente donde bajar a un tercio del costo de GPT-5.4 es el factor decisivo.",
         "releaseDate": "Abril 2026",
-        "familyPosition": "Variante que ahorra costos de la familia GPT-5. El par del lado OpenAI de Kimi K2.6.",
+        "familyPosition": "Variante que ahorra costos de la familia GPT-5. El par del lado OpenAI de Kimi K2.7 Code.",
         "background": [
           "GPT-5.4 Mini es el miembro optimizado en costo de la generación GPT-5 de OpenAI, lanzado en abril de 2026 junto con GPT-5.5 y GPT-5.4. OpenAI lo posiciona como el nivel de alto rendimiento — el modelo que mantienes ejecutándose en pasos de clasificación, enrutamiento y prefiltrado donde 5.4 o 5.5 más grandes se desperdiciarían en decisiones rutinarias.",
           "Arquitectónicamente comparte la ventana de contexto de 400K tokens de la familia GPT-5, el parámetro `reasoning_effort`, Prompt Caching, y la superficie Responses API que usa el codex CLI por defecto. El compromiso frente a 5.4 es la profundidad de razonamiento: Mini maneja bien llamadas a herramientas estándar, resúmenes cortos y cargas de salida estructurada, pero empieza a derivar en los planes multi-paso más difíciles donde 5.4 todavía aguanta. El compromiso frente a competidores al mismo precio es el ecosistema — si ya estás en Codex, quedarte dentro de la superficie OpenAI mantiene definiciones de herramientas y esquemas de salida estructurada consistentes.",
-          "En VM0 Mini se sitúa en el multiplicador de ×0,3 créditos, el mismo que Kimi K2.6. DeepSeek V4 Pro se sitúa más bajo en ×0,1. Dentro del nivel que ahorra costos la elección depende principalmente del framework y ajuste de comportamiento en tu carga de trabajo específica."
+          "En VM0 Mini se sitúa en el multiplicador de ×0,3 créditos, el mismo que Kimi K2.7 Code. DeepSeek V4 Pro se sitúa más bajo en ×0,1. Dentro del nivel que ahorra costos la elección depende principalmente del framework y ajuste de comportamiento en tu carga de trabajo específica."
         ],
         "architecture": "GPT-5.4 Mini usa la misma arquitectura que el resto de la familia GPT-5: ventana de contexto de 400K tokens, el parámetro `reasoning_effort` en cuatro niveles, Prompt Caching donde la entrada cacheada se factura a una décima parte de la tarifa de entrada, y la superficie Responses API. Tool-Use, salidas estructuradas y entradas de visión multimodal son soportadas. El modelo es un hermano menor más rápido — menos parámetros por token, más rendimiento por dólar.",
         "specs": [
@@ -5600,7 +5612,7 @@
             "value": "$0,75 entrada / $4,5 salida por 1M"
           }
         ],
-        "benchmarksNote": "Puntuaciones reportadas por el proveedor de los materiales de lanzamiento de GPT-5 Mini de OpenAI. Las reseñas independientes sitúan a 5.4 Mini en la misma banda que ahorra costos que Kimi K2.6 en la mayoría de benchmarks de agente. Trata los porcentajes absolutos como direccionales.",
+        "benchmarksNote": "Puntuaciones reportadas por el proveedor de los materiales de lanzamiento de GPT-5 Mini de OpenAI. Las reseñas independientes sitúan a 5.4 Mini en la misma banda que ahorra costos que Kimi K2.7 Code en la mayoría de benchmarks de agente. Trata los porcentajes absolutos como direccionales.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -5643,7 +5655,7 @@
           },
           {
             "title": "Eficiencia de costo",
-            "body": "×0,3 créditos con visión multimodal incluida. Mini y Kimi K2.6 se sitúan en la misma banda, mientras DeepSeek V4 Pro se sitúa más bajo en ×0,1 — la elección usualmente se reduce al ajuste de framework y comportamiento en tu carga de trabajo específica."
+            "body": "×0,3 créditos con visión multimodal incluida. Mini y Kimi K2.7 Code se sitúan en la misma banda, mientras DeepSeek V4 Pro se sitúa más bajo en ×0,1 — la elección usualmente se reduce al ajuste de framework y comportamiento en tu carga de trabajo específica."
           },
           {
             "title": "Cuándo escalar",
@@ -5669,6 +5681,14 @@
           {
             "vs": "GPT-5.4",
             "body": "Misma familia, diferente posicionamiento. 5.4 Mini (×0,3) gana en costo y velocidad; 5.4 (×1) gana en calidad de razonamiento y precisión de enrutamiento de herramientas en casos difíciles. El patrón estándar es prefiltrar con Mini y escalar los casos residuales a 5.4."
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "Claude Sonnet 4.6 es el punto de comparación más fiable cuando la calidad de enrutamiento de herramientas importa más que el rendimiento bruto. Mini es más barato y rápido para prefiltrado y pasos simples."
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro tiene un multiplicador VM0 más bajo y es la opción de razonamiento más fuerte cuando el costo va primero. Usa DeepSeek cuando dominan precio y profundidad de razonamiento; usa Mini cuando importan más el ajuste con OpenAI y el alto rendimiento."
           }
         ],
         "verdict": "GPT-5.4 Mini es el predeterminado que ahorra costos del lado OpenAI. Prefiltra con Mini, escala a GPT-5.4 para pasos rutinarios, escala a GPT-5.5 solo para el razonamiento más difícil.",
@@ -5682,7 +5702,7 @@
             "a": "Sí. Como el resto de la familia GPT-5 acepta entradas de imagen junto con texto y código."
           },
           {
-            "q": "¿Cuándo debería elegir GPT-5.4 Mini sobre Kimi K2.6?",
+            "q": "¿Cuándo debería elegir GPT-5.4 Mini sobre Kimi K2.7 Code?",
             "a": "Cuando tu agente ya está construido en el framework Codex o necesitas el ecosistema de salidas estructuradas / llamadas a herramientas de OpenAI. Ambos se sitúan en ×0,3 créditos, así que el costo es idéntico y la elección se reduce al framework y comportamiento."
           },
           {
@@ -5701,178 +5721,7 @@
           }
         ],
         "routingNotes": "Enrutado a través del framework Codex en VM0 mediante la Responses API de OpenAI. Disponible en VM0 Managed y mediante clave API directa de OpenAI, OAuth de ChatGPT (Codex), OpenRouter (Codex) y Vercel AI Gateway (Codex).",
-        "vm0Notes": "GPT-5.4 Mini se sitúa en el multiplicador de ×0,3 que ahorra costos junto a Kimi K2.6, por encima del nivel ×0,1 de DeepSeek V4 Pro. Prompt Caching está habilitado por defecto y el alto rendimiento hace de Mini un paso natural de prefiltrado en diseños de agente apilados que escalan a 5.4 o 5.5 solo en los casos difíciles residuales."
-      },
-      "kimi-k2-6": {
-        "name": "Kimi K2.6",
-        "pageTitle": "Kimi K2.6 en VM0. Agentes de contexto largo",
-        "tagline": "El último modelo de peso abierto de Moonshot. Los mejores benchmarks agénticos de su clase en la frontera de código abierto e interfaz compatible con Claude.",
-        "cardIntro": "Lo último de Moonshot. La mejor recuperación de contexto largo en nuestra evaluación interna e interfaz compatible con Claude.",
-        "metaTitle": "Kimi K2.6 en VM0: SWE-bench, Precios y Uso de Contexto Largo",
-        "metaDescription": "Reseña de Kimi K2.6 en VM0. MoE de 1T parámetros de peso abierto de Moonshot. SWE-bench Pro 58,6, costo de crédito ×0,3, contexto 256K. Especificaciones y tareas recomendadas.",
-        "summary": "Kimi K2.6 es el buque insignia de peso abierto de Moonshot y actualmente el modelo agéntico de código abierto más fuerte en varios benchmarks públicos. Mantiene ejecuciones muy largas sin perder el hilo (Moonshot ha documentado sesiones desatendidas de más de 12 horas y más de 4.000 llamadas a herramientas) y acepta entrada de imagen y video de forma nativa. SWE-bench Pro reportado por el proveedor alcanza 58,6 (por encima de Claude Opus 4.6 y GPT-5.4 en ese benchmark), y la tasa de alucinación bajó del ~65% de K2.5 al ~39%.\n\nEl precio de lista del proveedor es $0,60 / $3 por 1M tokens, pesos abiertos bajo licencia MIT Modificada, y la API es compatible con Anthropic. Recurre a Sonnet 4.6 cuando la fiabilidad de enrutamiento de herramientas en producción importa más que las puntuaciones de benchmark, y a Kimi K2.6 cuando la latencia domina.",
-        "releaseDate": "20 de abril de 2026",
-        "familyPosition": "Cima de la serie Kimi K2 de peso abierto de Moonshot. Sucesor de K2.5 y K2 Thinking.",
-        "background": [
-          "Kimi K2.6 es el modelo agéntico de peso abierto de Moonshot AI lanzado el 20 de abril de 2026. Es un modelo Mixture-of-Experts (MoE) de 1 billón de parámetros con 32B parámetros activos por token. La misma familia de arquitectura que K2.5 y K2 Thinking, con ganancias sustanciales en codificación agéntica y razonamiento de largo horizonte.",
-          "K2.6 causó un gran impacto en los rankings independientes. Las puntuaciones reportadas por el proveedor lo sitúan por delante de GPT-5.4 (xhigh) y Claude Opus 4.6 (esfuerzo máximo) en SWE-bench Pro, con una tasa de alucinación del 39% (bajando del 65% de K2.5). Artificial Analysis lo clasifica #4 en su Índice de Inteligencia. La opción líder de peso abierto.",
-          "En VM0 se expone a través de la clave API de Moonshot como modelo predeterminado, mediante VM0 Managed con el mismo multiplicador ×0,3, y vía OpenRouter. La API es compatible con Anthropic, por lo que los agentes VM0 escritos para Claude funcionan sin cambios de código."
-        ],
-        "architecture": "K2.6 es un modelo Mixture-of-Experts con 1B parámetros totales y 32B activos por token, con una ventana de contexto de 256K tokens y entrada multimodal de imagen y video (salida solo texto). Moonshot lo combina con un runtime Agent Swarm que escala horizontalmente a 300 sub-agentes y 4.000 pasos coordinados, y ha documentado sesiones de codificación de largo horizonte de 12 horas o más. Los pesos abiertos están publicados en Hugging Face bajo una Licencia MIT Modificada.",
-        "specs": [
-          {
-            "label": "Familia",
-            "value": "Serie Kimi K2"
-          },
-          {
-            "label": "Parámetros",
-            "value": "1B total / 32B activos (MoE)"
-          },
-          {
-            "label": "Modalidades",
-            "value": "Imagen, video, texto"
-          },
-          {
-            "label": "Idiomas",
-            "value": "Multilingüe"
-          },
-          {
-            "label": "Ventana de contexto",
-            "value": "256K tokens"
-          },
-          {
-            "label": "Licencia",
-            "value": "MIT Modificada (pesos abiertos)"
-          },
-          {
-            "label": "Disponible en VM0",
-            "value": "Abril 2026"
-          }
-        ],
-        "benchmarksNote": "Puntuaciones reportadas por el proveedor del blog de lanzamiento de K2.6 de Moonshot. Terceros independientes (Artificial Analysis, TokenMix) corroboran el orden relativo. La tasa de alucinación de K2.6 bajó al 39% desde el 65% de K2.5. Una mejora significativa en seguridad/fiabilidad.",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "58,6",
-            "note": "reportado por el proveedor; supera a GPT-5.4, Opus 4.6"
-          },
-          {
-            "name": "SWE-bench Verified",
-            "score": "80,2",
-            "note": "reportado por el proveedor"
-          },
-          {
-            "name": "Terminal-Bench 2.0",
-            "score": "66,7",
-            "note": "framework Terminus-2"
-          },
-          {
-            "name": "LiveCodeBench (v6)",
-            "score": "89,6",
-            "note": "reportado por el proveedor"
-          },
-          {
-            "name": "HLE (con herramientas)",
-            "score": "54,0",
-            "note": "supera a GPT-5.4 y Opus 4.6"
-          },
-          {
-            "name": "BrowseComp (Agent Swarm)",
-            "score": "86,3",
-            "note": "sube desde 78,4 de K2.5"
-          },
-          {
-            "name": "Índice de Inteligencia Artificial Analysis",
-            "score": "54",
-            "note": "#4 general, líder en pesos abiertos"
-          }
-        ],
-        "performance": [
-          {
-            "title": "Recuperación de contexto largo",
-            "body": "La recuperación de contexto largo más fuerte en nuestra evaluación interna en todo el catálogo Built-in. Mantiene la coherencia en transcripciones largas de agente donde Anthropic Sonnet empieza a desviarse."
-          },
-          {
-            "title": "Benchmarks agénticos",
-            "body": "SWE-bench Pro 58,6 reportado por el proveedor es el más alto del catálogo al momento de escribir. Supera a GPT-5.4 y Opus 4.6."
-          },
-          {
-            "title": "Codificación de largo horizonte",
-            "body": "Sesiones autónomas documentadas de más de 12 horas completando más de 4.000 llamadas a herramientas. El modelo realmente mantiene el rendimiento en ejecuciones muy largas."
-          },
-          {
-            "title": "Uso de herramientas",
-            "body": "Fiable en los flujos de herramientas comunes de VM0. La API compatible con Anthropic significa que los esquemas de herramientas diseñados para Claude funcionan directamente."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "La investigación que tiene que leer cada hilo antiguo",
-            "body": "Excava en seis meses de conversaciones de Slack para encontrar por qué un cliente se dio de baja, peina el backlog de tickets de soporte en busca de un patrón de bug recurrente, o une ideas a través de cientos de RFCs. La recuperación de contexto largo de K2.6 se mantiene en transcripciones donde Anthropic Sonnet empieza a olvidar turnos anteriores, que es exactamente lo que necesitan los flujos de trabajo de \"leer todo el montón\"."
-          },
-          {
-            "title": "La refactorización autónoma que se ejecuta durante la noche",
-            "body": "Moonshot ha documentado una refactorización autónoma de 13 horas de un motor de matching de ocho años, con K2.6 manteniendo más de 4.000 llamadas a herramientas sin desviarse de la tarea. Ese es el tipo de ejecución donde la mayoría de los modelos pierden el objetivo alrededor de la segunda hora; la estabilidad de largo horizonte de K2.6 es lo que hace que \"empezar el viernes por la noche, revisar el lunes por la mañana\" realmente funcione."
-          },
-          {
-            "title": "El agente multimodal que maneja capturas de pantalla y clips",
-            "body": "K2.6 acepta tanto entrada de imagen como de video a través de MoonViT, lo cual es inusual fuera de la familia Claude. Útil para agentes de QA basados en capturas de pantalla, pipelines de visión de documentos y cualquier despliegue donde de otro modo tendrías que incorporar un modelo de visión separado solo para leer imágenes."
-          }
-        ],
-        "avoidFor": "Evita K2.6 en los casos límite más difíciles de enrutamiento de herramientas donde Sonnet 4.6 aún lidera en fiabilidad de producción, y en flujos legacy fijados donde el multiplicador más bajo de K2.5 ya es suficiente.",
-        "comparisons": [
-          {
-            "vs": "GLM-5.1",
-            "body": "Ambos son opciones de contexto largo. K2.6 gana en recuperación bruta de contexto largo en nuestra evaluación interna; GLM-5.1 gana en tamaño de contexto (1M vs 256K). Predetermina K2.6 para transcripciones largas; recurre a GLM-5.1 solo cuando necesitas más de 256K tokens en un solo prompt."
-          },
-          {
-            "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet (×1) lidera en fiabilidad de enrutamiento multi-herramienta en inglés. K2.6 (×0,3) gana en costo y en benchmarks agénticos (SWE-bench Pro). Combínalos: Sonnet para enrutamiento complejo de herramientas, K2.6 para trabajo de agente sensible al costo."
-          },
-          {
-            "vs": "Kimi K2.5",
-            "body": "K2.6 es la generación más reciente con mejor uso de herramientas, menor tasa de alucinación (39% vs 65%) y mejor razonamiento. K2.5 (×0,2) es ligeramente más barato. Prefiere K2.6 para trabajo nuevo."
-          }
-        ],
-        "verdict": "El predeterminado de peso abierto para trabajo de agente serio — contexto largo, costo-efectivo. Las brechas restantes frente a Sonnet 4.6 son fiabilidad de enrutamiento de herramientas y soporte empresarial.",
-        "faqs": [
-          {
-            "q": "¿Cuándo se lanzó Kimi K2.6?",
-            "a": "Moonshot AI lanzó Kimi K2.6 el 20 de abril de 2026. Los pesos abiertos están publicados en Hugging Face bajo una Licencia MIT Modificada."
-          },
-          {
-            "q": "¿Cuál es la ventana de contexto?",
-            "a": "256K tokens. K2.6 se diferencia por la calidad de recuperación a ese tamaño, no por el tamaño bruto de la ventana. La recuperación empieza a degradarse pasados ~180K (similar a otros modelos de 256K)."
-          },
-          {
-            "q": "¿Necesito reescribir mi agente para usar Kimi?",
-            "a": "No. Kimi K2.6 expone una API compatible con Anthropic, por lo que los agentes VM0 ajustados para Claude funcionan sin cambios de código."
-          },
-          {
-            "q": "¿Cómo se compara Kimi K2.6 con Claude Opus 4.6?",
-            "a": "En benchmarks agénticos (reportados por el proveedor), K2.6 lidera. SWE-bench Pro 58,6 vs 53,4 de Opus 4.6, HLE con herramientas 54,0 vs 53,0. Opus 4.6 mantiene una ventaja en perfil de seguridad y fiabilidad de enrutamiento de herramientas en inglés en producción."
-          },
-          {
-            "q": "¿K2.6 soporta entrada de imágenes?",
-            "a": "Sí. K2.6 acepta entrada de imagen y video. Salida solo texto. Los agentes multimodales funcionan de forma nativa."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-5",
-            "reason": "Generación anterior, multiplicador ligeramente más barato"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Ventana de contexto aún más larga (1M tokens)"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Alternativa más barata para trabajo sensible al costo"
-          }
-        ],
-        "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de Moonshot en `api.moonshot.ai`. Modelo predeterminado en el proveedor Moonshot; también disponible en VM0 Managed y vía OpenRouter.",
-        "vm0Notes": "K2.6 tiene la recuperación de contexto largo más fuerte del catálogo Built-in según nuestra evaluación interna, y a ×0,3 créditos es lo suficientemente barato como para actuar como un sustituto viable de Sonnet para trabajo sensible al costo."
+        "vm0Notes": "GPT-5.4 Mini se sitúa en el multiplicador de ×0,3 que ahorra costos junto a Kimi K2.7 Code, por encima del nivel ×0,1 de DeepSeek V4 Pro. Prompt Caching está habilitado por defecto y el alto rendimiento hace de Mini un paso natural de prefiltrado en diseños de agente apilados que escalan a 5.4 o 5.5 solo en los casos difíciles residuales."
       },
       "kimi-k2-7-code": {
         "name": "Kimi K2.7 Code",
@@ -5993,16 +5842,16 @@
         "avoidFor": "Evita K2.7 en los casos límite más difíciles de enrutamiento de herramientas donde Sonnet 4.6 aún lidera en fiabilidad de producción, y en flujos legacy fijados donde el multiplicador más bajo de K2.6 ya es suficiente.",
         "comparisons": [
           {
-            "vs": "GLM-5.1",
-            "body": "Ambos son opciones de contexto largo. K2.7 gana en recuperación bruta de contexto largo en nuestra evaluación interna; GLM-5.1 gana en tamaño de contexto (1M vs 256K). Predetermina K2.7 para transcripciones largas; recurre a GLM-5.1 solo cuando necesitas más de 256K tokens en un solo prompt."
+            "vs": "GLM-5.2",
+            "body": "Ambos son opciones actuales de contexto largo que ahorran costos. K2.7 Code es el predeterminado de Moonshot con mejor ajuste para código multimodal; GLM-5.2 es el predeterminado actual de Z.AI con una ventana de contexto mayor de 1M tokens."
           },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet (×1) lidera en fiabilidad de enrutamiento multi-herramienta en inglés. K2.7 (×0,3) gana en costo y en benchmarks agénticos (SWE-bench Pro). Combínalos: Sonnet para enrutamiento complejo de herramientas, K2.7 para trabajo de agente sensible al costo."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "K2.7 es la generación más reciente con mejor uso de herramientas, menor tasa de alucinación (39% vs 65%) y mejor razonamiento. K2.6 (×0,2) es ligeramente más barato. Prefiere K2.7 para trabajo nuevo."
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Pro es más barato y tiene una ventana de contexto mayor de 1M tokens. Kimi K2.7 Code es la ruta de código nativa de Moonshot más fuerte e incluye entrada de visión. Elige según el ajuste del proveedor y la forma de la carga de trabajo."
           }
         ],
         "verdict": "El predeterminado de peso abierto para trabajo de agente serio — contexto largo, costo-efectivo. Las brechas restantes frente a Sonnet 4.6 son fiabilidad de enrutamiento de herramientas y soporte empresarial.",
@@ -6030,16 +5879,16 @@
         ],
         "alternatives": [
           {
-            "slug": "claude-sonnet-4-6",
-            "reason": "Generación anterior, multiplicador ligeramente más barato"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Ventana de contexto aún más larga (1M tokens)"
+            "slug": "glm-5-2",
+            "reason": "Ruta Z.AI actual para contexto largo"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Alternativa más barata para trabajo sensible al costo"
+            "reason": "Alternativa de razonamiento más barata para trabajo sensible al costo"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "Base más fiable para uso complejo de herramientas"
           }
         ],
         "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de Moonshot en `api.moonshot.ai`. Modelo predeterminado en el proveedor Moonshot; también disponible en VM0 Managed.",
@@ -6052,13 +5901,13 @@
         "cardIntro": "El buque insignia de DeepSeek. Razonamiento potente con un bajo multiplicador de crédito en VM0, API compatible con Claude.",
         "metaTitle": "DeepSeek V4 Pro en VM0: Benchmarks, Precios y Comparación",
         "metaDescription": "Reseña de DeepSeek V4 Pro en VM0. MoE de 1,6T de peso abierto con SWE-bench Verified 80,6%, costo de crédito ×0,1, contexto 1M. Precios, especificaciones y comparación con Claude.",
-        "summary": "DeepSeek V4 Pro es el buque insignia de la generación V4 de DeepSeek — un MoE de 1,6T parámetros de peso abierto bajo licencia MIT. El titular es la relación precio-calidad: SWE-bench Verified reportado por el proveedor es 80,6%, a una fracción de punto de Claude Opus 4.6, a aproximadamente un séptimo del costo de proveedor de Anthropic. Esto hace que los agentes intensivos en razonamiento — revisión masiva de PR, análisis de documentos por lotes, resúmenes programados — sean asequibles a alto volumen.\n\nEl precio de lista del proveedor es $1,74 / $3,48 por 1M tokens con lecturas de caché a $0,028 / 1M y escrituras de caché gratuitas (único en el catálogo). Contexto de 1M tokens, API compatible con Anthropic. Recurre a Sonnet 4.6 cuando la fiabilidad de enrutamiento de herramientas en producción es el factor decisivo, y a GPT-5.4 Mini o Kimi K2.6 cuando el trabajo masivo de un solo paso no necesita la profundidad de razonamiento de V4 Pro.",
+        "summary": "DeepSeek V4 Pro es el buque insignia de la generación V4 de DeepSeek — un MoE de 1,6T parámetros de peso abierto bajo licencia MIT. El titular es la relación precio-calidad: SWE-bench Verified reportado por el proveedor es 80,6%, a una fracción de punto de Claude Opus 4.6, a aproximadamente un séptimo del costo de proveedor de Anthropic. Esto hace que los agentes intensivos en razonamiento — revisión masiva de PR, análisis de documentos por lotes, resúmenes programados — sean asequibles a alto volumen.\n\nEl precio de lista del proveedor es $1,74 / $3,48 por 1M tokens con lecturas de caché a $0,028 / 1M y escrituras de caché gratuitas (único en el catálogo). Contexto de 1M tokens, API compatible con Anthropic. Recurre a Sonnet 4.6 cuando la fiabilidad de enrutamiento de herramientas en producción es el factor decisivo, y a GPT-5.4 Mini o Kimi K2.7 Code cuando el trabajo masivo de un solo paso no necesita la profundidad de razonamiento de V4 Pro.",
         "releaseDate": "24 de abril de 2026",
         "familyPosition": "Variante de razonamiento de la familia DeepSeek V4, enfocada en máxima calidad de razonamiento.",
         "background": [
           "DeepSeek V4 Pro es el buque insignia de la generación V4 de DeepSeek, lanzado el 24 de abril de 2026 bajo la Licencia MIT. Es un modelo Mixture-of-Experts de peso abierto con 1,6T parámetros totales y 49B activos por token.",
           "V4 Pro soporta una ventana de contexto de 1M tokens, 384K de salida máxima, tres modos de esfuerzo de razonamiento (standard, think, think-max), salida JSON, llamadas a herramientas y completado FIM en modo no-think. El modelo Pro añade una arquitectura de atención híbrida (Compressed Sparse Attention + Heavily Compressed Attention) para una eficiencia de contexto largo drásticamente mejorada. 27% de los FLOPs de inferencia por token y 10% de la caché KV vs DeepSeek V3.2 en contexto de 1M.",
-          "DeepSeek causó sensación durante 2025 al ofrecer razonamiento de nivel Anthropic a una fracción del precio. V4 Pro continúa ese patrón: SWE-bench Verified 80,6% reportado por el proveedor está a 0,2 puntos de Claude Opus 4.6, a aproximadamente un séptimo del costo de proveedor. En VM0 se expone a través del proveedor de clave API de DeepSeek y en VM0 Managed a ×0,1. Multiplicador más bajo que Kimi K2.6, con un comportamiento de razonamiento sustancialmente más fuerte."
+          "DeepSeek causó sensación durante 2025 al ofrecer razonamiento de nivel Anthropic a una fracción del precio. V4 Pro continúa ese patrón: SWE-bench Verified 80,6% reportado por el proveedor está a 0,2 puntos de Claude Opus 4.6, a aproximadamente un séptimo del costo de proveedor. En VM0 se expone a través del proveedor de clave API de DeepSeek y en VM0 Managed a ×0,1. Multiplicador más bajo que Kimi K2.7 Code, con un comportamiento de razonamiento sustancialmente más fuerte."
         ],
         "architecture": "V4 Pro es un modelo Mixture-of-Experts con 1,6T parámetros totales y 49B activos por token, con una pila de atención híbrida (Compressed Sparse Attention más Heavily Compressed Attention) que mantiene la inferencia de contexto largo económica. Soporta una ventana de contexto de 1M tokens con 384K de salida máxima, tres modos de esfuerzo de razonamiento (standard, think y think-max), y usa Conexiones Hiper-Restringidas de Variedad para propagación estable de señales. El modelo fue entrenado en más de 32T tokens con el optimizador Muon y se publica bajo la Licencia MIT con pesos abiertos.",
         "specs": [
@@ -6095,7 +5944,7 @@
             "value": "24 de abril de 2026"
           }
         ],
-        "benchmarksNote": "Puntuaciones reportadas por el proveedor del lanzamiento de V4 Pro de DeepSeek. Reseñas independientes (Geeky Gadgets, Code Arena) sitúan a V4 Pro tercero en Code Arena detrás de GLM-5.1 y Kimi K2.6. Las afirmaciones de benchmark más fuertes provienen de los propios materiales de DeepSeek. Trátalas como direccionales, no como verdad absoluta.",
+        "benchmarksNote": "Puntuaciones reportadas por el proveedor del lanzamiento de V4 Pro de DeepSeek. Reseñas independientes (Geeky Gadgets, Code Arena) sitúan a V4 Pro tercero en Code Arena detrás de GLM-5.1 y Kimi K2.7 Code. Las afirmaciones de benchmark más fuertes provienen de los propios materiales de DeepSeek. Trátalas como direccionales, no como verdad absoluta.",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -6152,7 +6001,7 @@
           },
           {
             "title": "Velocidad",
-            "body": "Alrededor de 36 tokens/seg en esfuerzo máximo según Artificial Analysis. Más lento que Kimi K2.6, ligeramente más lento que Opus 4.6."
+            "body": "Alrededor de 36 tokens/seg en esfuerzo máximo según Artificial Analysis. Más lento que Kimi K2.7 Code, ligeramente más lento que Opus 4.6."
           }
         ],
         "bestForExamples": [
@@ -6169,18 +6018,22 @@
             "body": "Contexto de 1M tokens con atención híbrida (Compressed Sparse Attention más Heavily Compressed Attention) significa que un código base de tamaño medio cabe en un solo prompt y el costo de inferencia se mantiene manejable a medida que la ventana se llena. Para refactorizaciones entre archivos y revisiones a nivel de arquitectura, aquí es donde obtienes el flujo de trabajo estilo Opus de \"ver todo a la vez\" sin la factura estilo Opus."
           }
         ],
-        "avoidFor": "Evita V4 Pro en los casos límite más difíciles de enrutamiento de herramientas donde Sonnet 4.6 aún lidera, y en trabajo masivo de un solo paso donde GPT-5.4 Mini o Kimi K2.6 basta a menor costo.",
+        "avoidFor": "Evita V4 Pro en los casos límite más difíciles de enrutamiento de herramientas donde Sonnet 4.6 aún lidera, y en trabajo masivo de un solo paso donde GPT-5.4 Mini o Kimi K2.7 Code basta a menor costo.",
         "comparisons": [
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet 4.6 (×1) gana en casos límite de enrutamiento de herramientas y razonamiento en inglés. V4 Pro (×0,1) gana en costo y es competitivo en benchmarks de codificación (reportados por el proveedor). Vale la pena hacer pruebas A/B en un agente real antes de comprometerse."
           },
           {
-            "vs": "Kimi K2.6",
+            "vs": "Kimi K2.7 Code",
             "body": "Multiplicador más bajo que Kimi (×0,1 vs ×0,3). Kimi tiene mejor recuperación de contexto largo y un Índice de Inteligencia más alto (54 vs 52); V4 Pro tiene mejor economía de caché (escrituras gratuitas) y una ventana de contexto de 1M vs 256K de Kimi. Elige según qué propiedad importa más."
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2 es la ruta Z.AI predeterminada actual en VM0. Es la mejor comparación para nuevos agentes respaldados por Z.AI, mientras GLM-5.1 queda disponible solo por compatibilidad con flujos ya ajustados."
           }
         ],
-        "verdict": "Prefiltra con GPT-5.4 Mini o Kimi K2.6, escala a V4 Pro para razonamiento, escala a Sonnet 4.6 solo cuando V4 Pro se estanca en casos límite de enrutamiento de herramientas.",
+        "verdict": "Prefiltra con GPT-5.4 Mini o Kimi K2.7 Code, escala a V4 Pro para razonamiento, escala a Sonnet 4.6 solo cuando V4 Pro se estanca en casos límite de enrutamiento de herramientas.",
         "faqs": [
           {
             "q": "¿Cuándo se lanzó DeepSeek V4 Pro?",
@@ -6206,146 +6059,15 @@
         "alternatives": [
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Subir de nivel para enrutamiento difícil de herramientas"
+            "reason": "Sube de nivel para enrutamiento de herramientas difícil"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "Mismo precio, mejor recuperación de contexto largo"
+            "slug": "kimi-k2-7-code",
+            "reason": "Predeterminado de Moonshot con mejor ajuste de código multimodal"
           }
         ],
         "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de DeepSeek en `api.deepseek.com`. Disponible en VM0 Managed y el proveedor DeepSeek.",
         "vm0Notes": "DeepSeek factura lecturas de caché pero no escrituras, lo que supone un ahorro real cuando el prompt de sistema es estable. VM0 establece un timeout de API de 10 minutos para el proveedor DeepSeek y deshabilita el tráfico no esencial para mantener la capacidad de respuesta de los agentes de larga duración. El resultado es el razonamiento más fuerte de cualquier modelo sub-Sonnet en el catálogo Built-in."
-      },
-      "kimi-k2-5": {
-        "name": "Kimi K2.5",
-        "pageTitle": "Kimi K2.5 en VM0. La generación anterior de Moonshot",
-        "tagline": "La generación anterior de Kimi. Más barato que K2.6 pero con uso de herramientas más débil; mantenlo fijado solo si un agente específico fue validado en esta versión.",
-        "cardIntro": "La generación anterior de Kimi. Más barato que K2.6 pero con uso de herramientas más débil; mantenlo fijado solo si un agente específico fue validado en esta versión.",
-        "metaTitle": "Kimi K2.5 en VM0: Especificaciones, Precios y Migración a K2.6",
-        "metaDescription": "Reseña de Kimi K2.5 en VM0. El anterior buque insignia de Moonshot a costo de crédito ×0,2. SWE-bench Pro 50,7, contexto 256K. Cuándo mantener K2.5 en lugar de K2.6.",
-        "summary": "Kimi K2.5 es el anterior buque insignia de Moonshot, el modelo de peso abierto que K2.6 reemplazó en abril de 2026. Sigue siendo capaz — fuerte en resúmenes de contexto largo — pero K2.6 lidera en cada benchmark publicado al mismo precio de proveedor, y la brecha en tasa de alucinación es amplia (K2.5 ~65% en la evaluación de Moonshot versus ~39% de K2.6).\n\nEl precio de lista del proveedor es $0,60 / $3 por 1M tokens, idéntico a K2.6. La propuesta honesta: si construiste sobre K2.5 y funciona, déjalo; si empiezas desde cero, comienza en K2.6.",
-        "releaseDate": "Finales de 2025 (serie Kimi K2)",
-        "familyPosition": "Generación anterior de la serie Kimi K2 de peso abierto de Moonshot. Reemplazada por K2.6.",
-        "background": [
-          "Kimi K2.5 fue el modelo Kimi insignia de Moonshot antes de K2.6. Fue el primer Kimi ampliamente desplegado en combinar razonamiento de contexto largo con una superficie API compatible con Claude, y sigue siendo un modelo capaz para trabajo de resumen de contexto largo.",
-          "En VM0 tiene el mismo precio de lista de proveedor que K2.6 pero un multiplicador de crédito más bajo (×0,2). El multiplicador más bajo refleja el posicionamiento en lugar del costo bruto por token. K2.6 es el predeterminado recomendado para trabajo nuevo; K2.5 es la fijación legacy.",
-          "K2.5 tiene una puntuación SWE-bench Pro reportada por el proveedor de 50,7 y una tasa de alucinación de ~65%. Ambas significativamente por detrás de K2.6 (58,6 y 39%). En comportamiento, se mantiene estable para agentes de producción fijados."
-        ],
-        "architecture": "K2.5 es un modelo Mixture-of-Experts con 1B parámetros totales y 32B activos por token de la misma familia que K2.6, con una ventana de contexto de 256K tokens y una superficie API compatible con Anthropic. Los pesos abiertos están publicados en Hugging Face.",
-        "specs": [
-          {
-            "label": "Familia",
-            "value": "Serie Kimi K2"
-          },
-          {
-            "label": "Modalidades",
-            "value": "Imagen, texto, código"
-          },
-          {
-            "label": "Idiomas",
-            "value": "Multilingüe"
-          },
-          {
-            "label": "Ventana de contexto",
-            "value": "256K tokens"
-          },
-          {
-            "label": "Licencia",
-            "value": "MIT Modificada (pesos abiertos)"
-          },
-          {
-            "label": "Disponible en VM0",
-            "value": "Disponible desde el lanzamiento"
-          }
-        ],
-        "benchmarksNote": "Los benchmarks de K2.5 ahora son más útiles como línea base de comparación para K2.6. El modelo más nuevo lidera en cada métrica publicada al mismo costo de proveedor.",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "50,7",
-            "note": "reportado por el proveedor"
-          },
-          {
-            "name": "BrowseComp",
-            "score": "78,4",
-            "note": "reportado por el proveedor"
-          },
-          {
-            "name": "Tasa de alucinación",
-            "score": "~65%",
-            "note": "bajó a 39% en K2.6"
-          }
-        ],
-        "performance": [
-          {
-            "title": "Contexto largo",
-            "body": "Fuerte, forma similar a K2.6 pero con K2.6 teniendo ventaja en benchmarks de recuperación más difíciles."
-          },
-          {
-            "title": "Uso de herramientas",
-            "body": "Sólido en flujos comunes; K2.6 es significativamente mejor en agentes multi-herramienta complejos."
-          },
-          {
-            "title": "Alucinaciones",
-            "body": "Tasa de alucinación reportada por el proveedor de ~65%. Mucho más alta que el 39% de K2.6. Espera más salidas confiadas pero incorrectas."
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "El agente legacy que ya funciona",
-            "body": "Tu equipo validó un agente contra K2.5 hace unos meses, los prompts están ajustados, la suite de evaluación pasa, los clientes están contentos. Fijar a K2.5 mantiene ese comportamiento exacto mientras decides si la actualización a K2.6 vale la pena volver a ejecutar la validación. Mismo endpoint de Moonshot, misma interfaz compatible con Anthropic — solo cambian los pesos del modelo cuando cambias."
-          },
-          {
-            "title": "El trabajo de resumen masivo donde la ventaja de K2.6 no se nota",
-            "body": "Transcripciones de cientos de miles de tokens entrando, resúmenes de tres párrafos saliendo. La precisión de enrutamiento de herramientas no es parte de la carga de trabajo, la resistencia a alucinaciones importa menos cuando un humano va a revisar la salida de todos modos, y al mismo precio de proveedor que K2.6 puedes ejecutar K2.5 en estos trabajos sin tocar el pipeline existente."
-          }
-        ],
-        "avoidFor": "No inicies nuevos agentes en K2.5, ya que K2.6 es una actualización gratuita en todos los sentidos significativos excepto el multiplicador. Evítalo en enrutamiento multi-herramienta en inglés donde Sonnet 4.6 lidera, y en tareas donde la alucinación es costosa porque la tasa de K2.5 es materialmente peor que la de K2.6.",
-        "comparisons": [
-          {
-            "vs": "Kimi K2.6",
-            "body": "K2.6 es la generación más reciente con mejor uso de herramientas, menor tasa de alucinación (39% vs 65%) y mejor razonamiento. K2.5 (×0,2) es ligeramente más barato. Elige K2.5 solo para agentes legacy fijados."
-          },
-          {
-            "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro (×0,1) tiene razonamiento más fuerte. K2.5 (×0,2) gana en tamaño de contexto y se mantiene dentro de la superficie API de Moonshot."
-          }
-        ],
-        "verdict": "Modo mantenimiento. Fíjalo si tienes un agente ya validado en él; de lo contrario, comienza en K2.6.",
-        "faqs": [
-          {
-            "q": "¿Por qué K2.5 tiene un multiplicador más bajo que K2.6 al mismo precio de proveedor?",
-            "a": "Los multiplicadores reflejan el posicionamiento de VM0 de cada modelo en el catálogo, no solo el costo por token. K2.6 es el predeterminado Kimi recomendado a ×0,3; K2.5 está posicionado como legacy a ×0,2."
-          },
-          {
-            "q": "¿Debería migrar de K2.5 a K2.6?",
-            "a": "Sí para trabajo nuevo. Mismo precio de proveedor, mejor uso de herramientas y razonamiento, tasa de alucinación mucho más baja. Migra los agentes fijados solo después de ejecutarlos en tu suite de regresión."
-          },
-          {
-            "q": "¿Cuál es la tasa de alucinación?",
-            "a": "~65% reportada por el proveedor. Significativamente más alta que K2.6 (39%). Si tu agente reporta hechos a usuarios, esto importa; considera K2.6 en su lugar."
-          },
-          {
-            "q": "¿Cuál es la ventana de contexto de K2.5?",
-            "a": "256K tokens. Igual que K2.6."
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-6",
-            "reason": "Kimi más nuevo con mejor uso de herramientas"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "Ventana de contexto más grande si la necesitas"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "Razonamiento más fuerte a multiplicador ligeramente más alto"
-          }
-        ],
-        "routingNotes": "Enrutado a través del endpoint compatible con Anthropic de Moonshot en `api.moonshot.ai`. Disponible en VM0 Managed, Moonshot, OpenRouter y Vercel AI Gateway.",
-        "vm0Notes": "K2.5 tiene el mismo precio de proveedor por token que K2.6 pero un multiplicador más bajo (×0,2 versus ×0,3) porque el multiplicador refleja el posicionamiento en lugar del costo bruto. El comportamiento en contexto largo es sólido, pero K2.6 es la opción recomendada para cualquier trabajo nuevo en VM0."
       },
       "minimax-m3": {
         "name": "MiniMax M3",
@@ -6433,12 +6155,16 @@
         "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
-            "body": "Both target coding and agentic work at low cost. Kimi has broader existing gateway support on VM0, while M3 uses the official MiniMax route and gives MiniMax users the newer model."
+            "vs": "Kimi K2.7 Code",
+            "body": "Ambos apuntan a trabajo de código y agentes a bajo costo. Kimi tiene soporte de gateway existente más amplio en VM0, mientras M3 usa la ruta oficial de MiniMax y da a los usuarios de MiniMax el modelo más nuevo."
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 remains the baseline for reliability on complex English tool-use. M3 is much cheaper and attractive for MiniMax-native coding agents, but should be validated on critical workflows."
+            "body": "Sonnet 4.6 sigue siendo la base de fiabilidad para uso complejo de herramientas en inglés. M3 es mucho más barato y atractivo para agentes de código nativos de MiniMax, pero debe validarse en flujos críticos."
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2 es la ruta Z.AI predeterminada actual en VM0. Es la mejor comparación para nuevos agentes respaldados por Z.AI, mientras GLM-5.1 queda disponible solo por compatibilidad con flujos ya ajustados."
           }
         ],
         "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
@@ -6458,12 +6184,12 @@
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "Low-cost coding model with existing gateway coverage"
+            "slug": "kimi-k2-7-code",
+            "reason": "Modelo de código de bajo costo con cobertura de gateway existente más amplia"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Higher-reliability baseline for complex tool use"
+            "reason": "Base más fiable para uso complejo de herramientas"
           }
         ],
         "routingNotes": "Routed through MiniMax's official Anthropic-compatible endpoint at `api.minimax.io`. Available on VM0 Managed and MiniMax API-key providers only.",
@@ -6918,12 +6644,12 @@
         ],
         "alternatives": [
           {
-            "slug": "flux-pro-1-1-ultra",
-            "reason": "Calidad premium de toma hero"
-          },
-          {
             "slug": "gpt-image-1",
             "reason": "Ilustración estilizada más fuerte"
+          },
+          {
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "Calidad premium para hero shots"
           }
         ],
         "routingNotes": "Enrutado al endpoint de texto a imagen SeedDream V4 de ByteDance y facturado por imagen generada.",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -4710,7 +4710,7 @@
           },
           {
             "title": "Speed",
-            "body": "Slower than Sonnet 4.6 and Kimi K2.7 Code; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
+            "body": "Sonnet 4.6 や Kimi K2.7 Code より遅く、Opus 4.7 と同程度です。Artificial Analysis によると、最大 effort で約 41 トークン/秒です。"
           }
         ],
         "bestForExamples": [
@@ -5036,7 +5036,7 @@
           },
           {
             "title": "Speed",
-            "body": "Faster than Opus and slower than Kimi K2.7 Code. The right speed/quality balance for production agents."
+            "body": "Opus より速く、Kimi K2.7 Code より遅いモデルです。本番エージェントにとって速度と品質のバランスがよい選択肢です。"
           },
           {
             "title": "Cost predictability",
@@ -5288,88 +5288,88 @@
       },
       "glm-5-2": {
         "name": "GLM-5.2",
-        "pageTitle": "GLM-5.2 on VM0. Z.AI's default long-context model",
-        "tagline": "The current Z.AI default on VM0. Up to a 1M-token context window, Anthropic-compatible routing, and cost-saving x0.4 VM0 Managed pricing.",
-        "cardIntro": "Z.AI's current default on VM0. Long-context text and code agents at x0.4 VM0 Managed pricing.",
-        "metaTitle": "GLM-5.2 on VM0: Pricing, Context & Best Agent Tasks",
-        "metaDescription": "GLM-5.2 on VM0. Z.AI's current default model with up to 1M-token context, x0.4 credit cost, OpenRouter-backed VM0 Managed routing, and direct Z.AI BYOK support.",
-        "summary": "GLM-5.2 is the current GLM default on VM0 for Z.AI API-key users and is also available through VM0 Managed via OpenRouter. It keeps the GLM series' long-context profile while becoming the preferred Z.AI route for new agents.\n\nUse it for large codebases, large document sets, and cost-sensitive long-context planning where Sonnet-class pricing is unnecessary. GLM-5.1 remains available for compatibility, but new Z.AI routes should start on GLM-5.2 unless a workflow has been tuned specifically against 5.1.",
-        "releaseDate": "June 2026",
-        "familyPosition": "Current default model in VM0's Z.AI / GLM route.",
+        "pageTitle": "VM0 の GLM-5.2。Z.AI のデフォルト長文コンテキストモデル",
+        "tagline": "VM0 における現在の Z.AI デフォルト。最大 1M トークンのコンテキスト、Anthropic 互換ルーティング、VM0 Managed で ×0.4 の低コスト料金。",
+        "cardIntro": "VM0 における Z.AI の現在のデフォルト。長文コンテキストのテキスト・コードエージェントを VM0 Managed の ×0.4 で利用できます。",
+        "metaTitle": "VM0 の GLM-5.2: 料金、コンテキスト、適したエージェントタスク",
+        "metaDescription": "VM0 の GLM-5.2。最大 1M トークンのコンテキスト、×0.4 クレジット、OpenRouter 経由の VM0 Managed ルーティング、直接 Z.AI BYOK をサポートする Z.AI の現在のデフォルトモデル。",
+        "summary": "GLM-5.2 は、Z.AI API キーユーザー向けの VM0 における現在の GLM デフォルトであり、OpenRouter 経由の VM0 Managed でも利用できます。GLM シリーズの長文コンテキスト特性を保ちながら、新しいエージェント向けの推奨 Z.AI ルートになっています。\n\n大きなコードベース、大量の文書、Sonnet 級の価格が不要なコスト重視の長文コンテキスト計画に使います。GLM-5.1 は互換性のために残りますが、5.1 向けに特別に調整済みのワークフローでない限り、新しい Z.AI ルートは GLM-5.2 から始めるべきです。",
+        "releaseDate": "2026年6月",
+        "familyPosition": "VM0 の Z.AI / GLM ルートにおける現在のデフォルトモデル。",
         "background": [
-          "GLM-5.2 extends the GLM 5 family as the current Z.AI default exposed by VM0. It is available through VM0 Managed, where VM0 routes to OpenRouter with the upstream id `z-ai/glm-5.2`, and through direct Z.AI API keys using the canonical `glm-5.2` id.",
-          "The route is Anthropic-compatible, so Claude-style agents can keep the same runtime interface. Existing GLM-5.1 agents do not need to migrate immediately, but new Z.AI-backed agents should prefer GLM-5.2.",
-          "On VM0 Managed it sits at x0.4 credits, matching GLM-5.1's cost tier while taking over the Z.AI default slot."
+          "GLM-5.2 は、VM0 で公開される現在の Z.AI デフォルトとして GLM 5 ファミリーを拡張します。VM0 Managed では upstream id `z-ai/glm-5.2` で OpenRouter にルーティングされ、直接 Z.AI API キーでは正規の `glm-5.2` id を使います。",
+          "このルートは Anthropic 互換なので、Claude スタイルのエージェントは同じランタイムインターフェースを維持できます。既存の GLM-5.1 エージェントはすぐ移行する必要はありませんが、新しい Z.AI ベースのエージェントでは GLM-5.2 を優先してください。",
+          "VM0 Managed では ×0.4 クレジットで、GLM-5.1 と同じコスト帯にありながら Z.AI のデフォルト枠を引き継ぎます。"
         ],
-        "architecture": "GLM-5.2 is exposed on VM0 through Anthropic-compatible endpoints. VM0 Managed uses OpenRouter's `z-ai/glm-5.2` id; direct Z.AI BYOK uses `glm-5.2`.",
+        "architecture": "GLM-5.2 は VM0 上で Anthropic 互換エンドポイントとして提供されます。VM0 Managed は OpenRouter の `z-ai/glm-5.2` id を使い、直接 Z.AI BYOK は `glm-5.2` を使います。",
         "specs": [
           {
-            "label": "Family",
+            "label": "ファミリー",
             "value": "GLM-5 series"
           },
           {
-            "label": "Modalities",
-            "value": "Text, code"
+            "label": "モダリティ",
+            "value": "テキスト、コード"
           },
           {
-            "label": "Languages",
-            "value": "Multilingual"
+            "label": "言語",
+            "value": "多言語"
           },
           {
-            "label": "Context window",
-            "value": "Up to 1M tokens"
+            "label": "コンテキストウィンドウ",
+            "value": "最大 1M トークン"
           },
           {
-            "label": "Prompt caching",
-            "value": "Supported"
+            "label": "プロンプトキャッシュ",
+            "value": "対応"
           },
           {
-            "label": "Available on VM0",
-            "value": "June 2026"
+            "label": "VM0での利用開始",
+            "value": "2026年6月"
           }
         ],
-        "benchmarksNote": "Treat GLM-5.2 as the preferred GLM route on VM0. Third-party rankings can move quickly, so VM0 keeps the page focused on routing, cost, and operational fit rather than frozen leaderboard percentages.",
+        "benchmarksNote": "GLM-5.2 は VM0 における推奨 GLM ルートとして扱ってください。サードパーティのランキングはすばやく変わるため、このページでは固定された leaderboard の割合ではなく、ルーティング、コスト、運用上の適合性に焦点を当てています。",
         "benchmarks": [
           {
-            "name": "Long-context tasks",
-            "score": "Strong fit",
-            "note": "VM0 routing profile"
+            "name": "長文コンテキストタスク",
+            "score": "適合度が高い",
+            "note": "VM0 のルーティング特性"
           },
           {
-            "name": "Cost tier",
-            "score": "x0.4 credits",
+            "name": "コスト帯",
+            "score": "×0.4 クレジット",
             "note": "VM0 Managed"
           }
         ],
         "performance": [
           {
-            "title": "Long-context work",
-            "body": "GLM-5.2 is best used when the agent needs a large working set: repositories, documentation folders, design notes, or long research material."
+            "title": "長文コンテキスト作業",
+            "body": "GLM-5.2 は、リポジトリ、ドキュメントフォルダ、設計メモ、長い調査資料など、エージェントが大きな作業セットを必要とする場合に向いています。"
           },
           {
-            "title": "Cost control",
-            "body": "At x0.4 credits it is a cost-saving alternative to Sonnet-class routes for workflows where context size and price matter more than maximum English reasoning depth."
+            "title": "コスト管理",
+            "body": "×0.4 クレジットなので、コンテキストサイズと価格が英語推論の最大品質より重要なワークフローでは、Sonnet クラスのルートに対する低コストな代替になります。"
           },
           {
-            "title": "Routing",
-            "body": "VM0 Managed routes through OpenRouter using `z-ai/glm-5.2`; direct Z.AI API keys use `glm-5.2`. Both paths keep the Claude-compatible agent interface."
+            "title": "ルーティング",
+            "body": "VM0 Managed は `z-ai/glm-5.2` を使って OpenRouter 経由でルーティングし、直接 Z.AI API キーでは `glm-5.2` を使います。どちらの経路も Claude 互換のエージェントインターフェースを維持します。"
           }
         ],
         "bestForExamples": [
           {
-            "title": "Whole-repo review on a budget",
-            "body": "Use GLM-5.2 when the agent needs to inspect a large codebase and produce concrete file-level recommendations without paying for a premium reasoning model on every pass."
+            "title": "予算を抑えたリポジトリ全体レビュー",
+            "body": "エージェントが大きなコードベースを確認し、ファイル単位の具体的な提案を出す必要がある一方で、毎回プレミアム推論モデルに支払いたくない場合に GLM-5.2 を使います。"
           },
           {
-            "title": "Large document synthesis",
-            "body": "Load policy documents, tickets, transcripts, or internal docs together and ask for cross-document patterns. The long context and x0.4 multiplier keep repeated runs practical."
+            "title": "大量ドキュメントの統合",
+            "body": "ポリシー文書、チケット、議事録、社内ドキュメントをまとめて読み込み、文書横断のパターンを尋ねます。長いコンテキストと ×0.4 のマルチプライヤーにより、繰り返し実行しても現実的です。"
           },
           {
-            "title": "Z.AI BYOK default route",
-            "body": "Teams using a direct Z.AI API key get GLM-5.2 as the default VM0 model while retaining GLM-5.1 for existing tuned workflows."
+            "title": "Z.AI BYOK のデフォルトルート",
+            "body": "直接 Z.AI API キーを使うチームでは、GLM-5.2 が VM0 のデフォルトモデルになり、既存の調整済みワークフロー向けに GLM-5.1 も保持されます。"
           }
         ],
-        "avoidFor": "Skip GLM-5.2 for workflows that depend on vision input, or when maximum English-language reasoning and tool routing quality matter more than context size and cost.",
+        "avoidFor": "画像入力に依存するワークフローや、英語推論とツールルーティングの最大品質がコンテキストサイズやコストより重要な場合は、GLM-5.2 を避けてください。",
         "comparisons": [
           {
             "vs": "GLM-5.1",
@@ -5388,19 +5388,19 @@
             "body": "DeepSeek V4 ProはVM0クレジットが低く、コスト優先の推論ではより強い選択肢です。価格が支配的ならDeepSeekを、Z.AIとの相性や長いコンテキストが重要ならGLM-5.2を使います。"
           }
         ],
-        "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
+        "verdict": "VM0 の Z.AI 標準ルートには GLM-5.2 を選んでください。GLM-5.1 は、すでにそれ向けに調整されたワークフローとの互換性が必要な場合だけ残します。",
         "faqs": [
           {
-            "q": "Is GLM-5.2 available through VM0 Managed?",
-            "a": "Yes. VM0 Managed routes GLM-5.2 through OpenRouter with the upstream id `z-ai/glm-5.2`."
+            "q": "GLM-5.2 は VM0 Managed で利用できますか？",
+            "a": "はい。VM0 Managed は upstream id `z-ai/glm-5.2` で OpenRouter 経由に GLM-5.2 をルーティングします。"
           },
           {
-            "q": "Is GLM-5.2 the default for direct Z.AI API keys?",
-            "a": "Yes. The Z.AI provider defaults to `glm-5.2` while keeping `glm-5.1` available."
+            "q": "GLM-5.2 は直接 Z.AI API キーのデフォルトですか？",
+            "a": "はい。Z.AI プロバイダーは `glm-5.2` をデフォルトにしつつ、`glm-5.1` も利用可能なままにしています。"
           },
           {
-            "q": "Does GLM-5.2 support image input?",
-            "a": "No. VM0 exposes GLM-5.2 for text and code agents. Use Claude Sonnet 4.6 or Kimi K2.7 Code when vision input is required."
+            "q": "GLM-5.2 は画像入力をサポートしていますか？",
+            "a": "いいえ。VM0 は GLM-5.2 をテキストとコードのエージェント向けに提供しています。画像入力が必要な場合は Claude Sonnet 4.6 または Kimi K2.7 Code を使ってください。"
           }
         ],
         "alternatives": [
@@ -5417,8 +5417,8 @@
             "reason": "標準コンテキスト向けの安価な代替"
           }
         ],
-        "routingNotes": "On VM0 Managed, GLM-5.2 routes through OpenRouter with the upstream id `z-ai/glm-5.2`. With a Z.AI API key it talks directly to `api.z.ai` as `glm-5.2`. It is the default model on the Z.AI provider.",
-        "vm0Notes": "VM0 sets a 50-minute API timeout for the Z.AI provider, so long-context planning and analysis runs have room to finish."
+        "routingNotes": "VM0 Managed では、GLM-5.2 は upstream id `z-ai/glm-5.2` で OpenRouter 経由にルーティングされます。Z.AI API キーを使う場合は `glm-5.2` として `api.z.ai` に直接接続します。Z.AI プロバイダーのデフォルトモデルです。",
+        "vm0Notes": "VM0 は Z.AI プロバイダーに 50 分の API タイムアウトを設定しているため、長文コンテキストの計画や分析の実行が完了しやすくなっています。"
       },
       "glm-5-1": {
         "name": "GLM-5.1",
@@ -5462,45 +5462,45 @@
             "value": "2026年4月"
           }
         ],
-        "benchmarksNote": "Independent reviews place GLM-5.1 in the top tier of open-weight models for long-context tasks. Numbers shift weekly on third-party leaderboards. We deliberately don't pin exact percentages here.",
+        "benchmarksNote": "独立レビューでは、GLM-5.1 は長文コンテキストタスク向けのオープンウェイトモデルの上位層に位置付けられています。サードパーティの leaderboard は週ごとに変動するため、ここでは意図的に正確な割合を固定していません。",
         "benchmarks": [
           {
             "name": "Code Arena",
             "score": "Top-3 (open weights)",
-            "note": "third-party leaderboard"
+            "note": "サードパーティ leaderboard"
           },
           {
-            "name": "Long-context recall",
-            "score": "Strong across 1M-token window",
-            "note": "vendor-reported"
+            "name": "長文コンテキスト再現",
+            "score": "1M トークン全体で強い",
+            "note": "ベンダー報告"
           }
         ],
         "performance": [
           {
-            "title": "Long-context recall",
-            "body": "GLM-5.1's 1M-token window is genuinely usable. It maintains coherence well past the 200K boundary that limits the Anthropic family on the older 200K models. Useful for whole-repo or whole-doc-corpus agents."
+            "title": "長文コンテキスト再現",
+            "body": "GLM-5.1 の 1M トークンウィンドウは実用的です。古い 200K モデルの Anthropic ファミリーを制限していた 200K 境界を大きく超えても一貫性を保ちます。リポジトリ全体や文書コーパス全体を扱うエージェントに有用です。"
           },
           {
-            "title": "Reasoning",
-            "body": "Solid general reasoning. Below Sonnet 4.6 on the hardest English-language multi-tool routing, but the gap is small relative to the cost difference."
+            "title": "推論",
+            "body": "一般的な推論は堅実です。最難関の英語マルチツールルーティングでは Sonnet 4.6 を下回りますが、コスト差に比べれば差は小さいです。"
           },
           {
-            "title": "Tool use",
-            "body": "Reliable across the common VM0 tool surface (Slack, GitHub, Notion, Linear). Some edge cases in deeply nested tool calls are handled less crisply than Claude Sonnet 4.6."
+            "title": "ツール利用",
+            "body": "Slack、GitHub、Notion、Linear など一般的な VM0 ツール面では信頼できます。深くネストしたツール呼び出しの一部のエッジケースでは、Claude Sonnet 4.6 ほど明瞭には処理しません。"
           }
         ],
         "bestForExamples": [
           {
-            "title": "The whole-repo refactor that fits in one prompt",
-            "body": "Drop a 500K-token mid-sized codebase into a single GLM-5.1 call and ask for a cross-file rename, an architectural review, or a security pass. Models with smaller windows force you to chunk the repo and stitch results together, which is where bugs creep in. GLM-5.1 keeps every file in working memory and references the right paths in its output."
+            "title": "1つのプロンプトに収まるリポジトリ全体リファクタ",
+            "body": "500K トークン規模の中規模コードベースを1回の GLM-5.1 呼び出しに入れ、ファイル横断のリネーム、アーキテクチャレビュー、セキュリティ確認を依頼します。小さいウィンドウのモデルではリポジトリを分割して結果をつなぐ必要があり、そこにバグが入り込みます。GLM-5.1 は各ファイルを作業メモリに保持し、出力で正しいパスを参照します。"
           },
           {
-            "title": "The research run over hundreds of documents",
-            "body": "Wikis, RFCs, contracts, last year's support tickets — load the whole pile at once and ask for cross-document patterns. The cost-per-run stays manageable because of the low vendor price, which is what makes this kind of \"read everything, summarise once\" workflow actually affordable in production rather than a one-off science project."
+            "title": "数百の文書をまたぐ調査実行",
+            "body": "Wiki、RFC、契約書、昨年のサポートチケットをまとめて読み込み、文書横断のパターンを尋ねます。低いベンダー価格により実行あたりのコストが管理しやすく、この「全部読んで一度で要約する」ワークフローを単発の実験ではなく本番で使えるものにします。"
           },
           {
-            "title": "The thinking job that needs more than ten minutes",
-            "body": "Some agent steps genuinely take five to thirty minutes — deep research, multi-document analysis, long planning passes. VM0 sets a 50-minute API timeout for the Z.AI provider so those long thinking steps don't get cut off mid-thought, which makes GLM-5.1 the safe pick over models routed through providers with shorter default timeouts."
+            "title": "10分以上かかる思考ジョブ",
+            "body": "深い調査、複数文書分析、長い計画パスなど、一部のエージェントステップは本当に5分から30分かかります。VM0 は Z.AI プロバイダーに 50 分の API タイムアウトを設定しているため、長い思考ステップが途中で切れません。デフォルトタイムアウトが短いプロバイダー経由のモデルより、GLM-5.1 を安全に選べます。"
           }
         ],
         "avoidFor": "最難関の英語推論ではSonnet 4.6やOpus 4.7がまだ優位であり、低レイテンシのチャット応答ではKimi K2.7 Codeの方が大幅に高速なため、GLM-5.1は避けてください。",
@@ -5511,29 +5511,29 @@
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 (×1) leads on tool-routing accuracy and English-language reasoning. GLM-5.1 (×0.4) leads on context window and is the right pick when cost or context size dominates the decision."
+            "body": "Sonnet 4.6（×1）はツールルーティング精度と英語推論で優れています。GLM-5.1（×0.4）はコンテキストウィンドウで優れ、コストやコンテキストサイズが意思決定を支配する場合に適しています。"
           },
           {
             "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro (×0.1) is cheaper and benchmarks higher on Code Arena per third-party reviews. GLM-5.1 still wins on context size. Pick DeepSeek for cost-sensitive standard-context work; pick GLM-5.1 when context size is the constraint."
+            "body": "DeepSeek V4 Pro（×0.1）はより安く、サードパーティレビューでは Code Arena でより高いベンチマークを出しています。GLM-5.1 はコンテキストサイズでまだ勝ります。コスト重視の標準コンテキスト作業には DeepSeek、コンテキストサイズが制約なら GLM-5.1 を選びます。"
           }
         ],
         "verdict": "GLM-5.1はテキストとコードベースのタスクに堅実なコスト効率の選択肢です。画像入力不要で、Claude Sonnet 4.6のより安価な代替を探している場合に検討してください。",
         "faqs": [
           {
-            "q": "How big is GLM-5.1's context window on VM0?",
-            "a": "Up to 1 million tokens. The largest in our Built-in lineup. Enough to fit a mid-sized repository or several hundred documents in a single prompt."
+            "q": "VM0 での GLM-5.1 のコンテキストウィンドウはどれくらいですか？",
+            "a": "最大 100 万トークンです。Built-in ラインアップで最大で、中規模リポジトリや数百の文書を1つのプロンプトに収められます。"
           },
           {
-            "q": "Which provider should I use for GLM-5.1?",
-            "a": "VM0 Managed is the simplest path. If you want vendor-direct billing, connect a Z.AI API key."
+            "q": "GLM-5.1 にはどのプロバイダーを使うべきですか？",
+            "a": "VM0 Managed が最も簡単です。ベンダー直接課金が必要なら、Z.AI API キーを接続してください。"
           },
           {
-            "q": "Is GLM-5.1 open weights?",
-            "a": "Z.AI publishes open-weight variants of the GLM series. The version exposed on VM0 routes to the Z.AI hosted API for production reliability."
+            "q": "GLM-5.1 はオープンウェイトですか？",
+            "a": "Z.AI は GLM シリーズのオープンウェイト版を公開しています。VM0 で公開されているバージョンは、本番信頼性のため Z.AI のホスト API にルーティングされます。"
           },
           {
-            "q": "Does GLM-5.1 support image input?",
+            "q": "GLM-5.1 は画像入力をサポートしますか？",
             "a": "VM0のGLM-5.1はテキストとコード向けです。マルチモーダル入力（画像/動画）にはClaude Sonnet 4.6またはKimi K2.7 Codeを選んでください。"
           }
         ],
@@ -5555,8 +5555,8 @@
             "reason": "コストが制約でない場合のより強い推論"
           }
         ],
-        "routingNotes": "On VM0 Managed, GLM-5.1 is routed through OpenRouter with the upstream id `z-ai/glm-5.1`. With a Z.AI API key it talks to `api.z.ai`'s Anthropic-compatible endpoint directly. GLM-5.2 is now the default model on the Z.AI provider.",
-        "vm0Notes": "VM0 sets a 50-minute API timeout for the Z.AI provider so long thinking steps complete reliably without dropping, and pairs the model's 1M-token context with high-volume document agents that need the room."
+        "routingNotes": "VM0 Managed では、GLM-5.1 は upstream id `z-ai/glm-5.1` で OpenRouter 経由にルーティングされます。Z.AI API キーを使う場合は、`api.z.ai` の Anthropic 互換エンドポイントに直接接続します。GLM-5.2 は現在 Z.AI プロバイダーのデフォルトモデルです。",
+        "vm0Notes": "VM0 は Z.AI プロバイダーに 50 分の API タイムアウトを設定しているため、長い思考ステップが確実に完了しやすく、1M トークンのコンテキストを必要とする高ボリュームの文書エージェントにも適しています。"
       },
       "gpt-5-4-mini": {
         "name": "GPT-5.4 Mini",
@@ -6067,88 +6067,88 @@
       },
       "minimax-m3": {
         "name": "MiniMax M3",
-        "pageTitle": "MiniMax M3 on VM0. Official MiniMax coding model at ×0.2",
-        "tagline": "Official MiniMax M3 routing for coding agents, 1M context, and native multimodal understanding.",
-        "cardIntro": "Official MiniMax M3 routing for coding agents with 1M context, prompt cache reads, and a ×0.2 VM0 multiplier.",
-        "metaTitle": "MiniMax M3 on VM0: Pricing, Specs & Official Routing",
-        "metaDescription": "MiniMax M3 review on VM0. Official MiniMax coding model with 1M context, multimodal understanding, prompt cache reads, and ×0.2 credits.",
-        "summary": "MiniMax M3 is MiniMax's frontier coding and agentic model, exposed on VM0 through the official MiniMax Anthropic-compatible endpoint. It is the right MiniMax choice when an agent needs stronger coding, tool use, long-context reasoning, and native vision understanding than the retained M2 series.\n\nVM0 prices M3 from MiniMax's standard non-promotional pay-as-you-go tier for the base context band: $0.60 / $2.40 per 1M tokens, with prompt cache reads at $0.12 / 1M and no separate cache-write billing in the M3 table. MiniMax M2.1 remains available for lower-cost compatibility, while M3 is the default MiniMax BYOK model.",
-        "releaseDate": "June 1, 2026",
-        "familyPosition": "Official MiniMax M3 text model alongside the retained M2 series.",
+        "pageTitle": "VM0 の MiniMax M3。×0.2 の公式 MiniMax コードモデル",
+        "tagline": "コードエージェント向けの公式 MiniMax M3 ルーティング、1M コンテキスト、ネイティブなマルチモーダル理解。",
+        "cardIntro": "1M コンテキスト、プロンプトキャッシュ読み取り、×0.2 の VM0 マルチプライヤーを備えたコードエージェント向け公式 MiniMax M3 ルーティング。",
+        "metaTitle": "VM0 の MiniMax M3: 料金、仕様、公式ルーティング",
+        "metaDescription": "VM0 の MiniMax M3。1M コンテキスト、マルチモーダル理解、プロンプトキャッシュ読み取り、×0.2 クレジットを備えた公式 MiniMax コードモデル。",
+        "summary": "MiniMax M3 は、MiniMax の frontier コード・エージェントモデルで、VM0 では公式の Anthropic 互換 MiniMax エンドポイントを通じて提供されます。保持されている M2 シリーズよりも強いコーディング、ツール利用、長文コンテキスト推論、ネイティブな画像理解が必要なエージェントに適した MiniMax の選択肢です。\n\nVM0 は、基準コンテキスト帯について MiniMax の非プロモーション標準 pay-as-you-go 料金を M3 に使います。1M トークンあたり $0.60 / $2.40、プロンプトキャッシュ読み取りは $0.12 / 1M で、M3 の表ではキャッシュ書き込みの別課金はありません。MiniMax M2.1 は低コスト互換性のため引き続き利用でき、M3 が MiniMax BYOK のデフォルトモデルになります。",
+        "releaseDate": "2026年6月1日",
+        "familyPosition": "保持されている M2 シリーズと並ぶ公式 MiniMax M3 テキストモデル。",
         "background": [
-          "MiniMax M3 is the new official MiniMax text model for coding and agentic workloads. MiniMax describes it as combining frontier coding capability, a 1M-token context window, and native multimodal understanding.",
-          "On VM0, M3 is added to the existing MiniMax API-key provider instead of creating a new integration. It uses the same `api.minimax.io/anthropic` routing surface and the same `MINIMAX_API_KEY` secret as M2.",
-          "The existing M2 entries stay available, while M3 is the MiniMax provider default for new selections."
+          "MiniMax M3 は、コード作業とエージェント型ワークロード向けの新しい公式 MiniMax テキストモデルです。MiniMax は、frontier レベルのコーディング能力、1M トークンのコンテキストウィンドウ、ネイティブなマルチモーダル理解を組み合わせたモデルと説明しています。",
+          "VM0 では、新しい統合を作るのではなく、既存の MiniMax API キープロバイダーに M3 を追加します。M2 と同じ `api.minimax.io/anthropic` ルーティング面と同じ `MINIMAX_API_KEY` シークレットを使います。",
+          "既存の M2 エントリは引き続き利用でき、M3 は新規選択時の MiniMax プロバイダーデフォルトになります。"
         ],
-        "architecture": "M3 uses MiniMax Sparse Attention for ultra-long context. The official API supports up to 1M tokens with a 512K guaranteed minimum, automatic prompt cache support, and native multimodal understanding.",
+        "architecture": "M3 は超長文コンテキスト向けに MiniMax Sparse Attention を使います。公式 API は最大 1M トークン、512K の保証最小値、自動プロンプトキャッシュ対応、ネイティブなマルチモーダル理解をサポートします。",
         "specs": [
           {
-            "label": "Family",
+            "label": "ファミリー",
             "value": "MiniMax M3"
           },
           {
-            "label": "Modalities",
-            "value": "Text, vision, code"
+            "label": "モダリティ",
+            "value": "テキスト、ビジョン、コード"
           },
           {
-            "label": "Languages",
-            "value": "Multilingual"
+            "label": "言語",
+            "value": "多言語"
           },
           {
-            "label": "Context window",
-            "value": "1M tokens (512K guaranteed minimum)"
+            "label": "コンテキストウィンドウ",
+            "value": "1M トークン（512K の保証最小値）"
           },
           {
-            "label": "Prompt caching",
-            "value": "Supported with automatic cache reads"
+            "label": "プロンプトキャッシュ",
+            "value": "自動キャッシュ読み取りに対応"
           },
           {
-            "label": "Available on VM0",
-            "value": "June 1, 2026"
+            "label": "VM0での利用開始",
+            "value": "2026年6月1日"
           }
         ],
-        "benchmarksNote": "MiniMax positions M3 around coding, agentic tasks, and long-horizon execution. Treat these as vendor-reported signals and validate against your own VM0 agent regression set.",
+        "benchmarksNote": "MiniMax は M3 をコード、エージェント型タスク、長い実行ホライズン向けに位置付けています。これらはベンダー報告のシグナルとして扱い、自分の VM0 エージェント回帰セットで検証してください。",
         "benchmarks": [
           {
             "name": "PostTrainBench Live",
-            "score": "Rank #3",
-            "note": "vendor reported"
+            "score": "3位",
+            "note": "ベンダー報告"
           },
           {
             "name": "BrowseComp",
             "score": "83.5",
-            "note": "vendor reported"
+            "note": "ベンダー報告"
           }
         ],
         "performance": [
           {
-            "title": "Coding agents",
-            "body": "The best MiniMax option for coding assistants, long tool chains, and multi-step repository work."
+            "title": "コードエージェント",
+            "body": "コードアシスタント、長いツールチェーン、複数ステップのリポジトリ作業に最適な MiniMax の選択肢です。"
           },
           {
-            "title": "Long context",
-            "body": "A 1M context window lets agents keep large documents, code, logs, and previous work in scope without switching model families."
+            "title": "長文コンテキスト",
+            "body": "1M のコンテキストウィンドウにより、モデルファミリーを切り替えずに大きな文書、コード、ログ、過去の作業をスコープ内に保てます。"
           },
           {
-            "title": "Multimodal",
-            "body": "Native vision understanding makes M3 a better fit than M2 when screenshots, diagrams, or visual artifacts are part of the workflow."
+            "title": "マルチモーダル",
+            "body": "スクリーンショット、図、視覚的な成果物がワークフローに含まれる場合、ネイティブな画像理解により M3 は M2 より適しています。"
           }
         ],
         "bestForExamples": [
           {
-            "title": "The coding agent that must stay on MiniMax",
-            "body": "Repository edits, debugging, and agentic coding flows where your deployment already uses MiniMax keys but needs a stronger coding model than M2.1."
+            "title": "MiniMax に留める必要があるコードエージェント",
+            "body": "デプロイがすでに MiniMax キーを使っているが、M2.1 より強いコードモデルが必要なリポジトリ編集、デバッグ、エージェント型コードフロー。"
           },
           {
-            "title": "The long-context review run",
-            "body": "Large pull requests, logs, notebooks, or design documents that should stay in one model context while the agent reasons and edits."
+            "title": "長文コンテキストのレビュー実行",
+            "body": "エージェントが推論と編集を行う間、1つのモデルコンテキスト内に留めたい大きな Pull Request、ログ、ノートブック、設計文書。"
           },
           {
-            "title": "The multimodal investigation",
-            "body": "Workflows that mix text with screenshots or diagrams. M3 is marked image-input capable on VM0, while the M2 entries stay text/code only."
+            "title": "マルチモーダル調査",
+            "body": "テキストとスクリーンショットや図を組み合わせるワークフロー。VM0 では M3 が画像入力対応としてマークされ、M2 エントリはテキスト/コードのみです。"
           }
         ],
-        "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
+        "avoidFor": "MiniMax の絶対的な最低コストが必要で、テキストのみの M2.1 で十分な場合、または OpenRouter/Vercel ルーティングが必要な場合は M3 を避けてください。この VM0 エントリは意図的に公式 MiniMax パスのみを使います。",
         "comparisons": [
           {
             "vs": "Kimi K2.7 Code",
@@ -6163,19 +6163,19 @@
             "body": "GLM-5.2はVM0における現在のZ.AIデフォルトルートです。新しいZ.AIベースのエージェントではこちらがより適切な比較対象で、GLM-5.1は調整済みワークフローとの互換性のためだけに残ります。"
           }
         ],
-        "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
+        "verdict": "長文コンテキストと Vision サポートを備えた公式 MiniMax コードモデルが必要な場合は MiniMax M3 を使います。コストと互換性がより重要な場合は M2.1 を維持してください。",
         "faqs": [
           {
-            "q": "Is MiniMax M2.1 still available?",
-            "a": "Yes. VM0 keeps MiniMax M2.1 in the direct MiniMax provider. M3 is now the default MiniMax BYOK model."
+            "q": "MiniMax M2.1 はまだ利用できますか？",
+            "a": "はい。VM0 は直接 MiniMax プロバイダーで MiniMax M2.1 を保持しています。M3 は現在 MiniMax BYOK のデフォルトモデルです。"
           },
           {
-            "q": "Does VM0 route MiniMax M3 through OpenRouter or Vercel?",
-            "a": "No. This entry intentionally uses only the official MiniMax Anthropic-compatible endpoint."
+            "q": "VM0 は MiniMax M3 を OpenRouter や Vercel 経由でルーティングしますか？",
+            "a": "いいえ。このエントリは意図的に公式の Anthropic 互換 MiniMax エンドポイントだけを使います。"
           },
           {
-            "q": "Which M3 pricing tier does VM0 show?",
-            "a": "The VM0 model page and usage seed use MiniMax's non-promotional standard base tier. MiniMax also documents a higher standard tier for input above 512K tokens."
+            "q": "VM0 はどの M3 料金ティアを表示していますか？",
+            "a": "VM0 のモデルページと usage seed は、MiniMax の非プロモーション標準ベースティアを使います。MiniMax は 512K トークンを超える入力向けの上位標準ティアも文書化しています。"
           }
         ],
         "alternatives": [
@@ -6188,8 +6188,8 @@
             "reason": "複雑なツール利用のためのより信頼できる基準"
           }
         ],
-        "routingNotes": "Routed through MiniMax's official Anthropic-compatible endpoint at `api.minimax.io`. Available on VM0 Managed and MiniMax API-key providers only.",
-        "vm0Notes": "VM0 maps `MiniMax-M3` to the existing MiniMax vendor key pool for Built-in routing. The direct MiniMax provider uses M3 as its default model while keeping M2.1 selectable."
+        "routingNotes": "`api.minimax.io` の公式 Anthropic 互換 MiniMax エンドポイント経由でルーティングされます。VM0 Managed と MiniMax API キープロバイダーでのみ利用できます。",
+        "vm0Notes": "VM0 は Built-in ルーティングのために `MiniMax-M3` を既存の MiniMax ベンダーキープールへマップします。直接 MiniMax プロバイダーは M3 をデフォルトモデルにしつつ、M2.1 も選択可能なままにします。"
       },
       "gpt-image-2": {
         "name": "GPT Image 2",

--- a/turbo/apps/web/messages/ja.json
+++ b/turbo/apps/web/messages/ja.json
@@ -2380,7 +2380,7 @@
           },
           {
             "name": "Zero",
-            "text": "**コスト最適化監査 - 今週**\n\n🟢 **既に最適**（このままで）:\n• morning-brief (Sonnet) - マルチソース集約、妥当\n• pr-review-merge (Sonnet) - トリガー時のコードレビュー、妥当\n\n🟡 **過剰プロビジョニング**（ダウングレード可）:\n| タスク | 現在のモデル | 推奨 | 推定節約額 |\n|------|--------------|-------------|-------------|\n| tech-debt-scan | Opus | GLM-5.1 | 約5〜10倍 |\n| merge-queue-monitor | Sonnet | GLM-5.1 | 約3倍 |\n| standup-summary | Sonnet | GPT-4o mini | 約4倍 |\n| daily-email-check | Sonnet | GPT-4o mini | 約4倍 |\n\n🔴 **要確認**:\n• auto-test-coverage - 実際のコードを書く、境界線。Sonnetで1週間試して合格率を比較してみて。\n\n**推定月間節約額: $2,400〜3,800**"
+            "text": "**コスト最適化監査 - 今週**\n\n🟢 **既に最適**（このままで）:\n• morning-brief (Sonnet) - マルチソース集約、妥当\n• pr-review-merge (Sonnet) - トリガー時のコードレビュー、妥当\n\n🟡 **過剰プロビジョニング**（ダウングレード可）:\n| タスク | 現在のモデル | 推奨 | 推定節約額 |\n|------|--------------|-------------|-------------|\n| tech-debt-scan | Opus | GLM-5.2 | 約5〜10倍 |\n| merge-queue-monitor | Sonnet | GLM-5.2 | 約3倍 |\n| standup-summary | Sonnet | GPT-4o mini | 約4倍 |\n| daily-email-check | Sonnet | GPT-4o mini | 約4倍 |\n\n🔴 **要確認**:\n• auto-test-coverage - 実際のコードを書く、境界線。Sonnetで1週間試して合格率を比較してみて。\n\n**推定月間節約額: $2,400〜3,800**"
           }
         ],
         "steps": [
@@ -2401,12 +2401,12 @@
           {
             "title": "低リスクタスクをより安価なモデルに切り替え",
             "description": "最も安全な推奨から始め、品質が維持されることを確認します。",
-            "examplePrompt": "@Zero merge-queue-monitorのスケジュールをSonnetからGLM-5.1に切り替えて"
+            "examplePrompt": "@Zero merge-queue-monitorのスケジュールをSonnetからGLM-5.2に切り替えて"
           },
           {
             "title": "比較テストを実施",
             "description": "両方のモデルで同じタスクを実行し、コミット前に結果を比較します。",
-            "examplePrompt": "@Zero tech-debt-scanのプロンプトをOpusとGLM-5.1の両方で実行して、結果を並べて比較して"
+            "examplePrompt": "@Zero tech-debt-scanのプロンプトをOpusとGLM-5.2の両方で実行して、結果を並べて比較して"
           },
           {
             "title": "定期実行にする",
@@ -4343,7 +4343,7 @@
             "body": "2.5倍速度のファストモードは、以前は現在の3倍のコストがかかっていました（$10/$50/1M対前ティア）。インタラクティブなコパイロット、オンコール要約、または実時間レイテンシが体験を左右するあらゆるステップで、ファストモードの4.8は今やClaudeファミリーのデフォルト選択肢です。"
           }
         ],
-        "avoidFor": "Sonnet 4.6が一部のコストで同じ品質基準を満たす大量ルーチン作業、Kimi K2.6が遥かに高速なレイテンシ重視のチャット応答、GPT-5.5がTerminal-Bench 2.1で依然としてリードするエージェンティックターミナルコーディング（78.2%対4.8の74.6%）、サンドボックス化なしで信頼できない入力を取り込むパイプライン（4.8のプロンプトインジェクション耐性は4.7よりわずかに弱い）では、Opus 4.8の使用を避けてください。",
+        "avoidFor": "Sonnet 4.6が一部のコストで同じ品質基準を満たす大量ルーチン作業、Kimi K2.7 Codeが遥かに高速なレイテンシ重視のチャット応答、GPT-5.5がTerminal-Bench 2.1で依然としてリードするエージェンティックターミナルコーディング（78.2%対4.8の74.6%）、サンドボックス化なしで信頼できない入力を取り込むパイプライン（4.8のプロンプトインジェクション耐性は4.7よりわずかに弱い）では、Opus 4.8の使用を避けてください。",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
@@ -4351,7 +4351,7 @@
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6（×1）は依然としてほとんどのエージェントループのワークホースデフォルトです。Sonnetが難しい推論、長文コンテキスト再現、一発のコード編集で明らかに失敗する場合にOpus 4.8に昇格させてください — 通常はSonnetやKimi K2.6レベルのサブエージェントに委任するプランナーとして使用します。動的ワークフローにより、オーケストレーターとしてのOpus 4.8 + ワーカーとしてのSonnet 4.6が新しい推奨パターンです。"
+            "body": "Sonnet 4.6（×1）は依然としてほとんどのエージェントループのワークホースデフォルトです。Sonnetが難しい推論、長文コンテキスト再現、一発のコード編集で明らかに失敗する場合にOpus 4.8に昇格させてください — 通常はSonnetやKimi K2.7 Codeレベルのサブエージェントに委任するプランナーとして使用します。動的ワークフローにより、オーケストレーターとしてのOpus 4.8 + ワーカーとしてのSonnet 4.6が新しい推奨パターンです。"
           },
           {
             "vs": "GPT-5.5",
@@ -4529,7 +4529,7 @@
           },
           {
             "title": "短い単発タスクにはオーバースペック",
-            "body": "単純なタスクにOpus 4.7を使うと不要なレイテンシとコストが発生します。分類や短い要約にはSonnetかKimi K2.6がほぼ同等の品質をわずかなコストで提供します。"
+            "body": "単純なタスクにOpus 4.7を使うと不要なレイテンシとコストが発生します。分類や短い要約にはSonnetかKimi K2.7 Codeがほぼ同等の品質をわずかなコストで提供します。"
           },
           {
             "title": "最も広範なツールルーティング能力",
@@ -4554,8 +4554,12 @@
             "body": "1Mトークンコンテキストと強力な長文再現力により、Opusはリポジトリ全体のコードを1ラウンドで読み取り、正確に参照できます。"
           }
         ],
-        "avoidFor": "すべてのエージェントアクションにOpus 4.7をデフォルトで使用すること。日々の作業のほとんど（短い要約、分類、単純なQ&A、軽いコードレビュー）では、Sonnet 4.6かKimi K2.6が3〜50倍低コストでほぼ同等の品質を提供します。",
+        "avoidFor": "すべてのエージェントアクションにOpus 4.7をデフォルトで使用すること。日々の作業のほとんど（短い要約、分類、単純なQ&A、軽いコードレビュー）では、Sonnet 4.6かKimi K2.7 Codeが3〜50倍低コストでほぼ同等の品質を提供します。",
         "comparisons": [
+          {
+            "vs": "Claude Opus 4.8",
+            "body": "Opus 4.8は同じVM0マルチプライヤーの新しいフラッグシップです。新しい高リスクのエージェントには4.8を使い、既存ワークフローが4.7で検証済みで、最新ベンチマークより安定性を優先する場合だけ4.7を維持します。"
+          },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Opus 4.7はより一貫した長ループの一貫性と高い初回コードパッチ品質を提供します。Sonnet 4.6は約2倍安く（×1 vs ×2クレジット）、より高いスループットを持ちます。標準パターン：Sonnetをデフォルトに、Opusをクリティカルなステップに。"
@@ -4565,16 +4569,12 @@
             "body": "Opus 4.7はSWE-bench Verified（80.6% vs 73.8%）、Terminal-Bench（48.3% vs 37.1%）、GPQA Diamond（93.1% vs 90.2%）でOpus 4.6を上回ります。同一価格、同一API — 残留する理由はありません。"
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Opus 4.7は高度な推論と長文コンテキストでK2.6を上回りますが、K2.6は×0.3クレジットです。バルクコードレビューにはK2.6の方がコスト効率が優れています。"
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 CodeはMoonshotの現在のコスト削減型コードモデルです。Opus 4.7はツールルーティングの信頼性、安全性プロファイル、英語の高リスク推論でより強く、Kimiは大量のコード作業で安価な選択肢です。"
           },
           {
             "vs": "DeepSeek V4 Pro",
             "body": "Opus 4.7の方が推論の上限は高いですが、V4 Pro（×0.1クレジット）はフロントエンドスタックや日常的なパッチで優れたコストパフォーマンスを提供します。"
-          },
-          {
-            "vs": "GPT-5.2 / Gemini 3 Pro",
-            "body": "Opus 4.7はOpenAIとGoogleの同世代フラッグシップと直接競合します。ランキングはベンチマークによって変動 — OpusはGPQA DiamondとTerminal-Benchでリード。VM0の乗数モデルが横断比較を容易にします。"
           }
         ],
         "verdict": "予算が許し、深い推論が必要なタスクがある場合、Opus 4.7はVM0ラインナップで最高の選択肢です。Sonnet 4.6をデフォルトにし、最も難しい10〜20%のステップをOpus 4.7にエスカレーションしてください。",
@@ -4602,16 +4602,16 @@
         ],
         "alternatives": [
           {
+            "slug": "claude-opus-4-8",
+            "reason": "高リスクのエージェント向けの新しいフラッグシップ"
+          },
+          {
             "slug": "claude-sonnet-4-6",
-            "reason": "同じファミリー、2倍安価、高速な推論。ほとんどのエージェントタスクの標準モデル。"
+            "reason": "ほとんどのエージェントループ向けの安価なデフォルト"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "×0.3クレジットで良好な推論品質。コスト最適化に最適な候補。"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "×0.1クレジットで強力なコードベンチマーク。セルフホストセットアップに最適。"
+            "slug": "kimi-k2-7-code",
+            "reason": "コストを抑えたオープンウェイトのコード代替"
           }
         ],
         "routingNotes": "On VM0, Opus 4.7 is routed directly to Anthropic's Messages API and is exposed three ways: through the VM0 Managed credit pool, through a direct Anthropic API key, and through the Claude Code OAuth provider for teams already authenticated with Claude Code.",
@@ -4710,7 +4710,7 @@
           },
           {
             "title": "Speed",
-            "body": "Slower than Sonnet 4.6 and Kimi K2.6; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
+            "body": "Slower than Sonnet 4.6 and Kimi K2.7 Code; comparable to Opus 4.7. Around 41 tokens/sec at max effort per Artificial Analysis."
           }
         ],
         "bestForExamples": [
@@ -4734,8 +4734,8 @@
             "body": "Sonnet 4.6 is ×1 and handles most agent loops. Reach for Opus only when Sonnet visibly fails. Usually for orchestration or hard code edits."
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "Kimi K2.6 (×0.3) edges Opus 4.6 on SWE-bench Pro (58.6 vs 53.4 vendor-reported) and is much cheaper. Opus 4.6 retains the safety-profile advantage and is the default Western enterprise pick."
+            "vs": "Kimi K2.7 Code",
+            "body": "Kimi K2.7 Code（×0.3）はエージェント型コード作業でOpus 4.6より大幅に安価です。Opus 4.6は安全性プロファイルで優位を保ち、保守的なエンタープライズ用途ではより無難な選択です。"
           }
         ],
         "verdict": "Opus 4.6は引き続き使用可能ですが、Opus 4.7は同一価格での厳密なアップグレードです。ワークフローを検証次第、移行してください。",
@@ -4754,7 +4754,7 @@
           },
           {
             "q": "Why is Opus 4.6 the default on the Anthropic API key provider?",
-            "a": "Historical default from before Opus 4.7 launched. You can switch any agent to Opus 4.7, Sonnet 4.6, or Kimi K2.6 in VM0 Settings → Model Providers without changing the API key."
+            "a": "Opus 4.7登場前からの歴史的なデフォルトです。APIキーを変更せずに、VM0 Settings → Model Providersで任意のエージェントをOpus 4.7、Sonnet 4.6、Kimi K2.7 Codeへ切り替えられます。"
           },
           {
             "q": "What's adaptive thinking?",
@@ -4764,15 +4764,15 @@
         "alternatives": [
           {
             "slug": "claude-opus-4-7",
-            "reason": "同一価格でより優れたベンチマークを持つ直接の後継。"
+            "reason": "より新しく、ベンダーコストが低い"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Claude 4ファミリー内のより安価な代替。"
+            "reason": "大幅に低コストなSonnetの基準モデル"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "良好な推論品質で大幅に安価（×0.3クレジット）。"
+            "slug": "kimi-k2-7-code",
+            "reason": "エージェントベンチマーク向けの安価なオープンウェイト代替"
           }
         ],
         "routingNotes": "Routed directly to Anthropic's Messages API. Available on VM0 Managed and as the default model on the Anthropic API-key and Claude Code OAuth providers.",
@@ -5036,7 +5036,7 @@
           },
           {
             "title": "Speed",
-            "body": "Faster than Opus and slower than Kimi K2.6. The right speed/quality balance for production agents."
+            "body": "Faster than Opus and slower than Kimi K2.7 Code. The right speed/quality balance for production agents."
           },
           {
             "title": "Cost predictability",
@@ -5053,23 +5053,27 @@
             "body": "Sonnet handles the bulk of code-aware work — PR review, test scaffolding, refactor suggestions, bug bisection — without leaving stylistic comments that nobody asked for. The 1M-token context window lets it pull in the related files and prior reviews when it matters, and you only escalate to Opus 4.7 for the patches Sonnet visibly struggles with."
           },
           {
-            "title": "The research agent that makes 20 tool calls in a row",
-            "body": "GitHub plus Linear plus Notion plus the web, stitched together across twenty-plus tool turns to answer a question like \"why did this customer churn last quarter?\" Sonnet keeps the goal in view across the whole chain at a fraction of Opus's cost, which is what makes it sustainable for everyday research as opposed to one-off deep dives."
+            "title": "安定したシステムプロンプトを持つカスタマーサポートアシスタント",
+            "body": "長い会話履歴、CRMへの頻繁なツール呼び出し、毎ターン同じ大きなシステムプロンプトとツールスキーマ。Sonnetのプロンプトキャッシュは、初回呼び出し後にその固定プレフィックスの入力コストを大きく下げ、会話量が増えても1会話あたりのコストを安定させます。"
           },
           {
             "title": "The customer-support assistant with a stable system prompt",
             "body": "Long conversation histories, frequent tool calls into the CRM, the same hefty system prompt and tool schema on every turn. Sonnet's prompt caching turns that fixed prefix into a fraction of the input cost after the first call, which is what keeps per-conversation cost flat as volume grows."
           }
         ],
-        "avoidFor": "Skip Sonnet 4.6 on the hardest reasoning steps where it visibly drops instructions and you should escalate to Opus 4.7, on bulk classification at high volume where GPT-5.4 Mini is the cheaper supported bulk option, and on latency-critical micro-replies where Kimi K2.6 is meaningfully faster.",
+        "avoidFor": "最難関の推論ステップで指示を明らかに落とす場合はOpus 4.7へ上げるべきです。高ボリュームの分類ではGPT-5.4 Miniがより安価な一括処理モデルであり、低レイテンシの短い応答ではKimi K2.7 Codeの方が大幅に高速なため、Sonnet 4.6は避けてください。",
         "comparisons": [
           {
             "vs": "Claude Opus 4.7",
-            "body": "Sonnet 4.6 is ×1; Opus 4.7 is ×2. Sonnet handles most agents; Opus is the upgrade when reasoning depth matters more than throughput. Many teams use Opus as the planner and Sonnet as the worker."
+            "body": "Sonnet 4.6は×1、Opus 4.7は×2です。Sonnetはほとんどのエージェントを処理でき、推論の深さがスループットより重要なときにOpusへ上げます。多くのチームはOpusをプランナー、Sonnetをワーカーとして使います。"
           },
           {
             "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro (×0.1) matches Sonnet on coding benchmarks (vendor-reported SWE-bench Verified) at much lower cost. The trade is some tool-routing reliability and a less-mature safety profile."
+            "body": "DeepSeek V4 Pro（×0.1）はコーディングベンチマークでSonnetに近い品質をかなり低いコストで出します。代償はツールルーティングの信頼性と安全性プロファイルがやや成熟していない点です。"
+          },
+          {
+            "vs": "GPT-5.4 Mini",
+            "body": "GPT-5.4 MiniはOpenAI側の安価な大量処理オプションです。ツールルーティングの信頼性が重要ならSonnetを使い、高ボリュームの事前フィルタリングやSonnet級のルーティングを必要としない簡単なステップではMiniを使います。"
           }
         ],
         "verdict": "Sonnet 4.6はVM0の正しいデフォルトモデルです。どのカテゴリーでも最高ではありませんが、エージェントステップの80%以上で十分な性能です。ここから始め、特定の理由がある場合のみ他のモデルにルーティングしてください。",
@@ -5088,7 +5092,7 @@
           },
           {
             "q": "Sonnet 4.6から切り替えるべきタイミングは？",
-            "a": "高度な推論や長ループにはOpus 4.7に。高ボリューム、レイテンシ重視、コスト重視のタスクにはKimi K2.6またはGPT-5.4 Miniに切り替え。"
+            "a": "高度な推論や長ループにはOpus 4.7に。高ボリューム、レイテンシ重視、コスト重視のタスクにはKimi K2.7 CodeまたはGPT-5.4 Miniに切り替え。"
           },
           {
             "q": "Sonnet 4.6はSonnet 4.5と同じですか？",
@@ -5369,15 +5373,19 @@
         "comparisons": [
           {
             "vs": "GLM-5.1",
-            "body": "GLM-5.1 remains available for compatibility. GLM-5.2 is the default choice for new Z.AI routes on VM0."
+            "body": "GLM-5.1は互換性のために引き続き利用できます。VM0の新しいZ.AIルートではGLM-5.2がデフォルトの選択肢です。"
           },
           {
             "vs": "Kimi K2.7 Code",
-            "body": "Both sit in cost-saving territory. Kimi is the Moonshot default and a strong code-focused alternative; GLM-5.2 is the preferred Z.AI long-context route."
+            "body": "どちらもコスト削減帯のモデルです。KimiはMoonshotのデフォルトでコードに強い代替、GLM-5.2はZ.AIの推奨ロングコンテキストルートです。"
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 remains the stronger default for premium tool-routing quality. GLM-5.2 is cheaper and better suited when context size dominates."
+            "body": "高品質なツールルーティングではSonnet 4.6がより強いデフォルトです。GLM-5.2は安価で、コンテキストサイズが支配的な場合に向いています。"
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 ProはVM0クレジットが低く、コスト優先の推論ではより強い選択肢です。価格が支配的ならDeepSeekを、Z.AIとの相性や長いコンテキストが重要ならGLM-5.2を使います。"
           }
         ],
         "verdict": "Pick GLM-5.2 as the default Z.AI route on VM0. Keep GLM-5.1 only for compatibility with workflows already tuned against it.",
@@ -5398,15 +5406,15 @@
         "alternatives": [
           {
             "slug": "glm-5-1",
-            "reason": "Compatibility with existing GLM-5.1 workflows"
+            "reason": "既存のGLM-5.1ワークフローとの互換性"
           },
           {
             "slug": "kimi-k2-7-code",
-            "reason": "Moonshot's cost-saving code model"
+            "reason": "Moonshotのコスト削減型コードモデル"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "Cheaper standard-context alternative"
+            "reason": "標準コンテキスト向けの安価な代替"
           }
         ],
         "routingNotes": "On VM0 Managed, GLM-5.2 routes through OpenRouter with the upstream id `z-ai/glm-5.2`. With a Z.AI API key it talks directly to `api.z.ai` as `glm-5.2`. It is the default model on the Z.AI provider.",
@@ -5423,11 +5431,11 @@
         "releaseDate": "2026年4月",
         "familyPosition": "Z.AIのGLMファミリーのフラッグシップ。",
         "background": [
-          "GLM-5.1 is the flagship of Zhipu AI's GLM series, distributed via Z.AI. It's a reasoning model with strong general capability and an unusually large context window. Up to 1M tokens, several times larger than the Anthropic and Moonshot defaults at the same price tier.",
-          "On VM0, GLM-5.1 is exposed two ways: through VM0 Managed (routed via OpenRouter with the upstream id `z-ai/glm-5.1`), and via a direct Z.AI API key. GLM-5.2 is now the Z.AI default, while GLM-5.1 remains available for compatibility.",
-          "GLM-5.1 became broadly available on VM0 in April 2026 when its feature flag was retired (PR #10497). It's the cost-efficient long-context option in the lineup, sitting at ×0.4 credits. Less than half of Sonnet 4.6."
+          "GLM-5.1はZhipu AIのGLMシリーズのフラッグシップで、Z.AI経由で提供されます。強い汎用能力を持つ推論モデルで、最大1Mトークンという非常に大きなコンテキストウィンドウを備え、同じ価格帯のAnthropicやMoonshotのデフォルトより数倍大きいです。",
+          "VM0ではGLM-5.1を2つの方法で提供します。VM0 ManagedではOpenRouter経由で上流ID `z-ai/glm-5.1` にルーティングし、もう一方は直接のZ.AI APIキーです。現在のZ.AIデフォルトはGLM-5.2で、GLM-5.1は互換性のために残っています。",
+          "GLM-5.1は、Feature Flagが削除された2026年4月（PR #10497）にVM0で広く利用可能になりました。カタログ内のコスト効率の良いロングコンテキスト選択肢で、×0.4クレジットに位置し、Sonnet 4.6の半分未満です。"
         ],
-        "architecture": "GLM-5.1 exposes an up-to-1M-token context window (the largest in the Built-in lineup) through an Anthropic-compatible API surface, so Claude-style agents drop in unchanged. The upstream supports prompt caching at `api.z.ai`.",
+        "architecture": "GLM-5.1はAnthropic互換のAPI表面を通じて最大1Mトークンのコンテキストウィンドウ（Built-inラインアップ最大）を提供するため、Claudeスタイルのエージェントは変更なしで利用できます。上流は `api.z.ai` でプロンプトキャッシュをサポートします。",
         "specs": [
           {
             "label": "ファミリー",
@@ -5495,11 +5503,11 @@
             "body": "Some agent steps genuinely take five to thirty minutes — deep research, multi-document analysis, long planning passes. VM0 sets a 50-minute API timeout for the Z.AI provider so those long thinking steps don't get cut off mid-thought, which makes GLM-5.1 the safe pick over models routed through providers with shorter default timeouts."
           }
         ],
-        "avoidFor": "Skip GLM-5.1 on the hardest English-language reasoning where Sonnet 4.6 or Opus 4.7 still leads, and on latency-critical chat replies where Kimi K2.6 is much faster.",
+        "avoidFor": "最難関の英語推論ではSonnet 4.6やOpus 4.7がまだ優位であり、低レイテンシのチャット応答ではKimi K2.7 Codeの方が大幅に高速なため、GLM-5.1は避けてください。",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
-            "body": "Both are long-context options at similar credit cost (×0.4 vs ×0.3). Kimi has stronger long-context recall in our internal evaluation; GLM-5.1 wins on raw context size (1M vs 256K). Pick Kimi for very long transcripts; pick GLM-5.1 when you need to stuff a whole codebase into one prompt."
+            "vs": "Kimi K2.7 Code",
+            "body": "どちらもロングコンテキストの選択肢です。クレジットコストは近く（×0.4 vs ×0.3）、内部評価ではKimiのロングコンテキスト再現率が強く、GLM-5.1は純粋なコンテキストサイズ（1M vs 256K）で勝ります。長いトランスクリプトにはKimi、コードベース全体を1つのプロンプトに入れる必要がある場合はGLM-5.1を選びます。"
           },
           {
             "vs": "Claude Sonnet 4.6",
@@ -5526,21 +5534,25 @@
           },
           {
             "q": "Does GLM-5.1 support image input?",
-            "a": "GLM-5.1 on VM0 is exposed for text and code. For multimodal (image/video) input, choose Claude Sonnet 4.6 or Kimi K2.6."
+            "a": "VM0のGLM-5.1はテキストとコード向けです。マルチモーダル入力（画像/動画）にはClaude Sonnet 4.6またはKimi K2.7 Codeを選んでください。"
           }
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "画像サポートと強力なベンチマークで類似価格。"
+            "slug": "glm-5-2",
+            "reason": "現在のZ.AIデフォルトルート"
+          },
+          {
+            "slug": "kimi-k2-7-code",
+            "reason": "より強いロングコンテキスト再現率"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "類似コスト（×0.1クレジット）のオープンソース代替。"
+            "reason": "短めのコンテキストでより安価な代替"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "高コスト（×1.0クレジット）でより優れたオールラウンド品質。"
+            "reason": "コストが制約でない場合のより強い推論"
           }
         ],
         "routingNotes": "On VM0 Managed, GLM-5.1 is routed through OpenRouter with the upstream id `z-ai/glm-5.1`. With a Z.AI API key it talks to `api.z.ai`'s Anthropic-compatible endpoint directly. GLM-5.2 is now the default model on the Z.AI provider.",
@@ -5552,14 +5564,14 @@
         "tagline": "OpenAIのGPT-5ファミリーのコスト最適化メンバー。×0.3クレジット、マルチモーダルビジョン、大量のルーティング、分類、事前フィルタ作業に十分な速度。",
         "cardIntro": "OpenAIのコスト削減型GPT-5。×0.3クレジット、高速かつマルチモーダル — Codexフレームワーク上のバルク事前フィルタ作業に対する正しい選択。",
         "metaTitle": "GPT-5.4 Mini on VM0: ベンチマーク、価格、比較",
-        "metaDescription": "VM0上のGPT-5.4 Miniレビュー。コスト削減型OpenAI GPT-5モデル、$0.75/$4.5ベンダー価格、×0.3クレジット、400Kコンテキスト、マルチモーダルビジョン。仕様、挙動、Kimi K2.6との比較。",
-        "summary": "GPT-5.4 MiniはOpenAIのGPT-5ファミリーのコスト削減メンバー — ピーク推論品質よりもユニットコストが重要な場合に手を伸ばすモデルです。ファミリーの残りと同じ400Kコンテキストウィンドウとマルチモーダル入力を維持しますが、トークンあたりの計算を削減しており、それがより低い価格（$0.75/$4.5/1M）と顕著に高い速度に翻訳されます。\n\nVM0では×0.3クレジット — Kimi K2.6と同じ乗数 — に位置し、バルク分類、ファンアウトルーティング、事前フィルタ、およびGPT-5.4のコストの3分の1に落とすことが決定要因となるエージェントステップに対する自然なOpenAI側の選択です。",
+        "metaDescription": "VM0上のGPT-5.4 Miniレビュー。コスト削減型OpenAI GPT-5モデル、$0.75/$4.5ベンダー価格、×0.3クレジット、400Kコンテキスト、マルチモーダルビジョン。仕様、挙動、Kimi K2.7 Codeとの比較。",
+        "summary": "GPT-5.4 MiniはOpenAIのGPT-5ファミリーのコスト削減メンバー — ピーク推論品質よりもユニットコストが重要な場合に手を伸ばすモデルです。ファミリーの残りと同じ400Kコンテキストウィンドウとマルチモーダル入力を維持しますが、トークンあたりの計算を削減しており、それがより低い価格（$0.75/$4.5/1M）と顕著に高い速度に翻訳されます。\n\nVM0では×0.3クレジット — Kimi K2.7 Codeと同じ乗数 — に位置し、バルク分類、ファンアウトルーティング、事前フィルタ、およびGPT-5.4のコストの3分の1に落とすことが決定要因となるエージェントステップに対する自然なOpenAI側の選択です。",
         "releaseDate": "2026年4月",
-        "familyPosition": "GPT-5ファミリーのコスト削減バリアント。Kimi K2.6のOpenAI側の同等。",
+        "familyPosition": "GPT-5ファミリーのコスト削減バリアント。Kimi K2.7 CodeのOpenAI側の同等。",
         "background": [
           "GPT-5.4 MiniはOpenAIのGPT-5世代のコスト最適化メンバーで、2026年4月にGPT-5.5とGPT-5.4と一緒にリリースされました。OpenAIは、高スループットティアとして位置付けています — より大きな5.4や5.5がルーチンな決定では無駄になる、分類、ルーティング、事前フィルタステップで実行し続けるモデルです。",
           "アーキテクチャ的にはGPT-5ファミリーの400Kトークンコンテキストウィンドウ、`reasoning_effort`パラメーター、プロンプトキャッシュ、codex CLIがデフォルトで使用するResponses APIサーフェスを共有しています。5.4とのトレードオフは推論深度です：Miniは標準的なツール呼び出し、短い要約、構造化出力ワークロードを十分に処理しますが、5.4がまだ持ちこたえるより難しいマルチステッププランでドリフトし始めます。同じ価格帯の競合とのトレードオフはエコシステム — 既にCodex上にいる場合、OpenAIサーフェス内に留まることでツール定義と構造化出力スキーマが一貫したまま保たれます。",
-          "VM0上ではMiniは×0.3クレジット乗数に位置し、Kimi K2.6と同じです。DeepSeek V4 Proはより低い×0.1です。コスト削減ティア内では、選択は主にフレームワークと特定のワークロードでの挙動の適合性に依存します。"
+          "VM0上ではMiniは×0.3クレジット乗数に位置し、Kimi K2.7 Codeと同じです。DeepSeek V4 Proはより低い×0.1です。コスト削減ティア内では、選択は主にフレームワークと特定のワークロードでの挙動の適合性に依存します。"
         ],
         "architecture": "GPT-5.4 MiniはGPT-5ファミリーの残りと同じアーキテクチャを使用します：400Kトークンコンテキストウィンドウ、4レベルの`reasoning_effort`パラメーター、キャッシュ入力が入力レートの10分の1で課金されるプロンプトキャッシュ、Responses APIサーフェス。ツール使用、構造化出力、マルチモーダルビジョン入力がサポートされています。モデルはより小さく高速な兄弟 — トークンあたり少ないパラメーター、ドルあたりより多くのスループット。",
         "specs": [
@@ -5596,7 +5608,7 @@
             "value": "入力$0.75 / 出力$4.5 /1M"
           }
         ],
-        "benchmarksNote": "OpenAIのGPT-5 Miniリリース資料からのベンダー報告スコア。独立レビューはほとんどのエージェントベンチマークで5.4 MiniをKimi K2.6と同じコスト削減帯に位置付けています。絶対パーセンテージは方向性として捉えてください。",
+        "benchmarksNote": "OpenAIのGPT-5 Miniリリース資料からのベンダー報告スコア。独立レビューはほとんどのエージェントベンチマークで5.4 MiniをKimi K2.7 Codeと同じコスト削減帯に位置付けています。絶対パーセンテージは方向性として捉えてください。",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -5639,7 +5651,7 @@
           },
           {
             "title": "コスト効率",
-            "body": "マルチモーダルビジョンを含む×0.3クレジット。MiniとKimi K2.6は同じ帯にあり、DeepSeek V4 Proはより低い×0.1です — 選択は通常フレームワークの適合性と特定のワークロードでの挙動に帰着します。"
+            "body": "マルチモーダルビジョンを含む×0.3クレジット。MiniとKimi K2.7 Codeは同じ帯にあり、DeepSeek V4 Proはより低い×0.1です — 選択は通常フレームワークの適合性と特定のワークロードでの挙動に帰着します。"
           },
           {
             "title": "エスカレートするタイミング",
@@ -5665,6 +5677,14 @@
           {
             "vs": "GPT-5.4",
             "body": "同じファミリー、異なるポジショニング。5.4 Mini（×0.3）はコストと速度で勝ち、5.4（×1）は難しいケースでの推論品質とツールルーティング精度で勝ちます。標準パターンはMiniで事前フィルタし、残りのケースを5.4にエスカレートすることです。"
+          },
+          {
+            "vs": "Claude Sonnet 4.6",
+            "body": "ツールルーティング品質が純粋なスループットより重要な場合、Claude Sonnet 4.6の方が信頼できる比較対象です。Miniは事前フィルタリングや簡単なステップでより安価かつ高速です。"
+          },
+          {
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 ProはVM0クレジットが低く、コスト優先の推論ではより強い選択肢です。価格と推論の深さが支配的ならDeepSeek、OpenAIフレームワークとの相性と高スループットが重要ならMiniを使います。"
           }
         ],
         "verdict": "GPT-5.4 MiniはOpenAI側のコスト削減デフォルト。Miniで事前フィルタし、ルーチンステップにはGPT-5.4にエスカレート、最も難しい推論にのみGPT-5.5にエスカレートしてください。",
@@ -5678,7 +5698,7 @@
             "a": "はい。GPT-5ファミリーの残りと同様にテキストとコードと並んで画像入力を受け付けます。"
           },
           {
-            "q": "GPT-5.4 MiniとKimi K2.6のどちらを選ぶべき？",
+            "q": "GPT-5.4 MiniとKimi K2.7 Codeのどちらを選ぶべき？",
             "a": "エージェントが既にCodexフレームワーク上に構築されている場合、またはOpenAI構造化出力/ツール呼び出しエコシステムが必要な場合。両者とも×0.3クレジットなのでコストは同一で、選択はフレームワークと挙動に帰着します。"
           },
           {
@@ -5697,178 +5717,7 @@
           }
         ],
         "routingNotes": "Routed through the Codex framework on VM0 via OpenAI's Responses API. Available on VM0 Managed and via direct OpenAI API key, ChatGPT (Codex) OAuth, OpenRouter (Codex) and Vercel AI Gateway (Codex).",
-        "vm0Notes": "GPT-5.4 Mini sits at the ×0.3 cost-saving multiplier alongside Kimi K2.6, above DeepSeek V4 Pro's ×0.1 tier. Prompt caching is enabled by default and the high throughput makes Mini a natural pre-filter step in stacked agent designs that escalate to 5.4 or 5.5 only on the residual hard cases."
-      },
-      "kimi-k2-6": {
-        "name": "Kimi K2.6",
-        "pageTitle": "Kimi K2.6 on VM0. 長文コンテキストエージェント",
-        "tagline": "Moonshotの最新オープンウェイトモデル。オープンソース最前線で最高クラスのエージェントベンチマーク、Claude互換インターフェース。",
-        "cardIntro": "Moonshotの最新。社内評価で最高クラスの長文コンテキスト再現率、Claude互換インターフェース。",
-        "metaTitle": "Kimi K2.6 on VM0: SWE-bench、価格、長文コンテキスト活用",
-        "metaDescription": "VM0でのKimi K2.6レビュー。Moonshotのオープンウェイト1TパラメータMoE。SWE-bench Pro 58.6、×0.3クレジットコスト、256Kコンテキスト。仕様と推奨タスク。",
-        "summary": "Kimi K2.6はMoonshotのオープンウェイトフラッグシップであり、複数の公開ベンチマークで現在最強のオープンソースエージェントモデルです。非常に長い実行でもスレッドを見失わず（Moonshotは12時間以上・4,000回以上のツール呼び出しの無人のセッションを文書化）、画像と動画の入力をネイティブに受け付けます。ベンダー報告のSWE-bench Proは58.6（当該ベンチマークでClaude Opus 4.6とGPT-5.4を上回る）で、ハルシネーション率はK2.5の約65%から約39%に低下しました。\n\nベンダー価格は$0.60/$3/1Mトークン、オープンウェイトはModified MITライセンスで公開、APIはAnthropic互換です。プロダクションのツールルーティング信頼性がベンチマークスコアより重要な場合はSonnet 4.6を、レイテンシが支配的な場合はKimi K2.6を選びましょう。",
-        "releaseDate": "2026年4月20日",
-        "familyPosition": "MoonshotのオープンウェイトKimi K2シリーズの最上位。K2.5とK2 Thinkingの後継。",
-        "background": [
-          "Kimi K2.6は2026年4月20日にリリースされたMoonshot AIのオープンウェイトエージェントモデルです。1兆パラメータのMixture-of-Experts（MoE）モデルで、トークンあたり32Bのアクティブパラメータを持ちます。K2.5およびK2 Thinkingと同じアーキテクチャファミリーで、エージェントコーディングと長期的推論において大幅な向上を達成しています。",
-          "K2.6は独立したリーダーボードで大きな話題を呼びました。ベンダー報告のスコアはSWE-bench ProでGPT-5.4（xhigh）とClaude Opus 4.6（max effort）を上回り、ハルシネーション率は39%（K2.5の65%から低下）です。Artificial AnalysisのIntelligence Indexで#4にランクイン。オープンウェイトのトップ選択肢です。",
-          "VM0ではMoonshot APIキー経由でデフォルトモデルとして、VM0 Managed経由で同じ×0.3マルチプライヤーで、さらにOpenRouter経由でも利用可能です。APIはAnthropic互換のため、Claude向けに作成されたVM0エージェントはコード変更なしで動作します。"
-        ],
-        "architecture": "K2.6は1T総パラメータ・32Bアクティブ/トークンのMixture-of-Expertsモデルで、256Kトークンのコンテキストウィンドウと画像・動画入力（テキスト出力のみ）に対応します。MoonshotはこれをAgent Swarmランタイムと組み合わせており、300のサブエージェントと4,000の調整ステップに水平スケーリングし、12時間以上の長期的コーディングセッションを文書化しています。オープンウェイトはModified MITライセンスでHugging Faceに公開されています。",
-        "specs": [
-          {
-            "label": "ファミリー",
-            "value": "Kimi K2シリーズ"
-          },
-          {
-            "label": "パラメータ",
-            "value": "1T総/32Bアクティブ（MoE）"
-          },
-          {
-            "label": "モダリティ",
-            "value": "画像、動画、テキスト"
-          },
-          {
-            "label": "言語",
-            "value": "多言語"
-          },
-          {
-            "label": "コンテキストウィンドウ",
-            "value": "256Kトークン"
-          },
-          {
-            "label": "ライセンス",
-            "value": "Modified MIT（オープンウェイト）"
-          },
-          {
-            "label": "VM0での利用開始",
-            "value": "2026年4月"
-          }
-        ],
-        "benchmarksNote": "MoonshotのK2.6リリースブログからのベンダー報告スコア。独立した第三者（Artificial Analysis、TokenMix）が相対的な順位を裏付けています。K2.6のハルシネーション率はK2.5の65%から39%に低下。安全性/信頼性の大幅な改善です。",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "58.6",
-            "note": "ベンダー報告；GPT-5.4、Opus 4.6を上回る"
-          },
-          {
-            "name": "SWE-bench Verified",
-            "score": "80.2",
-            "note": "ベンダー報告"
-          },
-          {
-            "name": "Terminal-Bench 2.0",
-            "score": "66.7",
-            "note": "Terminus-2フレームワーク"
-          },
-          {
-            "name": "LiveCodeBench (v6)",
-            "score": "89.6",
-            "note": "ベンダー報告"
-          },
-          {
-            "name": "HLE（ツール使用）",
-            "score": "54.0",
-            "note": "GPT-5.4とOpus 4.6をリード"
-          },
-          {
-            "name": "BrowseComp（Agent Swarm）",
-            "score": "86.3",
-            "note": "K2.5の78.4から向上"
-          },
-          {
-            "name": "Artificial Analysis Intelligence Index",
-            "score": "54",
-            "note": "#4総合、オープンウェイトトップ"
-          }
-        ],
-        "performance": [
-          {
-            "title": "長文コンテキスト再現率",
-            "body": "Built-inラインアップで社内評価上最強の長文コンテキスト再現率。Anthropic Sonnetがドリフトし始める長いエージェントトランスクリプトでも一貫性を維持します。"
-          },
-          {
-            "title": "エージェントベンチマーク",
-            "body": "ベンダー報告のSWE-bench Pro 58.6は執筆時点でラインアップ最高。GPT-5.4とOpus 4.6を上回ります。"
-          },
-          {
-            "title": "長期的コーディング",
-            "body": "4,000回以上のツール呼び出しを伴う12時間以上の自律セッションが文書化されています。このモデルは非常に長い実行でも真にパフォーマンスを維持します。"
-          },
-          {
-            "title": "ツール使用",
-            "body": "一般的なVM0ツールフローで信頼性があります。Anthropic互換APIにより、Claude向けに設計されたツールスキーマがそのまま動作します。"
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "すべての古いスレッドを読まなければならない調査",
-            "body": "顧客が解約した理由を見つけるために6ヶ月分のSlack会話を掘り下げる、繰り返し発生するバグパターンをサポートチケットのバックログから探す、100件のRFCにわたるインサイトをつなぎ合わせる。K2.6の長文コンテキスト再現率は、Anthropic Sonnetが初期のターンを見落とし始めるようなトランスクリプトでも維持されます。これは「山全体を読む」ワークフローに必要なものです。"
-          },
-          {
-            "title": "一晩で実行する自律的リファクタリング",
-            "body": "Moonshotは8年前のマッチングエンジンの13時間の自律的リファクタリングを文書化しており、K2.6は4,000回以上のツール呼び出しをタスクから逸脱せずに維持しました。これは、ほとんどのモデルが2時間目あたりで目標を見失うような実行です。K2.6の長期的安定性が「金曜の夜に開始して月曜の朝に確認する」を実際に機能させます。"
-          },
-          {
-            "title": "スクリーンショットと動画を扱うマルチモーダルエージェント",
-            "body": "K2.6はMoonViTを通じて画像と動画の両方の入力を受け付けます。これはClaudeファミリー以外では珍しいことです。スクリーンショットベースのQAエージェント、ドキュメントビジョンパイプライン、画像を読むためだけに別のビジョンモデルを組み込む必要があるようなデプロイメントに有用です。"
-          }
-        ],
-        "avoidFor": "プロダクションの信頼性でSonnet 4.6が依然リードする最も難しいツールルーティングのエッジケースではK2.6をスキップし、K2.5の低いマルチプライヤーで十分な固定済みレガシーワークフローでも避けてください。",
-        "comparisons": [
-          {
-            "vs": "GLM-5.1",
-            "body": "両方とも長文コンテキストの選択肢です。K2.6は社内評価で生の長文コンテキスト再現率が勝り、GLM-5.1はコンテキストサイズ（1M vs 256K）で勝ります。長いトランスクリプトにはK2.6をデフォルトに、1プロンプトで256Kトークンを超える必要がある場合のみGLM-5.1を選択してください。"
-          },
-          {
-            "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet（×1）はマルチツールの英語ルーティング信頼性でリード。K2.6（×0.3）はコストとエージェントベンチマーク（SWE-bench Pro）で勝ります。組み合わせて：複雑なツールルーティングにはSonnet、コスト重視のエージェント作業にはK2.6。"
-          },
-          {
-            "vs": "Kimi K2.5",
-            "body": "K2.6はツール使用が強化され、ハルシネーション率が低く（39% vs 65%）、推論が優れた新世代です。K2.5（×0.2）はわずかに安価です。新規作業にはK2.6を推奨。"
-          }
-        ],
-        "verdict": "本格的なエージェント作業のためのオープンウェイトデフォルト — 長文コンテキスト、コスト効率。Sonnet 4.6に対する残存ギャップはツールルーティングの信頼性とエンタープライズサポートです。",
-        "faqs": [
-          {
-            "q": "Kimi K2.6はいつリリースされましたか？",
-            "a": "Moonshot AIは2026年4月20日にKimi K2.6をリリースしました。オープンウェイトはModified MITライセンスでHugging Faceに公開されています。"
-          },
-          {
-            "q": "コンテキストウィンドウは？",
-            "a": "256Kトークン。K2.6は生のウィンドウサイズではなく、そのサイズでの再現品質で差別化しています。再現率は約180Kを超えると低下し始めます（他の256Kモデルと同様です）。"
-          },
-          {
-            "q": "Kimiを使うためにエージェントを書き換える必要がありますか？",
-            "a": "いいえ。Kimi K2.6はAnthropic互換APIを提供しているため、Claude向けに調整されたVM0エージェントはコード変更なしで動作します。"
-          },
-          {
-            "q": "Kimi K2.6はClaude Opus 4.6と比べてどうですか？",
-            "a": "エージェントベンチマーク（ベンダー報告）ではK2.6がリード。SWE-bench Pro 58.6 vs Opus 4.6の53.4、HLE（ツール使用）54.0 vs 53.0。Opus 4.6は安全性プロファイルとプロダクションでの英語ツールルーティング信頼性で優位を保っています。"
-          },
-          {
-            "q": "K2.6は画像入力に対応していますか？",
-            "a": "はい。K2.6は画像と動画の入力を受け付けます。テキスト出力のみ。マルチモーダルエージェントはネイティブに動作します。"
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-5",
-            "reason": "旧世代、わずかに安いマルチプライヤー"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "さらに長いコンテキストウィンドウ（1Mトークン）"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "コスト重視の作業のための安価な代替"
-          }
-        ],
-        "routingNotes": "MoonshotのAnthropic互換エンドポイント`api.moonshot.ai`経由でルーティング。Moonshotプロバイダーのデフォルトモデル。VM0 ManagedおよびOpenRouter経由でも利用可能。",
-        "vm0Notes": "K2.6は社内評価に基づきBuilt-inラインアップで最強の長文コンテキスト再現率を持ち、×0.3クレジットでコスト重視の作業におけるSonnetの有力な代替として十分な安さです。"
+        "vm0Notes": "GPT-5.4 MiniはKimi K2.7 Codeと同じ×0.3のコスト削減マルチプライヤーにあり、DeepSeek V4 Proの×0.1帯より上です。Prompt Cachingはデフォルトで有効で、高いスループットにより、難しい残余ケースだけを5.4や5.5へエスカレーションする積層型エージェント設計の自然な事前フィルタになります。"
       },
       "kimi-k2-7-code": {
         "name": "Kimi K2.7 Code",
@@ -5989,16 +5838,16 @@
         "avoidFor": "プロダクションの信頼性でSonnet 4.6が依然リードする最も難しいツールルーティングのエッジケースではK2.7をスキップし、K2.6の低いマルチプライヤーで十分な固定済みレガシーワークフローでも避けてください。",
         "comparisons": [
           {
-            "vs": "GLM-5.1",
-            "body": "両方とも長文コンテキストの選択肢です。K2.7は社内評価で生の長文コンテキスト再現率が勝り、GLM-5.1はコンテキストサイズ（1M vs 256K）で勝ります。長いトランスクリプトにはK2.7をデフォルトに、1プロンプトで256Kトークンを超える必要がある場合のみGLM-5.1を選択してください。"
+            "vs": "GLM-5.2",
+            "body": "どちらも現在のコスト削減型ロングコンテキストモデルです。K2.7 Codeはマルチモーダルなコード作業に強いMoonshotのデフォルトで、GLM-5.2はより大きい1Mトークンのコンテキストウィンドウを持つ現在のZ.AIデフォルトです。"
           },
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet（×1）はマルチツールの英語ルーティング信頼性でリード。K2.7（×0.3）はコストとエージェントベンチマーク（SWE-bench Pro）で勝ります。組み合わせて：複雑なツールルーティングにはSonnet、コスト重視のエージェント作業にはK2.7。"
           },
           {
-            "vs": "Kimi K2.6",
-            "body": "K2.7はツール使用が強化され、ハルシネーション率が低く（39% vs 65%）、推論が優れた新世代です。K2.6（×0.2）はわずかに安価です。新規作業にはK2.7を推奨。"
+            "vs": "DeepSeek V4 Pro",
+            "body": "DeepSeek V4 Proはより安価で、1Mトークンの大きなコンテキストウィンドウを持ちます。Kimi K2.7 CodeはMoonshotネイティブのより強いコードルートで、画像入力も含みます。プロバイダーの相性とワークロードの形で選びます。"
           }
         ],
         "verdict": "本格的なエージェント作業のためのオープンウェイトデフォルト — 長文コンテキスト、コスト効率。Sonnet 4.6に対する残存ギャップはツールルーティングの信頼性とエンタープライズサポートです。",
@@ -6026,16 +5875,16 @@
         ],
         "alternatives": [
           {
-            "slug": "claude-sonnet-4-6",
-            "reason": "旧世代、わずかに安いマルチプライヤー"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "さらに長いコンテキストウィンドウ（1Mトークン）"
+            "slug": "glm-5-2",
+            "reason": "現在のZ.AIロングコンテキストルート"
           },
           {
             "slug": "deepseek-v4-pro",
-            "reason": "コスト重視の作業のための安価な代替"
+            "reason": "コスト重視の作業向けの安価な推論代替"
+          },
+          {
+            "slug": "claude-sonnet-4-6",
+            "reason": "複雑なツール利用のためのより信頼できる基準"
           }
         ],
         "routingNotes": "MoonshotのAnthropic互換エンドポイント`api.moonshot.ai`経由でルーティング。Moonshotプロバイダーのデフォルトモデル。VM0 Managedでも利用可能。",
@@ -6048,13 +5897,13 @@
         "cardIntro": "DeepSeekのフラッグシップ。低いVM0クレジット乗数で強力な推論、Claude互換API。",
         "metaTitle": "DeepSeek V4 Pro on VM0: ベンチマーク、価格、比較",
         "metaDescription": "VM0でのDeepSeek V4 Proレビュー。SWE-bench Verified 80.6%のオープンウェイト1.6T MoE、×0.1クレジットコスト、1Mコンテキスト。価格、仕様、Claude比較。",
-        "summary": "DeepSeek V4 ProはDeepSeekのV4世代のフラッグシップ — MITライセンスのオープンウェイト1.6TパラメータMoEです。最大の特徴は価格品質比：ベンダー報告のSWE-bench Verifiedは80.6%で、Claude Opus 4.6と小数点以下の差、Anthropicのベンダーコストの約7分の1です。これにより、推論重視のエージェント（バルクPRレビュー、バッチ文書分析、定期要約）を高ボリュームで手頃に実行できます。\n\nベンダー価格は$1.74/$3.48/1Mトークン、キャッシュ読み取り$0.028/1M、キャッシュ書き込み無料（ラインアップで唯一）。1Mトークンコンテキスト、Anthropic互換API。プロダクションのツールルーティング信頼性が決定要因の場合はSonnet 4.6を、単発バルク作業がV4 Proの推論深度を必要としない場合はGPT-5.4 MiniまたはKimi K2.6を選びましょう。",
+        "summary": "DeepSeek V4 ProはDeepSeekのV4世代のフラッグシップ — MITライセンスのオープンウェイト1.6TパラメータMoEです。最大の特徴は価格品質比：ベンダー報告のSWE-bench Verifiedは80.6%で、Claude Opus 4.6と小数点以下の差、Anthropicのベンダーコストの約7分の1です。これにより、推論重視のエージェント（バルクPRレビュー、バッチ文書分析、定期要約）を高ボリュームで手頃に実行できます。\n\nベンダー価格は$1.74/$3.48/1Mトークン、キャッシュ読み取り$0.028/1M、キャッシュ書き込み無料（ラインアップで唯一）。1Mトークンコンテキスト、Anthropic互換API。プロダクションのツールルーティング信頼性が決定要因の場合はSonnet 4.6を、単発バルク作業がV4 Proの推論深度を必要としない場合はGPT-5.4 MiniまたはKimi K2.7 Codeを選びましょう。",
         "releaseDate": "2026年4月24日",
         "familyPosition": "DeepSeek V4ファミリーの推論バリアント。最大の推論品質にフォーカス。",
         "background": [
           "DeepSeek V4 ProはDeepSeekのV4世代のフラッグシップで、2026年4月24日にMITライセンスでリリースされました。1.6T総パラメータ・49Bアクティブ/トークンのオープンウェイトMixture-of-Expertsモデルです。",
           "V4 Proは1Mトークンコンテキストウィンドウ、384K最大出力、3つの推論努力モード（standard、think、think-max）、JSON出力、ツール呼び出し、非thinkモードでのFIM補完をサポートします。Proモデルはハイブリッドアテンションアーキテクチャ（Compressed Sparse Attention + Heavily Compressed Attention）を追加し、長文コンテキスト効率を劇的に改善。1MコンテキストでDeepSeek V3.2と比較してシングルトークン推論FLOPの27%、KVキャッシュの10%。",
-          "DeepSeekは2025年を通じて、Anthropic級の推論を数分の一の価格で提供することで波紋を広げました。V4 Proはそのパターンを継承：ベンダー報告のSWE-bench Verified 80.6%はClaude Opus 4.6と0.2ポイント差、ベンダーコストは約7分の1。VM0ではDeepSeek APIキープロバイダーとVM0 Managedで×0.1で利用可能。Kimi K2.6より低いマルチプライヤーで、大幅に強力な推論動作を持ちます。"
+          "DeepSeekは2025年を通じて、Anthropic級の推論を数分の一の価格で提供することで波紋を広げました。V4 Proはそのパターンを継承：ベンダー報告のSWE-bench Verified 80.6%はClaude Opus 4.6と0.2ポイント差、ベンダーコストは約7分の1。VM0ではDeepSeek APIキープロバイダーとVM0 Managedで×0.1で利用可能。Kimi K2.7 Codeより低いマルチプライヤーで、大幅に強力な推論動作を持ちます。"
         ],
         "architecture": "V4 Proは1.6T総パラメータ・49Bアクティブ/トークンのMixture-of-Expertsモデルで、ハイブリッドアテンションスタック（Compressed Sparse Attention + Heavily Compressed Attention）を備え、長文コンテキスト推論を低コストに保ちます。1Mトークンのコンテキストウィンドウと384Kの最大出力、3つの推論努力モード（standard、think、think-max）をサポートし、安定した信号伝播のためにManifold-Constrained Hyper-Connectionsを使用しています。32T+トークンでMuonオプティマイザを使用して訓練され、MITライセンスでオープンウェイトが公開されています。",
         "specs": [
@@ -6091,7 +5940,7 @@
             "value": "2026年4月24日"
           }
         ],
-        "benchmarksNote": "DeepSeekのV4 Proリリースからのベンダー報告スコア。独立したレビュー（Geeky Gadgets、Code Arena）ではV4 ProはCode ArenaでGLM-5.1とKimi K2.6に次ぐ3位。最も強いベンチマーク主張はDeepSeek自身の資料からです。絶対的真実ではなく方向性として扱ってください。",
+        "benchmarksNote": "DeepSeekのV4 Proリリースからのベンダー報告スコア。独立したレビュー（Geeky Gadgets、Code Arena）ではV4 ProはCode ArenaでGLM-5.1とKimi K2.7 Codeに次ぐ3位。最も強いベンチマーク主張はDeepSeek自身の資料からです。絶対的真実ではなく方向性として扱ってください。",
         "benchmarks": [
           {
             "name": "SWE-bench Verified",
@@ -6148,7 +5997,7 @@
           },
           {
             "title": "速度",
-            "body": "Artificial Analysisによると最大努力で約36トークン/秒。Kimi K2.6より遅く、Opus 4.6よりわずかに遅い。"
+            "body": "Artificial Analysisによると最大努力で約36トークン/秒。Kimi K2.7 Codeより遅く、Opus 4.6よりわずかに遅い。"
           }
         ],
         "bestForExamples": [
@@ -6165,18 +6014,22 @@
             "body": "ハイブリッドアテンション（Compressed Sparse Attention + Heavily Compressed Attention）を備えた1Mトークンコンテキストにより、中規模のコードベースが1プロンプトに収まり、ウィンドウが埋まっても推論コストが管理可能です。クロスファイルリファクタリングやアーキテクチャレベルのレビューでは、「すべてを一度に見る」OpusスタイルのワークフローをOpusスタイルの請求書なしで実現できます。"
           }
         ],
-        "avoidFor": "Sonnet 4.6が依然リードする最も難しいツールルーティングのエッジケースではV4 Proをスキップし、GPT-5.4 MiniまたはKimi K2.6で低コストに十分なバルク単発作業でもスキップします。",
+        "avoidFor": "Sonnet 4.6が依然リードする最も難しいツールルーティングのエッジケースではV4 Proをスキップし、GPT-5.4 MiniまたはKimi K2.7 Codeで低コストに十分なバルク単発作業でもスキップします。",
         "comparisons": [
           {
             "vs": "Claude Sonnet 4.6",
             "body": "Sonnet 4.6（×1）はツールルーティングのエッジケースと英語推論で勝ります。V4 Pro（×0.1）はコストで勝り、コーディングベンチマーク（ベンダー報告）で競争力があります。コミットする前に実際のエージェントでA/Bテストする価値があります。"
           },
           {
-            "vs": "Kimi K2.6",
+            "vs": "Kimi K2.7 Code",
             "body": "Kimiより低いマルチプライヤー（×0.1 vs ×0.3）。Kimiは長文コンテキスト再現率が強くIntelligence Indexが高い（54 vs 52）。V4 Proはキャッシュ経済性が優れ（書き込み無料）、1Mコンテキストウィンドウ（Kimiは256K）。どちらの特性がより重要かで選択します。"
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2はVM0における現在のZ.AIデフォルトルートです。新しいZ.AIベースのエージェントではこちらがより適切な比較対象で、GLM-5.1は調整済みワークフローとの互換性のためだけに残ります。"
           }
         ],
-        "verdict": "GPT-5.4 MiniまたはKimi K2.6で事前フィルタリングし、推論にはV4 Proにエスカレーション、V4 Proがツールルーティングのエッジケースで止まった場合のみSonnet 4.6にエスカレーション。",
+        "verdict": "GPT-5.4 MiniまたはKimi K2.7 Codeで事前フィルタリングし、推論にはV4 Proにエスカレーション、V4 Proがツールルーティングのエッジケースで止まった場合のみSonnet 4.6にエスカレーション。",
         "faqs": [
           {
             "q": "DeepSeek V4 Proはいつリリースされましたか？",
@@ -6202,146 +6055,15 @@
         "alternatives": [
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "難しいツールルーティングへのステップアップ"
+            "reason": "難しいツールルーティング向けの上位選択肢"
           },
           {
-            "slug": "kimi-k2-6",
-            "reason": "同じ価格、より強力な長文コンテキスト再現率"
+            "slug": "kimi-k2-7-code",
+            "reason": "マルチモーダルなコード作業に強いMoonshotデフォルト"
           }
         ],
         "routingNotes": "DeepSeekのAnthropic互換エンドポイント`api.deepseek.com`経由でルーティング。VM0 ManagedおよびDeepSeekプロバイダーで利用可能。",
         "vm0Notes": "DeepSeekはキャッシュ書き込みではなくキャッシュ読み取りに課金するため、システムプロンプトが安定している場合は実質的なコスト削減になります。VM0はDeepSeekプロバイダーに10分のAPIタイムアウトを設定し、長時間実行エージェントの応答性を保つために非必須トラフィックを無効化しています。結果として、Built-inラインアップでサブSonnetモデル中最強の推論力を実現しています。"
-      },
-      "kimi-k2-5": {
-        "name": "Kimi K2.5",
-        "pageTitle": "Kimi K2.5 on VM0. Moonshotの前世代",
-        "tagline": "前世代のKimi。K2.6より安価だがツール使用は弱い。このバージョンで特定のエージェントが検証されている場合のみ固定してください。",
-        "cardIntro": "前世代のKimi。K2.6より安価だがツール使用は弱い。このバージョンで特定のエージェントが検証されている場合のみ固定してください。",
-        "metaTitle": "Kimi K2.5 on VM0: 仕様、価格、K2.6への移行",
-        "metaDescription": "VM0でのKimi K2.5レビュー。Moonshotの前フラッグシップ、×0.2クレジットコスト。SWE-bench Pro 50.7、256Kコンテキスト。K2.6ではなくK2.5を固定する場合。",
-        "summary": "Kimi K2.5はMoonshotの前フラッグシップで、2026年4月にK2.6が後継したオープンウェイトモデルです。依然として有能で、長文コンテキスト要約に強いですが、K2.6は同じベンダー価格ですべての公開ベンチマークでリードしており、ハルシネーション率の差は大きいです（K2.5はMoonshotの評価で約65%、K2.6は約39%）。\n\nベンダー価格は$0.60/$3/1MトークンでK2.6と同じ。正直な売り文句：K2.5で構築して動作しているならそのままに、新規で始めるならK2.6で始めましょう。",
-        "releaseDate": "2025年後半（Kimi K2シリーズ）",
-        "familyPosition": "MoonshotのオープンウェイトKimi K2シリーズの前世代。K2.6に後継されました。",
-        "background": [
-          "Kimi K2.5はK2.6以前のMoonshotのフラッグシップKimiモデルでした。長文コンテキスト推論とClaude互換API表面を組み合わせた初の広く展開されたKimiであり、長文コンテキスト要約作業において有能なモデルであり続けています。",
-          "VM0ではK2.6と同じベンダー価格ですが、より低いクレジットマルチプライヤー（×0.2）です。低いマルチプライヤーは生のトークンコストではなくポジショニングを反映しています。K2.6が新規作業の推奨デフォルトで、K2.5はレガシー固定用です。",
-          "K2.5のベンダー報告SWE-bench Proスコアは50.7、ハルシネーション率は約65%です。どちらもK2.6（58.6と39%）に有意に劣ります。動作的には、固定されたプロダクションエージェントに対して安定しています。"
-        ],
-        "architecture": "K2.5はK2.6と同じファミリーの1T総パラメータ・32Bアクティブ/トークンのMixture-of-Expertsモデルで、256KトークンのコンテキストウィンドウとAnthropic互換API表面を備えています。オープンウェイトはHugging Faceに公開されています。",
-        "specs": [
-          {
-            "label": "ファミリー",
-            "value": "Kimi K2シリーズ"
-          },
-          {
-            "label": "モダリティ",
-            "value": "画像、テキスト、コード"
-          },
-          {
-            "label": "言語",
-            "value": "多言語"
-          },
-          {
-            "label": "コンテキストウィンドウ",
-            "value": "256Kトークン"
-          },
-          {
-            "label": "ライセンス",
-            "value": "Modified MIT（オープンウェイト）"
-          },
-          {
-            "label": "VM0での利用開始",
-            "value": "ローンチ以来利用可能"
-          }
-        ],
-        "benchmarksNote": "K2.5のベンチマークは現在、K2.6の比較ベースラインとして最も有用です。新しいモデルは同じベンダーコストですべての公開指標でリードしています。",
-        "benchmarks": [
-          {
-            "name": "SWE-bench Pro",
-            "score": "50.7",
-            "note": "ベンダー報告"
-          },
-          {
-            "name": "BrowseComp",
-            "score": "78.4",
-            "note": "ベンダー報告"
-          },
-          {
-            "name": "ハルシネーション率",
-            "score": "約65%",
-            "note": "K2.6では39%に低下"
-          }
-        ],
-        "performance": [
-          {
-            "title": "長文コンテキスト",
-            "body": "強力で、K2.6と似た形状ですが、より難しい再現ベンチマークではK2.6が優位です。"
-          },
-          {
-            "title": "ツール使用",
-            "body": "一般的なフローでは安定。複雑なマルチツールエージェントではK2.6が有意に優れています。"
-          },
-          {
-            "title": "ハルシネーション",
-            "body": "ベンダー報告のハルシネーション率は約65%。K2.6の39%よりはるかに高い。自信を持って間違った出力が増えることを想定してください。"
-          }
-        ],
-        "bestForExamples": [
-          {
-            "title": "すでに動作しているレガシーエージェント",
-            "body": "あなたのチームは数ヶ月前にK2.5に対してエージェントを検証し、プロンプトは調整済みで、評価スイートはパスし、顧客は満足しています。K2.5に固定することで、K2.6アップグレードの再検証を行う価値があるか判断する間、その正確な動作を維持します。同じMoonshotエンドポイント、同じAnthropic互換インターフェース — 切り替え時に変更されるのはモデルウェイトだけです。"
-          },
-          {
-            "title": "K2.6の優位性が現れないバルク要約ジョブ",
-            "body": "数十万トークンのトランスクリプトが入力され、3段落の要約が出力されます。ツールルーティングの精度はワークロードの一部ではなく、ハルシネーション耐性は人間がとにかく出力をざっと読む場合にはあまり重要ではなく、K2.6と同じベンダー価格なので、既存のパイプラインに触れることなくこれらのジョブでK2.5を実行できます。"
-          }
-        ],
-        "avoidFor": "K2.6がマルチプライヤー以外のすべての意味のある面で無料アップグレードであるため、K2.5で新しいエージェントを開始しないでください。Sonnet 4.6がリードするマルチツール英語ルーティングではスキップし、ハルシネーションがコスト高になるタスクでもK2.5の割合がK2.6より著しく悪いためスキップします。",
-        "comparisons": [
-          {
-            "vs": "Kimi K2.6",
-            "body": "K2.6はツール使用が強化され、ハルシネーション率が低く（39% vs 65%）、推論が優れた新世代です。K2.5（×0.2）はわずかに安価です。固定されたレガシーエージェントにのみK2.5を選択してください。"
-          },
-          {
-            "vs": "DeepSeek V4 Pro",
-            "body": "DeepSeek V4 Pro（×0.1）はより強力な推論を持ちます。K2.5（×0.2）はコンテキストサイズで勝り、Moonshot API表面内に留まります。"
-          }
-        ],
-        "verdict": "メンテナンスモード。すでに検証済みのエージェントがある場合は固定し、それ以外はK2.6で開始してください。",
-        "faqs": [
-          {
-            "q": "なぜK2.5は同じベンダー価格でK2.6より低いマルチプライヤーなのですか？",
-            "a": "マルチプライヤーはVM0の各モデルのラインナップにおけるポジショニングを反映しており、トークンあたりのコストだけではありません。K2.6は×0.3で推奨されるKimiデフォルト、K2.5は×0.2でレガシーとして位置付けられています。"
-          },
-          {
-            "q": "K2.5からK2.6に移行すべきですか？",
-            "a": "新規作業の場合ははい。同じベンダー価格で、より強力なツール使用と推論、はるかに低いハルシネーション率です。固定されたエージェントは回帰スイートで実行した後にのみ移行してください。"
-          },
-          {
-            "q": "ハルシネーション率は？",
-            "a": "ベンダー報告で約65%。K2.6（39%）より有意に高い。エージェントがユーザーに事実を報告する場合、これは重要です。代わりにK2.6を検討してください。"
-          },
-          {
-            "q": "K2.5のコンテキストウィンドウは？",
-            "a": "256Kトークン。K2.6と同じです。"
-          }
-        ],
-        "alternatives": [
-          {
-            "slug": "kimi-k2-6",
-            "reason": "より優れたツール使用を持つ新しいKimi"
-          },
-          {
-            "slug": "glm-5-1",
-            "reason": "必要な場合のより大きなコンテキストウィンドウ"
-          },
-          {
-            "slug": "deepseek-v4-pro",
-            "reason": "わずかに高いマルチプライヤーでより強力な推論"
-          }
-        ],
-        "routingNotes": "MoonshotのAnthropic互換エンドポイント`api.moonshot.ai`経由でルーティング。VM0 Managed、Moonshot、OpenRouter、Vercel AI Gatewayで利用可能。",
-        "vm0Notes": "K2.5はK2.6と同じトークンあたりのベンダー価格ですが、マルチプライヤーはポジショニングを反映して低くなっています（×0.2 vs ×0.3）。長文コンテキスト動作は安定していますが、VM0での新規作業にはK2.6が推奨されます。"
       },
       "minimax-m3": {
         "name": "MiniMax M3",
@@ -6429,12 +6151,16 @@
         "avoidFor": "Skip M3 when you need the absolute lowest MiniMax cost and text-only M2.1 is already good enough, or when you need OpenRouter/Vercel routing because this VM0 entry intentionally uses only the official MiniMax path.",
         "comparisons": [
           {
-            "vs": "Kimi K2.6",
-            "body": "Both target coding and agentic work at low cost. Kimi has broader existing gateway support on VM0, while M3 uses the official MiniMax route and gives MiniMax users the newer model."
+            "vs": "Kimi K2.7 Code",
+            "body": "どちらも低コストのコード作業とエージェント作業を対象にしています。KimiはVM0で既存のゲートウェイ対応がより広く、M3は公式MiniMaxルートを使ってMiniMaxユーザーに新しいモデルを提供します。"
           },
           {
             "vs": "Claude Sonnet 4.6",
-            "body": "Sonnet 4.6 remains the baseline for reliability on complex English tool-use. M3 is much cheaper and attractive for MiniMax-native coding agents, but should be validated on critical workflows."
+            "body": "複雑な英語ツール利用の信頼性ではSonnet 4.6が基準です。M3は大幅に安価でMiniMaxネイティブのコードエージェントに魅力的ですが、重要なワークフローでは検証が必要です。"
+          },
+          {
+            "vs": "GLM-5.2",
+            "body": "GLM-5.2はVM0における現在のZ.AIデフォルトルートです。新しいZ.AIベースのエージェントではこちらがより適切な比較対象で、GLM-5.1は調整済みワークフローとの互換性のためだけに残ります。"
           }
         ],
         "verdict": "Use MiniMax M3 when you want the official MiniMax coding model with long context and vision support. Keep M2.1 when cost and compatibility matter more.",
@@ -6454,12 +6180,12 @@
         ],
         "alternatives": [
           {
-            "slug": "kimi-k2-6",
-            "reason": "Low-cost coding model with existing gateway coverage"
+            "slug": "kimi-k2-7-code",
+            "reason": "既存ゲートウェイ対応がより広い低コストのコードモデル"
           },
           {
             "slug": "claude-sonnet-4-6",
-            "reason": "Higher-reliability baseline for complex tool use"
+            "reason": "複雑なツール利用のためのより信頼できる基準"
           }
         ],
         "routingNotes": "Routed through MiniMax's official Anthropic-compatible endpoint at `api.minimax.io`. Available on VM0 Managed and MiniMax API-key providers only.",
@@ -6914,12 +6640,12 @@
         ],
         "alternatives": [
           {
-            "slug": "flux-pro-1-1-ultra",
-            "reason": "プレミアムヒーローショット品質"
+            "slug": "gpt-image-1",
+            "reason": "スタイライズされたイラストにより強い"
           },
           {
-            "slug": "gpt-image-1",
-            "reason": "より強力なスタイライズドイラスト"
+            "slug": "flux-pro-1-1-ultra",
+            "reason": "ヒーローショット向けのプレミアム品質"
           }
         ],
         "routingNotes": "Routed to ByteDance's SeedDream V4 text-to-image endpoint and billed per generated image.",

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -12,7 +12,9 @@ const withNextIntl = createNextIntlPlugin("./i18n.ts");
 //   leaving old public URLs as dead ends.
 const MODEL_SLUG_REDIRECTS = [
   ["kimi-k2.6", "kimi-k2-7-code"],
+  ["kimi-k2-6", "kimi-k2-7-code"],
   ["kimi-k2.5", "kimi-k2-7-code"],
+  ["kimi-k2-5", "kimi-k2-7-code"],
   ["glm-5.2", "glm-5-2"],
   ["glm-5.1", "glm-5-1"],
   ["claude-haiku-4-5", "claude-sonnet-4-6"],


### PR DESCRIPTION
## Summary
- align model comparison and alternative targets across data.ts and localized content
- remove unreachable Kimi K2.6/K2.5 model content while keeping old hyphenated slugs redirected
- update GLM cost-optimizer copy to GLM-5.2 and add regression coverage for locale/data drift

## Testing
- pnpm -C turbo -F web exec vitest run 'app/[locale]/models/__tests__/data.test.ts' '__tests__/security-headers.test.ts'
- pnpm -C turbo -F web lint
- pnpm -C turbo -F web check-types

Closes #18042