### PR TITLE
perf: migrate permission ui to firewall metadata

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -87,6 +87,23 @@ export default [
             "Use now() from src/lib/time instead of Date.now() so tests can control the platform clock.",
         },
       ],
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@vm0/connectors/firewalls",
+              message:
+                "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
+            },
+            {
+              name: "@vm0/core/firewalls",
+              message:
+                "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -102,6 +102,13 @@ export default [
                 "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
             },
           ],
+          patterns: [
+            {
+              group: ["@vm0/connectors/firewalls/*", "@vm0/core/firewalls/*"],
+              message:
+                "Platform frontend code must use @vm0/connectors/firewall-metadata instead of runtime firewall catalogs.",
+            },
+          ],
         },
       ],
     },

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -1,7 +1,7 @@
 import {
-  isFirewallConnectorType,
-  type FirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+  isFirewallMetadataConnectorType,
+  type FirewallMetadataConnectorType,
+} from "@vm0/connectors/firewall-metadata";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { parseUserPermissionGrantExpiresIn } from "../permission-allow/permission-grant-expiration.ts";
 
@@ -10,7 +10,7 @@ type PlatformHostTarget = "api" | "www" | "app" | "platform";
 
 export interface PermissionActionDescriptor {
   agentId: string;
-  connectorRef: FirewallConnectorType;
+  connectorRef: FirewallMetadataConnectorType;
   permission: string;
   action: PermissionAction;
   method: string | null;
@@ -168,7 +168,7 @@ export function parsePermissionActionUrl(
   if (
     !agentId ||
     !connectorRef ||
-    !isFirewallConnectorType(connectorRef) ||
+    !isFirewallMetadataConnectorType(connectorRef) ||
     !permission ||
     !isPermissionAction(action)
   ) {

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -1,0 +1,37 @@
+import { computed, type Computed } from "ccstate";
+import {
+  isFirewallMetadataConnectorType,
+  loadFirewallPermissionMetadata,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
+
+interface FirewallPermissionMetadataParams {
+  readonly connectorType: string;
+}
+
+function createFirewallPermissionMetadataFactory(): (
+  params: FirewallPermissionMetadataParams,
+) => Computed<Promise<FirewallPermissionDetailMetadata | null>> {
+  const cache = new Map<
+    string,
+    Computed<Promise<FirewallPermissionDetailMetadata | null>>
+  >();
+  return (params) => {
+    const key = params.connectorType;
+    const existing = cache.get(key);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = computed(async () => {
+      if (!isFirewallMetadataConnectorType(params.connectorType)) {
+        return null;
+      }
+      return await loadFirewallPermissionMetadata(params.connectorType);
+    });
+    cache.set(key, atom$);
+    return atom$;
+  };
+}
+
+export const firewallPermissionMetadataByConnector =
+  createFirewallPermissionMetadataFactory();

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -10,11 +10,10 @@ import {
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
   permissionGrantsToFirewallPolicies,
-  resolveFirewallPolicies,
-} from "@vm0/connectors/firewalls";
+  resolveFirewallMetadataPolicies,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
@@ -68,7 +67,7 @@ export const permissionAllowAgent$ = computed((get) => {
 });
 
 // ---------------------------------------------------------------------------
-// Permissions list (derived from connector config)
+// Permissions list (derived from firewall metadata)
 // ---------------------------------------------------------------------------
 
 export interface Permission {
@@ -76,34 +75,18 @@ export interface Permission {
   description?: string;
 }
 
-function extractPermissions(ref: string): Permission[] {
-  if (!isFirewallConnectorType(ref)) {
-    return [];
-  }
-  const config = getConnectorFirewall(ref);
-  const seen = new Map<string, Permission>();
-  for (const api of config.apis) {
-    if (!api.permissions) {
-      continue;
-    }
-    for (const p of api.permissions) {
-      if (!seen.has(p.name)) {
-        seen.set(p.name, { name: p.name, description: p.description });
-      }
-    }
-  }
-  return [...seen.values()];
-}
-
-export function findPermission(ref: string, name: string): Permission | null {
-  if (name === UNKNOWN_PERMISSION_GRANT && isFirewallConnectorType(ref)) {
+export function findPermissionInMetadata(
+  metadata: FirewallPermissionDetailMetadata,
+  name: string,
+): Permission | null {
+  if (name === UNKNOWN_PERMISSION_GRANT) {
     return {
       name: UNKNOWN_PERMISSION_GRANT,
       description: "Unknown endpoints",
     };
   }
   return (
-    extractPermissions(ref).find((permission) => {
+    metadata.permissions.find((permission) => {
       return permission.name === name;
     }) ?? null
   );
@@ -117,13 +100,13 @@ const internalUserPermissionGrantsReload$ = state(0);
 
 export function resolveUserPermissionGrantPolicy(
   grants: readonly UserPermissionGrantResponse[],
-  connectorRef: string,
+  metadata: FirewallPermissionDetailMetadata,
   permission: string,
 ): FirewallPolicyValue | undefined {
-  const policies = resolveFirewallPolicies(
+  const policies = resolveFirewallMetadataPolicies(
     permissionGrantsToFirewallPolicies(grants),
-    [connectorRef],
-  )?.[connectorRef];
+    [metadata],
+  )?.[metadata.type];
   return permission === UNKNOWN_PERMISSION_GRANT
     ? policies?.unknownPolicy
     : policies?.policies[permission];

--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions.ts
@@ -1,19 +1,10 @@
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+import { hasFirewallMetadataPermissions } from "@vm0/connectors/firewall-metadata";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
 
 /** Check if a connector has any permissions defined. */
 export function hasConnectorPermissions(type: ConnectorType): boolean {
-  if (!isFirewallConnectorType(type)) {
-    return false;
-  }
-  const config = getConnectorFirewall(type);
-  return config.apis.some((api) => {
-    return api.permissions && api.permissions.length > 0;
-  });
+  return hasFirewallMetadataPermissions(type);
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -9,11 +9,12 @@ import {
 } from "@tabler/icons-react";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
-import { isFirewallConnectorType } from "@vm0/connectors/firewalls";
+import { isFirewallMetadataConnectorType } from "@vm0/connectors/firewall-metadata";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
+import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
 import {
-  findPermission,
+  findPermissionInMetadata,
   permissionAllowAction$,
   permissionAllowActionParam$,
   permissionAllowAgent$,
@@ -67,7 +68,7 @@ function ConnectorPermissionCard({
   permission: Permission;
   action: "allow" | "deny";
 }) {
-  const connectorConfig = isFirewallConnectorType(connectorRef)
+  const connectorConfig = isFirewallMetadataConnectorType(connectorRef)
     ? CONNECTOR_TYPES[connectorRef]
     : undefined;
   const connectorLabel = connectorConfig?.label ?? connectorRef;
@@ -77,7 +78,7 @@ function ConnectorPermissionCard({
     <div className="w-full rounded-lg border border-border px-4 py-3">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2 border-b border-border/70 pb-4 pt-1">
-          {isFirewallConnectorType(connectorRef) && (
+          {isFirewallMetadataConnectorType(connectorRef) && (
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-muted/40">
               <ConnectorIcon type={connectorRef} size={20} />
             </span>
@@ -331,11 +332,15 @@ function PermissionAllowDoctorPage({
   const agentLoadable = useLastLoadable(permissionAllowAgent$);
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
+  const metadataLoadable = useLastLoadable(
+    firewallPermissionMetadataByConnector({ connectorType: ref }),
+  );
 
   if (
     agentLoadable.state === "loading" ||
     userLoadable.state === "loading" ||
-    grantsLoadable.state === "loading"
+    grantsLoadable.state === "loading" ||
+    metadataLoadable.state === "loading"
   ) {
     return <LoadingCard />;
   }
@@ -346,13 +351,20 @@ function PermissionAllowDoctorPage({
   if (grantsLoadable.state === "hasError") {
     return <ErrorMessage message="Failed to load permission grants" />;
   }
+  if (metadataLoadable.state === "hasError") {
+    return <ErrorMessage message="Failed to load permission metadata" />;
+  }
 
   const agent = agentLoadable.data;
   if (!agent) {
     return <ErrorMessage message="Agent not found" />;
   }
+  const metadata = metadataLoadable.data;
+  if (!metadata) {
+    return <ErrorMessage message={`Unknown connector: ${ref}`} />;
+  }
 
-  const focusedPermission = findPermission(ref, permission);
+  const focusedPermission = findPermissionInMetadata(metadata, permission);
   if (!focusedPermission) {
     return <ErrorMessage message={`Unknown permission: ${permission}`} />;
   }
@@ -360,7 +372,7 @@ function PermissionAllowDoctorPage({
   const grants = grantsLoadable.state === "hasData" ? grantsLoadable.data : [];
   const effectivePolicy = resolveUserPermissionGrantPolicy(
     grants,
-    ref,
+    metadata,
     focusedPermission.name,
   );
   const explicitGrant = grants.find((grant) => {
@@ -419,7 +431,7 @@ export function PermissionAllowPage() {
     return <ErrorMessage message="Missing permission in URL parameters" />;
   }
 
-  if (!isFirewallConnectorType(ref)) {
+  if (!isFirewallMetadataConnectorType(ref)) {
     return <ErrorMessage message={`Unknown connector: ${ref}`} />;
   }
 

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Button } from "@vm0/ui";
 import {
@@ -332,7 +332,7 @@ function PermissionAllowDoctorPage({
   const agentLoadable = useLastLoadable(permissionAllowAgent$);
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
-  const metadataLoadable = useLastLoadable(
+  const metadataLoadable = useLoadable(
     firewallPermissionMetadataByConnector({ connectorType: ref }),
   );
 

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import { getPermissionCategories } from "@vm0/connectors/firewalls";
+import { loadFirewallPermissionMetadata } from "@vm0/connectors/firewall-metadata";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
@@ -36,6 +36,8 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 const context = testContext();
 const zeroAgentId = "c0000000-0000-4000-a000-000000000001";
 const researchAgentId = "a0000000-0000-4000-a000-000000000401";
+const PERMISSION_METADATA_TIMEOUT_MS = 15_000;
+const PERMISSION_UI_TEST_TIMEOUT_MS = 20_000;
 
 function createAgent(id: string, displayName: string): TeamComposeItem {
   return {
@@ -119,33 +121,52 @@ function tabByText(text: string): HTMLElement {
 }
 
 async function permissionRowByName(
-  container: HTMLElement,
+  _container: HTMLElement,
   name: string,
 ): Promise<HTMLElement> {
-  const row = (await within(container).findByText(name)).closest(
-    "div",
-  )?.parentElement;
+  const row = (
+    await screen.findByText(
+      name,
+      {},
+      { timeout: PERMISSION_METADATA_TIMEOUT_MS },
+    )
+  ).closest("div")?.parentElement;
   if (!(row instanceof HTMLElement)) {
     throw new Error(`${name} permission row not found`);
   }
   return row;
 }
 
-function unknownEndpointsRow(container: HTMLElement): HTMLElement {
-  const row = within(container)
-    .getByText("Other endpoints")
-    .closest("div")?.parentElement;
+async function unknownEndpointsRow(
+  _container: HTMLElement,
+): Promise<HTMLElement> {
+  const row = (
+    await screen.findByText(
+      "Other endpoints",
+      {},
+      { timeout: PERMISSION_METADATA_TIMEOUT_MS },
+    )
+  ).closest("div")?.parentElement;
   if (!(row instanceof HTMLElement)) {
     throw new Error("Other endpoints row not found");
   }
   return row;
 }
 
-function connectorCategoryLabel(
+function dialogForElement(element: HTMLElement): HTMLElement {
+  const dialog = element.closest('[role="dialog"]');
+  if (!(dialog instanceof HTMLElement)) {
+    throw new Error("dialog not found for element");
+  }
+  return dialog;
+}
+
+async function connectorCategoryLabel(
   connectorType: ConnectorType,
   category: string,
-): string {
-  const categoryData = getPermissionCategories(connectorType);
+): Promise<string> {
+  const metadata = await loadFirewallPermissionMetadata(connectorType);
+  const categoryData = metadata?.categories;
   if (!categoryData) {
     throw new Error(`${connectorType} categories not found`);
   }
@@ -567,299 +588,339 @@ describe("team page navigation", () => {
     });
   });
 
-  it("updates connector permission policies from an agent page", async () => {
-    mockTeamAPIs();
-    detachedSetupPage({
-      context,
-      path: `/agents/${researchAgentId}`,
-    });
+  it(
+    "updates connector permission policies from an agent page",
+    async () => {
+      mockTeamAPIs();
+      detachedSetupPage({
+        context,
+        path: `/agents/${researchAgentId}`,
+      });
 
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Research Agent" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("@workspace")).toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Manage Axiom permissions"));
+
+      const permissionsDialog = await screen.findByRole("dialog");
       expect(
-        screen.getByRole("heading", { name: "Research Agent" }),
+        within(permissionsDialog).getByText("Axiom permissions"),
       ).toBeInTheDocument();
-      expect(screen.getByText("@workspace")).toBeInTheDocument();
-    });
-
-    click(screen.getByLabelText("Manage Axiom permissions"));
-
-    const permissionsDialog = await screen.findByRole("dialog");
-    expect(
-      within(permissionsDialog).getByText("Axiom permissions"),
-    ).toBeInTheDocument();
-    expect(
-      within(permissionsDialog).getByText("for Research Agent"),
-    ).toBeInTheDocument();
-
-    const permissionRow = await permissionRowByName(
-      permissionsDialog,
-      "annotations|create",
-    );
-    click(screen.getByLabelText("annotations|create allow options"));
-    click(menuItemByText("Allow for 24h"));
-    await waitFor(() => {
-      expect(within(permissionRow).getByText("24h")).toBeInTheDocument();
-      expect(buttonByText("Apply", permissionsDialog)).toBeEnabled();
-    });
-    click(buttonByText("Apply", permissionsDialog));
-
-    await waitFor(() => {
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-      expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
-    });
-
-    click(screen.getByLabelText("Manage Axiom permissions"));
-
-    const resetDialog = await screen.findByRole("dialog");
-    expect(
-      within(resetDialog).getByText("Axiom permissions"),
-    ).toBeInTheDocument();
-
-    const resetPermissionRow = await permissionRowByName(
-      resetDialog,
-      "annotations|create",
-    );
-    click(buttonByText("Deny", resetPermissionRow));
-    click(buttonByText("Deny", unknownEndpointsRow(resetDialog)));
-
-    await waitFor(() => {
-      expect(buttonByText("Restore", resetDialog)).toBeEnabled();
-    });
-    click(buttonByText("Restore", resetDialog));
-    await waitFor(() => {
-      expect(buttonByText("Apply", resetDialog)).toBeEnabled();
-    });
-    click(buttonByText("Apply", resetDialog));
-
-    await waitFor(() => {
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-      expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
-    });
-  });
-
-  it("uses Cloudflare unknown endpoint deny as the permissions drawer default", async () => {
-    mockTeamAPIs();
-    context.mocks.data.connectors([createConnector("cloudflare", "cf-team")]);
-    detachedSetupPage({
-      context,
-      path: `/agents/${researchAgentId}`,
-    });
-
-    await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "Research Agent" }),
+        within(permissionsDialog).getByText("for Research Agent"),
       ).toBeInTheDocument();
-      expect(screen.getByText("@cf-team")).toBeInTheDocument();
-    });
 
-    click(screen.getByLabelText("Manage Cloudflare permissions"));
-
-    const permissionsDialog = await screen.findByRole("dialog");
-    expect(
-      within(permissionsDialog).getByText("Cloudflare permissions"),
-    ).toBeInTheDocument();
-
-    const unknownRow = unknownEndpointsRow(permissionsDialog);
-    expect(buttonByText("Deny", unknownRow)).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(buttonByText("Restore", permissionsDialog)).toBeDisabled();
-
-    click(buttonByText("Allow", unknownRow));
-    await waitFor(() => {
-      expect(buttonByText("Allow", unknownRow)).toHaveAttribute(
-        "aria-pressed",
-        "true",
+      const permissionRow = await permissionRowByName(
+        permissionsDialog,
+        "annotations|create",
       );
-      expect(buttonByText("Restore", permissionsDialog)).toBeEnabled();
-    });
+      const loadedPermissionsDialog = dialogForElement(permissionRow);
+      click(screen.getByLabelText("annotations|create allow options"));
+      click(menuItemByText("Allow for 24h"));
+      await waitFor(() => {
+        expect(within(permissionRow).getByText("24h")).toBeInTheDocument();
+        expect(buttonByText("Apply", loadedPermissionsDialog)).toBeEnabled();
+      });
+      click(buttonByText("Apply", loadedPermissionsDialog));
 
-    click(buttonByText("Restore", permissionsDialog));
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+        expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Manage Axiom permissions"));
+
+      const resetDialog = dialogForElement(
+        await screen.findByText("Axiom permissions"),
+      );
+
+      const resetPermissionRow = await permissionRowByName(
+        resetDialog,
+        "annotations|create",
+      );
+      const loadedResetDialog = dialogForElement(resetPermissionRow);
+      click(buttonByText("Deny", resetPermissionRow));
+      click(buttonByText("Deny", await unknownEndpointsRow(loadedResetDialog)));
+
+      await waitFor(() => {
+        expect(buttonByText("Restore", loadedResetDialog)).toBeEnabled();
+      });
+      click(buttonByText("Restore", loadedResetDialog));
+      await waitFor(() => {
+        expect(buttonByText("Apply", loadedResetDialog)).toBeEnabled();
+      });
+      click(buttonByText("Apply", loadedResetDialog));
+
+      await waitFor(() => {
+        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+        expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
+      });
+    },
+    PERMISSION_UI_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "uses Cloudflare unknown endpoint deny as the permissions drawer default",
+    async () => {
+      mockTeamAPIs();
+      context.mocks.data.connectors([createConnector("cloudflare", "cf-team")]);
+      detachedSetupPage({
+        context,
+        path: `/agents/${researchAgentId}`,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Research Agent" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("@cf-team")).toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Manage Cloudflare permissions"));
+
+      const permissionsDialog = await screen.findByRole("dialog");
+      expect(
+        within(permissionsDialog).getByText("Cloudflare permissions"),
+      ).toBeInTheDocument();
+
+      const unknownRow = await unknownEndpointsRow(permissionsDialog);
+      const loadedPermissionsDialog = dialogForElement(unknownRow);
       expect(buttonByText("Deny", unknownRow)).toHaveAttribute(
         "aria-pressed",
         "true",
       );
-      expect(buttonByText("Restore", permissionsDialog)).toBeDisabled();
-    });
-  });
+      expect(buttonByText("Restore", loadedPermissionsDialog)).toBeDisabled();
 
-  it("saves permission duration changes from an agent page", async () => {
-    mockNow();
-    mockTeamAPIs();
-    const capturedUpserts: UpsertUserPermissionGrantRequest[] = [];
-    let grants: UserPermissionGrantResponse[] = [
-      {
-        agentId: researchAgentId,
-        connectorRef: "axiom",
-        permission: "annotations|create",
-        action: "allow",
-        expiresAt: isoFromNowMs(30 * 60 * 1000),
-        createdAt: "2026-03-01T00:00:00.000Z",
-        updatedAt: "2026-03-01T00:00:00.000Z",
-      },
-    ];
-    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
-      return respond(200, grants);
-    });
-    context.mocks.api(
-      zeroUserPermissionGrantsContract.upsert,
-      ({ body, respond }) => {
-        capturedUpserts.push(body);
-        const grant: UserPermissionGrantResponse = {
-          agentId: body.agentId,
-          connectorRef: body.connectorRef,
-          permission: body.permission,
-          action: body.action,
-          expiresAt:
-            body.action === "allow" && body.expiresIn !== "always"
-              ? isoFromNowMs(60 * 60 * 1000)
-              : null,
-          createdAt: "2026-03-01T00:00:00.000Z",
-          updatedAt: "2026-03-01T00:30:00.000Z",
-        };
-        grants = [
-          ...grants.filter((current) => {
-            return (
-              current.connectorRef !== grant.connectorRef ||
-              current.permission !== grant.permission
-            );
-          }),
-          grant,
-        ];
-        return respond(200, grant);
-      },
-    );
+      click(buttonByText("Allow", unknownRow));
+      await waitFor(() => {
+        expect(buttonByText("Allow", unknownRow)).toHaveAttribute(
+          "aria-pressed",
+          "true",
+        );
+        expect(buttonByText("Restore", loadedPermissionsDialog)).toBeEnabled();
+      });
 
-    detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
+      click(buttonByText("Restore", loadedPermissionsDialog));
+      await waitFor(() => {
+        expect(buttonByText("Deny", unknownRow)).toHaveAttribute(
+          "aria-pressed",
+          "true",
+        );
+        expect(buttonByText("Restore", loadedPermissionsDialog)).toBeDisabled();
+      });
+    },
+    PERMISSION_UI_TEST_TIMEOUT_MS,
+  );
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Research Agent" }),
-      ).toBeInTheDocument();
-      expect(screen.getByText("@workspace")).toBeInTheDocument();
-    });
-
-    click(screen.getByLabelText("Manage Axiom permissions"));
-
-    const permissionsDialog = await screen.findByRole("dialog");
-    const createRow = await permissionRowByName(
-      permissionsDialog,
-      "annotations|create",
-    );
-    expect(within(createRow).getByText("< 1 hour")).toBeInTheDocument();
-
-    click(screen.getByLabelText("annotations|create allow options"));
-    click(menuItemByText("Allow always"));
-    await waitFor(() => {
-      expect(within(createRow).getByText("Always")).toBeInTheDocument();
-      expect(buttonByText("Apply", permissionsDialog)).toBeEnabled();
-    });
-
-    click(buttonByText("Apply", permissionsDialog));
-
-    await waitFor(() => {
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-    });
-    expect(capturedUpserts).toStrictEqual(
-      expect.arrayContaining([
+  it(
+    "saves permission duration changes from an agent page",
+    async () => {
+      mockNow();
+      mockTeamAPIs();
+      const capturedUpserts: UpsertUserPermissionGrantRequest[] = [];
+      let grants: UserPermissionGrantResponse[] = [
         {
           agentId: researchAgentId,
           connectorRef: "axiom",
           permission: "annotations|create",
           action: "allow",
-          expiresIn: "always",
+          expiresAt: isoFromNowMs(30 * 60 * 1000),
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
         },
-      ]),
-    );
-  });
+      ];
+      context.mocks.api(
+        zeroUserPermissionGrantsContract.list,
+        ({ respond }) => {
+          return respond(200, grants);
+        },
+      );
+      context.mocks.api(
+        zeroUserPermissionGrantsContract.upsert,
+        ({ body, respond }) => {
+          capturedUpserts.push(body);
+          const grant: UserPermissionGrantResponse = {
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: body.permission,
+            action: body.action,
+            expiresAt:
+              body.action === "allow" && body.expiresIn !== "always"
+                ? isoFromNowMs(60 * 60 * 1000)
+                : null,
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedAt: "2026-03-01T00:30:00.000Z",
+          };
+          grants = [
+            ...grants.filter((current) => {
+              return (
+                current.connectorRef !== grant.connectorRef ||
+                current.permission !== grant.permission
+              );
+            }),
+            grant,
+          ];
+          return respond(200, grant);
+        },
+      );
 
-  it("updates grouped connector permission policies from an agent page", async () => {
-    mockTeamAPIs();
-    detachedSetupPage({
-      context,
-      path: `/agents/${researchAgentId}`,
-    });
+      detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
 
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Research Agent" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("@workspace")).toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Manage Axiom permissions"));
+
+      const permissionsDialog = await screen.findByRole("dialog");
+      const createRow = await permissionRowByName(
+        permissionsDialog,
+        "annotations|create",
+      );
+      const loadedPermissionsDialog = dialogForElement(createRow);
+      expect(within(createRow).getByText("< 1 hour")).toBeInTheDocument();
+
+      click(screen.getByLabelText("annotations|create allow options"));
+      click(menuItemByText("Allow always"));
+      await waitFor(() => {
+        expect(within(createRow).getByText("Always")).toBeInTheDocument();
+        expect(buttonByText("Apply", loadedPermissionsDialog)).toBeEnabled();
+      });
+
+      click(buttonByText("Apply", loadedPermissionsDialog));
+
+      await waitFor(() => {
+        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      });
+      expect(capturedUpserts).toStrictEqual(
+        expect.arrayContaining([
+          {
+            agentId: researchAgentId,
+            connectorRef: "axiom",
+            permission: "annotations|create",
+            action: "allow",
+            expiresIn: "always",
+          },
+        ]),
+      );
+    },
+    PERMISSION_UI_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "updates grouped connector permission policies from an agent page",
+    async () => {
+      mockTeamAPIs();
+      detachedSetupPage({
+        context,
+        path: `/agents/${researchAgentId}`,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Research Agent" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("@ops")).toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Manage Slack permissions"));
+
+      const groupedDialog = await screen.findByRole("dialog");
       expect(
-        screen.getByRole("heading", { name: "Research Agent" }),
+        within(groupedDialog).getByText("Slack permissions"),
       ).toBeInTheDocument();
-      expect(screen.getByText("@ops")).toBeInTheDocument();
-    });
+      const readGroupLabel = await connectorCategoryLabel("slack", "Read");
+      const writeGroupLabel = await connectorCategoryLabel("slack", "Write");
+      const miscGroupLabel = await connectorCategoryLabel("slack", "Misc");
+      const readGroupElement = await screen.findByText(
+        readGroupLabel,
+        {},
+        { timeout: PERMISSION_METADATA_TIMEOUT_MS },
+      );
+      const loadedGroupedDialog = dialogForElement(readGroupElement);
+      expect(readGroupElement).toBeInTheDocument();
+      const writeGroupElement = await screen.findByText(
+        writeGroupLabel,
+        {},
+        { timeout: PERMISSION_METADATA_TIMEOUT_MS },
+      );
+      expect(writeGroupElement).toBeInTheDocument();
+      const miscGroupElement = await screen.findByText(
+        miscGroupLabel,
+        {},
+        { timeout: PERMISSION_METADATA_TIMEOUT_MS },
+      );
+      expect(miscGroupElement).toBeInTheDocument();
 
-    click(screen.getByLabelText("Manage Slack permissions"));
+      click(screen.getByText(miscGroupLabel));
+      const miscGroup = screen.getByText(miscGroupLabel).closest("div");
+      if (!(miscGroup instanceof HTMLElement)) {
+        throw new Error("Misc permission group not found");
+      }
+      click(within(miscGroup).getByLabelText("Misc allow options"));
+      click(menuItemByText("Allow for 7d"));
+      await waitFor(() => {
+        expect(within(miscGroup).getByText("7d")).toBeInTheDocument();
+      });
+      click(buttonByText("Deny", miscGroup));
+      await waitFor(() => {
+        expect(within(miscGroup).queryByText("7d")).not.toBeInTheDocument();
+      });
+      click(buttonByText("Allow", miscGroup));
+      click(within(miscGroup).getByLabelText("Misc allow options"));
+      click(menuItemByText("Allow always"));
 
-    const groupedDialog = await screen.findByRole("dialog");
-    expect(
-      within(groupedDialog).getByText("Slack permissions"),
-    ).toBeInTheDocument();
-    const readGroupLabel = connectorCategoryLabel("slack", "Read");
-    const writeGroupLabel = connectorCategoryLabel("slack", "Write");
-    const miscGroupLabel = connectorCategoryLabel("slack", "Misc");
-    expect(within(groupedDialog).getByText(readGroupLabel)).toBeInTheDocument();
-    expect(
-      within(groupedDialog).getByText(writeGroupLabel),
-    ).toBeInTheDocument();
-    expect(within(groupedDialog).getByText(miscGroupLabel)).toBeInTheDocument();
+      const permissionsScrollArea =
+        loadedGroupedDialog.querySelector(".overflow-y-auto");
+      if (!(permissionsScrollArea instanceof HTMLElement)) {
+        throw new Error("permissions scroll area not found");
+      }
+      Object.defineProperty(permissionsScrollArea, "scrollTop", {
+        configurable: true,
+        value: 24,
+      });
+      fireEvent.scroll(permissionsScrollArea);
 
-    click(screen.getByText(miscGroupLabel));
-    const miscGroup = screen.getByText(miscGroupLabel).closest("div");
-    if (!(miscGroup instanceof HTMLElement)) {
-      throw new Error("Misc permission group not found");
-    }
-    click(within(miscGroup).getByLabelText("Misc allow options"));
-    click(menuItemByText("Allow for 7d"));
-    await waitFor(() => {
-      expect(within(miscGroup).getByText("7d")).toBeInTheDocument();
-    });
-    click(buttonByText("Deny", miscGroup));
-    await waitFor(() => {
-      expect(within(miscGroup).queryByText("7d")).not.toBeInTheDocument();
-    });
-    click(buttonByText("Allow", miscGroup));
-    click(within(miscGroup).getByLabelText("Misc allow options"));
-    click(menuItemByText("Allow always"));
+      const channelsJoinRow = await permissionRowByName(
+        loadedGroupedDialog,
+        "channels:join",
+      );
+      click(
+        within(channelsJoinRow).getByLabelText("Undo channels:join changes"),
+      );
+      await waitFor(() => {
+        expect(
+          within(channelsJoinRow).queryByLabelText(
+            "Undo channels:join changes",
+          ),
+        ).not.toBeInTheDocument();
+      });
 
-    const permissionsScrollArea =
-      groupedDialog.querySelector(".overflow-y-auto");
-    if (!(permissionsScrollArea instanceof HTMLElement)) {
-      throw new Error("permissions scroll area not found");
-    }
-    Object.defineProperty(permissionsScrollArea, "scrollTop", {
-      configurable: true,
-      value: 24,
-    });
-    fireEvent.scroll(permissionsScrollArea);
+      const unknownRow = await unknownEndpointsRow(loadedGroupedDialog);
+      click(within(unknownRow).getByLabelText("__unknown__ allow options"));
+      click(menuItemByText("Allow for 1h"));
+      await waitFor(() => {
+        expect(within(unknownRow).getByText("1h")).toBeInTheDocument();
+      });
+      click(within(unknownRow).getByLabelText("Undo __unknown__ changes"));
+      await waitFor(() => {
+        expect(within(unknownRow).queryByText("1h")).not.toBeInTheDocument();
+      });
 
-    const channelsJoinRow = await permissionRowByName(
-      groupedDialog,
-      "channels:join",
-    );
-    click(within(channelsJoinRow).getByLabelText("Undo channels:join changes"));
-    await waitFor(() => {
-      expect(
-        within(channelsJoinRow).queryByLabelText("Undo channels:join changes"),
-      ).not.toBeInTheDocument();
-    });
+      click(buttonByText("Apply", loadedGroupedDialog));
 
-    const unknownRow = unknownEndpointsRow(groupedDialog);
-    click(within(unknownRow).getByLabelText("__unknown__ allow options"));
-    click(menuItemByText("Allow for 1h"));
-    await waitFor(() => {
-      expect(within(unknownRow).getByText("1h")).toBeInTheDocument();
-    });
-    click(within(unknownRow).getByLabelText("Undo __unknown__ changes"));
-    await waitFor(() => {
-      expect(within(unknownRow).queryByText("1h")).not.toBeInTheDocument();
-    });
-
-    click(buttonByText("Apply", groupedDialog));
-
-    await waitFor(() => {
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-      expect(screen.queryByText("Slack permissions")).not.toBeInTheDocument();
-    });
-  });
+      await waitFor(() => {
+        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+        expect(screen.queryByText("Slack permissions")).not.toBeInTheDocument();
+      });
+    },
+    PERMISSION_UI_TEST_TIMEOUT_MS,
+  );
 });

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -832,10 +832,6 @@ describe("team page navigation", () => {
 
       click(screen.getByLabelText("Manage Slack permissions"));
 
-      const groupedDialog = await screen.findByRole("dialog");
-      expect(
-        within(groupedDialog).getByText("Slack permissions"),
-      ).toBeInTheDocument();
       const readGroupLabel = await connectorCategoryLabel("slack", "Read");
       const writeGroupLabel = await connectorCategoryLabel("slack", "Write");
       const miscGroupLabel = await connectorCategoryLabel("slack", "Misc");
@@ -845,6 +841,9 @@ describe("team page navigation", () => {
         { timeout: PERMISSION_METADATA_TIMEOUT_MS },
       );
       const loadedGroupedDialog = dialogForElement(readGroupElement);
+      expect(
+        within(loadedGroupedDialog).getByText("Slack permissions"),
+      ).toBeInTheDocument();
       expect(readGroupElement).toBeInTheDocument();
       const writeGroupElement = await screen.findByText(
         writeGroupLabel,

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -161,6 +161,18 @@ function dialogForElement(element: HTMLElement): HTMLElement {
   return dialog;
 }
 
+async function findLoadedPermissionsDialog(
+  title: string,
+): Promise<HTMLElement> {
+  const dialog = await screen.findByRole("dialog");
+  await within(dialog).findByText(
+    title,
+    {},
+    { timeout: PERMISSION_METADATA_TIMEOUT_MS },
+  );
+  return dialog;
+}
+
 async function connectorCategoryLabel(
   connectorType: ConnectorType,
   category: string,
@@ -606,10 +618,8 @@ describe("team page navigation", () => {
 
       click(screen.getByLabelText("Manage Axiom permissions"));
 
-      const permissionsDialog = await screen.findByRole("dialog");
-      expect(
-        within(permissionsDialog).getByText("Axiom permissions"),
-      ).toBeInTheDocument();
+      const permissionsDialog =
+        await findLoadedPermissionsDialog("Axiom permissions");
       expect(
         within(permissionsDialog).getByText("for Research Agent"),
       ).toBeInTheDocument();
@@ -682,10 +692,9 @@ describe("team page navigation", () => {
 
       click(screen.getByLabelText("Manage Cloudflare permissions"));
 
-      const permissionsDialog = await screen.findByRole("dialog");
-      expect(
-        within(permissionsDialog).getByText("Cloudflare permissions"),
-      ).toBeInTheDocument();
+      const permissionsDialog = await findLoadedPermissionsDialog(
+        "Cloudflare permissions",
+      );
 
       const unknownRow = await unknownEndpointsRow(permissionsDialog);
       const loadedPermissionsDialog = dialogForElement(unknownRow);

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -36,8 +36,6 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 const context = testContext();
 const zeroAgentId = "c0000000-0000-4000-a000-000000000001";
 const researchAgentId = "a0000000-0000-4000-a000-000000000401";
-const PERMISSION_METADATA_TIMEOUT_MS = 15_000;
-const PERMISSION_UI_TEST_TIMEOUT_MS = 20_000;
 
 function createAgent(id: string, displayName: string): TeamComposeItem {
   return {
@@ -124,13 +122,7 @@ async function permissionRowByName(
   _container: HTMLElement,
   name: string,
 ): Promise<HTMLElement> {
-  const row = (
-    await screen.findByText(
-      name,
-      {},
-      { timeout: PERMISSION_METADATA_TIMEOUT_MS },
-    )
-  ).closest("div")?.parentElement;
+  const row = (await screen.findByText(name)).closest("div")?.parentElement;
   if (!(row instanceof HTMLElement)) {
     throw new Error(`${name} permission row not found`);
   }
@@ -140,13 +132,9 @@ async function permissionRowByName(
 async function unknownEndpointsRow(
   _container: HTMLElement,
 ): Promise<HTMLElement> {
-  const row = (
-    await screen.findByText(
-      "Other endpoints",
-      {},
-      { timeout: PERMISSION_METADATA_TIMEOUT_MS },
-    )
-  ).closest("div")?.parentElement;
+  const row = (await screen.findByText("Other endpoints")).closest(
+    "div",
+  )?.parentElement;
   if (!(row instanceof HTMLElement)) {
     throw new Error("Other endpoints row not found");
   }
@@ -162,11 +150,7 @@ function dialogForElement(element: HTMLElement): HTMLElement {
 }
 
 async function findLoadedPermissionsDialog(): Promise<HTMLElement> {
-  const unknownEndpoints = await screen.findByText(
-    "Other endpoints",
-    {},
-    { timeout: PERMISSION_METADATA_TIMEOUT_MS },
-  );
+  const unknownEndpoints = await screen.findByText("Other endpoints");
   return dialogForElement(unknownEndpoints);
 }
 
@@ -597,332 +581,297 @@ describe("team page navigation", () => {
     });
   });
 
-  it(
-    "updates connector permission policies from an agent page",
-    async () => {
-      mockTeamAPIs();
-      detachedSetupPage({
-        context,
-        path: `/agents/${researchAgentId}`,
-      });
+  it("updates connector permission policies from an agent page", async () => {
+    mockTeamAPIs();
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+    });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: "Research Agent" }),
-        ).toBeInTheDocument();
-        expect(screen.getByText("@workspace")).toBeInTheDocument();
-      });
-
-      click(screen.getByLabelText("Manage Axiom permissions"));
-
-      const permissionsDialog = await findLoadedPermissionsDialog();
+    await waitFor(() => {
       expect(
-        within(permissionsDialog).getByText("for Research Agent"),
+        screen.getByRole("heading", { name: "Research Agent" }),
       ).toBeInTheDocument();
+      expect(screen.getByText("@workspace")).toBeInTheDocument();
+    });
 
-      const permissionRow = await permissionRowByName(
-        permissionsDialog,
-        "annotations|create",
+    click(screen.getByLabelText("Manage Axiom permissions"));
+
+    const permissionsDialog = await findLoadedPermissionsDialog();
+    expect(
+      within(permissionsDialog).getByText("for Research Agent"),
+    ).toBeInTheDocument();
+
+    const permissionRow = await permissionRowByName(
+      permissionsDialog,
+      "annotations|create",
+    );
+    const loadedPermissionsDialog = dialogForElement(permissionRow);
+    click(screen.getByLabelText("annotations|create allow options"));
+    click(menuItemByText("Allow for 24h"));
+    await waitFor(() => {
+      expect(within(permissionRow).getByText("24h")).toBeInTheDocument();
+      expect(buttonByText("Apply", loadedPermissionsDialog)).toBeEnabled();
+    });
+    click(buttonByText("Apply", loadedPermissionsDialog));
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Manage Axiom permissions"));
+
+    const resetDialog = dialogForElement(
+      await screen.findByText("Axiom permissions"),
+    );
+
+    const resetPermissionRow = await permissionRowByName(
+      resetDialog,
+      "annotations|create",
+    );
+    const loadedResetDialog = dialogForElement(resetPermissionRow);
+    click(buttonByText("Deny", resetPermissionRow));
+    click(buttonByText("Deny", await unknownEndpointsRow(loadedResetDialog)));
+
+    await waitFor(() => {
+      expect(buttonByText("Restore", loadedResetDialog)).toBeEnabled();
+    });
+    click(buttonByText("Restore", loadedResetDialog));
+    await waitFor(() => {
+      expect(buttonByText("Apply", loadedResetDialog)).toBeEnabled();
+    });
+    click(buttonByText("Apply", loadedResetDialog));
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
+    });
+  });
+
+  it("uses Cloudflare unknown endpoint deny as the permissions drawer default", async () => {
+    mockTeamAPIs();
+    context.mocks.data.connectors([createConnector("cloudflare", "cf-team")]);
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("@cf-team")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Manage Cloudflare permissions"));
+
+    const permissionsDialog = await findLoadedPermissionsDialog();
+
+    const unknownRow = await unknownEndpointsRow(permissionsDialog);
+    const loadedPermissionsDialog = dialogForElement(unknownRow);
+    expect(buttonByText("Deny", unknownRow)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(buttonByText("Restore", loadedPermissionsDialog)).toBeDisabled();
+
+    click(buttonByText("Allow", unknownRow));
+    await waitFor(() => {
+      expect(buttonByText("Allow", unknownRow)).toHaveAttribute(
+        "aria-pressed",
+        "true",
       );
-      const loadedPermissionsDialog = dialogForElement(permissionRow);
-      click(screen.getByLabelText("annotations|create allow options"));
-      click(menuItemByText("Allow for 24h"));
-      await waitFor(() => {
-        expect(within(permissionRow).getByText("24h")).toBeInTheDocument();
-        expect(buttonByText("Apply", loadedPermissionsDialog)).toBeEnabled();
-      });
-      click(buttonByText("Apply", loadedPermissionsDialog));
+      expect(buttonByText("Restore", loadedPermissionsDialog)).toBeEnabled();
+    });
 
-      await waitFor(() => {
-        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-        expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
-      });
-
-      click(screen.getByLabelText("Manage Axiom permissions"));
-
-      const resetDialog = dialogForElement(
-        await screen.findByText("Axiom permissions"),
-      );
-
-      const resetPermissionRow = await permissionRowByName(
-        resetDialog,
-        "annotations|create",
-      );
-      const loadedResetDialog = dialogForElement(resetPermissionRow);
-      click(buttonByText("Deny", resetPermissionRow));
-      click(buttonByText("Deny", await unknownEndpointsRow(loadedResetDialog)));
-
-      await waitFor(() => {
-        expect(buttonByText("Restore", loadedResetDialog)).toBeEnabled();
-      });
-      click(buttonByText("Restore", loadedResetDialog));
-      await waitFor(() => {
-        expect(buttonByText("Apply", loadedResetDialog)).toBeEnabled();
-      });
-      click(buttonByText("Apply", loadedResetDialog));
-
-      await waitFor(() => {
-        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-        expect(screen.queryByText("Axiom permissions")).not.toBeInTheDocument();
-      });
-    },
-    PERMISSION_UI_TEST_TIMEOUT_MS,
-  );
-
-  it(
-    "uses Cloudflare unknown endpoint deny as the permissions drawer default",
-    async () => {
-      mockTeamAPIs();
-      context.mocks.data.connectors([createConnector("cloudflare", "cf-team")]);
-      detachedSetupPage({
-        context,
-        path: `/agents/${researchAgentId}`,
-      });
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: "Research Agent" }),
-        ).toBeInTheDocument();
-        expect(screen.getByText("@cf-team")).toBeInTheDocument();
-      });
-
-      click(screen.getByLabelText("Manage Cloudflare permissions"));
-
-      const permissionsDialog = await findLoadedPermissionsDialog();
-
-      const unknownRow = await unknownEndpointsRow(permissionsDialog);
-      const loadedPermissionsDialog = dialogForElement(unknownRow);
+    click(buttonByText("Restore", loadedPermissionsDialog));
+    await waitFor(() => {
       expect(buttonByText("Deny", unknownRow)).toHaveAttribute(
         "aria-pressed",
         "true",
       );
       expect(buttonByText("Restore", loadedPermissionsDialog)).toBeDisabled();
+    });
+  });
 
-      click(buttonByText("Allow", unknownRow));
-      await waitFor(() => {
-        expect(buttonByText("Allow", unknownRow)).toHaveAttribute(
-          "aria-pressed",
-          "true",
-        );
-        expect(buttonByText("Restore", loadedPermissionsDialog)).toBeEnabled();
-      });
+  it("saves permission duration changes from an agent page", async () => {
+    mockNow();
+    mockTeamAPIs();
+    const capturedUpserts: UpsertUserPermissionGrantRequest[] = [];
+    let grants: UserPermissionGrantResponse[] = [
+      {
+        agentId: researchAgentId,
+        connectorRef: "axiom",
+        permission: "annotations|create",
+        action: "allow",
+        expiresAt: isoFromNowMs(30 * 60 * 1000),
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      },
+    ];
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, grants);
+    });
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.upsert,
+      ({ body, respond }) => {
+        capturedUpserts.push(body);
+        const grant: UserPermissionGrantResponse = {
+          agentId: body.agentId,
+          connectorRef: body.connectorRef,
+          permission: body.permission,
+          action: body.action,
+          expiresAt:
+            body.action === "allow" && body.expiresIn !== "always"
+              ? isoFromNowMs(60 * 60 * 1000)
+              : null,
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:30:00.000Z",
+        };
+        grants = [
+          ...grants.filter((current) => {
+            return (
+              current.connectorRef !== grant.connectorRef ||
+              current.permission !== grant.permission
+            );
+          }),
+          grant,
+        ];
+        return respond(200, grant);
+      },
+    );
 
-      click(buttonByText("Restore", loadedPermissionsDialog));
-      await waitFor(() => {
-        expect(buttonByText("Deny", unknownRow)).toHaveAttribute(
-          "aria-pressed",
-          "true",
-        );
-        expect(buttonByText("Restore", loadedPermissionsDialog)).toBeDisabled();
-      });
-    },
-    PERMISSION_UI_TEST_TIMEOUT_MS,
-  );
+    detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
 
-  it(
-    "saves permission duration changes from an agent page",
-    async () => {
-      mockNow();
-      mockTeamAPIs();
-      const capturedUpserts: UpsertUserPermissionGrantRequest[] = [];
-      let grants: UserPermissionGrantResponse[] = [
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("@workspace")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Manage Axiom permissions"));
+
+    const permissionsDialog = await screen.findByRole("dialog");
+    const createRow = await permissionRowByName(
+      permissionsDialog,
+      "annotations|create",
+    );
+    const loadedPermissionsDialog = dialogForElement(createRow);
+    expect(within(createRow).getByText("< 1 hour")).toBeInTheDocument();
+
+    click(screen.getByLabelText("annotations|create allow options"));
+    click(menuItemByText("Allow always"));
+    await waitFor(() => {
+      expect(within(createRow).getByText("Always")).toBeInTheDocument();
+      expect(buttonByText("Apply", loadedPermissionsDialog)).toBeEnabled();
+    });
+
+    click(buttonByText("Apply", loadedPermissionsDialog));
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+    });
+    expect(capturedUpserts).toStrictEqual(
+      expect.arrayContaining([
         {
           agentId: researchAgentId,
           connectorRef: "axiom",
           permission: "annotations|create",
           action: "allow",
-          expiresAt: isoFromNowMs(30 * 60 * 1000),
-          createdAt: "2026-03-01T00:00:00.000Z",
-          updatedAt: "2026-03-01T00:00:00.000Z",
+          expiresIn: "always",
         },
-      ];
-      context.mocks.api(
-        zeroUserPermissionGrantsContract.list,
-        ({ respond }) => {
-          return respond(200, grants);
-        },
-      );
-      context.mocks.api(
-        zeroUserPermissionGrantsContract.upsert,
-        ({ body, respond }) => {
-          capturedUpserts.push(body);
-          const grant: UserPermissionGrantResponse = {
-            agentId: body.agentId,
-            connectorRef: body.connectorRef,
-            permission: body.permission,
-            action: body.action,
-            expiresAt:
-              body.action === "allow" && body.expiresIn !== "always"
-                ? isoFromNowMs(60 * 60 * 1000)
-                : null,
-            createdAt: "2026-03-01T00:00:00.000Z",
-            updatedAt: "2026-03-01T00:30:00.000Z",
-          };
-          grants = [
-            ...grants.filter((current) => {
-              return (
-                current.connectorRef !== grant.connectorRef ||
-                current.permission !== grant.permission
-              );
-            }),
-            grant,
-          ];
-          return respond(200, grant);
-        },
-      );
+      ]),
+    );
+  });
 
-      detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
+  it("updates grouped connector permission policies from an agent page", async () => {
+    mockTeamAPIs();
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+    });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: "Research Agent" }),
-        ).toBeInTheDocument();
-        expect(screen.getByText("@workspace")).toBeInTheDocument();
-      });
-
-      click(screen.getByLabelText("Manage Axiom permissions"));
-
-      const permissionsDialog = await screen.findByRole("dialog");
-      const createRow = await permissionRowByName(
-        permissionsDialog,
-        "annotations|create",
-      );
-      const loadedPermissionsDialog = dialogForElement(createRow);
-      expect(within(createRow).getByText("< 1 hour")).toBeInTheDocument();
-
-      click(screen.getByLabelText("annotations|create allow options"));
-      click(menuItemByText("Allow always"));
-      await waitFor(() => {
-        expect(within(createRow).getByText("Always")).toBeInTheDocument();
-        expect(buttonByText("Apply", loadedPermissionsDialog)).toBeEnabled();
-      });
-
-      click(buttonByText("Apply", loadedPermissionsDialog));
-
-      await waitFor(() => {
-        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-      });
-      expect(capturedUpserts).toStrictEqual(
-        expect.arrayContaining([
-          {
-            agentId: researchAgentId,
-            connectorRef: "axiom",
-            permission: "annotations|create",
-            action: "allow",
-            expiresIn: "always",
-          },
-        ]),
-      );
-    },
-    PERMISSION_UI_TEST_TIMEOUT_MS,
-  );
-
-  it(
-    "updates grouped connector permission policies from an agent page",
-    async () => {
-      mockTeamAPIs();
-      detachedSetupPage({
-        context,
-        path: `/agents/${researchAgentId}`,
-      });
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: "Research Agent" }),
-        ).toBeInTheDocument();
-        expect(screen.getByText("@ops")).toBeInTheDocument();
-      });
-
-      click(screen.getByLabelText("Manage Slack permissions"));
-
-      const readGroupLabel = await connectorCategoryLabel("slack", "Read");
-      const writeGroupLabel = await connectorCategoryLabel("slack", "Write");
-      const miscGroupLabel = await connectorCategoryLabel("slack", "Misc");
-      const readGroupElement = await screen.findByText(
-        readGroupLabel,
-        {},
-        { timeout: PERMISSION_METADATA_TIMEOUT_MS },
-      );
-      const loadedGroupedDialog = dialogForElement(readGroupElement);
+    await waitFor(() => {
       expect(
-        within(loadedGroupedDialog).getByText("Slack permissions"),
+        screen.getByRole("heading", { name: "Research Agent" }),
       ).toBeInTheDocument();
-      expect(readGroupElement).toBeInTheDocument();
-      const writeGroupElement = await screen.findByText(
-        writeGroupLabel,
-        {},
-        { timeout: PERMISSION_METADATA_TIMEOUT_MS },
-      );
-      expect(writeGroupElement).toBeInTheDocument();
-      const miscGroupElement = await screen.findByText(
-        miscGroupLabel,
-        {},
-        { timeout: PERMISSION_METADATA_TIMEOUT_MS },
-      );
-      expect(miscGroupElement).toBeInTheDocument();
+      expect(screen.getByText("@ops")).toBeInTheDocument();
+    });
 
