### PR TITLE
fix: guard workflow storage object deletion

### DIFF
--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -171,6 +171,14 @@ export function listS3Objects(
   });
 }
 
+export function listS3ObjectsUnderPrefix(
+  bucket: string,
+  prefix: string,
+): Computed<Promise<readonly S3Object[]>> {
+  const boundedPrefix = prefix.endsWith("/") ? prefix : `${prefix}/`;
+  return listS3Objects(bucket, boundedPrefix);
+}
+
 export function deleteS3Objects(
   bucket: string,
   keys: readonly string[],

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-workflows.ts
@@ -313,6 +313,28 @@ export function mockWorkflowContent(
   });
 }
 
+export function mockMissingWorkflowContent(
+  context: TestContext,
+  args: { readonly s3Key: string },
+): void {
+  context.mocks.s3.send.mockImplementation((cmd: unknown): Promise<unknown> => {
+    const key = commandKey(cmd);
+    if (
+      key === `${args.s3Key}/manifest.json` ||
+      key === `${args.s3Key}/archive.tar.gz`
+    ) {
+      return Promise.reject(
+        Object.assign(new Error(`No such key: ${key}`), {
+          name: "NoSuchKey",
+          Code: "NoSuchKey",
+          $metadata: { httpStatusCode: 404 },
+        }),
+      );
+    }
+    return Promise.resolve({});
+  });
+}
+
 interface InstructionsStorageSeed {
   readonly orgId: string;
   readonly userId: string;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
@@ -106,6 +106,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function commandName(command: unknown): string {
+  if (!isRecord(command)) {
+    return "";
+  }
+  return command.constructor.name;
+}
+
+function s3CommandCount(name: string): number {
+  return context.mocks.s3.send.mock.calls.filter((call) => {
+    return commandName(call[0]) === name;
+  }).length;
+}
+
 function expectRecord(value: unknown, label: string): Record<string, unknown> {
   if (!isRecord(value)) {
     throw new Error(`Expected ${label} to be an object`);
@@ -259,7 +272,8 @@ describe("POST /api/zero/agents", () => {
         ),
       );
     expect(instructionsStorage?.headVersionId).toMatch(/^[a-f0-9]{64}$/);
-    expect(context.mocks.s3.send).toHaveBeenCalledTimes(2);
+    expect(s3CommandCount("PutObjectCommand")).toBe(2);
+    expect(s3CommandCount("HeadObjectCommand")).toBe(2);
   });
 
   it("returns 409 when the public agent limit has been reached", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -5,6 +5,7 @@ import {
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
 } from "@vm0/api-contracts/contracts/zero-workflows";
+import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 import {
   zeroWorkflowAgents,
   zeroWorkflows,
@@ -16,6 +17,7 @@ import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { writeDb$ } from "../../external/db";
 import {
   deleteWorkflowsForFixture$,
+  mockMissingWorkflowContent,
   mockWorkflowContent,
   seedAgentForInstructions$,
   seedWorkflow$,
@@ -46,6 +48,38 @@ function detailClient() {
 
 function agentsClient() {
   return setupApp({ context })(zeroWorkflowAgentsContract);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function commandName(command: unknown): string {
+  if (!isRecord(command)) {
+    return "";
+  }
+  return command.constructor.name;
+}
+
+function commandInput(command: unknown): Record<string, unknown> {
+  if (!isRecord(command) || !isRecord(command.input)) {
+    return {};
+  }
+  return command.input;
+}
+
+function deleteObjectKeys(command: unknown): string[] {
+  const input = commandInput(command);
+  const deletePayload = input.Delete;
+  if (!isRecord(deletePayload) || !Array.isArray(deletePayload.Objects)) {
+    return [];
+  }
+  return deletePayload.Objects.flatMap((object) => {
+    if (!isRecord(object) || typeof object.Key !== "string") {
+      return [];
+    }
+    return [object.Key];
+  });
 }
 
 function workflowFiles(content: string) {
@@ -361,6 +395,166 @@ describe("zero workflows", () => {
         { path: "notes.md", content: "details" },
       ],
     });
+  });
+
+  it("returns workflow metadata when backing storage objects are missing", async () => {
+    const fixture = await track(
+      store.set(seedWorkflowsFixture$, undefined, context.signal),
+    );
+    const workflowName = "dangling-workflow";
+    const s3Key = "test-workflows/dangling-workflow";
+    await store.set(
+      seedWorkflow$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: workflowName,
+        displayName: "Dangling Workflow",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedWorkflowStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        workflowName,
+        s3Key,
+        headVersionId: randomUUID(),
+      },
+      context.signal,
+    );
+    mockMissingWorkflowContent(context, { s3Key });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      detailClient().get({
+        headers: authHeaders(),
+        params: { name: workflowName },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      name: workflowName,
+      displayName: "Dangling Workflow",
+      content: null,
+      files: null,
+      fileContents: null,
+    });
+  });
+
+  it("deletes workflow storage using a slash-bounded prefix", async () => {
+    const fixture = await track(
+      store.set(seedWorkflowsFixture$, undefined, context.signal),
+    );
+    const deletedWorkflowName = "posthog";
+    const keptWorkflowName = "posthog-tracking";
+    const deletedPrefix = `orgs/${fixture.orgId}/${getCustomSkillStorageName(
+      deletedWorkflowName,
+    )}`;
+    const keptPrefix = `orgs/${fixture.orgId}/${getCustomSkillStorageName(
+      keptWorkflowName,
+    )}`;
+    const deletedKeys = [
+      `${deletedPrefix}/version/archive.tar.gz`,
+      `${deletedPrefix}/version/manifest.json`,
+    ];
+    const allKeys = [
+      ...deletedKeys,
+      `${keptPrefix}/version/archive.tar.gz`,
+      `${keptPrefix}/version/manifest.json`,
+    ];
+
+    await store.set(
+      seedWorkflow$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: deletedWorkflowName,
+      },
+      context.signal,
+    );
+    await store.set(
+      seedWorkflow$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: keptWorkflowName,
+      },
+      context.signal,
+    );
+    await store.set(
+      seedWorkflowStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        workflowName: deletedWorkflowName,
+        s3Key: `${deletedPrefix}/version`,
+        headVersionId: randomUUID(),
+      },
+      context.signal,
+    );
+    await store.set(
+      seedWorkflowStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        workflowName: keptWorkflowName,
+        s3Key: `${keptPrefix}/version`,
+        headVersionId: randomUUID(),
+      },
+      context.signal,
+    );
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (commandName(command) === "ListObjectsV2Command") {
+        const prefix = commandInput(command).Prefix;
+        if (typeof prefix !== "string") {
+          return Promise.resolve({ Contents: [] });
+        }
+        return Promise.resolve({
+          Contents: allKeys
+            .filter((key) => {
+              return key.startsWith(prefix);
+            })
+            .map((key) => {
+              return {
+                Key: key,
+                Size: 1,
+                LastModified: new Date("2026-06-18T00:00:00.000Z"),
+              };
+            }),
+        });
+      }
+      return Promise.resolve({});
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    await accept(
+      detailClient().delete({
+        headers: authHeaders(),
+        params: { name: deletedWorkflowName },
+      }),
+      [204],
+    );
+
+    const listCommand = context.mocks.s3.send.mock.calls
+      .map((call) => {
+        return call[0];
+      })
+      .find((command) => {
+        return commandName(command) === "ListObjectsV2Command";
+      });
+    expect(commandInput(listCommand).Prefix).toBe(`${deletedPrefix}/`);
+
+    const deleteCommand = context.mocks.s3.send.mock.calls
+      .map((call) => {
+        return call[0];
+      })
+      .find((command) => {
+        return commandName(command) === "DeleteObjectsCommand";
+      });
+    expect(deleteObjectKeys(deleteCommand)).toStrictEqual(deletedKeys);
   });
 
   it("deletes workflows and cascades agent attachments", async () => {

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -31,7 +31,11 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
-import { deleteS3Objects, listS3Objects, putS3Object } from "../external/s3";
+import {
+  deleteS3Objects,
+  listS3ObjectsUnderPrefix,
+  putS3Object,
+} from "../external/s3";
 import { settle } from "../utils";
 import type { FileEntryWithHash } from "./storage-content-hash.service";
 
@@ -600,7 +604,9 @@ function removeOrphanedSkills(
     for (const storage of orphanStorages) {
       const cleanupResult = await settle(
         (async () => {
-          const objects = await get(listS3Objects(bucket, storage.s3Prefix));
+          const objects = await get(
+            listS3ObjectsUnderPrefix(bucket, storage.s3Prefix),
+          );
           signal.throwIfAborted();
           if (objects.length > 0) {
             await get(

--- a/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-upload.service.ts
@@ -5,14 +5,14 @@ import { tmpdir } from "node:os";
 
 import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
-import { command } from "ccstate";
+import { command, type Computed } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { create } from "tar";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
-import { putS3Object } from "../external/s3";
+import { putS3Object, verifyS3FilesExist } from "../external/s3";
 import { onRejection, safeSync } from "../utils";
 import {
   computeContentHashFromHashes,
@@ -108,6 +108,46 @@ function createArchiveBuffer(
   );
 }
 
+async function uploadAndVerifyVolumeObjects(
+  get: <T>(computedValue: Computed<T>) => T,
+  args: {
+    readonly bucketName: string;
+    readonly s3Key: string;
+    readonly archiveBuffer: Buffer;
+    readonly manifest: S3StorageManifest;
+    readonly fileCount: number;
+    readonly storageName: string;
+  },
+): Promise<void> {
+  await Promise.all([
+    get(
+      putS3Object(
+        args.bucketName,
+        `${args.s3Key}/archive.tar.gz`,
+        args.archiveBuffer,
+        "application/gzip",
+      ),
+    ),
+    get(
+      putS3Object(
+        args.bucketName,
+        `${args.s3Key}/manifest.json`,
+        JSON.stringify(args.manifest),
+        "application/json",
+      ),
+    ),
+  ]);
+
+  const uploadVerified = await get(
+    verifyS3FilesExist(args.bucketName, args.s3Key, args.fileCount),
+  );
+  if (!uploadVerified) {
+    throw new Error(
+      `Uploaded volume files are not available for ${args.storageName}`,
+    );
+  }
+}
+
 const uploadVolumeServerSideInner$ = command(
   async (
     { get, set },
@@ -183,24 +223,14 @@ const uploadVolumeServerSideInner$ = command(
       files: fileEntries,
     };
 
-    await Promise.all([
-      get(
-        putS3Object(
-          bucketName,
-          `${s3Key}/archive.tar.gz`,
-          archiveBuffer,
-          "application/gzip",
-        ),
-      ),
-      get(
-        putS3Object(
-          bucketName,
-          `${s3Key}/manifest.json`,
-          JSON.stringify(manifest),
-          "application/json",
-        ),
-      ),
-    ]);
+    await uploadAndVerifyVolumeObjects(get, {
+      bucketName,
+      s3Key,
+      archiveBuffer,
+      manifest,
+      fileCount: files.length,
+      storageName: args.storageName,
+    });
     signal.throwIfAborted();
 
     await writeDb.transaction(async (tx) => {

--- a/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
@@ -14,7 +14,7 @@ import { getInstructionsStorageName } from "@vm0/core/storage-names";
 import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { db$, writeDb$ } from "../external/db";
-import { deleteS3Objects, listS3Objects } from "../external/s3";
+import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 import { nowDate } from "../external/time";
 import { env } from "../../lib/env";
 import { conflict, notFound } from "../../lib/error";
@@ -271,7 +271,9 @@ export const deleteCompose$ = command(
 
     if (result.s3Prefix) {
       const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const objects = await get(listS3Objects(bucket, result.s3Prefix));
+      const objects = await get(
+        listS3ObjectsUnderPrefix(bucket, result.s3Prefix),
+      );
       signal.throwIfAborted();
       await get(
         deleteS3Objects(
@@ -370,7 +372,9 @@ export const deleteComposeById$ = command(
 
     if (result.s3Prefix) {
       const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const objects = await get(listS3Objects(bucket, result.s3Prefix));
+      const objects = await get(
+        listS3ObjectsUnderPrefix(bucket, result.s3Prefix),
+      );
       signal.throwIfAborted();
       await get(
         deleteS3Objects(

--- a/turbo/apps/api/src/signals/services/zero-workflow-delete.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-delete.service.ts
@@ -9,7 +9,7 @@ import { and, eq } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { writeDb$ } from "../external/db";
-import { deleteS3Objects, listS3Objects } from "../external/s3";
+import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 
 interface DeleteZeroWorkflowInput {
   readonly orgId: string;
@@ -73,7 +73,9 @@ export const deleteZeroWorkflow$ = command(
 
     if (result.s3Prefix) {
       const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const objects = await get(listS3Objects(bucket, result.s3Prefix));
+      const objects = await get(
+        listS3ObjectsUnderPrefix(bucket, result.s3Prefix),
+      );
       signal.throwIfAborted();
       await get(
         deleteS3Objects(

--- a/turbo/apps/api/src/signals/services/zero-workflow-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-detail.service.ts
@@ -9,6 +9,7 @@ import { and, eq } from "drizzle-orm";
 
 import { db$ } from "../external/db";
 import { downloadS3Buffer, downloadManifest } from "../external/s3";
+import { settle } from "../utils";
 import { env } from "../../lib/env";
 import { extractFilesFromTarGz } from "../../lib/tar";
 import {
@@ -33,6 +34,22 @@ function emptyWorkflowContent(): WorkflowContentResult {
     files: null,
     fileContents: null,
   };
+}
+
+function isMissingS3ObjectError(error: unknown): boolean {
+  const candidate = error as {
+    readonly name?: string;
+    readonly Code?: string;
+    readonly code?: string;
+    readonly $metadata?: { readonly httpStatusCode?: number };
+  };
+  const code = candidate.Code ?? candidate.code ?? candidate.name;
+  return (
+    code === "NoSuchKey" ||
+    code === "NotFound" ||
+    (candidate.name === "NotFound" &&
+      candidate.$metadata?.httpStatusCode === 404)
+  );
 }
 
 export function zeroWorkflowDetail(args: {
@@ -103,7 +120,16 @@ async function loadWorkflowContent(
     return emptyWorkflowContent();
   }
 
-  const manifest = await get(downloadManifest(bucket, version.s3Key));
+  const manifestResult = await settle(
+    get(downloadManifest(bucket, version.s3Key)),
+  );
+  if (!manifestResult.ok) {
+    if (isMissingS3ObjectError(manifestResult.error)) {
+      return emptyWorkflowContent();
+    }
+    throw manifestResult.error;
+  }
+  const manifest = manifestResult.value;
   const normalize = (p: string): string => {
     return p.replace(/^\.\//, "");
   };
@@ -116,7 +142,14 @@ async function loadWorkflowContent(
   });
 
   const archiveKey = `${version.s3Key}/archive.tar.gz`;
-  const archiveBuffer = await get(downloadS3Buffer(bucket, archiveKey));
+  const archiveResult = await settle(get(downloadS3Buffer(bucket, archiveKey)));
+  if (!archiveResult.ok) {
+    if (isMissingS3ObjectError(archiveResult.error)) {
+      return emptyWorkflowContent();
+    }
+    throw archiveResult.error;
+  }
+  const archiveBuffer = archiveResult.value;
   const fileContents = extractFilesFromTarGz(
     archiveBuffer,
     filesList.map((file) => {


### PR DESCRIPTION
## Summary

- Return workflow metadata with empty content when the backing skill volume objects are missing instead of bubbling an S3 `NoSuchKey` into a 500.
- Delete storage-backed workflow/compose/skill-cleanup objects using a slash-bounded storage prefix so `custom-skill@posthog` cannot match `custom-skill@posthog-tracking`.
- Verify server-side workflow volume uploads are readable in R2 before recording the new storage head version.

Fixes #18137

## Testing

- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-workflows.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest src/signals/routes/__tests__/zero-workflows.test.ts src/signals/routes/__tests__/cron-sync-skills.test.ts src/signals/routes/__tests__/composes.bdd.test.ts`
- pre-commit: prettier, knip, full `pnpm check-types`