### PR TITLE
test(mitm-addon): assert usage counters through pending snapshots

### DIFF
--- a/crates/runner/mitm-addon/tests/pending_helpers.py
+++ b/crates/runner/mitm-addon/tests/pending_helpers.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 
+import usage
+
 
 def _pending_state(path: Path) -> dict:
     return json.loads(path.read_text())
@@ -50,3 +52,22 @@ def assert_pending(
     if flush_request_id is not None:
         assert state["flushRequestId"] == flush_request_id
     return state
+
+
+def assert_current_pending(
+    path: Path,
+    *,
+    flows: int,
+    buffered: int,
+    reports: int,
+    flush_request_id: str | None = None,
+) -> dict:
+    """Write and assert the current runner-facing pending-state snapshot."""
+    usage.write_pending_snapshot(flush_request_id=flush_request_id)
+    return assert_pending(
+        path,
+        flows=flows,
+        buffered=buffered,
+        reports=reports,
+        flush_request_id=flush_request_id,
+    )

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -327,7 +327,7 @@ class TestUsagePendingCounter:
             pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
         )
 
-    def test_no_op_when_path_not_set(self):
+    def test_no_op_when_path_not_set(self, tmp_path):
         usage.set_pending_path("")
         usage.increment_in_flight_flows()
         usage.decrement_in_flight_flows()
@@ -335,7 +335,9 @@ class TestUsagePendingCounter:
         usage.counters.decrement_pending_reports()
         usage.write_pending_snapshot(flush_request_id="request-1")
         # Should not raise — just no file written.
-        assert usage.read_usage_flush_request_id() is None
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+        assert_pending(pending_path, flows=0, buffered=0, reports=0)
 
     # ---- one-shot error signal on write failure (issue #10483) ----
 

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -7,7 +7,7 @@ import pytest
 
 import usage
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
-from tests.pending_helpers import assert_pending
+from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 
 
@@ -71,33 +71,35 @@ class TestUsagePendingCounter:
 
         usage.increment_in_flight_flows()
         usage.increment_in_flight_flows()
-        assert usage.counters._in_flight_flows == 2
         assert_pending(pending_path, flows=0, buffered=0, reports=0)
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=2, buffered=0, reports=0, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=2, buffered=0, reports=0, flush_request_id="request-1"
+        )
 
         usage.decrement_in_flight_flows()
-        assert usage.counters._in_flight_flows == 1
         assert_pending(pending_path, flows=2, buffered=0, reports=0, flush_request_id="request-1")
-        usage.write_pending_snapshot(flush_request_id="request-2")
-        assert_pending(pending_path, flows=1, buffered=0, reports=0, flush_request_id="request-2")
+        assert_current_pending(
+            pending_path, flows=1, buffered=0, reports=0, flush_request_id="request-2"
+        )
 
         usage.decrement_in_flight_flows()
-        usage.write_pending_snapshot(flush_request_id="request-3")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-3")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-3"
+        )
 
     def test_increment_decrement_pending_reports(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         usage.counters.increment_pending_reports()
-        assert usage.counters._pending_reports == 1
         assert_pending(pending_path, flows=0, buffered=0, reports=0)
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=0, reports=1, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=1, flush_request_id="request-1"
+        )
 
         usage.counters.decrement_pending_reports()
-        usage.write_pending_snapshot(flush_request_id="request-2")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2"
+        )
 
     def test_set_buffered_usage_events(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
@@ -135,9 +137,9 @@ class TestUsagePendingCounter:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert usage.counters._pending_reports == 0
-        usage.write_pending_snapshot(flush_request_id="request-2")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2"
+        )
 
     def test_enqueue_logs_body_free_payload_summary(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
@@ -189,10 +191,10 @@ class TestUsagePendingCounter:
                 "usage_event",
             )
 
-        assert usage.counters._pending_reports == 0
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
+        )
 
     def test_sync_fallback_log_failure_rolls_back_pending_report(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
@@ -215,10 +217,10 @@ class TestUsagePendingCounter:
                 "usage_event",
             )
 
