### PR TITLE
feat: manage workflow agent attachments

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -1,6 +1,8 @@
 import {
+  zeroWorkflowAgentsContract,
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
+  type ZeroWorkflowAgentSummary,
   type ZeroWorkflowContentResponse,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
@@ -22,6 +24,28 @@ function metadata(workflow: ZeroWorkflowDetailResponse): ZeroWorkflowSummary {
     attachedAgentCount: workflow.attachedAgentCount,
     attachedAgents: workflow.attachedAgents,
     canManage: workflow.canManage,
+  };
+}
+
+function fallbackAgent(agentId: string): ZeroWorkflowAgentSummary {
+  return {
+    agentId,
+    ownerId: "test-user-123",
+    displayName: null,
+    description: null,
+    avatarUrl: null,
+    visibility: "public",
+  };
+}
+
+function withAttachedAgents(
+  workflow: ZeroWorkflowDetailResponse,
+  attachedAgents: readonly ZeroWorkflowAgentSummary[],
+): ZeroWorkflowDetailResponse {
+  return {
+    ...workflow,
+    attachedAgentCount: attachedAgents.length,
+    attachedAgents: [...attachedAgents],
   };
 }
 
@@ -84,5 +108,69 @@ export const apiWorkflowsHandlers = [
     };
     mockWorkflows[index] = updated;
     return respond(200, response);
+  }),
+
+  mockApi(zeroWorkflowAgentsContract.list, ({ params, respond }) => {
+    const workflow = mockWorkflows.find((item) => {
+      return item.name === params.name;
+    });
+    if (!workflow) {
+      return respond(404, {
+        error: {
+          message: `Workflow not found: ${params.name}`,
+          code: "NOT_FOUND",
+        },
+      });
+    }
+    return respond(200, workflow.attachedAgents);
+  }),
+
+  mockApi(zeroWorkflowAgentsContract.attach, ({ body, params, respond }) => {
+    const index = mockWorkflows.findIndex((item) => {
+      return item.name === params.name;
+    });
+    if (index === -1) {
+      return respond(404, {
+        error: {
+          message: `Workflow not found: ${params.name}`,
+          code: "NOT_FOUND",
+        },
+      });
+    }
+
+    const workflow = mockWorkflows[index]!;
+    const alreadyAttached = workflow.attachedAgents.some((agent) => {
+      return agent.agentId === body.agentId;
+    });
+    if (!alreadyAttached) {
+      mockWorkflows[index] = withAttachedAgents(workflow, [
+        ...workflow.attachedAgents,
+        fallbackAgent(body.agentId),
+      ]);
+    }
+    return respond(200, metadata(mockWorkflows[index]!));
+  }),
+
+  mockApi(zeroWorkflowAgentsContract.detach, ({ params, respond }) => {
+    const index = mockWorkflows.findIndex((item) => {
+      return item.name === params.name;
+    });
+    if (index === -1) {
+      return respond(404, {
+        error: {
+          message: `Workflow not found: ${params.name}`,
+          code: "NOT_FOUND",
+        },
+      });
+    }
+
+    const workflow = mockWorkflows[index]!;
+    mockWorkflows[index] = withAttachedAgents(
+      workflow,
+      workflow.attachedAgents.filter((agent) => {
+        return agent.agentId !== params.agentId;
+      }),
+    );
+    return respond(200, metadata(mockWorkflows[index]!));
   }),
 ];

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -1,5 +1,7 @@
 import { command, computed, state } from "ccstate";
+import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
+  zeroWorkflowAgentsContract,
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
   type ZeroWorkflowAgentSummary,
@@ -8,15 +10,20 @@ import {
 } from "@vm0/api-contracts/contracts/zero-workflows";
 
 import { accept } from "../../lib/accept.ts";
+import { agents$ } from "../agent.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { user$ } from "../auth.ts";
+import { isOrgAdmin$ } from "../org.ts";
 
 export type WorkflowAttachmentFilter = "all" | "attached" | "unbound";
+type WorkflowAttachmentAgent = ZeroWorkflowAgentSummary;
 
 const internalSelectedWorkflowName$ = state<string | null>(null);
 const internalSelectedWorkflowFilePath$ = state<string | null>(null);
 const internalWorkflowSearch$ = state("");
 const internalSelectedAgentId$ = state<string | null>(null);
 const internalAttachmentFilter$ = state<WorkflowAttachmentFilter>("all");
