### PR TITLE
refactor(vsock-host): deduplicate terminal result logging

### DIFF
--- a/crates/vsock-host/src/exec_operation/diagnostics.rs
+++ b/crates/vsock-host/src/exec_operation/diagnostics.rs
@@ -131,37 +131,28 @@ impl ExecOperationDiagnostic {
             return;
         };
 
+        macro_rules! emit_terminal_result_log {
+            ($level:expr) => {
+                tracing::event!(
+                    $level,
+                    seq = self.seq,
+                    label = %self.label_log,
+                    elapsed_ms,
+                    guest_duration_ms = result.duration_ms,
+                    termination = ?result.termination,
+                    stream_overflowed,
+                    stdout_truncated,
+                    stderr_truncated,
+                    diagnostic_present,
+                    host_cancel_requested,
+                    "exec operation terminal result"
+                )
+            };
+        }
+
         match severity {
-            ExecTerminalLogSeverity::Info => {
-                tracing::info!(
-                    seq = self.seq,
-                    label = %self.label_log,
-                    elapsed_ms,
-                    guest_duration_ms = result.duration_ms,
-                    termination = ?result.termination,
-                    stream_overflowed,
-                    stdout_truncated,
-                    stderr_truncated,
-                    diagnostic_present,
-                    host_cancel_requested,
-                    "exec operation terminal result"
-                );
-            }
-            ExecTerminalLogSeverity::Warn => {
-                tracing::warn!(
-                    seq = self.seq,
-                    label = %self.label_log,
-                    elapsed_ms,
-                    guest_duration_ms = result.duration_ms,
-                    termination = ?result.termination,
-                    stream_overflowed,
-                    stdout_truncated,
-                    stderr_truncated,
-                    diagnostic_present,
-                    host_cancel_requested,
-                    "exec operation terminal result"
-                );
-            }
+            ExecTerminalLogSeverity::Info => emit_terminal_result_log!(tracing::Level::INFO),
+            ExecTerminalLogSeverity::Warn => emit_terminal_result_log!(tracing::Level::WARN),
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace duplicated `tracing::info!` / `tracing::warn!` terminal result field lists with one local `tracing::event!` emission macro.
- Keep the existing terminal severity policy, structured field names, and message text unchanged.

Closes #18159.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation_diagnostic_logs_terminal_result_at_classified_level`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation_diagnostic_preserves_terminal_log_fields`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host dispatch_result_logs_terminal_result_with_operation_lifecycle`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --tests -- -D warnings`

Note: `cargo fmt --manifest-path crates/Cargo.toml --check` was not usable on the virtual workspace manifest (`Failed to find targets`), so the workspace form with `--all --check` was used.
