### PR TITLE
fix: remove deprecated youtube oauth scopes

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/youtube_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/youtube_0.py
@@ -82,14 +82,6 @@ JSON_PART = r"""{
           ]
         },
         {
-          "description": "See a list of your current active channel members, their current level, and when they became a member",
-          "name": "youtube.channel-memberships.creator",
-          "rules": [
-            "GET /v3/members",
-            "GET /v3/membershipsLevels"
-          ]
-        },
-        {
           "description": "See, edit, and permanently delete your YouTube videos, ratings, comments and captions",
           "name": "youtube.force-ssl",
           "rules": [
@@ -206,61 +198,6 @@ JSON_PART = r"""{
             "POST /v3/videos",
             "POST /v3/watermarks/set"
           ]
-        },
-        {
-          "description": "View and manage your assets and associated content on YouTube",
-          "name": "youtubepartner",
-          "rules": [
-            "GET /v3/captions",
-            "POST /v3/captions",
-            "PUT /v3/captions",
-            "DELETE /v3/captions",
-            "GET /v3/captions/{id}",
-            "GET /v3/channelSections",
-            "POST /v3/channelSections",
-            "PUT /v3/channelSections",
-            "DELETE /v3/channelSections",
-            "GET /v3/channels",
-            "PUT /v3/channels",
-            "GET /v3/i18nLanguages",
-            "GET /v3/i18nRegions",
-            "POST /v3/liveBroadcasts/cuepoint",
-            "GET /v3/playlistImages",
-            "POST /v3/playlistImages",
-            "PUT /v3/playlistImages",
-            "DELETE /v3/playlistImages",
-            "GET /v3/playlistItems",
-            "POST /v3/playlistItems",
-            "PUT /v3/playlistItems",
-            "DELETE /v3/playlistItems",
-            "GET /v3/playlists",
-            "POST /v3/playlists",
-            "PUT /v3/playlists",
-            "DELETE /v3/playlists",
-            "GET /v3/search",
-            "GET /v3/subscriptions",
-            "POST /v3/subscriptions",
-            "DELETE /v3/subscriptions",
-            "POST /v3/thumbnails/set",
-            "GET /v3/videoCategories",
-            "GET /v3/videoTrainability",
-            "GET /v3/videos",
-            "POST /v3/videos",
-            "PUT /v3/videos",
-            "DELETE /v3/videos",
-            "GET /v3/videos/getRating",
-            "POST /v3/videos/rate",
-            "POST /v3/videos/reportAbuse",
-            "POST /v3/watermarks/set",
-            "POST /v3/watermarks/unset"
-          ]
-        },
-        {
-          "description": "View private information of your YouTube channel relevant during the audit process with a YouTube partner",
-          "name": "youtubepartner-channel-audit",
-          "rules": [
-            "GET /v3/channels"
-          ]
         }
       ]
     },
@@ -307,19 +244,6 @@ JSON_PART = r"""{
             "POST /v3/videos",
             "POST /v3/watermarks/set"
           ]
-        },
-        {
-          "description": "View and manage your assets and associated content on YouTube",
-          "name": "youtubepartner",
-          "rules": [
-            "POST /v3/captions",
-            "PUT /v3/captions",
-            "POST /v3/playlistImages",
-            "PUT /v3/playlistImages",
-            "POST /v3/thumbnails/set",
-            "POST /v3/videos",
-            "POST /v3/watermarks/set"
-          ]
         }
       ]
     },
@@ -362,19 +286,6 @@ JSON_PART = r"""{
           "name": "youtube.upload",
           "rules": [
             "POST /v3/channelBanners/insert",
-            "POST /v3/thumbnails/set",
-            "POST /v3/videos",
-            "POST /v3/watermarks/set"
-          ]
-        },
-        {
-          "description": "View and manage your assets and associated content on YouTube",
-          "name": "youtubepartner",
-          "rules": [
-            "POST /v3/captions",
-            "PUT /v3/captions",
-            "POST /v3/playlistImages",
-            "PUT /v3/playlistImages",
             "POST /v3/thumbnails/set",
             "POST /v3/videos",
             "POST /v3/watermarks/set"

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -36,9 +36,6 @@ const YOUTUBE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/youtube.force-ssl",
   "https://www.googleapis.com/auth/youtube.readonly",
   "https://www.googleapis.com/auth/youtube.upload",
-  "https://www.googleapis.com/auth/youtube.channel-memberships.creator",
-  "https://www.googleapis.com/auth/youtubepartner",
-  "https://www.googleapis.com/auth/youtubepartner-channel-audit",
   "https://www.googleapis.com/auth/userinfo.email",
 ] as const;
 

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -127,9 +127,6 @@ const YOUTUBE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/youtube.force-ssl",
   "https://www.googleapis.com/auth/youtube.readonly",
   "https://www.googleapis.com/auth/youtube.upload",
-  "https://www.googleapis.com/auth/youtube.channel-memberships.creator",
-  "https://www.googleapis.com/auth/youtubepartner",
-  "https://www.googleapis.com/auth/youtubepartner-channel-audit",
   "https://www.googleapis.com/auth/userinfo.email",
 ] as const;
 
