### PR TITLE
test(guest-agent): centralize shared api mock fixture

### DIFF
--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -8,8 +8,8 @@ use serde_json::json;
 
 #[tokio::test]
 async fn recovery_checkpoint_uploads_valid_session_history() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let _files_guard = SessionCheckpointFilesGuard::new();
     let dir = tempfile::tempdir().unwrap();
@@ -57,15 +57,12 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
-    prepare_mock.delete_async().await;
-    upload_mock.delete_async().await;
-    checkpoint_mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let _files_guard = SessionCheckpointFilesGuard::new();
     let dir = tempfile::tempdir().unwrap();
@@ -102,14 +99,12 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
     );
     prepare_mock.assert_calls_async(0).await;
     checkpoint_mock.assert_calls_async(0).await;
-    prepare_mock.delete_async().await;
-    checkpoint_mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn recovery_checkpoint_skips_when_session_id_is_missing() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let _files_guard = SessionCheckpointFilesGuard::new();
 
@@ -132,14 +127,12 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
     );
     prepare_mock.assert_calls_async(0).await;
     checkpoint_mock.assert_calls_async(0).await;
-    prepare_mock.delete_async().await;
-    checkpoint_mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let _files_guard = SessionCheckpointFilesGuard::new();
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "missing-history")
@@ -164,6 +157,4 @@ async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
     );
     prepare_mock.assert_calls_async(0).await;
     checkpoint_mock.assert_calls_async(0).await;
-    prepare_mock.delete_async().await;
-    checkpoint_mock.delete_async().await;
 }

--- a/crates/guest-agent/tests/integration/complete.rs
+++ b/crates/guest-agent/tests/integration/complete.rs
@@ -13,10 +13,10 @@ use serde_json::json;
 
 #[tokio::test]
 async fn complete_report_success_posts_full_payload_when_metadata_present() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
-    // VM0_SANDBOX_ID / VM0_SANDBOX_REUSE_RESULT come from MOCK_SERVER init.
+    // VM0_SANDBOX_ID / VM0_SANDBOX_REUSE_RESULT come from shared API mock init.
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/complete")
@@ -43,7 +43,6 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
     .await;
 
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }
 
 /// Unset runner metadata (guest launched without `VM0_SANDBOX_ID` /
