### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.179"
+CLAUDE_CODE_VERSION="2.1.181"
 CODEX_CLI_VERSION="0.140.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"


### PR DESCRIPTION
## Summary

Updates pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`.

Updated versions:
- Claude Code CLI: `2.1.179` -> `2.1.181`

Checked and already current/applicable:
- Go: `1.26.4`
- Codex CLI: `0.140.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- agent-browser: `0.28.0`
- pnpm: `11.7.0`
- Node.js: NodeSource `node_24.x` LTS line
- PostgreSQL: `18` major from PGDG

## Validation

- `bash -n crates/runner/scripts/build-template.sh`