### PR TITLE
fix(web): hide monthly rankings change column

### DIFF
--- a/turbo/apps/web/app/[locale]/rankings/page.tsx
+++ b/turbo/apps/web/app/[locale]/rankings/page.tsx
@@ -380,10 +380,12 @@ function RankingTable({
   rows,
   totalTokens,
   messages,
+  showChange,
 }: {
   rows: RankingRow[];
   totalTokens: number;
   messages: RankingTableMessages;
+  showChange: boolean;
 }) {
   if (rows.length === 0) {
     return (
@@ -417,7 +419,7 @@ function RankingTable({
         <table
           style={{
             width: "100%",
-            minWidth: "640px",
+            minWidth: showChange ? "640px" : "530px",
             borderCollapse: "collapse",
             textAlign: "left",
             tableLayout: "fixed",
@@ -428,7 +430,7 @@ function RankingTable({
             <col />
             <col style={{ width: "180px" }} />
             <col style={{ width: "100px" }} />
-            <col style={{ width: "110px" }} />
+            {showChange ? <col style={{ width: "110px" }} /> : null}
           </colgroup>
           <thead>
             <tr>
@@ -440,9 +442,11 @@ function RankingTable({
               <th style={tableHeadCell({ align: "right" })}>
                 {messages.headerShare}
               </th>
-              <th style={tableHeadCell({ align: "right" })}>
-                {messages.headerChange}
-              </th>
+              {showChange ? (
+                <th style={tableHeadCell({ align: "right" })}>
+                  {messages.headerChange}
+                </th>
+              ) : null}
             </tr>
           </thead>
           <tbody>
@@ -567,18 +571,20 @@ function RankingTable({
                       {formatShare(row.share)}
                     </span>
                   </td>
-                  <td
-                    style={{
-                      ...tableBodyCell({ isLast, align: "right" }),
-                      fontSize: 14,
-                    }}
-                  >
-                    <ChangeBadge
-                      current={row.totalTokens}
-                      previous={row.previousTotalTokens}
-                      changeNewLabel={messages.changeNew}
-                    />
-                  </td>
+                  {showChange ? (
+                    <td
+                      style={{
+                        ...tableBodyCell({ isLast, align: "right" }),
+                        fontSize: 14,
+                      }}
+                    >
+                      <ChangeBadge
+                        current={row.totalTokens}
+                        previous={row.previousTotalTokens}
+                        changeNewLabel={messages.changeNew}
+                      />
+                    </td>
+                  ) : null}
                 </tr>
               );
             })}
@@ -744,6 +750,7 @@ export default async function RankingsPage({
             rows={rankings.rows}
             totalTokens={rankings.totalTokens}
             messages={tableMessages}
+            showChange={activePeriod !== "month"}
           />
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Hide the rankings table `Change` column when the active period is `This month`
- Keep the `Change` column visible for today and week views
- Leave the public model rankings API response unchanged

Fixes #18008

## Tests

- `pnpm format`
- `pnpm -F web lint`
- `pnpm -F web check-types`
- `pnpm -F web test`
- pre-commit: prettier, knip, `pnpm check-types`, commitlint

Note: the first `pnpm -F web check-types` run exposed a local missing generated firewall file; I regenerated ignored connector firewall artifacts via `pnpm install`/postinstall, then reran and passed.