@@ -53,8 +52,8 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
 /// contract end-to-end.
 #[tokio::test]
 async fn complete_report_success_omits_metadata_when_env_absent() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -69,13 +68,12 @@ async fn complete_report_success_omits_metadata_when_env_absent() {
     guest_agent::complete::report_success(&http_client!(), "", "", None).await;
 
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn complete_report_success_swallows_server_error() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/complete");
@@ -93,7 +91,6 @@ async fn complete_report_success_swallows_server_error() {
     .await;
 
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }
 
 /// 4xx takes a different branch in `post_json` than 5xx: it returns Err
@@ -103,8 +100,8 @@ async fn complete_report_success_swallows_server_error() {
 /// call that actually transitions the run.
 #[tokio::test]
 async fn complete_report_success_swallows_4xx_auth_error() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/complete");
@@ -122,5 +119,4 @@ async fn complete_report_success_swallows_4xx_auth_error() {
     .await;
 
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -10,8 +10,8 @@ use serde_json::json;
 
 #[tokio::test]
 async fn send_event_correct_payload() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -27,13 +27,12 @@ async fn send_event_correct_payload() {
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_masks_secrets() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -51,13 +50,12 @@ async fn send_event_masks_secrets() {
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_masks_lowercase_percent_encoded_secret() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -75,13 +73,12 @@ async fn send_event_masks_lowercase_percent_encoded_secret() {
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_captures_session_metadata_before_masking() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
     let tmp = tempfile::tempdir().unwrap();
     let system_log_path = tmp.path().join("system.log");
@@ -141,14 +138,11 @@ async fn send_event_captures_session_metadata_before_masking() {
         !system_log.contains(&history),
         "system log must not contain the full session history marker payload, got: {system_log}"
     );
-
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn prepare_event_does_not_capture_session_metadata() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _server = &*MOCK_SERVER;
+    let _api = SharedApiMock::new().await;
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -176,8 +170,8 @@ async fn prepare_event_does_not_capture_session_metadata() {
 
 #[tokio::test]
 async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -210,14 +204,12 @@ async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
         !std::path::Path::new(hist_file).exists(),
         "invalid session id must not create a history marker"
     );
-
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_keeps_existing_session_metadata() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -254,14 +246,12 @@ async fn send_event_keeps_existing_session_metadata() {
     );
     assert_eq!(masker.mask_string("first-session"), "***");
     assert_eq!(masker.mask_string("second-session"), "***");
-
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -305,7 +295,6 @@ async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
     }
 
     mock.assert_calls_async(2).await;
-    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -314,8 +303,8 @@ async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
 
 #[tokio::test]
 async fn send_event_extracts_claude_session_id() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -353,14 +342,12 @@ async fn send_event_extracts_claude_session_id() {
         history.ends_with(".jsonl"),
         "claude-code history path should end with .jsonl, got: {history}"
     );
-
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_rejects_unsafe_claude_session_id() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -396,13 +383,12 @@ async fn send_event_rejects_unsafe_claude_session_id() {
     }
 
     mock.assert_calls_async(invalid_session_ids.len()).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn send_event_skips_session_id_for_non_init() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
     let sid_file = guest_agent::paths::session_id_file();
@@ -423,8 +409,6 @@ async fn send_event_skips_session_id_for_non_init() {
         !std::path::Path::new(sid_file).exists(),
         "session ID file should NOT be written for non-init events"
     );
-
-    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -433,13 +417,13 @@ async fn send_event_skips_session_id_for_non_init() {
 
 #[tokio::test]
 async fn send_event_failure_writes_error_flag() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let flag_path = guest_agent::paths::event_error_flag();
     let _ = std::fs::remove_file(flag_path);
 
-    let mock = server.mock(|when, then| {
+    let _mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");
         then.status(500);
     });
@@ -453,7 +437,6 @@ async fn send_event_failure_writes_error_flag() {
         std::path::Path::new(flag_path).exists(),
         "event error flag should be written on failure"
     );
-    mock.delete_async().await;
 
     // Clean up
     let _ = std::fs::remove_file(flag_path);

--- a/crates/guest-agent/tests/integration/heartbeat.rs
+++ b/crates/guest-agent/tests/integration/heartbeat.rs
@@ -10,8 +10,8 @@ use tokio_util::sync::CancellationToken;
 
 #[tokio::test]
 async fn heartbeat_first_success() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let observer = MockCallObserver::default();
     let observer_for_mock = observer.clone();
 
@@ -46,8 +46,8 @@ async fn heartbeat_first_success() {
 
 #[tokio::test]
 async fn heartbeat_first_failure_fatal() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/heartbeat");
@@ -64,8 +64,8 @@ async fn heartbeat_first_failure_fatal() {
 
 #[tokio::test]
 async fn heartbeat_consecutive_failures_fatal() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let observer = MockCallObserver::default();
     let observer_for_mock = observer.clone();
 
@@ -116,8 +116,8 @@ async fn heartbeat_consecutive_failures_fatal() {
 
 #[tokio::test]
 async fn heartbeat_recovery_resets_counter() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     let observer = MockCallObserver::default();
     let observer_for_mock = observer.clone();
 

--- a/crates/guest-agent/tests/integration/http_client.rs
+++ b/crates/guest-agent/tests/integration/http_client.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn post_json_success_json_response() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/success");
@@ -20,7 +20,7 @@ async fn post_json_success_json_response() {
             .json_body(json!({"status": "ok"}));
     });
 
-    let url = format!("{}/test/success", server.base_url());
+    let url = api.url("/test/success");
     let result = http_client!()
         .post_json(&url, &json!({"key": "val"}), 1)
         .await;
@@ -28,14 +28,13 @@ async fn post_json_success_json_response() {
     mock.assert_calls_async(1).await;
     let val = result.unwrap().unwrap();
     assert_eq!(val["status"], "ok");
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn for_current_env_uses_enabled_client_when_api_token_is_set()
 -> Result<(), Box<dyn std::error::Error>> {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -44,22 +43,21 @@ async fn for_current_env_uses_enabled_client_when_api_token_is_set()
         then.status(200).json_body(json!({"status": "ok"}));
     });
 
-    let url = format!("{}/test/for-current-env", server.base_url());
+    let url = api.url("/test/for-current-env");
     let result = guest_agent::http::HttpClient::for_current_env()?
         .post_json(&url, &json!({}), 1)
         .await?;
 
     mock.assert_calls_async(1).await;
     assert_eq!(result.unwrap()["status"], "ok");
-    mock.delete_async().await;
     Ok(())
 }
 
 #[tokio::test]
 async fn for_current_env_uses_env_api_url_for_webhook_routes()
 -> Result<(), Box<dyn std::error::Error>> {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -82,34 +80,32 @@ async fn for_current_env_uses_env_api_url_for_webhook_routes()
     .await?;
 
     mock.assert_calls_async(1).await;
-    mock.delete_async().await;
     Ok(())
 }
 
 #[tokio::test]
 async fn post_json_success_empty_response() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/empty");
         then.status(200);
     });
 
-    let url = format!("{}/test/empty", server.base_url());
+    let url = api.url("/test/empty");
     let result = http_client!()
         .post_json(&url, &json!({"key": "val"}), 1)
         .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.unwrap().is_none());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn post_json_retry_then_succeed() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/retry-succeed");
@@ -119,31 +115,29 @@ async fn post_json_retry_then_succeed() {
         ));
     });
 
-    let url = format!("{}/test/retry-succeed", server.base_url());
+    let url = api.url("/test/retry-succeed");
     let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     let val = result.unwrap().unwrap();
     assert_eq!(val["recovered"], true);
     mock.assert_calls_async(3).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn post_json_retry_exhausted() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/exhaust");
         then.status(500);
     });
 
