### PR TITLE
fix(vsock-guest): refresh non-signalable child pgid targets

### DIFF
--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -649,6 +649,10 @@ wait
         command.process_group(0);
 
         let mut child = Some(command.spawn().unwrap());
+        if !wait_for_path(&direct_pid_path, Duration::from_secs(2)) {
+            kill_spawned_child(&mut child);
+            panic!("parent should publish same-group child pid before snapshot");
+        }
         if !wait_for_path(&child_ready, Duration::from_secs(2)) {
             kill_spawned_child(&mut child);
             panic!("same-group child should block on fifo before snapshot");

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -541,8 +541,14 @@ mod tests {
         let mut child = Some(command.spawn().unwrap());
         let stdout = child.as_mut().unwrap().stdout.take().unwrap();
         let mut ready = String::new();
-        BufReader::new(stdout).read_line(&mut ready).unwrap();
-        assert_eq!(ready, "ready\n");
+        if let Err(e) = BufReader::new(stdout).read_line(&mut ready) {
+            kill_spawned_child(&mut child);
+            panic!("failed to read setsid child ready marker: {e}");
+        }
+        if ready != "ready\n" {
+            kill_spawned_child(&mut child);
+            panic!("setsid child should publish ready marker, got {ready:?}");
+        }
         let child_pid_text = match std::fs::read_to_string(&child_pid_path) {
             Ok(pid) => pid,
             Err(e) => {

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -62,8 +62,10 @@ fn signalable_child_pgid(child_id: u32, pgid: u32) -> Option<u32> {
 /// the `su` process's group — the child's group (where the actual command
 /// runs) is missed.
 ///
-/// This function scans `/proc` to find that child and returns its PGID so
-/// the timeout killer can send SIGKILL to both process groups.
+/// This function scans `/proc` to find that child and returns its distinct PGID
+/// so the timeout killer can send SIGKILL to both process groups. Same-group
+/// children are skipped because `kill(-parent_pid, SIGKILL)` already reaches
+/// them, and a later refresh can still capture a child that calls `setsid()`.
 ///
 /// Must be called BEFORE killing the parent, because once the parent dies
 /// the child's PPID changes to 1 (init).
@@ -120,7 +122,7 @@ pub(crate) fn process_tree_kill_target(child_id: u32) -> ProcessTreeKillTarget {
 }
 
 /// Refresh a snapshotted process-tree target while the direct child may still
-/// have a child session visible in `/proc`.
+/// have a distinct child session visible in `/proc`.
 pub(crate) fn refresh_process_tree_kill_target(target: &mut ProcessTreeKillTarget) {
     if target.child_pgid_to_signal().is_none() {
         target.child_pgid = find_child_pgid(target.child_id);

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -578,6 +578,10 @@ mod tests {
                 panic!("failed to parse setsid child pid {child_pid_text:?}: {e}");
             }
         };
+        if child_pid <= 0 {
+            kill_spawned_child(&mut child);
+            panic!("setsid child pid should be positive, got {child_pid}");
+        }
         let child_pidfd = match open_pidfd(child_pid) {
             Ok(pidfd) => pidfd,
             Err(e) => {
@@ -742,6 +746,10 @@ wait
                     panic!("setsid child should publish its pid before kill");
                 }
             };
+        if setsid_child_pid <= 0 {
+            kill_spawned_child(&mut child);
+            panic!("setsid child pid should be positive, got {setsid_child_pid}");
+        }
         let setsid_child_pidfd = match open_pidfd(setsid_child_pid) {
             Ok(pidfd) => pidfd,
             Err(e) => {

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -50,7 +50,7 @@ fn parse_stat_ppid_pgid(stat: &str) -> Option<(u32, u32)> {
     Some((ppid, pgid))
 }
 
-fn child_pgid_to_signal(child_id: u32, pgid: u32) -> Option<u32> {
+fn signalable_child_pgid(child_id: u32, pgid: u32) -> Option<u32> {
     (pgid > 1 && pgid != child_id).then_some(pgid)
 }
 
@@ -82,7 +82,7 @@ fn find_child_pgid(parent_pid: u32) -> Option<u32> {
         };
 
         if ppid == parent_pid
-            && let Some(pgid) = child_pgid_to_signal(parent_pid, pgid)
+            && let Some(pgid) = signalable_child_pgid(parent_pid, pgid)
         {
             return Some(pgid);
         }
@@ -103,7 +103,7 @@ impl ProcessTreeKillTarget {
 
     fn child_pgid_to_signal(self) -> Option<u32> {
         self.child_pgid
-            .and_then(|pgid| child_pgid_to_signal(self.child_id, pgid))
+            .and_then(|pgid| signalable_child_pgid(self.child_id, pgid))
     }
 }
 
@@ -608,7 +608,7 @@ mod tests {
 
         let (dir, _guard) = temp_dir("refresh-same-group");
         let fifo = dir.join("child-fifo");
-        let ready = dir.join("ready");
+        let child_ready = dir.join("child-ready");
         let direct_pid_path = dir.join("direct-child-pid");
         let setsid_child_pid_path = dir.join("setsid-child-pid");
         let child_script = dir.join("child.sh");
@@ -617,7 +617,10 @@ mod tests {
         std::fs::write(
             &child_script,
             r#"#!/bin/sh
-read _ < "$FIFO"
+exec 3<> "$FIFO"
+touch "$CHILD_READY"
+read _ <&3
+exec 3>&-
 exec setsid sh -c 'printf %s "$$" > "$SETSID_CHILD_PID"; sleep 60'
 "#,
         )
@@ -628,7 +631,6 @@ exec setsid sh -c 'printf %s "$$" > "$SETSID_CHILD_PID"; sleep 60'
 mkfifo "$FIFO"
 sh "$CHILD_SCRIPT" &
 echo $! > "$DIRECT_PID"
-touch "$READY"
 wait
 "#,
         )
@@ -638,7 +640,7 @@ wait
         command
             .arg(&parent_script)
             .env("FIFO", &fifo)
-            .env("READY", &ready)
+            .env("CHILD_READY", &child_ready)
             .env("DIRECT_PID", &direct_pid_path)
             .env("SETSID_CHILD_PID", &setsid_child_pid_path)
             .env("CHILD_SCRIPT", &child_script)
@@ -647,9 +649,9 @@ wait
         command.process_group(0);
 
         let mut child = Some(command.spawn().unwrap());
-        if !wait_for_path(&ready, Duration::from_secs(2)) {
+        if !wait_for_path(&child_ready, Duration::from_secs(2)) {
             kill_spawned_child(&mut child);
-            panic!("parent should start same-group child before snapshot");
+            panic!("same-group child should block on fifo before snapshot");
         }
         let direct_pid_text = match std::fs::read_to_string(&direct_pid_path) {
             Ok(pid) => pid,

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -217,7 +217,7 @@ pub(crate) fn kill_and_reap_child_with_target(mut child: Child, mut target: Proc
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -257,6 +257,21 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         path.exists()
+    }
+
+    fn read_pid_file<T: std::str::FromStr>(path: &Path) -> Option<T> {
+        std::fs::read_to_string(path).ok()?.trim().parse().ok()
+    }
+
+    fn wait_for_pid_file<T: std::str::FromStr>(path: &Path, timeout: Duration) -> Option<T> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Some(pid) = read_pid_file(path) {
+                return Some(pid);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        read_pid_file(path)
     }
 
     #[test]
@@ -677,28 +692,17 @@ wait
         command.process_group(0);
 
         let mut child = Some(command.spawn().unwrap());
-        if !wait_for_path(&direct_pid_path, Duration::from_secs(2)) {
-            kill_spawned_child(&mut child);
-            panic!("parent should publish same-group child pid before snapshot");
-        }
+        let direct_pid: u32 = match wait_for_pid_file(&direct_pid_path, Duration::from_secs(2)) {
+            Some(pid) => pid,
+            None => {
+                kill_spawned_child(&mut child);
+                panic!("parent should publish same-group child pid before snapshot");
+            }
+        };
         if !wait_for_path(&child_ready, Duration::from_secs(2)) {
             kill_spawned_child(&mut child);
             panic!("same-group child should block on fifo before snapshot");
         }
-        let direct_pid_text = match std::fs::read_to_string(&direct_pid_path) {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to read direct child pid: {e}");
-            }
-        };
-        let direct_pid: u32 = match direct_pid_text.trim().parse() {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to parse direct child pid {direct_pid_text:?}: {e}");
-            }
-        };
         let parent_pid = child.as_ref().unwrap().id();
         let direct_stat = match std::fs::read_to_string(format!("/proc/{direct_pid}/stat")) {
             Ok(stat) => stat,
@@ -730,24 +734,14 @@ wait
             }
         }
 
-        if !wait_for_path(&setsid_child_pid_path, Duration::from_secs(2)) {
-            kill_spawned_child(&mut child);
-            panic!("setsid child should publish its pid before kill");
-        }
-        let setsid_child_pid_text = match std::fs::read_to_string(&setsid_child_pid_path) {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to read setsid child pid: {e}");
-            }
-        };
-        let setsid_child_pid: libc::pid_t = match setsid_child_pid_text.trim().parse() {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child(&mut child);
-                panic!("failed to parse setsid child pid {setsid_child_pid_text:?}: {e}");
-            }
-        };
+        let setsid_child_pid: libc::pid_t =
+            match wait_for_pid_file(&setsid_child_pid_path, Duration::from_secs(2)) {
+                Some(pid) => pid,
+                None => {
+                    kill_spawned_child(&mut child);
+                    panic!("setsid child should publish its pid before kill");
+                }
+            };
         let setsid_child_pidfd = match open_pidfd(setsid_child_pid) {
             Ok(pidfd) => pidfd,
             Err(e) => {

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -50,8 +50,13 @@ fn parse_stat_ppid_pgid(stat: &str) -> Option<(u32, u32)> {
     Some((ppid, pgid))
 }
 
+fn process_group_signal_pid(pgid: u32) -> Option<libc::pid_t> {
+    let pgid = libc::pid_t::try_from(pgid).ok()?;
+    (pgid > 1).then_some(-pgid)
+}
+
 fn signalable_child_pgid(child_id: u32, pgid: u32) -> Option<u32> {
-    (pgid > 1 && pgid != child_id).then_some(pgid)
+    (pgid != child_id && process_group_signal_pid(pgid).is_some()).then_some(pgid)
 }
 
 /// Find the process-group ID of a direct child of `parent_pid`.
@@ -149,14 +154,25 @@ pub(crate) unsafe fn kill_process_tree(child_id: u32) -> bool {
 /// `target.child_id` must come from a PID returned by `Command::spawn()`.
 pub(crate) unsafe fn kill_process_tree_target(target: ProcessTreeKillTarget) -> bool {
     // Kill the direct child's process group (the su wrapper).
-    let ret = unsafe { libc::kill(-(target.child_id as i32), libc::SIGKILL) };
-    let mut signalled = ret == 0;
-    if ret != 0 {
-        let err = std::io::Error::last_os_error();
+    let mut signalled = false;
+    if let Some(signal_pid) = process_group_signal_pid(target.child_id) {
+        let ret = unsafe { libc::kill(signal_pid, libc::SIGKILL) };
+        signalled = ret == 0;
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            log(
+                "WARN",
+                &format!(
+                    "process-tree kill(-{}, SIGKILL) failed: {err}",
+                    target.child_id
+                ),
+            );
+        }
+    } else {
         log(
             "WARN",
             &format!(
-                "process-tree kill(-{}, SIGKILL) failed: {err}",
+                "process-tree kill skipped invalid process group id {}",
                 target.child_id
             ),
         );
@@ -167,7 +183,10 @@ pub(crate) unsafe fn kill_process_tree_target(target: ProcessTreeKillTarget) -> 
     // Guard pgid > 1: kill(0, sig) targets the caller's group, and kill(-1, sig)
     // broadcasts to every process the caller may signal.
     if let Some(pgid) = target.child_pgid_to_signal() {
-        let ret = unsafe { libc::kill(-(pgid as i32), libc::SIGKILL) };
+        let Some(signal_pid) = process_group_signal_pid(pgid) else {
+            return signalled;
+        };
+        let ret = unsafe { libc::kill(signal_pid, libc::SIGKILL) };
         if ret == 0 {
             signalled = true;
         } else {
@@ -395,6 +414,23 @@ mod tests {
             .child_pgid_to_signal(),
             Some(43)
         );
+        assert_eq!(
+            ProcessTreeKillTarget {
+                child_id: 42,
+                child_pgid: Some(i32::MAX as u32 + 1)
+            }
+            .child_pgid_to_signal(),
+            None
+        );
+    }
+
+    #[test]
+    fn process_group_signal_pid_skips_reserved_and_unrepresentable_targets() {
+        assert_eq!(process_group_signal_pid(0), None);
+        assert_eq!(process_group_signal_pid(1), None);
+        assert_eq!(process_group_signal_pid(42), Some(-42));
+        assert_eq!(process_group_signal_pid(i32::MAX as u32), Some(-i32::MAX));
+        assert_eq!(process_group_signal_pid(i32::MAX as u32 + 1), None);
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -43,11 +43,15 @@ fn parse_stat_ppid_pgid(stat: &str) -> Option<(u32, u32)> {
         return None;
     }
     let remainder = &stat[close_paren + 2..]; // skip ") "
-    let fields: Vec<&str> = remainder.split_whitespace().collect();
-    // fields: [0]=state [1]=ppid [2]=pgid [3]=session ...
-    let ppid = fields.get(1)?.parse().ok()?;
-    let pgid = fields.get(2)?.parse().ok()?;
+    let mut fields = remainder.split_whitespace();
+    fields.next()?; // state
+    let ppid = fields.next()?.parse().ok()?;
+    let pgid = fields.next()?.parse().ok()?;
     Some((ppid, pgid))
+}
+
+fn child_pgid_to_signal(child_id: u32, pgid: u32) -> Option<u32> {
+    (pgid > 1 && pgid != child_id).then_some(pgid)
 }
 
 /// Find the process-group ID of a direct child of `parent_pid`.
@@ -77,7 +81,9 @@ fn find_child_pgid(parent_pid: u32) -> Option<u32> {
             continue;
         };
 
-        if ppid == parent_pid {
+        if ppid == parent_pid
+            && let Some(pgid) = child_pgid_to_signal(parent_pid, pgid)
+        {
             return Some(pgid);
         }
     }
@@ -97,7 +103,7 @@ impl ProcessTreeKillTarget {
 
     fn child_pgid_to_signal(self) -> Option<u32> {
         self.child_pgid
-            .filter(|pgid| *pgid > 1 && *pgid != self.child_id)
+            .and_then(|pgid| child_pgid_to_signal(self.child_id, pgid))
     }
 }
 
@@ -116,7 +122,7 @@ pub(crate) fn process_tree_kill_target(child_id: u32) -> ProcessTreeKillTarget {
 /// Refresh a snapshotted process-tree target while the direct child may still
 /// have a child session visible in `/proc`.
 pub(crate) fn refresh_process_tree_kill_target(target: &mut ProcessTreeKillTarget) {
-    if target.child_pgid.is_none() {
+    if target.child_pgid_to_signal().is_none() {
         target.child_pgid = find_child_pgid(target.child_id);
     }
 }
@@ -589,6 +595,151 @@ mod tests {
                 let cleanup = kill_pidfd_and_wait(&child_pidfd);
                 panic!(
                     "failed to wait for setsid child pid {child_pid} exit: {e}; cleanup={cleanup:?}"
+                );
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refresh_process_tree_target_retries_same_group_child_pgid() {
+        use std::io::Write;
+        use std::os::unix::process::CommandExt;
+
+        let (dir, _guard) = temp_dir("refresh-same-group");
+        let fifo = dir.join("child-fifo");
+        let ready = dir.join("ready");
+        let direct_pid_path = dir.join("direct-child-pid");
+        let setsid_child_pid_path = dir.join("setsid-child-pid");
+        let child_script = dir.join("child.sh");
+        let parent_script = dir.join("parent.sh");
+
+        std::fs::write(
+            &child_script,
+            r#"#!/bin/sh
+read _ < "$FIFO"
+exec setsid sh -c 'printf %s "$$" > "$SETSID_CHILD_PID"; sleep 60'
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &parent_script,
+            r#"#!/bin/sh
+mkfifo "$FIFO"
+sh "$CHILD_SCRIPT" &
+echo $! > "$DIRECT_PID"
+touch "$READY"
+wait
+"#,
+        )
+        .unwrap();
+
+        let mut command = Command::new("sh");
+        command
+            .arg(&parent_script)
+            .env("FIFO", &fifo)
+            .env("READY", &ready)
+            .env("DIRECT_PID", &direct_pid_path)
+            .env("SETSID_CHILD_PID", &setsid_child_pid_path)
+            .env("CHILD_SCRIPT", &child_script)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        command.process_group(0);
+
+        let mut child = Some(command.spawn().unwrap());
+        if !wait_for_path(&ready, Duration::from_secs(2)) {
+            kill_spawned_child(&mut child);
+            panic!("parent should start same-group child before snapshot");
+        }
+        let direct_pid_text = match std::fs::read_to_string(&direct_pid_path) {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to read direct child pid: {e}");
+            }
+        };
+        let direct_pid: u32 = match direct_pid_text.trim().parse() {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to parse direct child pid {direct_pid_text:?}: {e}");
+            }
+        };
+        let parent_pid = child.as_ref().unwrap().id();
+        let direct_stat = match std::fs::read_to_string(format!("/proc/{direct_pid}/stat")) {
+            Ok(stat) => stat,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to read direct child stat: {e}");
+            }
+        };
+        let direct_target = parse_stat_ppid_pgid(&direct_stat);
+        assert_eq!(
+            direct_target,
+            Some((parent_pid, parent_pid)),
+            "direct child should initially share the parent process group"
+        );
+
+        let mut target = process_tree_kill_target(parent_pid);
+        {
+            let mut fifo_writer = match std::fs::OpenOptions::new().write(true).open(&fifo) {
+                Ok(writer) => writer,
+                Err(e) => {
+                    kill_spawned_child(&mut child);
+                    panic!("failed to open child fifo: {e}");
+                }
+            };
+            if let Err(e) = writeln!(fifo_writer, "go") {
+                kill_spawned_child(&mut child);
+                panic!("failed to release child fifo: {e}");
+            }
+        }
+
+        if !wait_for_path(&setsid_child_pid_path, Duration::from_secs(2)) {
+            kill_spawned_child(&mut child);
+            panic!("setsid child should publish its pid before kill");
+        }
+        let setsid_child_pid_text = match std::fs::read_to_string(&setsid_child_pid_path) {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to read setsid child pid: {e}");
+            }
+        };
+        let setsid_child_pid: libc::pid_t = match setsid_child_pid_text.trim().parse() {
+            Ok(pid) => pid,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                panic!("failed to parse setsid child pid {setsid_child_pid_text:?}: {e}");
+            }
+        };
+        let setsid_child_pidfd = match open_pidfd(setsid_child_pid) {
+            Ok(pidfd) => pidfd,
+            Err(e) => {
+                kill_spawned_child(&mut child);
+                // SAFETY: best-effort cleanup of a test-owned process.
+                let _ = unsafe { libc::kill(setsid_child_pid, libc::SIGKILL) };
+                panic!("failed to open pidfd for setsid child pid {setsid_child_pid}: {e}");
+            }
+        };
+
+        refresh_process_tree_kill_target(&mut target);
+        assert!(unsafe { kill_process_tree_target(target) });
+        let _ = child.take().unwrap().wait().unwrap();
+
+        match wait_for_pidfd_exit(&setsid_child_pidfd, Duration::from_secs(2)) {
+            Ok(true) => {}
+            Ok(false) => {
+                kill_pidfd_and_wait(&setsid_child_pidfd)
+                    .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
+                panic!(
+                    "refresh should replace same-group child pgid and kill setsid child pid {setsid_child_pid}"
+                );
+            }
+            Err(e) => {
+                let cleanup = kill_pidfd_and_wait(&setsid_child_pidfd);
+                panic!(
+                    "failed to wait for setsid child pid {setsid_child_pid} exit: {e}; cleanup={cleanup:?}"
                 );
             }
         }

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -50,8 +50,13 @@ fn parse_stat_ppid_pgid(stat: &str) -> Option<(u32, u32)> {
     Some((ppid, pgid))
 }
 
+pub(crate) fn process_signal_pid(pid: u32) -> Option<libc::pid_t> {
+    let pid = libc::pid_t::try_from(pid).ok()?;
+    (pid > 0).then_some(pid)
+}
+
 fn process_group_signal_pid(pgid: u32) -> Option<libc::pid_t> {
-    let pgid = libc::pid_t::try_from(pgid).ok()?;
+    let pgid = process_signal_pid(pgid)?;
     (pgid > 1).then_some(-pgid)
 }
 
@@ -426,6 +431,10 @@ mod tests {
 
     #[test]
     fn process_group_signal_pid_skips_reserved_and_unrepresentable_targets() {
+        assert_eq!(process_signal_pid(0), None);
+        assert_eq!(process_signal_pid(1), Some(1));
+        assert_eq!(process_signal_pid(i32::MAX as u32), Some(i32::MAX));
+        assert_eq!(process_signal_pid(i32::MAX as u32 + 1), None);
         assert_eq!(process_group_signal_pid(0), None);
         assert_eq!(process_group_signal_pid(1), None);
         assert_eq!(process_group_signal_pid(42), Some(-42));

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -583,7 +583,11 @@ mod tests {
         assert!(status.success());
 
         // SAFETY: `target` came from the spawned shell before it exited.
-        assert!(unsafe { kill_process_tree_target(target) });
+        if !unsafe { kill_process_tree_target(target) } {
+            kill_pidfd_and_wait(&child_pidfd)
+                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
+            panic!("snapshotted target should signal at least one process group");
+        }
         match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {
             Ok(true) => {}
             Ok(false) => {
@@ -732,7 +736,12 @@ wait
         };
 
         refresh_process_tree_kill_target(&mut target);
-        assert!(unsafe { kill_process_tree_target(target) });
+        if !unsafe { kill_process_tree_target(target) } {
+            kill_spawned_child(&mut child);
+            kill_pidfd_and_wait(&setsid_child_pidfd)
+                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
+            panic!("refreshed target should signal at least one process group");
+        }
         let _ = child.take().unwrap().wait().unwrap();
 
         match wait_for_pidfd_exit(&setsid_child_pidfd, Duration::from_secs(2)) {

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -577,10 +577,26 @@ mod tests {
                     panic!("failed to open parent fifo: {e}");
                 }
             };
-            writeln!(fifo_writer, "done").unwrap();
+            if let Err(e) = writeln!(fifo_writer, "done") {
+                kill_spawned_child(&mut child);
+                kill_pidfd_and_wait(&child_pidfd)
+                    .unwrap_or_else(|cleanup| panic!("fifo write failed: {e}; cleanup={cleanup}"));
+                panic!("failed to release parent fifo: {e}");
+            }
         }
-        let status = child.take().unwrap().wait().unwrap();
-        assert!(status.success());
+        let status = match child.take().unwrap().wait() {
+            Ok(status) => status,
+            Err(e) => {
+                kill_pidfd_and_wait(&child_pidfd)
+                    .unwrap_or_else(|cleanup| panic!("parent wait failed: {e}; cleanup={cleanup}"));
+                panic!("failed to wait for parent shell: {e}");
+            }
+        };
+        if !status.success() {
+            kill_pidfd_and_wait(&child_pidfd)
+                .unwrap_or_else(|cleanup| panic!("parent exited with {status}; cleanup={cleanup}"));
+            panic!("parent shell should exit successfully, got {status}");
+        }
 
         // SAFETY: `target` came from the spawned shell before it exited.
         if !unsafe { kill_process_tree_target(target) } {
@@ -686,11 +702,12 @@ wait
             }
         };
         let direct_target = parse_stat_ppid_pgid(&direct_stat);
-        assert_eq!(
-            direct_target,
-            Some((parent_pid, parent_pid)),
-            "direct child should initially share the parent process group"
-        );
+        if direct_target != Some((parent_pid, parent_pid)) {
+            kill_spawned_child(&mut child);
+            panic!(
+                "direct child should initially share the parent process group, got {direct_target:?}"
+            );
+        }
 
         let mut target = process_tree_kill_target(parent_pid);
         {
@@ -742,7 +759,11 @@ wait
                 .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
             panic!("refreshed target should signal at least one process group");
         }
-        let _ = child.take().unwrap().wait().unwrap();
+        if let Err(e) = child.take().unwrap().wait() {
+            kill_pidfd_and_wait(&setsid_child_pidfd)
+                .unwrap_or_else(|cleanup| panic!("parent wait failed: {e}; cleanup={cleanup}"));
+            panic!("failed to wait for killed parent shell: {e}");
+        }
 
         match wait_for_pidfd_exit(&setsid_child_pidfd, Duration::from_secs(2)) {
             Ok(true) => {}

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -303,6 +303,23 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    fn read_pid_file<T: std::str::FromStr>(path: &Path) -> Option<T> {
+        std::fs::read_to_string(path).ok()?.trim().parse().ok()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn wait_for_pid_file<T: std::str::FromStr>(path: &Path, timeout: Duration) -> Option<T> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if let Some(pid) = read_pid_file(path) {
+                return Some(pid);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        read_pid_file(path)
+    }
+
+    #[cfg(target_os = "linux")]
     fn kill_spawned_child_with_watchdog(child: &mut Option<Child>) {
         if let Some(mut child) = child.take() {
             kill_child(process_tree_kill_target(child.id()), KillReason::Cancelled);
@@ -479,24 +496,20 @@ mod tests {
             }
         }
 
-        if !wait_for_path(&child_pid_path, Duration::from_secs(2)) {
+        let child_pid: libc::pid_t =
+            match wait_for_pid_file(&child_pid_path, Duration::from_secs(2)) {
+                Some(pid) => pid,
+                None => {
+                    let child_pid_text =
+                        std::fs::read_to_string(&child_pid_path).unwrap_or_default();
+                    kill_spawned_child_with_watchdog(&mut child);
+                    panic!("failed to parse setsid child pid {child_pid_text:?}");
+                }
+            };
+        if child_pid <= 0 {
             kill_spawned_child_with_watchdog(&mut child);
-            panic!("setsid child should publish its pid before watchdog kill");
+            panic!("setsid child pid should be positive, got {child_pid}");
         }
-        let child_pid_text = match std::fs::read_to_string(&child_pid_path) {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child_with_watchdog(&mut child);
-                panic!("failed to read setsid child pid: {e}");
-            }
-        };
-        let child_pid: libc::pid_t = match child_pid_text.trim().parse() {
-            Ok(pid) => pid,
-            Err(e) => {
-                kill_spawned_child_with_watchdog(&mut child);
-                panic!("failed to parse setsid child pid {child_pid_text:?}: {e}");
-            }
-        };
         let child_pidfd = match open_pidfd(child_pid) {
             Ok(pidfd) => pidfd,
             Err(e) => {

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use crate::process::{
     ProcessTreeKillTarget, kill_and_reap_child_with_target, kill_process_tree_target,
-    process_tree_kill_target, refresh_process_tree_kill_target,
+    process_signal_pid, process_tree_kill_target, refresh_process_tree_kill_target,
 };
 use crate::threading::spawn_scoped_named;
 
@@ -237,8 +237,9 @@ fn kill_child(kill_target: ProcessTreeKillTarget, reason: KillReason) -> Watchdo
     let child_id = kill_target.child_id();
     // SAFETY: kill_target comes from a PID returned by Command::spawn.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
-    // SAFETY: child_id is a process id from Command::spawn.
-    let child_killed = unsafe { libc::kill(child_id as i32, libc::SIGKILL) == 0 };
+    let child_killed = process_signal_pid(child_id)
+        // SAFETY: child_id is a process id from Command::spawn and was validated as pid_t.
+        .is_some_and(|pid| unsafe { libc::kill(pid, libc::SIGKILL) == 0 });
     let killed = tree_killed || child_killed;
     WatchdogKill { reason, killed }
 }


### PR DESCRIPTION
## Summary

- parse `/proc/{pid}/stat` ppid/pgid fields without collecting the remaining fields into a `Vec`
- only cache child process groups that are safe and useful to signal
- refresh stale process-tree targets when the cached child pgid is not signalable
- add a Linux regression test for a same-group child that later moves into a `setsid` process group

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest refresh_process_tree_target_retries_same_group_child_pgid`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest process::tests`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest wait::tests`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`

Closes #18182