### PR TITLE
feat(guest-agent): add claude active input support

### DIFF
--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -1,6 +1,6 @@
 //! Guest-agent local active-input state for Claude stream-json stdin.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use serde::Deserialize;
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 const ACTIVE_INPUT_TYPE: &str = "active-input";
 const ACTIVE_INPUT_QUEUE_CAPACITY: usize = 8;
+const ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActiveInputFrame {
@@ -66,6 +67,7 @@ struct ActiveInputState {
     initial_prompt_replay_seen: bool,
     observed_result: bool,
     seen_message_ids: HashSet<String>,
+    seen_message_id_order: VecDeque<String>,
     pending_by_uuid: HashMap<String, PendingInput>,
 }
 
@@ -76,12 +78,43 @@ impl Default for ActiveInputState {
             initial_prompt_replay_seen: false,
             observed_result: false,
             seen_message_ids: HashSet::new(),
+            seen_message_id_order: VecDeque::new(),
             pending_by_uuid: HashMap::new(),
         }
     }
 }
 
 impl ActiveInputState {
+    fn has_seen_message_id(&self, message_id: &str) -> bool {
+        self.seen_message_ids.contains(message_id)
+    }
+
+    fn remember_message_id(&mut self, message_id: String) {
+        if !self.seen_message_ids.insert(message_id.clone()) {
+            return;
+        }
+        self.seen_message_id_order.push_back(message_id);
+        while self.seen_message_ids.len() > ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY {
+            let Some(oldest) = self.seen_message_id_order.pop_front() else {
+                break;
+            };
+            self.seen_message_ids.remove(&oldest);
+        }
+    }
+
+    fn forget_message_id(&mut self, message_id: &str) {
+        if !self.seen_message_ids.remove(message_id) {
+            return;
+        }
+        if let Some(index) = self
+            .seen_message_id_order
+            .iter()
+            .position(|seen| seen == message_id)
+        {
+            self.seen_message_id_order.remove(index);
+        }
+    }
+
     fn remove_pending_by_uuid(&mut self, uuid: &str) -> bool {
         self.pending_by_uuid.remove(uuid).is_some()
     }
@@ -298,7 +331,7 @@ impl ActiveInputController {
                 diagnostic: "active input is closed",
             };
         }