-    let url = format!("{}/test/exhaust", server.base_url());
+    let url = api.url("/test/exhaust");
     let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     mock.assert_calls_async(3).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -152,40 +146,38 @@ async fn post_json_retry_exhausted() {
 
 #[tokio::test]
 async fn post_json_4xx_returns_immediately_no_retry() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/post-400");
         then.status(400);
     });
 
-    let url = format!("{}/test/post-400", server.base_url());
+    let url = api.url("/test/post-400");
     let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     // Should fail immediately — only 1 call, no retries.
     mock.assert_calls_async(1).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn post_json_429_retries() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/post-429");
         then.status(429);
     });
 
-    let url = format!("{}/test/post-429", server.base_url());
+    let url = api.url("/test/post-429");
     let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     // 429 is retriable — should exhaust all retries.
     mock.assert_calls_async(3).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -194,8 +186,8 @@ async fn post_json_429_retries() {
 
 #[tokio::test]
 async fn post_json_sends_bearer_token() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -204,18 +196,17 @@ async fn post_json_sends_bearer_token() {
         then.status(200);
     });
 
-    let url = format!("{}/test/auth", server.base_url());
+    let url = api.url("/test/auth");
     let result = http_client!().post_json(&url, &json!({}), 1).await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn post_json_sends_vercel_bypass_header() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -224,12 +215,11 @@ async fn post_json_sends_vercel_bypass_header() {
         then.status(200);
     });
 
-    let url = format!("{}/test/bypass", server.base_url());
+    let url = api.url("/test/bypass");
     let result = http_client!().post_json(&url, &json!({}), 1).await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
