### PR TITLE
fix(guest-agent): flush final telemetry after producer shutdown

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -46,6 +46,7 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 use termination::{TerminationReason, TerminationState};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::sync::oneshot;
 use uuid::Uuid;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -177,10 +178,23 @@ pub struct CliExecutionResult {
     pub failure_diagnostic: Option<CliFailureDiagnostic>,
 }
 
+/// Heartbeat completion signal observed by [`execute_cli`].
+///
+/// The top-level guest-agent owns the heartbeat task handle so shutdown can
+/// stop it before final telemetry. `execute_cli` only needs this one-shot
+/// status while the CLI process is running.
+pub enum HeartbeatStatus {
+    Failed(AgentError),
+    Stopped,
+    TaskFailed(String),
+}
+
+pub type HeartbeatMonitor = Option<oneshot::Receiver<HeartbeatStatus>>;
+
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
 pub async fn execute_cli(
     masker: &SecretMasker,
-    mut heartbeat_handle: tokio::task::JoinHandle<Result<(), AgentError>>,
+    mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();
@@ -258,7 +272,6 @@ pub async fn execute_cli(
     let initial_prompt_stdin = if behavior.uses_stream_json_stdin() {
         let Some(stdin) = child.stdin.take() else {
             let _ = child.start_kill();
-            heartbeat_handle.abort();
             return Err(AgentError::Execution("no stdin".into()));
         };
         Some(stdin)
@@ -670,10 +683,18 @@ pub async fn execute_cli(
                     );
                 }
             }
-            hb_result = &mut heartbeat_handle, if !heartbeat_done => {
+            heartbeat_result = async {
+                match heartbeat_monitor.as_mut() {
+                    Some(receiver) => receiver.await,
+                    None => {
+                        std::future::pending::<Result<HeartbeatStatus, oneshot::error::RecvError>>()
+                            .await
+                    }
+                }
+            }, if !heartbeat_done => {
                 heartbeat_done = true;
-                match hb_result {
-                    Ok(Err(e)) => {
+                match heartbeat_result {
+                    Ok(HeartbeatStatus::Failed(e)) => {
                         // Heartbeat failed — kill process group
                         if termination_error.is_none() {
                             log_warn!(
@@ -694,16 +715,37 @@ pub async fn execute_cli(
                             );
                         }
                     }
-                    Ok(Ok(())) => {
+                    Ok(HeartbeatStatus::Stopped) => {
                         // Heartbeat shutdown (should not happen before CLI exits)
                         break Ok(());
                     }
-                    Err(e) => {
-                        let error = AgentError::Execution(format!("heartbeat task panicked: {e}"));
+                    Ok(HeartbeatStatus::TaskFailed(message)) => {
+                        let error = AgentError::Execution(format!("heartbeat task panicked: {message}"));
                         if termination_error.is_none() {
                             log_warn!(
                                 LOG_TAG,
                                 "Heartbeat task panicked, SIGTERM pgid={}",
+                                pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+                            );
+                            if let Some(pid) = pgid {
+                                unsafe { libc::kill(-pid, libc::SIGTERM); }
+                            }
+                            termination_error = Some(error);
+                            termination_state = TerminationState::SigkillPending {
+                                reason: TerminationReason::HeartbeatPanic,
+                            };
+                            termination_deadline.as_mut().reset(
+                                tokio::time::Instant::now()
+                                    + Duration::from_secs(env::post_result_sigkill_grace_secs()),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        let error = AgentError::Execution(format!("heartbeat task stopped before reporting status: {e}"));
+                        if termination_error.is_none() {
+                            log_warn!(
+                                LOG_TAG,
+                                "Heartbeat task stopped before reporting status, SIGTERM pgid={}",
                                 pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                             );
                             if let Some(pid) = pgid {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -6,7 +6,6 @@ use guest_agent::cli;
 use guest_agent::complete;
 use guest_agent::control;
 use guest_agent::env;
-use guest_agent::error;
 use guest_agent::heartbeat;
 use guest_agent::http::HttpClient;
 use guest_agent::masker;
@@ -79,11 +78,8 @@ async fn run() -> i32 {
     );
 
     let t = Instant::now();
-    let heartbeat_handle = tokio::spawn({
-        let shutdown = shutdown.clone();
-        let http = http.clone();
-        async move { heartbeat::heartbeat_loop(http, shutdown).await }
-    });
+    let (heartbeat_status_tx, heartbeat_status_rx) = tokio::sync::oneshot::channel();
+    let heartbeat_handle = spawn_heartbeat(shutdown.clone(), http.clone(), heartbeat_status_tx);
     log_info!(LOG_TAG, "Heartbeat started");
     record_sandbox_op("heartbeat_start", t.elapsed(), true, None);
 
@@ -100,21 +96,21 @@ async fn run() -> i32 {
     log_info!(LOG_TAG, "Telemetry upload started");
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
-    // Execute main logic (init + CLI + checkpoint + cleanup telemetry).
+    // Execute main logic (init + CLI + checkpoint/recovery + /complete).
     // On the success path, `execute` overlaps the pre-checkpoint telemetry
-    // flush with checkpoint creation; the final flush still runs after
-    // `/complete` so the acknowledgement log line is uploaded.
-    let exit_code = execute(&masker, start, heartbeat_handle, &telemetry, http).await;
+    // flush with checkpoint creation. The EOF-consuming final flush runs below,
+    // after background producers stop, so `/complete` logs still upload without
+    // racing metrics or heartbeat writes.
+    let exit_code = execute(&masker, start, Some(heartbeat_status_rx), &telemetry, http).await;
 
-    // Stop all background processes. Telemetry uses its own command
-    // channel; `shutdown` only covers heartbeat/metrics.
-    shutdown.cancel();
-    if let Some(control_handle) = control_handle {
-        control_handle.join();
-    }
-    let _ = metrics_handle.await;
-    telemetry.shutdown().await;
-    log_info!(LOG_TAG, "Background processes stopped");
+    stop_background_and_flush_final_telemetry(
+        shutdown,
+        control_handle,
+        metrics_handle,
+        heartbeat_handle,
+        telemetry,
+    )
+    .await;
 
     if exit_code == 0 {
         log_info!(LOG_TAG, "✓ Sandbox finished successfully");
@@ -125,13 +121,14 @@ async fn run() -> i32 {
     exit_code
 }
 
-/// Main execution logic: working dir, CLI, checkpoint, and cleanup telemetry.
+/// Main execution logic: working dir, CLI, checkpoint/recovery, and `/complete`.
 /// The success path overlaps the pre-checkpoint telemetry flush with
-/// checkpoint creation, then runs the final flush after `/complete`.
+/// checkpoint creation. Final telemetry is owned by [`run`] after producer
+/// shutdown.
 async fn execute(
     masker: &masker::SecretMasker,
     start: Instant,
-    heartbeat_handle: tokio::task::JoinHandle<Result<(), error::AgentError>>,
+    heartbeat_monitor: cli::HeartbeatMonitor,
     telemetry: &Telemetry,
     http: HttpClient,
 ) -> i32 {
@@ -189,7 +186,7 @@ async fn execute(
         error_message,
         skip_recovery_checkpoint_for_no_history,
         failure_diagnostic,
-    ) = match cli::execute_cli(masker, heartbeat_handle, http.clone()).await {
+    ) = match cli::execute_cli(masker, heartbeat_monitor, http.clone()).await {
         Ok(cli_result) => {
             last_event_sequence = cli_result.last_event_sequence;
             let cli_exit_code = cli_result.exit_code;
@@ -717,11 +714,9 @@ async fn complete_execution(
 
     // Checkpoint on success (skip when no API — local/test mode). The
     // pre-checkpoint flush runs in `tokio::join!` with the snapshot work so
-    // its ~1s upload overlaps the ~4s checkpoint. The post-checkpoint flush
-    // catches records checkpoint itself wrote (`session_id_read`, VAS
-    // snapshot timings, `checkpoint_total`, etc.) and is the EOF-consuming
-    // final pass. Both go through the single-writer uploader, so the two
-    // flushes never race the periodic tick on the pos files.
+    // its ~1s upload overlaps the ~4s checkpoint. The EOF-consuming final
+    // pass runs from the top-level shutdown path after telemetry producers
+    // stop, so it can safely catch checkpoint and `/complete` logs.
     let agent_type = env::Framework::from_env().agent_type();
     if should_create_success_checkpoint(cli_exit_code, exit_code) && http.has_api() {
         log_info!(LOG_TAG, "{agent_type} completed successfully");
@@ -747,13 +742,12 @@ async fn complete_execution(
                 // only trigger). Runner still posts /complete after VM
                 // exit; its call is idempotency-short-circuited.
                 //
-                // Serialize /complete before final_telemetry so the ack log
-                // line lands in the file before the telemetry uploader
-                // snapshots its EOF — parallelizing the two hides the ack
-                // from `vm0 logs --system`. The ~hundreds-of-ms we pay for
-                // serialization is invisible to users because the host's
-                // status transition already happened the moment /complete
-                // returned.
+                // Serialize /complete before returning to the top-level final
+                // telemetry pass so the ack log line lands in the file before
+                // the telemetry uploader snapshots its EOF. The
+                // ~hundreds-of-ms we pay for serialization is invisible to
+                // users because the host's status transition already happened
+                // the moment /complete returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
                 complete::report_success(
                     http,
@@ -762,7 +756,6 @@ async fn complete_execution(
                     state.last_event_sequence,
                 )
                 .await;
-                final_telemetry(telemetry).await;
             }
             Err(e) => {
                 let msg = format!("Checkpoint failed: {e}");
@@ -785,7 +778,6 @@ async fn complete_execution(
                 // provider.complete() fallback posts exitCode=1, triggering
                 // the route's "checkpoint not found → failed" branch.
                 log_info!(LOG_TAG, "▷ Cleanup");
-                final_telemetry(telemetry).await;
             }
         }
     } else {
@@ -819,10 +811,63 @@ async fn complete_execution(
         }
 
         log_info!(LOG_TAG, "▷ Cleanup");
-        final_telemetry(telemetry).await;
     }
 
     exit_code
+}
+
+async fn stop_background_and_flush_final_telemetry(
+    shutdown: CancellationToken,
+    control_handle: Option<control::ControlHandle>,
+    metrics_handle: tokio::task::JoinHandle<()>,
+    heartbeat_handle: tokio::task::JoinHandle<()>,
+    telemetry: Telemetry,
+) {
+    // Stop telemetry producers before the EOF-consuming final pass.
+    shutdown.cancel();
+    stop_heartbeat(heartbeat_handle).await;
+    if let Some(control_handle) = control_handle {
+        control_handle.join();
+    }
+    let _ = metrics_handle.await;
+    final_telemetry(telemetry).await;
+    log_info!(LOG_TAG, "Background processes stopped");
+}
+
+fn spawn_heartbeat(
+    shutdown: CancellationToken,
+    http: HttpClient,
+    status_tx: tokio::sync::oneshot::Sender<cli::HeartbeatStatus>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let heartbeat_task = tokio::spawn(heartbeat::heartbeat_loop(http, shutdown));
+        let _abort_on_drop = AbortTaskOnDrop(heartbeat_task.abort_handle());
+        let status = match heartbeat_task.await {
+            Ok(Ok(())) => cli::HeartbeatStatus::Stopped,
+            Ok(Err(error)) => cli::HeartbeatStatus::Failed(error),
+            Err(error) => cli::HeartbeatStatus::TaskFailed(error.to_string()),
+        };
+        let _ = status_tx.send(status);
+    })
+}
+
+struct AbortTaskOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn stop_heartbeat(handle: tokio::task::JoinHandle<()>) {
+    if !handle.is_finished() {
+        handle.abort();
+    }
+    match handle.await {
+        Ok(()) => {}
+        Err(error) if error.is_cancelled() => {}
+        Err(error) => log_warn!(LOG_TAG, "Heartbeat task stopped: {error}"),
+    }
 }
 
 fn should_create_success_checkpoint(cli_exit_code: i32, exit_code: i32) -> bool {
@@ -836,10 +881,11 @@ fn setup_working_dir(path: impl AsRef<Path>) -> std::io::Result<()> {
 }
 
 /// Final telemetry upload — best-effort and logs on failure.
-/// The complete API is called by the runner after VM exits, not by guest-agent.
-async fn final_telemetry(telemetry: &Telemetry) {
+/// Success `/complete` reporting has already run before this point; the runner
+/// still keeps its idempotent VM-exit fallback.
+async fn final_telemetry(telemetry: Telemetry) {
     log_info!(LOG_TAG, "Performing final telemetry upload...");
-    if telemetry.flush(UploadMode::Final).await.is_err() {
+    if telemetry.final_flush_and_shutdown().await.is_err() {
         log_error!(LOG_TAG, "Final telemetry upload failed");
     }
 }
@@ -1792,8 +1838,7 @@ mod tests {
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http);
 
-        final_telemetry(&telemetry).await;
-        telemetry.shutdown().await;
+        final_telemetry(telemetry).await;
 
         telemetry_mock.assert_calls_async(1).await;
         telemetry_mock.delete_async().await;
@@ -1806,6 +1851,86 @@ mod tests {
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
+    }
+
+    #[test]
+    fn final_telemetry_waits_for_background_producers_before_upload() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
+                server.reset_async().await;
+                unsafe {
+                    set_test_env(server, None);
+                }
+
+                let marker = "producer_after_shutdown_before_final_upload";
+                let cleanup_paths = [
+                    paths::sandbox_ops_file().to_string(),
+                    paths::telemetry_system_log_pos_file().to_string(),
+                    paths::telemetry_metrics_pos_file().to_string(),
+                    paths::telemetry_sandbox_ops_pos_file().to_string(),
+                ];
+                for path in &cleanup_paths {
+                    let _ = std::fs::remove_file(path);
+                }
+
+                let telemetry_mock = server.mock(|when, then| {
+                    when.method(POST)
+                        .path("/api/webhooks/agent/telemetry")
+                        .body_includes(marker);
+                    then.status(200)
+                        .header("Content-Type", "application/json")
+                        .json_body(json!({}));
+                });
+
+                let shutdown = CancellationToken::new();
+                let producer_shutdown = shutdown.clone();
+                let metrics_handle = tokio::spawn(async move {
+                    producer_shutdown.cancelled().await;
+                    record_sandbox_op(marker, Duration::from_millis(1), true, None);
+                });
+                let heartbeat_handle = tokio::spawn(async {
+                    std::future::pending::<()>().await;
+                });
+                let masker = Arc::new(masker::SecretMasker::from_env());
+                let http = test_http_client(server);
+                let telemetry = Telemetry::spawn(masker, http);
+
+                stop_background_and_flush_final_telemetry(
+                    shutdown,
+                    None,
+                    metrics_handle,
+                    heartbeat_handle,
+                    telemetry,
+                )
+                .await;
+
+                telemetry_mock.assert_calls_async(1).await;
+                telemetry_mock.delete_async().await;
+                for path in cleanup_paths {
+                    let _ = std::fs::remove_file(path);
+                }
+            });
+    }
+
+    #[test]
+    fn stop_heartbeat_aborts_pending_task_promptly() {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let heartbeat_handle = tokio::spawn(async {
+                    std::future::pending::<()>().await;
+                });
+                tokio::time::timeout(Duration::from_secs(1), stop_heartbeat(heartbeat_handle))
+                    .await
+                    .expect("stop_heartbeat should not wait for the heartbeat loop");
+            });
     }
 
     #[test]
@@ -1883,7 +2008,7 @@ mod tests {
         }
         paths::write_private(paths::event_error_flag(), "").unwrap();
 
-        let telemetry_mock = server.mock(|when, then| {
+        let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -1923,8 +2048,6 @@ mod tests {
             diagnostic.session_history_status,
             SessionHistoryStatus::Missing
         );
-        telemetry_mock.assert_calls_async(1).await;
-
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
@@ -1952,7 +2075,7 @@ mod tests {
             let _ = std::fs::remove_file(path);
         }
 
-        let telemetry_mock = server.mock(|when, then| {
+        let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -1990,8 +2113,6 @@ mod tests {
             diagnostic.session_history_status,
             SessionHistoryStatus::Missing
         );
-        telemetry_mock.assert_calls_async(1).await;
-
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
@@ -2020,7 +2141,7 @@ mod tests {
         }
         paths::write_private(paths::event_error_flag(), "").unwrap();
 
-        let telemetry_mock = server.mock(|when, then| {
+        let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -2063,8 +2184,6 @@ mod tests {
             serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
                 .unwrap();
         assert_eq!(diagnostic, failure_diagnostic);
-        telemetry_mock.assert_calls_async(1).await;
-
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
@@ -2209,7 +2328,7 @@ mod tests {
                 .header("Content-Type", "application/json")
                 .json_body(json!({"checkpointId": "checkpoint-from-main"}));
         });
-        let telemetry_mock = server.mock(|when, then| {
+        let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -2255,7 +2374,6 @@ mod tests {
         prepare_mock.assert_calls_async(1).await;
         upload_mock.assert_calls_async(1).await;
         checkpoint_mock.assert_calls_async(1).await;
-        telemetry_mock.assert_calls_async(1).await;
 
         for path in cleanup_paths {
             let _ = std::fs::remove_file(path);

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -8,7 +8,8 @@
 //!
 //! Callers interact via [`Telemetry`]: spawn the task with
 //! [`Telemetry::spawn`], request uploads with [`Telemetry::flush`], and
-//! release with [`Telemetry::shutdown`].
+//! release with [`Telemetry::shutdown`] or
+//! [`Telemetry::final_flush_and_shutdown`].
 
 mod delta;
 
@@ -142,6 +143,10 @@ enum Cmd {
         mode: UploadMode,
         reply: oneshot::Sender<Result<(), AgentError>>,
     },
+    /// Perform the EOF-consuming final flush, then stop the loop.
+    FinalFlushAndShutdown {
+        reply: oneshot::Sender<Result<(), AgentError>>,
+    },
     /// Stop the loop. Any in-flight upload completes first.
     Shutdown,
 }
@@ -201,6 +206,26 @@ impl Telemetry {
         let _ = self.tx.send(Cmd::Shutdown).await;
         let _ = self.handle.await;
     }
+
+    /// Perform the final telemetry upload and stop the uploader task.
+    ///
+    /// Consumes `self`, so no later periodic `Live` tick or caller-driven
+    /// flush can run after the EOF-consuming final pass.
+    pub async fn final_flush_and_shutdown(self) -> Result<(), AgentError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .tx
+            .send(Cmd::FinalFlushAndShutdown { reply: reply_tx })
+            .await
+            .is_err()
+        {
+            let _ = self.handle.await;
+            return Err(AgentError::TelemetryUnavailable);
+        }
+        let result = reply_rx.await.map_err(|_| AgentError::TelemetryUnavailable);
+        let _ = self.handle.await;
+        result?
+    }
 }
 
 /// Single-writer task. Owns all pos-file mutations.
@@ -217,6 +242,10 @@ async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>, http: HttpC
             match cmd {
                 Cmd::Flush { reply, .. } => {
                     let _ = reply.send(Ok(()));
+                }
+                Cmd::FinalFlushAndShutdown { reply } => {
+                    let _ = reply.send(Ok(()));
+                    break;
                 }
                 Cmd::Shutdown => break,
             }
@@ -239,6 +268,11 @@ async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>, http: HttpC
                 Some(Cmd::Flush { mode, reply }) => {
                     let result = upload_telemetry(&http, &masker, mode).await;
                     let _ = reply.send(result);
+                }
+                Some(Cmd::FinalFlushAndShutdown { reply }) => {
+                    let result = upload_telemetry(&http, &masker, UploadMode::Final).await;
+                    let _ = reply.send(result);
+                    break;
                 }
                 Some(Cmd::Shutdown) | None => break,
             },

--- a/crates/guest-agent/tests/cli_setup_failure.rs
+++ b/crates/guest-agent/tests/cli_setup_failure.rs
@@ -39,7 +39,7 @@ async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn
     common::ensure_canonical_workspace_for_test()?;
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
-    let heartbeat = tokio::spawn(async { Ok(()) });
+    let heartbeat = common::spawn_heartbeat_monitor(async { Ok::<(), AgentError>(()) });
 
     let result = tokio::time::timeout(
         Duration::from_secs(1),

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -21,9 +21,13 @@
 
 mod system_log;
 
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
@@ -524,4 +528,65 @@ where
 /// code path entirely.
 pub fn spawn_dummy_heartbeat() -> guest_agent::cli::HeartbeatMonitor {
     None
+}
+
+pub async fn wait_for_path(path: &Path, timeout: Duration) -> io::Result<()> {
+    tokio::time::timeout(timeout, wait_for_path_event(path))
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!("timed out waiting for {}", path.display()),
+            )
+        })?
+}
+
+async fn wait_for_path_event(path: &Path) -> io::Result<()> {
+    if tokio::fs::try_exists(path).await? {
+        return Ok(());
+    }
+
+    let dir = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path has no parent directory: {}", path.display()),
+        )
+    })?;
+    let inotify = Inotify::init(InitFlags::IN_NONBLOCK)
+        .map_err(|error| io::Error::other(format!("inotify init: {error}")))?;
+    inotify
+        .add_watch(dir, AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
+        .map_err(|error| io::Error::other(format!("inotify watch: {error}")))?;
+
+    if tokio::fs::try_exists(path).await? {
+        return Ok(());
+    }
+
+    let async_fd = async_inotify_fd(inotify)?;
+    loop {
+        let mut guard = async_fd.readable().await?;
+        drain_inotify_fd(async_fd.get_ref().as_fd());
+        guard.clear_ready();
+
+        if tokio::fs::try_exists(path).await? {
+            return Ok(());
+        }
+    }
+}
+
+fn async_inotify_fd(inotify: Inotify) -> io::Result<AsyncFd<OwnedFd>> {
+    let fd: OwnedFd = inotify.into();
+    AsyncFd::new(fd).map_err(|error| io::Error::other(format!("AsyncFd: {error}")))
+}
+
+fn drain_inotify_fd(fd: std::os::fd::BorrowedFd<'_>) {
+    let mut buf = [0u8; 4096];
+    loop {
+        // SAFETY: fd is a valid non-blocking inotify descriptor borrowed from
+        // AsyncFd. The stack buffer is valid for the requested byte length.
+        let result = unsafe { libc::read(fd.as_raw_fd(), buf.as_mut_ptr().cast(), buf.len()) };
+        if result <= 0 {
+            break;
+        }
+    }
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -501,11 +501,27 @@ pub unsafe fn setup_env(
     Ok(())
 }
 
+pub fn spawn_heartbeat_monitor<F>(future: F) -> guest_agent::cli::HeartbeatMonitor
+where
+    F: std::future::Future<Output = Result<(), guest_agent::error::AgentError>> + Send + 'static,
+{
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let task = tokio::spawn(future);
+        let status = match task.await {
+            Ok(Ok(())) => guest_agent::cli::HeartbeatStatus::Stopped,
+            Ok(Err(error)) => guest_agent::cli::HeartbeatStatus::Failed(error),
+            Err(error) => guest_agent::cli::HeartbeatStatus::TaskFailed(error.to_string()),
+        };
+        let _ = tx.send(status);
+    });
+    Some(rx)
+}
+
 /// Dummy heartbeat that never completes. The CLI-wait / reap-deadline
 /// branches of `execute_cli`'s select! loop are the intended exit paths
 /// for these tests; a heartbeat failure would go through a different
 /// code path entirely.
-pub fn spawn_dummy_heartbeat() -> tokio::task::JoinHandle<Result<(), guest_agent::error::AgentError>>
-{
-    tokio::spawn(std::future::pending())
+pub fn spawn_dummy_heartbeat() -> guest_agent::cli::HeartbeatMonitor {
+    None
 }

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -6,21 +6,7 @@
 mod common;
 
 use guest_agent::error::AgentError;
-use std::path::PathBuf;
 use std::time::Duration;
-
-async fn wait_for_marker(path: PathBuf) -> Result<(), AgentError> {
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if tokio::fs::metadata(&path).await.is_ok() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .map_err(|_| AgentError::Execution("mock did not ignore SIGTERM".to_string()))
-}
 
 #[tokio::test]
 async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
@@ -34,7 +20,9 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
     let heartbeat = common::spawn_heartbeat_monitor(async move {
-        wait_for_marker(sigterm_ignored_marker).await?;
+        common::wait_for_path(&sigterm_ignored_marker, Duration::from_secs(5))
+            .await
+            .map_err(|_| AgentError::Execution("mock did not ignore SIGTERM".to_string()))?;
         panic!("heartbeat panic for reap test")
     });
 

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -33,7 +33,7 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
-    let heartbeat = tokio::spawn(async move {
+    let heartbeat = common::spawn_heartbeat_monitor(async move {
         wait_for_marker(sigterm_ignored_marker).await?;
         panic!("heartbeat panic for reap test")
     });

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -20,16 +20,9 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
     let heartbeat = common::spawn_heartbeat_monitor(async move {
-        tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                if tokio::fs::metadata(&sigterm_ignored_marker).await.is_ok() {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .map_err(|_| AgentError::Execution("mock did not ignore SIGTERM".to_string()))?;
+        common::wait_for_path(&sigterm_ignored_marker, Duration::from_secs(5))
+            .await
+            .map_err(|_| AgentError::Execution("mock did not ignore SIGTERM".to_string()))?;
 
         Err(AgentError::Execution(
             "heartbeat failed for reap test".to_string(),

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -19,7 +19,7 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
-    let heartbeat = tokio::spawn(async move {
+    let heartbeat = common::spawn_heartbeat_monitor(async move {
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 if tokio::fs::metadata(&sigterm_ignored_marker).await.is_ok() {

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -97,7 +97,7 @@ async fn flush_is_incremental_between_calls() {
 }
 
 #[tokio::test]
-async fn final_flush_uploads_log_emitted_immediately_before_it() {
+async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -120,11 +120,9 @@ async fn final_flush_uploads_log_emitted_immediately_before_it() {
 
     guest_common::log_warn!("sandbox:guest-agent", "{marker}");
     telemetry
-        .flush(guest_agent::telemetry::UploadMode::Final)
+        .final_flush_and_shutdown()
         .await
-        .expect("final flush should upload just-emitted log");
-
-    telemetry.shutdown().await;
+        .expect("final flush and shutdown should upload just-emitted log");
     drop(system_log_guard);
 
     upload_mock.assert_calls_async(1).await;

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -71,10 +71,7 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
 
     let masker = Arc::new(SecretMasker::from_raw(""));
     let telemetry = guest_agent::telemetry::Telemetry::spawn(Arc::clone(&masker), http.clone());
-    telemetry
-        .flush(guest_agent::telemetry::UploadMode::Final)
-        .await?;
-    telemetry.shutdown().await;
+    telemetry.final_flush_and_shutdown().await?;
 
     let shutdown = CancellationToken::new();
     let heartbeat = tokio::spawn(guest_agent::heartbeat::heartbeat_loop(


### PR DESCRIPTION
## Summary
- move final telemetry upload to the top-level shutdown path after heartbeat, metrics, and process-control producers stop
- add a consuming Telemetry::final_flush_and_shutdown API so the EOF-consuming final pass and uploader shutdown are atomic
- keep heartbeat task ownership in run(), while execute_cli observes only a heartbeat status signal for failure handling
- update tests for producer-shutdown ordering, prompt heartbeat abort, no-API shutdown, and heartbeat failure/panic monitors

Fixes #18136

## Tests
- cargo check --manifest-path crates/Cargo.toml -p guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent final_telemetry -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent stop_heartbeat -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration telemetry:: -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test cli_setup_failure --test heartbeat_reap_sigkill --test heartbeat_panic_reap_sigkill -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test no_api_mode -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent complete_execution -- --nocapture
- pre-commit: cargo-doc, cargo-clippy, file checks