### PR TITLE
test: add live stream-json mock Claude input

### DIFF
--- a/crates/guest-mock-claude/src/args.rs
+++ b/crates/guest-mock-claude/src/args.rs
@@ -2,6 +2,7 @@
 pub(crate) struct ParsedArgs {
     pub(crate) input_format: String,
     pub(crate) output_format: String,
+    pub(crate) replay_user_messages: bool,
     pub(crate) prompt: String,
 }
 
@@ -17,6 +18,7 @@ fn skip_flag_value(args: &[String], i: &mut usize) {
 pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
     let mut input_format = "text".to_string();
     let mut output_format = "text".to_string();
+    let mut replay_user_messages = false;
     let mut remaining: Vec<String> = Vec::new();
 
     let mut i = 0;
@@ -60,11 +62,14 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
                 // Skip the flag and its single JSON value argument
                 skip_flag_value(args, &mut i);
             }
+            "--replay-user-messages" => {
+                replay_user_messages = true;
+                i += 1;
+            }
             "--print"
             | "--verbose"
             | "--dangerously-skip-permissions"
-            | "--include-partial-messages"
-            | "--replay-user-messages" => {
+            | "--include-partial-messages" => {
                 i += 1;
             }
             "--" => {
@@ -89,6 +94,7 @@ pub(crate) fn parse_args(args: &[String]) -> ParsedArgs {
     ParsedArgs {
         input_format,
         output_format,
+        replay_user_messages,
         prompt,
     }
 }
@@ -103,6 +109,7 @@ mod tests {
         let result = parse_args(&args);
         assert_eq!(result.input_format, "text");
         assert_eq!(result.output_format, "text");
+        assert!(!result.replay_user_messages);
         assert!(result.prompt.is_empty());
     }
 
@@ -200,6 +207,7 @@ mod tests {
             .collect();
         let result = parse_args(&args);
         assert_eq!(result.prompt, "echo hi");
+        assert!(result.replay_user_messages);
     }
 
     #[test]

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -33,6 +33,9 @@
 //!                               emit result, and exit(0)
 //!   @ECHO@                    - First-line marker. Validate remaining non-empty
 //!                               lines as JSONL and emit them unchanged.
+//!   @active-input-smoke:<n>   - Stream-json stdin marker. Emit a first result,
+//!                               then read n later user frames from the same
+//!                               stdin stream and emit a deterministic final result.
 
 mod args;
 mod process;

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -60,7 +60,13 @@ fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
             eprintln!("invalid @active-input-smoke follow-up count: {count:?}");
             ExitCode::from(1)
         }
-        scenario => run_scenario(scenario, &first_frame.content, &parsed.output_format),
+        scenario => {
+            if let Err(message) = drain_remaining_stream_json_stdin(&mut reader) {
+                eprintln!("{message}");
+                return ExitCode::from(1);
+            }
+            run_scenario(scenario, &first_frame.content, &parsed.output_format)
+        }
     }
 }
 
@@ -168,6 +174,14 @@ fn read_next_stream_json_user_frame(
 
         return parse_stream_json_user_frame(trimmed, kind).map(Some);
     }
