### PR TITLE
refactor(vsock-host): classify read_file structured exec results

### DIFF
--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -26,9 +26,9 @@ pub(crate) use start::{
     exec_capture_with_composite_on_shared_and_observer,
     exec_cleanup_untracked_on_shared_with_write_observer,
     exec_cleanup_with_composite_on_shared_and_observer, exec_on_shared,
-    exec_operation_capture_on_shared, exec_operation_stream_on_shared,
-    exec_operation_stream_with_composite_on_shared_and_observer, start_exec_operation_on_shared,
-    start_supervised_exec_on_shared,
+    exec_operation_capture_on_shared, exec_operation_capture_on_shared_with_write_observer,
+    exec_operation_stream_on_shared, exec_operation_stream_with_composite_on_shared_and_observer,
+    start_exec_operation_on_shared, start_supervised_exec_on_shared,
 };
 pub(crate) use state::Operations;
 

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -53,7 +53,7 @@ pub(crate) fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
     stderr.extend_from_slice(diagnostic.as_bytes());
 }
 
-fn result_to_exec_result(result: ExecOperationResult) -> io::Result<ExecResult> {
+fn operation_result_to_legacy_exec_result(result: ExecOperationResult) -> io::Result<ExecResult> {
     if result.stream_overflowed {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -387,6 +387,20 @@ pub(crate) async fn exec_operation_capture_on_shared(
     handle.wait(request.wait_timeout).await
 }
 
+pub(crate) async fn exec_operation_capture_on_shared_with_write_observer(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    write_observer: FrameWriteObserver,
+) -> io::Result<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking(
+        shared,
+        request,
+        ExecOperationTracking::Tracked,
+        write_observer,
+    )
+    .await
+}
+
 async fn exec_operation_capture_on_shared_with_tracking(
     shared: &Arc<Shared>,
     request: ExecCaptureRequest<'_>,
@@ -531,7 +545,7 @@ pub(crate) async fn exec_cleanup_untracked_on_shared_with_write_observer(
         write_observer,
     )
     .await?;
-    result_to_exec_result(result)
+    operation_result_to_legacy_exec_result(result)
 }
 
 pub(crate) async fn exec_cleanup_with_composite_on_shared_and_observer(
@@ -561,7 +575,7 @@ pub(crate) async fn exec_cleanup_with_composite_on_shared_and_observer(
         write_observer,
     )
     .await?;
-    result_to_exec_result(result)
+    operation_result_to_legacy_exec_result(result)
 }
 
 pub(crate) async fn exec_capture_with_composite_on_shared_and_observer(
@@ -577,7 +591,7 @@ pub(crate) async fn exec_capture_with_composite_on_shared_and_observer(
         write_observer,
     )
     .await?;
-    result_to_exec_result(result)
+    operation_result_to_legacy_exec_result(result)
 }
 
 pub(crate) async fn exec_capture_on_shared(
@@ -598,12 +612,8 @@ pub(crate) async fn exec_capture_on_shared_with_write_observer(
             "exec requires a positive timeout; use supervised exec for unbounded commands",
         ));
     }
-    let result = exec_operation_capture_on_shared_with_tracking(
-        shared,
-        request,
-        ExecOperationTracking::Tracked,
-        write_observer,
-    )
-    .await?;
-    result_to_exec_result(result)
+    let result =
+        exec_operation_capture_on_shared_with_write_observer(shared, request, write_observer)
+            .await?;
+    operation_result_to_legacy_exec_result(result)
 }

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -1,21 +1,76 @@
 use std::io;
 use std::time::Duration;
 
-use crate::{ExecCaptureRequest, ExecResult, FrameWriteObserver, VsockHost, exec_operation};
+use vsock_proto::ExecTermination;
+
+use crate::{
+    ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput, FrameWriteObserver,
+    VsockHost, exec_operation,
+};
 
 use super::{
     MISSING_FILE_EXIT_CODE, normalize_file_exec_stderr, read_regular_file_command,
     validate_guest_file_path,
 };
 