-        assert usage.counters._pending_reports == 0
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
+        )
 
     def test_saturated_usage_flush_keeps_buffered_pending_snapshot(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
@@ -317,11 +319,13 @@ class TestUsagePendingCounter:
         assert usage.read_usage_flush_request_id() is None
 
     def test_decrement_does_not_go_negative(self, tmp_path):
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         usage.decrement_in_flight_flows()
         usage.counters.decrement_pending_reports()
-        assert usage.counters._in_flight_flows == 0
-        assert usage.counters._pending_reports == 0
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
+        )
 
     def test_no_op_when_path_not_set(self):
         usage.set_pending_path("")
@@ -331,8 +335,7 @@ class TestUsagePendingCounter:
         usage.counters.decrement_pending_reports()
         usage.write_pending_snapshot(flush_request_id="request-1")
         # Should not raise — just no file written.
-        assert usage.counters._in_flight_flows == 0
-        assert usage.counters._pending_reports == 0
+        assert usage.read_usage_flush_request_id() is None
 
     # ---- one-shot error signal on write failure (issue #10483) ----
 
@@ -395,10 +398,10 @@ class TestUsagePendingCounter:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert usage.counters._pending_reports == 0
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1"
+        )
 
     def test_enqueue_increments_and_drains_reports(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
@@ -419,10 +422,10 @@ class TestUsagePendingCounter:
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        assert usage.counters._pending_reports == 0
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
+        )
 
     def test_sync_fallback_decrements_reports(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
@@ -445,7 +448,7 @@ class TestUsagePendingCounter:
             usage.report_model_provider_usage(flow, "run-1")
             usage.flush_usage_events(trigger="test")
 
-        assert usage.counters._pending_reports == 0
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        usage.write_pending_snapshot(flush_request_id="request-1")
-        assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
+        )

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -4,6 +4,7 @@ import uuid
 
 import usage
 import usage.buffer as usage_buffer
+from tests.pending_helpers import assert_current_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 
 
@@ -293,7 +294,9 @@ def test_flushes_when_aggregate_bucket_count_reaches_exact_bound(tmp_path):
 
 
 def test_flushes_when_source_event_count_reaches_bound(tmp_path):
+    pending_path = tmp_path / "usage-pending"
     enqueue = RecordingEnqueue()
+    usage.set_pending_path(str(pending_path))
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
     events = [
         event(source_key=f"source-{index}", quantity=1)
@@ -321,6 +324,13 @@ def test_flushes_when_source_event_count_reaches_bound(tmp_path):
             "quantity": usage_buffer.MAX_BUFFERED_SOURCE_EVENTS,
         }
     ]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="threshold-flushed",
+    )
 
 
 def test_empty_flush_is_noop():

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -321,7 +321,6 @@ def test_flushes_when_source_event_count_reaches_bound(tmp_path):
             "quantity": usage_buffer.MAX_BUFFERED_SOURCE_EVENTS,
         }
     ]
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_empty_flush_is_noop():

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -72,6 +72,7 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
 
 def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_success(tmp_path):
     attempted_payloads = []
+    pending_path = tmp_path / "usage-pending"
 
     def fail_second_batch(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, path, log_type
@@ -81,6 +82,7 @@ def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_suc
 
     enqueue = RecordingEnqueue(side_effect=fail_second_batch)
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -102,6 +104,13 @@ def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_suc
 
     assert enqueue.call_count == 2
     assert [payload["runId"] for payload in attempted_payloads] == ["run-1", "run-2"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="partial-retained",
+    )
 
     enqueue.side_effect = None
     enqueue.clear()
@@ -114,6 +123,13 @@ def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_suc
         == attempted_payloads[1]["events"][0]["idempotencyKey"]
     )
     assert_usage_buffer_drained(enqueue)
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="partial-drained",
+    )
 
 
 def test_partial_flush_failure_waits_for_unfinished_admitted_batch(tmp_path):
@@ -653,6 +669,7 @@ def test_same_priority_retained_batches_retry_fifo(tmp_path):
     callbacks: list[DeliveryOutcomeCallback] = []
     first_attempt_runs: list[str] = []
     retry_runs: list[str] = []
