### PR TITLE
Allow paid onboarding trial checkout for free orgs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 
+import { createStore } from "ccstate";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import {
   createAuthOrgAgentsBddApi,
   type ApiTestUser,
@@ -24,6 +28,7 @@ helper gap:
 */
 
 const context = testContext();
+const store = createStore();
 const api = createAuthOrgAgentsBddApi(context);
 const bdd = createBddApi(context);
 const runsApi = createRunsAutomationsApi(context);
@@ -141,6 +146,43 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
       );
     }
     expect(repeatedSetup.body.agentId).toBe(defaultAgentId);
+
+    const writeDb = store.set(writeDb$);
+    const adminOrgId = admin.orgId;
+    if (!adminOrgId) {
+      throw new Error("Expected BDD admin to have an org");
+    }
+    await writeDb
+      .update(orgMetadata)
+      .set({ tier: "free", onboardingPaymentPending: false })
+      .where(eq(orgMetadata.orgId, adminOrgId));
+
+    const paidOnboardingSetup = await api.setupOnboarding(admin, {
+      displayName: "BDD Paid Onboarding Agent",
+      workspaceName: "BDD Chain Org",
+    });
+    if (
+      paidOnboardingSetup.status !== 200 &&
+      paidOnboardingSetup.status !== 409
+    ) {
+      throw new Error(
+        `Expected paid onboarding setup to succeed, got ${paidOnboardingSetup.status}`,
+      );
+    }
+    expect(paidOnboardingSetup.body.agentId).toBe(defaultAgentId);
+    const [paidOnboardingMetadata] = await writeDb
+      .select({
+        tier: orgMetadata.tier,
+        onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, adminOrgId))
+      .limit(1);
+    expect(paidOnboardingMetadata).toStrictEqual({
+      tier: "free",
+      onboardingPaymentPending: true,
+    });
+
     const afterRepeatedSetup = await api.listAgents(admin);
     expect(
       afterRepeatedSetup.filter((agent) => {

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -10,7 +10,7 @@ import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type { AuthContext } from "../../types/auth";
 import { logger } from "../../lib/log";
@@ -397,7 +397,10 @@ async function updateOnboardingPaymentPending(
     })
     .where(
       onboardingPaymentPending
-        ? and(eq(orgMetadata.orgId, orgId), eq(orgMetadata.tier, "pro-suspend"))
+        ? and(
+            eq(orgMetadata.orgId, orgId),
+            inArray(orgMetadata.tier, ["free", "pro-suspend"]),
+          )
         : eq(orgMetadata.orgId, orgId),
     );
 }


### PR DESCRIPTION
## Summary
- Allow onboarding setup to mark both free and pro-suspend orgs as onboarding payment pending
- Keep paid Pro/Team orgs protected from re-entering onboarding trial checkout
- Add regression coverage for an existing default-agent org re-entering paid onboarding from the free tier

## Why
The paid onboarding CTA could show "Start my 7-day free trial" but the checkout API returned "Pro trial checkout is only available during onboarding" for existing free orgs/default-agent orgs because setup did not set onboardingPaymentPending=true for free-tier org rows.

## Verification
- PASS: NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types
- BLOCKED: pnpm exec vitest run src/signals/routes/__tests__/auth-org-agents.bdd.test.ts src/signals/routes/__tests__/zero-billing-checkout.test.ts, local Postgres is not running in this environment, fails with ECONNREFUSED 127.0.0.1:5432 before assertions complete