@@ -4168,7 +4165,7 @@ describe("getConnectorAuthMethodGrantScopes - google-cloud scopes", () => {
 });
 
 describe("getConnectorAuthMethodGrantScopes - youtube scopes", () => {
-  it("uses the official YouTube Data API OAuth scopes", () => {
+  it("uses the configured YouTube Data API OAuth scopes", () => {
     const grant = getConnectorAuthMethodAuthCodeGrantConfig("youtube", "oauth");
     const scopes = getConnectorAuthMethodGrantScopes("youtube", "oauth");
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/youtube.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/youtube.test.ts
@@ -20,9 +20,6 @@ const YOUTUBE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/youtube.force-ssl",
   "https://www.googleapis.com/auth/youtube.readonly",
   "https://www.googleapis.com/auth/youtube.upload",
-  "https://www.googleapis.com/auth/youtube.channel-memberships.creator",
-  "https://www.googleapis.com/auth/youtubepartner",
-  "https://www.googleapis.com/auth/youtubepartner-channel-audit",
   "https://www.googleapis.com/auth/userinfo.email",
 ] as const;
 const testAuthClient = {

--- a/turbo/packages/connectors/src/connectors/youtube.ts
+++ b/turbo/packages/connectors/src/connectors/youtube.ts
@@ -27,9 +27,6 @@ export const youtube = {
             "https://www.googleapis.com/auth/youtube.force-ssl",
             "https://www.googleapis.com/auth/youtube.readonly",
             "https://www.googleapis.com/auth/youtube.upload",
-            "https://www.googleapis.com/auth/youtube.channel-memberships.creator",
-            "https://www.googleapis.com/auth/youtubepartner",
-            "https://www.googleapis.com/auth/youtubepartner-channel-audit",
             "https://www.googleapis.com/auth/userinfo.email",
           ],
           outputs: {

--- a/turbo/packages/firewalls-generator/src/google.ts
+++ b/turbo/packages/firewalls-generator/src/google.ts
@@ -106,9 +106,11 @@ function buildGroups(
   discovery: DiscoveryDocument,
   stripPrefix: string,
   uploadOnly?: boolean,
+  excludedScopes: readonly string[] = [],
 ): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
   const strip = stripPrefix ? `${stripPrefix}/` : "";
+  const excludedScopeSet = new Set(excludedScopes);
 
   // servicePath is non-empty for APIs with relative paths (Drive, Calendar).
   // Extract just the version part (e.g. "drive/v3/" → "v3/") to prepend.
@@ -145,6 +147,11 @@ function buildGroups(
       continue;
     }
 
+    const includedScopes = scopes.filter(
+      (scope) => !excludedScopeSet.has(scope),
+    );
+    if (includedScopes.length === 0) continue;
+
     // For APIs with servicePath (Drive, Calendar): paths are relative,
     // prepend version prefix. e.g. "about" → "v3/about"
     // For APIs without servicePath (Gmail, Docs, Sheets): paths include
@@ -159,7 +166,7 @@ function buildGroups(
     }
 
     const rule = `${httpMethod.toUpperCase()} /${rulePath}`;
-    for (const scope of scopes) {
+    for (const scope of includedScopes) {
       const scopeName = shortScope(scope);
       let ruleSet = groups.get(scopeName);
       if (!ruleSet) {
@@ -323,6 +330,8 @@ interface GoogleFirewallConfig {
       addRules?: string[];
     }
   >;
+  /** Full OAuth scope URLs to exclude from generated permission groups. */
+  excludedScopes?: string[];
   /**
    * Default allowed permissions export.
    * Generates a typed const array (e.g. gmailDefaultAllowed).
@@ -377,11 +386,16 @@ async function generateGoogleFirewall(
 
     mergePermissions(
       allPermissions,
-      buildGroups(discovery, config.stripPrefix),
+      buildGroups(discovery, config.stripPrefix, false, config.excludedScopes),
     );
 
     // Build upload-specific permissions (only methods with supportsMediaUpload)
-    const uploadGroups = buildGroups(discovery, config.stripPrefix, true);
+    const uploadGroups = buildGroups(
+      discovery,
+      config.stripPrefix,
+      true,
+      config.excludedScopes,
+    );
     if (uploadGroups.length > 0) {
       hasUpload = true;
       mergePermissions(uploadPermissions, uploadGroups);
@@ -657,6 +671,11 @@ const CONFIGS: Record<string, GoogleFirewallConfig> = {
     placeholderKey: "YOUTUBE_TOKEN",
     placeholderValue: OAUTH_PLACEHOLDER,
     auth: bearerAuth("YOUTUBE_TOKEN"),
+    excludedScopes: [
+      "https://www.googleapis.com/auth/youtube.channel-memberships.creator",
+      "https://www.googleapis.com/auth/youtubepartner",
+      "https://www.googleapis.com/auth/youtubepartner-channel-audit",
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- remove deprecated YouTube OAuth scopes for channel memberships and YouTube Partner access
- update OAuth URL scope expectations in connectors and API tests
- add a YouTube excluded-scope list to the Google firewall generator so regenerated firewall permissions stay aligned

## Verification
- pnpm format
- pnpm -F @vm0/connectors lint
- pnpm -F api lint
- pnpm -F @vm0/firewalls-generator check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts src/auth-providers/connectors/__tests__/youtube.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
- pnpm knip (via pre-commit hook)

## Notes
- Local full check-types is currently blocked by existing API test helper type errors such as `Property 'body' does not exist on type 'never'` across API route tests; the changed YouTube connector and generator workspaces typecheck successfully.