### PR TITLE
refactor(vsock-host): extract read file exec validation

### DIFF
--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -354,10 +354,12 @@ fn validate_copy_exec_result(
                 String::from_utf8_lossy(&stderr)
             ),
         )),
-        ExecTermination::Exited { exit_code: 66 } if stderr.is_empty() => {
-            Ok(CopyFileExecStatus::Missing)
-        }
-        ExecTermination::Exited { exit_code: 66 } => Err(io::Error::new(
+        ExecTermination::Exited {
+            exit_code: MISSING_FILE_EXIT_CODE,
+        } if stderr.is_empty() => Ok(CopyFileExecStatus::Missing),
+        ExecTermination::Exited {
+            exit_code: MISSING_FILE_EXIT_CODE,
+        } => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
                 "copy_file missing result for {path} included stderr: {}",

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 
 use super::{
-    file_operation_error_is_terminal, read_regular_file_command, validate_guest_file_path,
+    MISSING_FILE_EXIT_CODE, file_operation_error_is_terminal, normalize_file_exec_stderr,
+    read_regular_file_command, validate_guest_file_path,
 };
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
@@ -340,10 +341,8 @@ fn validate_copy_exec_result(
             "copy_file exec operation unexpectedly captured stdout",
         ));
     }
-    let (mut stderr, stderr_truncated) = copy_exec_stderr(&result)?;
-    if stderr_truncated {
-        exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
-    }
+    let (stderr, stderr_truncated) = copy_exec_stderr(&result)?;
+    let stderr = normalize_file_exec_stderr(stderr, stderr_truncated);
     match result.termination {
         ExecTermination::Exited { exit_code: 0 } if stderr.is_empty() => {
             Ok(CopyFileExecStatus::Present)
@@ -516,7 +515,6 @@ impl VsockHost {
             missing_ok,
             write_observer,
         } = request;
-        const MISSING_FILE_EXIT_CODE: i32 = 66;
         let command = read_regular_file_command(path, MISSING_FILE_EXIT_CODE);
         let expected_exit_codes: &[i32] = if missing_ok {
             &[MISSING_FILE_EXIT_CODE]

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -4,7 +4,11 @@ mod write;
 
 use std::io;
 
+use crate::exec_operation;
+
 pub use copy::{CopyFileOptions, CopyFileResult};
+
+const MISSING_FILE_EXIT_CODE: i32 = 66;
 
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
@@ -31,6 +35,13 @@ fn read_regular_file_command(path: &str, missing_file_exit_code: i32) -> String 
     format!(
         "if test -f {path}; then cat 2>/dev/null < {path} || {{ test -f {path} || exit {missing_file_exit_code}; printf '%s\\n' 'failed to read file' >&2; exit 1; }}; else exit {missing_file_exit_code}; fi"
     )
+}
+
+fn normalize_file_exec_stderr(mut stderr: Vec<u8>, stderr_truncated: bool) -> Vec<u8> {
+    if stderr_truncated {
+        exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
+    }
+    stderr
 }
 
 fn file_operation_error_is_terminal(error: &io::Error) -> bool {

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -1,9 +1,66 @@
 use std::io;
 use std::time::Duration;
 
-use crate::{ExecCaptureRequest, FrameWriteObserver, VsockHost, exec_operation};
+use crate::{ExecCaptureRequest, ExecResult, FrameWriteObserver, VsockHost, exec_operation};
 
-use super::{read_regular_file_command, validate_guest_file_path};
+use super::{
+    MISSING_FILE_EXIT_CODE, normalize_file_exec_stderr, read_regular_file_command,
+    validate_guest_file_path,
+};
+
+fn validate_read_exec_result(
+    path: &str,
+    max_bytes: u64,
+    result: ExecResult,
+) -> io::Result<Option<Vec<u8>>> {
+    if result.exit_code == MISSING_FILE_EXIT_CODE {
+        if result.stdout_truncated || !result.stdout.is_empty() {
+            let stdout_detail = if result.stdout_truncated {
+                "stdout truncated"
+            } else {
+                "stdout"
+            };
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("read_file missing result for {path} included {stdout_detail}"),
+            ));
+        }
+        let stderr = normalize_file_exec_stderr(result.stderr, result.stderr_truncated);
+        if !stderr.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "read_file missing result for {path} included stderr: {}",
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
+        }
+        return Ok(None);
+    }
+    if result.exit_code != 0 {
+        let stderr = normalize_file_exec_stderr(result.stderr, result.stderr_truncated);
+        return Err(io::Error::other(format!(
+            "failed to read file {path}: {}",
+            String::from_utf8_lossy(&stderr)
+        )));
+    }
+    if result.stdout_truncated {
+        return Err(io::Error::other(format!(
+            "file {path} exceeded {max_bytes} bytes"
+        )));
+    }
+    let stderr = normalize_file_exec_stderr(result.stderr, result.stderr_truncated);
+    if !stderr.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "read_file result for {path} included stderr: {}",
+                String::from_utf8_lossy(&stderr)
+            ),
+        ));
+    }
+    Ok(Some(result.stdout))
+}
 
 impl VsockHost {
     /// Read a small file from the guest through exec capture.
@@ -53,7 +110,6 @@ impl VsockHost {
             ));
         }
 
