### PR TITLE
fix: simplify presentation template detail title

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1652,7 +1652,17 @@ describe("chat composer templates", () => {
       "true",
     );
 
-    click(within(templateDialog).getByRole("button", { name: "Template" }));
+    const templateButton = queryAllByRoleFast("button", templateDialog).find(
+      (candidate) => {
+        return (
+          candidate.textContent?.replace(/\s+/g, " ").trim() === "Template"
+        );
+      },
+    );
+    if (!templateButton) {
+      throw new Error("Template button not found");
+    }
+    click(templateButton);
     click(screen.getByLabelText(`View template ${template.title}`));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1631,6 +1631,13 @@ describe("chat composer templates", () => {
     await fill(screen.getByLabelText("Search templates"), template.title);
     click(screen.getByLabelText(`View template ${template.title}`));
 
+    const templateDialog = screen.getByRole("dialog");
+    expect(
+      within(templateDialog).getByRole("heading", {
+        name: `Template ${template.title}`,
+      }),
+    ).toBeInTheDocument();
+
     await waitFor(() => {
       expect(screen.getByText("1 of 15")).toBeInTheDocument();
     });
@@ -1645,7 +1652,7 @@ describe("chat composer templates", () => {
       "true",
     );
 
-    click(screen.getByText("Templates"));
+    click(within(templateDialog).getByRole("button", { name: "Template" }));
     click(screen.getByLabelText(`View template ${template.title}`));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2180,11 +2180,9 @@ function TemplatePreviewPage({
             className="shrink-0 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={onBack}
           >
-            Templates
+            Template
           </button>
-          <span className="shrink-0 text-muted-foreground">/</span>
-          <span className="shrink-0 text-muted-foreground">Presentation</span>
-          <span className="shrink-0 text-muted-foreground">/</span>
+          {" "}
           <span className="min-w-0 truncate">{item.title}</span>
         </DialogTitle>
       </DialogHeader>


### PR DESCRIPTION
## Summary
- change the presentation template detail dialog title from a breadcrumb to `Template {title}`
- update the composer template test to assert the new title and back button copy

## Tests
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`