### PR TITLE
fix: align completed-work fold chip with assistant avatar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3025,7 +3025,7 @@ function CompletedWorkFoldRow({
         aria-expanded={expanded}
         aria-label={expanded ? "Collapse work history" : "Expand work history"}
         onClick={onToggle}
-        className="mt-0.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-muted/50"
+        className="mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-muted/50"
       >
         <IconHourglass
           aria-hidden


### PR DESCRIPTION
Nudges the "Worked for …" fold chip down so it sits vertically centered on the assistant avatar in the chat thread.

- `CompletedWorkFoldRow` button: `mt-0.5` → `mt-1.5` (chip text center moves ~4px down to line up with the 36px avatar).

Visual-only change; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)