+    pending_path = tmp_path / "usage-pending"
     retrying = False
 
     def enqueue_webhook(
@@ -674,6 +691,7 @@ def test_same_priority_retained_batches_retry_fifo(tmp_path):
         return True
 
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = tmp_path / "proxy.jsonl"
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -696,11 +714,25 @@ def test_same_priority_retained_batches_retry_fifo(tmp_path):
 
     callbacks[0]("retryable_failure")
     callbacks[1]("retryable_failure")
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=2,
+        reports=0,
+        flush_request_id="fifo-retained",
+    )
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert retry_runs == ["run-a", "run-b"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="fifo-drained",
+    )
 
 
 def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_callbacks(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -772,6 +772,7 @@ def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
     retrying = False
     first_attempt_runs: list[str] = []
     retry_runs: list[str] = []
+    pending_path = tmp_path / "usage-pending"
 
     def enqueue_webhook(
         url: str,
@@ -795,6 +796,7 @@ def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
         return False
 
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = tmp_path / "proxy.jsonl"
     for run_id, source_key in (("run-a", "source-a"), ("run-b", "source-b")):
         usage.buffer_usage_events(
@@ -807,11 +809,25 @@ def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
 
     assert usage.flush_usage_events(trigger="test") == 1
     assert first_attempt_runs == ["run-a", "run-b"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=2,
+        reports=0,
+        flush_request_id="synchronous-retained",
+    )
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert retry_runs == ["run-a", "run-b"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="synchronous-drained",
+    )
 
 
 def test_delivery_in_progress_does_not_block_live_usage_snapshot(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -120,6 +120,7 @@ def test_partial_flush_failure_waits_for_unfinished_admitted_batch(tmp_path):
     callbacks: list[DeliveryOutcomeCallback] = []
     attempted_runs: list[str] = []
     retry_runs: list[str] = []
+    pending_path = tmp_path / "usage-pending"
     retrying = False
 
     def fail_second_batch(
@@ -144,6 +145,7 @@ def test_partial_flush_failure_waits_for_unfinished_admitted_batch(tmp_path):
         raise OSError("second batch rejected")
 
     usage.reset_usage_buffer_for_tests(enqueue_webhook=fail_second_batch)
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -164,13 +166,34 @@ def test_partial_flush_failure_waits_for_unfinished_admitted_batch(tmp_path):
         usage.flush_usage_events(trigger="test")
 
     assert attempted_runs == ["run-1", "run-2"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=2,
+        reports=0,
+        flush_request_id="run-1-delivering-run-2-retained",
+    )
 
     callbacks[0]("success")
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="run-2-retained",
+    )
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 1
 
     assert retry_runs == ["run-2"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="partial-drained",
+    )
 
 
 def test_threshold_flush_failure_preserves_retryable_payload_with_same_idempotency_key(
@@ -685,6 +708,7 @@ def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_ca
 ):
     callbacks: list[DeliveryOutcomeCallback] = []
     retry_runs: list[str] = []
+    pending_path = tmp_path / "usage-pending"
     retrying = False
 
     def enqueue_webhook(
@@ -705,6 +729,7 @@ def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_ca
         return True
 
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue_webhook)
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = tmp_path / "proxy.jsonl"
     for run_id, source_key in (("run-a", "source-a"), ("run-b", "source-b")):
         usage.buffer_usage_events(
@@ -720,11 +745,25 @@ def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_ca
 
     callbacks[1]("retryable_failure")
     callbacks[0]("retryable_failure")
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=2,
+        reports=0,
+        flush_request_id="out-of-order-retained",
+    )
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert retry_runs == ["run-a", "run-b"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="out-of-order-drained",
+    )
 
 
 def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -7,7 +7,7 @@ import pytest
 import usage
 import usage.buffer as usage_buffer
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
-from tests.pending_helpers import assert_pending
+from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import DeliveryOutcomeCallback, RecordingEnqueue, event
 
 
@@ -86,7 +86,6 @@ def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_suc
 
     assert enqueue.call_count == 2
     assert [payload["runId"] for payload in attempted_payloads] == ["run-1", "run-2"]
-    assert usage.counters._buffered_usage_events == 1
 
     enqueue.side_effect = None
     enqueue.clear()
@@ -149,16 +148,13 @@ def test_partial_flush_failure_waits_for_unfinished_admitted_batch(tmp_path):
         usage.flush_usage_events(trigger="test")
 
     assert attempted_runs == ["run-1", "run-2"]
-    assert usage.counters._buffered_usage_events == 2
 
     callbacks[0]("success")
-    assert usage.counters._buffered_usage_events == 1
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 1
 
     assert retry_runs == ["run-2"]
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_threshold_flush_failure_preserves_retryable_payload_with_same_idempotency_key(
@@ -590,7 +586,13 @@ def test_partial_delivery_failure_retains_only_failed_batch_with_same_key(
         usage_webhook_server.requests[1].json_body(),
     ]
     assert [body["runId"] for body in first_attempts] == ["run-a", "run-b"]
-    assert usage.counters._buffered_usage_events == 1
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="run-b-retained",
+    )
 
     usage_webhook_server.queue_response(204)
     assert usage.flush_usage_events(trigger="test") == 1
@@ -655,13 +657,11 @@ def test_same_priority_retained_batches_retry_fifo(tmp_path):
 
     callbacks[0]("retryable_failure")
     callbacks[1]("retryable_failure")
-    assert usage.counters._buffered_usage_events == 2
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert retry_runs == ["run-a", "run-b"]
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_callbacks(
@@ -704,13 +704,11 @@ def test_same_flush_retryable_batches_preserve_batch_order_after_out_of_order_ca
 
     callbacks[1]("retryable_failure")
     callbacks[0]("retryable_failure")
-    assert usage.counters._buffered_usage_events == 2
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert retry_runs == ["run-a", "run-b"]
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
@@ -754,13 +752,11 @@ def test_synchronous_retryable_delivery_before_admission_saturation_is_retained(
 
     assert usage.flush_usage_events(trigger="test") == 1
     assert first_attempt_runs == ["run-a", "run-b"]
-    assert usage.counters._buffered_usage_events == 2
 
     retrying = True
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert retry_runs == ["run-a", "run-b"]
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_delivery_in_progress_does_not_block_live_usage_snapshot(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -19,6 +19,7 @@ def assert_usage_buffer_drained(enqueue: RecordingEnqueue) -> None:
 
 def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp_path):
     failed_payloads = []
+    pending_path = tmp_path / "usage-pending"
 
     def fail_enqueue(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, path, log_type
@@ -27,6 +28,7 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
 
     enqueue = RecordingEnqueue(side_effect=fail_enqueue)
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -41,6 +43,13 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
 
     enqueue.assert_called_once()
     failed_key = failed_payloads[0]["events"][0]["idempotencyKey"]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="enqueue-failed",
+    )
 
     enqueue.side_effect = None
     enqueue.clear()
@@ -52,6 +61,13 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
     assert retry_payload["events"][0]["quantity"] == 10
     assert retry_payload["events"][0]["idempotencyKey"] == failed_key
     assert_usage_buffer_drained(enqueue)
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="enqueue-drained",
+    )
 
 
 def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_success(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_logging.py
@@ -81,7 +81,6 @@ def test_flush_logs_retained_webhook_batches(tmp_path):
     assert entries[1]["retained_source_event_count"] == 1
     assert entries[1]["webhook_batch_count"] == 1
     assert "secret-token" not in json.dumps(entries)
-    assert usage.counters._buffered_usage_events == 1
 
 
 def test_flush_logs_delivery_retry_retained_counts(tmp_path):
@@ -126,7 +125,6 @@ def test_flush_logs_delivery_retry_retained_counts(tmp_path):
     assert retained_entry["retained_webhook_batch_count"] == 1
     assert retained_entry["retained_source_event_count"] == 2
     assert "secret-token" not in json.dumps(entries)
-    assert usage.counters._buffered_usage_events == 2
 
 
 def test_flush_logs_failure_without_token(tmp_path):
@@ -164,4 +162,3 @@ def test_flush_logs_failure_without_token(tmp_path):
     assert isinstance(entries[1]["duration_ms"], int)
     assert entries[1]["duration_ms"] >= 0
     assert "secret-token" not in json.dumps(entries)
-    assert usage.counters._buffered_usage_events == 1

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -324,6 +324,8 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
 
 
 def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_path):
+    pending_path = tmp_path / "usage-pending"
+
     def fail_enqueue(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, payload, path, log_type
         raise OSError("shutdown failed")
@@ -331,6 +333,7 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
     enqueue = RecordingEnqueue(side_effect=fail_enqueue)
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)
     proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -345,6 +348,13 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
 
     assert len(timers) == 1
     assert timers[0].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="shutdown-retained",
+    )
     retained_entries = [
         entry
         for entry in flush_log_entries(proxy_log_path)
@@ -364,6 +374,13 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-1"
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-drained",
+    )
 
 
 def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
@@ -408,8 +425,10 @@ def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
 
 
 def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
+    pending_path = tmp_path / "usage-pending"
     enqueue = RecordingEnqueue(return_value=False)
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -426,6 +445,13 @@ def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].started is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="timer-retained",
+    )
 
     enqueue.return_value = True
     enqueue.clear()
@@ -434,12 +460,21 @@ def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-1"
     assert timers[1].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="timer-drained",
+    )
 
 
 def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(tmp_path):
+    pending_path = tmp_path / "usage-pending"
     enqueue = RecordingEnqueue(return_value=False)
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)
     proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.set_pending_path(str(pending_path))
     usage.buffer_model_usage_observations(
         "https://api.test/api/webhooks/agent/model-usage-observation",
         "token-a",
@@ -487,12 +522,26 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
     assert len(timers) == 4
     assert timers[2].cancelled is True
     assert timers[3].started is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="priority-deferred",
+    )
 
     enqueue.clear()
     timers[3].callback()
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-2"
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="priority-drained",
+    )
 
 
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -90,6 +90,7 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
     shutdown_results: list[int] = []
     enqueued_runs: list[str] = []
     enqueue_call_count = 0
