### PR TITLE
fix: center scroll to bottom button

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3232,7 +3232,7 @@ function ScrollToBottomButton({
       onClick={() => {
         scrollToBottom();
       }}
-      className="absolute bottom-4 right-[calc(var(--github-pr-tracking-content-inset,0px)_+_1rem)] z-20 flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-md transition-colors hover:bg-accent hover:text-foreground"
+      className="absolute bottom-4 left-[calc((100%-var(--github-pr-tracking-content-inset,0px))/2)] z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-md transition-colors hover:bg-accent hover:text-foreground"
     >
       <IconArrowDown size={18} />
     </button>


### PR DESCRIPTION
Summary:
- Move the floating Scroll to bottom button from the chat area's lower-right edge to the horizontal center of the visible chat area.
- Keep the existing bottom offset and account for the GitHub PR tracking dock inset when it is open.

Testing:
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
- pnpm exec oxlint src/views/zero-page/zero-chat-thread-page.tsx
- pnpm exec eslint src/views/zero-page/zero-chat-thread-page.tsx --max-warnings 0
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "keeps chat scroll controls visible while browsing older messages"