-      click(screen.getByText(miscGroupLabel));
-      const miscGroup = screen.getByText(miscGroupLabel).closest("div");
-      if (!(miscGroup instanceof HTMLElement)) {
-        throw new Error("Misc permission group not found");
-      }
-      click(within(miscGroup).getByLabelText("Misc allow options"));
-      click(menuItemByText("Allow for 7d"));
-      await waitFor(() => {
-        expect(within(miscGroup).getByText("7d")).toBeInTheDocument();
-      });
-      click(buttonByText("Deny", miscGroup));
-      await waitFor(() => {
-        expect(within(miscGroup).queryByText("7d")).not.toBeInTheDocument();
-      });
-      click(buttonByText("Allow", miscGroup));
-      click(within(miscGroup).getByLabelText("Misc allow options"));
-      click(menuItemByText("Allow always"));
+    click(screen.getByLabelText("Manage Slack permissions"));
 
-      const permissionsScrollArea =
-        loadedGroupedDialog.querySelector(".overflow-y-auto");
-      if (!(permissionsScrollArea instanceof HTMLElement)) {
-        throw new Error("permissions scroll area not found");
-      }
-      Object.defineProperty(permissionsScrollArea, "scrollTop", {
-        configurable: true,
-        value: 24,
-      });
-      fireEvent.scroll(permissionsScrollArea);
+    const readGroupLabel = await connectorCategoryLabel("slack", "Read");
+    const writeGroupLabel = await connectorCategoryLabel("slack", "Write");
+    const miscGroupLabel = await connectorCategoryLabel("slack", "Misc");
+    const readGroupElement = await screen.findByText(readGroupLabel);
+    const loadedGroupedDialog = dialogForElement(readGroupElement);
+    expect(
+      within(loadedGroupedDialog).getByText("Slack permissions"),
+    ).toBeInTheDocument();
+    expect(readGroupElement).toBeInTheDocument();
+    const writeGroupElement = await screen.findByText(writeGroupLabel);
+    expect(writeGroupElement).toBeInTheDocument();
+    const miscGroupElement = await screen.findByText(miscGroupLabel);
+    expect(miscGroupElement).toBeInTheDocument();
 