+    pending_path = tmp_path / "usage-pending"
 
     def enqueue_webhook(url, sandbox_token, payload, path, log_type):
         nonlocal enqueue_call_count
@@ -113,6 +114,7 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
         enqueue_webhook=enqueue,
         flush_owner_lock=flush_owner_lock,
     )
+    usage.set_pending_path(str(pending_path))
     proxy_log_path = str(tmp_path / "proxy.jsonl")
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -148,6 +150,13 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
     assert enqueued_runs == ["run-1", "run-2"]
     assert len(timers) == 2
     assert timers[1].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-wait-drained",
+    )
 
 
 def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(tmp_path):
@@ -159,6 +168,7 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
     enqueued_run_ids: list[str] = []
     enqueued_idempotency_keys: list[str] = []
     timer_errors: list[str] = []
+    pending_path = tmp_path / "usage-pending"
 
     def enqueue_webhook(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, path
@@ -175,6 +185,7 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
         enqueue_webhook=enqueue,
         flush_owner_lock=flush_owner_lock,
     )
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -216,6 +227,13 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-retry-drained",
+    )
 
 
 def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(tmp_path):
@@ -225,6 +243,7 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
     shutdown_returned = threading.Event()
     shutdown_results: list[int] = []
     enqueued_run_ids: list[str] = []
