### PR TITLE
test(runner): move workspace cache GC invariant coverage

### DIFF
--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -285,11 +285,10 @@ fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::unix::fs::MetadataExt;
     use std::path::PathBuf;
 
     use crate::ids::RunId;
-    use crate::paths::{scoped_session_workspace_cache_key, session_workspace_cache_key};
+    use crate::paths::session_workspace_cache_key;
 
     fn tmp_image_path(home: &HomePaths, cache_key: &str, run_id: RunId) -> PathBuf {
         home.workspace_image_cache_dir()
@@ -474,68 +473,5 @@ mod tests {
         .unwrap();
 
         assert!(tmp.exists());
-    }
-
-    #[tokio::test]
-    async fn workspace_image_cache_gc_preserves_valid_group_scoped_entry() {
-        let dir = tempfile::tempdir().unwrap();
-        let home = HomePaths::with_root(dir.path().join("home"));
-        let cache_key = scoped_session_workspace_cache_key(
-            "vm0/test",
-            "vm0/default",
-            "sess-1",
-            "/workspace",
-            b"image".len() as u64,
-        );
-        let entry_dir = home.workspace_image_cache_dir().join(&cache_key);
-        tokio::fs::create_dir_all(&entry_dir).await.unwrap();
-        let current = entry_dir.join("current.ext4");
-        tokio::fs::write(&current, b"image").await.unwrap();
-        let current_metadata = std::fs::metadata(&current).unwrap();
-        let metadata = serde_json::json!({
-            "formatVersion": 1,
-            "keyVersion": 1,
-            "cacheScope": "vm0/test",
-            "profileName": "vm0/default",
-            "sessionId": "sess-1",
-            "workingDir": "/workspace",
-            "lastCompletedAt": "2026-05-28T00:00:00.000Z",
-            "lastUsedAt": "2026-05-28T00:00:00.000Z",
-            "lastTerminalStatus": "success",
-            "workspaceTrust": "clean",
-            "logicalImageSizeBytes": current_metadata.len(),
-            "allocatedBytes": current_metadata.blocks().saturating_mul(512),
-            "currentImage": {
-                "dev": current_metadata.dev(),
-                "ino": current_metadata.ino(),
-                "len": current_metadata.len(),
-            },
-            "driveLayout": "workspace-drive-v1",
-            "storageFingerprints": {
-                "storages": {},
-                "artifacts": {},
-            },
-            "state": "current",
-        });
-        tokio::fs::write(
-            entry_dir.join("metadata.json"),
-            serde_json::to_vec_pretty(&metadata).unwrap(),
-        )
-        .await
-        .unwrap();
-
-        run_workspace_image_cache_with_home(
-            WorkspaceImageCacheArgs {
-                command: WorkspaceImageCacheCommand::Gc(WorkspaceImageCacheGcArgs {
-                    dry_run: false,
-                }),
-            },
-            &home,
-        )
-        .await
-        .unwrap();
-
-        assert!(current.exists());
-        assert!(entry_dir.join("metadata.json").exists());
     }
 }

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1665,6 +1665,38 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
 }
 
 #[tokio::test]
+async fn maintenance_gc_preserves_valid_group_scoped_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().join("home"));
+    tokio::fs::create_dir_all(home.workspace_image_cache_dir().parent().unwrap())
+        .await
+        .unwrap();
+    let runner = RunnerPaths::new(dir.path().join("runner"));
+    let maintenance_runner = RunnerPaths::new(dir.path().join("maintenance-runner"));
+    tokio::fs::create_dir_all(runner.base_dir()).await.unwrap();
+    tokio::fs::create_dir_all(maintenance_runner.base_dir())
+        .await
+        .unwrap();
+    let cache = SessionWorkspaceCache::shared(runner.clone(), &home, "group-a");
+    let maintenance_cache = SessionWorkspaceCache::shared(maintenance_runner, &home, "");
+    let key = promote_current_cache_entry(
+        &cache,
+        &runner,
+        "sess-1",
+        b"image",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let current = cache.session_workspace_cache_current_image(&key);
+    let metadata = cache.session_workspace_cache_metadata(&key);
+
+    maintenance_cache.gc(false).await.unwrap();
+
+    assert!(current.exists());
+    assert!(metadata.exists());
+}
+
+#[tokio::test]
 async fn global_gc_candidates_include_other_group_cache_entries() {
     let dir = tempfile::tempdir().unwrap();
     let home = HomePaths::with_root(dir.path().join("home"));


### PR DESCRIPTION
## Summary

- Move the group-scoped workspace image cache GC invariant out of the CLI command test and into the workspace cache test suite.
- Remove raw `metadata.json` construction from `cmd/workspace_image_cache.rs` tests.
- Keep CLI GC tests focused on shared cache root cleanup and dry-run command behavior.

Fixes #18131.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache::tests::maintenance_gc_preserves_valid_group_scoped_entry`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::workspace_image_cache::tests::workspace_image_cache_gc`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache`
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `git diff --check`

Lefthook also ran Rust fmt/doc/clippy during commit.