-        const MISSING_FILE_EXIT_CODE: i32 = 66;
         let command = read_regular_file_command(path, MISSING_FILE_EXIT_CODE);
         let result = self
             .exec_capture_with_write_observer(
@@ -72,61 +128,6 @@ impl VsockHost {
                 write_observer,
             )
             .await?;
-        if result.exit_code == MISSING_FILE_EXIT_CODE {
-            if result.stdout_truncated || !result.stdout.is_empty() {
-                let stdout_detail = if result.stdout_truncated {
-                    "stdout truncated"
-                } else {
-                    "stdout"
-                };
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("read_file missing result for {path} included {stdout_detail}"),
-                ));
-            }
-            let mut stderr = result.stderr;
-            if result.stderr_truncated {
-                exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
-            }
-            if !stderr.is_empty() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "read_file missing result for {path} included stderr: {}",
-                        String::from_utf8_lossy(&stderr)
-                    ),
-                ));
-            }
-            return Ok(None);
-        }
-        if result.exit_code != 0 {
-            let mut stderr = result.stderr;
-            if result.stderr_truncated {
-                exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
-            }
-            return Err(io::Error::other(format!(
-                "failed to read file {path}: {}",
-                String::from_utf8_lossy(&stderr)
-            )));
-        }
-        if result.stdout_truncated {
-            return Err(io::Error::other(format!(
-                "file {path} exceeded {max_bytes} bytes"
-            )));
-        }
-        let mut stderr = result.stderr;
-        if result.stderr_truncated {
-            exec_operation::append_diagnostic(&mut stderr, "stderr truncated");
-        }
-        if !stderr.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "read_file result for {path} included stderr: {}",
-                    String::from_utf8_lossy(&stderr)
-                ),
-            ));
-        }
-        Ok(Some(result.stdout))
+        validate_read_exec_result(path, max_bytes, result)
     }
 }

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -103,6 +103,34 @@ async fn read_file_rejects_success_result_with_stderr() {
 }
 
 #[tokio::test]
+async fn read_file_rejects_success_result_with_truncated_stderr() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    let payload = vsock_proto::encode_exec_result(
+        ExecTermination::Exited { exit_code: 0 },
+        12,
+        ExecCapturedOutput::Captured {
+            bytes: b"session-id\n",
+            truncated: false,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: true,
+        },
+        "",
+    )
+    .unwrap();
+    send_raw_exec_result(&mut guest, start.seq(), payload).await;
+
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(err.to_string().contains("stderr truncated"));
+}
+
+#[tokio::test]
 async fn read_file_rejects_missing_result_with_output() {
     let (host, mut guest) = setup_host_and_guest().await;
     let read_task =


### PR DESCRIPTION
## Summary

- Centralize the guest file missing-file exit code and stderr truncation normalization in the file module.
- Extract read-file exec result classification from `read_file_with_write_observer` into a read-specific helper.
- Reuse the shared file-helper protocol pieces from copy-file validation without merging read/copy validators.
- Add read-file coverage for successful exec results with truncated stderr.

Closes #18132

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host read_file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host copy_file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