+    pending_path = tmp_path / "usage-pending"
 
     def enqueue_webhook(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token
@@ -240,6 +259,7 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
         enqueue_webhook=enqueue,
         flush_owner_lock=flush_owner_lock,
     )
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -285,10 +305,18 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-threshold-drained",
+    )
 
 
 def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     enqueued_runs: list[str] = []
+    pending_path = tmp_path / "usage-pending"
 
     def enqueue_webhook(url, sandbox_token, payload, path, log_type):
         enqueued_runs.append(payload["runId"])
@@ -306,6 +334,7 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     enqueue = RecordingEnqueue(side_effect=enqueue_webhook)
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)
     proxy_log_path = str(tmp_path / "proxy.jsonl")
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -321,6 +350,13 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-own-enqueue-drained",
+    )
 
 
 def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_path):
@@ -585,12 +621,15 @@ def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
 
 
 def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
+    pending_path = tmp_path / "usage-pending"
+
     def fail_enqueue(url, sandbox_token, payload, path, log_type):
         del url, sandbox_token, payload, path, log_type
         raise OSError("no threads")
 
     enqueue = RecordingEnqueue(side_effect=fail_enqueue)
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    usage.set_pending_path(str(pending_path))
 
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
@@ -610,11 +649,19 @@ def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
     assert len(timers) == 2
     assert timers[1].started is True
     assert timers[1].cancelled is False
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="timer-failure-retained",
+    )
 
 
 def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
     callbacks: list[Callable[[usage.webhook.WebhookDeliveryOutcome], None]] = []
     enqueued_keys: list[str] = []