+fn read_exec_output(
+    path: &str,
+    name: &str,
+    output: ExecOwnedCapturedOutput,
+) -> io::Result<(Vec<u8>, bool)> {
+    match output {
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
+        ExecOwnedCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("read_file result for {path} discarded {name} capture"),
+        )),
+    }
+}
+
+fn read_terminal_error_message(prefix: String, stderr: &[u8], diagnostic: &str) -> String {
+    let mut details = Vec::new();
+    if !stderr.is_empty() {
+        details.push(format!("stderr: {}", String::from_utf8_lossy(stderr)));
+    }
+    if !diagnostic.is_empty() {
+        details.push(format!("diagnostic: {diagnostic}"));
+    }
+    if details.is_empty() {
+        prefix
+    } else {
+        format!("{prefix}: {}", details.join("; "))
+    }
+}
+
 fn validate_read_exec_result(
     path: &str,
     max_bytes: u64,
-    result: ExecResult,
+    result: ExecOperationResult,
 ) -> io::Result<Option<Vec<u8>>> {
-    if result.exit_code == MISSING_FILE_EXIT_CODE {
-        if result.stdout_truncated || !result.stdout.is_empty() {
-            let stdout_detail = if result.stdout_truncated {
+    if result.stream_overflowed {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "read_file exec operation unexpectedly overflowed a stream queue",
+        ));
+    }
+
+    let ExecOperationResult {
+        termination,
+        stdout,
+        stderr,
+        diagnostic,
+        ..
+    } = result;
+    let (stdout, stdout_truncated) = read_exec_output(path, "stdout", stdout)?;
+    let (stderr, stderr_truncated) = read_exec_output(path, "stderr", stderr)?;
+
+    if termination
+        == (ExecTermination::Exited {
+            exit_code: MISSING_FILE_EXIT_CODE,
+        })
+    {
+        if stdout_truncated || !stdout.is_empty() {
+            let stdout_detail = if stdout_truncated {
                 "stdout truncated"
             } else {
                 "stdout"
@@ -25,7 +80,7 @@ fn validate_read_exec_result(
                 format!("read_file missing result for {path} included {stdout_detail}"),
             ));
         }
-        let stderr = normalize_file_exec_stderr(result.stderr, result.stderr_truncated);
+        let stderr = normalize_file_exec_stderr(stderr, stderr_truncated);
         if !stderr.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -37,29 +92,54 @@ fn validate_read_exec_result(
         }
         return Ok(None);
     }
-    if result.exit_code != 0 {
-        let stderr = normalize_file_exec_stderr(result.stderr, result.stderr_truncated);
-        return Err(io::Error::other(format!(
+
+    let stderr = normalize_file_exec_stderr(stderr, stderr_truncated);
+    match termination {
+        ExecTermination::Exited { exit_code: 0 } => {
+            if stdout_truncated {
+                return Err(io::Error::other(format!(
+                    "file {path} exceeded {max_bytes} bytes"
+                )));
+            }
+            if !stderr.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "read_file result for {path} included stderr: {}",
+                        String::from_utf8_lossy(&stderr)
+                    ),
+                ));
+            }
+            Ok(Some(stdout))
+        }
+        ExecTermination::Exited { exit_code: _ } => Err(io::Error::other(format!(
             "failed to read file {path}: {}",
             String::from_utf8_lossy(&stderr)
-        )));
-    }
-    if result.stdout_truncated {
-        return Err(io::Error::other(format!(
-            "file {path} exceeded {max_bytes} bytes"
-        )));
-    }
-    let stderr = normalize_file_exec_stderr(result.stderr, result.stderr_truncated);
-    if !stderr.is_empty() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "read_file result for {path} included stderr: {}",
-                String::from_utf8_lossy(&stderr)
+        ))),
+        ExecTermination::TimedOut => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            read_terminal_error_message(
+                format!("read_file timed out for {path}"),
+                &stderr,
+                &diagnostic,
             ),
-        ));
+        )),
+        ExecTermination::Cancelled => Err(io::Error::other(read_terminal_error_message(
+            format!("read_file was cancelled for {path}"),
+            &stderr,
+            &diagnostic,
+        ))),
+        ExecTermination::StartFailed => Err(io::Error::other(read_terminal_error_message(
+            format!("read_file exec start failed for {path}"),
+            &stderr,
+            &diagnostic,
+        ))),
+        ExecTermination::WaitFailed => Err(io::Error::other(read_terminal_error_message(
+            format!("read_file exec wait failed for {path}"),
+            &stderr,
+            &diagnostic,
+        ))),
     }
-    Ok(Some(result.stdout))
 }
 
 impl VsockHost {
@@ -111,23 +191,23 @@ impl VsockHost {
         }
 
         let command = read_regular_file_command(path, MISSING_FILE_EXIT_CODE);
-        let result = self
-            .exec_capture_with_write_observer(
-                ExecCaptureRequest {
-                    timeout_ms,
-                    command: &command,
-                    env: &[],
-                    sudo: false,
-                    label: "read-file",
-                    stdout_limit_bytes,
-                    stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
-                    expected_exit_codes: &[MISSING_FILE_EXIT_CODE],
-                    stdin_bytes: None,
-                    wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
-                },
-                write_observer,
-            )
-            .await?;
+        let result = exec_operation::exec_operation_capture_on_shared_with_write_observer(
+            &self.shared,
+            ExecCaptureRequest {
+                timeout_ms,
+                command: &command,
+                env: &[],
+                sudo: false,
+                label: "read-file",
+                stdout_limit_bytes,
+                stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+                expected_exit_codes: &[MISSING_FILE_EXIT_CODE],
+                stdin_bytes: None,
+                wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
+            },
+            write_observer,
+        )
+        .await?;
         validate_read_exec_result(path, max_bytes, result)
     }
 }

