### PR TITLE
fix: remove presentation card template label

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1439,7 +1439,7 @@ function PptCard({
       )}
     >
       <TemplatePreview item={item} onPreview={onPreview} />
-      <div className="flex flex-1 items-start justify-between gap-3 px-3.5 py-3">
+      <div className="flex flex-1 items-center justify-between gap-3 px-3.5 py-3">
         <div className="min-w-0">
           <TooltipProvider delayDuration={300}>
             <Tooltip>
@@ -1451,9 +1451,6 @@ function PptCard({
               <TooltipContent side="bottom">{item.title}</TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <p className="mt-1 truncate text-xs text-muted-foreground">
-            {formatPresentationTemplateKind(item.templateId)}
-          </p>
         </div>
         <div className="flex shrink-0 items-center">
           <button


### PR DESCRIPTION
## Summary
- Remove the template kind subtitle from PptCard footers
- Center the remaining title and Use button in the card footer

## Verification
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-composer.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- Captured a Chromium screenshot from a temporary local PptCard preview fixture