+}
+
+fn drain_remaining_stream_json_stdin(reader: &mut impl BufRead) -> Result<(), String> {
+    let mut input = String::new();
+    reader
+        .read_to_string(&mut input)
+        .map(|_| ())
+        .map_err(|e| format!("read stream-json stdin: {e}"))
 }
 
 fn parse_stream_json_user_frame(

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -240,7 +240,7 @@ fn run_active_input_smoke_scenario(
     transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
     let _ = std::io::stdout().flush();
 
-    let mut follow_up_contents = Vec::with_capacity(expected_follow_ups);
+    let mut follow_up_contents = Vec::new();
     for index in 1..=expected_follow_ups {
         let frame = match read_next_stream_json_user_frame(
             stdin,

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -57,7 +57,7 @@ fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
             expected_follow_ups,
         ),
         MockScenario::InvalidActiveInputSmokeCount(count) => {
-            eprintln!("invalid @active-input-smoke follow-up count: {count:?}");
+            eprintln!("{}", invalid_active_input_count_message(count));
             ExitCode::from(1)
         }
         scenario => {
@@ -74,6 +74,13 @@ fn run_prompt_scenario(prompt: &str, output_format: &str) -> ExitCode {
     run_scenario(MockScenario::from_prompt(prompt), prompt, output_format)
 }
 
+fn invalid_active_input_count_message(count: &str) -> String {
+    format!(
+        "invalid @active-input-smoke follow-up count ({} bytes)",
+        count.len()
+    )
+}
+
 fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -> ExitCode {
     match scenario {
         MockScenario::ActiveInputSmoke { .. } => {
@@ -81,7 +88,7 @@ fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -
             ExitCode::from(1)
         }
         MockScenario::InvalidActiveInputSmokeCount(count) => {
-            eprintln!("invalid @active-input-smoke follow-up count: {count:?}");
+            eprintln!("{}", invalid_active_input_count_message(count));
             ExitCode::from(1)
         }
         MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload),

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -2,28 +2,82 @@ use crate::args::ParsedArgs;
 use crate::scenario::{MockScenario, echo_session_id, parse_echo_jsonl};
 use crate::transcript::{
     JsonlTranscript, assistant_text_event, create_session_history, generate_session_id, init_event,
-    is_valid_session_history_id, result_event, tool_result_event, tool_use_event,
+    is_valid_session_history_id, replayed_user_event, result_event, tool_result_event,
+    tool_use_event,
 };
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Command, ExitCode, Stdio};
 use std::time::Duration;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
+const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
 
 pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
-    let prompt = match prompt_from_input(&parsed) {
-        Ok(prompt) => prompt,
-        Err(message) => {
-            eprintln!("{message}");
-            return ExitCode::from(1);
-        }
-    };
+    if parsed.input_format == "stream-json" {
+        return run_stream_json_input(parsed);
+    }
 
-    match MockScenario::from_prompt(&prompt) {
+    run_prompt_scenario(&parsed.prompt, &parsed.output_format)
+}
+
+#[derive(Debug)]
+struct StreamJsonUserFrame {
+    content: String,
+    uuid: Option<String>,
+}
+
+fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
+    let stdin = std::io::stdin();
+    let mut reader = BufReader::new(stdin.lock());
+    let first_frame =
+        match read_next_stream_json_user_frame(&mut reader, StreamJsonFrameKind::First) {
+            Ok(Some(frame)) => frame,
+            Ok(None) => {
+                eprintln!("stream-json stdin did not contain a user message");
+                return ExitCode::from(1);
+            }
+            Err(message) => {
+                eprintln!("{message}");
+                return ExitCode::from(1);
+            }
+        };
+
+    match MockScenario::from_prompt(&first_frame.content) {
+        MockScenario::ActiveInputSmoke {
+            expected_follow_ups,
+        } => run_active_input_smoke_scenario(
+            &parsed.output_format,
+            parsed.replay_user_messages,
+            first_frame,
+            &mut reader,
+            expected_follow_ups,
+        ),
+        MockScenario::InvalidActiveInputSmokeCount(count) => {
+            eprintln!("invalid @active-input-smoke follow-up count: {count:?}");
+            ExitCode::from(1)
+        }
+        scenario => run_scenario(scenario, &first_frame.content, &parsed.output_format),
+    }
+}
+
+fn run_prompt_scenario(prompt: &str, output_format: &str) -> ExitCode {
+    run_scenario(MockScenario::from_prompt(prompt), prompt, output_format)
+}
+
+fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -> ExitCode {
+    match scenario {
+        MockScenario::ActiveInputSmoke { .. } => {
+            eprintln!("@active-input-smoke requires --input-format stream-json");
+            ExitCode::from(1)
+        }
+        MockScenario::InvalidActiveInputSmokeCount(count) => {
+            eprintln!("invalid @active-input-smoke follow-up count: {count:?}");
+            ExitCode::from(1)
+        }
         MockScenario::EchoJsonl(payload) => run_echo_jsonl_mode(payload),
         MockScenario::FailNoNewline(msg) => {
             eprint!("{msg}");
@@ -47,10 +101,10 @@ pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
             ExitCode::from(1)
         }
         MockScenario::StuckTool { deaf, close_stdout } => {
-            run_stuck_tool_scenario(&parsed.output_format, deaf, close_stdout)
+            run_stuck_tool_scenario(output_format, deaf, close_stdout)
         }
         MockScenario::OrphanPipe => {
-            if parsed.output_format == "stream-json" {
+            if output_format == "stream-json" {
                 emit_post_result_pair();
 
                 // Spawn a child after flushing the completed stream. It inherits
@@ -62,10 +116,10 @@ pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
             ExitCode::SUCCESS
         }
         MockScenario::HangAfterResult { deaf } => {
-            run_hang_after_result_scenario(&parsed.output_format, deaf)
+            run_hang_after_result_scenario(output_format, deaf)
         }
         MockScenario::ExitAfterResult => {
-            if parsed.output_format == "stream-json" {
+            if output_format == "stream-json" {
                 emit_post_result_pair();
                 // Exit immediately. Exercises the happy path: guest-agent
                 // either arms post-result reap and observes `child.wait()`
@@ -74,59 +128,157 @@ pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
             }
             ExitCode::SUCCESS
         }
-        MockScenario::WriteEnvJson(path) => {
-            run_write_env_json_scenario(&parsed.output_format, path)
-        }
+        MockScenario::WriteEnvJson(path) => run_write_env_json_scenario(output_format, path),
         MockScenario::Shell => {
             let session_id = generate_session_id();
 
-            if parsed.output_format == "stream-json" {
-                run_stream_json_mode(&prompt, &session_id)
+            if output_format == "stream-json" {
+                run_stream_json_mode(prompt, &session_id)
             } else {
-                run_text_mode(&prompt)
+                run_text_mode(prompt)
             }
         }
     }
 }
 
-fn prompt_from_input(parsed: &ParsedArgs) -> Result<String, String> {
-    if parsed.input_format == "stream-json" {
-        read_stream_json_prompt_from_stdin()
-    } else {
-        Ok(parsed.prompt.clone())
+#[derive(Clone, Copy)]
+enum StreamJsonFrameKind {
+    First,
+    FollowUp { index: usize },
+}
+
+fn read_next_stream_json_user_frame(
+    reader: &mut impl BufRead,
+    kind: StreamJsonFrameKind,
+) -> Result<Option<StreamJsonUserFrame>, String> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .map_err(|e| format!("read stream-json stdin: {e}"))?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        return parse_stream_json_user_frame(trimmed, kind).map(Some);
     }
 }
 
-fn read_stream_json_prompt_from_stdin() -> Result<String, String> {
-    let mut input = String::new();
-    std::io::stdin()
-        .read_to_string(&mut input)
-        .map_err(|e| format!("read stream-json stdin: {e}"))?;
+fn parse_stream_json_user_frame(
+    line: &str,
+    kind: StreamJsonFrameKind,
+) -> Result<StreamJsonUserFrame, String> {
+    let event: Value = serde_json::from_str(line).map_err(|e| match kind {
+        StreamJsonFrameKind::First => format!("parse stream-json stdin: {e}"),
+        StreamJsonFrameKind::FollowUp { index } => {
+            format!("parse stream-json stdin follow-up message {index}: {e}")
+        }
+    })?;
 
-    let line = input
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .ok_or_else(|| "stream-json stdin did not contain a user message".to_string())?;
-    let event: Value =
-        serde_json::from_str(line).map_err(|e| format!("parse stream-json stdin: {e}"))?;
+    let description = match kind {
+        StreamJsonFrameKind::First => "first message".to_string(),
+        StreamJsonFrameKind::FollowUp { index } => format!("follow-up message {index}"),
+    };
 
     if event.get("type").and_then(Value::as_str) != Some("user") {
-        return Err("stream-json stdin first message must have type \"user\"".to_string());
+        return Err(format!(
+            "stream-json stdin {description} must have type \"user\""
+        ));
     }
     if let Some(role) = event.pointer("/message/role").and_then(Value::as_str)
         && role != "user"
     {
-        return Err("stream-json stdin first message role must be \"user\"".to_string());
+        return Err(format!(
+            "stream-json stdin {description} role must be \"user\""
+        ));
     }
 
-    event
+    let content = event
         .pointer("/message/content")
         .and_then(Value::as_str)
         .map(str::to_string)
         .ok_or_else(|| {
-            "stream-json stdin first message must contain string message.content".to_string()
-        })
+            format!("stream-json stdin {description} must contain string message.content")
+        })?;
+    let uuid = event
+        .get("uuid")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    Ok(StreamJsonUserFrame { content, uuid })
+}
+
+fn run_active_input_smoke_scenario(
+    output_format: &str,
+    replay_user_messages: bool,
+    initial_frame: StreamJsonUserFrame,
+    stdin: &mut impl BufRead,
+    expected_follow_ups: usize,
+) -> ExitCode {
+    if output_format != "stream-json" {
+        eprintln!("@active-input-smoke requires --output-format stream-json");
+        return ExitCode::from(1);
+    }
+
+    let session_id = generate_session_id();
+    let mut transcript = JsonlTranscript::default();
+
+    transcript.emit_value(init_event(&session_id, &["Bash"]));
+    if replay_user_messages {
+        transcript.emit_value(replayed_user_event(
+            &session_id,
+            initial_frame.uuid.as_deref(),
+            &initial_frame.content,
+        ));
+    }
+    transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
+    let _ = std::io::stdout().flush();
+
+    let mut follow_up_contents = Vec::with_capacity(expected_follow_ups);
+    for index in 1..=expected_follow_ups {
+        let frame = match read_next_stream_json_user_frame(
+            stdin,
+            StreamJsonFrameKind::FollowUp { index },
+        ) {
+            Ok(Some(frame)) => frame,
+            Ok(None) => {
+                eprintln!(
+                    "active-input stdin closed after {} of {expected_follow_ups} follow-up user messages",
+                    follow_up_contents.len()
+                );
+                return ExitCode::from(1);
+            }
+            Err(message) => {
+                eprintln!("{message}");
+                return ExitCode::from(1);
+            }
+        };
+
+        if replay_user_messages {
+            transcript.emit_value(replayed_user_event(
+                &session_id,
+                frame.uuid.as_deref(),
+                &frame.content,
+            ));
+            let _ = std::io::stdout().flush();
+        }
+        follow_up_contents.push(frame.content);
+    }
+
+    transcript.emit_value(result_event(
+        &session_id,
+        false,
+        &format!("RESULT={}", follow_up_contents.join("+")),
+    ));
+    transcript.write_session_history(&session_id);
+    let _ = std::io::stdout().flush();
+    ExitCode::SUCCESS
 }
 
 fn run_echo_jsonl_mode(payload: &str) -> ExitCode {

--- a/crates/guest-mock-claude/src/scenario.rs
+++ b/crates/guest-mock-claude/src/scenario.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 
+const ACTIVE_INPUT_SMOKE_MARKER: &str = "@active-input-smoke:";
 const ECHO_MARKER: &str = "@ECHO@";
 const FAIL_NO_NEWLINE_MARKER: &str = "@fail-no-newline:";
 const FAIL_INVALID_UTF8_MARKER: &str = "@fail-invalid-utf8";
@@ -16,6 +17,8 @@ const HANG_AFTER_RESULT_MARKER: &str = "@hang-after-result";
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum MockScenario<'a> {
+    ActiveInputSmoke { expected_follow_ups: usize },
+    InvalidActiveInputSmokeCount(&'a str),
     EchoJsonl(&'a str),
     FailNoNewline(&'a str),
     FailInvalidUtf8,
@@ -39,6 +42,7 @@ enum ScenarioMatchKind {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ScenarioKind {
+    ActiveInputSmoke,
     EchoJsonl,
     FailNoNewline,
     FailInvalidUtf8,
@@ -64,6 +68,11 @@ enum ScenarioMatch<'a> {
 }
 
 const SCENARIO_RULES: &[ScenarioRule] = &[
+    ScenarioRule {
+        marker: ACTIVE_INPUT_SMOKE_MARKER,
+        match_kind: ScenarioMatchKind::PrefixPayload,
+        scenario_kind: ScenarioKind::ActiveInputSmoke,
+    },
     ScenarioRule {
         marker: ECHO_MARKER,
         match_kind: ScenarioMatchKind::FirstLinePayload,
@@ -161,6 +170,16 @@ impl ScenarioRule {
 impl ScenarioKind {
     fn to_mock_scenario<'a>(self, scenario_match: ScenarioMatch<'a>) -> Option<MockScenario<'a>> {
         let scenario = match (self, scenario_match) {
+            (Self::ActiveInputSmoke, ScenarioMatch::Payload(payload)) => {
+                match payload.parse::<usize>() {
+                    Ok(expected_follow_ups) if expected_follow_ups > 0 => {
+                        MockScenario::ActiveInputSmoke {
+                            expected_follow_ups,
+                        }
+                    }
+                    _ => MockScenario::InvalidActiveInputSmokeCount(payload),
+                }
+            }
             (Self::EchoJsonl, ScenarioMatch::Payload(payload)) => MockScenario::EchoJsonl(payload),
             (Self::FailNoNewline, ScenarioMatch::Payload(msg)) => MockScenario::FailNoNewline(msg),
             (Self::Fail, ScenarioMatch::Payload(msg)) => MockScenario::Fail(msg),
@@ -250,6 +269,12 @@ mod tests {
     #[test]
     fn classifies_all_scenario_rules() {
         let cases = [
+            (
+                "@active-input-smoke:2",
+                MockScenario::ActiveInputSmoke {
+                    expected_follow_ups: 2,
+                },
+            ),
             (
                 "@ECHO@\n{\"type\":\"result\"}",
                 MockScenario::EchoJsonl("{\"type\":\"result\"}"),
@@ -398,6 +423,14 @@ mod tests {
 
     #[test]
     fn payload_markers_keep_remainder_as_payload() {
+        assert_eq!(
+            MockScenario::from_prompt("@active-input-smoke:not-a-number"),
+            MockScenario::InvalidActiveInputSmokeCount("not-a-number")
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@active-input-smoke:0"),
+            MockScenario::InvalidActiveInputSmokeCount("0")
+        );
         assert_eq!(
             MockScenario::from_prompt("@fail-no-newline:"),
             MockScenario::FailNoNewline("")

--- a/crates/guest-mock-claude/src/transcript.rs
+++ b/crates/guest-mock-claude/src/transcript.rs
@@ -161,6 +161,19 @@ pub(crate) fn tool_result_event(
     })
 }
 
+pub(crate) fn replayed_user_event(session_id: &str, uuid: Option<&str>, content: &str) -> Value {
+    json!({
+        "type": "user",
+        "session_id": session_id,
+        "uuid": uuid,
+        "message": {
+            "role": "user",
+            "content": content
+        },
+        "parent_tool_use_id": null
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -220,16 +220,17 @@ fn wait_child(
     stdout_thread: JoinHandle<()>,
 ) -> Result<(ExitStatus, String), Box<dyn std::error::Error>> {
     let pid = child.id();
+    let child_stderr = child.stderr.take();
+    let stderr_thread = std::thread::spawn(move || -> Result<String, std::io::Error> {
+        let mut stderr = String::new();
+        if let Some(mut child_stderr) = child_stderr {
+            child_stderr.read_to_string(&mut stderr)?;
+        }
+        Ok(stderr)
+    });
     let (tx, rx) = mpsc::channel();
     let wait_thread = std::thread::spawn(move || {
-        let result = (|| -> Result<(ExitStatus, String), std::io::Error> {
-            let status = child.wait()?;
-            let mut stderr = String::new();
-            if let Some(mut child_stderr) = child.stderr.take() {
-                child_stderr.read_to_string(&mut stderr)?;
-            }
-            Ok((status, stderr))
-        })();
+        let result = child.wait();
         let _ = tx.send(result);
     });
 
@@ -259,7 +260,10 @@ fn wait_child(
     stdout_thread
         .join()
         .map_err(|_| std::io::Error::other("stdout reader thread panicked"))?;
-    Ok(child_result?)
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| std::io::Error::other("stderr reader thread panicked"))??;
+    Ok((child_result?, stderr))
 }
 
 #[test]
@@ -580,6 +584,31 @@ fn active_input_stream_rejects_early_eof() -> Result<(), Box<dyn std::error::Err
     assert!(
         stderr.contains("active-input stdin closed after 0 of 2 follow-up user messages"),
         "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn active_input_invalid_large_count_drains_stderr() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
+    let invalid_count = "x".repeat(128 * 1024);
+
+    stream.stdin_mut()?.write_all(
+        stream_json_user_frame_with_uuid(
+            &format!("@active-input-smoke:{invalid_count}"),
+            "active-initial",
+        )
+        .as_bytes(),
+    )?;
+    stream.close_stdin();
+
+    let (status, stderr) = stream.wait()?;
+    assert!(!status.success());
+    assert!(
+        stderr.contains("invalid @active-input-smoke follow-up count"),
+        "unexpected stderr prefix: {}",
+        stderr.chars().take(120).collect::<String>()
     );
     Ok(())
 }

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -421,6 +421,7 @@ fn active_input_stream_replays_user_messages() -> Result<(), Box<dyn std::error:
     assert!(status.success(), "expected success, stderr: {stderr}");
     assert!(stderr.is_empty());
 
+    let session_id = init_session_id(&events)?;
     let replayed_users = events
         .iter()
         .filter(|event| event.get("type").and_then(Value::as_str) == Some("user"))
@@ -446,10 +447,9 @@ fn active_input_stream_replays_user_messages() -> Result<(), Box<dyn std::error:
     assert!(
         replayed_users
             .iter()
-            .all(|(_, _, session_id)| session_id.is_some())
+            .all(|(_, _, replayed_session_id)| *replayed_session_id == Some(session_id.as_str()))
     );
 
-    let session_id = init_session_id(&events)?;
     let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
     assert_eq!(parse_jsonl(history.as_bytes())?, events);
     Ok(())

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,9 +1,22 @@
 use std::collections::HashSet;
 use std::fs;
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 use serde_json::Value;
+
+const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
+const EVENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct StreamJsonChild {
+    child: Child,
+    stdin: ChildStdin,
+    rx: Receiver<Result<Value, String>>,
+    stdout_thread: JoinHandle<()>,
+}
 
 fn mock_claude() -> Command {
     Command::new(env!("CARGO_BIN_EXE_guest-mock-claude"))
@@ -57,6 +70,10 @@ fn event_kind(event: &Value) -> String {
 }
 
 fn stream_json_user_frame(prompt: &str) -> String {
+    stream_json_user_frame_with_uuid(prompt, "mock-test-user-1")
+}
+
+fn stream_json_user_frame_with_uuid(prompt: &str, uuid: &str) -> String {
     format!(
         "{}\n",
         serde_json::json!({
@@ -65,10 +82,107 @@ fn stream_json_user_frame(prompt: &str) -> String {
                 "role": "user",
                 "content": prompt,
             },
-            "uuid": "mock-test-user-1",
+            "uuid": uuid,
             "parent_tool_use_id": null,
         })
     )
+}
+
+fn spawn_stream_json_child(
+    home: &std::path::Path,
+    replay_user_messages: bool,
+) -> Result<StreamJsonChild, Box<dyn std::error::Error>> {
+    let mut command = mock_claude();
+    command.env("HOME", home).args([
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+    ]);
+    if replay_user_messages {
+        command.arg("--replay-user-messages");
+    }
+    command
+        .arg("--")
+        .arg("printf argv-wrong")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = command.spawn()?;
+    let stdin = child.stdin.take().ok_or("missing stdin")?;
+    let stdout = child.stdout.take().ok_or("missing stdout")?;
+    let (tx, rx) = mpsc::channel();
+    let stdout_thread = std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    let _ = tx.send(Err(format!("read stdout line: {error}")));
+                    break;
+                }
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            let event = serde_json::from_str::<Value>(&line)
+                .map_err(|error| format!("parse stdout JSONL: {error}; line={line:?}"));
+            if tx.send(event).is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(StreamJsonChild {
+        child,
+        stdin,
+        rx,
+        stdout_thread,
+    })
+}
+
+fn recv_event(rx: &Receiver<Result<Value, String>>) -> Result<Value, Box<dyn std::error::Error>> {
+    match rx.recv_timeout(EVENT_TIMEOUT) {
+        Ok(Ok(event)) => Ok(event),
+        Ok(Err(message)) => Err(std::io::Error::other(message).into()),
+        Err(error) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("timed out waiting for mock event: {error}"),
+        )
+        .into()),
+    }
+}
+
+fn recv_until_result(
+    rx: &Receiver<Result<Value, String>>,
+    result: &str,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let mut events = Vec::new();
+    loop {
+        let event = recv_event(rx)?;
+        let matches_result = event.get("type").and_then(Value::as_str) == Some("result")
+            && event.get("result").and_then(Value::as_str) == Some(result);
+        events.push(event);
+        if matches_result {
+            return Ok(events);
+        }
+    }
+}
+
+fn wait_child(
+    mut child: Child,
+    stdout_thread: JoinHandle<()>,
+) -> Result<(ExitStatus, String), Box<dyn std::error::Error>> {
+    let status = child.wait()?;
+    let mut stderr = String::new();
+    if let Some(mut child_stderr) = child.stderr.take() {
+        child_stderr.read_to_string(&mut stderr)?;
+    }
+    stdout_thread
+        .join()
+        .map_err(|_| std::io::Error::other("stdout reader thread panicked"))?;
+    Ok((status, stderr))
 }
 
 #[test]
@@ -235,6 +349,135 @@ fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error:
         .and_then(Value::as_str)
         .ok_or("missing command")?;
     assert_eq!(command, "printf stdin-ok");
+    Ok(())
+}
+
+#[test]
+fn active_input_stream_reads_followups_after_first_result() -> Result<(), Box<dyn std::error::Error>>
+{
+    let home = tempfile::tempdir()?;
+    let StreamJsonChild {
+        child,
+        mut stdin,
+        rx,
+        stdout_thread,
+    } = spawn_stream_json_child(home.path(), false)?;
+
+    stdin.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke:2", "active-initial").as_bytes(),
+    )?;
+    stdin.flush()?;
+
+    let mut events = recv_until_result(&rx, ACTIVE_INPUT_READY_RESULT)?;
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        ["system/init", "result/success"]
+    );
+
+    stdin.write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
+    stdin.write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
+    stdin.flush()?;
+
+    events.extend(recv_until_result(&rx, "RESULT=first+second")?);
+    drop(stdin);
+
+    let (status, stderr) = wait_child(child, stdout_thread)?;
+    assert!(status.success(), "expected success, stderr: {stderr}");
+    assert!(stderr.is_empty());
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        ["system/init", "result/success", "result/success"]
+    );
+
+    let session_id = init_session_id(&events)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+    assert_eq!(parse_jsonl(history.as_bytes())?, events);
+    Ok(())
+}
+
+#[test]
+fn active_input_stream_replays_user_messages() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let StreamJsonChild {
+        child,
+        mut stdin,
+        rx,
+        stdout_thread,
+    } = spawn_stream_json_child(home.path(), true)?;
+
+    stdin.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke:2", "active-initial").as_bytes(),
+    )?;
+    stdin.flush()?;
+
+    let mut events = recv_until_result(&rx, ACTIVE_INPUT_READY_RESULT)?;
+    stdin.write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
+    stdin.write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
+    stdin.flush()?;
+    events.extend(recv_until_result(&rx, "RESULT=first+second")?);
+    drop(stdin);
+
+    let (status, stderr) = wait_child(child, stdout_thread)?;
+    assert!(status.success(), "expected success, stderr: {stderr}");
+    assert!(stderr.is_empty());
+
+    let replayed_users = events
+        .iter()
+        .filter(|event| event.get("type").and_then(Value::as_str) == Some("user"))
+        .map(|event| {
+            (
+                event.get("uuid").and_then(Value::as_str),
+                event.pointer("/message/content").and_then(Value::as_str),
+                event.get("session_id").and_then(Value::as_str),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        replayed_users
+            .iter()
+            .map(|(uuid, content, _)| (*uuid, *content))
+            .collect::<Vec<_>>(),
+        [
+            (Some("active-initial"), Some("@active-input-smoke:2")),
+            (Some("follow-up-1"), Some("first")),
+            (Some("follow-up-2"), Some("second")),
+        ]
+    );
+    assert!(
+        replayed_users
+            .iter()
+            .all(|(_, _, session_id)| session_id.is_some())
+    );
+
+    let session_id = init_session_id(&events)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+    assert_eq!(parse_jsonl(history.as_bytes())?, events);
+    Ok(())
+}
+
+#[test]
+fn active_input_stream_rejects_early_eof() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let StreamJsonChild {
+        child,
+        mut stdin,
+        rx,
+        stdout_thread,
+    } = spawn_stream_json_child(home.path(), false)?;
+
+    stdin.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke:2", "active-initial").as_bytes(),
+    )?;
+    stdin.flush()?;
+    let _ = recv_until_result(&rx, ACTIVE_INPUT_READY_RESULT)?;
+    drop(stdin);
+
+    let (status, stderr) = wait_child(child, stdout_thread)?;
+    assert!(!status.success());
+    assert!(
+        stderr.contains("active-input stdin closed after 0 of 2 follow-up user messages"),
+        "unexpected stderr: {stderr}"
+    );
     Ok(())
 }
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -610,6 +610,9 @@ fn active_input_invalid_large_count_drains_stderr() -> Result<(), Box<dyn std::e
         "unexpected stderr prefix: {}",
         stderr.chars().take(120).collect::<String>()
     );
+    assert!(stderr.contains("(131072 bytes)"));
+    assert!(!stderr.contains(&invalid_count));
+    assert!(stderr.len() < 128);
     Ok(())
 }
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -14,10 +14,48 @@ const EVENT_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_STREAM_JSON_EVENTS: usize = 32;
 
 struct StreamJsonChild {
-    child: Child,
-    stdin: ChildStdin,
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
     rx: Receiver<Result<Value, String>>,
-    stdout_thread: JoinHandle<()>,
+    stdout_thread: Option<JoinHandle<()>>,
+}
+
+impl StreamJsonChild {
+    fn stdin_mut(&mut self) -> Result<&mut ChildStdin, Box<dyn std::error::Error>> {
+        self.stdin
+            .as_mut()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stdin closed"))
+            .map_err(Into::into)
+    }
+
+    fn close_stdin(&mut self) {
+        self.stdin.take();
+    }
+
+    fn wait(mut self) -> Result<(ExitStatus, String), Box<dyn std::error::Error>> {
+        self.close_stdin();
+        let child = self.child.take().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "mock child already reaped")
+        })?;
+        let stdout_thread = self
+            .stdout_thread
+            .take()
+            .ok_or_else(|| std::io::Error::other("stdout reader thread already joined"))?;
+        wait_child(child, stdout_thread)
+    }
+}
+
+impl Drop for StreamJsonChild {
+    fn drop(&mut self) {
+        self.close_stdin();
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(stdout_thread) = self.stdout_thread.take() {
+            let _ = stdout_thread.join();
+        }
+    }
 }
 
 fn mock_claude() -> Command {
@@ -137,10 +175,10 @@ fn spawn_stream_json_child(
     });
 
     Ok(StreamJsonChild {
-        child,
-        stdin,
+        child: Some(child),
+        stdin: Some(stdin),
         rx,
-        stdout_thread,
+        stdout_thread: Some(stdout_thread),
     })
 }
 
@@ -429,32 +467,31 @@ fn one_shot_stream_json_drains_trailing_stdin() -> Result<(), Box<dyn std::error
 fn active_input_stream_reads_followups_after_first_result() -> Result<(), Box<dyn std::error::Error>>
 {
     let home = tempfile::tempdir()?;
-    let StreamJsonChild {
-        child,
-        mut stdin,
-        rx,
-        stdout_thread,
-    } = spawn_stream_json_child(home.path(), false)?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
 
-    stdin.write_all(
+    stream.stdin_mut()?.write_all(
         stream_json_user_frame_with_uuid("@active-input-smoke:2", "active-initial").as_bytes(),
     )?;
-    stdin.flush()?;
+    stream.stdin_mut()?.flush()?;
 
-    let mut events = recv_until_result(&rx, ACTIVE_INPUT_READY_RESULT)?;
+    let mut events = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
     assert_eq!(
         events.iter().map(event_kind).collect::<Vec<_>>(),
         ["system/init", "result/success"]
     );
 
-    stdin.write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
-    stdin.write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
-    stdin.flush()?;
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
 
-    events.extend(recv_until_result(&rx, "RESULT=first+second")?);
-    drop(stdin);
+    events.extend(recv_until_result(&stream.rx, "RESULT=first+second")?);
+    stream.close_stdin();
 
-    let (status, stderr) = wait_child(child, stdout_thread)?;
+    let (status, stderr) = stream.wait()?;
     assert!(status.success(), "expected success, stderr: {stderr}");
     assert!(stderr.is_empty());
     assert_eq!(
@@ -471,26 +508,25 @@ fn active_input_stream_reads_followups_after_first_result() -> Result<(), Box<dy
 #[test]
 fn active_input_stream_replays_user_messages() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
-    let StreamJsonChild {
-        child,
-        mut stdin,
-        rx,
-        stdout_thread,
-    } = spawn_stream_json_child(home.path(), true)?;
+    let mut stream = spawn_stream_json_child(home.path(), true)?;
 
-    stdin.write_all(
+    stream.stdin_mut()?.write_all(
         stream_json_user_frame_with_uuid("@active-input-smoke:2", "active-initial").as_bytes(),
     )?;
-    stdin.flush()?;
+    stream.stdin_mut()?.flush()?;
 
-    let mut events = recv_until_result(&rx, ACTIVE_INPUT_READY_RESULT)?;
-    stdin.write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
-    stdin.write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
-    stdin.flush()?;
-    events.extend(recv_until_result(&rx, "RESULT=first+second")?);
-    drop(stdin);
+    let mut events = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
+    events.extend(recv_until_result(&stream.rx, "RESULT=first+second")?);
+    stream.close_stdin();
 
-    let (status, stderr) = wait_child(child, stdout_thread)?;
+    let (status, stderr) = stream.wait()?;
     assert!(status.success(), "expected success, stderr: {stderr}");
     assert!(stderr.is_empty());
 
@@ -531,21 +567,16 @@ fn active_input_stream_replays_user_messages() -> Result<(), Box<dyn std::error:
 #[test]
 fn active_input_stream_rejects_early_eof() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
-    let StreamJsonChild {
-        child,
-        mut stdin,
-        rx,
-        stdout_thread,
-    } = spawn_stream_json_child(home.path(), false)?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
 
-    stdin.write_all(
+    stream.stdin_mut()?.write_all(
         stream_json_user_frame_with_uuid("@active-input-smoke:2", "active-initial").as_bytes(),
     )?;
-    stdin.flush()?;
-    let _ = recv_until_result(&rx, ACTIVE_INPUT_READY_RESULT)?;
-    drop(stdin);
+    stream.stdin_mut()?.flush()?;
+    let _ = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
+    stream.close_stdin();
 
-    let (status, stderr) = wait_child(child, stdout_thread)?;
+    let (status, stderr) = stream.wait()?;
     assert!(!status.success());
     assert!(
         stderr.contains("active-input stdin closed after 0 of 2 follow-up user messages"),

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
 const CHILD_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const EVENT_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_STREAM_JSON_EVENTS: usize = 32;
 
 struct StreamJsonChild {
     child: Child,
@@ -160,7 +161,7 @@ fn recv_until_result(
     result: &str,
 ) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
     let mut events = Vec::new();
-    loop {
+    for _ in 0..MAX_STREAM_JSON_EVENTS {
         let event = recv_event(rx)?;
         let matches_result = event.get("type").and_then(Value::as_str) == Some("result")
             && event.get("result").and_then(Value::as_str) == Some(result);
@@ -169,6 +170,11 @@ fn recv_until_result(
             return Ok(events);
         }
     }
+
+    Err(std::io::Error::other(format!(
+        "mock did not emit result {result:?} within {MAX_STREAM_JSON_EVENTS} events"
+    ))
+    .into())
 }
 
 fn wait_child(

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -464,8 +464,7 @@ fn one_shot_stream_json_drains_trailing_stdin() -> Result<(), Box<dyn std::error
 }
 
 #[test]
-fn active_input_stream_reads_followups_after_first_result() -> Result<(), Box<dyn std::error::Error>>
-{
+fn active_input_stream_reads_followups_after_ready() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
     let mut stream = spawn_stream_json_child(home.path(), false)?;
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
+const CHILD_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const EVENT_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct StreamJsonChild {
@@ -174,15 +175,47 @@ fn wait_child(
     mut child: Child,
     stdout_thread: JoinHandle<()>,
 ) -> Result<(ExitStatus, String), Box<dyn std::error::Error>> {
-    let status = child.wait()?;
-    let mut stderr = String::new();
-    if let Some(mut child_stderr) = child.stderr.take() {
-        child_stderr.read_to_string(&mut stderr)?;
-    }
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+    let wait_thread = std::thread::spawn(move || {
+        let result = (|| -> Result<(ExitStatus, String), std::io::Error> {
+            let status = child.wait()?;
+            let mut stderr = String::new();
+            if let Some(mut child_stderr) = child.stderr.take() {
+                child_stderr.read_to_string(&mut stderr)?;
+            }
+            Ok((status, stderr))
+        })();
+        let _ = tx.send(result);
+    });
+
+    let child_result = match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            // SAFETY: this is a test cleanup path for the child process that
+            // this helper just spawned. The wait thread reaps it below.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            rx.recv_timeout(CHILD_EXIT_TIMEOUT).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("mock child did not exit after SIGKILL: {error}"),
+                )
+            })?
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
+            "mock child wait thread exited without status",
+        )),
+    };
+
+    wait_thread
+        .join()
+        .map_err(|_| std::io::Error::other("child wait thread panicked"))?;
     stdout_thread
         .join()
         .map_err(|_| std::io::Error::other("stdout reader thread panicked"))?;
-    Ok((status, stderr))
+    Ok(child_result?)
 }
 
 #[test]

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -386,6 +386,40 @@ fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error:
 }
 
 #[test]
+fn one_shot_stream_json_drains_trailing_stdin() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut child = mock_claude()
+        .env("HOME", home.path())
+        .args([
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--",
+            "printf argv-wrong",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().ok_or("missing stdin")?;
+    stdin.write_all(stream_json_user_frame("printf stdin-ok").as_bytes())?;
+    stdin.write_all(b"\xff\n")?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("read stream-json stdin"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(output.stdout.is_empty());
+    Ok(())
+}
+
+#[test]
 fn active_input_stream_reads_followups_after_first_result() -> Result<(), Box<dyn std::error::Error>>
 {
     let home = tempfile::tempdir()?;

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -589,6 +589,63 @@ fn active_input_stream_rejects_early_eof() -> Result<(), Box<dyn std::error::Err
 }
 
 #[test]
+fn active_input_stream_rejects_non_user_followup() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
+
+    stream.stdin_mut()?.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke:1", "active-initial").as_bytes(),
+    )?;
+    stream.stdin_mut()?.flush()?;
+    let _ = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
+
+    stream.stdin_mut()?.write_all(
+        serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": "not a user frame",
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    )?;
+    stream.stdin_mut()?.write_all(b"\n")?;
+    stream.close_stdin();
+
+    let (status, stderr) = stream.wait()?;
+    assert!(!status.success());
+    assert!(
+        stderr.contains("stream-json stdin follow-up message 1 must have type \"user\""),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn active_input_stream_rejects_invalid_followup_json() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
+
+    stream.stdin_mut()?.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke:1", "active-initial").as_bytes(),
+    )?;
+    stream.stdin_mut()?.flush()?;
+    let _ = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
+
+    stream.stdin_mut()?.write_all(b"{\"type\":\"user\"\n")?;
+    stream.close_stdin();
+
+    let (status, stderr) = stream.wait()?;
+    assert!(!status.success());
+    assert!(
+        stderr.contains("parse stream-json stdin follow-up message 1"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
 fn active_input_invalid_large_count_drains_stderr() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
     let mut stream = spawn_stream_json_child(home.path(), false)?;


### PR DESCRIPTION
## Summary
- add a guest-mock-claude stream-json active-input smoke scenario that waits for follow-up user frames after an initial result
- preserve normal stream-json mock behavior while adding --replay-user-messages support for the active-input scenario
- cover success, replayed user events, early EOF, and session history with subprocess integration tests

Fixes #18091

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude
- cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-claude --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent unread_claude_stdin_does_not_block_result_reap
- cargo test --manifest-path crates/Cargo.toml -p guest-agent claude_exit_before_stdin_read_preserves_stderr