+    pending_path = tmp_path / "usage-pending"
 
     def enqueue_webhook(url, sandbox_token, payload, path, log_type, delivery_callback):
         del url, sandbox_token, path
@@ -627,6 +674,7 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
         return True
 
     timers = install_recording_usage_timer(enqueue_webhook=enqueue_webhook)
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -639,8 +687,22 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
 
     assert len(callbacks) == 1
     assert len(timers) == 1
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="timer-delivering",
+    )
     callbacks[0]("retryable_failure")
 
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="timer-delivery-retained",
+    )
     assert len(timers) == 2
     assert timers[1].started is True
     assert timers[1].cancelled is False
@@ -648,6 +710,13 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
     timers[1].callback()
 
     assert enqueued_keys == [enqueued_keys[0], enqueued_keys[0]]
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="timer-delivery-drained",
+    )
 
 
 def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -384,9 +384,11 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
 
 
 def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
+    pending_path = tmp_path / "usage-pending"
     proxy_log_path = tmp_path / "proxy.jsonl"
     enqueue = RecordingEnqueue(return_value=False)
     timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "token-a",
@@ -401,6 +403,13 @@ def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
     enqueue.assert_called_once()
     assert len(timers) == 1
     assert timers[0].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="shutdown-saturated",
+    )
     retained_entries = [
         entry
         for entry in flush_log_entries(proxy_log_path)
@@ -422,6 +431,13 @@ def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-1"
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-saturated-drained",
+    )
 
 
 def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
@@ -704,6 +720,7 @@ def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):
 def test_shutdown_saturated_retry_budget_exhaustion_drops_without_rescheduling_timer(
     tmp_path,
 ):
+    pending_path = tmp_path / "usage-pending"
     proxy_log_path = tmp_path / "proxy.jsonl"
 
     enqueue = RecordingEnqueue(return_value=False)
@@ -711,6 +728,7 @@ def test_shutdown_saturated_retry_budget_exhaustion_drops_without_rescheduling_t
         enqueue_webhook=enqueue,
         max_retained_batch_retries=1,
     )
+    usage.set_pending_path(str(pending_path))
     usage.buffer_usage_events(
         "https://api.test/api/webhooks/agent/usage-event",
         "secret-token",
@@ -722,12 +740,26 @@ def test_shutdown_saturated_retry_budget_exhaustion_drops_without_rescheduling_t
     assert usage.flush_usage_events(trigger="shutdown") == 0
     assert len(timers) == 1
     assert timers[0].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="shutdown-retry-retained",
+    )
 
     enqueue.clear()
     assert usage.flush_usage_events(trigger="shutdown") == 0
 
     enqueue.assert_called_once()
     assert len(timers) == 1
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-retry-dropped",
+    )
     dropped_entries = [
         entry for entry in flush_log_entries(proxy_log_path) if entry["phase"] == "dropped"
     ]

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -7,7 +7,7 @@ import pytest
 
 import usage
 import usage.buffer as usage_buffer
-from tests.pending_helpers import assert_pending
+from tests.pending_helpers import assert_current_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
 from tests.usage_helpers import RecordingTimer, install_recording_usage_timer
 
@@ -146,7 +146,6 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
     assert shutdown_returned.is_set()
     assert shutdown_results == [1]
     assert enqueued_runs == ["run-1", "run-2"]
