### PR TITLE
fix(mitm-addon): require complete compressed usage streams

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -10,7 +10,7 @@ Exports:
 import contextlib
 import zlib
 from collections.abc import Callable
-from typing import IO, Literal, NamedTuple
+from typing import Literal, NamedTuple
 
 import brotli  # type: ignore[import-untyped]
 import zstandard
@@ -29,6 +29,11 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
+_ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE = 4
+
+INVALID_COMPRESSED_BODY = "invalid compressed body"
+INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
+DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
 
 
 class BodyDecodeResult(NamedTuple):
@@ -38,6 +43,12 @@ class BodyDecodeResult(NamedTuple):
 
 
 _StreamDecodeFeed = Callable[[bytes], None]
+_StreamDecodeFinishError = Callable[[], str | None]
+
+
+class StreamDecodeSession(NamedTuple):
+    feed: _StreamDecodeFeed
+    finish_error: _StreamDecodeFinishError
 
 
 def _log_streaming_decode_error(encoding_label: str, exc: Exception) -> None:
@@ -52,55 +63,42 @@ def _log_streaming_decode_skipped(encoding_label: str, reason: str) -> None:
         ctx.log.debug(f"Streaming decompression skipped ({encoding_label}): {reason}")
 
 
-def _make_streaming_decode_guard(
-    decode_fn: _StreamDecodeFeed,
-    error_cls: type[Exception] | tuple[type[Exception], ...],
-    encoding_label: str,
-) -> _StreamDecodeFeed:
-    """Wrap a streaming decoder with log-once + short-circuit on failure.
-
-    ``zlib`` / ``zstd`` streaming decompressors have internal state that becomes
-    undefined after a decompression error — subsequent ``decode_fn(chunk)``
-    calls may keep raising or silently produce garbage plaintext. On first
-    error we log once (at debug, mirroring the
-    non-streaming ``decompress_body`` pattern), latch a broken flag, and
-    ignore every subsequent chunk so downstream parsers don't
-    consume corrupt output.
-    """
-    broken = False
-
-    def wrapper(chunk: bytes) -> None:
-        nonlocal broken
-        if broken:
-            return
-        try:
-            decode_fn(chunk)
-        except error_cls as exc:
-            broken = True
-            _log_streaming_decode_error(encoding_label, exc)
-
-    return wrapper
-
-
 def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -> None:
     for offset in range(0, len(data), max_decoded_chunk):
         feed(data[offset : offset + max_decoded_chunk])
 
 
-def _create_zlib_stream_decode_feed(
+def _no_stream_decode_error() -> str | None:
+    return None
+
+
+def _create_zlib_stream_decode_session(
     feed: _StreamDecodeFeed,
     *,
     encoding: Literal["gzip", "deflate"],
     max_decoded_chunk: int,
-) -> _StreamDecodeFeed:
+) -> StreamDecodeSession:
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     obj = zlib.decompressobj(wbits)
+    decode_error: str | None = None
+    member_in_progress = False
+    saw_input = False
 
     def decode(chunk: bytes) -> None:
-        nonlocal obj
+        nonlocal decode_error, member_in_progress, obj, saw_input
+        if decode_error is not None:
+            return
+        if chunk:
+            saw_input = True
         data = chunk
         while data:
-            decoded = obj.decompress(data, max_length=max_decoded_chunk)
+            member_in_progress = True
+            try:
+                decoded = obj.decompress(data, max_length=max_decoded_chunk)
+            except zlib.error as exc:
+                decode_error = INVALID_COMPRESSED_BODY
+                _log_streaming_decode_error(encoding, exc)
+                return
             if decoded:
                 feed(decoded)
             if obj.unconsumed_tail:
@@ -109,42 +107,66 @@ def _create_zlib_stream_decode_feed(
             if obj.eof:
                 data = obj.unused_data
                 obj = zlib.decompressobj(wbits)
+                member_in_progress = False
                 if data:
                     continue
             return
 
-    return _make_streaming_decode_guard(decode, zlib.error, encoding)
-
-
-class _ChunkedDecodeSink(IO[bytes]):
-    def __init__(self, feed: _StreamDecodeFeed, max_decoded_chunk: int) -> None:
-        self._feed = feed
-        self._max_decoded_chunk = max_decoded_chunk
-
-    def write(self, data: bytes) -> int:
-        _feed_chunks(self._feed, data, self._max_decoded_chunk)
-        return len(data)
-
-    def writable(self) -> bool:
-        return True
-
-    def flush(self) -> None:
+    def finish_error() -> str | None:
+        if decode_error is not None:
+            return decode_error
+        if saw_input and member_in_progress:
+            return INCOMPLETE_COMPRESSED_BODY
         return None
 
-    def close(self) -> None:
-        return None
+    return StreamDecodeSession(decode, finish_error)
 
 
-def _create_zstd_stream_decode_feed(
+def _create_zstd_stream_decode_session(
     feed: _StreamDecodeFeed, *, max_decoded_chunk: int
-) -> _StreamDecodeFeed:
-    sink = _ChunkedDecodeSink(feed, max_decoded_chunk)
-    writer = zstandard.ZstdDecompressor().stream_writer(sink)
+) -> StreamDecodeSession:
+    obj = zstandard.ZstdDecompressor().decompressobj()
+    decode_error: str | None = None
+    frame_in_progress = False
+    saw_input = False
 
     def decode(chunk: bytes) -> None:
-        writer.write(chunk)
+        nonlocal decode_error, frame_in_progress, obj, saw_input
+        if decode_error is not None:
+            return
+        if chunk:
+            saw_input = True
+        data = chunk
+        while data:
+            source = data[:_ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE]
+            remainder = data[_ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE:]
+            frame_in_progress = True
+            try:
+                decoded = obj.decompress(source)
+            except zstandard.ZstdError as exc:
+                decode_error = INVALID_COMPRESSED_BODY
+                _log_streaming_decode_error("zstd", exc)
+                return
+            if decoded:
+                _feed_chunks(feed, decoded, max_decoded_chunk)
+            if obj.eof:
+                data = obj.unused_data + remainder
+                obj = zstandard.ZstdDecompressor().decompressobj()
+                frame_in_progress = False
+                continue
+            if obj.unconsumed_tail:
+                data = obj.unconsumed_tail + remainder
+                continue
+            data = remainder
 
-    return _make_streaming_decode_guard(decode, zstandard.ZstdError, "zstd")
+    def finish_error() -> str | None:
+        if decode_error is not None:
+            return decode_error
+        if saw_input and frame_in_progress:
+            return INCOMPLETE_COMPRESSED_BODY
+        return None
+
+    return StreamDecodeSession(decode, finish_error)
 
 
 def _stream_decode_skip_reason(encoding: str) -> str | None:
@@ -167,19 +189,23 @@ def can_stream_decode_usage(headers: http.Headers) -> bool:
     return False
 
 
-def create_stream_decode_feed(
+def create_stream_decode_session(
     headers: http.Headers,
     feed: _StreamDecodeFeed,
     *,
     max_decoded_chunk: int = STREAM_DECODE_CHUNK_LIMIT,
-) -> _StreamDecodeFeed | None:
-    """Create a bounded streaming decoder that feeds decoded usage-parser chunks.
+) -> StreamDecodeSession | None:
+    """Create a bounded streaming decoder session for usage-parser chunks.
 
     Usage parsers are bounded-state scanners and may need to inspect long
     responses, so this helper does not enforce a total decoded-byte cap. It
     bounds each decoded chunk before parser entry to prevent high-ratio
     compressed input from materialising one large ``bytes`` object. Returns
     None when a content encoding cannot be safely decoded incrementally.
+
+    The returned session exposes ``finish_error()`` so billing paths can reject
+    parser state from compressed streams that never reached a valid frame/member
+    ending. Best-effort capture paths should continue to use ``decompress_body``.
     """
     if max_decoded_chunk <= 0:
         raise ValueError("max_decoded_chunk must be positive")
@@ -187,16 +213,31 @@ def create_stream_decode_feed(
     if not can_stream_decode_usage(headers):
         return None
     if not encoding or encoding == "identity":
-        return feed
+        return StreamDecodeSession(feed, _no_stream_decode_error)
     if encoding in ("gzip", "deflate"):
-        return _create_zlib_stream_decode_feed(
+        return _create_zlib_stream_decode_session(
             feed,
             encoding=encoding,
             max_decoded_chunk=max_decoded_chunk,
         )
     if encoding == "zstd":
-        return _create_zstd_stream_decode_feed(feed, max_decoded_chunk=max_decoded_chunk)
+        return _create_zstd_stream_decode_session(feed, max_decoded_chunk=max_decoded_chunk)
     return None
+
+
+def create_stream_decode_feed(
+    headers: http.Headers,
+    feed: _StreamDecodeFeed,
+    *,
+    max_decoded_chunk: int = STREAM_DECODE_CHUNK_LIMIT,
+) -> _StreamDecodeFeed | None:
+    """Create a bounded streaming decoder that feeds decoded usage-parser chunks."""
+    session = create_stream_decode_session(
+        headers,
+        feed,
+        max_decoded_chunk=max_decoded_chunk,
+    )
+    return None if session is None else session.feed
 
 
 def decompress_body(
@@ -312,9 +353,11 @@ def decode_body_bounded(
     return BodyDecodeResult(data, False)
 
 
-def _decompress_brotli_bounded_with_finished(data: bytes, max_output: int) -> tuple[bytes, bool]:
+def _decompress_brotli_bounded_with_status(
+    data: bytes, max_output: int
+) -> tuple[bytes, bool, bool]:
     if max_output <= 0:
-        return b"", False
+        return b"", False, bool(data)
 
     chunk_size = min(
         _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE,
@@ -334,29 +377,38 @@ def _decompress_brotli_bounded_with_finished(data: bytes, max_output: int) -> tu
             continue
 
         remaining = max_output - len(out)
-        if len(decoded) >= remaining:
+        if remaining <= 0:
+            return bytes(out), dec.is_finished(), True
+        if len(decoded) > remaining:
             out.extend(decoded[:remaining])
-            return bytes(out), dec.is_finished()
+            return bytes(out), dec.is_finished(), True
+        if len(decoded) == remaining:
+            out.extend(decoded)
+            finished = dec.is_finished()
+            return bytes(out), finished, not finished
         out.extend(decoded)
 
-    return bytes(out), dec.is_finished()
+    return bytes(out), dec.is_finished(), False
 
 
 def _decompress_brotli_bounded(data: bytes, max_output: int) -> bytes:
-    body, _finished = _decompress_brotli_bounded_with_finished(data, max_output)
+    body, _finished, _limited = _decompress_brotli_bounded_with_status(data, max_output)
     return body
 
 
 def _decompress_zlib_json_usage_body(
     data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
 ) -> tuple[bytes, str | None]:
+    if max_output <= 0:
+        return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
+
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     remaining_data = data
     out = bytearray()
 
     while remaining_data:
         if len(out) >= max_output:
-            return bytes(out), None
+            return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
 
         obj = zlib.decompressobj(wbits)
         try:
@@ -365,13 +417,13 @@ def _decompress_zlib_json_usage_body(
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return b"", "invalid compressed body"
+            return b"", INVALID_COMPRESSED_BODY
 
         out.extend(decoded)
         if not obj.eof:
-            if data and not out:
-                return bytes(out), "incomplete compressed body"
-            return bytes(out), None
+            if len(out) >= max_output:
+                return bytes(out), DECODED_BODY_LIMIT_EXCEEDED
+            return bytes(out), INCOMPLETE_COMPRESSED_BODY
         if not obj.unused_data:
             return bytes(out), None
         remaining_data = obj.unused_data
@@ -386,16 +438,16 @@ def _validate_complete_zstd_frames(data: bytes) -> str | None:
         try:
             obj.decompress(remaining_data)
         except zstandard.ZstdError:
-            return "invalid compressed body"
+            return INVALID_COMPRESSED_BODY
         if not obj.eof:
-            return "incomplete compressed body"
+            return INCOMPLETE_COMPRESSED_BODY
         remaining_data = obj.unused_data
     return None
 
 
 def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[bytes, str | None]:
     if max_output <= 0:
-        return b"", None
+        return b"", DECODED_BODY_LIMIT_EXCEEDED if data else None
 
     try:
         with zstandard.ZstdDecompressor().stream_reader(data, read_across_frames=True) as reader:
@@ -406,10 +458,10 @@ def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[byte
         with contextlib.suppress(AttributeError):
             # ctx.log unavailable outside mitmproxy runtime
             ctx.log.debug(f"Decompression failed (zstd): {exc}")
-        return b"", "invalid compressed body"
+        return b"", INVALID_COMPRESSED_BODY
 
     if extra:
-        return body, None
+        return body, DECODED_BODY_LIMIT_EXCEEDED
     return body, _validate_complete_zstd_frames(data)
 
 
@@ -429,14 +481,16 @@ def decompress_json_usage_body(
         return _decompress_zlib_json_usage_body(data, encoding, max_output)
     if encoding == "br":
         try:
-            body, finished = _decompress_brotli_bounded_with_finished(data, max_output)
+            body, finished, limited = _decompress_brotli_bounded_with_status(data, max_output)
         except brotli.error as exc:
             with contextlib.suppress(AttributeError):
                 # ctx.log unavailable outside mitmproxy runtime
                 ctx.log.debug(f"Decompression failed ({encoding}): {exc}")
-            return b"", "invalid compressed body"
-        if data and not body and not finished:
-            return body, "incomplete compressed body"
+            return b"", INVALID_COMPRESSED_BODY
+        if limited:
+            return body, DECODED_BODY_LIMIT_EXCEEDED
+        if data and not finished:
+            return body, INCOMPLETE_COMPRESSED_BODY
         return body, None
     if encoding == "zstd":
         return _decompress_zstd_json_usage_body(data, max_output)

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -65,11 +65,11 @@ def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
     return bool(flow.metadata.get(_MODEL_WEBSOCKET_USAGE_ENABLED, False))
 
 
-def _make_response_chunk_parser(
+def _make_response_decode_session(
     feed: _ResponseChunkParser,
     headers: http.Headers,
-) -> _ResponseChunkParser | None:
-    return body_decoding.create_stream_decode_feed(headers, feed)
+) -> body_decoding.StreamDecodeSession | None:
+    return body_decoding.create_stream_decode_session(headers, feed)
 
 
 def _make_model_sse_parse_error_logger(
@@ -116,40 +116,58 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return None
     if is_observable_model_provider:
-        if not body_decoding.can_stream_decode_usage(flow.response.headers):
-            return None
         content_type = flow.response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
             if uses_openai_responses_usage_protocol(flow):
+                usage_protocol = "openai_responses_sse"
+                log_parse_error = _make_model_sse_parse_error_logger(
+                    flow,
+                    usage_protocol=usage_protocol,
+                )
                 parser_fn, usage_dict = usage.create_openai_responses_sse_usage_extractor(
-                    on_parse_error=_make_model_sse_parse_error_logger(
-                        flow,
-                        usage_protocol="openai_responses_sse",
-                    )
+                    on_parse_error=log_parse_error
                 )
             else:
-                parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor(
-                    on_parse_error=_make_model_sse_parse_error_logger(
-                        flow,
-                        usage_protocol="anthropic_messages_sse",
-                    )
+                usage_protocol = "anthropic_messages_sse"
+                log_parse_error = _make_model_sse_parse_error_logger(
+                    flow,
+                    usage_protocol=usage_protocol,
                 )
-            parser = _make_response_chunk_parser(parser_fn, flow.response.headers)
-            if parser is None:
+                parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor(
+                    on_parse_error=log_parse_error
+                )
+            decode_session = _make_response_decode_session(parser_fn, flow.response.headers)
+            if decode_session is None:
                 return None
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
-            flow.metadata[_MODEL_SSE_USAGE_FINISH] = parser_fn.finish
-            return parser
+
+            def finish_sse_usage() -> None:
+                decode_error = decode_session.finish_error()
+                if decode_error is not None:
+                    usage_dict.clear()
+                    log_parse_error("compressed_body", decode_error)
+                    return
+                parser_fn.finish()
+
+            flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_usage
+            return decode_session.feed
 
         if uses_openai_responses_usage_protocol(flow):
             extractor = usage.create_openai_responses_json_usage_extractor()
         else:
             extractor = usage.create_anthropic_messages_json_usage_extractor()
-        parser = _make_response_chunk_parser(extractor.feed, flow.response.headers)
-        if parser is None:
+        decode_session = _make_response_decode_session(extractor.feed, flow.response.headers)
+        if decode_session is None:
             return None
-        flow.metadata[_MODEL_JSON_USAGE_FINISH] = extractor.finish
-        return parser
+
+        def finish_json_usage() -> tuple[dict | None, str | None]:
+            decode_error = decode_session.finish_error()
+            if decode_error is not None:
+                return None, decode_error
+            return extractor.finish()
+
+        flow.metadata[_MODEL_JSON_USAGE_FINISH] = finish_json_usage
+        return decode_session.feed
 
     if not is_billable_flow:
         return None
@@ -157,12 +175,22 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         return None
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
-        parser = _make_response_chunk_parser(connector_parser.feed, flow.response.headers)
-        if parser is None:
+        decode_session = _make_response_decode_session(connector_parser.feed, flow.response.headers)
+        if decode_session is None:
             return None
-        if connector_parser.finish is not None:
-            flow.metadata[_CONNECTOR_RESPONSE_FINISH] = connector_parser.finish
-        return parser
+        if connector_parser.finish is not None or connector_parser.finish_decode_error is not None:
+
+            def finish_connector_response() -> None:
+                decode_error = decode_session.finish_error()
+                if decode_error is not None:
+                    if connector_parser.finish_decode_error is not None:
+                        connector_parser.finish_decode_error(decode_error)
+                    return
+                if connector_parser.finish is not None:
+                    connector_parser.finish()
+
+            flow.metadata[_CONNECTOR_RESPONSE_FINISH] = finish_connector_response
+        return decode_session.feed
 
     return None
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -29,7 +29,13 @@ class ConnectorResponseParser(NamedTuple):
     error paths can release unfinished parser state without finalizing it, so
     parser correctness must not rely on ``finish`` running for every interrupted
     response.
+
+    ``finish_decode_error`` is optional. When provided, response streaming calls
+    it instead of ``finish`` if the transport decoder cannot prove a compressed
+    response body completed. It should publish connector-owned unparsed state so
+    later fallback parsing does not trust best-effort decoded bytes.
     """
 
     feed: Callable[[bytes], None]
     finish: Callable[[], None] | None = None
+    finish_decode_error: Callable[[str], None] | None = None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -466,7 +466,21 @@ def create_response_parser(
             # report_model_provider_usage and triggers the model-provider webhook.
             # x_ndjson_state is only consumed by report_connector_usage.
             flow.metadata[metadata_keys.X_NDJSON_STATE] = extractor.state
-            return ConnectorResponseParser(feed=extractor.feed, finish=extractor.finish)
+
+            def finish_ndjson_decode_error(error: str) -> None:
+                flow.metadata.pop(metadata_keys.X_NDJSON_STATE, None)
+                flow.metadata[metadata_keys.X_JSON_STATE] = {
+                    "body_parsed": False,
+                    "body_truncated": False,
+                    "body_format": "ndjson",
+                    "parse_error": error,
+                }
+
+            return ConnectorResponseParser(
+                feed=extractor.feed,
+                finish=extractor.finish,
+                finish_decode_error=finish_ndjson_decode_error,
+            )
 
     if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
         return None
@@ -479,7 +493,18 @@ def create_response_parser(
             state["parse_error"] = error
         flow.metadata[metadata_keys.X_JSON_STATE] = state
 
-    return ConnectorResponseParser(feed=extractor.feed, finish=finish_json_state)
+    def finish_json_decode_error(error: str) -> None:
+        flow.metadata[metadata_keys.X_JSON_STATE] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": error,
+        }
+
+    return ConnectorResponseParser(
+        feed=extractor.feed,
+        finish=finish_json_state,
+        finish_decode_error=finish_json_decode_error,
+    )
 
 
 def _count_bounded_non_empty_comma_segments(value: str, max_count: int) -> int | None:
@@ -740,9 +765,12 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
         return result
     if not flow.response:
         return result
-    body = body_decoding.decompress_body(
+    body, decode_error = body_decoding.decompress_json_usage_body(
         bytes(buf), flow.response.headers, max_output=LARGE_RESPONSE_DECOMPRESS_LIMIT
     )
+    if decode_error is not None:
+        result["parse_error"] = decode_error
+        return result
     fields = _parse_x_json_response_fields_from_body(body)
     if fields is None:
         return result

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -7,7 +7,11 @@ import brotli
 import pytest
 import zstandard
 
-from body_decoding import create_stream_decode_feed, decompress_body
+from body_decoding import (
+    create_stream_decode_feed,
+    create_stream_decode_session,
+    decompress_body,
+)
 from body_limits import STREAM_BUFFER_LIMIT, STREAM_DECODE_CHUNK_LIMIT
 from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
 
@@ -46,6 +50,32 @@ class TestStreamDecodeFeed:
             for idx in range(0, len(compressed), 3):
                 parse(compressed[idx : idx + 3])
             assert b"".join(chunks) == plaintext, encoding
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_session_reports_truncated_trailer(self, headers, encoding):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        compressed = gzip.compress(plaintext) if encoding == "gzip" else zlib.compress(plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(
+            headers(("Content-Encoding", encoding)), chunks.append
+        )
+        assert session is not None
+
+        session.feed(compressed[:-1])
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() == "incomplete compressed body"
+
+    def test_zstd_session_reports_truncated_frame(self, headers):
+        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
+        compressed = zstandard.ZstdCompressor().compress(plaintext)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert session is not None
+
+        session.feed(compressed[:-1])
+
+        assert session.finish_error() == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
     def test_concatenated_zlib_members_same_callback(self, headers, encoding):
@@ -119,7 +149,7 @@ class TestStreamDecodeFeed:
         assert len(chunks) > 1
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
 
-    def test_zstd_streaming_uses_writer_instead_of_decompressobj(self, headers, monkeypatch):
+    def test_zstd_streaming_uses_decompressobj_for_finalization(self, headers, monkeypatch):
         real_decompressor = zstandard.ZstdDecompressor
         stats = {"stream_writer": 0, "decompressobj": 0}
 
@@ -129,11 +159,11 @@ class TestStreamDecodeFeed:
 
             def stream_writer(self, sink):
                 stats["stream_writer"] += 1
-                return self._inner.stream_writer(sink)
+                raise AssertionError("streaming usage decoder must not use stream_writer")
 
             def decompressobj(self):
                 stats["decompressobj"] += 1
-                raise AssertionError("streaming usage decoder must not use decompressobj")
+                return self._inner.decompressobj()
 
         monkeypatch.setattr("body_decoding.zstandard.ZstdDecompressor", CountingZstdDecompressor)
         chunks: list[bytes] = []
@@ -143,7 +173,8 @@ class TestStreamDecodeFeed:
         parse(zstandard.ZstdCompressor().compress(b"hello world"))
 
         assert b"".join(chunks) == b"hello world"
-        assert stats == {"stream_writer": 1, "decompressobj": 0}
+        assert stats["stream_writer"] == 0
+        assert stats["decompressobj"] >= 1
 
     def test_gzip_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
         chunks: list[bytes] = []

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -108,6 +108,14 @@ def _truncated_gzip_prefix(payload: bytes) -> bytes:
     return gzip.compress(payload)[:10]
 
 
+def _truncated_gzip_trailer(payload: bytes) -> bytes:
+    return gzip.compress(payload)[:-1]
+
+
+def _truncated_deflate_trailer(payload: bytes) -> bytes:
+    return zlib.compress(payload)[:-1]
+
+
 def _empty_gzip_member_before_garbage(_payload: bytes) -> bytes:
     return gzip.compress(b"") + b"garbage"
 
@@ -118,6 +126,10 @@ def _empty_deflate_stream_before_garbage(_payload: bytes) -> bytes:
 
 def _truncated_brotli_prefix(payload: bytes) -> bytes:
     return brotli.compress(payload)[:2]
+
+
+def _truncated_brotli_trailer(payload: bytes) -> bytes:
+    return brotli.compress(payload)[:-1]
 
 
 def _truncated_zstd_prefix(payload: bytes) -> bytes:
@@ -177,6 +189,18 @@ JSON_COMPRESSION_FAILURE_CASES = (
         expected_error="incomplete compressed body",
     ),
     JsonCompressionFailureCase(
+        id="truncated-gzip-trailer",
+        make_body=_truncated_gzip_trailer,
+        content_encoding="gzip",
+        expected_error="incomplete compressed body",
+    ),
+    JsonCompressionFailureCase(
+        id="truncated-deflate-trailer",
+        make_body=_truncated_deflate_trailer,
+        content_encoding="deflate",
+        expected_error="incomplete compressed body",
+    ),
+    JsonCompressionFailureCase(
         id="empty-gzip-member-before-garbage",
         make_body=_empty_gzip_member_before_garbage,
         content_encoding="gzip",
@@ -191,6 +215,12 @@ JSON_COMPRESSION_FAILURE_CASES = (
     JsonCompressionFailureCase(
         id="truncated-brotli-prefix",
         make_body=_truncated_brotli_prefix,
+        content_encoding="br",
+        expected_error="incomplete compressed body",
+    ),
+    JsonCompressionFailureCase(
+        id="truncated-brotli-trailer",
+        make_body=_truncated_brotli_trailer,
         content_encoding="br",
         expected_error="incomplete compressed body",
     ),
@@ -949,6 +979,51 @@ class TestModelProviderResponseUsage:
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == _expected_event_quantities(provider_case)
+
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
+    @pytest.mark.parametrize(
+        "provider_case",
+        MODEL_PROVIDER_JSON_CASES,
+        ids=_model_provider_json_case_id,
+    )
+    def test_full_pipeline_truncated_compressed_model_json_does_not_report_usage(
+        self, tmp_path, real_flow, encoding_case, provider_case
+    ):
+        """Incremental JSON usage must reject compressed streams missing a trailer."""
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = self._model_provider_flow(
+            real_flow,
+            tmp_path,
+            provider_case,
+            proxy_log_path=proxy_log_path,
+        )
+        payload = _standard_success_payload(provider_case)
+        if encoding_case == "gzip":
+            compressed = gzip.compress(payload)[:-1]
+        else:
+            compressed = zlib.compress(payload)[:-1]
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {"content-type": "application/json", "content-encoding": encoding_case}
+            ),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(compressed)
+
+        webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
+        usage_warnings = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert len(usage_warnings) == 1
+        assert usage_warnings[0]["error"] == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
     def test_full_pipeline_concatenated_zlib_model_json_reports_usage(

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -1,5 +1,6 @@
 """Tests for model-provider SSE usage reporting paths."""
 
+import gzip
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -138,6 +139,34 @@ class TestModelProviderSseUsage:
             "tokens.cache_read": 2000,
         }
         assert {event["provider"] for event in events} == {"gpt-5.5"}
+
+    @pytest.mark.parametrize("hook_name", ["response", "error"])
+    def test_full_pipeline_compressed_openai_sse_truncated_trailer_does_not_report_usage(
+        self, tmp_path, real_flow, hook_name
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"response":{"id":"resp_sse_1","model":"gpt-5.5",'
+            b'"usage":{"input_tokens":50,"output_tokens":20}}}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(gzip.compress(plaintext)[:-1])
+        if hook_name == "error":
+            flow.error = Error("connection reset by peer")
+            webhook = self._run_error(flow)
+        else:
+            webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="openai_responses_sse",
+            event="compressed_body",
+        )
 
     def test_full_pipeline_anthropic_sse_logs_truncated_message_start(self, tmp_path, real_flow):
         flow = _model_provider_sse_flow(

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -1,6 +1,8 @@
 """Tests for X connector response and error hook lifecycle."""
 
+import gzip
 import json
+import zlib
 from pathlib import Path
 
 import brotli
@@ -90,6 +92,62 @@ class TestXConnectorResponsePipeline:
         assert "x_ndjson_state" not in flow.metadata
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+
+    def test_responseheaders_brotli_x_stream_does_not_leave_parser_state(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "br"
+
+        with mitm_ctx() as log:
+            mitm_addon.responseheaders(flow)
+
+        assert "connector_response_finish" not in flow.metadata
+        assert "x_ndjson_state" not in flow.metadata
+        assert log.debug.call_count == 1
+        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate", "br"])
+    def test_full_response_pipeline_truncated_compressed_x_json_does_not_bill(
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, encoding_case
+    ):
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            path="/2/tweets/search/recent",
+            query="query=vm0",
+            sandbox_value="tok-xyz",
+            rule="GET /2/tweets/search/recent",
+            content_encoding=encoding_case,
+        )
+        payload = b'{"data":[{"id":"1"}],"meta":{"result_count":1}}'
+        if encoding_case == "gzip":
+            compressed = gzip.compress(payload)[:-1]
+        elif encoding_case == "deflate":
+            compressed = zlib.compress(payload)[:-1]
+        else:
+            compressed = brotli.compress(payload)[:-1]
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(compressed)
+
+        with self._usage_webhook_api() as webhook:
+            mitm_addon.response(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        entries = read_jsonl_entries_after_flush(proxy_log)
+        lost_visibility_entries = [
+            entry for entry in entries if "unparseable" in entry["message"].lower()
+        ]
+        assert len(lost_visibility_entries) == 1
+        entry = lost_visibility_entries[0]
+        assert entry["level"] == "error"
+        assert entry["body_truncated"] is False
+        assert entry["parse_error"] == "incomplete compressed body"
+        assert "connector_response_finish" not in flow.metadata
 
     def test_full_response_pipeline_x_data_object_bills_single_resource(
         self, tmp_path, real_flow, mitm_ctx
@@ -215,6 +273,38 @@ class TestXConnectorResponsePipeline:
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
         assert by_cat == {"posts.read": 2, "user.read": 1}
         assert "connector_response_finish" not in flow.metadata
+
+    def test_full_pipeline_compressed_stream_error_does_not_bill_unverified_rows(
+        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+    ):
+        flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "gzip"
+
+        mitm_addon.responseheaders(flow)
+        callback = response_stream(flow)
+        callback(
+            gzip.compress(
+                b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n{"data":{"id":"2"}}\n'
+            )[:-1]
+        )
+        assert flow.metadata["x_ndjson_state"]["data_count"] == 2
+        flow.error = Error("connection reset by peer")
+
+        with usage_webhook_api() as webhook:
+            mitm_addon.error(flow)
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        assert webhook.request_count == 0
+        assert "x_ndjson_state" not in flow.metadata
+        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        entries = read_jsonl_entries_after_flush(proxy_log)
+        lost_visibility_entries = [
+            entry for entry in entries if "unparseable" in entry["message"].lower()
+        ]
+        assert len(lost_visibility_entries) == 1
+        assert lost_visibility_entries[0]["parse_error"] == "incomplete compressed body"
 
     def test_full_streaming_pipeline_ignores_malformed_include_values(
         self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor


### PR DESCRIPTION
## Summary
- Add strict streaming decode sessions for billing usage parsers so compressed gzip/deflate/zstd bodies must complete before parsed usage is accepted.
- Tighten strict JSON usage decompression for gzip/deflate/brotli/zstd incomplete bodies and decoded-output caps while keeping capture decompression best-effort.
- Thread decode completion failures through model JSON/SSE and X connector JSON/NDJSON finalizers, with regression coverage for trailer-only truncation and compressed partial streams.

Closes #18027

## Testing
- cd crates/runner/mitm-addon && /tmp/vm5-mitm-addon-venv/bin/pytest tests/test_body_decoding.py tests/test_model_provider_sse_usage.py tests/test_x_connector_pipeline.py tests/test_response_streaming.py tests/test_error_handler.py
- cd crates/runner/mitm-addon && /tmp/vm5-mitm-addon-venv/bin/pytest tests/test_model_provider_response_usage.py
- cd crates/runner/mitm-addon && /tmp/vm5-mitm-addon-venv/bin/ruff check src tests/test_body_decoding.py tests/test_model_provider_response_usage.py tests/test_model_provider_sse_usage.py tests/test_x_connector_pipeline.py tests/test_response_streaming.py tests/test_error_handler.py
- cd crates/runner/mitm-addon && /tmp/vm5-mitm-addon-venv/bin/ruff format --check src tests/test_body_decoding.py tests/test_model_provider_response_usage.py tests/test_model_provider_sse_usage.py tests/test_x_connector_pipeline.py tests/test_response_streaming.py tests/test_error_handler.py
- cd crates/runner/mitm-addon && /tmp/vm5-mitm-addon-venv/bin/basedpyright -p .
