### PR TITLE
chore: override tmp to >=0.2.6 to resolve dependabot alerts

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -82,6 +82,7 @@
       "protobufjs@<=7.6.2": "7.6.3",
       "protobufjs@>=8.0.0 <=8.5.0": "8.6.3",
       "form-data": ">=4.0.6",
+      "tmp": ">=0.2.6",
       "@babel/core": ">=7.29.6",
       "@opentelemetry/core": ">=2.8.0",
       "markdown-it": ">=14.2.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   protobufjs@<=7.6.2: 7.6.3
   protobufjs@>=8.0.0 <=8.5.0: 8.6.3
   form-data: '>=4.0.6'
+  tmp: '>=0.2.6'
   '@babel/core': '>=7.29.6'
   '@opentelemetry/core': '>=2.8.0'
   markdown-it: '>=14.2.0'
@@ -8269,10 +8270,6 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
@@ -9534,9 +9531,9 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -16182,7 +16179,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.7
 
   extract-zip@2.0.1:
     dependencies:
@@ -18176,8 +18173,6 @@ snapshots:
 
   orderedmap@2.1.1: {}
 
-  os-tmpdir@1.0.2: {}
-
   outvariant@1.4.3: {}
 
   own-keys@1.0.1:
@@ -19683,9 +19678,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.28
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves the two open Dependabot alerts for `tmp@0.0.33` in `turbo/pnpm-lock.yaml`:

- **High** — CVE-2026-44705 (patched in `tmp@0.2.6`)
- **Low** — CVE-2025-54798 (patched in `tmp@0.2.4`)

`tmp@0.0.33` is pulled in **only** through the desktop dev tooling chain:

```
@vm0/desktop (devDependency)
└─ @electron-forge/cli
   └─ @inquirer/prompts
      └─ @inquirer/editor
         └─ external-editor@3.1.0
            └─ tmp@0.0.33   ← vulnerable
```

It is not on any product runtime path, but it keeps the alerts open.

## Approach

`external-editor@3.1.0` is the latest release and is pinned to `tmp@^0.0.33`, so there is no upstream upgrade available. However, it uses a single `tmp` API — `tmp.tmpNameSync(options)` — whose signature and behavior are unchanged across `0.0.33 → 0.2.x`. `tmp` has exactly one consumer in the dependency tree, so a global pnpm override is conflict-free.

Added `"tmp": ">=0.2.6"` to `pnpm.overrides`, matching the existing security-bump convention already used for `form-data`, `axios`, `ws`, etc. This resolves to `tmp@0.2.7` and also removes the now-unused `os-tmpdir` transitive dependency.

## Verification

- ✅ `tmp@0.0.33` and `os-tmpdir@1.0.2` fully removed from the lockfile; replaced by `tmp@0.2.7`
- ✅ Lockfile diff is minimal (6 insertions, 13 deletions) — no unrelated dependency drift
- ✅ Smoke-tested `external-editor` against `tmp@0.2.7`: `tmpNameSync`, `ExternalEditor` construction, and `cleanup()` all work
- ✅ `electron-forge --version` still loads correctly (7.11.2)
- ✅ `prettier --check` passes; commitlint passes

Closes #16370

🤖 Generated with [Claude Code](https://claude.com/claude-code)