-        if state.seen_message_ids.contains(message_id) {
+        if state.has_seen_message_id(message_id) {
             return ActiveInputControlOutcome::Rejected {
                 diagnostic: "active input message id is duplicate",
             };
@@ -309,7 +342,7 @@ impl ActiveInputController {
             };
         }
 
-        state.seen_message_ids.insert(message_id.to_owned());
+        state.remember_message_id(message_id.to_owned());
         state.pending_by_uuid.insert(
             uuid.clone(),
             PendingInput {
@@ -321,14 +354,14 @@ impl ActiveInputController {
         match self.inner.tx.try_send(frame) {
             Ok(()) => ActiveInputControlOutcome::Accepted,
             Err(mpsc::error::TrySendError::Full(frame)) => {
-                state.seen_message_ids.remove(&frame.message_id);
+                state.forget_message_id(&frame.message_id);
                 state.pending_by_uuid.remove(&frame.uuid);
                 ActiveInputControlOutcome::Rejected {
                     diagnostic: "active input queue is full",
                 }
             }
             Err(mpsc::error::TrySendError::Closed(frame)) => {
-                state.seen_message_ids.remove(&frame.message_id);
+                state.forget_message_id(&frame.message_id);
                 state.pending_by_uuid.remove(&frame.uuid);
                 state.lifecycle = Lifecycle::Closed;
                 ActiveInputControlOutcome::Rejected {
@@ -551,6 +584,70 @@ mod tests {
             controller.handle_control_payload("overflow", br#"{"type":"active-input","text":"hello"}"#),
             ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input queue is full"
         ));
+    }
+
+    #[tokio::test]
+    async fn active_input_bounds_seen_message_id_cache() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        let mut writer = runtime.into_writer();
+
+        for index in 0..=ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY {
+            let message_id = format!("msg-{index}");
+            let text = format!("follow-up-{index}");
+            let payload = serde_json::to_vec(&json!({
+                "type": ACTIVE_INPUT_TYPE,
+                "text": &text,
+            }))
+            .expect("active input payload should serialize");
+            assert_eq!(
+                controller.handle_control_payload(&message_id, &payload),
+                ActiveInputControlOutcome::Accepted
+            );
+            let frame = writer
+                .next_frame()
+                .await
+                .expect("active input frame should be queued");
+            assert_eq!(frame.message_id, message_id);
+
+            let active = json!({
+                "type": "user",
+                "uuid": frame.uuid,
+                "message": {"role": "user", "content": text}
+            });
+            assert_eq!(
+                controller.replay_user_event_action(&active),
+                ReplayUserEventAction::InternalActiveInput
+            );
+        }
+
+        let state = controller
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert_eq!(
+            state.seen_message_ids.len(),
+            ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY
+        );
+        assert!(!state.has_seen_message_id("msg-0"));
+        assert!(
+            state.has_seen_message_id(&format!("msg-{}", ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY))
+        );
+        drop(state);
+
+        assert!(matches!(
+            controller.handle_control_payload(
+                &format!("msg-{}", ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY),
+                br#"{"type":"active-input","text":"duplicate"}"#
+            ),
+            ActiveInputControlOutcome::Rejected { diagnostic }
+                if diagnostic == "active input message id is duplicate"
+        ));
+        assert_eq!(
+            controller.handle_control_payload("msg-0", br#"{"type":"active-input","text":"old"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -118,6 +118,23 @@ fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
     .to_string()
 }
 
+fn is_prompt_like_user_content(event: &Value) -> bool {
+    let Some(content) = event.pointer("/message/content") else {
+        return false;
+    };
+    if content.as_str().is_some() {
+        return true;
+    }
+    let Some(items) = content.as_array() else {
+        return false;
+    };
+
+    !items.is_empty()
+        && items
+            .iter()
+            .all(|item| item.get("type").and_then(Value::as_str) != Some("tool_result"))
+}
+
 impl ActiveInputRuntime {
     pub fn new(run_id: &str, enabled: bool) -> Self {
         let (tx, rx) = mpsc::channel(ACTIVE_INPUT_QUEUE_CAPACITY);
@@ -289,11 +306,7 @@ impl ActiveInputController {
             }
         }
 
-        if event
-            .pointer("/message/content")
-            .and_then(Value::as_str)
-            .is_some()
-        {
+        if is_prompt_like_user_content(event) {
             return ReplayUserEventAction::UnknownPromptUser;
         }
 
@@ -509,5 +522,22 @@ mod tests {
             ReplayUserEventAction::InternalActiveInput
         );
         assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_treats_text_block_user_events_without_uuid_as_unknown_prompt() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let event = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "follow-up"}]
+            }
+        });
+
+        assert_eq!(
+            runtime.controller().replay_user_event_action(&event),
+            ReplayUserEventAction::UnknownPromptUser
+        );
     }
 }

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -47,6 +47,13 @@ enum PendingState {
     Written,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplayEventUuid<'a> {
+    Missing,
+    String(&'a str),
+    NonString,
+}
+
 #[derive(Debug)]
 struct PendingInput {
     state: PendingState,
@@ -166,6 +173,14 @@ fn user_message_role_allows_replay(event: &Value) -> bool {
 
 fn parent_tool_use_allows_replay(event: &Value) -> bool {
     matches!(event.get("parent_tool_use_id"), Some(Value::Null) | None)
+}
+
+fn replay_event_uuid(event: &Value) -> ReplayEventUuid<'_> {
+    match event.get("uuid") {
+        Some(Value::String(uuid)) => ReplayEventUuid::String(uuid),
+        Some(_) => ReplayEventUuid::NonString,
+        None => ReplayEventUuid::Missing,
+    }
 }
 
 fn prompt_like_user_content(event: &Value) -> Option<String> {
@@ -381,8 +396,8 @@ impl ActiveInputController {
             return ReplayUserEventAction::External;
         }
 
-        let event_uuid = event.get("uuid").and_then(Value::as_str);
-        if let Some(uuid) = event_uuid {
+        let event_uuid = replay_event_uuid(event);
+        if let ReplayEventUuid::String(uuid) = event_uuid {
             if uuid == self.inner.initial_prompt_uuid {
                 let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
                 state.initial_prompt_replay_seen = true;
@@ -397,7 +412,7 @@ impl ActiveInputController {
 
         if let Some(text) = prompt_like_user_content(event) {
             let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-            if event_uuid.is_none() {
+            if event_uuid == ReplayEventUuid::Missing {
                 if state.remove_replayable_pending_by_text(&text) {
                     return ReplayUserEventAction::InternalActiveInput;
                 }
@@ -865,6 +880,42 @@ mod tests {
     }
 
     #[test]
+    fn replay_filter_does_not_consume_text_match_with_non_string_uuid() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+        assert!(!controller.close_for_result_if_idle());
+
+        for uuid in [json!(123), Value::Null] {
+            let event = json!({
+                "type": "user",
+                "uuid": uuid,
+                "message": {"role": "user", "content": "follow-up"}
+            });
+            assert_eq!(
+                controller.replay_user_event_action(&event),
+                ReplayUserEventAction::UnknownPromptUser
+            );
+        }
+
+        let uuidless = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&uuidless),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
     fn replay_filter_does_not_unlock_initial_prompt_from_unknown_uuid() {
         let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
@@ -903,6 +954,57 @@ mod tests {
         assert_eq!(
             controller.replay_user_event_action(&initial),
             ReplayUserEventAction::InternalInitialPrompt
+        );
+
+        let active_after_initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active_after_initial),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_unlock_initial_prompt_from_non_string_uuid() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let malformed_initial = json!({
+            "type": "user",
+            "uuid": 123,
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&malformed_initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let active_before_initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active_before_initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::UnknownPromptUser
         );
 
         let active_after_initial = json!({

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -66,6 +66,7 @@ struct ActiveInputState {
     lifecycle: Lifecycle,
     initial_prompt_replay_seen: bool,
     observed_result: bool,
+    next_input_sequence: u64,
     seen_message_ids: HashSet<String>,
     seen_message_id_order: VecDeque<String>,
     pending_by_uuid: HashMap<String, PendingInput>,
@@ -77,6 +78,7 @@ impl Default for ActiveInputState {
             lifecycle: Lifecycle::Open,
             initial_prompt_replay_seen: false,
             observed_result: false,
+            next_input_sequence: 0,
             seen_message_ids: HashSet::new(),
             seen_message_id_order: VecDeque::new(),
             pending_by_uuid: HashMap::new(),
@@ -113,6 +115,12 @@ impl ActiveInputState {
         {
             self.seen_message_id_order.remove(index);
         }
+    }
+
+    fn allocate_active_input_uuid(&mut self, run_id: &str, message_id: &str) -> String {
+        let sequence = self.next_input_sequence;
+        self.next_input_sequence = self.next_input_sequence.saturating_add(1);
+        claude_active_input_uuid(run_id, sequence, message_id)
     }
 
     fn remove_pending_by_uuid(&mut self, uuid: &str) -> bool {
@@ -188,10 +196,10 @@ pub fn claude_initial_prompt_uuid(run_id: &str) -> String {
     .to_string()
 }
 
-fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
+fn claude_active_input_uuid(run_id: &str, sequence: u64, message_id: &str) -> String {
     Uuid::new_v5(
         &Uuid::NAMESPACE_OID,
-        format!("vm0:{run_id}:claude-active-input:{message_id}").as_bytes(),
+        format!("vm0:{run_id}:claude-active-input:{sequence}:{message_id}").as_bytes(),
     )
     .to_string()
 }
@@ -317,13 +325,7 @@ impl ActiveInputController {
             };
         }
 
-        let uuid = claude_active_input_uuid(&self.inner.run_id, message_id);
         let text = payload.text;
-        let frame = ActiveInputFrame {
-            message_id: message_id.to_owned(),
-            uuid: uuid.clone(),
-            text: text.clone(),
-        };
 
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
         if state.lifecycle != Lifecycle::Open {
@@ -342,6 +344,12 @@ impl ActiveInputController {
             };
         }
 
+        let uuid = state.allocate_active_input_uuid(&self.inner.run_id, message_id);
+        let frame = ActiveInputFrame {
+            message_id: message_id.to_owned(),
+            uuid: uuid.clone(),
+            text: text.clone(),
+        };
         state.remember_message_id(message_id.to_owned());
         state.pending_by_uuid.insert(
             uuid.clone(),
@@ -591,6 +599,7 @@ mod tests {
         let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         let mut writer = runtime.into_writer();
+        let mut first_message_uuid = None;
 
         for index in 0..=ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY {
             let message_id = format!("msg-{index}");
@@ -609,6 +618,9 @@ mod tests {
                 .await
                 .expect("active input frame should be queued");
             assert_eq!(frame.message_id, message_id);
+            if index == 0 {
+                first_message_uuid = Some(frame.uuid.clone());
+            }
 
             let active = json!({
                 "type": "user",
@@ -621,20 +633,22 @@ mod tests {
             );
         }
 
-        let state = controller
-            .inner
-            .state
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        assert_eq!(
-            state.seen_message_ids.len(),
-            ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY
-        );
-        assert!(!state.has_seen_message_id("msg-0"));
-        assert!(
-            state.has_seen_message_id(&format!("msg-{}", ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY))
-        );
-        drop(state);
+        {
+            let state = controller
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            assert_eq!(
+                state.seen_message_ids.len(),
+                ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY
+            );
+            assert!(!state.has_seen_message_id("msg-0"));
+            assert!(
+                state
+                    .has_seen_message_id(&format!("msg-{}", ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY))
+            );
+        }
 
         assert!(matches!(
             controller.handle_control_payload(
@@ -648,6 +662,15 @@ mod tests {
             controller.handle_control_payload("msg-0", br#"{"type":"active-input","text":"old"}"#),
             ActiveInputControlOutcome::Accepted
         );
+        let frame = writer
+            .next_frame()
+            .await
+            .expect("reused active input frame should be queued");
+        assert_eq!(frame.message_id, "msg-0");
+        assert_ne!(
+            frame.uuid,
+            first_message_uuid.expect("first active input uuid should be captured")
+        );
     }
 
     #[test]
@@ -659,7 +682,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"hello"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
 
         let initial = json!({
             "type": "user",
@@ -725,7 +748,7 @@ mod tests {
 
         let active = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
             "message": {
                 "role": "user",
                 "content": [{"type": "text", "text": "follow-up"}]
@@ -764,7 +787,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
         assert!(!controller.close_for_result_if_idle());
 
@@ -788,7 +811,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_writing(&active_uuid);
         assert!(!controller.close_for_result_if_idle());
 
@@ -839,7 +862,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"same-text"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let event = json!({
@@ -862,7 +885,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         assert!(!controller.close_for_result_if_idle());
@@ -882,7 +905,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_writing(&active_uuid);
 
         assert!(!controller.close_for_result_if_idle());
@@ -919,7 +942,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let initial = json!({
@@ -951,7 +974,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
         assert!(!controller.close_for_result_if_idle());
 
@@ -985,7 +1008,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
         assert!(!controller.close_for_result_if_idle());
 
@@ -1021,7 +1044,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let unknown_uuid_initial_text = json!({
@@ -1073,7 +1096,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let malformed_initial = json!({
@@ -1124,7 +1147,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"same-text"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let initial = json!({
@@ -1156,7 +1179,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
         assert!(!controller.close_for_result_if_idle());
 
@@ -1200,7 +1223,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let malformed = json!({
@@ -1241,7 +1264,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
 
         let malformed = json!({
             "type": "user",
@@ -1255,7 +1278,7 @@ mod tests {
 
         let replay = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
             "message": {"role": "user", "content": "follow-up"}
         });
         assert_eq!(
@@ -1277,7 +1300,7 @@ mod tests {
 
         let malformed = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
             "message": {"role": 123, "content": "follow-up"}
         });
         assert_eq!(
@@ -1287,7 +1310,7 @@ mod tests {
 
         let replay = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
             "message": {"role": "user", "content": "follow-up"}
         });
         assert_eq!(
@@ -1309,7 +1332,7 @@ mod tests {
 
         let child = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
             "parent_tool_use_id": "tool-1",
             "message": {"role": "user", "content": "follow-up"}
         });
@@ -1320,7 +1343,7 @@ mod tests {
 
         let replay = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
             "parent_tool_use_id": null,
             "message": {"role": "user", "content": "follow-up"}
         });
@@ -1340,7 +1363,7 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
-        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
         controller.mark_written(&active_uuid);
 
         let historical = json!({

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -53,15 +53,10 @@ struct PendingInput {
     text: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum PromptLikeUserContent {
-    Text(String),
-    Unmatchable,
-}
-
 #[derive(Debug)]
 struct ActiveInputState {
     lifecycle: Lifecycle,
+    observed_result: bool,
     seen_message_ids: HashSet<String>,
     pending_by_uuid: HashMap<String, PendingInput>,
 }
@@ -70,6 +65,7 @@ impl Default for ActiveInputState {
     fn default() -> Self {
         Self {
             lifecycle: Lifecycle::Open,
+            observed_result: false,
             seen_message_ids: HashSet::new(),
             pending_by_uuid: HashMap::new(),
         }
@@ -82,6 +78,10 @@ impl ActiveInputState {
     }
 
     fn remove_replayable_pending_by_text(&mut self, text: &str) -> bool {
+        if !self.observed_result {
+            return false;
+        }
+
         let uuid = self
             .pending_by_uuid
             .iter()
@@ -148,10 +148,10 @@ fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
     .to_string()
 }
 
-fn prompt_like_user_content(event: &Value) -> Option<PromptLikeUserContent> {
+fn prompt_like_user_content(event: &Value) -> Option<String> {
     let content = event.pointer("/message/content")?;
     if let Some(text) = content.as_str() {
-        return Some(PromptLikeUserContent::Text(text.to_owned()));
+        return Some(text.to_owned());
     }
     let items = content.as_array()?;
     if items.is_empty() {
@@ -159,26 +159,18 @@ fn prompt_like_user_content(event: &Value) -> Option<PromptLikeUserContent> {
     }
 
     let mut text = String::new();
-    let mut all_text = true;
     for item in items {
         match item.get("type").and_then(Value::as_str) {
             Some("tool_result") => return None,
             Some("text") => {
-                let Some(part) = item.get("text").and_then(Value::as_str) else {
-                    all_text = false;
-                    continue;
-                };
+                let part = item.get("text").and_then(Value::as_str)?;
                 text.push_str(part);
             }
-            _ => all_text = false,
+            _ => return None,
         }
     }
 
-    if all_text {
-        Some(PromptLikeUserContent::Text(text))
-    } else {
-        Some(PromptLikeUserContent::Unmatchable)
-    }
+    Some(text)
 }
 
 impl ActiveInputRuntime {
@@ -326,6 +318,7 @@ impl ActiveInputController {
         }
 
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.observed_result = true;
         if !state.pending_by_uuid.is_empty() {
             return false;
         }
@@ -361,12 +354,10 @@ impl ActiveInputController {
             }
         }
 
-        if let Some(content) = prompt_like_user_content(event) {
-            if let PromptLikeUserContent::Text(text) = content {
-                let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-                if state.remove_replayable_pending_by_text(&text) {
-                    return ReplayUserEventAction::InternalActiveInput;
-                }
+        if let Some(text) = prompt_like_user_content(event) {
+            let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+            if state.remove_replayable_pending_by_text(&text) {
+                return ReplayUserEventAction::InternalActiveInput;
             }
             return ReplayUserEventAction::UnknownPromptUser;
         }
@@ -617,6 +608,7 @@ mod tests {
         );
         let active_uuid = claude_active_input_uuid("run-1", "msg-1");
         controller.mark_writing(&active_uuid);
+        assert!(!controller.close_for_result_if_idle());
 
         let event = json!({
             "type": "user",
@@ -651,6 +643,29 @@ mod tests {
     }
 
     #[test]
+    fn replay_filter_does_not_consume_uuidless_text_match_before_first_result() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"same-text"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "same-text"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+        assert!(!controller.close_for_result_if_idle());
+    }
+
+    #[test]
     fn replay_filter_consumes_uuidless_text_block_active_input_replay() {
         let runtime = ActiveInputRuntime::new("run-1", true);
         let controller = runtime.controller();
@@ -661,6 +676,7 @@ mod tests {
         );
         let active_uuid = claude_active_input_uuid("run-1", "msg-1");
         controller.mark_written(&active_uuid);
+        assert!(!controller.close_for_result_if_idle());
 
         let event = json!({
             "type": "user",
@@ -674,5 +690,22 @@ mod tests {
             ReplayUserEventAction::InternalActiveInput
         );
         assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_keeps_unknown_user_content_blocks_external() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let event = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "image", "source": "future-schema"}]
+            }
+        });
+
+        assert_eq!(
+            runtime.controller().replay_user_event_action(&event),
+            ReplayUserEventAction::External
+        );
     }
 }

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -151,14 +151,14 @@ fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
     .to_string()
 }
 
-fn prompt_like_user_content(event: &Value) -> Option<String> {
-    if matches!(
+fn user_message_role_allows_replay(event: &Value) -> bool {
+    !matches!(
         event.pointer("/message/role").and_then(Value::as_str),
         Some(role) if role != "user"
-    ) {
-        return None;
-    }
+    )
+}
 
+fn prompt_like_user_content(event: &Value) -> Option<String> {
     let content = event.pointer("/message/content")?;
     if let Some(text) = content.as_str() {
         return Some(text.to_owned());
@@ -184,8 +184,8 @@ fn prompt_like_user_content(event: &Value) -> Option<String> {
 }
 
 impl ActiveInputRuntime {
-    pub fn new(run_id: &str, enabled: bool) -> Self {
-        Self::new_with_initial_prompt(run_id, enabled, "")
+    pub fn new_disabled(run_id: &str) -> Self {
+        Self::new_with_initial_prompt(run_id, false, "")
     }
 
     pub fn new_with_initial_prompt(run_id: &str, enabled: bool, initial_prompt_text: &str) -> Self {
@@ -357,6 +357,9 @@ impl ActiveInputController {
         if event.get("type").and_then(Value::as_str) != Some("user") {
             return ReplayUserEventAction::External;
         }
+        if !user_message_role_allows_replay(event) {
+            return ReplayUserEventAction::External;
+        }
 
         if let Some(uuid) = event.get("uuid").and_then(Value::as_str) {
             if uuid == self.inner.initial_prompt_uuid {
@@ -432,7 +435,7 @@ mod tests {
 
     #[test]
     fn active_input_accepts_valid_payload_once() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
 
         assert_eq!(
@@ -452,7 +455,7 @@ mod tests {
 
     #[test]
     fn active_input_rejects_invalid_payloads() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
 
         for (message_id, payload) in [
@@ -472,7 +475,7 @@ mod tests {
 
     #[test]
     fn active_input_rejects_when_disabled_or_closed() {
-        let disabled = ActiveInputRuntime::new("run-1", false);
+        let disabled = ActiveInputRuntime::new_disabled("run-1");
         assert!(matches!(
             disabled
                 .controller()
@@ -481,7 +484,7 @@ mod tests {
                 if diagnostic == "active input is not supported for this agent"
         ));
 
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert!(controller.close_for_result_if_idle());
         assert!(matches!(
@@ -492,7 +495,7 @@ mod tests {
 
     #[test]
     fn active_input_capacity_counts_pending_inputs() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
 
         for index in 0..ACTIVE_INPUT_QUEUE_CAPACITY {
@@ -514,7 +517,7 @@ mod tests {
 
     #[test]
     fn replay_filter_consumes_initial_and_active_input_user_events() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -547,7 +550,7 @@ mod tests {
 
     #[test]
     fn replay_filter_keeps_tool_result_user_events_external() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let event = json!({
             "type": "user",
             "message": {
@@ -564,7 +567,7 @@ mod tests {
 
     #[test]
     fn replay_filter_consumes_matching_uuid_even_with_non_string_content() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -602,7 +605,7 @@ mod tests {
 
     #[test]
     fn replay_filter_treats_text_block_user_events_without_uuid_as_unknown_prompt() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let event = json!({
             "type": "user",
             "message": {
@@ -619,7 +622,7 @@ mod tests {
 
     #[test]
     fn replay_filter_consumes_uuidless_active_input_replay_by_text() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -643,7 +646,7 @@ mod tests {
 
     #[test]
     fn replay_filter_does_not_consume_unwritten_uuidless_text_match() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -664,7 +667,7 @@ mod tests {
 
     #[test]
     fn replay_filter_does_not_consume_uuidless_text_match_before_first_result() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -751,7 +754,7 @@ mod tests {
 
     #[test]
     fn replay_filter_consumes_uuidless_text_block_active_input_replay() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -778,7 +781,7 @@ mod tests {
 
     #[test]
     fn replay_filter_keeps_unknown_user_content_blocks_external() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let event = json!({
             "type": "user",
             "message": {
@@ -829,6 +832,39 @@ mod tests {
         });
         assert_eq!(
             controller.replay_user_event_action(&second_valid_prompt_like),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_keeps_non_user_role_uuid_matches_external() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+
+        let malformed = json!({
+            "type": "user",
+            "uuid": active_uuid,
+            "message": {"role": "assistant", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&malformed),
+            ReplayUserEventAction::External
+        );
+
+        let replay = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&replay),
             ReplayUserEventAction::InternalActiveInput
         );
         assert!(controller.close_for_result_if_idle());

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -384,7 +384,8 @@ impl ActiveInputController {
             return ReplayUserEventAction::External;
         }
 
-        if let Some(uuid) = event.get("uuid").and_then(Value::as_str) {
+        let event_uuid = event.get("uuid").and_then(Value::as_str);
+        if let Some(uuid) = event_uuid {
             if uuid == self.inner.initial_prompt_uuid {
                 let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
                 state.initial_prompt_replay_seen = true;
@@ -399,11 +400,13 @@ impl ActiveInputController {
 
         if let Some(text) = prompt_like_user_content(event) {
             let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-            if state.remove_replayable_pending_by_text(&text) {
-                return ReplayUserEventAction::InternalActiveInput;
-            }
-            if !state.observed_result && text == self.inner.initial_prompt_text {
-                state.initial_prompt_replay_seen = true;
+            if event_uuid.is_none() {
+                if state.remove_replayable_pending_by_text(&text) {
+                    return ReplayUserEventAction::InternalActiveInput;
+                }
+                if !state.observed_result && text == self.inner.initial_prompt_text {
+                    state.initial_prompt_replay_seen = true;
+                }
             }
             return ReplayUserEventAction::UnknownPromptUser;
         }
@@ -777,6 +780,92 @@ mod tests {
         });
         assert_eq!(
             controller.replay_user_event_action(&active),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_consume_text_match_with_unknown_uuid() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+        assert!(!controller.close_for_result_if_idle());
+
+        let unknown_uuid = json!({
+            "type": "user",
+            "uuid": "not-vm0-active-input",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&unknown_uuid),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let uuidless = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&uuidless),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_unlock_initial_prompt_from_unknown_uuid() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let unknown_uuid_initial_text = json!({
+            "type": "user",
+            "uuid": "not-vm0-initial-prompt",
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&unknown_uuid_initial_text),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let active_before_initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active_before_initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let initial = json!({
+            "type": "user",
+            "uuid": claude_initial_prompt_uuid("run-1"),
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::InternalInitialPrompt
+        );
+
+        let active_after_initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active_after_initial),
             ReplayUserEventAction::InternalActiveInput
         );
         assert!(controller.close_for_result_if_idle());

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -43,12 +43,20 @@ enum Lifecycle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PendingState {
     Accepted,
+    Writing,
     Written,
 }
 
 #[derive(Debug)]
 struct PendingInput {
     state: PendingState,
+    text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PromptLikeUserContent {
+    Text(String),
+    Unmatchable,
 }
 
 #[derive(Debug)]
@@ -65,6 +73,28 @@ impl Default for ActiveInputState {
             seen_message_ids: HashSet::new(),
             pending_by_uuid: HashMap::new(),
         }
+    }
+}
+
+impl ActiveInputState {
+    fn remove_pending_by_uuid(&mut self, uuid: &str) -> bool {
+        self.pending_by_uuid.remove(uuid).is_some()
+    }
+
+    fn remove_replayable_pending_by_text(&mut self, text: &str) -> bool {
+        let uuid = self
+            .pending_by_uuid
+            .iter()
+            .find(|(_, input)| {
+                matches!(input.state, PendingState::Writing | PendingState::Written)
+                    && input.text == text
+            })
+            .map(|(uuid, _)| uuid.clone());
+        let Some(uuid) = uuid else {
+            return false;
+        };
+
+        self.pending_by_uuid.remove(&uuid).is_some()
     }
 }
 
@@ -118,21 +148,37 @@ fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
     .to_string()
 }
 
-fn is_prompt_like_user_content(event: &Value) -> bool {
-    let Some(content) = event.pointer("/message/content") else {
-        return false;
-    };
-    if content.as_str().is_some() {
-        return true;
+fn prompt_like_user_content(event: &Value) -> Option<PromptLikeUserContent> {
+    let content = event.pointer("/message/content")?;
+    if let Some(text) = content.as_str() {
+        return Some(PromptLikeUserContent::Text(text.to_owned()));
     }
-    let Some(items) = content.as_array() else {
-        return false;
-    };
+    let items = content.as_array()?;
+    if items.is_empty() {
+        return None;
+    }
 
-    !items.is_empty()
-        && items
-            .iter()
-            .all(|item| item.get("type").and_then(Value::as_str) != Some("tool_result"))
+    let mut text = String::new();
+    let mut all_text = true;
+    for item in items {
+        match item.get("type").and_then(Value::as_str) {
+            Some("tool_result") => return None,
+            Some("text") => {
+                let Some(part) = item.get("text").and_then(Value::as_str) else {
+                    all_text = false;
+                    continue;
+                };
+                text.push_str(part);
+            }
+            _ => all_text = false,
+        }
+    }
+
+    if all_text {
+        Some(PromptLikeUserContent::Text(text))
+    } else {
+        Some(PromptLikeUserContent::Unmatchable)
+    }
 }
 
 impl ActiveInputRuntime {
@@ -207,10 +253,11 @@ impl ActiveInputController {
         }
 
         let uuid = claude_active_input_uuid(&self.inner.run_id, message_id);
+        let text = payload.text;
         let frame = ActiveInputFrame {
             message_id: message_id.to_owned(),
             uuid: uuid.clone(),
-            text: payload.text,
+            text: text.clone(),
         };
 
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -235,6 +282,7 @@ impl ActiveInputController {
             uuid.clone(),
             PendingInput {
                 state: PendingState::Accepted,
+                text,
             },
         );
 
@@ -262,6 +310,13 @@ impl ActiveInputController {
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(input) = state.pending_by_uuid.get_mut(uuid) {
             input.state = PendingState::Written;
+        }
+    }
+
+    pub fn mark_writing(&self, uuid: &str) {
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(input) = state.pending_by_uuid.get_mut(uuid) {
+            input.state = PendingState::Writing;
         }
     }
 
@@ -301,12 +356,18 @@ impl ActiveInputController {
             }
 
             let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-            if state.pending_by_uuid.remove(uuid).is_some() {
+            if state.remove_pending_by_uuid(uuid) {
                 return ReplayUserEventAction::InternalActiveInput;
             }
         }
 
-        if is_prompt_like_user_content(event) {
+        if let Some(content) = prompt_like_user_content(event) {
+            if let PromptLikeUserContent::Text(text) = content {
+                let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+                if state.remove_replayable_pending_by_text(&text) {
+                    return ReplayUserEventAction::InternalActiveInput;
+                }
+            }
             return ReplayUserEventAction::UnknownPromptUser;
         }
 
@@ -342,6 +403,10 @@ impl ActiveInputWriter {
 
     pub fn mark_written(&self, uuid: &str) {
         self.controller.mark_written(uuid);
+    }
+
+    pub fn mark_writing(&self, uuid: &str) {
+        self.controller.mark_writing(uuid);
     }
 
     pub fn close_terminal(&self) {
@@ -539,5 +604,75 @@ mod tests {
             runtime.controller().replay_user_event_action(&event),
             ReplayUserEventAction::UnknownPromptUser
         );
+    }
+
+    #[test]
+    fn replay_filter_consumes_uuidless_active_input_replay_by_text() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_writing(&active_uuid);
+
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_consume_unwritten_uuidless_text_match() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"same-text"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "same-text"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+        assert!(!controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_consumes_uuidless_text_block_active_input_replay() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let event = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "follow-up"}]
+            }
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
     }
 }

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -105,6 +105,7 @@ struct ActiveInputInner {
     enabled: bool,
     run_id: String,
     initial_prompt_uuid: String,
+    initial_prompt_text: String,
     tx: mpsc::Sender<ActiveInputFrame>,
     close_tx: watch::Sender<bool>,
     state: Mutex<ActiveInputState>,
@@ -184,6 +185,10 @@ fn prompt_like_user_content(event: &Value) -> Option<String> {
 
 impl ActiveInputRuntime {
     pub fn new(run_id: &str, enabled: bool) -> Self {
+        Self::new_with_initial_prompt(run_id, enabled, "")
+    }
+
+    pub fn new_with_initial_prompt(run_id: &str, enabled: bool, initial_prompt_text: &str) -> Self {
         let (tx, rx) = mpsc::channel(ACTIVE_INPUT_QUEUE_CAPACITY);
         let (close_tx, close_rx) = watch::channel(false);
         let controller = ActiveInputController {
@@ -191,6 +196,7 @@ impl ActiveInputRuntime {
                 enabled,
                 run_id: run_id.to_owned(),
                 initial_prompt_uuid: claude_initial_prompt_uuid(run_id),
+                initial_prompt_text: initial_prompt_text.to_owned(),
                 tx,
                 close_tx,
                 state: Mutex::new(ActiveInputState::default()),
@@ -370,7 +376,7 @@ impl ActiveInputController {
             if state.remove_replayable_pending_by_text(&text) {
                 return ReplayUserEventAction::InternalActiveInput;
             }
-            if !state.observed_result {
+            if !state.observed_result && text == self.inner.initial_prompt_text {
                 state.initial_prompt_replay_seen = true;
             }
             return ReplayUserEventAction::UnknownPromptUser;
@@ -681,7 +687,7 @@ mod tests {
 
     #[test]
     fn replay_filter_consumes_uuidless_text_match_after_initial_replay_before_first_result() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -713,7 +719,7 @@ mod tests {
 
     #[test]
     fn replay_filter_waits_for_second_uuidless_same_text_before_first_result() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "same-text");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -789,7 +795,7 @@ mod tests {
 
     #[test]
     fn replay_filter_keeps_non_user_role_events_external_without_advancing_prompt_replay() {
-        let runtime = ActiveInputRuntime::new("run-1", true);
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "follow-up");
         let controller = runtime.controller();
         assert_eq!(
             controller
@@ -823,6 +829,56 @@ mod tests {
         });
         assert_eq!(
             controller.replay_user_event_action(&second_valid_prompt_like),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_unlock_uuidless_match_from_non_initial_prompt_like_event() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let historical = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "historical"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&historical),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let active_before_initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active_before_initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let active_after_initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active_after_initial),
             ReplayUserEventAction::InternalActiveInput
         );
         assert!(controller.close_for_result_if_idle());

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -189,10 +189,15 @@ impl ActiveInputState {
         }
     }
 
-    fn remove_oldest_pending_if_written(&mut self) -> bool {
+    fn remove_oldest_pending_if_delivered(&mut self) -> bool {
         while let Some(uuid) = self.pending_uuid_order.front().cloned() {
             match self.pending_by_uuid.get(&uuid) {
-                Some(input) if matches!(input.state, PendingState::Written) => {
+                Some(input)
+                    if matches!(
+                        input.state,
+                        PendingState::WritingWithUuidlessReplay | PendingState::Written
+                    ) =>
+                {
                     return self.remove_pending_by_uuid(&uuid);
                 }
                 Some(_) => return false,
@@ -474,7 +479,7 @@ impl ActiveInputController {
             // Claude should replay stdin user frames before the follow-up
             // result. If replay is missing, a later result can prove progress
             // for the oldest writer-owned input, not for every queued follow-up.
-            if !state.remove_oldest_pending_if_written() {
+            if !state.remove_oldest_pending_if_delivered() {
                 return false;
             }
             if !state.pending_by_uuid.is_empty() {
@@ -988,6 +993,36 @@ mod tests {
         }
 
         assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn followup_result_can_close_after_uuidless_replay_before_mark_written() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        assert!(!controller.close_for_result_if_idle());
+
+        controller.mark_writing(&active_uuid);
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+
+        assert!(controller.close_for_result_if_idle());
+        controller.mark_written(&active_uuid);
+        assert!(matches!(
+            controller.handle_control_payload("msg-2", br#"{"type":"active-input","text":"late"}"#),
+            ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
+        ));
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -76,6 +76,7 @@ struct ActiveInputState {
     next_input_sequence: u64,
     seen_message_ids: HashSet<String>,
     seen_message_id_order: VecDeque<String>,
+    pending_uuid_order: VecDeque<String>,
     pending_by_uuid: HashMap<String, PendingInput>,
 }
 
@@ -88,6 +89,7 @@ impl Default for ActiveInputState {
             next_input_sequence: 0,
             seen_message_ids: HashSet::new(),
             seen_message_id_order: VecDeque::new(),
+            pending_uuid_order: VecDeque::new(),
             pending_by_uuid: HashMap::new(),
         }
     }
@@ -130,8 +132,23 @@ impl ActiveInputState {
         claude_active_input_uuid(run_id, sequence, message_id)
     }
 
+    fn insert_pending(&mut self, uuid: String, input: PendingInput) {
+        self.pending_uuid_order.push_back(uuid.clone());
+        self.pending_by_uuid.insert(uuid, input);
+    }
+
     fn remove_pending_by_uuid(&mut self, uuid: &str) -> bool {
-        self.pending_by_uuid.remove(uuid).is_some()
+        if self.pending_by_uuid.remove(uuid).is_none() {
+            return false;
+        }
+        if let Some(index) = self
+            .pending_uuid_order
+            .iter()
+            .position(|pending_uuid| pending_uuid == uuid)
+        {
+            self.pending_uuid_order.remove(index);
+        }
+        true
     }
 
     fn remove_replayable_pending_by_text(&mut self, text: &str) -> bool {
@@ -140,23 +157,34 @@ impl ActiveInputState {
         }
 
         let uuid = self
-            .pending_by_uuid
+            .pending_uuid_order
             .iter()
-            .find(|(_, input)| matches!(input.state, PendingState::Written) && input.text == text)
-            .map(|(uuid, _)| uuid.clone());
+            .find(|uuid| {
+                self.pending_by_uuid.get(*uuid).is_some_and(|input| {
+                    matches!(input.state, PendingState::Written) && input.text == text
+                })
+            })
+            .cloned();
         let Some(uuid) = uuid else {
             return false;
         };
 
-        self.pending_by_uuid.remove(&uuid).is_some()
+        self.remove_pending_by_uuid(&uuid)
     }
 
-    fn pending_inputs_are_written_to_stdin(&self) -> bool {
-        !self.pending_by_uuid.is_empty()
-            && self
-                .pending_by_uuid
-                .values()
-                .all(|input| matches!(input.state, PendingState::Written))
+    fn remove_oldest_pending_if_written(&mut self) -> bool {
+        while let Some(uuid) = self.pending_uuid_order.front().cloned() {
+            match self.pending_by_uuid.get(&uuid) {
+                Some(input) if matches!(input.state, PendingState::Written) => {
+                    return self.remove_pending_by_uuid(&uuid);
+                }
+                Some(_) => return false,
+                None => {
+                    self.pending_uuid_order.pop_front();
+                }
+            }
+        }
+        false
     }
 }
 
@@ -364,7 +392,7 @@ impl ActiveInputController {
             text: text.clone(),
         };
         state.remember_message_id(message_id.to_owned());
-        state.pending_by_uuid.insert(
+        state.insert_pending(
             uuid.clone(),
             PendingInput {
                 state: PendingState::Accepted,
@@ -376,14 +404,14 @@ impl ActiveInputController {
             Ok(()) => ActiveInputControlOutcome::Accepted,
             Err(mpsc::error::TrySendError::Full(frame)) => {
                 state.forget_message_id(&frame.message_id);
-                state.pending_by_uuid.remove(&frame.uuid);
+                state.remove_pending_by_uuid(&frame.uuid);
                 ActiveInputControlOutcome::Rejected {
                     diagnostic: "active input queue is full",
                 }
             }
             Err(mpsc::error::TrySendError::Closed(frame)) => {
                 state.forget_message_id(&frame.message_id);
-                state.pending_by_uuid.remove(&frame.uuid);
+                state.remove_pending_by_uuid(&frame.uuid);
                 state.lifecycle = Lifecycle::Closed;
                 ActiveInputControlOutcome::Rejected {
                     diagnostic: "active input is closed",
@@ -415,13 +443,18 @@ impl ActiveInputController {
         let had_observed_result = state.observed_result;
         state.observed_result = true;
         if !state.pending_by_uuid.is_empty() {
-            if !had_observed_result || !state.pending_inputs_are_written_to_stdin() {
+            if !had_observed_result {
                 return false;
             }
-            // Claude should replay stdin user frames before the follow-up result.
-            // If that replay is missing, a later result still proves the CLI
-            // made progress after the writer took ownership of the frame.
-            state.pending_by_uuid.clear();
+            // Claude should replay stdin user frames before the follow-up
+            // result. If replay is missing, a later result can prove progress
+            // for the oldest writer-owned input, not for every queued follow-up.
+            if !state.remove_oldest_pending_if_written() {
+                return false;
+            }
+            if !state.pending_by_uuid.is_empty() {
+                return false;
+            }
         }
         match state.lifecycle {
             Lifecycle::Open => {
@@ -818,6 +851,51 @@ mod tests {
     }
 
     #[test]
+    fn replay_filter_consumes_oldest_uuidless_text_match() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+
+        for message_id in ["msg-1", "msg-2"] {
+            assert_eq!(
+                controller.handle_control_payload(
+                    message_id,
+                    br#"{"type":"active-input","text":"same-text"}"#
+                ),
+                ActiveInputControlOutcome::Accepted
+            );
+        }
+        let first_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        let second_uuid = claude_active_input_uuid("run-1", 1, "msg-2");
+        controller.mark_written(&first_uuid);
+        controller.mark_written(&second_uuid);
+        assert!(!controller.close_for_result_if_idle());
+
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "same-text"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        {
+            let state = controller
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            assert!(!state.pending_by_uuid.contains_key(&first_uuid));
+            assert!(state.pending_by_uuid.contains_key(&second_uuid));
+        }
+
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
     fn replay_filter_does_not_consume_uuidless_text_match_while_writing() {
         let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
@@ -909,6 +987,74 @@ mod tests {
             controller.handle_control_payload("msg-2", br#"{"type":"active-input","text":"late"}"#),
             ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
         ));
+    }
+
+    #[test]
+    fn followup_result_without_replay_completes_one_written_pending_input_at_a_time() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+
+        for message_id in ["msg-1", "msg-2"] {
+            assert_eq!(
+                controller.handle_control_payload(
+                    message_id,
+                    br#"{"type":"active-input","text":"follow-up"}"#
+                ),
+                ActiveInputControlOutcome::Accepted
+            );
+        }
+        let first_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        let second_uuid = claude_active_input_uuid("run-1", 1, "msg-2");
+        controller.mark_written(&first_uuid);
+        controller.mark_written(&second_uuid);
+
+        assert!(!controller.close_for_result_if_idle());
+        assert!(!controller.close_for_result_if_idle());
+        {
+            let state = controller
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            assert!(!state.pending_by_uuid.contains_key(&first_uuid));
+            assert!(state.pending_by_uuid.contains_key(&second_uuid));
+        }
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn followup_result_without_replay_keeps_later_unwritten_pending_input_open() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+
+        for message_id in ["msg-1", "msg-2"] {
+            assert_eq!(
+                controller.handle_control_payload(
+                    message_id,
+                    br#"{"type":"active-input","text":"follow-up"}"#
+                ),
+                ActiveInputControlOutcome::Accepted
+            );
+        }
+        let first_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        let second_uuid = claude_active_input_uuid("run-1", 1, "msg-2");
+        controller.mark_written(&first_uuid);
+
+        assert!(!controller.close_for_result_if_idle());
+        assert!(!controller.close_for_result_if_idle());
+        {
+            let state = controller
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            assert!(!state.pending_by_uuid.contains_key(&first_uuid));
+            assert!(state.pending_by_uuid.contains_key(&second_uuid));
+        }
+        assert!(!controller.close_for_result_if_idle());
+
+        controller.mark_written(&second_uuid);
+        assert!(controller.close_for_result_if_idle());
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -306,20 +306,29 @@ fn prompt_user_content(event: &Value) -> PromptUserContent {
     }
 
     let mut text = String::new();
+    let mut saw_text = false;
+    let mut saw_tool_result = false;
     for item in items {
         match item.get("type").and_then(Value::as_str) {
-            Some("tool_result") => return PromptUserContent::ToolResult,
+            Some("tool_result") => {
+                saw_tool_result = true;
+            }
             Some("text") => {
                 let Some(part) = item.get("text").and_then(Value::as_str) else {
                     return PromptUserContent::Unknown;
                 };
+                saw_text = true;
                 text.push_str(part);
             }
             _ => return PromptUserContent::Unknown,
         }
     }
 
-    PromptUserContent::Text(text)
+    match (saw_text, saw_tool_result) {
+        (true, false) => PromptUserContent::Text(text),
+        (false, true) => PromptUserContent::ToolResult,
+        _ => PromptUserContent::Unknown,
+    }
 }
 
 impl ActiveInputRuntime {
@@ -810,6 +819,46 @@ mod tests {
         assert_eq!(
             runtime.controller().replay_user_event_action(&event),
             ReplayUserEventAction::External
+        );
+    }
+
+    #[test]
+    fn replay_filter_keeps_multi_tool_result_user_events_external() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let event = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tool-1"},
+                    {"type": "tool_result", "tool_use_id": "tool-2"}
+                ]
+            }
+        });
+
+        assert_eq!(
+            runtime.controller().replay_user_event_action(&event),
+            ReplayUserEventAction::External
+        );
+    }
+
+    #[test]
+    fn replay_filter_filters_mixed_text_and_tool_result_user_events() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let event = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "prompt-like text"},
+                    {"type": "tool_result", "tool_use_id": "tool-1"}
+                ]
+            }
+        });
+
+        assert_eq!(
+            runtime.controller().replay_user_event_action(&event),
+            ReplayUserEventAction::UnknownPromptUser
         );
     }
 

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -151,6 +151,13 @@ fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
 }
 
 fn prompt_like_user_content(event: &Value) -> Option<String> {
+    if matches!(
+        event.pointer("/message/role").and_then(Value::as_str),
+        Some(role) if role != "user"
+    ) {
+        return None;
+    }
+
     let content = event.pointer("/message/content")?;
     if let Some(text) = content.as_str() {
         return Some(text.to_owned());
@@ -778,5 +785,46 @@ mod tests {
             runtime.controller().replay_user_event_action(&event),
             ReplayUserEventAction::External
         );
+    }
+
+    #[test]
+    fn replay_filter_keeps_non_user_role_events_external_without_advancing_prompt_replay() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let malformed = json!({
+            "type": "user",
+            "message": {"role": "assistant", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&malformed),
+            ReplayUserEventAction::External
+        );
+
+        let first_valid_prompt_like = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&first_valid_prompt_like),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let second_valid_prompt_like = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&second_valid_prompt_like),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
     }
 }

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -152,6 +152,16 @@ impl ActiveInputState {
         true
     }
 
+    fn remove_replayable_pending_by_uuid(&mut self, uuid: &str) -> bool {
+        let Some(input) = self.pending_by_uuid.get(uuid) else {
+            return false;
+        };
+        if matches!(input.state, PendingState::Accepted) {
+            return false;
+        }
+        self.remove_pending_by_uuid(uuid)
+    }
+
     fn remove_replayable_pending_by_text(&mut self, text: &str) -> bool {
         if !self.initial_prompt_replay_seen && !self.observed_result {
             return false;
@@ -522,7 +532,7 @@ impl ActiveInputController {
             }
 
             let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-            if state.remove_pending_by_uuid(uuid) {
+            if state.remove_replayable_pending_by_uuid(uuid) {
                 return ReplayUserEventAction::InternalActiveInput;
             }
         }
@@ -699,6 +709,7 @@ mod tests {
             if index == 0 {
                 first_message_uuid = Some(frame.uuid.clone());
             }
+            controller.mark_written(&frame.uuid);
 
             let active = json!({
                 "type": "user",
@@ -771,6 +782,7 @@ mod tests {
             controller.replay_user_event_action(&initial),
             ReplayUserEventAction::InternalInitialPrompt
         );
+        controller.mark_written(&active_uuid);
 
         let active = json!({
             "type": "user",
@@ -823,6 +835,7 @@ mod tests {
             controller.replay_user_event_action(&initial),
             ReplayUserEventAction::InternalInitialPrompt
         );
+        controller.mark_written(&claude_active_input_uuid("run-1", 0, "msg-1"));
 
         let active = json!({
             "type": "user",
@@ -834,6 +847,41 @@ mod tests {
         });
         assert_eq!(
             controller.replay_user_event_action(&active),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_consume_accepted_uuid_before_writer_owns_input() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        let stale = json!({
+            "type": "user",
+            "uuid": active_uuid,
+            "message": {"role": "user", "content": "follow-up"}
+        });
+
+        assert_eq!(
+            controller.replay_user_event_action(&stale),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+        assert!(!controller.close_for_result_if_idle());
+
+        controller.mark_writing(&claude_active_input_uuid("run-1", 0, "msg-1"));
+        let replay = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&replay),
             ReplayUserEventAction::InternalActiveInput
         );
         assert!(controller.close_for_result_if_idle());
@@ -1533,6 +1581,7 @@ mod tests {
             ActiveInputControlOutcome::Accepted
         );
         let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        controller.mark_written(&active_uuid);
 
         let malformed = json!({
             "type": "user",
@@ -1565,10 +1614,12 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        controller.mark_written(&active_uuid);
 
         let malformed = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
+            "uuid": active_uuid,
             "message": {"role": 123, "content": "follow-up"}
         });
         assert_eq!(
@@ -1597,10 +1648,12 @@ mod tests {
                 .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
             ActiveInputControlOutcome::Accepted
         );
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        controller.mark_written(&active_uuid);
 
         let child = json!({
             "type": "user",
-            "uuid": claude_active_input_uuid("run-1", 0, "msg-1"),
+            "uuid": active_uuid,
             "parent_tool_use_id": "tool-1",
             "message": {"role": "user", "content": "follow-up"}
         });

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -1,0 +1,476 @@
+//! Guest-agent local active-input state for Claude stream-json stdin.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::{mpsc, watch};
+use uuid::Uuid;
+
+const ACTIVE_INPUT_TYPE: &str = "active-input";
+const ACTIVE_INPUT_QUEUE_CAPACITY: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveInputFrame {
+    pub message_id: String,
+    pub uuid: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActiveInputControlOutcome {
+    Accepted,
+    Rejected { diagnostic: &'static str },
+    Error { diagnostic: &'static str },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayUserEventAction {
+    External,
+    InternalInitialPrompt,
+    InternalActiveInput,
+    UnknownPromptUser,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Lifecycle {
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingState {
+    Accepted,
+    Written,
+}
+
+#[derive(Debug)]
+struct PendingInput {
+    state: PendingState,
+}
+
+#[derive(Debug)]
+struct ActiveInputState {
+    lifecycle: Lifecycle,
+    seen_message_ids: HashSet<String>,
+    pending_by_uuid: HashMap<String, PendingInput>,
+}
+
+impl Default for ActiveInputState {
+    fn default() -> Self {
+        Self {
+            lifecycle: Lifecycle::Open,
+            seen_message_ids: HashSet::new(),
+            pending_by_uuid: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ActiveInputInner {
+    enabled: bool,
+    run_id: String,
+    initial_prompt_uuid: String,
+    tx: mpsc::Sender<ActiveInputFrame>,
+    close_tx: watch::Sender<bool>,
+    state: Mutex<ActiveInputState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ActiveInputController {
+    inner: Arc<ActiveInputInner>,
+}
+
+#[derive(Debug)]
+pub struct ActiveInputWriter {
+    controller: ActiveInputController,
+    rx: mpsc::Receiver<ActiveInputFrame>,
+    close_rx: watch::Receiver<bool>,
+}
+
+pub struct ActiveInputRuntime {
+    controller: ActiveInputController,
+    writer: ActiveInputWriter,
+}
+
+#[derive(Deserialize)]
+struct ActiveInputPayload {
+    #[serde(rename = "type")]
+    payload_type: String,
+    text: String,
+}
+
+pub fn claude_initial_prompt_uuid(run_id: &str) -> String {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("vm0:{run_id}:claude-initial-prompt").as_bytes(),
+    )
+    .to_string()
+}
+
+fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("vm0:{run_id}:claude-active-input:{message_id}").as_bytes(),
+    )
+    .to_string()
+}
+
+impl ActiveInputRuntime {
+    pub fn new(run_id: &str, enabled: bool) -> Self {
+        let (tx, rx) = mpsc::channel(ACTIVE_INPUT_QUEUE_CAPACITY);
+        let (close_tx, close_rx) = watch::channel(false);
+        let controller = ActiveInputController {
+            inner: Arc::new(ActiveInputInner {
+                enabled,
+                run_id: run_id.to_owned(),
+                initial_prompt_uuid: claude_initial_prompt_uuid(run_id),
+                tx,
+                close_tx,
+                state: Mutex::new(ActiveInputState::default()),
+            }),
+        };
+        let writer = ActiveInputWriter {
+            controller: controller.clone(),
+            rx,
+            close_rx,
+        };
+        Self { controller, writer }
+    }
+
+    pub fn controller(&self) -> ActiveInputController {
+        self.controller.clone()
+    }
+
+    pub fn into_writer(self) -> ActiveInputWriter {
+        self.writer
+    }
+}
+
+impl ActiveInputController {
+    pub fn is_enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    pub fn handle_control_payload(
+        &self,
+        message_id: &str,
+        payload: &[u8],
+    ) -> ActiveInputControlOutcome {
+        if !self.inner.enabled {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input is not supported for this agent",
+            };
+        }
+        if message_id.is_empty() {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input message id is empty",
+            };
+        }
+
+        let payload = match serde_json::from_slice::<ActiveInputPayload>(payload) {
+            Ok(payload) => payload,
+            Err(_) => {
+                return ActiveInputControlOutcome::Rejected {
+                    diagnostic: "active input payload is invalid",
+                };
+            }
+        };
+        if payload.payload_type != ACTIVE_INPUT_TYPE {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input payload type is unsupported",
+            };
+        }
+        if payload.text.is_empty() {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input text is empty",
+            };
+        }
+
+        let uuid = claude_active_input_uuid(&self.inner.run_id, message_id);
+        let frame = ActiveInputFrame {
+            message_id: message_id.to_owned(),
+            uuid: uuid.clone(),
+            text: payload.text,
+        };
+
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if state.lifecycle != Lifecycle::Open {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input is closed",
+            };
+        }
+        if state.seen_message_ids.contains(message_id) {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input message id is duplicate",
+            };
+        }
+        if state.pending_by_uuid.len() >= ACTIVE_INPUT_QUEUE_CAPACITY {
+            return ActiveInputControlOutcome::Rejected {
+                diagnostic: "active input queue is full",
+            };
+        }
+
+        state.seen_message_ids.insert(message_id.to_owned());
+        state.pending_by_uuid.insert(
+            uuid.clone(),
+            PendingInput {
+                state: PendingState::Accepted,
+            },
+        );
+
+        match self.inner.tx.try_send(frame) {
+            Ok(()) => ActiveInputControlOutcome::Accepted,
+            Err(mpsc::error::TrySendError::Full(frame)) => {
+                state.seen_message_ids.remove(&frame.message_id);
+                state.pending_by_uuid.remove(&frame.uuid);
+                ActiveInputControlOutcome::Rejected {
+                    diagnostic: "active input queue is full",
+                }
+            }
+            Err(mpsc::error::TrySendError::Closed(frame)) => {
+                state.seen_message_ids.remove(&frame.message_id);
+                state.pending_by_uuid.remove(&frame.uuid);
+                state.lifecycle = Lifecycle::Closed;
+                ActiveInputControlOutcome::Rejected {
+                    diagnostic: "active input is closed",
+                }
+            }
+        }
+    }
+
+    pub fn mark_written(&self, uuid: &str) {
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(input) = state.pending_by_uuid.get_mut(uuid) {
+            input.state = PendingState::Written;
+        }
+    }
+
+    pub fn close_for_result_if_idle(&self) -> bool {
+        if !self.inner.enabled {
+            return true;
+        }
+
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if !state.pending_by_uuid.is_empty() {
+            return false;
+        }
+        match state.lifecycle {
+            Lifecycle::Open => {
+                state.lifecycle = Lifecycle::Closing;
+                let _ = self.inner.close_tx.send(true);
+                true
+            }
+            Lifecycle::Closing | Lifecycle::Closed => false,
+        }
+    }
+
+    pub fn close_terminal(&self) {
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.lifecycle = Lifecycle::Closed;
+        let _ = self.inner.close_tx.send(true);
+    }
+
+    pub fn replay_user_event_action(&self, event: &Value) -> ReplayUserEventAction {
+        if event.get("type").and_then(Value::as_str) != Some("user") {
+            return ReplayUserEventAction::External;
+        }
+        if event
+            .pointer("/message/content")
+            .and_then(Value::as_str)
+            .is_none()
+        {
+            return ReplayUserEventAction::External;
+        }
+
+        let Some(uuid) = event.get("uuid").and_then(Value::as_str) else {
+            return ReplayUserEventAction::UnknownPromptUser;
+        };
+
+        if uuid == self.inner.initial_prompt_uuid {
+            return ReplayUserEventAction::InternalInitialPrompt;
+        }
+
+        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if state.pending_by_uuid.remove(uuid).is_some() {
+            return ReplayUserEventAction::InternalActiveInput;
+        }
+
+        ReplayUserEventAction::UnknownPromptUser
+    }
+}
+
+impl ActiveInputWriter {
+    pub fn controller(&self) -> ActiveInputController {
+        self.controller.clone()
+    }
+
+    pub async fn next_frame(&mut self) -> Option<ActiveInputFrame> {
+        loop {
+            if *self.close_rx.borrow() {
+                return None;
+            }
+            tokio::select! {
+                biased;
+                close = self.close_rx.changed() => {
+                    if close.is_err() || *self.close_rx.borrow() {
+                        return None;
+                    }
+                }
+                frame = self.rx.recv() => return frame,
+            }
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.controller.is_enabled()
+    }
+
+    pub fn mark_written(&self, uuid: &str) {
+        self.controller.mark_written(uuid);
+    }
+
+    pub fn close_terminal(&self) {
+        self.controller.close_terminal();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn active_input_accepts_valid_payload_once() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"hello"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        assert!(matches!(
+            controller.handle_control_payload(
+                "msg-1",
+                br#"{"type":"active-input","text":"hello again"}"#
+            ),
+            ActiveInputControlOutcome::Rejected { diagnostic }
+                if diagnostic == "active input message id is duplicate"
+        ));
+    }
+
+    #[test]
+    fn active_input_rejects_invalid_payloads() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+
+        for (message_id, payload) in [
+            ("bad-json", br#"{"type":"active-input""#.as_slice()),
+            ("bad-type", br#"{"type":"other","text":"hello"}"#.as_slice()),
+            ("empty", br#"{"type":"active-input","text":""}"#.as_slice()),
+        ] {
+            assert!(
+                matches!(
+                    controller.handle_control_payload(message_id, payload),
+                    ActiveInputControlOutcome::Rejected { .. }
+                ),
+                "payload should reject: {message_id}"
+            );
+        }
+    }
+
+    #[test]
+    fn active_input_rejects_when_disabled_or_closed() {
+        let disabled = ActiveInputRuntime::new("run-1", false);
+        assert!(matches!(
+            disabled
+                .controller()
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"hello"}"#),
+            ActiveInputControlOutcome::Rejected { diagnostic }
+                if diagnostic == "active input is not supported for this agent"
+        ));
+
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert!(controller.close_for_result_if_idle());
+        assert!(matches!(
+            controller.handle_control_payload("msg-1", br#"{"type":"active-input","text":"hello"}"#),
+            ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
+        ));
+    }
+
+    #[test]
+    fn active_input_capacity_counts_pending_inputs() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+
+        for index in 0..ACTIVE_INPUT_QUEUE_CAPACITY {
+            let message_id = format!("msg-{index}");
+            assert_eq!(
+                controller.handle_control_payload(
+                    &message_id,
+                    br#"{"type":"active-input","text":"hello"}"#
+                ),
+                ActiveInputControlOutcome::Accepted
+            );
+        }
+
+        assert!(matches!(
+            controller.handle_control_payload("overflow", br#"{"type":"active-input","text":"hello"}"#),
+            ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input queue is full"
+        ));
+    }
+
+    #[test]
+    fn replay_filter_consumes_initial_and_active_input_user_events() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"hello"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+
+        let initial = json!({
+            "type": "user",
+            "uuid": claude_initial_prompt_uuid("run-1"),
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::InternalInitialPrompt
+        );
+
+        let active = json!({
+            "type": "user",
+            "uuid": active_uuid,
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_keeps_tool_result_user_events_external() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let event = json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tool-1"}]
+            }
+        });
+
+        assert_eq!(
+            runtime.controller().replay_user_event_action(&event),
+            ReplayUserEventAction::External
+        );
+    }
+}

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -87,10 +87,7 @@ impl ActiveInputState {
         let uuid = self
             .pending_by_uuid
             .iter()
-            .find(|(_, input)| {
-                matches!(input.state, PendingState::Writing | PendingState::Written)
-                    && input.text == text
-            })
+            .find(|(_, input)| matches!(input.state, PendingState::Written) && input.text == text)
             .map(|(uuid, _)| uuid.clone());
         let Some(uuid) = uuid else {
             return false;
@@ -99,12 +96,12 @@ impl ActiveInputState {
         self.pending_by_uuid.remove(&uuid).is_some()
     }
 
-    fn pending_inputs_are_in_stdin_writer(&self) -> bool {
+    fn pending_inputs_are_written_to_stdin(&self) -> bool {
         !self.pending_by_uuid.is_empty()
             && self
                 .pending_by_uuid
                 .values()
-                .all(|input| matches!(input.state, PendingState::Writing | PendingState::Written))
+                .all(|input| matches!(input.state, PendingState::Written))
     }
 }
 
@@ -349,7 +346,7 @@ impl ActiveInputController {
         let had_observed_result = state.observed_result;
         state.observed_result = true;
         if !state.pending_by_uuid.is_empty() {
-            if !had_observed_result || !state.pending_inputs_are_in_stdin_writer() {
+            if !had_observed_result || !state.pending_inputs_are_written_to_stdin() {
                 return false;
             }
             // Claude should replay stdin user frames before the follow-up result.
@@ -656,6 +653,30 @@ mod tests {
             ActiveInputControlOutcome::Accepted
         );
         let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+        assert!(!controller.close_for_result_if_idle());
+
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_does_not_consume_uuidless_text_match_while_writing() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
         controller.mark_writing(&active_uuid);
         assert!(!controller.close_for_result_if_idle());
 
@@ -663,6 +684,12 @@ mod tests {
             "type": "user",
             "message": {"role": "user", "content": "follow-up"}
         });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        controller.mark_written(&active_uuid);
         assert_eq!(
             controller.replay_user_event_action(&event),
             ReplayUserEventAction::InternalActiveInput
@@ -724,7 +751,7 @@ mod tests {
             ActiveInputControlOutcome::Accepted
         );
         let active_uuid = claude_active_input_uuid("run-1", "msg-1");
-        controller.mark_writing(&active_uuid);
+        controller.mark_written(&active_uuid);
 
         assert!(!controller.close_for_result_if_idle());
         assert!(controller.close_for_result_if_idle());
@@ -732,6 +759,24 @@ mod tests {
             controller.handle_control_payload("msg-2", br#"{"type":"active-input","text":"late"}"#),
             ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
         ));
+    }
+
+    #[test]
+    fn followup_result_keeps_writing_pending_input_open_without_replay() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_writing(&active_uuid);
+
+        assert!(!controller.close_for_result_if_idle());
+        assert!(!controller.close_for_result_if_idle());
+        controller.mark_written(&active_uuid);
+        assert!(controller.close_for_result_if_idle());
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -277,28 +277,27 @@ impl ActiveInputController {
         if event.get("type").and_then(Value::as_str) != Some("user") {
             return ReplayUserEventAction::External;
         }
+
+        if let Some(uuid) = event.get("uuid").and_then(Value::as_str) {
+            if uuid == self.inner.initial_prompt_uuid {
+                return ReplayUserEventAction::InternalInitialPrompt;
+            }
+
+            let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+            if state.pending_by_uuid.remove(uuid).is_some() {
+                return ReplayUserEventAction::InternalActiveInput;
+            }
+        }
+
         if event
             .pointer("/message/content")
             .and_then(Value::as_str)
-            .is_none()
+            .is_some()
         {
-            return ReplayUserEventAction::External;
-        }
-
-        let Some(uuid) = event.get("uuid").and_then(Value::as_str) else {
             return ReplayUserEventAction::UnknownPromptUser;
-        };
-
-        if uuid == self.inner.initial_prompt_uuid {
-            return ReplayUserEventAction::InternalInitialPrompt;
         }
 
-        let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-        if state.pending_by_uuid.remove(uuid).is_some() {
-            return ReplayUserEventAction::InternalActiveInput;
-        }
-
-        ReplayUserEventAction::UnknownPromptUser
+        ReplayUserEventAction::External
     }
 }
 
@@ -472,5 +471,43 @@ mod tests {
             runtime.controller().replay_user_event_action(&event),
             ReplayUserEventAction::External
         );
+    }
+
+    #[test]
+    fn replay_filter_consumes_matching_uuid_even_with_non_string_content() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"hello"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+
+        let initial = json!({
+            "type": "user",
+            "uuid": claude_initial_prompt_uuid("run-1"),
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "initial"}]
+            }
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::InternalInitialPrompt
+        );
+
+        let active = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "follow-up"}]
+            }
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
     }
 }

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -45,6 +45,7 @@ enum Lifecycle {
 enum PendingState {
     Accepted,
     Writing,
+    WritingWithUuidlessReplay,
     Written,
 }
 
@@ -161,7 +162,12 @@ impl ActiveInputState {
             .iter()
             .find(|uuid| {
                 self.pending_by_uuid.get(*uuid).is_some_and(|input| {
-                    matches!(input.state, PendingState::Written) && input.text == text
+                    matches!(
+                        input.state,
+                        PendingState::Writing
+                            | PendingState::WritingWithUuidlessReplay
+                            | PendingState::Written
+                    ) && input.text == text
                 })
             })
             .cloned();
@@ -169,7 +175,18 @@ impl ActiveInputState {
             return false;
         };
 
-        self.remove_pending_by_uuid(&uuid)
+        let Some(input) = self.pending_by_uuid.get_mut(&uuid) else {
+            return false;
+        };
+        match input.state {
+            PendingState::Writing => {
+                input.state = PendingState::WritingWithUuidlessReplay;
+                true
+            }
+            PendingState::WritingWithUuidlessReplay => true,
+            PendingState::Written => self.remove_pending_by_uuid(&uuid),
+            PendingState::Accepted => false,
+        }
     }
 
     fn remove_oldest_pending_if_written(&mut self) -> bool {
@@ -422,8 +439,16 @@ impl ActiveInputController {
 
     pub fn mark_written(&self, uuid: &str) {
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(input) = state.pending_by_uuid.get_mut(uuid) {
-            input.state = PendingState::Written;
+        let should_remove = match state.pending_by_uuid.get_mut(uuid) {
+            Some(input) if matches!(input.state, PendingState::WritingWithUuidlessReplay) => true,
+            Some(input) => {
+                input.state = PendingState::Written;
+                false
+            }
+            None => false,
+        };
+        if should_remove {
+            state.remove_pending_by_uuid(uuid);
         }
     }
 
@@ -896,7 +921,7 @@ mod tests {
     }
 
     #[test]
-    fn replay_filter_does_not_consume_uuidless_text_match_while_writing() {
+    fn replay_filter_defers_uuidless_text_match_while_writing_until_written() {
         let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
         let controller = runtime.controller();
         assert_eq!(
@@ -914,14 +939,54 @@ mod tests {
         });
         assert_eq!(
             controller.replay_user_event_action(&event),
-            ReplayUserEventAction::UnknownPromptUser
-        );
-
-        controller.mark_written(&active_uuid);
-        assert_eq!(
-            controller.replay_user_event_action(&event),
             ReplayUserEventAction::InternalActiveInput
         );
+        {
+            let state = controller
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            assert!(state.pending_by_uuid.contains_key(&active_uuid));
+        }
+
+        controller.mark_written(&active_uuid);
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_clears_multiple_uuidless_writing_replays_after_writes() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+
+        for (message_id, text) in [("msg-1", "first"), ("msg-2", "second")] {
+            let payload = serde_json::to_vec(&json!({
+                "type": ACTIVE_INPUT_TYPE,
+                "text": text,
+            }))
+            .expect("active input payload should serialize");
+            assert_eq!(
+                controller.handle_control_payload(message_id, &payload),
+                ActiveInputControlOutcome::Accepted
+            );
+        }
+        let first_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        let second_uuid = claude_active_input_uuid("run-1", 1, "msg-2");
+        assert!(!controller.close_for_result_if_idle());
+
+        for (uuid, text) in [(&first_uuid, "first"), (&second_uuid, "second")] {
+            controller.mark_writing(uuid);
+            let event = json!({
+                "type": "user",
+                "message": {"role": "user", "content": text}
+            });
+            assert_eq!(
+                controller.replay_user_event_action(&event),
+                ReplayUserEventAction::InternalActiveInput
+            );
+            controller.mark_written(uuid);
+        }
+
         assert!(controller.close_for_result_if_idle());
     }
 

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -152,10 +152,11 @@ fn claude_active_input_uuid(run_id: &str, message_id: &str) -> String {
 }
 
 fn user_message_role_allows_replay(event: &Value) -> bool {
-    !matches!(
-        event.pointer("/message/role").and_then(Value::as_str),
-        Some(role) if role != "user"
-    )
+    match event.pointer("/message/role") {
+        Some(Value::String(role)) => role == "user",
+        Some(_) => false,
+        None => true,
+    }
 }
 
 fn prompt_like_user_content(event: &Value) -> Option<String> {
@@ -852,6 +853,38 @@ mod tests {
             "type": "user",
             "uuid": active_uuid,
             "message": {"role": "assistant", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&malformed),
+            ReplayUserEventAction::External
+        );
+
+        let replay = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&replay),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_keeps_non_string_role_events_external() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+
+        let malformed = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "message": {"role": 123, "content": "follow-up"}
         });
         assert_eq!(
             controller.replay_user_event_action(&malformed),

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -55,6 +55,13 @@ enum ReplayEventUuid<'a> {
     NonString,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PromptUserContent {
+    Text(String),
+    ToolResult,
+    Unknown,
+}
+
 #[derive(Debug)]
 struct PendingInput {
     state: PendingState,
@@ -224,29 +231,35 @@ fn replay_event_uuid(event: &Value) -> ReplayEventUuid<'_> {
     }
 }
 
-fn prompt_like_user_content(event: &Value) -> Option<String> {
-    let content = event.pointer("/message/content")?;
+fn prompt_user_content(event: &Value) -> PromptUserContent {
+    let Some(content) = event.pointer("/message/content") else {
+        return PromptUserContent::Unknown;
+    };
     if let Some(text) = content.as_str() {
-        return Some(text.to_owned());
+        return PromptUserContent::Text(text.to_owned());
     }
-    let items = content.as_array()?;
+    let Some(items) = content.as_array() else {
+        return PromptUserContent::Unknown;
+    };
     if items.is_empty() {
-        return None;
+        return PromptUserContent::Unknown;
     }
 
     let mut text = String::new();
     for item in items {
         match item.get("type").and_then(Value::as_str) {
-            Some("tool_result") => return None,
+            Some("tool_result") => return PromptUserContent::ToolResult,
             Some("text") => {
-                let part = item.get("text").and_then(Value::as_str)?;
+                let Some(part) = item.get("text").and_then(Value::as_str) else {
+                    return PromptUserContent::Unknown;
+                };
                 text.push_str(part);
             }
-            _ => return None,
+            _ => return PromptUserContent::Unknown,
         }
     }
 
-    Some(text)
+    PromptUserContent::Text(text)
 }
 
 impl ActiveInputRuntime {
@@ -451,20 +464,22 @@ impl ActiveInputController {
             }
         }
 
-        if let Some(text) = prompt_like_user_content(event) {
-            let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-            if event_uuid == ReplayEventUuid::Missing {
-                if state.remove_replayable_pending_by_text(&text) {
-                    return ReplayUserEventAction::InternalActiveInput;
+        match prompt_user_content(event) {
+            PromptUserContent::Text(text) => {
+                let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+                if event_uuid == ReplayEventUuid::Missing {
+                    if state.remove_replayable_pending_by_text(&text) {
+                        return ReplayUserEventAction::InternalActiveInput;
+                    }
+                    if !state.observed_result && text == self.inner.initial_prompt_text {
+                        state.initial_prompt_replay_seen = true;
+                    }
                 }
-                if !state.observed_result && text == self.inner.initial_prompt_text {
-                    state.initial_prompt_replay_seen = true;
-                }
+                ReplayUserEventAction::UnknownPromptUser
             }
-            return ReplayUserEventAction::UnknownPromptUser;
+            PromptUserContent::ToolResult => ReplayUserEventAction::External,
+            PromptUserContent::Unknown => ReplayUserEventAction::UnknownPromptUser,
         }
-
-        ReplayUserEventAction::External
     }
 }
 
@@ -1198,20 +1213,27 @@ mod tests {
     }
 
     #[test]
-    fn replay_filter_keeps_unknown_user_content_blocks_external() {
+    fn replay_filter_filters_unknown_user_content_blocks() {
         let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
-        let event = json!({
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": [{"type": "image", "source": "future-schema"}]
-            }
-        });
 
-        assert_eq!(
-            runtime.controller().replay_user_event_action(&event),
-            ReplayUserEventAction::External
-        );
+        for content in [
+            json!([{"type": "image", "source": "future-schema"}]),
+            json!({"type": "future-schema"}),
+            json!([]),
+        ] {
+            let event = json!({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": content
+                }
+            });
+
+            assert_eq!(
+                runtime.controller().replay_user_event_action(&event),
+                ReplayUserEventAction::UnknownPromptUser
+            );
+        }
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -56,6 +56,7 @@ struct PendingInput {
 #[derive(Debug)]
 struct ActiveInputState {
     lifecycle: Lifecycle,
+    initial_prompt_replay_seen: bool,
     observed_result: bool,
     seen_message_ids: HashSet<String>,
     pending_by_uuid: HashMap<String, PendingInput>,
@@ -65,6 +66,7 @@ impl Default for ActiveInputState {
     fn default() -> Self {
         Self {
             lifecycle: Lifecycle::Open,
+            initial_prompt_replay_seen: false,
             observed_result: false,
             seen_message_ids: HashSet::new(),
             pending_by_uuid: HashMap::new(),
@@ -78,7 +80,7 @@ impl ActiveInputState {
     }
 
     fn remove_replayable_pending_by_text(&mut self, text: &str) -> bool {
-        if !self.observed_result {
+        if !self.initial_prompt_replay_seen && !self.observed_result {
             return false;
         }
 
@@ -345,6 +347,8 @@ impl ActiveInputController {
 
         if let Some(uuid) = event.get("uuid").and_then(Value::as_str) {
             if uuid == self.inner.initial_prompt_uuid {
+                let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+                state.initial_prompt_replay_seen = true;
                 return ReplayUserEventAction::InternalInitialPrompt;
             }
 
@@ -358,6 +362,9 @@ impl ActiveInputController {
             let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
             if state.remove_replayable_pending_by_text(&text) {
                 return ReplayUserEventAction::InternalActiveInput;
+            }
+            if !state.observed_result {
+                state.initial_prompt_replay_seen = true;
             }
             return ReplayUserEventAction::UnknownPromptUser;
         }
@@ -663,6 +670,70 @@ mod tests {
             ReplayUserEventAction::UnknownPromptUser
         );
         assert!(!controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_consumes_uuidless_text_match_after_initial_replay_before_first_result() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "initial"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let active = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_waits_for_second_uuidless_same_text_before_first_result() {
+        let runtime = ActiveInputRuntime::new("run-1", true);
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"same-text"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_written(&active_uuid);
+
+        let initial = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "same-text"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&initial),
+            ReplayUserEventAction::UnknownPromptUser
+        );
+
+        let active = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "same-text"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&active),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -98,6 +98,14 @@ impl ActiveInputState {
 
         self.pending_by_uuid.remove(&uuid).is_some()
     }
+
+    fn pending_inputs_are_in_stdin_writer(&self) -> bool {
+        !self.pending_by_uuid.is_empty()
+            && self
+                .pending_by_uuid
+                .values()
+                .all(|input| matches!(input.state, PendingState::Writing | PendingState::Written))
+    }
 }
 
 #[derive(Debug)]
@@ -338,9 +346,16 @@ impl ActiveInputController {
         }
 
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        let had_observed_result = state.observed_result;
         state.observed_result = true;
         if !state.pending_by_uuid.is_empty() {
-            return false;
+            if !had_observed_result || !state.pending_inputs_are_in_stdin_writer() {
+                return false;
+            }
+            // Claude should replay stdin user frames before the follow-up result.
+            // If that replay is missing, a later result still proves the CLI
+            // made progress after the writer took ownership of the frame.
+            state.pending_by_uuid.clear();
         }
         match state.lifecycle {
             Lifecycle::Open => {
@@ -694,6 +709,45 @@ mod tests {
             ReplayUserEventAction::UnknownPromptUser
         );
         assert!(!controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn followup_result_closes_writer_owned_pending_input_without_replay() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", "msg-1");
+        controller.mark_writing(&active_uuid);
+
+        assert!(!controller.close_for_result_if_idle());
+        assert!(controller.close_for_result_if_idle());
+        assert!(matches!(
+            controller.handle_control_payload("msg-2", br#"{"type":"active-input","text":"late"}"#),
+            ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
+        ));
+    }
+
+    #[test]
+    fn followup_result_keeps_unwritten_pending_input_open_without_replay() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+
+        assert!(!controller.close_for_result_if_idle());
+        assert!(!controller.close_for_result_if_idle());
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-2", br#"{"type":"active-input","text":"still-open"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -478,7 +478,9 @@ impl ActiveInputController {
 
     pub fn mark_writing(&self, uuid: &str) {
         let mut state = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(input) = state.pending_by_uuid.get_mut(uuid) {
+        if let Some(input) = state.pending_by_uuid.get_mut(uuid)
+            && matches!(input.state, PendingState::Accepted)
+        {
             input.state = PendingState::Writing;
         }
     }
@@ -1120,6 +1122,32 @@ mod tests {
             controller.handle_control_payload("msg-2", br#"{"type":"active-input","text":"late"}"#),
             ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input is closed"
         ));
+    }
+
+    #[test]
+    fn mark_writing_does_not_regress_replay_observed_pending_input() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+        let active_uuid = claude_active_input_uuid("run-1", 0, "msg-1");
+        assert!(!controller.close_for_result_if_idle());
+
+        controller.mark_writing(&active_uuid);
+        let event = json!({
+            "type": "user",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&event),
+            ReplayUserEventAction::InternalActiveInput
+        );
+
+        controller.mark_writing(&active_uuid);
+        assert!(controller.close_for_result_if_idle());
     }
 
     #[test]

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -159,6 +159,10 @@ fn user_message_role_allows_replay(event: &Value) -> bool {
     }
 }
 
+fn parent_tool_use_allows_replay(event: &Value) -> bool {
+    matches!(event.get("parent_tool_use_id"), Some(Value::Null) | None)
+}
+
 fn prompt_like_user_content(event: &Value) -> Option<String> {
     let content = event.pointer("/message/content")?;
     if let Some(text) = content.as_str() {
@@ -359,6 +363,9 @@ impl ActiveInputController {
             return ReplayUserEventAction::External;
         }
         if !user_message_role_allows_replay(event) {
+            return ReplayUserEventAction::External;
+        }
+        if !parent_tool_use_allows_replay(event) {
             return ReplayUserEventAction::External;
         }
 
@@ -894,6 +901,40 @@ mod tests {
         let replay = json!({
             "type": "user",
             "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&replay),
+            ReplayUserEventAction::InternalActiveInput
+        );
+        assert!(controller.close_for_result_if_idle());
+    }
+
+    #[test]
+    fn replay_filter_keeps_child_user_events_external() {
+        let runtime = ActiveInputRuntime::new_with_initial_prompt("run-1", true, "initial");
+        let controller = runtime.controller();
+        assert_eq!(
+            controller
+                .handle_control_payload("msg-1", br#"{"type":"active-input","text":"follow-up"}"#),
+            ActiveInputControlOutcome::Accepted
+        );
+
+        let child = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "parent_tool_use_id": "tool-1",
+            "message": {"role": "user", "content": "follow-up"}
+        });
+        assert_eq!(
+            controller.replay_user_event_action(&child),
+            ReplayUserEventAction::External
+        );
+
+        let replay = json!({
+            "type": "user",
+            "uuid": claude_active_input_uuid("run-1", "msg-1"),
+            "parent_tool_use_id": null,
             "message": {"role": "user", "content": "follow-up"}
         });
         assert_eq!(

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -57,6 +57,7 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
         "stream-json".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
+        "--replay-user-messages".to_string(),
         "--dangerously-skip-permissions".to_string(),
     ];
 
@@ -275,7 +276,7 @@ mod tests {
         assert_eq!(args[input_idx + 1], "stream-json");
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert_claude_prompt_is_not_positional(&args, "hello world");
-        assert!(!args.contains(&"--replay-user-messages".to_string()));
+        assert!(args.contains(&"--replay-user-messages".to_string()));
         assert!(!args.contains(&"--append-system-prompt".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
     }

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -12,14 +12,18 @@ use super::LOG_TAG;
 
 /// Build the CLI command + args based on `CLI_AGENT_TYPE`.
 pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
-    build_cli_command_for_framework(env::Framework::from_env())
+    build_cli_command_for_framework(env::Framework::from_env(), false)
 }
 
 pub(super) fn build_cli_command_for_framework(
     framework: env::Framework,
+    replay_user_messages: bool,
 ) -> Result<Vec<String>, AgentError> {
     match framework {
-        env::Framework::ClaudeCode => Ok(build_claude_command(env::use_mock_claude())),
+        env::Framework::ClaudeCode => Ok(build_claude_command(
+            env::use_mock_claude(),
+            replay_user_messages,
+        )),
         env::Framework::Codex => Ok(build_codex_command(env::use_mock_codex())),
     }
 }
@@ -47,6 +51,7 @@ struct ClaudeArgsConfig<'a> {
     disallowed_tools: &'a str,
     tools: &'a str,
     settings: &'a str,
+    replay_user_messages: bool,
 }
 
 fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
@@ -57,9 +62,11 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
         "stream-json".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
-        "--replay-user-messages".to_string(),
         "--dangerously-skip-permissions".to_string(),
     ];
+    if config.replay_user_messages {
+        args.push("--replay-user-messages".to_string());
+    }
 
     if !config.resume_id.is_empty() {
         log_info!(LOG_TAG, "Resuming session");
@@ -85,13 +92,14 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
     args
 }
 
-fn build_claude_command(use_mock: bool) -> Vec<String> {
+fn build_claude_command(use_mock: bool, replay_user_messages: bool) -> Vec<String> {
     let args = build_claude_args(ClaudeArgsConfig {
         resume_id: env::resume_session_id(),
         append_system_prompt: env::append_system_prompt(),
         disallowed_tools: env::disallowed_tools(),
         tools: env::tools(),
         settings: env::settings(),
+        replay_user_messages,
     });
 
     let bin = if use_mock {
@@ -240,6 +248,24 @@ mod tests {
         tools: &str,
         settings: &str,
     ) -> Vec<String> {
+        build_claude_args_for_test_with_replay(
+            resume_id,
+            append_system_prompt,
+            disallowed_tools,
+            tools,
+            settings,
+            true,
+        )
+    }
+
+    fn build_claude_args_for_test_with_replay(
+        resume_id: &str,
+        append_system_prompt: &str,
+        disallowed_tools: &str,
+        tools: &str,
+        settings: &str,
+        replay_user_messages: bool,
+    ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
         build_claude_args(ClaudeArgsConfig {
@@ -248,13 +274,14 @@ mod tests {
             disallowed_tools,
             tools,
             settings,
+            replay_user_messages,
         })
     }
 
     fn build_claude_command_for_test(use_mock: bool) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_claude_command(use_mock)
+        build_claude_command(use_mock, true)
     }
 
     fn assert_claude_prompt_is_not_positional(args: &[String], prompt: &str) {
@@ -279,6 +306,12 @@ mod tests {
         assert!(args.contains(&"--replay-user-messages".to_string()));
         assert!(!args.contains(&"--append-system-prompt".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_omits_replay_user_messages_when_disabled() {
+        let args = build_claude_args_for_test_with_replay("", "", "", "", "", false);
+        assert!(!args.contains(&"--replay-user-messages".to_string()));
     }
 
     #[test]
@@ -311,6 +344,7 @@ mod tests {
             disallowed_tools: "",
             tools: "",
             settings: "",
+            replay_user_messages: true,
         });
         guest_common::log::clear_system_log_file();
         let system_log = std::fs::read_to_string(system_log_path).unwrap();

--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -50,6 +50,10 @@ impl CliFrameworkBehavior {
         matches!(self.framework, env::Framework::ClaudeCode)
     }
 
+    pub(super) fn filters_replayed_user_events(self) -> bool {
+        matches!(self.framework, env::Framework::ClaudeCode)
+    }
+
     pub(super) fn track_claude_tool_events(
         self,
         event: &serde_json::Value,
@@ -121,6 +125,14 @@ mod tests {
     fn framework_behavior_stream_json_stdin_only_for_claude_code() {
         assert!(CliFrameworkBehavior::new(env::Framework::ClaudeCode).uses_stream_json_stdin());
         assert!(!CliFrameworkBehavior::new(env::Framework::Codex).uses_stream_json_stdin());
+    }
+
+    #[test]
+    fn framework_behavior_filters_replayed_user_events_only_for_claude_code() {
+        assert!(
+            CliFrameworkBehavior::new(env::Framework::ClaudeCode).filters_replayed_user_events()
+        );
+        assert!(!CliFrameworkBehavior::new(env::Framework::Codex).filters_replayed_user_events());
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -502,38 +502,40 @@ async fn execute_cli_inner(
                         }
 
                         if let Ok(event) = serde_json::from_str::<serde_json::Value>(stripped) {
-                            match active_input_controller.replay_user_event_action(&event) {
-                                ReplayUserEventAction::External => {}
-                                ReplayUserEventAction::InternalInitialPrompt => {
-                                    let _ = log_file
-                                        .write_all(
-                                            br#"{"type":"vm0_internal","event":"filtered_replayed_initial_prompt"}"#,
-                                        )
-                                        .await;
-                                    let _ = log_file.write_all(b"\n").await;
-                                    continue;
-                                }
-                                ReplayUserEventAction::InternalActiveInput => {
-                                    let _ = log_file
-                                        .write_all(
-                                            br#"{"type":"vm0_internal","event":"filtered_replayed_active_input"}"#,
-                                        )
-                                        .await;
-                                    let _ = log_file.write_all(b"\n").await;
-                                    continue;
-                                }
-                                ReplayUserEventAction::UnknownPromptUser => {
-                                    let _ = log_file
-                                        .write_all(
-                                            br#"{"type":"vm0_internal","event":"filtered_unknown_prompt_user"}"#,
-                                        )
-                                        .await;
-                                    let _ = log_file.write_all(b"\n").await;
-                                    log_warn!(
-                                        LOG_TAG,
-                                        "Filtered unknown top-level Claude user replay event"
-                                    );
-                                    continue;
+                            if behavior.filters_replayed_user_events() {
+                                match active_input_controller.replay_user_event_action(&event) {
+                                    ReplayUserEventAction::External => {}
+                                    ReplayUserEventAction::InternalInitialPrompt => {
+                                        let _ = log_file
+                                            .write_all(
+                                                br#"{"type":"vm0_internal","event":"filtered_replayed_initial_prompt"}"#,
+                                            )
+                                            .await;
+                                        let _ = log_file.write_all(b"\n").await;
+                                        continue;
+                                    }
+                                    ReplayUserEventAction::InternalActiveInput => {
+                                        let _ = log_file
+                                            .write_all(
+                                                br#"{"type":"vm0_internal","event":"filtered_replayed_active_input"}"#,
+                                            )
+                                            .await;
+                                        let _ = log_file.write_all(b"\n").await;
+                                        continue;
+                                    }
+                                    ReplayUserEventAction::UnknownPromptUser => {
+                                        let _ = log_file
+                                            .write_all(
+                                                br#"{"type":"vm0_internal","event":"filtered_unknown_prompt_user"}"#,
+                                            )
+                                            .await;
+                                        let _ = log_file.write_all(b"\n").await;
+                                        log_warn!(
+                                            LOG_TAG,
+                                            "Filtered unknown top-level Claude user replay event"
+                                        );
+                                        continue;
+                                    }
                                 }
                             }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -655,6 +655,7 @@ async fn execute_cli_inner(
                     }
                     Ok(None) => {
                         stdout_eof = true;
+                        active_input_controller.close_terminal();
                         if cli_status.is_some() {
                             break Ok(());
                         }
@@ -668,6 +669,7 @@ async fn execute_cli_inner(
                         cli_exit_at = Some(Instant::now());
                         log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
                         cli_status = Some(s);
+                        active_input_controller.close_terminal();
                         // CLI exited on its own (possibly in response to our
                         // SIGTERM). Park the termination FSM so it can't
                         // re-arm on any late `type=result` event.

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -27,6 +27,7 @@ pub use codex_setup::setup_codex;
 pub use command::build_cli_command;
 pub use framework::ClaudeResultSummary;
 
+use crate::active_input::{ActiveInputRuntime, ActiveInputWriter, ReplayUserEventAction};
 use crate::constants;
 use crate::env;
 use crate::error::AgentError;
@@ -47,54 +48,73 @@ use std::time::{Duration, Instant};
 use termination::{TerminationReason, TerminationState};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::oneshot;
-use uuid::Uuid;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 #[derive(serde::Serialize)]
-struct ClaudeInitialPromptFrame<'a> {
+struct ClaudeUserFrame<'a> {
     #[serde(rename = "type")]
     event_type: &'static str,
     uuid: String,
     parent_tool_use_id: Option<&'static str>,
-    message: ClaudeInitialPromptMessage<'a>,
+    message: ClaudeUserMessage<'a>,
 }
 
 #[derive(serde::Serialize)]
-struct ClaudeInitialPromptMessage<'a> {
+struct ClaudeUserMessage<'a> {
     role: &'static str,
     content: &'a str,
 }
 
-fn claude_initial_prompt_uuid(run_id: &str) -> String {
-    Uuid::new_v5(
-        &Uuid::NAMESPACE_OID,
-        format!("vm0:{run_id}:claude-initial-prompt").as_bytes(),
-    )
-    .to_string()
-}
-
-fn claude_initial_prompt_frame<'a>(run_id: &str, prompt: &'a str) -> ClaudeInitialPromptFrame<'a> {
-    ClaudeInitialPromptFrame {
+fn claude_user_frame<'a>(uuid: &str, text: &'a str) -> ClaudeUserFrame<'a> {
+    ClaudeUserFrame {
         event_type: "user",
-        uuid: claude_initial_prompt_uuid(run_id),
+        uuid: uuid.to_owned(),
         parent_tool_use_id: None,
-        message: ClaudeInitialPromptMessage {
+        message: ClaudeUserMessage {
             role: "user",
-            content: prompt,
+            content: text,
         },
     }
 }
 
-async fn write_claude_initial_prompt_to_stdin(
-    mut stdin: tokio::process::ChildStdin,
-    run_id: &str,
-    prompt: &str,
+#[cfg(test)]
+fn claude_initial_prompt_frame<'a>(run_id: &str, prompt: &'a str) -> ClaudeUserFrame<'a> {
+    let uuid = crate::active_input::claude_initial_prompt_uuid(run_id);
+    claude_user_frame(&uuid, prompt)
+}
+
+async fn write_claude_user_frame_to_stdin(
+    stdin: &mut tokio::process::ChildStdin,
+    uuid: &str,
+    text: &str,
 ) -> Result<(), AgentError> {
-    let mut line = serde_json::to_vec(&claude_initial_prompt_frame(run_id, prompt))?;
+    let mut line = serde_json::to_vec(&claude_user_frame(uuid, text))?;
     line.push(b'\n');
     stdin.write_all(&line).await?;
     stdin.flush().await?;
+    Ok(())
+}
+
+async fn write_claude_stream_json_to_stdin(
+    mut stdin: tokio::process::ChildStdin,
+    run_id: &str,
+    prompt: &str,
+    mut active_input: ActiveInputWriter,
+) -> Result<(), AgentError> {
+    let initial_uuid = crate::active_input::claude_initial_prompt_uuid(run_id);
+    write_claude_user_frame_to_stdin(&mut stdin, &initial_uuid, prompt).await?;
+    if !active_input.is_enabled() {
+        active_input.close_terminal();
+        return Ok(());
+    }
+
+    while let Some(frame) = active_input.next_frame().await {
+        write_claude_user_frame_to_stdin(&mut stdin, &frame.uuid, &frame.text).await?;
+        active_input.mark_written(&frame.uuid);
+    }
+
+    active_input.close_terminal();
     Ok(())
 }
 
@@ -198,6 +218,34 @@ pub async fn execute_cli(
     http: HttpClient,
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();
+    let active_input = ActiveInputRuntime::new(env::run_id(), false);
+    execute_cli_inner(
+        masker,
+        heartbeat_monitor,
+        http,
+        framework,
+        active_input.into_writer(),
+    )
+    .await
+}
+
+pub async fn execute_cli_with_active_input(
+    masker: &SecretMasker,
+    heartbeat_monitor: HeartbeatMonitor,
+    http: HttpClient,
+    active_input: ActiveInputWriter,
+) -> Result<CliExecutionResult, AgentError> {
+    let framework = env::Framework::from_env();
+    execute_cli_inner(masker, heartbeat_monitor, http, framework, active_input).await
+}
+
+async fn execute_cli_inner(
+    masker: &SecretMasker,
+    mut heartbeat_monitor: HeartbeatMonitor,
+    http: HttpClient,
+    framework: env::Framework,
+    active_input: ActiveInputWriter,
+) -> Result<CliExecutionResult, AgentError> {
     let behavior = CliFrameworkBehavior::new(framework);
     masker.add_sensitive_value(env::resume_session_id());
     log_info!(LOG_TAG, "Starting {} execution...", behavior.agent_type());
@@ -269,7 +317,7 @@ pub async fn execute_cli(
 
     let mut child = cmd.spawn()?;
 
-    let initial_prompt_stdin = if behavior.uses_stream_json_stdin() {
+    let claude_stdin = if behavior.uses_stream_json_stdin() {
         let Some(stdin) = child.stdin.take() else {
             let _ = child.start_kill();
             return Err(AgentError::Execution("no stdin".into()));
@@ -292,12 +340,13 @@ pub async fn execute_cli(
     let mut stderr_handle =
         tokio::spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
 
-    let mut initial_prompt_write_handle = initial_prompt_stdin.map(|stdin| {
+    let active_input_controller = active_input.controller();
+    let mut claude_stdin_write_handle = claude_stdin.map(|stdin| {
         let run_id = env::run_id();
         let prompt = env::prompt();
-        tokio::spawn(
-            async move { write_claude_initial_prompt_to_stdin(stdin, run_id, prompt).await },
-        )
+        tokio::spawn(async move {
+            write_claude_stream_json_to_stdin(stdin, run_id, prompt, active_input).await
+        })
     });
 
     // Stream stdout JSONL, racing against heartbeat and process exit.
@@ -388,21 +437,22 @@ pub async fn execute_cli(
     let mut failure_diagnostic = None;
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
-            prompt_write_result = async {
-                match initial_prompt_write_handle.as_mut() {
+            stdin_write_result = async {
+                match claude_stdin_write_handle.as_mut() {
                     Some(handle) => Some(handle.await),
                     None => std::future::pending().await,
                 }
-            }, if initial_prompt_write_handle.is_some() => {
-                initial_prompt_write_handle = None;
+            }, if claude_stdin_write_handle.is_some() => {
+                claude_stdin_write_handle = None;
                 let can_terminate_for_stdin_error =
                     matches!(termination_state, TerminationState::Idle) && cli_status.is_none();
-                match prompt_write_result {
+                match stdin_write_result {
                     Some(Ok(Ok(()))) => {}
                     Some(Ok(Err(error))) if can_terminate_for_stdin_error => {
+                        active_input_controller.close_terminal();
                         log_warn!(
                             LOG_TAG,
-                            "Failed to write initial prompt to Claude stdin, SIGTERM pgid={}: {error}",
+                            "Claude stdin writer failed, SIGTERM pgid={}: {error}",
                             pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                         );
                         if let Some(pid) = pgid {
@@ -416,11 +466,14 @@ pub async fn execute_cli(
                                 + Duration::from_secs(env::post_result_sigkill_grace_secs()),
                         );
                     }
-                    Some(Ok(Err(_))) => {}
+                    Some(Ok(Err(_))) => {
+                        active_input_controller.close_terminal();
+                    }
                     Some(Err(error)) if can_terminate_for_stdin_error => {
+                        active_input_controller.close_terminal();
                         log_warn!(
                             LOG_TAG,
-                            "Initial prompt stdin task failed, SIGTERM pgid={}: {error}",
+                            "Claude stdin writer task failed, SIGTERM pgid={}: {error}",
                             pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                         );
                         if let Some(pid) = pgid {
@@ -434,23 +487,59 @@ pub async fn execute_cli(
                                 + Duration::from_secs(env::post_result_sigkill_grace_secs()),
                         );
                     }
-                    Some(Err(_)) => {}
+                    Some(Err(_)) => {
+                        active_input_controller.close_terminal();
+                    }
                     None => {}
                 }
             }
             line_result = reader.next_line(), if !stdout_eof => {
                 match line_result {
                     Ok(Some(line)) => {
-                        // Write to log
-                        let _ = log_file.write_all(line.as_bytes()).await;
-                        let _ = log_file.write_all(b"\n").await;
-
                         let stripped = line.trim();
                         if stripped.is_empty() {
                             continue;
                         }
 
                         if let Ok(event) = serde_json::from_str::<serde_json::Value>(stripped) {
+                            match active_input_controller.replay_user_event_action(&event) {
+                                ReplayUserEventAction::External => {}
+                                ReplayUserEventAction::InternalInitialPrompt => {
+                                    let _ = log_file
+                                        .write_all(
+                                            br#"{"type":"vm0_internal","event":"filtered_replayed_initial_prompt"}"#,
+                                        )
+                                        .await;
+                                    let _ = log_file.write_all(b"\n").await;
+                                    continue;
+                                }
+                                ReplayUserEventAction::InternalActiveInput => {
+                                    let _ = log_file
+                                        .write_all(
+                                            br#"{"type":"vm0_internal","event":"filtered_replayed_active_input"}"#,
+                                        )
+                                        .await;
+                                    let _ = log_file.write_all(b"\n").await;
+                                    continue;
+                                }
+                                ReplayUserEventAction::UnknownPromptUser => {
+                                    let _ = log_file
+                                        .write_all(
+                                            br#"{"type":"vm0_internal","event":"filtered_unknown_prompt_user"}"#,
+                                        )
+                                        .await;
+                                    let _ = log_file.write_all(b"\n").await;
+                                    log_warn!(
+                                        LOG_TAG,
+                                        "Filtered unknown top-level Claude user replay event"
+                                    );
+                                    continue;
+                                }
+                            }
+
+                            let _ = log_file.write_all(line.as_bytes()).await;
+                            let _ = log_file.write_all(b"\n").await;
+
                             if event.get("type").and_then(serde_json::Value::as_str)
                                 == Some("stream_event")
                             {
@@ -492,9 +581,15 @@ pub async fn execute_cli(
                                     // printing Claude's final result.
                                     println!("{}", masker.mask_string(result));
                                 }
+                                let active_input_idle =
+                                    active_input_controller.close_for_result_if_idle();
                                 // Arm the post-result reap deadline once per
-                                // run — see `TerminationState::should_arm_post_result`.
-                                if termination_state.should_arm_post_result(cli_status.is_some()) {
+                                // run when no active follow-up input is still
+                                // pending — see `TerminationState::should_arm_post_result`.
+                                if active_input_idle
+                                    && termination_state
+                                        .should_arm_post_result(cli_status.is_some())
+                                {
                                     termination_state = TerminationState::SigtermPending {
                                         reason: TerminationReason::PostResult,
                                     };
@@ -548,6 +643,9 @@ pub async fn execute_cli(
                                 }
                             }
                             seq += 1;
+                        } else {
+                            let _ = log_file.write_all(line.as_bytes()).await;
+                            let _ = log_file.write_all(b"\n").await;
                         }
                     }
                     Ok(None) => {
@@ -766,27 +864,28 @@ pub async fn execute_cli(
         }
     };
 
-    if let Some(handle) = initial_prompt_write_handle.take() {
+    if let Some(handle) = claude_stdin_write_handle.take() {
         if handle.is_finished() {
             match handle.await {
                 Ok(Ok(())) => {}
                 Ok(Err(error)) => {
                     log_warn!(
                         LOG_TAG,
-                        "Initial prompt stdin write finished after CLI loop with error: {error}"
+                        "Claude stdin writer finished after CLI loop with error: {error}"
                     );
                 }
                 Err(error) => {
                     log_warn!(
                         LOG_TAG,
-                        "Initial prompt stdin task failed after CLI loop: {error}"
+                        "Claude stdin writer failed after CLI loop: {error}"
                     );
                 }
             }
         } else {
             handle.abort();
             let _ = handle.await;
-            log_warn!(LOG_TAG, "Aborted unfinished initial prompt stdin task");
+            active_input_controller.close_terminal();
+            log_warn!(LOG_TAG, "Aborted unfinished Claude stdin writer");
         }
     }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -868,6 +868,7 @@ async fn execute_cli_inner(
         }
     };
 
+    active_input_controller.close_terminal();
     if let Some(handle) = claude_stdin_write_handle.take() {
         if handle.is_finished() {
             match handle.await {
@@ -888,7 +889,6 @@ async fn execute_cli_inner(
         } else {
             handle.abort();
             let _ = handle.await;
-            active_input_controller.close_terminal();
             log_warn!(LOG_TAG, "Aborted unfinished Claude stdin writer");
         }
     }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -215,7 +215,7 @@ pub type HeartbeatMonitor = Option<oneshot::Receiver<HeartbeatStatus>>;
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
 pub async fn execute_cli(
     masker: &SecretMasker,
-    mut heartbeat_monitor: HeartbeatMonitor,
+    heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -249,10 +249,11 @@ async fn execute_cli_inner(
     active_input: ActiveInputWriter,
 ) -> Result<CliExecutionResult, AgentError> {
     let behavior = CliFrameworkBehavior::new(framework);
+    let replay_user_messages = active_input.is_enabled();
     masker.add_sensitive_value(env::resume_session_id());
     log_info!(LOG_TAG, "Starting {} execution...", behavior.agent_type());
 
-    let cmd = command::build_cli_command_for_framework(framework)?;
+    let cmd = command::build_cli_command_for_framework(framework, replay_user_messages)?;
     let (bin, args) = cmd
         .split_first()
         .ok_or_else(|| AgentError::Execution("empty command".into()))?;
@@ -504,7 +505,7 @@ async fn execute_cli_inner(
                         }
 
                         if let Ok(event) = serde_json::from_str::<serde_json::Value>(stripped) {
-                            if behavior.filters_replayed_user_events() {
+                            if behavior.filters_replayed_user_events() && replay_user_messages {
                                 match active_input_controller.replay_user_event_action(&event) {
                                     ReplayUserEventAction::External => {}
                                     ReplayUserEventAction::InternalInitialPrompt => {
@@ -889,7 +890,7 @@ async fn execute_cli_inner(
         } else {
             handle.abort();
             let _ = handle.await;
-            log_warn!(LOG_TAG, "Aborted unfinished Claude stdin writer");
+            log_info!(LOG_TAG, "Stopped Claude stdin writer after CLI loop");
         }
     }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -110,6 +110,7 @@ async fn write_claude_stream_json_to_stdin(
     }
 
     while let Some(frame) = active_input.next_frame().await {
+        active_input.mark_writing(&frame.uuid);
         write_claude_user_frame_to_stdin(&mut stdin, &frame.uuid, &frame.text).await?;
         active_input.mark_written(&frame.uuid);
     }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -219,7 +219,8 @@ pub async fn execute_cli(
     http: HttpClient,
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();
-    let active_input = ActiveInputRuntime::new(env::run_id(), false);
+    let active_input =
+        ActiveInputRuntime::new_with_initial_prompt(env::run_id(), false, env::prompt());
     execute_cli_inner(
         masker,
         heartbeat_monitor,

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -175,7 +175,11 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
-        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
@@ -214,7 +218,11 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
-        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
@@ -255,7 +263,11 @@ mod tests {
         let endpoint = process_control_ipc::endpoint_name(43, &nonce);
         let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
         let shutdown = CancellationToken::new();
-        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
         let active_input = active_runtime.controller();
         let handle = ControlHandle::spawn_endpoint(endpoint, shutdown, active_input).unwrap();
 
@@ -284,7 +296,11 @@ mod tests {
         let endpoint = process_control_ipc::endpoint_name(45, &nonce);
         let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
         let shutdown = CancellationToken::new();
-        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
         let active_input = active_runtime.controller();
         let handle = ControlHandle::spawn_endpoint(endpoint, shutdown, active_input).unwrap();
 
@@ -315,7 +331,11 @@ mod tests {
         let shutdown = CancellationToken::new();
         let stream_slot = Arc::new(Mutex::new(None));
         let worker_slot = Arc::clone(&stream_slot);
-        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
         let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use crate::active_input::{ActiveInputControlOutcome, ActiveInputController};
 use guest_common::{log_info, log_warn};
 use tokio_util::sync::CancellationToken;
 
@@ -28,21 +29,25 @@ impl Drop for StreamSlotCleanup {
 }
 
 impl ControlHandle {
-    pub fn spawn(shutdown: CancellationToken) -> Option<Self> {
+    pub fn spawn(shutdown: CancellationToken, active_input: ActiveInputController) -> Option<Self> {
         let endpoint = match std::env::var(process_control_ipc::BOOTSTRAP_ENV) {
             Ok(endpoint) if !endpoint.is_empty() => endpoint,
             _ => return None,
         };
-        Self::spawn_endpoint(endpoint, shutdown)
+        Self::spawn_endpoint(endpoint, shutdown, active_input)
     }
 
-    fn spawn_endpoint(endpoint: String, shutdown: CancellationToken) -> Option<Self> {
+    fn spawn_endpoint(
+        endpoint: String,
+        shutdown: CancellationToken,
+        active_input: ActiveInputController,
+    ) -> Option<Self> {
         let stream = Arc::new(Mutex::new(None));
         let worker_stream = Arc::clone(&stream);
         let worker_shutdown = shutdown.clone();
         let join = thread::Builder::new()
             .name("guest-agent-process-control".to_owned())
-            .spawn(move || run(endpoint, worker_shutdown, worker_stream))
+            .spawn(move || run(endpoint, worker_shutdown, worker_stream, active_input))
             .map_err(|error| {
                 log_warn!(LOG_TAG, "Process control task failed to start: {error}");
             })
@@ -78,8 +83,13 @@ impl Drop for ControlHandle {
     }
 }
 
-fn run(endpoint: String, shutdown: CancellationToken, stream_slot: Arc<Mutex<Option<UnixStream>>>) {
-    match run_inner(&endpoint, shutdown, stream_slot) {
+fn run(
+    endpoint: String,
+    shutdown: CancellationToken,
+    stream_slot: Arc<Mutex<Option<UnixStream>>>,
+    active_input: ActiveInputController,
+) {
+    match run_inner(&endpoint, shutdown, stream_slot, active_input) {
         Ok(()) => log_info!(LOG_TAG, "Process control task stopped"),
         Err(error) => log_warn!(LOG_TAG, "Process control task stopped: {error}"),
     }
@@ -89,6 +99,7 @@ fn run_inner(
     endpoint: &str,
     shutdown: CancellationToken,
     stream_slot: Arc<Mutex<Option<UnixStream>>>,
+    active_input: ActiveInputController,
 ) -> io::Result<()> {
     let mut stream = process_control_ipc::connect_abstract(endpoint)?;
     let shutdown_stream = stream.try_clone()?;
@@ -103,12 +114,15 @@ fn run_inner(
     while !shutdown.is_cancelled() {
         match process_control_ipc::read_request(&mut stream) {
             Ok(request) => {
+                let outcome =
+                    active_input.handle_control_payload(&request.message_id, &request.payload);
+                let (status, diagnostic) = control_response_from_active_input(outcome);
                 process_control_ipc::write_response(
                     &mut stream,
                     &process_control_ipc::ControlResponse {
                         message_id: request.message_id,
-                        status: process_control_ipc::ControlResponseStatus::Accepted,
-                        diagnostic: String::new(),
+                        status,
+                        diagnostic,
                     },
                 )?;
             }
@@ -130,6 +144,25 @@ fn run_inner(
     Ok(())
 }
 
+fn control_response_from_active_input(
+    outcome: ActiveInputControlOutcome,
+) -> (process_control_ipc::ControlResponseStatus, String) {
+    match outcome {
+        ActiveInputControlOutcome::Accepted => (
+            process_control_ipc::ControlResponseStatus::Accepted,
+            String::new(),
+        ),
+        ActiveInputControlOutcome::Rejected { diagnostic } => (
+            process_control_ipc::ControlResponseStatus::Rejected,
+            diagnostic.to_owned(),
+        ),
+        ActiveInputControlOutcome::Error { diagnostic } => (
+            process_control_ipc::ControlResponseStatus::Error,
+            diagnostic.to_owned(),
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,9 +175,11 @@ mod tests {
         let shutdown = CancellationToken::new();
         let worker_shutdown = shutdown.clone();
         let stream_slot = Arc::new(Mutex::new(None));
+        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
-            move || run_inner(&endpoint, worker_shutdown, stream_slot)
+            move || run_inner(&endpoint, worker_shutdown, stream_slot, active_input)
         });
 
         let mut stream =
@@ -155,7 +190,7 @@ mod tests {
             &mut stream,
             &process_control_ipc::ControlRequest {
                 message_id: "msg-1".to_owned(),
-                payload: b"opaque".to_vec(),
+                payload: br#"{"type":"active-input","text":"hello"}"#.to_vec(),
             },
         )
         .unwrap();
@@ -172,12 +207,57 @@ mod tests {
     }
 
     #[test]
+    fn control_task_rejects_invalid_active_input_payload() {
+        let nonce = *b"0123456789abcdee";
+        let endpoint = process_control_ipc::endpoint_name(46, &nonce);
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+        let shutdown = CancellationToken::new();
+        let worker_shutdown = shutdown.clone();
+        let stream_slot = Arc::new(Mutex::new(None));
+        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_input = active_runtime.controller();
+        let worker = thread::spawn({
+            let endpoint = endpoint.clone();
+            move || run_inner(&endpoint, worker_shutdown, stream_slot, active_input)
+        });
+
+        let mut stream =
+            process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(1))
+                .expect("control task should connect");
+        process_control_ipc::read_hello(&mut stream).unwrap();
+        process_control_ipc::write_request(
+            &mut stream,
+            &process_control_ipc::ControlRequest {
+                message_id: "bad-1".to_owned(),
+                payload: br#"{"type":"other","text":"hello"}"#.to_vec(),
+            },
+        )
+        .unwrap();
+        let response = process_control_ipc::read_response(&mut stream).unwrap();
+        assert_eq!(response.message_id, "bad-1");
+        assert_eq!(
+            response.status,
+            process_control_ipc::ControlResponseStatus::Rejected
+        );
+        assert_eq!(
+            response.diagnostic,
+            "active input payload type is unsupported"
+        );
+
+        shutdown.cancel();
+        drop(stream);
+        worker.join().unwrap().unwrap();
+    }
+
+    #[test]
     fn control_handle_join_wakes_idle_reader() {
         let nonce = *b"fedcba9876543210";
         let endpoint = process_control_ipc::endpoint_name(43, &nonce);
         let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
         let shutdown = CancellationToken::new();
-        let handle = ControlHandle::spawn_endpoint(endpoint, shutdown).unwrap();
+        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_input = active_runtime.controller();
+        let handle = ControlHandle::spawn_endpoint(endpoint, shutdown, active_input).unwrap();
 
         let mut stream =
             process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(1))
@@ -204,7 +284,9 @@ mod tests {
         let endpoint = process_control_ipc::endpoint_name(45, &nonce);
         let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
         let shutdown = CancellationToken::new();
-        let handle = ControlHandle::spawn_endpoint(endpoint, shutdown).unwrap();
+        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_input = active_runtime.controller();
+        let handle = ControlHandle::spawn_endpoint(endpoint, shutdown, active_input).unwrap();
 
         let mut stream =
             process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(1))
@@ -233,9 +315,11 @@ mod tests {
         let shutdown = CancellationToken::new();
         let stream_slot = Arc::new(Mutex::new(None));
         let worker_slot = Arc::clone(&stream_slot);
+        let active_runtime = crate::active_input::ActiveInputRuntime::new("control-test", true);
+        let active_input = active_runtime.controller();
         let worker = thread::spawn({
             let endpoint = endpoint.clone();
-            move || run_inner(&endpoint, shutdown, worker_slot)
+            move || run_inner(&endpoint, shutdown, worker_slot, active_input)
         });
 
         let mut stream =

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -1,5 +1,6 @@
 //! Guest agent library — exposes modules for the binary and integration tests.
 
+pub mod active_input;
 mod artifact;
 pub mod checkpoint;
 pub mod cli;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -68,7 +68,15 @@ async fn run() -> i32 {
 
     let masker = Arc::new(masker::SecretMasker::from_env());
     let shutdown = CancellationToken::new();
-    let control_handle = control::ControlHandle::spawn(shutdown.clone());
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new(
+        env::run_id(),
+        matches!(env::Framework::from_env(), env::Framework::ClaudeCode)
+            && matches!(
+                std::env::var(process_control_ipc::BOOTSTRAP_ENV),
+                Ok(endpoint) if !endpoint.is_empty()
+            ),
+    );
+    let control_handle = control::ControlHandle::spawn(shutdown.clone(), active_input.controller());
     let start = Instant::now();
 
     log_info!(
@@ -101,7 +109,15 @@ async fn run() -> i32 {
     // flush with checkpoint creation. The EOF-consuming final flush runs below,
     // after background producers stop, so `/complete` logs still upload without
     // racing metrics or heartbeat writes.
-    let exit_code = execute(&masker, start, Some(heartbeat_status_rx), &telemetry, http).await;
+    let exit_code = execute(
+        &masker,
+        start,
+        Some(heartbeat_status_rx),
+        &telemetry,
+        http,
+        active_input.into_writer(),
+    )
+    .await;
 
     stop_background_and_flush_final_telemetry(
         shutdown,
@@ -131,6 +147,7 @@ async fn execute(
     heartbeat_monitor: cli::HeartbeatMonitor,
     telemetry: &Telemetry,
     http: HttpClient,
+    active_input: guest_agent::active_input::ActiveInputWriter,
 ) -> i32 {
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
@@ -186,7 +203,14 @@ async fn execute(
         error_message,
         skip_recovery_checkpoint_for_no_history,
         failure_diagnostic,
-    ) = match cli::execute_cli(masker, heartbeat_monitor, http.clone()).await {
+    ) = match cli::execute_cli_with_active_input(
+        masker,
+        heartbeat_monitor,
+        http.clone(),
+        active_input,
+    )
+    .await
+    {
         Ok(cli_result) => {
             last_event_sequence = cli_result.last_event_sequence;
             let cli_exit_code = cli_result.exit_code;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -68,13 +68,14 @@ async fn run() -> i32 {
 
     let masker = Arc::new(masker::SecretMasker::from_env());
     let shutdown = CancellationToken::new();
-    let active_input = guest_agent::active_input::ActiveInputRuntime::new(
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
         env::run_id(),
         matches!(env::Framework::from_env(), env::Framework::ClaudeCode)
             && matches!(
                 std::env::var(process_control_ipc::BOOTSTRAP_ENV),
                 Ok(endpoint) if !endpoint.is_empty()
             ),
+        env::prompt(),
     );
     let control_handle = control::ControlHandle::spawn(shutdown.clone(), active_input.controller());
     let start = Instant::now();

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -113,12 +113,18 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     });
 
     let masker = SecretMasker::from_raw("");
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+        guest_agent::env::run_id(),
+        true,
+        guest_agent::env::prompt(),
+    );
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
+        guest_agent::cli::execute_cli_with_active_input(
             &masker,
             common::spawn_dummy_heartbeat(),
             HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)?,
+            active_input.into_writer(),
         ),
     )
     .await

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -38,7 +38,12 @@ fn cleanup_run_files(ops_file: &str) {
     let _ = std::fs::remove_file(ops_file);
 }
 
-unsafe fn setup_api_env(mock_path: &Path, workdir: &Path, api_url: &str) -> Result<(), String> {
+unsafe fn setup_api_env(
+    mock_path: &Path,
+    workdir: &Path,
+    api_url: &str,
+    prompt: &str,
+) -> Result<(), String> {
     unsafe {
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
@@ -52,7 +57,7 @@ unsafe fn setup_api_env(mock_path: &Path, workdir: &Path, api_url: &str) -> Resu
             .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_else(|| "execute-cli-api-mode-test".to_string());
         std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", "@exit-after-result");
+        std::env::set_var("VM0_PROMPT", prompt);
         std::env::set_var("VM0_API_URL", api_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
@@ -71,9 +76,18 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     let mock_cli = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let server = MockServer::start();
+    let session_id = "preview-filtered-user";
+    let prompt = [
+        "@ECHO@",
+        r#"{"type":"system","subtype":"init","cwd":"/home/user/workspace","session_id":"preview-filtered-user","tools":["Bash"],"model":"mock-claude"}"#,
+        r#"{"type":"user","session_id":"preview-filtered-user","uuid":"unknown-user-replay","message":{"role":"user","content":"should-not-upload"},"parent_tool_use_id":null}"#,
+        r#"{"type":"result","subtype":"success","session_id":"preview-filtered-user","is_error":false,"duration_ms":100,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}"#,
+        "",
+    ]
+    .join("\n");
 
     unsafe {
-        setup_api_env(&mock_cli, tmp.path(), &server.base_url())?;
+        setup_api_env(&mock_cli, tmp.path(), &server.base_url(), &prompt)?;
     }
     let _run_files = RunFilesGuard::new();
 
@@ -88,6 +102,13 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         when.method(POST)
             .path("/api/webhooks/agent/events")
             .body_includes(r#""type":"result""#);
+        then.status(200);
+    });
+    let replayed_user_event = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/events")
+            .body_includes(r#""type":"user""#)
+            .body_includes("should-not-upload");
         then.status(200);
     });
 
@@ -111,15 +132,13 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     );
     init_event.assert_calls_async(1).await;
     result_event.assert_calls_async(1).await;
+    replayed_user_event.assert_calls_async(0).await;
 
-    let session_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
-    assert!(
-        session_id.starts_with("mock-"),
-        "execute_cli should capture the mock CLI session id, got {session_id}"
-    );
+    let captured_session_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    assert_eq!(captured_session_id, session_id);
     let history_path = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
     assert!(
-        history_path.contains(session_id.trim()),
+        history_path.contains(session_id),
         "history path should contain the captured session id, got {history_path}"
     );
 

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -7,12 +7,12 @@
 
 mod common;
 
-use std::io::{self, Write};
-use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use std::{fs::File, thread};
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use tokio::io::unix::AsyncFd;
@@ -24,67 +24,9 @@ const READY_CONTROL_MESSAGE_ID: &str = "process-control-after-cli-ready";
 
 type TestResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-struct FifoGuard {
-    path: PathBuf,
-}
-
-struct FifoGate {
-    file: Option<File>,
-}
-
 struct ConnectionHarness {
     host: Option<vsock_host::VsockHost>,
     guest: Option<thread::JoinHandle<io::Result<()>>>,
-}
-
-impl FifoGuard {
-    fn create(path: PathBuf) -> TestResult<Self> {
-        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
-        // SAFETY: c_path is a valid NUL-terminated path and the mode is a
-        // normal POSIX permission mask for a test-only FIFO.
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        if result != 0 {
-            return Err(std::io::Error::last_os_error().into());
-        }
-        Ok(Self { path })
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl FifoGate {
-    fn open(path: &Path) -> io::Result<Self> {
-        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
-        // SAFETY: c_path is NUL-terminated, flags request one read/write
-        // nonblocking FIFO fd, and ownership transfers to File on success.
-        let fd = unsafe {
-            libc::open(
-                c_path.as_ptr(),
-                libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC,
-            )
-        };
-        if fd < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        // SAFETY: fd is a freshly opened descriptor owned by this function.
-        let file = unsafe { File::from_raw_fd(fd) };
-        Ok(Self { file: Some(file) })
-    }
-
-    fn release(&mut self, payload: &[u8]) -> io::Result<()> {
-        if let Some(file) = self.file.as_mut() {
-            file.write_all(payload)?;
-        }
-        Ok(())
-    }
-}
-
-impl Drop for FifoGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
 }
 
 impl ConnectionHarness {
@@ -124,8 +66,6 @@ impl Drop for ConnectionHarness {
 async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let fifo = FifoGuard::create(tmp.path().join("release.fifo"))?;
-    let ready = tmp.path().join("fifo.ready");
     let run_id = format!(
         "process-control-channel-{}-{}",
         std::process::id(),
@@ -133,11 +73,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     );
 
     let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
-    let prompt = format!(
-        "exec 3< {}; IFS= read -r _ <&3; touch {}; IFS= read -r _ <&3; echo process-control-channel-done",
-        shell_quote_path(fifo.path()),
-        shell_quote_path(&ready)
-    );
+    let prompt = "@active-input-smoke:2";
     let workdir = tmp.path().to_string_lossy().into_owned();
     let mock_path = mock.to_string_lossy().into_owned();
     let env = [
@@ -147,7 +83,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
         ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
         ("VM0_RUN_ID", run_id.as_str()),
-        ("VM0_PROMPT", prompt.as_str()),
+        ("VM0_PROMPT", prompt),
         ("VM0_API_URL", "http://127.0.0.1:1"),
         ("VM0_API_TOKEN", ""),
         ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
@@ -155,7 +91,6 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         ("HOME", workdir.as_str()),
     ];
 
-    let mut fifo_gate = FifoGate::open(fifo.path())?;
     let connection = start_host_and_guest(tmp.path()).await?;
     let command = format!(
         "cleanup_home_user=0; \
@@ -208,8 +143,12 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         )
         .await?;
 
-    fifo_gate.release(b"ready\n")?;
-    wait_for_path(&ready, Duration::from_secs(10)).await?;
+    let mut stdout = collect_stdout_until(
+        &mut stdout_rx,
+        b"READY_FOR_ACTIVE_INPUT",
+        Duration::from_secs(10),
+    )
+    .await?;
 
     let ack = handle
         .control(
@@ -219,9 +158,8 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         )
         .await?;
 
-    fifo_gate.release(b"release\n")?;
     let exit = handle.wait(Duration::from_secs(20)).await?;
-    let stdout = collect_stdout(&mut stdout_rx, Duration::from_secs(5)).await?;
+    stdout.extend(collect_stdout(&mut stdout_rx, Duration::from_secs(5)).await?);
 
     connection.finish()?;
 
@@ -235,12 +173,41 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         captured_output_lossy(&exit.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&stdout).contains("process-control-channel-done"),
-        "guest-agent stdout did not include mock CLI completion marker: {}",
+        String::from_utf8_lossy(&stdout).contains("RESULT=before-ready+after-ready"),
+        "guest-agent stdout did not include active-input result: {}",
         String::from_utf8_lossy(&stdout)
     );
 
     Ok(())
+}
+
+async fn collect_stdout_until(
+    stdout_rx: &mut tokio::sync::mpsc::Receiver<vsock_host::ExecOutputEvent>,
+    needle: &[u8],
+    timeout: Duration,
+) -> io::Result<Vec<u8>> {
+    tokio::time::timeout(timeout, async {
+        let mut stdout = Vec::new();
+        while let Some(event) = stdout_rx.recv().await {
+            if event.stream == ExecOutputStream::Stdout && !event.truncated {
+                stdout.extend_from_slice(&event.chunk);
+                if stdout.windows(needle.len()).any(|window| window == needle) {
+                    return Ok(stdout);
+                }
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "stdout closed before expected marker",
+        ))
+    })
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            "timed out waiting for stdout marker",
+        )
+    })?
 }
 
 async fn start_host_and_guest(dir: &Path) -> TestResult<ConnectionHarness> {
@@ -376,10 +343,6 @@ fn join_guest(guest: thread::JoinHandle<io::Result<()>>) -> TestResult<()> {
         .join()
         .map_err(|_| io::Error::other("guest thread panicked"))??;
     Ok(())
-}
-
-fn shell_quote_path(path: &Path) -> String {
-    shell_quote(&path.to_string_lossy())
 }
 
 fn shell_quote(raw: &str) -> String {

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -92,22 +92,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     ];
 
     let connection = start_host_and_guest(tmp.path()).await?;
-    let command = format!(
-        "cleanup_home_user=0; \
-         cleanup_workspace=0; \
-         if [ ! -e /home/user ]; then cleanup_home_user=1; fi; \
-         if [ ! -e /home/user/workspace ]; then cleanup_workspace=1; fi; \
-         {}; \
-         status=$?; \
-         if [ \"$cleanup_workspace\" = 1 ]; then \
-           rmdir /home/user/workspace 2>/dev/null || true; \
-         fi; \
-         if [ \"$cleanup_home_user\" = 1 ]; then \
-           rmdir /home/user 2>/dev/null || true; \
-        fi; \
-         exit $status",
-        shell_quote(guest_agent)
-    );
+    let command = guest_agent_wrapper_command(guest_agent);
     let sudo = needs_sudo_for_canonical_workspace();
     let mut handle = connection
         .host()
@@ -176,6 +161,81 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         String::from_utf8_lossy(&stdout).contains("RESULT=before-ready+after-ready"),
         "guest-agent stdout did not include active-input result: {}",
         String::from_utf8_lossy(&stdout)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> TestResult<()> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let run_id = format!(
+        "process-control-plain-run-{}-{}",
+        std::process::id(),
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+    );
+
+    let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
+    let prompt = "printf no-active-input";
+    let workdir = tmp.path().to_string_lossy().into_owned();
+    let mock_path = mock.to_string_lossy().into_owned();
+    let env = [
+        ("CLI_AGENT_TYPE", "claude-code"),
+        ("VM0_MOCK_CLAUDE_PATH", mock_path.as_str()),
+        ("USE_MOCK_CLAUDE", "true"),
+        ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
+        ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
+        ("VM0_RUN_ID", run_id.as_str()),
+        ("VM0_PROMPT", prompt),
+        ("VM0_API_URL", "http://127.0.0.1:1"),
+        ("VM0_API_TOKEN", ""),
+        ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
+        ("VM0_SANDBOX_REUSE_RESULT", "reused"),
+        ("HOME", workdir.as_str()),
+    ];
+
+    let connection = start_host_and_guest(tmp.path()).await?;
+    let command = guest_agent_wrapper_command(guest_agent);
+    let sudo = needs_sudo_for_canonical_workspace();
+    let handle = connection
+        .host()
+        .start_supervised_exec(SupervisedExecRequest {
+            timeout: ExecTimeoutPolicy::Duration { timeout_ms: 30_000 },
+            command: &command,
+            env: &env,
+            sudo,
+            label: "guest-agent-process-control-plain-run",
+            stdout: ExecOutputPolicy::Capture {
+                limit_bytes: 1024 * 1024,
+            },
+            stderr: ExecOutputPolicy::Capture {
+                limit_bytes: 1024 * 1024,
+            },
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            control: SupervisedExecControl::Enabled { sink: true },
+            stream_queue_capacity: None,
+            start_timeout: Duration::from_secs(10),
+        })
+        .await?;
+
+    let exit = handle.wait(Duration::from_secs(20)).await?;
+
+    connection.finish()?;
+
+    let stdout = captured_output_lossy(&exit.stdout);
+    assert!(
+        matches!(exit.termination, ExecTermination::Exited { exit_code: 0 }),
+        "guest-agent failed: termination={:?} diagnostic={} stdout={} stderr={}",
+        exit.termination,
+        exit.diagnostic,
+        stdout,
+        captured_output_lossy(&exit.stderr)
+    );
+    assert!(
+        stdout.contains("no-active-input"),
+        "guest-agent stdout did not include plain run result: {stdout}"
     );
 
     Ok(())
@@ -347,6 +407,25 @@ fn join_guest(guest: thread::JoinHandle<io::Result<()>>) -> TestResult<()> {
 
 fn shell_quote(raw: &str) -> String {
     format!("'{}'", raw.replace('\'', "'\\''"))
+}
+
+fn guest_agent_wrapper_command(guest_agent: &str) -> String {
+    format!(
+        "cleanup_home_user=0; \
+         cleanup_workspace=0; \
+         if [ ! -e /home/user ]; then cleanup_home_user=1; fi; \
+         if [ ! -e /home/user/workspace ]; then cleanup_workspace=1; fi; \
+         {}; \
+         status=$?; \
+         if [ \"$cleanup_workspace\" = 1 ]; then \
+           rmdir /home/user/workspace 2>/dev/null || true; \
+         fi; \
+         if [ \"$cleanup_home_user\" = 1 ]; then \
+           rmdir /home/user 2>/dev/null || true; \
+        fi; \
+         exit $status",
+        shell_quote(guest_agent)
+    )
 }
 
 fn needs_sudo_for_canonical_workspace() -> bool {

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -60,13 +60,7 @@ fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
             eprintln!("{}", invalid_active_input_count_message(count));
             ExitCode::from(1)
         }
-        scenario => {
-            if let Err(message) = drain_remaining_stream_json_stdin(&mut reader) {
-                eprintln!("{message}");
-                return ExitCode::from(1);
-            }
-            run_scenario(scenario, &first_frame.content, &parsed.output_format)
-        }
+        scenario => run_scenario(scenario, &first_frame.content, &parsed.output_format),
     }
 }
 
@@ -181,14 +175,6 @@ fn read_next_stream_json_user_frame(
 
         return parse_stream_json_user_frame(trimmed, kind).map(Some);
     }
-}
-
-fn drain_remaining_stream_json_stdin(reader: &mut impl BufRead) -> Result<(), String> {
-    let mut input = String::new();
-    reader
-        .read_to_string(&mut input)
-        .map(|_| ())
-        .map_err(|e| format!("read stream-json stdin: {e}"))
 }
 
 fn parse_stream_json_user_frame(

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -434,36 +434,35 @@ fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error:
 }
 
 #[test]
-fn one_shot_stream_json_drains_trailing_stdin() -> Result<(), Box<dyn std::error::Error>> {
+fn stream_json_input_does_not_wait_for_stdin_eof() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
-    let mut child = mock_claude()
-        .env("HOME", home.path())
-        .args([
-            "--input-format",
-            "stream-json",
-            "--output-format",
-            "stream-json",
-            "--",
-            "printf argv-wrong",
-        ])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
 
-    let mut stdin = child.stdin.take().ok_or("missing stdin")?;
-    stdin.write_all(stream_json_user_frame("printf stdin-ok").as_bytes())?;
-    stdin.write_all(b"\xff\n")?;
-    drop(stdin);
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame("printf stdin-ok").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
 
-    let output = child.wait_with_output()?;
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("read stream-json stdin"),
-        "unexpected stderr: {stderr}"
-    );
-    assert!(output.stdout.is_empty());
+    let events = recv_until_result(&stream.rx, "stdin-ok")?;
+    stream.close_stdin();
+
+    let (status, stderr) = stream.wait()?;
+    assert!(status.success(), "expected success, stderr: {stderr}");
+    assert!(stderr.is_empty());
+
+    let command = events
+        .iter()
+        .find(|event| {
+            event.get("type").and_then(Value::as_str) == Some("assistant")
+                && event
+                    .pointer("/message/content/0/type")
+                    .and_then(Value::as_str)
+                    == Some("tool_use")
+        })
+        .and_then(|event| event.pointer("/message/content/0/input/command"))
+        .and_then(Value::as_str)
+        .ok_or("missing command")?;
+    assert_eq!(command, "printf stdin-ok");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Add guest-agent active-input state for Claude stream-json stdin, including validation, dedupe, bounded queueing, pending tracking, and replay matching.
- Wire process-control requests into the active-input controller and keep CLI stdin owned by a single long-lived writer.
- Gate post-result cleanup on pending active input and filter replayed prompt-bearing user events before logs, sequence assignment, and webhook upload.
- Update process-control and API-mode tests for active input delivery and replay filtering.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent active_input
- cargo test --manifest-path crates/Cargo.toml -p guest-agent process_control_channel
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test execute_cli_api_mode
- cargo test --manifest-path crates/Cargo.toml -p guest-agent post_result_reap
- cargo test --manifest-path crates/Cargo.toml -p guest-agent

Closes #18092