### PR TITLE
fix: respect requested presentation slide counts

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -64,9 +64,46 @@ describe("zero generate presentation command", () => {
     );
     expect(stdout).toContain("Slide count: 10");
     expect(stdout).toContain("Use a fixed 1920x1080 slide canvas");
+    expect(stdout).toContain("Produce exactly the requested slide count");
+    expect(stdout).toContain("make an internal slide plan");
+    expect(stdout).toContain("Adapt the selected template");
+    expect(stdout).toContain(
+      "Do not add decorative, duplicate, or empty filler slides",
+    );
     expect(stdout).toContain("establish the deck's arc");
     expect(stdout).toContain("Vary slide forms across the deck");
     expect(stdout).toContain("Each slide carries one idea");
+  });
+
+  it("should reject slide counts outside the supported range", async () => {
+    const mockStderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => {
+        return true;
+      }) as never);
+
+    try {
+      await expect(async () => {
+        await generateCommand.parseAsync([
+          "node",
+          "cli",
+          "presentation",
+          "--prompt",
+          "launch plan",
+          "--slides",
+          "3",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      const stderr = mockStderrWrite.mock.calls
+        .map(([chunk]) => {
+          return String(chunk);
+        })
+        .join("");
+      expect(stderr).toContain("slides must be between 4 and 20");
+    } finally {
+      mockStderrWrite.mockRestore();
+    }
   });
 
   it("should expose only base artifact flags plus slides in help", () => {

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -37,6 +37,9 @@ function parseSlideCount(value: string): number {
   if (!Number.isInteger(slideCount)) {
     throw new InvalidArgumentError("slides must be an integer");
   }
+  if (slideCount < 4 || slideCount > 20) {
+    throw new InvalidArgumentError("slides must be between 4 and 20");
+  }
   return slideCount;
 }
 
@@ -184,6 +187,9 @@ ${formatRegistryListing(templates, "presentation templates")}`;
             "Use one section per slide and keep repeated elements in consistent positions.",
             "Make keyboard navigation work with ArrowLeft, ArrowRight, Home, and End.",
             "Keep slide text readable from across a room; avoid memo-like walls of text.",
+            "Produce exactly the requested slide count. Do not let a template's reference example or preview slide count override the requested count.",
+            "Before authoring, make an internal slide plan with exactly the requested count and map each slide to a narrative role plus a selected template layout or device.",
+            "Adapt the selected template to the requested slide count: for shorter decks, merge or omit lower-priority content roles; for longer decks, split dense sections into multiple focused slides or reuse layout patterns with different substantive content. Do not add decorative, duplicate, or empty filler slides.",
             "Before laying out slides, establish the deck's arc: the opening problem or question, how it develops, and what conclusion lands; every slide should serve a clear narrative role in that arc.",
             "Vary slide forms across the deck — full-bleed statement, evidence with data, pull quote, section break, summary — and avoid defaulting every slide to title-plus-bullets.",
             "Each slide carries one idea; prefer a single strong statement over a list, and never exceed three bullets on any slide.",


### PR DESCRIPTION
## Summary
- enforce the documented 4-20 slide range for `zero generate presentation --slides`
- instruct presentation authoring to produce exactly the requested slide count
- clarify that selected templates should be adapted to the requested count without decorative, duplicate, or empty filler slides

## Validation
- `pnpm prettier --check apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts apps/cli/src/commands/zero/shared/presentation-generate.ts`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm exec vitest run apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts`