### PR TITLE
fix: explain computer use doctor permissions

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
@@ -232,6 +232,46 @@ describe("zero doctor permission-change command", () => {
     );
   });
 
+  it("explains selected-host token grants for computer-use permission changes", async () => {
+    await permissionChangeCommand.parseAsync([
+      "node",
+      "cli",
+      "computer-use",
+      "--permission",
+      "computer-use:write",
+      "--enable",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain(
+      "Computer Use access is not managed as a connector permission.",
+    );
+    expect(logCalls).toContain("selected for the chat or thread");
+    expect(logCalls).toContain("Existing run tokens cannot be upgraded");
+    expect(logCalls).toContain("zero whoami");
+    expect(logCalls).not.toContain("[Manage");
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
+  it("recognizes computer-use:write even when the connector ref is wrong", async () => {
+    await permissionChangeCommand.parseAsync([
+      "node",
+      "cli",
+      "agent",
+      "--permission",
+      "computer-use:write",
+      "--enable",
+      "--duration",
+      "1h",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain(
+      "Computer Use access is not managed as a connector permission.",
+    );
+    expect(mockConsoleError).not.toHaveBeenCalled();
+  });
+
   it("exits with an error for an invalid permission name", async () => {
     await expect(async () => {
       await permissionChangeCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
@@ -102,6 +102,47 @@ describe("zero doctor permission-deny command", () => {
     });
   });
 
+  describe("computer-use capability denials", () => {
+    it("should explain selected-host token grants for computer-use ref", async () => {
+      await permissionDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "computer-use",
+        "--method",
+        "POST",
+        "--path",
+        "/computer-use/list-apps",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "Computer Use access is not managed as a connector permission.",
+      );
+      expect(logCalls).toContain("selected for the chat or thread");
+      expect(logCalls).toContain("Existing run tokens cannot be upgraded");
+      expect(logCalls).toContain("zero whoami");
+      expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+
+    it("should recognize computer-use paths before connector validation", async () => {
+      await permissionDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "agent",
+        "--method",
+        "POST",
+        "--path",
+        "/computer-use/list-apps",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "Computer Use access is not managed as a connector permission.",
+      );
+      expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+  });
+
   describe("slack matching", () => {
     it("should identify chat:write for POST /chat.postMessage", async () => {
       await permissionDenyCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/computer-use-guidance.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/computer-use-guidance.ts
@@ -1,0 +1,32 @@
+const COMPUTER_USE_CONNECTOR_REF = "computer-use";
+const COMPUTER_USE_CAPABILITY = "computer-use:write";
+const COMPUTER_USE_PATH_PREFIX = "/computer-use";
+
+interface ComputerUsePermissionTarget {
+  readonly connectorRef: string;
+  readonly path?: string;
+  readonly permission?: string;
+}
+
+export function isComputerUsePermissionTarget(
+  target: ComputerUsePermissionTarget,
+): boolean {
+  return (
+    target.connectorRef === COMPUTER_USE_CONNECTOR_REF ||
+    target.permission === COMPUTER_USE_CAPABILITY ||
+    target.path?.startsWith(COMPUTER_USE_PATH_PREFIX) === true
+  );
+}
+
+export function printComputerUsePermissionGuidance(): void {
+  console.log("Computer Use access is not managed as a connector permission.");
+  console.log(
+    "The current run token needs computer-use:write, which is issued only when a Zero Desktop Computer Use host is selected for the chat or thread before the run starts.",
+  );
+  console.log(
+    "Open Zero Desktop, make sure Computer Use is online, select the Computer Use host for this chat/thread, then start a new run. Existing run tokens cannot be upgraded in place.",
+  );
+  console.log(
+    "Run `zero whoami` to confirm whether the current ZERO_TOKEN includes computer-use:write.",
+  );
+}

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
@@ -8,6 +8,10 @@ import {
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
+import {
+  isComputerUsePermissionTarget,
+  printComputerUsePermissionGuidance,
+} from "./computer-use-guidance";
 
 const DEFAULT_PERMISSION_GRANT_DURATION: UserPermissionGrantExpiresIn = "1h";
 const PERMISSION_GRANT_DURATIONS = [
@@ -170,6 +174,7 @@ Examples:
   zero doctor permission-change github --permission contents:write --enable --duration 24h
   zero doctor permission-change slack --permission chat:write --disable
   zero doctor permission-change cloudflare --permission __unknown__ --disable
+  zero doctor permission-change computer-use --permission computer-use:write --enable
 
 Notes:
   - Outputs a platform URL for the user to adjust the permission
@@ -195,6 +200,16 @@ Notes:
         }
         if (opts.disable && opts.duration !== undefined) {
           throw new Error("--duration is only supported with --enable");
+        }
+
+        if (
+          isComputerUsePermissionTarget({
+            connectorRef,
+            permission: opts.permission,
+          })
+        ) {
+          printComputerUsePermissionGuidance();
+          return;
         }
 
         if (!isFirewallConnectorType(connectorRef)) {

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -7,6 +7,10 @@ import {
 } from "@vm0/connectors/firewalls";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
+import {
+  isComputerUsePermissionTarget,
+  printComputerUsePermissionGuidance,
+} from "./computer-use-guidance";
 
 function unknownPermissionChangeCommand(connectorRef: string): string {
   return `zero doctor permission-change ${connectorRef} --permission ${UNKNOWN_PERMISSION_GRANT} --enable --duration 1h`;
@@ -33,6 +37,7 @@ export const permissionDenyCommand = new Command()
 Examples:
   zero doctor permission-deny github --method GET --path /repos/owner/repo/pulls
   zero doctor permission-deny slack --method POST --path /chat.postMessage
+  zero doctor permission-deny computer-use --method POST --path /computer-use/list-apps
 
 Notes:
   - Identifies which named permission covers a denied request
@@ -42,6 +47,11 @@ Notes:
   .action(
     withErrorHandler(
       async (connectorRef: string, opts: { method: string; path: string }) => {
+        if (isComputerUsePermissionTarget({ connectorRef, path: opts.path })) {
+          printComputerUsePermissionGuidance();
+          return;
+        }
+
         if (!isFirewallConnectorType(connectorRef)) {
           throw new Error(`Unknown connector type: ${connectorRef}`);
         }


### PR DESCRIPTION
## Summary

- add a Computer Use-specific doctor guidance path instead of routing it through firewall connector validation
- recognize `computer-use`, `computer-use:write`, and `/computer-use/*` denials before unknown connector errors
- cover both `permission-deny` and `permission-change`, including the observed `agent --permission computer-use:write` fallback

Closes #18126

## Root cause

Computer Use is granted as a run-scoped `ZERO_TOKEN` capability only when a Zero Desktop Computer Use host is selected for the chat/thread before the run starts. It is not managed as a connector permission, so the existing doctor commands produced `Unknown connector type` instead of actionable guidance.

## Validation

Passed:

- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/permission-deny.test.ts src/commands/zero/doctor/__tests__/permission-change.test.ts`
- `pnpm format`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli test`
- `pnpm turbo run lint`
- `pnpm check-types`
- `mise x node@22 -- pnpm -F web exec vitest run app/components/__tests__/navbar-blog.test.tsx app/components/__tests__/theme-toggle.test.tsx`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agents-update.test.ts src/signals/routes/__tests__/zero-workflows.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts`
- `mise x node@22 -- pnpm knip --workspace @vm0/cli`

Local full-suite limitations observed:

- `pnpm vitest` under the local default Node 25 fails web happy-dom tests because Node 25 exposes a nonstandard global `localStorage`; the same web tests pass under Node 22.22.2.
- `mise x node@22 -- pnpm vitest` reaches 7417/7418 passing tests, with one unrelated API failure in `src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` because the local environment lacks `OPENROUTER_API_KEY`, causing run summary generation to be skipped and the expected `...[truncated]` marker not to appear.
- full `pnpm knip` reports existing monorepo-wide unused files/exports/devDependencies; the touched `@vm0/cli` workspace passes `knip`.