@@ -262,8 +252,8 @@ async fn post_json_uses_explicit_api_config_without_env_api_url() {
 #[tokio::test]
 async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
 -> Result<(), Box<dyn std::error::Error>> {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let env_server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let env_server = api.server();
     let explicit_server = MockServer::start();
 
     let env_mock = env_server.mock(|when, then| {
@@ -297,7 +287,6 @@ async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
     explicit_mock.assert_calls_async(1).await;
     env_mock.assert_calls_async(0).await;
     explicit_mock.delete_async().await;
-    env_mock.delete_async().await;
     Ok(())
 }
 
@@ -307,8 +296,8 @@ async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
 
 #[tokio::test]
 async fn post_json_malformed_json_response() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/test/malformed");
@@ -317,10 +306,9 @@ async fn post_json_malformed_json_response() {
             .body("not valid json {{{");
     });
 
-    let url = format!("{}/test/malformed", server.base_url());
+    let url = api.url("/test/malformed");
     let result = http_client!().post_json(&url, &json!({}), 3).await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }

--- a/crates/guest-agent/tests/integration/presigned_upload.rs
+++ b/crates/guest-agent/tests/integration/presigned_upload.rs
@@ -12,8 +12,8 @@ use std::sync::{
 
 #[tokio::test]
 async fn put_presigned_success() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(PUT)
@@ -22,7 +22,7 @@ async fn put_presigned_success() {
         then.status(200);
     });
 
-    let url = format!("{}/test/put-success", server.base_url());
+    let url = api.url("/test/put-success");
     let data = Bytes::from_static(b"test data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -30,7 +30,6 @@ async fn put_presigned_success() {
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
@@ -58,8 +57,8 @@ async fn transport_only_client_can_send_presigned_upload_without_api_config()
 
 #[tokio::test]
 async fn put_presigned_does_not_send_api_headers() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-no-api-headers");
@@ -74,7 +73,7 @@ async fn put_presigned_does_not_send_api_headers() {
         });
     });
 
-    let url = format!("{}/test/put-no-api-headers", server.base_url());
+    let url = api.url("/test/put-no-api-headers");
     let data = Bytes::from_static(b"test data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -82,20 +81,19 @@ async fn put_presigned_does_not_send_api_headers() {
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_retry_then_succeed() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-retry");
         then.respond_with(retry_then_response(1, http_status(200)));
     });
 
-    let url = format!("{}/test/put-retry", server.base_url());
+    let url = api.url("/test/put-retry");
     let data = Bytes::from_static(b"retry data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -103,7 +101,6 @@ async fn put_presigned_retry_then_succeed() {
 
     assert!(result.is_ok());
     mock.assert_calls_async(2).await;
-    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -112,15 +109,15 @@ async fn put_presigned_retry_then_succeed() {
 
 #[tokio::test]
 async fn put_presigned_4xx_returns_immediately_no_retry() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-403");
         then.status(403);
     });
 
-    let url = format!("{}/test/put-403", server.base_url());
+    let url = api.url("/test/put-403");
     let data = Bytes::from_static(b"forbidden data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -129,20 +126,19 @@ async fn put_presigned_4xx_returns_immediately_no_retry() {
     // Should fail immediately — only 1 call, no retries.
     mock.assert_calls_async(1).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_429_retries() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-429");
         then.status(429);
     });
 
-    let url = format!("{}/test/put-429", server.base_url());
+    let url = api.url("/test/put-429");
     let data = Bytes::from_static(b"rate limited data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -151,12 +147,11 @@ async fn put_presigned_429_retries() {
     // 429 is retriable — should exhaust all retries.
     mock.assert_calls_async(3).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_transport_error_does_not_log_presigned_url() {
-    let _guard = TEST_MUTEX.lock().unwrap();
+    let _api = SharedApiMock::new().await;
 
     let tmp = tempfile::tempdir().unwrap();
     let system_log_path = tmp.path().join("system.log");
@@ -199,8 +194,8 @@ async fn put_presigned_transport_error_does_not_log_presigned_url() {
 
 #[tokio::test]
 async fn put_presigned_file_success() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("test.bin");
@@ -214,20 +209,19 @@ async fn put_presigned_file_success() {
         then.status(200);
     });
 
-    let url = format!("{}/test/put-file-success", server.base_url());
+    let url = api.url("/test/put-file-success");
     let result = http_client!()
         .put_presigned_file(&url, &file_path, "application/gzip")
         .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_sets_content_length() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("sized.bin");
@@ -241,20 +235,19 @@ async fn put_presigned_file_sets_content_length() {
         then.status(200);
     });
 
-    let url = format!("{}/test/put-file-content-length", server.base_url());
+    let url = api.url("/test/put-file-content-length");
     let result = http_client!()
         .put_presigned_file(&url, &file_path, "application/gzip")
         .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_retry_then_succeed() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("retry.bin");
@@ -272,7 +265,7 @@ async fn put_presigned_file_retry_then_succeed() {
         });
     });
 
