### PR TITLE
fix: remove legacy google maps firewall host

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_maps_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_maps_0.py
@@ -11,15 +11,6 @@ JSON_PART = r"""{
           "Authorization": "Bearer ${{ secrets.GOOGLE_MAPS_TOKEN }}"
         }
       },
-      "base": "https://maps.googleapis.com",
-      "permissions": []
-    },
-    {
-      "auth": {
-        "headers": {
-          "Authorization": "Bearer ${{ secrets.GOOGLE_MAPS_TOKEN }}"
-        }
-      },
       "base": "https://geocode.googleapis.com",
       "permissions": []
     },

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -3720,7 +3720,6 @@ describe("getConnectorEnvBindingEntries", () => {
         return api.base;
       }),
     ).toStrictEqual([
-      "https://maps.googleapis.com",
       "https://geocode.googleapis.com",
       "https://places.googleapis.com",
       "https://routes.googleapis.com",
@@ -3731,6 +3730,7 @@ describe("getConnectorEnvBindingEntries", () => {
           Authorization: "Bearer ${{ secrets.GOOGLE_MAPS_TOKEN }}",
         },
       });
+      expect(api.permissions).toStrictEqual([]);
     }
   });
 

--- a/turbo/packages/connectors/src/connectors/google-maps.ts
+++ b/turbo/packages/connectors/src/connectors/google-maps.ts
@@ -6,7 +6,7 @@ export const googleMaps = {
     label: "Google Maps",
     category: "data-automation-infrastructure",
     helpText:
-      "Connect Google Maps Platform to access geocoding, places, directions, and other Maps APIs",
+      "Connect Google Maps Platform to access geocoding, places, directions, and route matrices",
     authMethods: {
       oauth: {
         featureFlag: FeatureSwitchKey.GoogleMapsConnector,

--- a/turbo/packages/firewalls-generator/src/google-maps.ts
+++ b/turbo/packages/firewalls-generator/src/google-maps.ts
@@ -14,7 +14,6 @@ const PLACEHOLDER_VALUE =
   "ya29.A0CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCoffeeSa";
 
 const GOOGLE_MAPS_BASE_URLS = [
-  "https://maps.googleapis.com",
   "https://geocode.googleapis.com",
   "https://places.googleapis.com",
   "https://routes.googleapis.com",


### PR DESCRIPTION
## Summary
- remove the legacy `https://maps.googleapis.com` host from the Google Maps OAuth firewall
- keep Google Maps firewall entries host-level with `permissions: []` for geocode, places, and routes
- update connector help text and tests, and regenerate the runner builtin firewall

## Tests
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/firewalls-generator check-types`
- `python3 -m pytest tests/test_builtin_firewalls_catalog.py`
- pre-commit hook: `pnpm check-types`, knip, prettier, ruff, file size checks

Refs #18143