### PR TITLE
fix: tighten template picker icon hover box to match connector buttons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2502,7 +2502,7 @@ function TemplatePickerButton({
             <button
               type="button"
               className={cn(
-                "rounded-lg p-[3px] transition-colors duration-200 hover:bg-accent hover:text-foreground sm:p-1",
+                "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 hover:bg-accent hover:text-foreground sm:h-9 sm:w-9",
                 picker.value && "bg-accent text-foreground",
               )}
               aria-label="Template"


### PR DESCRIPTION
## What

The illustration (template) picker icon in the chat composer toolbar rendered with an oversized hover background compared to the connector icons (GitHub/Gmail/Notion) next to it.

The button used `p-[3px]`/`sm:p-1` padding around the 32px illustration image, producing a ~40px hover box — taller and wider than the 36px connector buttons, and not square.

## Change

Replace the padding with a fixed square box that matches the connector buttons' hover area:

- **Hover box**: `h-8 w-8 sm:h-9 sm:w-9` → 32px (mobile) / 36px (desktop) square, aligned with the connector buttons' `h-8/h-9`
- **Icon visual**: unchanged at `h-[32px] w-[32px]`

Only the hover/click area shrinks; the icon itself looks identical at rest.

## Before / After

Faithful CSS replica of the toolbar with the real icon assets:
https://illu-icon-size-cmp-715f6d07-354b22d6.sites.vm0.io

| | Hover box | Icon |
|---|---|---|
| Before | ~40px (rectangle) | 32px |
| After | 36x36px (square) | 32px |

🤖 Generated with [Claude Code](https://claude.com/claude-code)