-    let url = format!("{}/test/put-file-retry", server.base_url());
+    let url = api.url("/test/put-file-retry");
     let path = file_path.clone();
     let result = http_client!()
         .put_presigned_file(&url, &path, "application/gzip")
@@ -280,13 +273,12 @@ async fn put_presigned_file_retry_then_succeed() {
 
     assert!(result.is_ok());
     mock.assert_calls_async(2).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_retry_fails_if_source_shrinks() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("retry-shrunk.bin");
@@ -311,7 +303,7 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
         });
     });
 
-    let url = format!("{}/test/put-file-retry-shrunk", server.base_url());
+    let url = api.url("/test/put-file-retry-shrunk");
     let path = file_path.clone();
     let result = http_client!()
         .put_presigned_file(&url, &path, "application/gzip")
@@ -321,13 +313,12 @@ async fn put_presigned_file_retry_fails_if_source_shrinks() {
     assert!(result.is_err());
     let calls = mock.calls_async().await;
     assert_eq!(calls, 1);
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_retry_uses_original_length_if_source_grows() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("retry-grown.bin");
@@ -352,7 +343,7 @@ async fn put_presigned_file_retry_uses_original_length_if_source_grows() {
         });
     });
 
-    let url = format!("{}/test/put-file-retry-grown", server.base_url());
+    let url = api.url("/test/put-file-retry-grown");
     let path = file_path.clone();
     let result = http_client!()
         .put_presigned_file(&url, &path, "application/gzip")
@@ -361,13 +352,12 @@ async fn put_presigned_file_retry_uses_original_length_if_source_grows() {
     assert!(mutation_done.load(Ordering::SeqCst));
     assert!(result.is_ok());
     mock.assert_calls_async(2).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_retry_uses_original_handle_if_path_is_replaced() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("retry-replaced.bin");
@@ -395,7 +385,7 @@ async fn put_presigned_file_retry_uses_original_handle_if_path_is_replaced() {
         });
     });
 
-    let url = format!("{}/test/put-file-retry-replaced", server.base_url());
+    let url = api.url("/test/put-file-retry-replaced");
     let path = file_path.clone();
     let result = http_client!()
         .put_presigned_file(&url, &path, "application/gzip")
@@ -404,13 +394,12 @@ async fn put_presigned_file_retry_uses_original_handle_if_path_is_replaced() {
     assert!(mutation_done.load(Ordering::SeqCst));
     assert!(result.is_ok());
     mock.assert_calls_async(2).await;
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_large_multi_chunk() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("large.bin");
@@ -425,20 +414,19 @@ async fn put_presigned_file_large_multi_chunk() {
         then.status(200);
     });
 
-    let url = format!("{}/test/put-file-large", server.base_url());
+    let url = api.url("/test/put-file-large");
     let result = http_client!()
         .put_presigned_file(&url, &file_path, "application/gzip")
         .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_ok());
-    mock.delete_async().await;
 }
 
 #[tokio::test]
 async fn put_presigned_file_4xx_no_retry() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("forbidden.bin");
@@ -449,14 +437,13 @@ async fn put_presigned_file_4xx_no_retry() {
         then.status(403);
     });
 
-    let url = format!("{}/test/put-file-403", server.base_url());
+    let url = api.url("/test/put-file-403");
     let result = http_client!()
         .put_presigned_file(&url, &file_path, "application/gzip")
         .await;
 
     mock.assert_calls_async(1).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }
 
 // =========================================================================
@@ -465,15 +452,15 @@ async fn put_presigned_file_4xx_no_retry() {
 
 #[tokio::test]
 async fn put_presigned_retry_exhausted() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-exhaust");
         then.status(500);
     });
 
-    let url = format!("{}/test/put-exhaust", server.base_url());
+    let url = api.url("/test/put-exhaust");
     let data = Bytes::from_static(b"exhaust data");
     let result = http_client!()
         .put_presigned(&url, data, "application/octet-stream")