-    assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 2
     assert timers[1].cancelled is True
 
@@ -214,7 +213,6 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
     assert shutdown_results == [1]
     assert enqueued_run_ids == ["run-1", "run-1"]
     assert enqueued_idempotency_keys[0] == enqueued_idempotency_keys[1]
-    assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].cancelled is True
@@ -284,7 +282,6 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
     assert not shutdown_thread.is_alive()
     assert shutdown_results == [1]
     assert enqueued_run_ids == ["run-1", "run-2"]
-    assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].cancelled is True
@@ -321,7 +318,6 @@ def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):
     assert usage.flush_usage_events(trigger="shutdown") == 2
 
     assert enqueued_runs == ["run-1", "run-2"]
-    assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].cancelled is True
@@ -347,7 +343,6 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
     with pytest.raises(OSError, match="shutdown failed"):
         usage.flush_usage_events(trigger="shutdown")
 
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 1
     assert timers[0].cancelled is True
     retained_entries = [
@@ -369,7 +364,6 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-1"
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
@@ -388,7 +382,6 @@ def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
     assert usage.flush_usage_events(trigger="shutdown") == 0
 
     enqueue.assert_called_once()
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 1
     assert timers[0].cancelled is True
     retained_entries = [
@@ -412,7 +405,6 @@ def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-1"
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
@@ -431,7 +423,6 @@ def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
     timers[0].callback()
 
     enqueue.assert_called_once()
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 2
     assert timers[0].cancelled is True
     assert timers[1].started is True
@@ -442,7 +433,6 @@ def test_timer_saturated_flush_reschedules_retry_without_real_sleep(tmp_path):
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-1"
-    assert usage.counters._buffered_usage_events == 0
     assert timers[1].cancelled is True
 
 
@@ -494,7 +484,6 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
     assert usage.flush_usage_events(trigger="test") == 2
 
     assert attempted_log_types == ["usage_event", "model_usage_observation"]
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 4
     assert timers[2].cancelled is True
     assert timers[3].started is True
@@ -504,7 +493,6 @@ def test_priority_preempted_flush_keeps_timer_for_usage_buffered_during_enqueue(
 
     enqueue.assert_called_once()
     assert enqueue.last_call.payload["runId"] == "run-2"
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_timer_flush_uses_scheduled_callback_without_real_sleep(tmp_path):
@@ -557,7 +545,6 @@ def test_timer_flush_failure_reschedules_retry_without_real_sleep(tmp_path):
     assert len(timers) == 2
     assert timers[1].started is True
     assert timers[1].cancelled is False
-    assert usage.counters._buffered_usage_events == 1
 
 
 def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
@@ -586,11 +573,9 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
     timers[0].callback()
 
     assert len(callbacks) == 1
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 1
     callbacks[0]("retryable_failure")
 
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 2
     assert timers[1].started is True
     assert timers[1].cancelled is False
@@ -598,7 +583,6 @@ def test_timer_delivery_failure_after_enqueue_reschedules_retry(tmp_path):
     timers[1].callback()
 
     assert enqueued_keys == [enqueued_keys[0], enqueued_keys[0]]
-    assert usage.counters._buffered_usage_events == 0
 
 
 def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):
@@ -633,15 +617,25 @@ def test_timer_delivery_retry_budget_exhaustion_drops_retained_usage(tmp_path):
 
     timers[0].callback()
 
-    assert usage.counters._buffered_usage_events == 1
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="retained",
+    )
     assert len(timers) == 2
     assert timers[1].started is True
 
     timers[1].callback()
 
-    assert usage.counters._buffered_usage_events == 0
-    usage.write_pending_snapshot(flush_request_id="request-1")
-    assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="request-1",
+    )
     assert len(timers) == 2
     entries = flush_log_entries(proxy_log_path)
     dropped_entries = [entry for entry in entries if entry["phase"] == "dropped"]
@@ -677,7 +671,6 @@ def test_shutdown_saturated_retry_budget_exhaustion_drops_without_rescheduling_t
     )
 
     assert usage.flush_usage_events(trigger="shutdown") == 0
