### PR TITLE
fix(desktop): slow computer use tray animation

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray.test.ts
@@ -264,17 +264,17 @@ describe("desktop tray", () => {
     expect(tray.image.path).toBe(disabledIconPath);
     expect(tray.image.templateImage).toBe(false);
 
-    vi.advanceTimersByTime(280);
+    vi.advanceTimersByTime(500);
 
     expect(tray.image.path).toBe(runningIconPath);
     expect(tray.image.templateImage).toBe(false);
 
-    vi.advanceTimersByTime(280);
+    vi.advanceTimersByTime(500);
 
     expect(tray.image.path).toBe(iconPath);
     expect(tray.image.templateImage).toBe(true);
 
-    vi.advanceTimersByTime(280);
+    vi.advanceTimersByTime(500);
 
     expect(tray.image.path).toBe(runningIconPath);
   });
@@ -290,11 +290,11 @@ describe("desktop tray", () => {
 
     runningCommand = false;
     controller.refresh();
-    vi.advanceTimersByTime(14_840);
+    vi.advanceTimersByTime(14_500);
 
     expect(tray.image.path).toBe(runningIconPath);
 
-    vi.advanceTimersByTime(280);
+    vi.advanceTimersByTime(500);
 
     expect(tray.image.path).toBe(iconPath);
     expect(tray.image.templateImage).toBe(true);

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -38,7 +38,7 @@ interface DesktopTrayControllerOptions {
 type DesktopTrayIconFrame = "disabled" | "online" | "running";
 type DesktopTrayIconMode = "disabled" | "online" | "running";
 
-const RUNNING_TRAY_ICON_FRAME_MS = 280;
+const RUNNING_TRAY_ICON_FRAME_MS = 500;
 const RUNNING_TRAY_ACTIVITY_LINGER_MS = 15_000;
 const RUNNING_TRAY_ICON_FRAME_COUNT = 4;
 


### PR DESCRIPTION
## Summary
- slow the Desktop Computer Use running tray icon from 280ms per frame to 500ms per frame
- update tray animation timer tests for the new cadence

## Tests
- pnpm format
- pnpm -F @vm0/desktop exec vitest src/desktop-tray.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop test