### PR TITLE
fix: timeout desktop computer use host requests

### DIFF
--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -31,6 +31,24 @@ function deferred<T>(): {
   return { promise, resolve };
 }
 
+function hungResponseUntilAbort(
+  init: RequestInit | undefined,
+): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    if (!init?.signal) {
+      reject(new Error("Expected request abort signal"));
+      return;
+    }
+    init.signal.addEventListener(
+      "abort",
+      () => {
+        reject(new Error("aborted"));
+      },
+      { once: true },
+    );
+  });
+}
+
 function createRuntime(
   options: {
     readonly sessionFetch?: ComputerUseHostFetch;
@@ -43,10 +61,7 @@ function createRuntime(
 ) {
   const sessionFetch =
     options.sessionFetch ??
-    vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.includes("/api/zero/computer-use/audit-events")) {
-        return jsonResponse({ auditEvents: [] });
-      }
+    vi.fn<ComputerUseHostFetch>(async () => {
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
   const hostFetch =
@@ -144,10 +159,7 @@ describe("ComputerUseHostRuntime", () => {
 
   it("uses the host bearer token for polling after registration", async () => {
     vi.useFakeTimers();
-    const sessionFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.includes("/api/zero/computer-use/audit-events")) {
-        return jsonResponse({ auditEvents: [] });
-      }
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
     const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
@@ -594,14 +606,64 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("retries hung command completion requests with a request timeout", async () => {
+    vi.useFakeTimers();
+    let nextCalls = 0;
+    let completeCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url, init) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? jsonResponse({
+              status: "command",
+              command: {
+                id: "cmd-1",
+                kind: "app.state",
+                payload: { app: "Chrome" },
+              },
+            })
+          : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        completeCalls++;
+        return completeCalls === 1
+          ? await hungResponseUntilAbort(init)
+          : jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(completeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(1_999);
+
+    expect(completeCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(completeCalls).toBe(2);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+    });
+    expect(runtime.getState().lastCommandAt).toEqual(expect.any(String));
+
+    await runtime.stop();
+  });
+
   it("retries transient start failures with recovery state", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-10T10:00:00.000Z"));
     let startCalls = 0;
-    const sessionFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
-      if (url.includes("/api/zero/computer-use/audit-events")) {
-        return jsonResponse({ auditEvents: [] });
-      }
+    const sessionFetch = vi.fn<ComputerUseHostFetch>(async () => {
       startCalls++;
       return startCalls === 1
         ? new Response("{}", { status: 503 })
@@ -679,6 +741,104 @@ describe("ComputerUseHostRuntime", () => {
 
     expect(heartbeatCalls).toBe(2);
     expect(nextCalls).toBe(1);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+      recovery: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("recovers hung heartbeat requests with a request timeout", async () => {
+    vi.useFakeTimers();
+    let heartbeatCalls = 0;
+    let nextCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url, init) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        heartbeatCalls++;
+        if (heartbeatCalls === 1) {
+          return await hungResponseUntilAbort(init);
+        }
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return jsonResponse({ status: "idle" });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(heartbeatCalls).toBe(1);
+    expect(nextCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(runtime.getState()).toMatchObject({
+      status: "recovering",
+      lastError: "Computer Use heartbeat timed out after 10000ms",
+      recovery: {
+        phase: "heartbeat",
+        attempt: 1,
+        retryDelayMs: 2_000,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(heartbeatCalls).toBe(2);
+    expect(nextCalls).toBeGreaterThan(1);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+      recovery: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("backs off hung command claim requests with a request timeout", async () => {
+    vi.useFakeTimers();
+    let nextCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url, init) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? await hungResponseUntilAbort(init)
+          : jsonResponse({ status: "idle" });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(nextCalls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(runtime.getState()).toMatchObject({
+      status: "recovering",
+      lastError: "Computer Use command poll timed out after 30000ms",
+      recovery: {
+        phase: "command_poll",
+        attempt: 1,
+        retryDelayMs: 2_000,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(nextCalls).toBe(2);
     expect(runtime.getState()).toMatchObject({
       status: "online",
       lastError: null,
@@ -775,12 +935,12 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
-  it("keeps the runtime online when audit history refresh fails", async () => {
+  it("does not fetch audit history while refreshing heartbeats", async () => {
     vi.useFakeTimers();
     let heartbeatCalls = 0;
     const sessionFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
       if (url.includes("/api/zero/computer-use/audit-events")) {
-        return new Response("{}", { status: 503 });
+        throw new Error("Heartbeat must not depend on audit history refresh");
       }
       return jsonResponse({ hostId: "host-1", hostToken: "token-1" });
     });
@@ -803,16 +963,16 @@ describe("ComputerUseHostRuntime", () => {
       status: "online",
       lastError: null,
       recovery: null,
-      errorLog: [
-        {
-          source: "audit",
-          message: "Computer Use audit history refresh failed: 503",
-        },
-      ],
+      errorLog: [],
     });
 
     await vi.advanceTimersByTimeAsync(2_000);
     expect(heartbeatCalls).toBe(2);
+    expect(
+      sessionFetch.mock.calls.some(([url]) => {
+        return url.includes("/api/zero/computer-use/audit-events");
+      }),
+    ).toBe(false);
 
     await runtime.stop();
   });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -8,7 +8,6 @@ import type {
   ComputerUseHostRuntimeState,
   ComputerUseLocalCommandLogEntry,
   ComputerUsePermissionState,
-  ComputerUseRuntimeAuditEvent,
   ComputerUseRuntimeErrorLogEntry,
   ComputerUseRuntimeRecoveryPhase,
   ComputerUseRuntimeErrorSource,
@@ -22,6 +21,9 @@ const ONLINE_POLL_MS = 2_000;
 const RECOVERY_RETRY_BASE_MS = 2_000;
 const RECOVERY_RETRY_MAX_MS = 60_000;
 const RECOVERY_RETRY_AFTER_MAX_MS = 5 * 60_000;
+const HEARTBEAT_REQUEST_TIMEOUT_MS = 10_000;
+const COMMAND_POLL_REQUEST_TIMEOUT_MS = 30_000;
+const COMMAND_COMPLETION_REQUEST_TIMEOUT_MS = 60_000;
 const COMMAND_COMPLETION_RETRY_DELAY_MS = 2_000;
 const COMMAND_COMPLETION_MAX_ATTEMPTS = 3;
 const AUTH_ME_PATH = "/api/auth/me";
@@ -63,10 +65,6 @@ interface ComputerUseHostStartResponse {
   readonly hostToken: string;
 }
 
-interface ComputerUseAuditEventsResponse {
-  readonly auditEvents: readonly ComputerUseRuntimeAuditEvent[];
-}
-
 interface ComputerUseHostNextIdleResponse {
   readonly status: "idle";
 }
@@ -87,7 +85,6 @@ type RuntimeErrorStateUpdate = Partial<
     | "lastHeartbeatAt"
     | "lastCommandAt"
     | "recovery"
-    | "recentAuditEvents"
     | "localCommandLog"
   >
 >;
@@ -248,7 +245,6 @@ export class ComputerUseHostRuntime {
     lastError: null,
     recovery: null,
     errorLog: [],
-    recentAuditEvents: [],
     localCommandLog: [],
   };
 
@@ -716,10 +712,51 @@ export class ComputerUseHostRuntime {
     return response.ok;
   }
 
+  private async runHostRequestWithTimeout(args: {
+    readonly label: string;
+    readonly timeoutMs: number;
+    readonly request: (signal: AbortSignal) => Promise<Response>;
+  }): Promise<Response> {
+    const { label, timeoutMs, request } = args;
+    const timeoutMessage = () => {
+      return new Error(`Computer Use ${label} timed out after ${timeoutMs}ms`);
+    };
+    const controller = new AbortController();
+    const requestPromise = request(controller.signal).catch((error) => {
+      if (controller.signal.aborted) {
+        throw timeoutMessage();
+      }
+      throw error;
+    });
+    let timer: NodeJS.Timeout | null = null;
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timer = this.scheduleTimeout(() => {
+        controller.abort();
+        reject(timeoutMessage());
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([requestPromise, timeoutPromise]);
+    } finally {
+      if (timer) {
+        this.clearScheduledTimeout(timer);
+        timer = null;
+      }
+    }
+  }
+
   private async heartbeat(): Promise<boolean> {
-    const response = await this.hostFetch("/api/zero/computer-use/heartbeat", {
-      method: "POST",
-      body: JSON.stringify(await this.runtimeBody()),
+    const response = await this.runHostRequestWithTimeout({
+      label: "heartbeat",
+      timeoutMs: HEARTBEAT_REQUEST_TIMEOUT_MS,
+      request: async (signal) => {
+        return await this.hostFetch("/api/zero/computer-use/heartbeat", {
+          method: "POST",
+          body: JSON.stringify(await this.runtimeBody()),
+          signal,
+        });
+      },
     });
     if (response.status === 401) {
       this.deactivateInvalidHostToken("heartbeat");
@@ -750,51 +787,26 @@ export class ComputerUseHostRuntime {
       lastError: commandPollRecovery ? this.state.lastError : null,
       recovery: commandPollRecovery,
     });
-    await this.refreshAuditEvents();
     return true;
   }
 
-  private async refreshAuditEvents(): Promise<void> {
-    const hostId = this.state.hostId;
-    if (!hostId) {
-      return;
-    }
-
-    const url = new URL(
-      `${this.apiBaseUrl}/api/zero/computer-use/audit-events`,
-    );
-    url.searchParams.set("hostId", hostId);
-    url.searchParams.set("limit", "25");
-
-    const response = await this.sessionFetch(url.toString(), { method: "GET" });
-    if (response.status === 401 || response.status === 403) {
-      this.setState({ recentAuditEvents: [] });
-      return;
-    }
-    if (!response.ok) {
-      this.appendRuntimeErrorLog(
-        "audit",
-        `Computer Use audit history refresh failed: ${response.status}`,
-      );
-      return;
-    }
-
-    const body = (await response.json()) as ComputerUseAuditEventsResponse;
-    this.setState({
-      recentAuditEvents: body.auditEvents,
-    });
-  }
-
   private async claimAndExecuteCommand(): Promise<void> {
-    const next = await this.hostFetch(
-      "/api/zero/computer-use/host/commands/next",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          supportedCapabilities: [...SUPPORTED_COMPUTER_USE_CAPABILITIES],
-        }),
+    const next = await this.runHostRequestWithTimeout({
+      label: "command poll",
+      timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
+      request: async (signal) => {
+        return await this.hostFetch(
+          "/api/zero/computer-use/host/commands/next",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              supportedCapabilities: [...SUPPORTED_COMPUTER_USE_CAPABILITIES],
+            }),
+            signal,
+          },
+        );
       },
-    );
+    });
     if (next.status === 401) {
       this.deactivateInvalidHostToken("command_poll");
       return;
@@ -849,7 +861,6 @@ export class ComputerUseHostRuntime {
       lastError: null,
       recovery: null,
     });
-    await this.refreshAuditEvents();
   }
 
   private async completeCommandWithRetry(
@@ -863,13 +874,20 @@ export class ComputerUseHostRuntime {
       attempt++
     ) {
       try {
-        const response = await this.hostFetch(
-          `/api/zero/computer-use/host/commands/${commandId}/complete`,
-          {
-            method: "POST",
-            body: JSON.stringify(completed),
+        const response = await this.runHostRequestWithTimeout({
+          label: "command completion",
+          timeoutMs: COMMAND_COMPLETION_REQUEST_TIMEOUT_MS,
+          request: async (signal) => {
+            return await this.hostFetch(
+              `/api/zero/computer-use/host/commands/${commandId}/complete`,
+              {
+                method: "POST",
+                body: JSON.stringify(completed),
+                signal,
+              },
+            );
           },
-        );
+        });
         if (response.ok) {
           return;
         }

--- a/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.test.ts
@@ -83,7 +83,6 @@ describe("resolveComputerUseStartupGate", () => {
         lastError: COMPUTER_USE_UNAUTHENTICATED_MESSAGE,
         recovery: null,
         errorLog: [],
-        recentAuditEvents: [],
         localCommandLog: [],
       },
     });

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -28,16 +28,6 @@ export interface ComputerUseRuntimeRecoveryState {
   readonly retryDelayMs: number;
 }
 
-export interface ComputerUseRuntimeAuditEvent {
-  readonly commandId: string;
-  readonly kind: string;
-  readonly app: string | null;
-  readonly event: "created" | "approved" | "denied" | "completed";
-  readonly approvalOutcome: "approved" | "denied" | null;
-  readonly redactedResult?: Record<string, unknown> | null;
-  readonly createdAt: string;
-}
-
 export type ComputerUseLocalCommandLogStatus =
   | "running"
   | "succeeded"
@@ -57,7 +47,6 @@ export interface ComputerUseLocalCommandLogEntry {
 }
 
 export type ComputerUseRuntimeErrorSource =
-  | "audit"
   | "start"
   | "stop"
   | "heartbeat"
@@ -80,7 +69,6 @@ export interface ComputerUseHostRuntimeState {
   readonly lastError: string | null;
   readonly recovery: ComputerUseRuntimeRecoveryState | null;
   readonly errorLog: readonly ComputerUseRuntimeErrorLogEntry[];
-  readonly recentAuditEvents: readonly ComputerUseRuntimeAuditEvent[];
   readonly localCommandLog: readonly ComputerUseLocalCommandLogEntry[];
 }
 
@@ -113,6 +101,5 @@ export const OFFLINE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =
     lastError: null,
     recovery: null,
     errorLog: [],
-    recentAuditEvents: [],
     localCommandLog: [],
   });

--- a/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.test.ts
@@ -44,7 +44,6 @@ function hostState(
     lastError: null,
     recovery: null,
     errorLog: [],
-    recentAuditEvents: [],
     localCommandLog: [],
     ...overrides,
   };

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -235,7 +235,6 @@ function createComputerUseState(): DesktopComputerUseState {
       lastError: null,
       recovery: null,
       errorLog: [],
-      recentAuditEvents: [],
       localCommandLog: [],
     },
     keepAwake: {

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -18,7 +18,6 @@ const baseHostState: ComputerUseHostRuntimeState = {
   lastError: null,
   recovery: null,
   errorLog: [],
-  recentAuditEvents: [],
   localCommandLog: [],
 };
 

--- a/turbo/apps/desktop/src/desktop-tray.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray.test.ts
@@ -135,7 +135,6 @@ function computerUseState(
       lastError: null,
       recovery: null,
       errorLog: [],
-      recentAuditEvents: [],
       localCommandLog: options.runningCommand
         ? [runningLocalCommandLogEntry()]
         : [],

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -65,7 +65,6 @@ function createComputerUseState({
       lastError: null,
       recovery: null,
       errorLog: [],
-      recentAuditEvents: [],
       localCommandLog: [],
     },
     keepAwake,

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -76,7 +76,6 @@ const COMMAND_STATUS_LABELS = {
 } as const satisfies Record<CommandLogEntry["status"], string>;
 
 const RUNTIME_ERROR_SOURCE_LABELS = {
-  audit: "Audit history",
   start: "Start",
   stop: "Stop",
   heartbeat: "Heartbeat",


### PR DESCRIPTION
## Summary
- remove the unused Desktop Computer Use audit-events refresh from host runtime state and UI labels
- add bounded request timeouts for heartbeat, command polling, and command completion
- keep existing recovery/retry behavior: heartbeat and poll failures enter runtime recovery, completion timeouts retry before surfacing failure

## Validation
- pnpm format
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm turbo run lint
- pnpm check-types

## Local environment notes
- pnpm knip was attempted and failed on the existing repo baseline with many unrelated unused files/exports and dependency hints.
- pnpm vitest was attempted; Desktop tests passed separately, but root vitest failed in API tests because the local DATABASE_URL/migrations were not valid in this worktree (`zero_workflows` / `zero_workflow_agents` missing), and web theme tests had a localStorage test-environment failure. `pnpm -F @vm0/db db:migrate` also failed locally with `invalid DATABASE_URL`.
