### PR TITLE
fix: recover from computer use completion conflicts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -669,6 +669,17 @@ describe("FILE-03 desktop computer-use runtime", () => {
       kind: "apps.list",
     });
 
+    const queuedComplete = await api.requestCompleteComputerUseCommand(
+      host.hostToken,
+      second.commandId,
+      { status: "succeeded", result: {} },
+      [409],
+    );
+    expectApiError(queuedComplete.body);
+    expect(queuedComplete.body.error.message).toBe(
+      "Computer-use command is not running",
+    );
+
     mockNow(base + 1500);
     const claimedSecond = await api.claimNextComputerUseCommand(host.hostToken);
     expect(claimedSecond.status).toBe("command");
@@ -697,16 +708,21 @@ describe("FILE-03 desktop computer-use runtime", () => {
       error: { code: "app_not_found", message: "Finder is not available" },
     });
 
-    const notRunning = await api.requestCompleteComputerUseCommand(
+    const duplicateComplete = await api.requestCompleteComputerUseCommand(
       host.hostToken,
       second.commandId,
       { status: "succeeded", result: {} },
-      [409],
+      [200],
     );
-    expectApiError(notRunning.body);
-    expect(notRunning.body.error.message).toBe(
-      "Computer-use command is not running",
+    expect(duplicateComplete.body).toStrictEqual({ ok: true });
+    const stillFailed = await api.readComputerUseCommand(
+      actor,
+      second.commandId,
     );
+    expect(stillFailed).toMatchObject({
+      status: "failed",
+      error: { code: "app_not_found", message: "Finder is not available" },
+    });
 
     const unknownComplete = await api.requestCompleteComputerUseCommand(
       host.hostToken,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -106,7 +106,7 @@ const DEFAULT_SUPPORTED_COMPUTER_USE_CAPABILITIES = [
 const DEFAULT_WRITE_COMMAND_BODY = {
   kind: "app.open",
   app: "Safari",
-  timeoutMs: 15_000,
+  timeoutMs: 60_000,
 } as const satisfies ComputerUseWriteCommandBody;
 
 function hostHeaders(hostToken: string): RequiredAuthHeaders {
@@ -468,7 +468,7 @@ export function createComputerUseBddApi(context: TestContext) {
       const response = await accept(
         commandClient().create({
           headers: authenticate(auth),
-          body: { timeoutMs: 15_000, ...body },
+          body: { timeoutMs: 60_000, ...body },
         }),
         [200],
       );
@@ -483,7 +483,7 @@ export function createComputerUseBddApi(context: TestContext) {
       return await accept(
         commandClient().create({
           headers: authenticate(auth),
-          body: { timeoutMs: 15_000, ...body },
+          body: { timeoutMs: 60_000, ...body },
         }),
         statuses,
       );
@@ -496,7 +496,7 @@ export function createComputerUseBddApi(context: TestContext) {
       const response = await accept(
         writeCommandClient().create({
           headers: authenticate(auth),
-          body: { timeoutMs: 15_000, ...body },
+          body: { timeoutMs: 60_000, ...body },
         }),
         [200],
       );
@@ -511,7 +511,7 @@ export function createComputerUseBddApi(context: TestContext) {
       return await accept(
         writeCommandClient().create({
           headers: authenticate(auth),
-          body: { timeoutMs: 15_000, ...body },
+          body: { timeoutMs: 60_000, ...body },
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -136,6 +136,9 @@ type CompleteComputerUseHostCommandResult =
   | { readonly status: "invalid_token" }
   | { readonly status: "not_found" }
   | { readonly status: "not_running" };
+type CompleteComputerUseHostCommandState =
+  | CompleteComputerUseHostCommandResult
+  | { readonly status: "running"; readonly host: ComputerUseHostRow };
 
 function hashSecret(value: string): string {
   return createHash("sha256").update(value).digest("hex");
@@ -1446,6 +1449,52 @@ export const claimNextComputerUseHostCommand$ = command(
   },
 );
 
+async function computerUseHostCommandCompletionState(
+  tx: ComputerUseTx,
+  params: {
+    readonly hostToken: string;
+    readonly commandId: string;
+    readonly now: Date;
+  },
+  signal: AbortSignal,
+): Promise<CompleteComputerUseHostCommandState> {
+  const host = await hostFromToken(tx, params.hostToken, signal);
+  if (!host) {
+    return { status: "invalid_token" };
+  }
+
+  const [commandRow] = await tx
+    .select()
+    .from(computerUseCommands)
+    .where(
+      and(
+        eq(computerUseCommands.id, params.commandId),
+        eq(computerUseCommands.hostId, host.id),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!commandRow) {
+    return { status: "not_found" };
+  }
+  if (commandRow.status === "succeeded" || commandRow.status === "failed") {
+    await tx
+      .update(computerUseHosts)
+      .set({ status: "online", lastSeenAt: params.now, updatedAt: params.now })
+      .where(eq(computerUseHosts.id, host.id));
+    signal.throwIfAborted();
+
+    return { status: "completed" };
+  }
+  if (commandRow.status !== "running") {
+    return { status: "not_running" };
+  }
+
+  return { status: "running", host };
+}
+
 export const completeComputerUseHostCommand$ = command(
   async (
     { get, set },
@@ -1466,6 +1515,22 @@ export const completeComputerUseHostCommand$ = command(
   ): Promise<CompleteComputerUseHostCommandResult> => {
     const db = set(writeDb$);
     const now = nowDate();
+    const commandState = await db.transaction(async (tx) => {
+      return await computerUseHostCommandCompletionState(
+        tx,
+        {
+          hostToken: params.hostToken,
+          commandId: params.commandId,
+          now,
+        },
+        signal,
+      );
+    });
+    signal.throwIfAborted();
+    if (commandState.status !== "running") {
+      return commandState;
+    }
+
     const storedResult =
       params.status === "succeeded"
         ? await get(
@@ -1480,30 +1545,19 @@ export const completeComputerUseHostCommand$ = command(
             ),
           )
         : null;
+    const completedAt = nowDate();
     const result = await db.transaction(async (tx) => {
-      const host = await hostFromToken(tx, params.hostToken, signal);
-      if (!host) {
-        return { status: "invalid_token" as const };
-      }
-
-      const [commandRow] = await tx
-        .select()
-        .from(computerUseCommands)
-        .where(
-          and(
-            eq(computerUseCommands.id, params.commandId),
-            eq(computerUseCommands.hostId, host.id),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      signal.throwIfAborted();
-
-      if (!commandRow) {
-        return { status: "not_found" as const };
-      }
-      if (commandRow.status !== "running") {
-        return { status: "not_running" as const };
+      const currentState = await computerUseHostCommandCompletionState(
+        tx,
+        {
+          hostToken: params.hostToken,
+          commandId: params.commandId,
+          now: completedAt,
+        },
+        signal,
+      );
+      if (currentState.status !== "running") {
+        return currentState;
       }
 
       const commandResult =
@@ -1516,8 +1570,8 @@ export const completeComputerUseHostCommand$ = command(
           status: params.status,
           result: commandResult,
           error: params.status === "failed" ? params.error.code : null,
-          completedAt: now,
-          updatedAt: now,
+          completedAt,
+          updatedAt: completedAt,
         })
         .where(eq(computerUseCommands.id, params.commandId))
         .returning();
@@ -1532,14 +1586,18 @@ export const completeComputerUseHostCommand$ = command(
         event: "completed",
         result: params.status === "succeeded" ? params.result : null,
         error: params.status === "failed" ? params.error : null,
-        createdAt: now,
+        createdAt: completedAt,
       });
       signal.throwIfAborted();
 
       await tx
         .update(computerUseHosts)
-        .set({ status: "online", lastSeenAt: now, updatedAt: now })
-        .where(eq(computerUseHosts.id, host.id));
+        .set({
+          status: "online",
+          lastSeenAt: completedAt,
+          updatedAt: completedAt,
+        })
+        .where(eq(computerUseHosts.id, currentState.host.id));
       signal.throwIfAborted();
 
       return { status: "completed" as const };

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -606,6 +606,57 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
+  it("keeps polling after command completion is already terminal on the server", async () => {
+    vi.useFakeTimers();
+    let nextCalls = 0;
+    let completeCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? jsonResponse({
+              status: "command",
+              command: {
+                id: "cmd-1",
+                kind: "app.state",
+                payload: { app: "Chrome" },
+              },
+            })
+          : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        completeCalls++;
+        return new Response("{}", { status: 409 });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const { runtime } = createRuntime({ hostFetch });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(completeCalls).toBe(1);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+      recovery: null,
+    });
+    expect(runtime.getState().lastCommandAt).toEqual(expect.any(String));
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(nextCalls).toBe(2);
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+    });
+
+    await runtime.stop();
+  });
+
   it("retries hung command completion requests with a request timeout", async () => {
     vi.useFakeTimers();
     let nextCalls = 0;

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -895,6 +895,9 @@ export class ComputerUseHostRuntime {
           this.deactivateInvalidHostToken("command_poll");
           return;
         }
+        if (response.status === 409) {
+          return;
+        }
         lastError = new ComputerUseHttpError(
           `Computer Use command completion failed: ${response.status}`,
           response,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
@@ -2,9 +2,32 @@ import { describe, expect, it } from "vitest";
 import {
   computerUseCommandErrorCodeSchema,
   computerUseHostCommandCompleteBodySchema,
+  zeroComputerUseCommandContract,
+  zeroComputerUseWriteCommandContract,
 } from "../zero-computer-use";
 
 describe("computer-use contract", () => {
+  it("defaults command timeout to 60 seconds and allows up to 120 seconds", () => {
+    expect(
+      zeroComputerUseCommandContract.create.body.parse({
+        kind: "apps.list",
+      }).timeoutMs,
+    ).toBe(60_000);
+    expect(
+      zeroComputerUseWriteCommandContract.create.body.parse({
+        kind: "app.open",
+        app: "Safari",
+        timeoutMs: 120_000,
+      }).timeoutMs,
+    ).toBe(120_000);
+    expect(() => {
+      zeroComputerUseCommandContract.create.body.parse({
+        kind: "apps.list",
+        timeoutMs: 120_001,
+      });
+    }).toThrow();
+  });
+
   it.each([
     "app_not_found",
     "app_open_failed",

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -81,7 +81,7 @@ const computerUseRuntimeBodySchema = z.object({
 });
 
 const computerUseCommandTargetShape = {
-  timeoutMs: z.number().int().min(1_000).max(60_000).default(15_000),
+  timeoutMs: z.number().int().min(1_000).max(120_000).default(60_000),
 } as const;
 
 const computerUseCommandPayloadShape = {


### PR DESCRIPTION
## Summary

- raise Computer Use command timeout defaults to 60s and allow commands up to 120s
- make host command completion idempotent for already-terminal commands without overwriting existing results
- keep the Desktop runtime online when command completion returns 409 from an older or conflicting server state

Fixes #18145

## Tests

- `pnpm format`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F api exec vitest src/signals/routes/__tests__/computer-use.bdd.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