+const internalWorkflowReload$ = state(0);
 
 export const workflowSearch$ = computed((get) => {
   return get(internalWorkflowSearch$);
@@ -69,6 +76,7 @@ export const selectedWorkflowName$ = computed((get) => {
 
 export const orgWorkflows$ = computed(
   async (get): Promise<readonly ZeroWorkflowSummary[]> => {
+    get(internalWorkflowReload$);
     const client = get(zeroClient$)(zeroWorkflowsCollectionContract);
     const result = await accept(client.list(), [200], { toast: false });
     return result.body;
@@ -139,6 +147,7 @@ export const filteredOrgWorkflows$ = computed(
 
 export const selectedWorkflowDetail$ = computed(
   async (get): Promise<ZeroWorkflowDetailResponse | null> => {
+    get(internalWorkflowReload$);
     const workflowName = await get(selectedWorkflowName$);
     if (!workflowName) {
       return null;
@@ -153,6 +162,120 @@ export const selectedWorkflowDetail$ = computed(
     return result.body;
   },
 );
+
+export const workflowAttachableAgents$ = computed(
+  async (get): Promise<readonly WorkflowAttachmentAgent[]> => {
+    const detail = await get(selectedWorkflowDetail$);
+    if (!detail?.canManage) {
+      return [];
+    }
+
+    const visibleAgents = await get(agents$);
+    const currentUser = await get(user$);
+    const isAdmin = await get(isOrgAdmin$);
+    const currentUserId = currentUser?.id ?? "";
+    const attachedIds = new Set(
+      detail.attachedAgents.map((agent) => {
+        return agent.agentId;
+      }),
+    );
+
+    return visibleAgents
+      .filter((agent) => {
+        return (
+          !attachedIds.has(agent.id) &&
+          canConfigureWorkflowAttachment(detail, agent, currentUserId, isAdmin)
+        );
+      })
+      .map(teamAgentToWorkflowAgent)
+      .sort((left, right) => {
+        return agentTitle(left).localeCompare(agentTitle(right));
+      });
+  },
+);
+
+export const attachSelectedWorkflowAgent$ = command(
+  async ({ get, set }, agentId: string, signal: AbortSignal) => {
+    const workflowName = await get(selectedWorkflowName$);
+    signal.throwIfAborted();
+    if (!workflowName) {
+      return;
+    }
+
+    const client = get(zeroClient$)(zeroWorkflowAgentsContract);
+    await accept(
+      client.attach({
+        params: { name: workflowName },
+        body: { agentId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(internalWorkflowReload$, (prev) => {
+      return prev + 1;
+    });
+  },
+);
+
+export const detachSelectedWorkflowAgent$ = command(
+  async ({ get, set }, agentId: string, signal: AbortSignal) => {
+    const workflowName = await get(selectedWorkflowName$);
+    signal.throwIfAborted();
+    if (!workflowName) {
+      return;
+    }
+
+    const client = get(zeroClient$)(zeroWorkflowAgentsContract);
+    await accept(
+      client.detach({
+        params: { name: workflowName, agentId },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(internalWorkflowReload$, (prev) => {
+      return prev + 1;
+    });
+  },
+);
+
+function teamAgentToWorkflowAgent(
+  agent: TeamComposeItem,
+): WorkflowAttachmentAgent {
+  return {
+    agentId: agent.id,
+    ownerId: agent.ownerId ?? "",
+    displayName: agent.displayName,
+    description: agent.description,
+    avatarUrl: agent.avatarUrl,
+    visibility: agent.visibility ?? "public",
+  };
+}
+
+function canConfigureWorkflowAttachment(
+  workflow: ZeroWorkflowDetailResponse,
+  agent: TeamComposeItem,
+  currentUserId: string,
+  isAdmin: boolean,
+): boolean {
+  const agentVisibility = agent.visibility ?? "public";
+
+  if (!workflow.canManage) {
+    return false;
+  }
+
+  if (workflow.visibility === "private" && agentVisibility === "public") {
+    return true;
+  }
+
+  if (agent.ownerId === currentUserId) {
+    return true;
+  }
+
+  return agentVisibility !== "private" && isAdmin;
+}
 
 function agentTitle(agent: ZeroWorkflowAgentSummary): string {
   return agent.displayName ?? agent.agentId;

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1,6 +1,8 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
+  zeroWorkflowAgentsContract,
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
   type ZeroWorkflowAgentSummary,
@@ -16,15 +18,19 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { setMockOrg } from "../../../mocks/handlers/api-org.ts";
+import { setMockTeam } from "../../../mocks/handlers/api-agents.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 const user = userEvent.setup({ delay: null });
+const CURRENT_USER_ID = "test-user-123";
+const OTHER_USER_ID = "user-other";
 
 function researchAgent(): ZeroWorkflowAgentSummary {
   return {
     agentId: "c0000000-0000-4000-a000-000000000101",
-    ownerId: "user-1",
+    ownerId: CURRENT_USER_ID,
     displayName: "Research Bot",
     description: "Finds account context",
     avatarUrl: "https://assets.example.test/research-bot.png",
@@ -35,7 +41,7 @@ function researchAgent(): ZeroWorkflowAgentSummary {
 function supportAgent(): ZeroWorkflowAgentSummary {
   return {
     agentId: "c0000000-0000-4000-a000-000000000102",
-    ownerId: "user-1",
+    ownerId: CURRENT_USER_ID,
     displayName: "Support Bot",
     description: "Triages customer work",
     avatarUrl: null,
@@ -43,13 +49,58 @@ function supportAgent(): ZeroWorkflowAgentSummary {
   };
 }
 
-const WORKFLOW_DETAILS: readonly ZeroWorkflowDetailResponse[] = [
+function opsAgent(): TeamComposeItem {
+  return {
+    id: "c0000000-0000-4000-a000-000000000103",
+    ownerId: CURRENT_USER_ID,
+    displayName: "Ops Bot",
+    description: "Runs release checks",
+    sound: null,
+    avatarUrl: null,
+    customSkills: [],
+    visibility: "private",
+    headVersionId: "version_ops",
+    updatedAt: "2026-06-17T00:00:00Z",
+  };
+}
+
+function sharedAgent(): TeamComposeItem {
+  return {
+    id: "c0000000-0000-4000-a000-000000000104",
+    ownerId: OTHER_USER_ID,
+    displayName: "Shared Bot",
+    description: "Shared public agent",
+    sound: null,
+    avatarUrl: null,
+    customSkills: [],
+    visibility: "public",
+    headVersionId: "version_shared",
+    updatedAt: "2026-06-17T00:00:00Z",
+  };
+}
+
+function otherPrivateAgent(): TeamComposeItem {
+  return {
+    id: "c0000000-0000-4000-a000-000000000105",
+    ownerId: OTHER_USER_ID,
+    displayName: "Other Private Bot",
+    description: "Not configurable by the current user",
+    sound: null,
+    avatarUrl: null,
+    customSkills: [],
+    visibility: "private",
+    headVersionId: "version_other_private",
+    updatedAt: "2026-06-17T00:00:00Z",
+  };
+}
+
+const BASE_WORKFLOW_DETAILS: readonly ZeroWorkflowDetailResponse[] = [
   {
     name: "sales-research",
     displayName: "Sales Research",
     description: "Collects account context before outreach.",
     visibility: "public",
-    ownerUserId: "user-1",
+    ownerUserId: CURRENT_USER_ID,
     attachedAgentCount: 2,
     attachedAgents: [researchAgent(), supportAgent()],
     canManage: true,
@@ -96,7 +147,7 @@ Use CRM context before outreach.
     displayName: "Support Escalation",
     description: "Summarizes urgent customer issues for the support queue.",
     visibility: "public",
-    ownerUserId: "user-1",
+    ownerUserId: CURRENT_USER_ID,
     attachedAgentCount: 1,
     attachedAgents: [supportAgent()],
     canManage: true,
@@ -114,7 +165,7 @@ Use CRM context before outreach.
     displayName: "Ops Playbook",
     description: null,
     visibility: "private",
-    ownerUserId: "user-1",
+    ownerUserId: CURRENT_USER_ID,
     attachedAgentCount: 0,
     attachedAgents: [],
     canManage: true,
@@ -129,8 +180,23 @@ Use CRM context before outreach.
   },
 ];
 
-function workflowMetadata(): readonly ZeroWorkflowSummary[] {
-  return WORKFLOW_DETAILS.map((workflow) => {
+function mutableWorkflowDetails(): ZeroWorkflowDetailResponse[] {
+  return BASE_WORKFLOW_DETAILS.map((workflow) => {
+    return {
+      ...workflow,
+      attachedAgents: [...workflow.attachedAgents],
+      files: workflow.files ? [...workflow.files] : workflow.files,
+      fileContents: workflow.fileContents
+        ? [...workflow.fileContents]
+        : workflow.fileContents,
+    };
+  });
+}
+
+function workflowMetadata(
+  workflows: readonly ZeroWorkflowDetailResponse[],
+): readonly ZeroWorkflowSummary[] {
+  return workflows.map((workflow) => {
     return {
       name: workflow.name,
       displayName: workflow.displayName,
@@ -144,12 +210,54 @@ function workflowMetadata(): readonly ZeroWorkflowSummary[] {
   });
 }
 
-function mockWorkflowApis(): void {
+function teamAgentToWorkflowAgent(
+  agent: TeamComposeItem,
+): ZeroWorkflowAgentSummary {
+  return {
+    agentId: agent.id,
+    ownerId: agent.ownerId ?? "",
+    displayName: agent.displayName,
+    description: agent.description,
+    avatarUrl: agent.avatarUrl,
+    visibility: agent.visibility ?? "public",
+  };
+}
+
+function setAttachedAgents(
+  workflows: ZeroWorkflowDetailResponse[],
+  workflowName: string,
+  agents: readonly ZeroWorkflowAgentSummary[],
+): ZeroWorkflowSummary | null {
+  const index = workflows.findIndex((workflow) => {
+    return workflow.name === workflowName;
+  });
+  if (index === -1) {
+    return null;
+  }
+
+  const updated = {
+    ...workflows[index]!,
+    attachedAgentCount: agents.length,
+    attachedAgents: [...agents],
+  };
+  workflows[index] = updated;
+  return workflowMetadata([updated])[0] ?? null;
+}
+
+function mockWorkflowApis(
+  workflows: ZeroWorkflowDetailResponse[] = mutableWorkflowDetails(),
+  team: readonly TeamComposeItem[] = [],
+): void {
+  const teamById = new Map(
+    team.map((agent) => {
+      return [agent.id, agent];
+    }),
+  );
   context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
-    return respond(200, [...workflowMetadata()]);
+    return respond(200, [...workflowMetadata(workflows)]);
   });
   context.mocks.api(zeroWorkflowsDetailContract.get, ({ params, respond }) => {
-    const detail = WORKFLOW_DETAILS.find((workflow) => {
+    const detail = workflows.find((workflow) => {
       return workflow.name === params.name;
     });
     if (!detail) {
@@ -162,6 +270,66 @@ function mockWorkflowApis(): void {
     }
     return respond(200, detail);
   });
+  context.mocks.api(
+    zeroWorkflowAgentsContract.attach,
+    ({ body, params, respond }) => {
+      const workflow = workflows.find((item) => {
+        return item.name === params.name;
+      });
+      if (!workflow) {
+        return respond(404, {
+          error: {
+            code: "NOT_FOUND",
+            message: `Workflow not found: ${params.name}`,
+          },
+        });
+      }
+
+      const agent = teamById.get(body.agentId);
+      if (!agent) {
+        return respond(404, {
+          error: {
+            code: "NOT_FOUND",
+            message: `Agent not found: ${body.agentId}`,
+          },
+        });
+      }
+
+      const attachedAgent = teamAgentToWorkflowAgent(agent);
+      const summary = setAttachedAgents(workflows, workflow.name, [
+        ...workflow.attachedAgents.filter((candidate) => {
+          return candidate.agentId !== attachedAgent.agentId;
+        }),
+        attachedAgent,
+      ]);
+      return respond(200, summary!);
+    },
+  );
+  context.mocks.api(
+    zeroWorkflowAgentsContract.detach,
+    ({ params, respond }) => {
+      const workflow = workflows.find((item) => {
+        return item.name === params.name;
+      });
+      if (!workflow) {
+        return respond(404, {
+          error: {
+            code: "NOT_FOUND",
+            message: `Workflow not found: ${params.name}`,
+          },
+        });
+      }
+
+      const summary = setAttachedAgents(
+        workflows,
+        workflow.name,
+        workflow.attachedAgents.filter((agent) => {
+          return agent.agentId !== params.agentId;
+        }),
+      );
+      return respond(200, summary!);
+    },
+  );
 }
 
 function getButtonContaining(text: string): HTMLElement {
@@ -284,5 +452,53 @@ describe("workflows page", () => {
       expect(screen.getByText("Workflows")).toBeInTheDocument();
     });
     expect(screen.getByText("Sales Research")).toBeInTheDocument();
+  });
+
+  it("attaches and detaches configurable agents from workflow details", async () => {
+    const ops = opsAgent();
+    const shared = sharedAgent();
+    const otherPrivate = otherPrivateAgent();
+    const workflows = mutableWorkflowDetails();
+    setMockTeam([ops, shared, otherPrivate]);
+    setMockOrg({ role: "member" });
+    mockWorkflowApis(workflows, [ops, shared, otherPrivate]);
+
+    detachedSetupPage({
+      context,
+      path: "/workflows",
+      featureSwitches: { [FeatureSwitchKey.WorkflowsViewer]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Ops Playbook")).toBeInTheDocument();
+    });
+
+    click(getButtonContaining("Ops Playbook"));
+    await waitFor(() => {
+      expect(
+        screen.getByText("Not attached to any agent."),
+      ).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Attach workflow to agent"));
+    const sharedOption = await screen.findByRole("option", {
+      name: "Shared Bot",
+    });
+    expect(sharedOption).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Ops Bot" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Other Private Bot" }),
+    ).not.toBeInTheDocument();
+
+    click(screen.getByRole("option", { name: "Shared Bot" }));
+    await waitFor(() => {
+      expect(screen.getByText("Shared Bot")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Detach workflow from Shared Bot"));
+    await waitFor(() => {
+      expect(screen.queryByText("Shared Bot")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Not attached to any agent.")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -1,4 +1,5 @@
 import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import type {
   ZeroWorkflowAgentSummary,
   ZeroWorkflowDetailResponse,
@@ -10,9 +11,12 @@ import {
   IconFile,
   IconFolderOpen,
   IconLock,
+  IconLoader2,
+  IconPlus,
   IconSearch,
   IconUsers,
   IconWorld,
+  IconX,
 } from "@tabler/icons-react";
 import {
   cn,
@@ -29,6 +33,8 @@ import {
 } from "@vm0/ui";
 
 import {
+  attachSelectedWorkflowAgent$,
+  detachSelectedWorkflowAgent$,
   filteredOrgWorkflows$,
   selectedWorkflowAgentId$,
   selectedWorkflowDetail$,
@@ -39,12 +45,15 @@ import {
   setSelectedWorkflowName$,
   setWorkflowAttachmentFilter$,
   setWorkflowSearch$,
+  workflowAttachableAgents$,
   workflowAgentOptions$,
   workflowAttachmentFilter$,
   workflowSearch$,
   type WorkflowAttachmentFilter,
 } from "../../signals/workflows-page/workflows-signals.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { Link } from "../router/link.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
@@ -531,10 +540,7 @@ function WorkflowViewer({
           )}
         </div>
         <aside className="min-h-0 border-t border-border/70 bg-muted/20 lg:border-l lg:border-t-0">
-          <AttachedAgentsPanel
-            agents={detail.attachedAgents}
-            count={detail.attachedAgentCount}
-          />
+          <AttachedAgentsPanel workflow={detail} />
           <WorkflowFiles
             files={files}
             selectedPath={selectedFilePath}
@@ -563,34 +569,121 @@ function VisibilityBadge({
 }
 
 function AttachedAgentsPanel({
-  agents,
-  count,
+  workflow,
 }: {
-  readonly agents: readonly ZeroWorkflowAgentSummary[];
-  readonly count: number;
+  readonly workflow: ZeroWorkflowDetailResponse;
 }) {
+  const attachableAgentsLoadable = useLoadable(workflowAttachableAgents$);
+  const pageSignal = useGet(pageSignal$);
+  const [attachLoadable, attachAgent] = useLoadableSet(
+    attachSelectedWorkflowAgent$,
+  );
+  const [detachLoadable, detachAgent] = useLoadableSet(
+    detachSelectedWorkflowAgent$,
+  );
+  const attachableAgents =
+    attachableAgentsLoadable.state === "hasData"
+      ? attachableAgentsLoadable.data
+      : [];
+  const attachableAgentsLoading = attachableAgentsLoadable.state === "loading";
+  const attaching = attachLoadable.state === "loading";
+  const detaching = detachLoadable.state === "loading";
+  const busy = attaching || detaching;
+  const attachDisabled =
+    busy || attachableAgentsLoading || attachableAgents.length === 0;
+  const attachPlaceholder = attachableAgentsLoading
+    ? "Loading agents"
+    : attachableAgents.length === 0
+      ? "No agents available"
+      : "Attach agent";
+
   return (
     <div className="border-b border-border/70">
       <div className="flex h-9 items-center justify-between px-3">
         <span className="text-xs font-medium text-muted-foreground">
           Attached agents
         </span>
-        <span className="text-xs text-muted-foreground">{count}</span>
+        <span className="text-xs text-muted-foreground">
+          {workflow.attachedAgentCount}
+        </span>
       </div>
+      {workflow.canManage ? (
+        <div className="px-2 pb-2">
+          <Select
+            value=""
+            disabled={attachDisabled}
+            onValueChange={(agentId) => {
+              detach(attachAgent(agentId, pageSignal), Reason.DomCallback);
+            }}
+          >
+            <SelectTrigger
+              aria-label="Attach workflow to agent"
+              className="zero-btn-morandi h-8 w-full gap-1.5 rounded-md px-2 text-xs"
+            >
+              {attaching ? (
+                <IconLoader2 size={13} className="shrink-0 animate-spin" />
+              ) : (
+                <IconPlus size={13} stroke={1.5} className="shrink-0" />
+              )}
+              <SelectValue placeholder={attachPlaceholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {attachableAgents.map((agent) => {
+                return (
+                  <SelectItem key={agent.agentId} value={agent.agentId}>
+                    {agentTitle(agent)}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
       <div className="max-h-[180px] overflow-auto px-2 pb-2">
-        {agents.length > 0 ? (
+        {workflow.attachedAgents.length > 0 ? (
           <div className="flex flex-col gap-1">
-            {agents.map((agent) => {
+            {workflow.attachedAgents.map((agent) => {
+              const title = agentTitle(agent);
               return (
-                <Link
+                <div
                   key={agent.agentId}
-                  pathname={ROUTES.agentDetail}
-                  options={{ pathParams: { agentId: agent.agentId } }}
-                  className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                  className="flex min-w-0 items-center gap-1 rounded-md"
                 >
-                  <AgentAvatar agent={agent} />
-                  <span className="truncate">{agentTitle(agent)}</span>
-                </Link>
+                  <Link
+                    pathname={ROUTES.agentDetail}
+                    options={{ pathParams: { agentId: agent.agentId } }}
+                    className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                  >
+                    <AgentAvatar agent={agent} />
+                    <span className="truncate">{title}</span>
+                  </Link>
+                  {workflow.canManage ? (
+                    <button
+                      type="button"
+                      aria-label={`Detach workflow from ${title}`}
+                      disabled={busy}
+                      className={cn(
+                        "inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs text-muted-foreground transition-colors",
+                        busy
+                          ? "cursor-not-allowed opacity-60"
+                          : "hover:bg-accent hover:text-foreground",
+                      )}
+                      onClick={() => {
+                        detach(
+                          detachAgent(agent.agentId, pageSignal),
+                          Reason.DomCallback,
+                        );
+                      }}
+                    >
+                      {detaching ? (
+                        <IconLoader2 size={13} className="animate-spin" />
+                      ) : (
+                        <IconX size={13} stroke={1.5} />
+                      )}
+                      <span>Detach</span>
+                    </button>
+                  ) : null}
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
## Summary

- add workflow-detail controls for attaching and detaching configurable agents
- derive attachable agents from visible team agents while matching backend attachment permissions
- refresh workflow list/detail after attachment changes and cover the flow in workflow viewer tests

Closes #18063
Parent #18051

## Tests

- pnpm prettier --write apps/platform/src/signals/workflows-page/workflows-signals.ts apps/platform/src/views/workflows-page/workflows-page.tsx apps/platform/src/mocks/handlers/api-workflows.ts apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm check-types
- pnpm turbo run lint
- pnpm knip
- pnpm format
- git diff --check

## Local full-suite note

- pnpm vitest fails locally before touching this PR surface due unrelated local/environment drift: api computer-use tests fail because the local DB is missing computer_use_hosts.installation_id; pnpm -F @vm0/db db:migrate also fails because this local DB has already dropped zero_skills while migration history still tries to rename it. The same full run also reports unrelated Cloudflare generated-count expectations and migration 0443 expectation drift. The scoped workflow tests above pass.