-    assert usage.counters._buffered_usage_events == 1
     assert len(timers) == 1
     assert timers[0].cancelled is True
 
@@ -685,7 +678,6 @@ def test_shutdown_saturated_retry_budget_exhaustion_drops_without_rescheduling_t
     assert usage.flush_usage_events(trigger="shutdown") == 0
 
     enqueue.assert_called_once()
-    assert usage.counters._buffered_usage_events == 0
     assert len(timers) == 1
     dropped_entries = [
         entry for entry in flush_log_entries(proxy_log_path) if entry["phase"] == "dropped"

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -16,6 +16,7 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
+from tests.pending_helpers import assert_current_pending
 
 
 class _QueuedUsageExecutor:
@@ -317,7 +318,8 @@ class TestUsageWebhookDelivery:
     ):
         """Synchronous executor fixture should store worker exceptions on its Future."""
         proxy_log = tmp_path / "proxy.jsonl"
-        usage.set_pending_path(str(tmp_path / "usage-pending"))
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         usage.counters.increment_pending_reports()
 
         usage.webhook._enqueue_webhook(
@@ -328,7 +330,13 @@ class TestUsageWebhookDelivery:
             "usage",
         )
 
-        assert usage.counters._pending_reports == 1
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=1,
+            flush_request_id="worker-error",
+        )
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
         assert "non-retryable" in read_jsonl_text_after_flush(proxy_log)
         with pytest.raises(ValueError, match="absolute http"):
@@ -436,7 +444,9 @@ class TestUsageWebhookDelivery:
 
     def test_does_not_admit_when_delivery_capacity_is_saturated(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
+        pending_path = tmp_path / "usage-pending"
         executor = _QueuedUsageExecutor()
+        usage.set_pending_path(str(pending_path))
 
         with patch.object(usage.webhook, "usage_executor", executor):
             for index in range(usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS):
@@ -462,7 +472,13 @@ class TestUsageWebhookDelivery:
 
         assert admitted is False
         assert len(executor.submissions) == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
-        assert usage.counters._pending_reports == usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=usage.webhook.MAX_PENDING_WEBHOOK_PAYLOADS,
+            flush_request_id="saturated",
+        )
 
         entries = read_jsonl_entries_after_flush(proxy_log)
         saturated_entry = entries[-1]
@@ -485,6 +501,8 @@ class TestUsageWebhookDelivery:
         self, tmp_path, sync_usage_executor, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         usage_webhook_server.queue_response(204)
 
         assert usage.webhook._enqueue_webhook(
@@ -497,12 +515,20 @@ class TestUsageWebhookDelivery:
 
         assert usage_webhook_server.request_count == 1
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert usage.counters._pending_reports == 0
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="success",
+        )
 
     def test_delivery_capacity_released_after_retry_exhaustion(
         self, tmp_path, sync_usage_executor, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         usage_webhook_server.queue_response(500)
         usage_webhook_server.queue_response(500)
 
@@ -517,4 +543,10 @@ class TestUsageWebhookDelivery:
 
         assert usage_webhook_server.request_count == 2
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert usage.counters._pending_reports == 0
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="retry-exhausted",
+        )


### PR DESCRIPTION
## Summary
- add a test helper that asserts the runner-facing pending snapshot after writing current pending state
- remove redundant private counter assertions from usage-buffer behavior tests
- replace remaining counter contract checks with pending snapshot assertions

## Verification
- `.venv/bin/ruff check tests/pending_helpers.py tests/test_usage_buffer_logging.py tests/test_usage_buffer_flush_failures.py tests/test_usage_buffer_timer_shutdown.py tests/test_usage_buffer_aggregation.py tests/test_webhook.py tests/test_counters.py`
- `.venv/bin/pytest tests/test_usage_buffer_logging.py tests/test_usage_buffer_flush_failures.py tests/test_usage_buffer_timer_shutdown.py tests/test_usage_buffer_aggregation.py tests/test_webhook.py tests/test_counters.py`
- `.venv/bin/pytest tests/`
- `rg "usage\.counters\._" crates/runner/mitm-addon/tests -n` produced no matches

Closes #18169