@@ -481,5 +468,4 @@ async fn put_presigned_retry_exhausted() {
 
     mock.assert_calls_async(3).await;
     assert!(result.is_err());
-    mock.delete_async().await;
 }

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -39,6 +39,7 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
 /// Serialize all tests - they share one mock server and process-wide env vars.
 pub(crate) static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
+#[must_use = "keep SharedApiMock alive for the full test to hold the shared mock lock"]
 pub(crate) struct SharedApiMock {
     _guard: MutexGuard<'static, ()>,
     server: &'static MockServer,

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -1,7 +1,7 @@
 use httpmock::prelude::*;
 use serde_json::Value;
 use std::sync::{
-    Arc, LazyLock, Mutex,
+    Arc, LazyLock, Mutex, MutexGuard,
     atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
@@ -38,6 +38,38 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
 
 /// Serialize all tests - they share one mock server and process-wide env vars.
 pub(crate) static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+pub(crate) struct SharedApiMock {
+    _guard: MutexGuard<'static, ()>,
+    server: &'static MockServer,
+}
+
+impl SharedApiMock {
+    pub(crate) async fn new() -> Self {
+        let guard = match TEST_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let server = &*MOCK_SERVER;
+        server.reset_async().await;
+        Self {
+            _guard: guard,
+            server,
+        }
+    }
+
+    pub(crate) fn server(&self) -> &MockServer {
+        self.server
+    }
+
+    pub(crate) fn url(&self, path: &str) -> String {
+        assert!(
+            path.starts_with('/'),
+            "shared API mock path must be absolute"
+        );
+        format!("{}{}", self.server.base_url(), path)
+    }
+}
 
 macro_rules! http_client {
     () => {

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -38,8 +38,8 @@ fn ensure_parent_dir(path: &str) {
 
 #[tokio::test]
 async fn flush_is_incremental_between_calls() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     // Reset per-run telemetry state so this test drives sandbox_ops
     // deterministically (other tests in this file don't record sandbox_ops,
@@ -98,8 +98,8 @@ async fn flush_is_incremental_between_calls() {
 
 #[tokio::test]
 async fn final_flush_uploads_log_emitted_immediately_before_it() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let system_log = guest_agent::paths::system_log_file();
     let pos_file = guest_agent::paths::telemetry_system_log_pos_file();
@@ -135,8 +135,8 @@ async fn final_flush_uploads_log_emitted_immediately_before_it() {
 
 #[tokio::test]
 async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     remove_telemetry_files();
     let _session_files = SessionCheckpointFilesGuard::new();
 
@@ -214,8 +214,8 @@ async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
 /// HTTP traffic (2).
 #[tokio::test]
 async fn concurrent_flushes_do_not_regress_pos_file() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let ops_file = guest_common::telemetry::sandbox_ops_log();
     let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
@@ -274,8 +274,8 @@ async fn concurrent_flushes_do_not_regress_pos_file() {
 ///    HTTP recovers).
 #[tokio::test]
 async fn flush_propagates_error_then_loop_recovers() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
 
     let ops_file = guest_common::telemetry::sandbox_ops_log();
     let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
@@ -334,8 +334,8 @@ async fn flush_propagates_error_then_loop_recovers() {
 
 #[tokio::test]
 async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     remove_telemetry_files();
 
     let metrics_file = guest_agent::paths::metrics_log_file();
@@ -375,8 +375,8 @@ async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload
 
 #[tokio::test]
 async fn oversized_system_log_uploads_marker_without_raw_line_fragment() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let server = &*MOCK_SERVER;
+    let api = SharedApiMock::new().await;
+    let server = api.server();
     remove_telemetry_files();
 
     let system_log = guest_agent::paths::system_log_file();


### PR DESCRIPTION
## Summary

- Add a SharedApiMock integration-test fixture that owns the shared guest API mock server lock and resets server state at test start.
- Migrate guest-agent integration tests away from direct TEST_MUTEX/MOCK_SERVER access and shared-server URL string assembly.
- Keep isolated MockServer::start() tests and explicit teardown for heartbeat/telemetry ordering-sensitive cases.

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration
- pre-commit hook cargo-fmt/cargo-clippy/cargo-doc

Closes #18130