### PR TITLE
fix: constrain illustration thumbnail scrolling

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1761,12 +1761,38 @@ describe("chat composer templates", () => {
     });
   });
 
-  it("navigates illustration variants by clicking the hero image halves and keeps the selected thumbnail in view", async () => {
+  it("scrolls illustration thumbnails only after clicking a variant thumbnail", async () => {
     const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
     const scrollIntoView = vi.fn();
+    const scrollTo = vi.fn();
+    const rect = ({
+      left,
+      right,
+    }: {
+      left: number;
+      right: number;
+    }): DOMRect => {
+      return {
+        x: left,
+        y: 0,
+        top: 0,
+        left,
+        right,
+        bottom: 48,
+        width: right - left,
+        height: 48,
+        toJSON: () => {
+          return {};
+        },
+      };
+    };
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
       value: scrollIntoView,
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
     });
     Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
       configurable: true,
@@ -1819,26 +1845,78 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
     });
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollTo).not.toHaveBeenCalled();
 
-    // Clicking the right half advances to the next variant.
-    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 150 });
+    const card = screen.getByAltText(heroAlt).closest<HTMLElement>("div.group");
+    if (!card) {
+      throw new Error("Illustration card not found");
+    }
+
+    // Clicking a thumbnail scrolls within the thumbnail strip only.
+    const variant2Thumbnail = within(card).getByLabelText("Show variant 2");
+    const thumbnailStrip = variant2Thumbnail.parentElement;
+    if (!thumbnailStrip) {
+      throw new Error("Illustration thumbnail strip not found");
+    }
+    Object.defineProperty(thumbnailStrip, "scrollLeft", {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+    Object.defineProperty(thumbnailStrip, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 0, right: 96 });
+      },
+    });
+    Object.defineProperty(variant2Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 72, right: 120 });
+      },
+    });
+    click(variant2Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
     });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 24 });
+    expect(scrollIntoView).not.toHaveBeenCalled();
 
-    // Switching the variant scrolls the now-selected thumbnail fully into view.
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      block: "nearest",
-      inline: "nearest",
+    // Clicking a left-clipped thumbnail nudges the strip back just enough.
+    scrollTo.mockClear();
+    const variant1Thumbnail = within(card).getByLabelText("Show variant 1");
+    Object.defineProperty(thumbnailStrip, "scrollLeft", {
+      configurable: true,
+      value: 64,
+      writable: true,
     });
-
-    // Clicking the left half goes back to the previous variant.
-    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 10 });
+    Object.defineProperty(variant1Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: -16, right: 32 });
+      },
+    });
+    click(variant1Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
     });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 48 });
+    expect(scrollIntoView).not.toHaveBeenCalled();
 
-    // Clicking the left half from the first variant wraps to the last one.
+    // Switching away and back to Illustration remounts the active thumbnail but
+    // must not scroll the dialog.
+    scrollTo.mockClear();
+    scrollIntoView.mockClear();
+    click(tabByText("Presentation"));
+    click(tabByText("Illustration"));
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Clicking the hero halves changes variants without scrolling thumbnails.
     fireEvent.click(screen.getByAltText(heroAlt), { clientX: 10 });
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute(
@@ -1846,6 +1924,16 @@ describe("chat composer templates", () => {
         heroSrc(lastIndex),
       );
     });
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Clicking the right half from the last variant wraps to the first one.
+    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 190 });
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
   it("keeps historical illustration labels behind the template picker feature switch", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2719,7 +2719,34 @@ function preloadIllustrationVariant(
 function scrollIllustrationThumbnailIntoView(
   node: HTMLButtonElement | null,
 ): void {
-  node?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  if (node === null) {
+    return;
+  }
+
+  const thumbnailStrip = node.closest<HTMLElement>(
+    "[data-illustration-variant-strip]",
+  );
+  if (thumbnailStrip === null) {
+    return;
+  }
+
+  const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
+  const thumbnailRect = node.getBoundingClientRect();
+
+  const leftOverflow = thumbnailStripRect.left - thumbnailRect.left;
+  if (leftOverflow > 0) {
+    thumbnailStrip.scrollTo({
+      left: Math.max(0, thumbnailStrip.scrollLeft - leftOverflow),
+    });
+    return;
+  }
+
+  const rightOverflow = thumbnailRect.right - thumbnailStripRect.right;
+  if (rightOverflow > 0) {
+    thumbnailStrip.scrollTo({
+      left: Math.max(0, thumbnailStrip.scrollLeft + rightOverflow),
+    });
+  }
 }
 
 function IllustrationTemplateCard({
@@ -2758,7 +2785,10 @@ function IllustrationTemplateCard({
         onVariantChange={onVariantChange}
       />
       {hasMultipleVariants && (
-        <div className="flex items-center gap-2 overflow-x-auto px-3 pt-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div
+          data-illustration-variant-strip=""
+          className="flex items-center gap-2 overflow-x-auto px-3 pt-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
           {images.map((image, index) => {
             const active = index === safeIndex;
             const thumbnailImage = r2ImageTransformUrl(
@@ -2769,10 +2799,6 @@ function IllustrationTemplateCard({
               <button
                 key={image}
                 type="button"
-                // Keep the selected thumbnail fully in view when the active
-                // variant changes (e.g. via hero navigation), so later
-                // thumbnails past the clipped strip edge stay reachable.
-                ref={active ? scrollIllustrationThumbnailIntoView : undefined}
                 aria-label={`Show variant ${index + 1}`}
                 aria-pressed={active}
                 className={cn(
@@ -2798,6 +2824,9 @@ function IllustrationTemplateCard({
                     item,
                     onVariantChange,
                   });
+                  if (!active) {
+                    scrollIllustrationThumbnailIntoView(event.currentTarget);
+                  }
                 }}
               >
                 <img


### PR DESCRIPTION
## Summary\n- remove the active-thumbnail callback ref that triggered scrolling on mount\n- scroll only the variant thumbnail strip, not the outer dialog/page\n- keep thumbnail scrolling click-only while preserving hero half-click variant navigation\n\n## Checks\n- pnpm vitest --run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "scrolls illustration thumbnails only after clicking a variant thumbnail"\n- pnpm vitest --run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "chat composer templates"\n- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx\n- pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --max-warnings 0\n- pnpm -F @vm0/app check-types