### PR TITLE
fix: clarify video template prompt guidance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -108,6 +108,12 @@ describe("buildGenerationTemplatePrompt", () => {
     expect(result.prompt).toContain(
       `zero generate video --provider built-in --template ${item.id}`,
     );
-    expect(result.prompt).toContain("Follow the returned authoring packet.");
+    expect(result.prompt).toContain(
+      "Run once to fetch the locked video authoring packet",
+    );
+    expect(result.prompt).toContain(
+      "read its SKILL.md before final generation",
+    );
+    expect(result.prompt).toContain("without `--template`");
   });
 });

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -151,9 +151,10 @@ function buildVideoGenerationTemplatePrompt(
       `- Template source: ${templateSource}`,
       "",
       "When you produce a video from the user's request:",
-      `- Resolve the selected template source first: ${templateSource}`,
-      `- Run: zero generate video --provider built-in --template ${template.id} --prompt "<user request>"`,
-      "- Follow the returned authoring packet. If a connector/provider is requested, follow connector guidance instead.",
+      `- Run once to fetch the locked video authoring packet: zero generate video --provider built-in --template ${template.id} --prompt "<user request>"`,
+      `- The packet points back to the selected template source (${templateSource}); read its SKILL.md before final generation.`,
+      "- Then run final direct video generation from the resolved prompt and parameters without `--template`.",
+      "- If a connector/provider is requested, follow connector guidance instead.",
       "- If a flag above no longer applies, run `zero generate video -h` to discover the current flags, models, and providers.",
     ].join("\n"),
   };

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/video.test.ts
@@ -217,11 +217,15 @@ describe("zero generate video command", () => {
     expect(stdout).toContain('"videoTemplates": [');
     expect(stdout).toContain('"id": "video-template:epic-grandeur"');
     expect(stdout).toContain("vm0-ai/vm0-skills");
+    expect(stdout).not.toContain("nexu-io/open-design");
+    expect(stdout).not.toContain("skill:presentation-deck-tools");
+    expect(stdout).not.toContain("image-style:");
     expect(stdout).not.toContain("previewVideo");
     expect(stdout).not.toContain(".mp4");
     expect(stdout).toContain(
-      "safe for all audiences, positive and uplifting, no violence, no explicit content",
+      "safe for all audiences, nonviolent, no explicit content",
     );
+    expect(stdout).not.toContain("positive and uplifting");
   });
 
   it("should describe video generation models in help", () => {

--- a/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/video-template-authoring.ts
@@ -34,7 +34,6 @@ interface VideoTemplateAuthoringPacket {
     readonly candidates: ResourceCandidateSlice["candidates"];
     readonly outputSchema: {
       readonly videoTemplate: "string";
-      readonly skills: "string[]";
       readonly rationale: "string";
     };
   };
@@ -60,7 +59,8 @@ const artifactRules = [
   "Resolve the selected video template source before generating the video.",
   "Use the template skill's locked dimensions, prompt construction rules, generation parameters, worked examples, and reference output.",
   "Keep the user's subject and intent; use the selected template only to shape the video's look and generation parameters.",
-  "Always end the final video prompt with: safe for all audiences, positive and uplifting, no violence, no explicit content.",
+  "Write the final prompt in the template's subject -> scene -> motion -> camera -> light -> style order, and explicitly include the template's medium/style locks.",
+  "End the final video prompt with: safe for all audiences, nonviolent, no explicit content.",
   "Do not pass --template again when you run the final video generation command from this packet.",
 ] as const;
 
@@ -69,15 +69,29 @@ export function createVideoTemplateAuthoringPacket(
 ): VideoTemplateAuthoringPacket {
   const baseSlice = selectResourceCandidates();
   const candidateSlice: ResourceCandidateSlice = {
-    ...baseSlice,
+    registryVersion: baseSlice.registryVersion,
+    source: {
+      repo: options.template.source.repo,
+      ref: options.template.source.ref,
+    },
+    sources: [
+      {
+        repo: options.template.source.repo,
+        ref: options.template.source.ref,
+      },
+    ],
     candidates: {
-      ...baseSlice.candidates,
+      skills: [],
+      templates: [],
+      designSystems: [],
+      imageStyles: [],
+      audioStyles: [],
       videoTemplates: [options.template],
+      bundleTemplates: [],
     },
   };
   const selectionSchema = {
     videoTemplate: "string",
-    skills: "string[]",
     rationale: "string",
   } as const;
   const artifact = {
@@ -108,9 +122,9 @@ export function createVideoTemplateAuthoringPacket(
     "## Selected Video Template",
     `- \`${options.template.id}\` - ${options.template.name}`,
     "",
-    "## Stage 1: Supporting Resource Selection",
-    "- The video template is locked. Optionally pick supporting skills/templates from the candidate slice below.",
-    "- Choose only IDs present in this packet; do not invent registry IDs.",
+    "## Stage 1: Locked Template",
+    "- The video template is already selected and locked.",
+    "- Do not pick supporting skills or templates from outside this packet.",
     "- Treat the selection JSON as internal working state, then continue to generation.",
     "",
     "## Selection Output Schema",
@@ -118,7 +132,7 @@ export function createVideoTemplateAuthoringPacket(
     JSON.stringify(selectionSchema, null, 2),
     "```",
     "",
-    "## Candidate Registry Slice",
+    "## Locked Template Source",
     `Registry: \`${candidateSlice.registryVersion}\``,
     "Sources:",
     ...candidateSlice.sources.map(formatCandidateSource),
@@ -130,8 +144,7 @@ export function createVideoTemplateAuthoringPacket(
     "## Stage 2: Resolve Selected Resources",
     "- Fetch or read the selected resource source before generation.",
     "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
-    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
-    "- For directory refs, inspect the most relevant files such as `SKILL.md`, references, examples, and templates.",
+    "- For directory refs, inspect the template `SKILL.md` first; only open examples or references if the SKILL.md points to them.",
     "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
     "",
     "## Stage 3: Generate Video",


### PR DESCRIPTION
## Summary
- clarify sticky video-template guidance so agents fetch the locked authoring packet first, read SKILL.md, then run final generation without `--template`
- shrink video template authoring packets to the locked video template source instead of dumping unrelated registry candidates
- keep the final video prompt aligned to the selected template's subject -> scene -> motion -> camera -> light -> style ordering and medium/style locks
- replace the uplifting safety suffix with neutral safety wording that does not fight melancholic templates

## Verification
- `pnpm exec prettier --write apps/api/src/signals/routes/generation-template-prompt.ts apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts apps/cli/src/commands/zero/shared/video-template-authoring.ts apps/cli/src/commands/zero/generate/__tests__/video.test.ts`
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts apps/cli/src/commands/zero/generate/__tests__/video.test.ts`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec oxlint src/commands/zero/shared/video-template-authoring.ts src/commands/zero/generate/__tests__/video.test.ts`
- `pnpm -F api exec oxlint src/signals/routes/generation-template-prompt.ts src/signals/routes/__tests__/generation-template-prompt.test.ts`
- after removing the extra negative-prompt wording: `pnpm exec prettier --write apps/cli/src/commands/zero/shared/video-template-authoring.ts apps/cli/src/commands/zero/generate/__tests__/video.test.ts` and `pnpm exec vitest run apps/cli/src/commands/zero/generate/__tests__/video.test.ts`

Note: `pnpm -F api check-types` was attempted after generating firewall files, but the local process was killed with exit 137 before producing TypeScript diagnostics.