### PR TITLE
fix: soften template picker card shadow to match chat composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -874,6 +874,16 @@ function VideoTemplatePreview({ item }: { item: VideoTemplateItem }) {
   );
 }
 
+/**
+ * Soft, cool-tinted card shadow matching the home chat composer
+ * (`--zero-card-shadow`). The token is scoped to `.zero-app`, but the template
+ * picker renders through a Radix portal on `document.body` — outside that
+ * scope — so the value is inlined here instead of referencing the CSS var.
+ * Replaces Tailwind `shadow-sm`, whose hard black tint reads muddy on white.
+ */
+const TEMPLATE_CARD_SHADOW =
+  "shadow-[0_2px_12px_hsl(220_12%_50%/0.04),0_0_0_0.5px_hsl(220_12%_50%/0.02)]";
+
 function VideoTemplateCard({
   item,
   selected,
@@ -886,7 +896,8 @@ function VideoTemplateCard({
   return (
     <div
       className={cn(
-        "group flex h-64 flex-col overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+        "group flex h-64 flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:bg-muted/20",
+        TEMPLATE_CARD_SHADOW,
         selected ? "border-primary ring-1 ring-primary" : "border-border",
       )}
     >
@@ -1435,7 +1446,8 @@ function PptCard({
   return (
     <div
       className={cn(
-        "group flex flex-col overflow-hidden rounded-lg border bg-card shadow-sm transition-colors hover:bg-muted/20",
+        "group flex flex-col overflow-hidden rounded-lg border bg-card transition-colors hover:bg-muted/20",
+        TEMPLATE_CARD_SHADOW,
         selected ? "border-primary ring-1 ring-primary" : "border-border",
       )}
     >
@@ -1776,7 +1788,8 @@ function IllustrationTemplateCard({
     <div
       data-illustration-template-card=""
       className={cn(
-        "group mb-4 break-inside-avoid overflow-hidden rounded-xl border bg-card shadow-sm transition-colors",
+        "group mb-4 break-inside-avoid overflow-hidden rounded-xl border bg-card transition-colors",
+        TEMPLATE_CARD_SHADOW,
         selected
           ? "border-primary ring-1 ring-primary"
           : "border-border hover:border-muted-foreground/30",


### PR DESCRIPTION
## What

The Templates picker modal's cards used Tailwind `shadow-sm`, whose hard black tint reads as a muddy gray halo on the white modal background. This swaps it for the soft, cool-tinted shadow used by the home chat composer card.

## Why

`--zero-card-shadow` (the composer's shadow) is scoped to `.zero-app`, but the template picker renders through a Radix `DialogPortal` mounted on `document.body` — outside that scope — so the CSS var doesn't resolve there. The value is inlined as a shared `TEMPLATE_CARD_SHADOW` constant and applied to all three card components (presentation, illustration, video).

## Before / After

| Current (muddy `shadow-sm`) | Reference (composer shadow) |
| --- | --- |
| ![current](https://github.com/vm0-ai/vm0/releases/download/web-v12.431.2/templates-modal-shadow.png) | ![reference](https://github.com/vm0-ai/vm0/releases/download/web-v12.431.2/chat-composer-reference.png) |

Closes #18140

🤖 Generated with [Claude Code](https://claude.com/claude-code)