### PR TITLE
feat: rename slash suggestions to workflows

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -40,25 +40,27 @@ export const setComposerSavingType$ = command(
   },
 );
 
-// -- Slash skill picker -----------------------------------------------------
+// -- Slash workflow picker --------------------------------------------------
 
-const internalSlashSkillCaretIndex$ = state(0);
-export const slashSkillCaretIndex$ = computed((get) => {
-  return get(internalSlashSkillCaretIndex$);
+const internalSlashWorkflowCaretIndex$ = state(0);
+export const slashWorkflowCaretIndex$ = computed((get) => {
+  return get(internalSlashWorkflowCaretIndex$);
 });
-export const setSlashSkillCaretIndex$ = command(
+export const setSlashWorkflowCaretIndex$ = command(
   ({ set }, caretIndex: number) => {
-    set(internalSlashSkillCaretIndex$, caretIndex);
+    set(internalSlashWorkflowCaretIndex$, caretIndex);
   },
 );
 
-const internalSelectedSlashSkillIndex$ = state(0);
-export const selectedSlashSkillIndex$ = computed((get) => {
-  return get(internalSelectedSlashSkillIndex$);
+const internalSelectedSlashWorkflowIndex$ = state(0);
+export const selectedSlashWorkflowIndex$ = computed((get) => {
+  return get(internalSelectedSlashWorkflowIndex$);
 });
-export const setSelectedSlashSkillIndex$ = command(({ set }, index: number) => {
-  set(internalSelectedSlashSkillIndex$, index);
-});
+export const setSelectedSlashWorkflowIndex$ = command(
+  ({ set }, index: number) => {
+    set(internalSelectedSlashWorkflowIndex$, index);
+  },
+);
 
 // -- Add-connectors dialog search filter ------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -28,7 +28,7 @@ import {
   zeroAgentsByIdContract,
   zeroAgentInstructionsContract,
 } from "@vm0/api-contracts/contracts/zero-agents";
-import { zeroWorkflowsCollectionContract as zeroSkillsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-claude-code-device-auth";
 import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
@@ -49,6 +49,7 @@ import {
 const context = testContext();
 
 const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
+const OTHER_AGENT_ID = "e0000000-0000-4000-a000-000000000011";
 const THREAD_ID = "thread-model-template-1";
 const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const MOONSHOT_PROVIDER_ID = "00000000-0000-4000-a000-000000000002";
@@ -499,7 +500,7 @@ function composerElementFrom(textarea: HTMLElement): HTMLElement {
   return composer;
 }
 
-// The slash-skill composer renders a TipTap contenteditable instead of a
+// The slash-workflow composer renders a TipTap contenteditable instead of a
 // textarea, so locate it directly rather than by placeholder.
 async function findComposerEditor(): Promise<HTMLElement> {
   return await waitFor(() => {
@@ -539,19 +540,34 @@ function placeCaretAfterText(root: HTMLElement, text: string): void {
   throw new Error(`${text} text node not found`);
 }
 
-function workflowSummary(
-  name: string,
-  displayName: string | null,
-  description: string | null,
-) {
+function workflowSummary({
+  name,
+  displayName,
+  description,
+  attachedAgentIds = [],
+}: {
+  readonly name: string;
+  readonly displayName: string | null;
+  readonly description: string | null;
+  readonly attachedAgentIds?: readonly string[];
+}) {
   return {
     name,
     displayName,
     description,
     visibility: "public" as const,
     ownerUserId: "user-1",
-    attachedAgentCount: 0,
-    attachedAgents: [],
+    attachedAgentCount: attachedAgentIds.length,
+    attachedAgents: attachedAgentIds.map((agentId) => {
+      return {
+        agentId,
+        ownerId: "test-user-123",
+        displayName: agentId === AGENT_ID ? "Scout" : "Other Agent",
+        description: null,
+        avatarUrl: null,
+        visibility: "public" as const,
+      };
+    }),
     canManage: true,
   };
 }
@@ -561,23 +577,35 @@ beforeEach(() => {
 });
 
 describe("chat composer models", () => {
-  it("suggests current agent skills from slash input and highlights inserted skill tokens", async () => {
+  it("suggests current agent workflows from slash input and highlights inserted workflow tokens", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");
-    mockAgent({ customSkills: ["sales-research", "support-escalation"] });
-    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+    mockAgent({ customSkills: ["legacy-skill"] });
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
       return respond(200, [
-        workflowSummary(
-          "sales-research",
-          "Sales Research",
-          "Find account context before outreach",
-        ),
-        workflowSummary(
-          "support-escalation",
-          "Support Escalation",
-          "Summarize customer issues for handoff",
-        ),
-        workflowSummary("deep-dive", "Deep Dive", "Seeded org skill"),
+        workflowSummary({
+          name: "sales-research",
+          displayName: "Sales Research",
+          description: "Find account context before outreach",
+          attachedAgentIds: [AGENT_ID],
+        }),
+        workflowSummary({
+          name: "support-escalation",
+          displayName: "Support Escalation",
+          description: "Summarize customer issues for handoff",
+          attachedAgentIds: [AGENT_ID],
+        }),
+        workflowSummary({
+          name: "deep-dive",
+          displayName: "Deep Dive",
+          description: "Seeded org workflow",
+        }),
+        workflowSummary({
+          name: "other-agent-workflow",
+          displayName: "Other Agent Workflow",
+          description: "Attached somewhere else",
+          attachedAgentIds: [OTHER_AGENT_ID],
+        }),
       ]);
     });
 
@@ -595,10 +623,12 @@ describe("chat composer models", () => {
     expect(salesSuggestion).toBeInTheDocument();
     expect(screen.getByText("/support-escalation")).toBeInTheDocument();
     expect(screen.queryByText("/deep-dive")).not.toBeInTheDocument();
+    expect(screen.queryByText("/other-agent-workflow")).not.toBeInTheDocument();
+    expect(screen.queryByText("/legacy-skill")).not.toBeInTheDocument();
     // The menu renders in a Radix Popover portal (Floating UI handles
     // cross-browser placement), so it lives outside the composer element.
-    const slashSkillMenu = screen.getByTestId("slash-skill-menu");
-    expect(slashSkillMenu).toBeInTheDocument();
+    const slashWorkflowMenu = screen.getByTestId("slash-workflow-menu");
+    expect(slashWorkflowMenu).toBeInTheDocument();
 
     await user.keyboard("sales");
 
@@ -614,21 +644,31 @@ describe("chat composer models", () => {
     });
     // The colored token is a real inline decoration in the same layer as the
     // text (no overlay), so it stays aligned when the composer scrolls.
-    const highlightedSkill = screen
+    const highlightedWorkflow = screen
       .getAllByText("/sales-research")
       .find((element) => {
         return element.tagName.toLowerCase() === "span";
       });
-    expect(highlightedSkill).toHaveClass("text-primary");
+    expect(highlightedWorkflow).toHaveClass("text-primary");
   });
 
-  it("does not suggest org skills that are not enabled on the current agent", async () => {
+  it("does not suggest workflows that are not attached to the current agent", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent({ customSkills: [] });
-    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
       return respond(200, [
-        workflowSummary("deep-dive", "Deep Dive", "Seeded org skill"),
+        workflowSummary({
+          name: "deep-dive",
+          displayName: "Deep Dive",
+          description: "Seeded org workflow",
+        }),
+        workflowSummary({
+          name: "other-agent-workflow",
+          displayName: "Other Agent Workflow",
+          description: null,
+          attachedAgentIds: [OTHER_AGENT_ID],
+        }),
       ]);
     });
 
@@ -648,13 +688,17 @@ describe("chat composer models", () => {
     expect(editor.textContent).toContain("/");
   });
 
-  it("links to the skills page from the slash skill menu footer", async () => {
+  it("links to the workflows page from the slash workflow menu footer", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent({ customSkills: [] });
-    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
       return respond(200, [
-        workflowSummary("deep-dive", "Deep Dive", "Seeded org skill"),
+        workflowSummary({
+          name: "deep-dive",
+          displayName: "Deep Dive",
+          description: "Seeded org workflow",
+        }),
       ]);
     });
 
@@ -672,21 +716,26 @@ describe("chat composer models", () => {
     await user.keyboard("/");
 
     await expect(
-      screen.findByText("No matching skills"),
+      screen.findByText("No matching workflows"),
     ).resolves.toBeInTheDocument();
     expect(screen.queryByText("/deep-dive")).not.toBeInTheDocument();
-    const link = linkByText("View all skills");
-    expect(link).toHaveAttribute("href", "/skills");
+    const link = linkByText("View all workflows");
+    expect(link).toHaveAttribute("href", "/workflows");
     expect(link.parentElement).toHaveClass("shrink-0", "border-t");
   });
 
-  it("hides slash skill suggestions when the feature switch is off", async () => {
+  it("hides slash workflow suggestions when the feature switch is off", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");
-    mockAgent({ customSkills: ["sales-research"] });
-    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+    mockAgent({ customSkills: [] });
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
       return respond(200, [
-        workflowSummary("sales-research", "Sales Research", null),
+        workflowSummary({
+          name: "sales-research",
+          displayName: "Sales Research",
+          description: null,
+          attachedAgentIds: [AGENT_ID],
+        }),
       ]);
     });
 
@@ -704,7 +753,7 @@ describe("chat composer models", () => {
     expect(textarea).toHaveValue("/");
   });
 
-  it("scrolls the slash picker with keyboard selection", async () => {
+  it("scrolls the slash workflow picker with keyboard selection", async () => {
     const user = userEvent.setup({ delay: null });
     const scrollIntoView = vi.fn();
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
@@ -712,15 +761,20 @@ describe("chat composer models", () => {
       value: scrollIntoView,
     });
     mockOrgModelRoutes("kimi-k2.7-code");
-    const customSkills = Array.from({ length: 12 }, (_, index) => {
-      return `custom-skill-${index + 1}`;
+    const customWorkflows = Array.from({ length: 12 }, (_, index) => {
+      return `custom-workflow-${index + 1}`;
     });
-    mockAgent({ customSkills });
-    context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+    mockAgent({ customSkills: [] });
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
       return respond(
         200,
-        customSkills.map((name) => {
-          return workflowSummary(name, null, null);
+        customWorkflows.map((name) => {
+          return workflowSummary({
+            name,
+            displayName: null,
+            description: null,
+            attachedAgentIds: [AGENT_ID],
+          });
         }),
       );
     });
@@ -735,7 +789,7 @@ describe("chat composer models", () => {
     await user.click(editor);
     await user.keyboard("/");
     await expect(
-      screen.findByText("/custom-skill-1"),
+      screen.findByText("/custom-workflow-1"),
     ).resolves.toBeInTheDocument();
 
     await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}");
@@ -753,7 +807,7 @@ describe("chat composer models", () => {
       const user = userEvent.setup({ delay: null });
       mockOrgModelRoutes("kimi-k2.7-code");
       mockAgent({ customSkills: [] });
-      context.mocks.api(zeroSkillsCollectionContract.list, ({ respond }) => {
+      context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
         return respond(200, []);
       });
 

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -1,30 +1,28 @@
-// Slash-skill domain helpers and the suggestion menu, shared by the chat
+// Slash-workflow domain helpers and the suggestion menu, shared by the chat
 // composer. Kept in its own module so the textarea composer and the TipTap
-// skill composer can both reuse them without an import cycle.
+// workflow composer can both reuse them without an import cycle.
 import { IconChevronRight, IconFileText } from "@tabler/icons-react";
+import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
 import { cn, PopoverContent } from "@vm0/ui";
 import { Link } from "../router/link.tsx";
 
-interface ZeroAgentCustomSkill {
-  readonly name: string;
-  readonly displayName: string | null;
-  readonly description: string | null;
-}
-
-export interface SlashSkillRange {
+export interface SlashWorkflowRange {
   readonly start: number;
   readonly end: number;
   readonly query: string;
 }
 
-export interface ComposerSlashSkill extends ZeroAgentCustomSkill {
+export interface ComposerSlashWorkflow {
+  readonly name: string;
+  readonly displayName: string | null;
+  readonly description: string | null;
   readonly token: string;
 }
 
-export function findActiveSlashSkillRange(
+export function findActiveSlashWorkflowRange(
   value: string,
   caretIndex: number,
-): SlashSkillRange | null {
+): SlashWorkflowRange | null {
   const beforeCaret = value.slice(0, caretIndex);
   const match = /(?:^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);
   if (!match) {
@@ -37,8 +35,8 @@ export function findActiveSlashSkillRange(
   return { start, end: caretIndex, query };
 }
 
-export function matchesSkillQuery(
-  skill: ComposerSlashSkill,
+export function matchesWorkflowQuery(
+  workflow: ComposerSlashWorkflow,
   query: string,
 ): boolean {
   if (!query) {
@@ -46,79 +44,86 @@ export function matchesSkillQuery(
   }
 
   const normalizedQuery = query.toLowerCase();
-  return [skill.name, skill.displayName ?? "", skill.description ?? ""]
+  return [workflow.name, workflow.displayName ?? "", workflow.description ?? ""]
     .join(" ")
     .toLowerCase()
     .includes(normalizedQuery);
 }
 
-export function skillTokenPattern(
-  skillNames: readonly string[],
+export function workflowTokenPattern(
+  workflowNames: readonly string[],
 ): RegExp | null {
-  if (skillNames.length === 0) {
+  if (workflowNames.length === 0) {
     return null;
   }
 
-  const escaped = skillNames.map((name) => {
+  const escaped = workflowNames.map((name) => {
     return name.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
   });
   return new RegExp(`/(?:${escaped.join("|")})(?=$|\\s)`, "g");
 }
 
-export function buildComposerSlashSkills({
-  agentSkillNames,
-  orgSkills,
+export function buildComposerSlashWorkflows({
+  agentId,
+  workflows,
 }: {
-  readonly agentSkillNames: readonly string[];
-  readonly orgSkills: readonly ZeroAgentCustomSkill[];
-}): readonly ComposerSlashSkill[] {
-  const metadataByName = new Map(
-    orgSkills.map((skill) => {
-      return [skill.name, skill];
-    }),
-  );
-  return agentSkillNames.map((name) => {
-    const metadata = metadataByName.get(name);
-    return {
-      name,
-      displayName: metadata?.displayName ?? null,
-      description: metadata?.description ?? null,
-      token: `/${name}`,
-    };
-  });
+  readonly agentId: string | null | undefined;
+  readonly workflows: readonly ZeroWorkflowSummary[];
+}): readonly ComposerSlashWorkflow[] {
+  if (!agentId) {
+    return [];
+  }
+
+  return workflows
+    .filter((workflow) => {
+      return workflow.attachedAgents.some((agent) => {
+        return agent.agentId === agentId;
+      });
+    })
+    .map((workflow) => {
+      const name = workflow.name;
+      return {
+        name,
+        displayName: workflow.displayName,
+        description: workflow.description,
+        token: `/${name}`,
+      };
+    });
 }
 
-function slashSkillOptionId(skillName: string): string {
-  return `slash-skill-option-${skillName}`;
+function slashWorkflowOptionId(workflowName: string): string {
+  return `slash-workflow-option-${workflowName}`;
 }
 
-export function scrollSlashSkillIntoView(
-  skill: ComposerSlashSkill | undefined,
+export function scrollSlashWorkflowIntoView(
+  workflow: ComposerSlashWorkflow | undefined,
 ): void {
-  if (!skill) {
+  if (!workflow) {
     return;
   }
 
   window.requestAnimationFrame(() => {
-    const option = document.getElementById(slashSkillOptionId(skill.name));
+    const option = document.getElementById(
+      slashWorkflowOptionId(workflow.name),
+    );
     if (option && typeof option.scrollIntoView === "function") {
       option.scrollIntoView({ block: "nearest" });
     }
   });
 }
 
-export function SlashSkillMenu({
-  skills,
+export function SlashWorkflowMenu({
+  workflows,
   loading,
   selectedIndex,
-  showSkillsPageLink,
+  showWorkflowsPageLink,
   onSelect,
 }: {
-  readonly skills: readonly ComposerSlashSkill[];
+  readonly workflows: readonly ComposerSlashWorkflow[];
   readonly loading: boolean;
   readonly selectedIndex: number;
-  readonly showSkillsPageLink: boolean;
-  readonly onSelect: (skill: ComposerSlashSkill) => void;
+  readonly showWorkflowsPageLink: boolean;
+  readonly onSelect: (workflow: ComposerSlashWorkflow) => void;
 }) {
   return (
     <PopoverContent
@@ -132,23 +137,23 @@ export function SlashSkillMenu({
         event.preventDefault();
       }}
       className="flex max-h-80 w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0"
-      data-testid="slash-skill-menu"
+      data-testid="slash-workflow-menu"
     >
       <div className="px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">
-        Skills
+        Workflows
       </div>
       {loading ? (
         <div className="px-2.5 py-2 text-sm text-muted-foreground">
-          Loading skills...
+          Loading workflows...
         </div>
-      ) : skills.length > 0 ? (
+      ) : workflows.length > 0 ? (
         <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
-          {skills.map((skill, index) => {
+          {workflows.map((workflow, index) => {
             const selected = index === selectedIndex;
             return (
               <button
-                id={slashSkillOptionId(skill.name)}
-                key={skill.name}
+                id={slashWorkflowOptionId(workflow.name)}
+                key={workflow.name}
                 type="button"
                 className={cn(
                   "flex w-full items-center rounded px-2 py-1.5 text-left transition-colors",
@@ -156,11 +161,11 @@ export function SlashSkillMenu({
                 )}
                 onMouseDown={(event) => {
                   event.preventDefault();
-                  onSelect(skill);
+                  onSelect(workflow);
                 }}
               >
                 <span className="truncate font-mono text-sm text-primary">
-                  {skill.token}
+                  {workflow.token}
                 </span>
               </button>
             );
@@ -168,13 +173,13 @@ export function SlashSkillMenu({
         </div>
       ) : (
         <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
-          No matching skills
+          No matching workflows
         </div>
       )}
-      {showSkillsPageLink && (
+      {showWorkflowsPageLink && (
         <div className="shrink-0 border-t border-border/60 bg-popover/95 p-1.5">
           <Link
-            pathname="/skills"
+            pathname="/workflows"
             className="flex h-9 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-accent"
           >
             <span className="flex min-w-0 items-center gap-2">
@@ -183,7 +188,7 @@ export function SlashSkillMenu({
                 stroke={1.8}
                 className="shrink-0 text-muted-foreground"
               />
-              <span className="truncate">View all skills</span>
+              <span className="truncate">View all workflows</span>
             </span>
             <IconChevronRight
               size={16}

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -1,4 +1,4 @@
-// TipTap-based chat composer input. Skill mentions are colored with ProseMirror
+// TipTap-based chat composer input. Workflow mentions are colored with ProseMirror
 // inline decorations rather than a transparent-textarea + colored overlay, so the
 // color lives in the same layer as the text and moves/scrolls with it — there is
 // no second layer to keep aligned when the input scrolls (issue #17539).
@@ -17,24 +17,24 @@ import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { Popover, PopoverAnchor, type KeyboardEventLike } from "@vm0/ui";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { currentChatAgent$ } from "../../signals/agent-chat.ts";
+import { currentChatAgentRecordId$ } from "../../signals/agent-chat.ts";
 import { orgWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
 import {
-  slashSkillCaretIndex$,
-  setSlashSkillCaretIndex$,
-  selectedSlashSkillIndex$,
-  setSelectedSlashSkillIndex$,
+  slashWorkflowCaretIndex$,
+  setSlashWorkflowCaretIndex$,
+  selectedSlashWorkflowIndex$,
+  setSelectedSlashWorkflowIndex$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
 import {
-  buildComposerSlashSkills,
-  findActiveSlashSkillRange,
-  matchesSkillQuery,
-  scrollSlashSkillIntoView,
-  skillTokenPattern,
-  SlashSkillMenu,
-  type ComposerSlashSkill,
-  type SlashSkillRange,
-} from "./slash-skill.tsx";
+  buildComposerSlashWorkflows,
+  findActiveSlashWorkflowRange,
+  matchesWorkflowQuery,
+  scrollSlashWorkflowIntoView,
+  workflowTokenPattern,
+  SlashWorkflowMenu,
+  type ComposerSlashWorkflow,
+  type SlashWorkflowRange,
+} from "./slash-workflow.tsx";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 
 // Match the textarea metrics so swapping inputs is visually seamless. The editor
@@ -45,10 +45,10 @@ const EDITOR_CONTENT_CLASS =
   "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
   "selection:bg-primary/20";
 
-const SKILL_HIGHLIGHT_CLASS = "text-primary";
+const WORKFLOW_HIGHLIGHT_CLASS = "text-primary";
 
-// Plain text -> document: one paragraph per line. Skill coloring is applied by
-// the decoration plugin, so the document stays plain text.
+// Plain text -> document: one paragraph per line. Workflow coloring is applied
+// by the decoration plugin, so the document stays plain text.
 function valueToDoc(value: string): JSONContent {
   const content: JSONContent[] = value.split("\n").map((line) => {
     return line.length > 0
@@ -80,11 +80,11 @@ function caretStringIndex(editor: Editor): number {
   }).length;
 }
 
-function buildSkillDecorations(
+function buildWorkflowDecorations(
   doc: ProseMirrorNode,
-  skillNames: readonly string[],
+  workflowNames: readonly string[],
 ): DecorationSet {
-  const pattern = skillTokenPattern(skillNames);
+  const pattern = workflowTokenPattern(workflowNames);
   if (!pattern) {
     return DecorationSet.empty;
   }
@@ -98,7 +98,7 @@ function buildSkillDecorations(
       const start = pos + (match.index ?? 0);
       decorations.push(
         Decoration.inline(start, start + match[0].length, {
-          class: SKILL_HIGHLIGHT_CLASS,
+          class: WORKFLOW_HIGHLIGHT_CLASS,
         }),
       );
     }
@@ -106,32 +106,32 @@ function buildSkillDecorations(
   return DecorationSet.create(doc, decorations);
 }
 
-interface SkillHighlightStorage {
-  skillNames: readonly string[];
+interface WorkflowHighlightStorage {
+  workflowNames: readonly string[];
 }
 
-// Colors `/skill` tokens via inline decorations. The skill list is read from
+// Colors `/workflow` tokens via inline decorations. The workflow list is read from
 // mutable storage (kept current by the component) so the editor never has to be
 // rebuilt when the list loads or changes.
-const SkillHighlight = Extension.create<
-  { skillNames: readonly string[] },
-  SkillHighlightStorage
+const WorkflowHighlight = Extension.create<
+  { workflowNames: readonly string[] },
+  WorkflowHighlightStorage
 >({
-  name: "skillHighlight",
+  name: "workflowHighlight",
   addOptions() {
-    return { skillNames: [] };
+    return { workflowNames: [] };
   },
   addStorage() {
-    return { skillNames: this.options.skillNames };
+    return { workflowNames: this.options.workflowNames };
   },
   addProseMirrorPlugins() {
     const storage = this.storage;
     return [
       new Plugin({
-        key: new PluginKey("skillHighlight"),
+        key: new PluginKey("workflowHighlight"),
         props: {
           decorations(state: EditorState) {
-            return buildSkillDecorations(state.doc, storage.skillNames);
+            return buildWorkflowDecorations(state.doc, storage.workflowNames);
           },
         },
       }),
@@ -247,22 +247,22 @@ function insertPlainTextLineBreak(
 
 // Replace the active `/query` text with the chosen token (reusing the space that
 // already follows the query, or appending one). The caret is moved past that
-// space so the inserted `/skill` reads as a finished token: typing the next word
+// space so the inserted `/workflow` reads as a finished token: typing the next word
 // can't merge into it, and — since menu visibility is a pure function of the
 // caret position — `beforeCaret` no longer ends in a live `/token`, so the menu
-// closes. Without this, selecting a skill when text already follows the query
+// closes. Without this, selecting a workflow when text already follows the query
 // left the caret between the token and its space, keeping the menu open. The
 // decoration plugin colors the token automatically.
-function insertSkillToken(
+function insertWorkflowToken(
   editor: Editor,
-  slashRange: SlashSkillRange,
+  slashRange: SlashWorkflowRange,
   input: string,
-  skill: ComposerSlashSkill,
+  workflow: ComposerSlashWorkflow,
 ): void {
   const head = editor.state.selection.head;
   const span = slashRange.end - slashRange.start;
   const from = head - span;
-  const token = `/${skill.name}`;
+  const token = `/${workflow.name}`;
   const suffix = input.slice(slashRange.end).startsWith(" ") ? "" : " ";
   editor
     .chain()
@@ -286,7 +286,7 @@ interface SlashCaretPosition {
 
 function slashCaretPosition(
   editor: Editor,
-  slashRange: SlashSkillRange,
+  slashRange: SlashWorkflowRange,
 ): SlashCaretPosition {
   const slashPos = Math.max(
     editor.state.selection.head - (slashRange.end - slashRange.start),
@@ -308,7 +308,7 @@ function SlashCaretAnchor({
   slashRange,
 }: {
   readonly editor: Editor | null;
-  readonly slashRange: SlashSkillRange | null;
+  readonly slashRange: SlashWorkflowRange | null;
 }) {
   const caret =
     editor && slashRange ? slashCaretPosition(editor, slashRange) : null;
@@ -329,11 +329,11 @@ function SlashCaretAnchor({
 }
 
 interface SlashMenuKeyContext {
-  readonly suggestions: readonly ComposerSlashSkill[];
+  readonly suggestions: readonly ComposerSlashWorkflow[];
   readonly selectedIndex: number;
   readonly setSelectedIndex: (index: number) => void;
   readonly setCaretIndex: (index: number) => void;
-  readonly onInsert: (skill: ComposerSlashSkill) => void;
+  readonly onInsert: (workflow: ComposerSlashWorkflow) => void;
 }
 
 // Drives the suggestion menu from the keyboard. Returns true when it consumes the
@@ -349,22 +349,22 @@ function handleSlashMenuKey(
       Math.max(ctx.suggestions.length - 1, 0),
     );
     ctx.setSelectedIndex(next);
-    scrollSlashSkillIntoView(ctx.suggestions[next]);
+    scrollSlashWorkflowIntoView(ctx.suggestions[next]);
     return true;
   }
   if (event.key === "ArrowUp") {
     event.preventDefault();
     const next = Math.max(ctx.selectedIndex - 1, 0);
     ctx.setSelectedIndex(next);
-    scrollSlashSkillIntoView(ctx.suggestions[next]);
+    scrollSlashWorkflowIntoView(ctx.suggestions[next]);
     return true;
   }
   if ((event.key === "Enter" || event.key === "Tab") && ctx.suggestions[0]) {
     event.preventDefault();
-    const skill =
+    const workflow =
       ctx.suggestions[Math.min(ctx.selectedIndex, ctx.suggestions.length - 1)];
-    if (skill) {
-      ctx.onInsert(skill);
+    if (workflow) {
+      ctx.onInsert(workflow);
     }
     return true;
   }
@@ -378,12 +378,12 @@ function handleSlashMenuKey(
 
 interface EditorOptionsParams {
   readonly input: string;
-  readonly skillNames: readonly string[];
+  readonly workflowNames: readonly string[];
   readonly autoFocus: boolean | undefined;
   readonly onInputChange: (value: string) => void;
   readonly onPaste: (event: ComposerPasteEvent) => void;
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
-  readonly setSelectedSkillIndex: (index: number) => void;
+  readonly setSelectedWorkflowIndex: (index: number) => void;
   readonly setCaretIndex: (index: number) => void;
   readonly onEditorKeyDown: (event: KeyboardEvent) => boolean;
 }
@@ -396,7 +396,7 @@ function buildEditorOptions(
   return {
     extensions: [
       STARTER_KIT,
-      SkillHighlight.configure({ skillNames: params.skillNames }),
+      WorkflowHighlight.configure({ workflowNames: params.workflowNames }),
     ],
     content: valueToDoc(params.input),
     autofocus: params.autoFocus && !isIOS() ? "end" : false,
@@ -422,7 +422,7 @@ function buildEditorOptions(
       if (value !== params.input) {
         params.onInputChange(value);
       }
-      params.setSelectedSkillIndex(0);
+      params.setSelectedWorkflowIndex(0);
       params.setCaretIndex(caretStringIndex(editor));
     },
     onSelectionUpdate: ({ editor }) => {
@@ -437,40 +437,31 @@ function buildEditorOptions(
   };
 }
 
-// Keep the highlight plugin's skill list current without rebuilding the editor
+// Keep the highlight plugin's workflow list current without rebuilding the editor
 // (decorations recompute on the next transaction), and reconcile the value when it
 // changes outside of typing (draft restore, the send-clear, template insertion).
 // Guarded so typing — where the serialized value already matches — never resets the
 // caret. shouldRerenderOnTransaction is off, so this never triggers a React re-render.
 function syncEditorState(
   editor: Editor,
-  skillNames: readonly string[],
+  workflowNames: readonly string[],
   input: string,
 ): void {
   const storage = (
     editor.storage as unknown as Record<
       string,
-      SkillHighlightStorage | undefined
+      WorkflowHighlightStorage | undefined
     >
-  ).skillHighlight;
+  ).workflowHighlight;
   if (storage) {
-    storage.skillNames = skillNames;
+    storage.workflowNames = workflowNames;
   }
   if (docToString(editor) !== input) {
     editor.commands.setContent(valueToDoc(input), { emitUpdate: false });
   }
 }
 
-export function TiptapSkillComposer({
-  input,
-  onInputChange,
-  onDraftChange,
-  sending,
-  autoFocus,
-  setInputRef,
-  onKeyDown,
-  onPaste,
-}: {
+interface TiptapWorkflowComposerProps {
   readonly input: string;
   readonly onInputChange: (value: string) => void;
   readonly onDraftChange: (() => void) | undefined;
@@ -479,48 +470,59 @@ export function TiptapSkillComposer({
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
   readonly onKeyDown: (event: KeyboardEventLike) => void;
   readonly onPaste: (event: ComposerPasteEvent) => void;
-}) {
-  const caretIndex = useGet(slashSkillCaretIndex$);
-  const setCaretIndex = useSet(setSlashSkillCaretIndex$);
-  const selectedSkillIndex = useGet(selectedSlashSkillIndex$);
-  const setSelectedSkillIndex = useSet(setSelectedSlashSkillIndex$);
-  const currentAgent = useLastResolved(currentChatAgent$);
+}
+
+export function TiptapWorkflowComposer({
+  input,
+  onInputChange,
+  onDraftChange,
+  sending,
+  autoFocus,
+  setInputRef,
+  onKeyDown,
+  onPaste,
+}: TiptapWorkflowComposerProps) {
+  const caretIndex = useGet(slashWorkflowCaretIndex$);
+  const setCaretIndex = useSet(setSlashWorkflowCaretIndex$);
+  const selectedWorkflowIndex = useGet(selectedSlashWorkflowIndex$);
+  const setSelectedWorkflowIndex = useSet(setSelectedSlashWorkflowIndex$);
+  const currentAgentId = useLastResolved(currentChatAgentRecordId$);
   const features = useLastResolved(featureSwitch$);
-  const orgSkillsLoadable = useLastLoadable(orgWorkflows$);
-  const orgSkillsData =
-    orgSkillsLoadable.state === "hasData" ? orgSkillsLoadable.data : [];
-  const composerSkills = buildComposerSlashSkills({
-    agentSkillNames: currentAgent?.customSkills ?? [],
-    orgSkills: orgSkillsData,
+  const orgWorkflowsLoadable = useLastLoadable(orgWorkflows$);
+  const orgWorkflowsData =
+    orgWorkflowsLoadable.state === "hasData" ? orgWorkflowsLoadable.data : [];
+  const composerWorkflows = buildComposerSlashWorkflows({
+    agentId: currentAgentId,
+    workflows: orgWorkflowsData,
   });
-  const skillNames = composerSkills.map((skill) => {
-    return skill.name;
+  const workflowNames = composerWorkflows.map((workflow) => {
+    return workflow.name;
   });
 
-  const slashRange = findActiveSlashSkillRange(input, caretIndex);
+  const slashRange = findActiveSlashWorkflowRange(input, caretIndex);
   const suggestions = slashRange
-    ? composerSkills.filter((skill) => {
-        return matchesSkillQuery(skill, slashRange.query);
+    ? composerWorkflows.filter((workflow) => {
+        return matchesWorkflowQuery(workflow, slashRange.query);
       })
     : [];
-  const isLoadingOrgSkills = orgSkillsLoadable.state === "loading";
-  const showSkillsPageLink =
+  const isLoadingOrgWorkflows = orgWorkflowsLoadable.state === "loading";
+  const showWorkflowsPageLink =
     features?.[FeatureSwitchKey.WorkflowsViewer] ?? false;
-  const showSlashSkillMenu =
+  const showSlashWorkflowMenu =
     slashRange !== null &&
-    (isLoadingOrgSkills || composerSkills.length > 0 || showSkillsPageLink);
+    (isLoadingOrgWorkflows ||
+      composerWorkflows.length > 0 ||
+      showWorkflowsPageLink);
 
-  // Created once; useEditor refreshes its options via setOptions on every render,
-  // so the handlers always close over the latest props/state (no refs needed).
   const editor = useEditor(
     buildEditorOptions({
       input,
-      skillNames,
+      workflowNames,
       autoFocus,
       onInputChange,
       onPaste,
       setInputRef,
-      setSelectedSkillIndex,
+      setSelectedWorkflowIndex,
       setCaretIndex,
       onEditorKeyDown: (event) => {
         return handleEditorKeyDown(event);
@@ -529,14 +531,14 @@ export function TiptapSkillComposer({
   );
 
   if (editor) {
-    syncEditorState(editor, skillNames, input);
+    syncEditorState(editor, workflowNames, input);
   }
 
-  function insertSkill(skill: ComposerSlashSkill): void {
+  function insertWorkflow(workflow: ComposerSlashWorkflow): void {
     if (!editor || !slashRange) {
       return;
     }
-    insertSkillToken(editor, slashRange, input, skill);
+    insertWorkflowToken(editor, slashRange, input, workflow);
     onDraftChange?.();
   }
 
@@ -556,13 +558,13 @@ export function TiptapSkillComposer({
     }
 
     if (
-      showSlashSkillMenu &&
+      showSlashWorkflowMenu &&
       handleSlashMenuKey(event, {
         suggestions,
-        selectedIndex: selectedSkillIndex,
-        setSelectedIndex: setSelectedSkillIndex,
+        selectedIndex: selectedWorkflowIndex,
+        setSelectedIndex: setSelectedWorkflowIndex,
         setCaretIndex,
-        onInsert: insertSkill,
+        onInsert: insertWorkflow,
       })
     ) {
       return true;
@@ -579,7 +581,7 @@ export function TiptapSkillComposer({
     // a zero-size element pinned to the slash the user typed (viewport coords from
     // ProseMirror), so the menu opens at the `/` rather than a fixed corner. `open`
     // is fully controlled by composer state, so Escape/typing close it.
-    <Popover open={showSlashSkillMenu}>
+    <Popover open={showSlashWorkflowMenu}>
       <SlashCaretAnchor editor={editor} slashRange={slashRange} />
       <div className="relative min-h-[96px]">
         {input === "" && (
@@ -594,14 +596,14 @@ export function TiptapSkillComposer({
         )}
         <EditorContent editor={editor} />
       </div>
-      {showSlashSkillMenu && (
-        <SlashSkillMenu
-          skills={suggestions}
-          loading={isLoadingOrgSkills}
-          selectedIndex={selectedSkillIndex}
-          showSkillsPageLink={showSkillsPageLink}
-          onSelect={(skill) => {
-            insertSkill(skill);
+      {showSlashWorkflowMenu && (
+        <SlashWorkflowMenu
+          workflows={suggestions}
+          loading={isLoadingOrgWorkflows}
+          selectedIndex={selectedWorkflowIndex}
+          showWorkflowsPageLink={showWorkflowsPageLink}
+          onSelect={(workflow) => {
+            insertWorkflow(workflow);
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -97,7 +97,7 @@ import type {
   PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { AttachmentChips } from "./zero-attachment-chips.tsx";
-import { TiptapSkillComposer } from "./tiptap-skill-composer.tsx";
+import { TiptapWorkflowComposer } from "./tiptap-workflow-composer.tsx";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
@@ -3289,12 +3289,12 @@ function ComposerInputSlot({
   readonly onPaste: (e: ComposerPasteEvent) => void;
 }) {
   const features = useLastResolved(featureSwitch$);
-  const slashSkillCommandsEnabled =
+  const slashWorkflowCommandsEnabled =
     features?.[FeatureSwitchKey.ChatSlashWorkflowCommands] ?? false;
 
-  if (slashSkillCommandsEnabled) {
+  if (slashWorkflowCommandsEnabled) {
     return (
-      <TiptapSkillComposer
+      <TiptapWorkflowComposer
         input={input}
         onInputChange={onInputChange}
         onDraftChange={onDraftChange}


### PR DESCRIPTION
Closes #18064

## Summary
- rename the TipTap slash suggestion composer/helpers from skill terminology to workflow terminology
- source slash suggestions from visible workflows attached to the current agent instead of `currentAgent.customSkills`
- update the slash menu copy, test id, and footer link to point at `/workflows`

## Validation
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm check-types`
- `pnpm turbo run lint`
- `pnpm knip`
- `pnpm format`
- `git diff --check`