-      const channelsJoinRow = await permissionRowByName(
-        loadedGroupedDialog,
-        "channels:join",
-      );
-      click(
-        within(channelsJoinRow).getByLabelText("Undo channels:join changes"),
-      );
-      await waitFor(() => {
-        expect(
-          within(channelsJoinRow).queryByLabelText(
-            "Undo channels:join changes",
-          ),
-        ).not.toBeInTheDocument();
-      });
+    click(screen.getByText(miscGroupLabel));
+    const miscGroup = screen.getByText(miscGroupLabel).closest("div");
+    if (!(miscGroup instanceof HTMLElement)) {
+      throw new Error("Misc permission group not found");
+    }
+    click(within(miscGroup).getByLabelText("Misc allow options"));
+    click(menuItemByText("Allow for 7d"));
+    await waitFor(() => {
+      expect(within(miscGroup).getByText("7d")).toBeInTheDocument();
+    });
+    click(buttonByText("Deny", miscGroup));
+    await waitFor(() => {
+      expect(within(miscGroup).queryByText("7d")).not.toBeInTheDocument();
+    });
+    click(buttonByText("Allow", miscGroup));
+    click(within(miscGroup).getByLabelText("Misc allow options"));
+    click(menuItemByText("Allow always"));
 
-      const unknownRow = await unknownEndpointsRow(loadedGroupedDialog);
-      click(within(unknownRow).getByLabelText("__unknown__ allow options"));
-      click(menuItemByText("Allow for 1h"));
-      await waitFor(() => {
-        expect(within(unknownRow).getByText("1h")).toBeInTheDocument();
-      });
-      click(within(unknownRow).getByLabelText("Undo __unknown__ changes"));
-      await waitFor(() => {
-        expect(within(unknownRow).queryByText("1h")).not.toBeInTheDocument();
-      });
+    const permissionsScrollArea =
+      loadedGroupedDialog.querySelector(".overflow-y-auto");
+    if (!(permissionsScrollArea instanceof HTMLElement)) {
+      throw new Error("permissions scroll area not found");
+    }
+    Object.defineProperty(permissionsScrollArea, "scrollTop", {
+      configurable: true,
+      value: 24,
+    });
+    fireEvent.scroll(permissionsScrollArea);
 
-      click(buttonByText("Apply", loadedGroupedDialog));
+    const channelsJoinRow = await permissionRowByName(
+      loadedGroupedDialog,
+      "channels:join",
+    );
+    click(within(channelsJoinRow).getByLabelText("Undo channels:join changes"));
+    await waitFor(() => {
+      expect(
+        within(channelsJoinRow).queryByLabelText("Undo channels:join changes"),
+      ).not.toBeInTheDocument();
+    });
 
-      await waitFor(() => {
-        expect(screen.getByText("Permissions updated")).toBeInTheDocument();
-        expect(screen.queryByText("Slack permissions")).not.toBeInTheDocument();
-      });
-    },
-    PERMISSION_UI_TEST_TIMEOUT_MS,
-  );
+    const unknownRow = await unknownEndpointsRow(loadedGroupedDialog);
+    click(within(unknownRow).getByLabelText("__unknown__ allow options"));
+    click(menuItemByText("Allow for 1h"));
+    await waitFor(() => {
+      expect(within(unknownRow).getByText("1h")).toBeInTheDocument();
+    });
+    click(within(unknownRow).getByLabelText("Undo __unknown__ changes"));
+    await waitFor(() => {
+      expect(within(unknownRow).queryByText("1h")).not.toBeInTheDocument();
+    });
+
+    click(buttonByText("Apply", loadedGroupedDialog));
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(screen.queryByText("Slack permissions")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -161,16 +161,13 @@ function dialogForElement(element: HTMLElement): HTMLElement {
   return dialog;
 }
 
-async function findLoadedPermissionsDialog(
-  title: string,
-): Promise<HTMLElement> {
-  const dialog = await screen.findByRole("dialog");
-  await within(dialog).findByText(
-    title,
+async function findLoadedPermissionsDialog(): Promise<HTMLElement> {
+  const unknownEndpoints = await screen.findByText(
+    "Other endpoints",
     {},
     { timeout: PERMISSION_METADATA_TIMEOUT_MS },
   );
-  return dialog;
+  return dialogForElement(unknownEndpoints);
 }
 
 async function connectorCategoryLabel(
@@ -618,8 +615,7 @@ describe("team page navigation", () => {
 
       click(screen.getByLabelText("Manage Axiom permissions"));
 
-      const permissionsDialog =
-        await findLoadedPermissionsDialog("Axiom permissions");
+      const permissionsDialog = await findLoadedPermissionsDialog();
       expect(
         within(permissionsDialog).getByText("for Research Agent"),
       ).toBeInTheDocument();
@@ -692,9 +688,7 @@ describe("team page navigation", () => {
 
       click(screen.getByLabelText("Manage Cloudflare permissions"));
 
-      const permissionsDialog = await findLoadedPermissionsDialog(
-        "Cloudflare permissions",
-      );
+      const permissionsDialog = await findLoadedPermissionsDialog();
 
       const unknownRow = await unknownEndpointsRow(permissionsDialog);
       const loadedPermissionsDialog = dialogForElement(unknownRow);

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -116,11 +116,11 @@ import {
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import {
-  getDefaultFirewallPolicies,
-  isFirewallConnectorType,
+  expandFirewallMetadataDefaultPolicy,
   permissionGrantsToFirewallPolicies,
-  resolveFirewallPolicies,
-} from "@vm0/connectors/firewalls";
+  resolveFirewallMetadataPolicies,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
 import type {
   UserPermissionGrantAction,
   UserPermissionGrantExpiresIn,
@@ -621,20 +621,22 @@ function addDefaultAllowExpirationChanges({
 
 function changedUserGrantPolicies({
   connectorType,
+  metadata,
   initialPolicies,
   initialGrants,
   policies,
   expiresInByPermission,
 }: {
   connectorType: ConnectorType;
+  metadata: FirewallPermissionDetailMetadata;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
   expiresInByPermission: GrantExpirationSelections;
 }): ChangedUserGrantPolicy[] {
-  const initial = resolveFirewallPolicies(initialPolicies, [connectorType])?.[
-    connectorType
-  ];
+  const initial = resolveFirewallMetadataPolicies(initialPolicies, [
+    metadata,
+  ])?.[connectorType];
   const current = policies[connectorType];
   const changes = new Map<string, ChangedUserGrantPolicy>();
 
@@ -670,19 +672,17 @@ function changedUserGrantPolicies({
 }
 
 function defaultFirewallPoliciesForConnector(
-  connectorType: ConnectorType,
+  metadata: FirewallPermissionDetailMetadata,
 ): FirewallPolicies {
-  if (!isFirewallConnectorType(connectorType)) {
-    throw new Error(`Cannot reset permissions for ${connectorType}`);
-  }
   return {
-    [connectorType]: getDefaultFirewallPolicies(connectorType),
+    [metadata.type]: expandFirewallMetadataDefaultPolicy(metadata),
   };
 }
 
 async function saveUserGrantPolicies({
   agentId,
   connectorType,
+  metadata,
   initialPolicies,
   initialGrants,
   policies,
@@ -694,6 +694,7 @@ async function saveUserGrantPolicies({
 }: {
   agentId: string;
   connectorType: ConnectorType;
+  metadata: FirewallPermissionDetailMetadata;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
@@ -714,12 +715,13 @@ async function saveUserGrantPolicies({
   }
 
   const basePolicies = resetPending
-    ? defaultFirewallPoliciesForConnector(connectorType)
+    ? defaultFirewallPoliciesForConnector(metadata)
     : initialPolicies;
   const baseGrants = resetPending ? [] : initialGrants;
 
   for (const { permission, action, expiresIn } of changedUserGrantPolicies({
     connectorType,
+    metadata,
     initialPolicies: basePolicies,
     initialGrants: baseGrants,
     policies,
@@ -741,6 +743,7 @@ async function saveUserGrantPolicies({
 async function saveDrawerPolicies({
   agentId,
   connectorType,
+  metadata,
   initialPolicies,
   initialGrants,
   policies,
@@ -752,6 +755,7 @@ async function saveDrawerPolicies({
 }: {
   agentId: string;
   connectorType: ConnectorType;
+  metadata: FirewallPermissionDetailMetadata;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
@@ -764,6 +768,7 @@ async function saveDrawerPolicies({
   await saveUserGrantPolicies({
     agentId,
     connectorType,
+    metadata,
     initialPolicies,
     initialGrants,
     policies,
@@ -979,7 +984,10 @@ function AgentPermissionsDrawer({
   onApply: (
     policies: FirewallPolicies,
     expiresInByPermission: GrantExpirationSelections,
-    options: { readonly resetConnectorGrants: boolean },
+    options: {
+      readonly resetConnectorGrants: boolean;
+      readonly metadata: FirewallPermissionDetailMetadata;
+    },
   ) => Promise<void>;
   onClose: () => void;
 }) {
@@ -1120,7 +1128,7 @@ function JobPermissionsTab({
             onApply={async (
               policies,
               expiresInByPermission,
-              { resetConnectorGrants },
+              { resetConnectorGrants, metadata },
             ) => {
               if (connectorType === null) {
                 throw new Error("Cannot save permissions without a connector");
@@ -1128,6 +1136,7 @@ function JobPermissionsTab({
               await saveDrawerPolicies({
                 agentId,
                 connectorType,
+                metadata,
                 initialPolicies: drawerInitialPolicies,
                 initialGrants: userGrants,
                 policies,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -9,7 +9,10 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
@@ -46,6 +49,38 @@ function mockAgentConnectorAuthorizations(initialTypes: string[]): void {
     enabledTypes = body.enabledTypes;
     return respond(200, { enabledTypes });
   });
+}
+
+function buttonByText(text: string, container: ParentNode): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!button) {
+    throw new Error(`${text} button not found`);
+  }
+  return button;
+}
+
+async function waitForButtonByText(
+  text: string,
+  container: ParentNode,
+): Promise<HTMLElement> {
+  let button: HTMLElement | undefined;
+  await waitFor(() => {
+    button = buttonByText(text, container);
+    expect(button).toBeEnabled();
+  });
+  if (!button) {
+    throw new Error(`${text} button not found`);
+  }
+  return button;
+}
+
+async function confirmPermissionAction(
+  user: ReturnType<typeof userEvent.setup>,
+  card: HTMLElement,
+): Promise<void> {
+  await user.click(await waitForButtonByText("Confirm", card));
 }
 
 describe("chat message action cards", () => {
@@ -105,7 +140,7 @@ describe("chat message action cards", () => {
     ).toBeInTheDocument();
     expect(within(permissionCard).getByText("24 hours")).toBeInTheDocument();
 
-    await user.click(within(permissionCard).getByText("Confirm"));
+    await confirmPermissionAction(user, permissionCard);
 
     await waitFor(() => {
       expect(
@@ -164,6 +199,7 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitForButtonByText("Confirm", permissionCard);
     await user.click(
       within(permissionCard).getByLabelText("Permission duration"),
     );
@@ -173,7 +209,7 @@ describe("chat message action cards", () => {
       expect(within(permissionCard).getByText("7 days")).toBeInTheDocument();
     });
 
-    await user.click(within(permissionCard).getByText("Confirm"));
+    await confirmPermissionAction(user, permissionCard);
 
     await waitFor(() => {
       expect(
@@ -246,7 +282,7 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText(`Allow ${UNKNOWN_PERMISSION_GRANT}`),
     ).toBeInTheDocument();
 
-    await user.click(within(permissionCard).getByText("Confirm"));
+    await confirmPermissionAction(user, permissionCard);
 
     await waitFor(() => {
       expect(
@@ -330,7 +366,7 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText("Deny admin.analytics:read"),
     ).toBeInTheDocument();
 
-    await user.click(within(permissionCard).getByText("Confirm"));
+    await confirmPermissionAction(user, permissionCard);
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -1,7 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import type { ReactNode } from "react";
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   Sheet,
@@ -26,15 +26,13 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  getConnectorFirewall,
-  getDefaultFirewallPolicies,
-  groupPermissionsByCategory,
-  isFirewallConnectorType,
-  resolveFirewallPolicies,
-} from "@vm0/connectors/firewalls";
+  expandFirewallMetadataDefaultPolicy,
+  groupFirewallMetadataPermissionsByCategory,
+  resolveFirewallMetadataPolicies,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
 import {
   UNKNOWN_PERMISSION_GRANT,
-  type FirewallConfig,
   type FirewallPolicies,
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
@@ -76,9 +74,11 @@ import {
   IconClock,
   IconChevronDown,
   IconArrowBackUp,
+  IconLoader2,
 } from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { firewallPermissionMetadataByConnector } from "../../../../signals/firewall-permission-metadata.ts";
 
 interface ConnectorPermission {
   name: string;
@@ -105,6 +105,7 @@ interface PermissionsDrawerProps {
 
 interface PermissionDrawerApplyOptions {
   readonly resetConnectorGrants: boolean;
+  readonly metadata: FirewallPermissionDetailMetadata;
 }
 
 interface PermissionsDrawerFooterProps {
@@ -119,25 +120,9 @@ interface PermissionsDrawerFooterProps {
   readonly onApply: () => void;
 }
 
-function extractPermissions(config: FirewallConfig): ConnectorPermission[] {
-  const seen = new Map<string, ConnectorPermission>();
-  for (const api of config.apis) {
-    if (!api.permissions) {
-      continue;
-    }
-    for (const p of api.permissions) {
-      if (!seen.has(p.name)) {
-        seen.set(p.name, {
-          name: p.name,
-          description: p.description,
-        });
-      }
-    }
-  }
-  return [...seen.values()];
-}
-
-function sortPermissions(perms: ConnectorPermission[]): ConnectorPermission[] {
+function sortPermissions(
+  perms: readonly ConnectorPermission[],
+): ConnectorPermission[] {
   return [...perms].sort((a, b) => {
     const [aBase, aSuffix] = splitPermName(a.name);
     const [bBase, bSuffix] = splitPermName(b.name);
@@ -237,29 +222,22 @@ function PolicyPill({
 }
 
 function buildSortedGroups(
-  config: FirewallConfig | null,
-  ref: string,
+  metadata: FirewallPermissionDetailMetadata,
 ): { category: string; permissions: ConnectorPermission[] }[] | null {
-  if (!config) {
-    return null;
-  }
   return (
-    groupPermissionsByCategory(extractPermissions(config), ref)?.map(
-      (group) => {
-        return { ...group, permissions: sortPermissions(group.permissions) };
-      },
-    ) ?? null
+    groupFirewallMetadataPermissionsByCategory(
+      metadata.permissions,
+      metadata,
+    )?.map((group) => {
+      return { ...group, permissions: sortPermissions(group.permissions) };
+    }) ?? null
   );
 }
 
-function permissionDrawerConfig(ref: ConnectorType): FirewallConfig | null {
-  return isFirewallConnectorType(ref) ? getConnectorFirewall(ref) : null;
-}
-
-function sortedPermissionsForConfig(
-  config: FirewallConfig | null,
+function sortedPermissionsForMetadata(
+  metadata: FirewallPermissionDetailMetadata,
 ): ConnectorPermission[] {
-  return config ? sortPermissions(extractPermissions(config)) : [];
+  return sortPermissions(metadata.permissions);
 }
 
 function permissionPolicyRecord(
@@ -275,36 +253,26 @@ function permissionPolicyRecord(
 
 function buildInitialPolicies(
   ref: string,
-  config: FirewallConfig | null,
+  metadata: FirewallPermissionDetailMetadata,
   initialPolicies: FirewallPolicies,
 ): Record<string, Record<string, PermissionPolicy>> {
   const result: Record<string, Record<string, PermissionPolicy>> = {};
-  if (!config) {
-    return result;
-  }
-  const perms = extractPermissions(config);
-  const resolved = resolveFirewallPolicies(initialPolicies, [ref]);
+  const resolved = resolveFirewallMetadataPolicies(initialPolicies, [metadata]);
   const refPolicies: Record<string, PermissionPolicy> = {};
-  for (const p of perms) {
+  for (const p of metadata.permissions) {
     refPolicies[p.name] = resolved?.[ref]?.policies[p.name] ?? "allow";
   }
   result[ref] = refPolicies;
   return result;
 }
 
-function buildDefaultPolicyState(
-  ref: ConnectorType,
-  config: FirewallConfig | null,
-): {
+function buildDefaultPolicyState(metadata: FirewallPermissionDetailMetadata): {
   readonly policies: Record<string, PermissionPolicy>;
   readonly unknownPolicy: FirewallPolicyValue;
 } {
-  if (!config || !isFirewallConnectorType(ref)) {
-    return { policies: {}, unknownPolicy: "allow" };
-  }
-  const defaults = getDefaultFirewallPolicies(ref);
+  const defaults = expandFirewallMetadataDefaultPolicy(metadata);
   const policies: Record<string, PermissionPolicy> = {};
-  for (const permission of extractPermissions(config)) {
+  for (const permission of metadata.permissions) {
     policies[permission.name] = defaults.policies[permission.name] ?? "allow";
   }
   return {
@@ -314,16 +282,13 @@ function buildDefaultPolicyState(
 }
 
 function buildInitialUnknownPolicy(
-  ref: ConnectorType,
-  config: FirewallConfig | null,
+  ref: string,
+  metadata: FirewallPermissionDetailMetadata,
   initialPolicies: FirewallPolicies,
 ): FirewallPolicyValue {
-  if (!config || !isFirewallConnectorType(ref)) {
-    return "allow";
-  }
   return (
-    resolveFirewallPolicies(initialPolicies, [ref])?.[ref]?.unknownPolicy ??
-    "allow"
+    resolveFirewallMetadataPolicies(initialPolicies, [metadata])?.[ref]
+      ?.unknownPolicy ?? "allow"
   );
 }
 
@@ -477,15 +442,15 @@ function hasPendingPermissionControlChange({
 }
 
 function canApplyPermissionPolicies({
-  config,
+  metadata,
   saving,
   hasChanges,
 }: {
-  config: FirewallConfig | null;
+  metadata: FirewallPermissionDetailMetadata;
   saving: boolean;
   hasChanges: boolean;
 }): boolean {
-  return config !== null && !saving && hasChanges;
+  return metadata.permissionCount > 0 && !saving && hasChanges;
 }
 
 function UnknownEndpointsToggle({
@@ -1213,7 +1178,7 @@ function PermissionsDrawerFooter({
   );
 }
 
-export function PermissionsDrawer({
+function LoadedPermissionsDrawer({
   agentId,
   connectorType,
   displayName,
@@ -1223,18 +1188,23 @@ export function PermissionsDrawer({
   readOnly,
   onApply,
   onClose,
-}: PermissionsDrawerProps) {
+  metadata,
+}: PermissionsDrawerProps & {
+  readonly metadata: FirewallPermissionDetailMetadata;
+}) {
   const ref = connectorType;
-
-  const config = permissionDrawerConfig(ref);
 
   const initialUnknownPolicy = buildInitialUnknownPolicy(
     ref,
-    config,
+    metadata,
     initialPolicies,
   );
-  const initialPolicyState = buildInitialPolicies(ref, config, initialPolicies);
-  const defaultPolicyState = buildDefaultPolicyState(ref, config);
+  const initialPolicyState = buildInitialPolicies(
+    ref,
+    metadata,
+    initialPolicies,
+  );
+  const defaultPolicyState = buildDefaultPolicyState(metadata);
   const explicitGrants = buildExplicitGrantMap(ref, initialGrants);
   const grantStateKey = explicitGrantStateKey(explicitGrants);
   const initialPolicyKey = `${agentId}\u0000${ref}\u0000${initialUnknownPolicy}\u0000${JSON.stringify(initialPolicyState[ref] ?? {})}\u0000${grantStateKey}`;
@@ -1267,11 +1237,11 @@ export function PermissionsDrawer({
   const saving = applyLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
 
-  const permissions = sortedPermissionsForConfig(config);
+  const permissions = sortedPermissionsForMetadata(metadata);
   const policiesForRef = allPolicies[ref];
   const policies = policiesForRef ?? {};
   const initialPoliciesForRef = initialPolicyState[ref] ?? {};
-  const groups = buildSortedGroups(config, ref);
+  const groups = buildSortedGroups(metadata);
   const hasPermissionChanges = hasPermissionPolicyChanges({
     currentPolicies: policiesForRef,
     initialPolicies: initialPoliciesForRef,
@@ -1309,7 +1279,7 @@ export function PermissionsDrawer({
     hasDefaultPolicyChanges ||
     hasExpirationDraftSelections;
   const canApply = canApplyPermissionPolicies({
-    config,
+    metadata,
     saving,
     hasChanges:
       hasPermissionChanges || hasExpirationChanges || hasResetPersistedEffect,
@@ -1387,7 +1357,7 @@ export function PermissionsDrawer({
           unknownPolicy: unknownFlag,
         }),
         expirationSelections,
-        { resetConnectorGrants },
+        { resetConnectorGrants, metadata },
       );
     };
     detach(
@@ -1427,103 +1397,94 @@ export function PermissionsDrawer({
           </SheetDescription>
         </SheetHeader>
 
-        {!config ? (
-          <div className="flex flex-1 items-center justify-center">
-            <p className="text-sm text-destructive">
-              No permission config found for {ref}
-            </p>
-          </div>
-        ) : (
-          <div className="flex flex-1 flex-col min-h-0">
-            {!groups && (
-              <div
-                className={`flex items-center justify-between pb-3 -mx-6 px-6 pr-9 transition-shadow ${scrolled ? "shadow-[0_4px_8px_-4px_rgba(0,0,0,0.08)]" : ""}`}
-              >
-                <span className="text-xs font-medium text-foreground">
-                  {readOnly ? "Permissions" : "Select all"} (
-                  {permissions.length})
-                </span>
-                {!readOnly && (
-                  <PolicyPill
-                    policy={getGroupPolicy(permissions, policies)}
-                    onChange={handleSetAll}
-                  />
-                )}
-              </div>
-            )}
-
+        <div className="flex flex-1 flex-col min-h-0">
+          {!groups && (
             <div
-              className={`flex-1 overflow-y-auto -mx-6 px-3 ${groups ? "pt-1" : ""}`}
-              onScroll={(e) => {
-                const target = e.currentTarget;
-                setScrolled(target.scrollTop > 0);
-              }}
+              className={`flex items-center justify-between pb-3 -mx-6 px-6 pr-9 transition-shadow ${scrolled ? "shadow-[0_4px_8px_-4px_rgba(0,0,0,0.08)]" : ""}`}
             >
-              <PermissionRows
-                groups={groups}
-                permissions={permissions}
-                initialPolicies={initialPoliciesForRef}
-                policies={policies}
-                expandedGroups={expandedGroups}
-                explicitGrants={effectiveExplicitGrants}
-                expirationSelections={expirationSelections}
-                readOnly={readOnly}
-                saving={saving}
-                onToggleGroup={toggleGroup}
-                onSetGroupAll={handleSetGroupAll}
-                onPolicyChange={handlePolicyChange}
-                onGrantExpirationChange={setGrantExpiration}
-                onResetPermission={handleResetPermission}
-              />
-            </div>
-
-            <UnknownEndpointsToggle
-              policyControl={
-                <PermissionGrantPolicyControl
-                  permission={UNKNOWN_PERMISSION_GRANT}
-                  policy={unknownPolicy}
-                  grant={unknownGrant}
-                  selected={unknownSelectedExpiration}
-                  hasPendingChange={hasPendingPermissionControlChange({
-                    grant: unknownGrant,
-                    initialPolicy: initialUnknownPolicy,
-                    policy: unknownPolicy,
-                    selected: unknownSelectedExpiration,
-                  })}
-                  allowAlwaysActive={hasAllowAlwaysPolicy(
-                    unknownGrant,
-                    unknownPolicy,
-                  )}
-                  readOnly={readOnly}
-                  saving={saving}
-                  onClearExpiration={() => {
-                    setGrantExpiration(UNKNOWN_PERMISSION_GRANT, null);
-                  }}
-                  onAllowDurationChange={(expiresIn) => {
-                    setGrantExpiration(
-                      UNKNOWN_PERMISSION_GRANT,
-                      menuOptionExpiresIn(
-                        expiresIn,
-                        unknownGrant?.action === "allow"
-                          ? unknownGrant
-                          : undefined,
-                      ),
-                    );
-                  }}
-                  onPolicyChange={(p) => {
-                    setUnknownPolicy(p);
-                  }}
-                  onReset={handleResetUnknownPermission}
+              <span className="text-xs font-medium text-foreground">
+                {readOnly ? "Permissions" : "Select all"} ({permissions.length})
+              </span>
+              {!readOnly && (
+                <PolicyPill
+                  policy={getGroupPolicy(permissions, policies)}
+                  onChange={handleSetAll}
                 />
-              }
+              )}
+            </div>
+          )}
+
+          <div
+            className={`flex-1 overflow-y-auto -mx-6 px-3 ${groups ? "pt-1" : ""}`}
+            onScroll={(e) => {
+              const target = e.currentTarget;
+              setScrolled(target.scrollTop > 0);
+            }}
+          >
+            <PermissionRows
+              groups={groups}
+              permissions={permissions}
+              initialPolicies={initialPoliciesForRef}
+              policies={policies}
+              expandedGroups={expandedGroups}
+              explicitGrants={effectiveExplicitGrants}
+              expirationSelections={expirationSelections}
+              readOnly={readOnly}
+              saving={saving}
+              onToggleGroup={toggleGroup}
+              onSetGroupAll={handleSetGroupAll}
+              onPolicyChange={handlePolicyChange}
+              onGrantExpirationChange={setGrantExpiration}
+              onResetPermission={handleResetPermission}
             />
           </div>
-        )}
+
+          <UnknownEndpointsToggle
+            policyControl={
+              <PermissionGrantPolicyControl
+                permission={UNKNOWN_PERMISSION_GRANT}
+                policy={unknownPolicy}
+                grant={unknownGrant}
+                selected={unknownSelectedExpiration}
+                hasPendingChange={hasPendingPermissionControlChange({
+                  grant: unknownGrant,
+                  initialPolicy: initialUnknownPolicy,
+                  policy: unknownPolicy,
+                  selected: unknownSelectedExpiration,
+                })}
+                allowAlwaysActive={hasAllowAlwaysPolicy(
+                  unknownGrant,
+                  unknownPolicy,
+                )}
+                readOnly={readOnly}
+                saving={saving}
+                onClearExpiration={() => {
+                  setGrantExpiration(UNKNOWN_PERMISSION_GRANT, null);
+                }}
+                onAllowDurationChange={(expiresIn) => {
+                  setGrantExpiration(
+                    UNKNOWN_PERMISSION_GRANT,
+                    menuOptionExpiresIn(
+                      expiresIn,
+                      unknownGrant?.action === "allow"
+                        ? unknownGrant
+                        : undefined,
+                    ),
+                  );
+                }}
+                onPolicyChange={(p) => {
+                  setUnknownPolicy(p);
+                }}
+                onReset={handleResetUnknownPermission}
+              />
+            }
+          />
+        </div>
 
         <PermissionsDrawerFooter
           readOnly={readOnly}
           resetEnabled={resetEnabled}
-          canReset={config !== null}
+          canReset
           resetAvailable={resetAvailable}
           saving={saving}
           canApply={canApply}
@@ -1531,6 +1492,71 @@ export function PermissionsDrawer({
           onClose={handleClose}
           onApply={handleApply}
         />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export function PermissionsDrawer(props: PermissionsDrawerProps) {
+  const metadataLoadable = useLoadable(
+    firewallPermissionMetadataByConnector({
+      connectorType: props.connectorType,
+    }),
+  );
+  const connectorLabel = CONNECTOR_TYPES[props.connectorType].label;
+
+  if (metadataLoadable.state === "hasData" && metadataLoadable.data) {
+    return (
+      <LoadedPermissionsDrawer {...props} metadata={metadataLoadable.data} />
+    );
+  }
+
+  const loading = metadataLoadable.state === "loading";
+  const message =
+    metadataLoadable.state === "hasError"
+      ? "Failed to load permission metadata"
+      : `No permission metadata found for ${props.connectorType}`;
+
+  return (
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        return !open && props.onClose();
+      }}
+    >
+      <SheetContent side="right">
+        <SheetHeader>
+          <div className="flex items-center gap-3">
+            <ConnectorIcon type={props.connectorType} size={24} />
+            <SheetTitle className="text-base">
+              {connectorLabel} permissions
+              <span className="text-sm font-normal text-muted-foreground ml-1">
+                for {props.displayName}
+              </span>
+            </SheetTitle>
+          </div>
+          <SheetDescription>
+            Configure which actions this agent is allowed to perform via this
+            connector.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-1 items-center justify-center">
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <IconLoader2 size={16} className="animate-spin" />
+              Loading permissions...
+            </div>
+          ) : (
+            <p className="text-sm text-destructive">{message}</p>
+          )}
+        </div>
+
+        <SheetFooter>
+          <Button variant="outline" onClick={props.onClose}>
+            {props.readOnly ? "Close" : "Cancel"}
+          </Button>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -245,11 +245,13 @@ import {
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agentById } from "../../signals/agent.ts";
 import {
-  findPermission,
+  findPermissionInMetadata,
   resolveUserPermissionGrantPolicy,
   upsertUserPermissionGrant$,
   userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
+import type { FirewallPermissionDetailMetadata } from "@vm0/connectors/firewall-metadata";
+import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
 import {
   billingStatusAsync$,
   type CreditCheckoutSelection,
@@ -4508,9 +4510,14 @@ function PermissionActionButton({
 
 function isPermissionActionLoading(params: {
   agentLoading: boolean;
+  permissionMetadataLoading: boolean;
   userGrantsLoading: boolean;
 }): boolean {
-  return params.agentLoading || params.userGrantsLoading;
+  return (
+    params.agentLoading ||
+    params.permissionMetadataLoading ||
+    params.userGrantsLoading
+  );
 }
 
 function isPermissionActionSaving(params: { grantLoading: boolean }): boolean {
@@ -4519,9 +4526,14 @@ function isPermissionActionSaving(params: { grantLoading: boolean }): boolean {
 
 function isPermissionActionLoadError(params: {
   agentError: boolean;
+  permissionMetadataError: boolean;
   userGrantsError: boolean;
 }): boolean {
-  return params.agentError || params.userGrantsError;
+  return (
+    params.agentError ||
+    params.permissionMetadataError ||
+    params.userGrantsError
+  );
 }
 
 function isPermissionActionAlreadyApplied(params: {
@@ -4547,23 +4559,25 @@ function isPermissionActionAlreadyApplied(params: {
   });
 }
 
-function findPermissionActionPermission(block: PermissionActionBlock) {
-  return findPermission(block.connectorRef, block.permission) ?? undefined;
+function findPermissionActionPermission(
+  block: PermissionActionBlock,
+  metadata: FirewallPermissionDetailMetadata | undefined,
+) {
+  return metadata
+    ? (findPermissionInMetadata(metadata, block.permission) ?? undefined)
+    : undefined;
 }
 
 function permissionActionUserGrantPolicy(
   loadable: LoadableLike<readonly PermissionActionUserGrant[]>,
   block: PermissionActionBlock,
+  metadata: FirewallPermissionDetailMetadata | undefined,
 ): FirewallPolicyValue | undefined {
   const grants = loadableData(loadable);
-  if (!grants) {
+  if (!grants || !metadata) {
     return undefined;
   }
-  return resolveUserPermissionGrantPolicy(
-    grants,
-    block.connectorRef,
-    block.permission,
-  );
+  return resolveUserPermissionGrantPolicy(grants, metadata, block.permission);
 }
 
 function permissionActionUserGrant(
@@ -4627,19 +4641,31 @@ function createPermissionActionCardViewState(params: {
   block: PermissionActionBlock;
   hasAgent: boolean;
   agentLoadableState: string;
+  permissionMetadataLoadable: LoadableLike<FirewallPermissionDetailMetadata | null>;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
   grantLoadableState: string;
   expirationAvailable: boolean;
   currentGrantExpiresAt: string | null | undefined;
 }) {
-  const focusedPermission = findPermissionActionPermission(params.block);
+  const permissionMetadata =
+    params.permissionMetadataLoadable.state === "hasData"
+      ? (params.permissionMetadataLoadable.data ?? undefined)
+      : undefined;
+  const focusedPermission = findPermissionActionPermission(
+    params.block,
+    permissionMetadata,
+  );
   const actionLabel = permissionActionVerb(params.block.action);
   const loading = isPermissionActionLoading({
     agentLoading: params.agentLoadableState === "loading",
+    permissionMetadataLoading:
+      params.permissionMetadataLoadable.state === "loading",
     userGrantsLoading: params.userGrantsLoadable.state === "loading",
   });
   const loadError = isPermissionActionLoadError({
     agentError: params.agentLoadableState === "hasError",
+    permissionMetadataError:
+      params.permissionMetadataLoadable.state === "hasError",
     userGrantsError: params.userGrantsLoadable.state === "hasError",
   });
   const saving = isPermissionActionSaving({
@@ -4648,6 +4674,7 @@ function createPermissionActionCardViewState(params: {
   const userGrantPolicy = permissionActionUserGrantPolicy(
     params.userGrantsLoadable,
     params.block,
+    permissionMetadata,
   );
   const alreadyApplied = isPermissionActionAlreadyApplied({
     hasAgent: params.hasAgent,
@@ -4819,6 +4846,11 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     block.expiresIn ??
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
   const agentLoadable = useLastLoadable(agentById(block.agentId));
+  const permissionMetadataLoadable = useLoadable(
+    firewallPermissionMetadataByConnector({
+      connectorType: block.connectorRef,
+    }),
+  );
   const [grantLoadable, upsertGrant] = useLoadableSet(
     upsertUserPermissionGrant$,
   );
@@ -4834,6 +4866,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     block,
     hasAgent,
     agentLoadableState: agentLoadable.state,
+    permissionMetadataLoadable,
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
     expirationAvailable,

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -7,8 +7,11 @@ import {
   expandFirewallMetadataDefaultPolicy,
   FIREWALL_PERMISSION_METADATA_SUMMARIES,
   getFirewallPermissionSummary,
+  groupFirewallMetadataPermissionsByCategory,
   isFirewallMetadataConnectorType,
   loadFirewallPermissionMetadata,
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallMetadataPolicies,
 } from "../firewall-metadata";
 import type { FirewallPermissionMetadataPermission } from "../firewall-metadata";
 import type { FirewallConfig } from "../firewall-types";
@@ -16,6 +19,8 @@ import {
   getAllConnectorFirewalls,
   getDefaultFirewallPolicies,
   getPermissionCategories,
+  groupPermissionsByCategory,
+  resolveFirewallPolicies,
   type FirewallConnectorType,
 } from "../firewalls";
 
@@ -239,6 +244,21 @@ describe("firewall metadata", () => {
     }
   });
 
+  it("groups metadata permissions like runtime categories", async () => {
+    for (const [type, firewall] of runtimeEntries()) {
+      const detail = await loadFirewallPermissionMetadata(type);
+      expect(detail).not.toBeNull();
+      expect(
+        groupFirewallMetadataPermissionsByCategory(
+          detail!.permissions,
+          detail!,
+        ),
+      ).toStrictEqual(
+        groupPermissionsByCategory(collectRuntimePermissions(firewall), type),
+      );
+    }
+  });
+
   it("expands compact default policy metadata to runtime default policies", async () => {
     for (const [type] of runtimeEntries()) {
       const detail = await loadFirewallPermissionMetadata(type);
@@ -247,5 +267,44 @@ describe("firewall metadata", () => {
         getDefaultFirewallPolicies(type),
       );
     }
+  });
+
+  it("resolves stored policies with metadata defaults like runtime helpers", async () => {
+    for (const [type] of runtimeEntries()) {
+      const detail = await loadFirewallPermissionMetadata(type);
+      expect(detail).not.toBeNull();
+      const stored = {
+        [type]: {
+          policies: { __metadata_test__: "deny" as const },
+          unknownPolicy: "deny" as const,
+        },
+      };
+      expect(resolveFirewallMetadataPolicies(stored, [detail!])).toStrictEqual(
+        resolveFirewallPolicies(stored, [type]),
+      );
+    }
+  });
+
+  it("converts permission grants without runtime firewall data", () => {
+    expect(
+      permissionGrantsToFirewallPolicies([
+        {
+          connectorRef: "slack",
+          permission: "channels:read",
+          action: "allow",
+        },
+        {
+          connectorRef: "slack",
+          permission: "__unknown__",
+          action: "deny",
+        },
+      ]),
+    ).toStrictEqual({
+      slack: {
+        policies: { "channels:read": "allow" },
+        unknownPolicy: "deny",
+      },
+    });
+    expect(permissionGrantsToFirewallPolicies([])).toBeNull();
   });
 });

--- a/turbo/packages/connectors/src/firewall-metadata/index.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/index.ts
@@ -1,4 +1,9 @@
-import type { FirewallPolicy, FirewallPolicyValue } from "../firewall-types";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicies,
+  type FirewallPolicy,
+  type FirewallPolicyValue,
+} from "../firewall-types";
 import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./summary.generated";
 import type {
   FirewallPermissionDetailMetadata,
@@ -18,6 +23,22 @@ export type {
 export type FirewallMetadataConnectorType =
   keyof typeof FIREWALL_PERMISSION_METADATA_SUMMARIES;
 
+export interface FirewallMetadataPermissionGroup<T extends { name: string }> {
+  readonly category: string;
+  readonly permissions: T[];
+}
+
+export type FirewallPermissionGrantAction = Extract<
+  FirewallPolicyValue,
+  "allow" | "deny"
+>;
+
+export interface FirewallPermissionGrant {
+  readonly connectorRef: string;
+  readonly permission: string;
+  readonly action: FirewallPermissionGrantAction;
+}
+
 export function isFirewallMetadataConnectorType(
   type: string,
 ): type is FirewallMetadataConnectorType {
@@ -34,6 +55,10 @@ export function getFirewallPermissionSummary(
     return null;
   }
   return FIREWALL_PERMISSION_METADATA_SUMMARIES[type];
+}
+
+export function hasFirewallMetadataPermissions(type: string): boolean {
+  return getFirewallPermissionSummary(type)?.hasPermissions ?? false;
 }
 
 export async function loadFirewallPermissionMetadata(
@@ -73,4 +98,87 @@ export function expandFirewallMetadataDefaultPolicy(
     policies,
     unknownPolicy: metadata.defaultPolicy.unknownPolicy,
   };
+}
+
+export function findFirewallMetadataPermission(
+  metadata: FirewallPermissionDetailMetadata,
+  name: string,
+): FirewallPermissionDetailMetadata["permissions"][number] | null {
+  return (
+    metadata.permissions.find((permission) => {
+      return permission.name === name;
+    }) ?? null
+  );
+}
+
+export function groupFirewallMetadataPermissionsByCategory<
+  T extends { name: string },
+>(
+  permissions: readonly T[],
+  metadata: FirewallPermissionDetailMetadata,
+): FirewallMetadataPermissionGroup<T>[] | null {
+  if (!metadata.categories) {
+    return null;
+  }
+
+  const grouped = new Map<string, T[]>();
+  for (const category of metadata.categories.displayOrder) {
+    grouped.set(category, []);
+  }
+
+  for (const permission of permissions) {
+    const category = metadata.categories.categories[permission.name];
+    if (!category) {
+      continue;
+    }
+    grouped.get(category)?.push(permission);
+  }
+
+  return [...grouped.entries()]
+    .filter(([, groupPermissions]) => {
+      return groupPermissions.length > 0;
+    })
+    .map(([category, groupPermissions]) => {
+      return { category, permissions: groupPermissions };
+    });
+}
+
+export function resolveFirewallMetadataPolicies(
+  stored: FirewallPolicies | null,
+  metadata: readonly FirewallPermissionDetailMetadata[],
+): FirewallPolicies | null {
+  let resolved: FirewallPolicies | null = stored;
+  for (const detail of metadata) {
+    const defaults = expandFirewallMetadataDefaultPolicy(detail);
+    const existing = resolved?.[detail.type];
+    resolved = {
+      ...resolved,
+      [detail.type]: {
+        policies: { ...defaults.policies, ...existing?.policies },
+        ...(existing?.unknownPolicy !== undefined
+          ? { unknownPolicy: existing.unknownPolicy }
+          : { unknownPolicy: defaults.unknownPolicy }),
+      },
+    };
+  }
+  return resolved;
+}
+
+export function permissionGrantsToFirewallPolicies(
+  grants: readonly FirewallPermissionGrant[],
+): FirewallPolicies | null {
+  const policies: FirewallPolicies = {};
+  for (const grant of grants) {
+    const current = policies[grant.connectorRef] ?? { policies: {} };
+    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
+      policies[grant.connectorRef] = {
+        ...current,
+        unknownPolicy: grant.action,
+      };
+      continue;
+    }
+    current.policies[grant.permission] = grant.action;
+    policies[grant.connectorRef] = current;
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
 }

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  UNKNOWN_PERMISSION_GRANT,
   type FirewallConfig,
   type FirewallPolicy,
   type FirewallPolicies,
@@ -311,6 +310,11 @@ import { gongFirewall } from "./gong.generated";
 import { ironcladFirewall } from "./ironclad.generated";
 import { snowflakeFirewall } from "./snowflake.generated";
 
+export {
+  permissionGrantsToFirewallPolicies,
+  type FirewallPermissionGrant,
+  type FirewallPermissionGrantAction,
+} from "../firewall-metadata";
 export * from "../firewall-types";
 
 // ── Permission categories ───────────────────────────────────────────────
@@ -889,36 +893,6 @@ export function resolveFirewallPolicies(
     };
   }
   return resolved;
-}
-
-export type FirewallPermissionGrantAction = Extract<
-  FirewallPolicyValue,
-  "allow" | "deny"
->;
-
-export interface FirewallPermissionGrant {
-  readonly connectorRef: string;
-  readonly permission: string;
-  readonly action: FirewallPermissionGrantAction;
-}
-
-export function permissionGrantsToFirewallPolicies(
-  grants: readonly FirewallPermissionGrant[],
-): FirewallPolicies | null {
-  const policies: FirewallPolicies = {};
-  for (const grant of grants) {
-    const current = policies[grant.connectorRef] ?? { policies: {} };
-    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
-      policies[grant.connectorRef] = {
-        ...current,
-        unknownPolicy: grant.action,
-      };
-      continue;
-    }
-    current.policies[grant.permission] = grant.action;
-    policies[grant.connectorRef] = current;
-  }
-  return Object.keys(policies).length > 0 ? policies : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add metadata-safe firewall permission helpers for summary checks, permission lookup/grouping, default policy resolution, and grant-to-policy conversion.
- Migrate platform permission UI, permission allow pages, and chat permission action cards to lazy per-connector firewall metadata instead of runtime firewall catalogs.
- Add an ESLint guard that blocks platform frontend imports from runtime firewall entrypoints.

Closes #18077

## Tests

- `pnpm format`
- `pnpm knip`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors test`
- pre-commit hook: `prettier`, `knip --cache`, `turbo run check-types --concurrency=1`