### PR TITLE
fix: remove meta ads preconnect notice

### DIFF
--- a/turbo/apps/platform/src/lib/google-security-warning.ts
+++ b/turbo/apps/platform/src/lib/google-security-warning.ts
@@ -7,13 +7,6 @@ export function shouldShowGoogleSecurityWarningNotice(
   return isGoogleOAuthConnector(type);
 }
 
-export function shouldShowMetaAdsReviewNotice(type: ConnectorType): boolean {
-  return type === "meta-ads";
-}
-
 export function shouldShowConnectorConnectNotice(type: ConnectorType): boolean {
-  return (
-    shouldShowGoogleSecurityWarningNotice(type) ||
-    shouldShowMetaAdsReviewNotice(type)
-  );
+  return shouldShowGoogleSecurityWarningNotice(type);
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -4,6 +4,7 @@ import {
   zeroCustomConnectorsContract,
   type CustomConnectorResponse,
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   CONNECTOR_TYPES,
@@ -453,6 +454,41 @@ describe("connectors page", () => {
     expect(
       within(dialog).getByText(/Google will show a security warning/),
     ).toBeInTheDocument();
+  });
+
+  it("starts Meta Ads OAuth without review guidance", async () => {
+    mockConnectors([]);
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ params, respond }) => {
+        return respond(200, {
+          authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
+    });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "meta");
+    click(await screen.findByLabelText("Connect Meta Ads"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/meta-ads/authorize",
+      );
+    });
+    expect(
+      screen.queryByText(/Meta Ads is currently in Meta's app review period/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Meta Ads" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a partially gated connector with only ungated auth methods", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -61,14 +61,8 @@ import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
-import {
-  shouldShowGoogleSecurityWarningNotice,
-  shouldShowMetaAdsReviewNotice,
-} from "../../../../lib/google-security-warning.ts";
-import {
-  GoogleSecurityWarningNotice,
-  MetaAdsReviewNotice,
-} from "../../zero-directed-shared.tsx";
+import { shouldShowGoogleSecurityWarningNotice } from "../../../../lib/google-security-warning.ts";
+import { GoogleSecurityWarningNotice } from "../../zero-directed-shared.tsx";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 
 // ---------------------------------------------------------------------------
@@ -1058,18 +1052,10 @@ function StandardConnectMethodsContent({
         return entry.authMethod;
       }),
     ) && shouldShowGoogleSecurityWarningNotice(item.type);
-  const showMetaAdsReviewNotice =
-    hasAuthCodeGrant(
-      item.type,
-      entries.map((entry) => {
-        return entry.authMethod;
-      }),
-    ) && shouldShowMetaAdsReviewNotice(item.type);
 
   return (
     <div className="flex flex-col gap-4">
       {showGoogleSecurityWarningNotice && <GoogleSecurityWarningNotice />}
-      {showMetaAdsReviewNotice && <MetaAdsReviewNotice />}
 
       <ConnectMethodsContent
         entries={entries}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -26,14 +26,10 @@ import {
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import {
-  shouldShowGoogleSecurityWarningNotice,
-  shouldShowMetaAdsReviewNotice,
-} from "../../lib/google-security-warning.ts";
+import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
 import {
   Vm0LogoLink,
   GoogleSecurityWarningNotice,
-  MetaAdsReviewNotice,
 } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
@@ -187,10 +183,6 @@ function DirectedAuthorizeCard() {
     !isAuthorized &&
     !isConnected &&
     shouldShowGoogleSecurityWarningNotice(connectorType);
-  const showMetaAdsReviewNotice =
-    !isAuthorized &&
-    !isConnected &&
-    shouldShowMetaAdsReviewNotice(connectorType);
 
   const handleAuthorize = () => {
     if (!canAuthorize) {
@@ -241,7 +233,6 @@ function DirectedAuthorizeCard() {
                   {showGoogleSecurityWarningNotice && (
                     <GoogleSecurityWarningNotice />
                   )}
-                  {showMetaAdsReviewNotice && <MetaAdsReviewNotice />}
                 </>
               )}
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -50,14 +50,10 @@ import {
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import {
-  shouldShowGoogleSecurityWarningNotice,
-  shouldShowMetaAdsReviewNotice,
-} from "../../lib/google-security-warning.ts";
+import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
 import {
   Vm0LogoLink,
   GoogleSecurityWarningNotice,
-  MetaAdsReviewNotice,
 } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
@@ -450,9 +446,6 @@ function ConnectorConnectNotices({
   }
   if (shouldShowGoogleSecurityWarningNotice(connectorType)) {
     return <GoogleSecurityWarningNotice />;
-  }
-  if (shouldShowMetaAdsReviewNotice(connectorType)) {
-    return <MetaAdsReviewNotice />;
   }
   return null;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -114,27 +114,3 @@ export function GoogleSecurityWarningNotice() {
     </div>
   );
 }
-
-export function MetaAdsReviewNotice() {
-  return (
-    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
-      <AvatarSvgPreview
-        config={getAvatarPresets()[0]}
-        size={36}
-        className="h-9 w-9 rounded-full"
-        alt="Zero"
-      />
-      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
-        <p>
-          Meta Ads is currently in Meta&apos;s app review period. You can
-          connect now, but the connector may encounter rate limiting issues
-          until the review is complete.
-        </p>
-        <p>
-          We only request the permissions needed for ads workflows, and your
-          connection tokens are encrypted at rest.
-        </p>
-      </div>
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- remove the Meta Ads app review preconnect notice from connector, directed connect, and directed authorize flows
- keep the Google OAuth verification guidance unchanged
- add a regression test that Meta Ads starts OAuth directly without showing the review dialog

## Testing
- pnpm exec prettier --write --ignore-unknown apps/platform/src/lib/google-security-warning.ts apps/platform/src/views/zero-page/zero-directed-shared.tsx apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx apps/platform/src/views/zero-page/zero-directed-connect-page.tsx apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
- pnpm check-types *(fails in @vm0/app with existing unrelated ts-rest/implicit-any type errors outside this change)*