--- a/crates/vsock-host/src/file/read.rs
+++ b/crates/vsock-host/src/file/read.rs
@@ -64,37 +64,33 @@ fn validate_read_exec_result(
     let (stdout, stdout_truncated) = read_exec_output(path, "stdout", stdout)?;
     let (stderr, stderr_truncated) = read_exec_output(path, "stderr", stderr)?;
 
-    if termination
-        == (ExecTermination::Exited {
-            exit_code: MISSING_FILE_EXIT_CODE,
-        })
-    {
-        if stdout_truncated || !stdout.is_empty() {
-            let stdout_detail = if stdout_truncated {
-                "stdout truncated"
-            } else {
-                "stdout"
-            };
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("read_file missing result for {path} included {stdout_detail}"),
-            ));
-        }
-        let stderr = normalize_file_exec_stderr(stderr, stderr_truncated);
-        if !stderr.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "read_file missing result for {path} included stderr: {}",
-                    String::from_utf8_lossy(&stderr)
-                ),
-            ));
-        }
-        return Ok(None);
-    }
-
     let stderr = normalize_file_exec_stderr(stderr, stderr_truncated);
     match termination {
+        ExecTermination::Exited {
+            exit_code: MISSING_FILE_EXIT_CODE,
+        } => {
+            if stdout_truncated || !stdout.is_empty() {
+                let stdout_detail = if stdout_truncated {
+                    "stdout truncated"
+                } else {
+                    "stdout"
+                };
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("read_file missing result for {path} included {stdout_detail}"),
+                ));
+            }
+            if !stderr.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "read_file missing result for {path} included stderr: {}",
+                        String::from_utf8_lossy(&stderr)
+                    ),
+                ));
+            }
+            Ok(None)
+        }
         ExecTermination::Exited { exit_code: 0 } => {
             if stdout_truncated {
                 return Err(io::Error::other(format!(
@@ -147,6 +143,7 @@ impl VsockHost {
     ///
     /// The guest path must be non-empty and must not contain NUL bytes.
     /// `max_bytes` must be positive and fit within the exec capture limit.
+    /// `timeout_ms` must be positive.
     ///
     /// Missing files return `Ok(None)`. Files larger than `max_bytes` return
     /// an error instead of silently returning truncated bytes.

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -9,6 +9,35 @@ use super::super::support::{
 };
 use super::support::expect_exec_start;
 
+async fn read_file_terminal_error(
+    termination: ExecTermination,
+    stderr: &'static [u8],
+    diagnostic: &'static str,
+) -> io::Error {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let read_task =
+        tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await });
+
+    let start = expect_exec_start(&mut guest).await;
+    let payload = vsock_proto::encode_exec_result(
+        termination,
+        12,
+        ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        ExecCapturedOutput::Captured {
+            bytes: stderr,
+            truncated: false,
+        },
+        diagnostic,
+    )
+    .unwrap();
+    send_raw_exec_result(&mut guest, start.seq(), payload).await;
+
+    read_task.await.unwrap().unwrap_err()
+}
+
 #[tokio::test]
 async fn read_file_returns_content_and_missing() {
     let (host, mut guest) = setup_host_and_guest().await;
@@ -254,6 +283,51 @@ async fn read_file_preserves_truncated_stderr_on_nonzero_exit() {
     let err = read_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Other);
     assert!(err.to_string().contains("stderr truncated"));
+}
+
+#[tokio::test]
+async fn read_file_reports_terminal_timeout_as_timed_out() {
+    let err = read_file_terminal_error(
+        ExecTermination::TimedOut,
+        b"helper timed out",
+        "guest reported timeout",
+    )
+    .await;
+
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    let message = err.to_string();
+    assert!(message.contains("read_file timed out for /tmp/session.txt"));
+    assert!(message.contains("helper timed out"));
+    assert!(message.contains("guest reported timeout"));
+}
+
+#[tokio::test]
+async fn read_file_reports_non_exit_terminal_states() {
+    for (termination, expected, diagnostic) in [
+        (
+            ExecTermination::Cancelled,
+            "read_file was cancelled for /tmp/session.txt",
+            "cancelled by guest",
+        ),
+        (
+            ExecTermination::StartFailed,
+            "read_file exec start failed for /tmp/session.txt",
+            "spawn failed",
+        ),
+        (
+            ExecTermination::WaitFailed,
+            "read_file exec wait failed for /tmp/session.txt",
+            "wait failed",
+        ),
+    ] {
+        let err = read_file_terminal_error(termination, b"helper stderr", diagnostic).await;
+
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        let message = err.to_string();
+        assert!(message.contains(expected));
+        assert!(message.contains("helper stderr"));
+        assert!(message.contains(diagnostic));
+    }
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -331,7 +331,7 @@ async fn read_file_reports_non_exit_terminal_states() {
 }
 
 #[tokio::test]
-async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
+async fn read_file_rejects_invalid_inputs_without_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -15,8 +15,11 @@ async fn read_file_terminal_error(
     diagnostic: &'static str,
 ) -> io::Error {
     let (host, mut guest) = setup_host_and_guest().await;
-    let read_task =
-        tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await });
+    let host = Arc::new(host);
+    let read_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.read_file("/tmp/session.txt", 1024, 5000).await })
+    };
 
     let start = expect_exec_start(&mut guest).await;
     let payload = vsock_proto::encode_exec_result(
@@ -35,7 +38,9 @@ async fn read_file_terminal_error(
     .unwrap();
     send_raw_exec_result(&mut guest, start.seq(), payload).await;
 
-    read_task.await.unwrap().unwrap_err()
+    let err = read_task.await.unwrap().unwrap_err();
+    assert_eq!(operation_count(&host), 0);
+    err
 }
 
 #[tokio::test]
@@ -122,6 +127,7 @@ async fn read_file_dispatches_concurrent_results_by_seq() {
     let second_content = second_task.await.unwrap().unwrap();
     assert_eq!(first_content.as_deref(), Some(&b"first\n"[..]));
     assert_eq!(second_content.as_deref(), Some(&b"second\n"[..]));
+    assert_eq!(operation_count(&host), 0);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -360,6 +360,14 @@ async fn read_file_rejects_invalid_max_bytes_without_sending_frame() {
 
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(operation_count(&host), 0);
+
+    let err = host
+        .read_file("/tmp/timeout.txt", 1024, 0)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(operation_count(&host), 0);
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 

--- a/crates/vsock-host/src/tests/file/read.rs
+++ b/crates/vsock-host/src/tests/file/read.rs
@@ -85,6 +85,46 @@ async fn read_file_returns_content_and_missing() {
 }
 
 #[tokio::test]
+async fn read_file_dispatches_concurrent_results_by_seq() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+
+    let first_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.read_file("/tmp/first.txt", 1024, 5000).await })
+    };
+    let first = expect_exec_start(&mut guest).await;
+
+    let second_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.read_file("/tmp/second.txt", 1024, 5000).await })
+    };
+    let second = expect_exec_start(&mut guest).await;
+
+    send_exec_result(
+        &mut guest,
+        second.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        b"second\n",
+        b"",
+    )
+    .await;
+    send_exec_result(
+        &mut guest,
+        first.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        b"first\n",
+        b"",
+    )
+    .await;
+
+    let first_content = first_task.await.unwrap().unwrap();
+    let second_content = second_task.await.unwrap().unwrap();
+    assert_eq!(first_content.as_deref(), Some(&b"first\n"[..]));
+    assert_eq!(second_content.as_deref(), Some(&b"second\n"[..]));
+}
+
+#[tokio::test]
 async fn read_file_errors_on_truncated_stdout() {
     let (host, mut guest) = setup_host_and_guest().await;
     let read_task = tokio::spawn(async move { host.read_file("/tmp/large.txt", 5, 5000).await });


### PR DESCRIPTION
## Summary
- add a crate-private structured capture helper with write-observer support
- route legacy `ExecResult` capture wrappers through an explicitly named legacy conversion boundary
- migrate `read_file` to classify `ExecOperationResult` directly, preserving success/missing/truncation behavior while distinguishing timeout, cancellation, start failure, and wait failure
- add read_file integration coverage for non-exit terminal states

## Notes
- public `VsockHost::exec` / `exec_capture` signatures remain unchanged
- legacy `exec_capture_*` zero-timeout behavior is preserved; `read_file` now reaches the existing structured exec-operation validation directly, with `InvalidInput` preserved at the error-kind level

Closes #18162

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host read_file_`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path crates/vsock-host/Cargo.toml --check`
- pre-commit lefthook: cargo-fmt, cargo-clippy, cargo-doc
