### PR TITLE
feat: productize computer use main window

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -125,6 +125,20 @@ export class DesktopAuthSession {
     return await this.refresh();
   }
 
+  async fetchWithSessionAuth(requestUrl: URL): Promise<Response> {
+    const response = await fetch(requestUrl, {
+      headers: await this.headersFor(requestUrl),
+    });
+    if (response.status !== 401 || !this.token) {
+      return response;
+    }
+
+    this.token = null;
+    return await fetch(requestUrl, {
+      headers: await this.headersFor(requestUrl),
+    });
+  }
+
   getCachedToken(): string | null {
     return this.token;
   }
@@ -276,20 +290,6 @@ export class DesktopAuthSession {
     }
     this.signingIn = value;
     this.onChange();
-  }
-
-  private async fetchWithSessionAuth(requestUrl: URL): Promise<Response> {
-    const response = await fetch(requestUrl, {
-      headers: await this.headersFor(requestUrl),
-    });
-    if (response.status !== 401 || !this.token) {
-      return response;
-    }
-
-    this.token = null;
-    return await fetch(requestUrl, {
-      headers: await this.headersFor(requestUrl),
-    });
   }
 
   private async headersFor(requestUrl: URL): Promise<Headers> {

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -56,10 +56,24 @@ export interface DesktopComputerUseApi {
   readonly subscribe: (callback: () => void) => () => void;
 }
 
+export interface DesktopDeveloperToolsState {
+  readonly available: boolean;
+  readonly enabled: boolean;
+}
+
+export interface DesktopDeveloperToolsApi {
+  readonly getState: () => Promise<DesktopDeveloperToolsState>;
+  readonly setEnabled: (
+    enabled: boolean,
+  ) => Promise<DesktopDeveloperToolsState>;
+  readonly subscribe: (callback: () => void) => () => void;
+}
+
 declare global {
   interface Window {
     vm0DesktopAuth?: DesktopAuthApi;
     vm0DesktopComputerUse?: DesktopComputerUseApi;
+    vm0DesktopDeveloperTools?: DesktopDeveloperToolsApi;
   }
 }
 

--- a/turbo/apps/desktop/src/desktop-developer-tools-electron.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-electron.ts
@@ -1,0 +1,55 @@
+import type { IpcMainInvokeEvent } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
+import type { DesktopDeveloperToolsState } from "./desktop-bridge";
+import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
+import { isDesktopComputerUsePageUrl } from "./computer-use-page-url";
+
+interface DesktopDeveloperToolsIpcOptions {
+  readonly rendererUrl: string;
+}
+
+interface DesktopDeveloperToolsNativeApi {
+  readonly getState: () => DesktopDeveloperToolsState;
+  readonly setEnabled: (enabled: boolean) => DesktopDeveloperToolsState;
+}
+
+export function notifyDesktopDeveloperToolsChanged(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed);
+    }
+  }
+}
+
+export function installDesktopDeveloperToolsIpc(
+  api: DesktopDeveloperToolsNativeApi,
+  options: DesktopDeveloperToolsIpcOptions,
+): void {
+  const assertComputerUsePage = (event: IpcMainInvokeEvent): void => {
+    if (
+      !isDesktopComputerUsePageUrl(
+        event.senderFrame?.url ?? "",
+        options.rendererUrl,
+      )
+    ) {
+      throw new Error("Desktop developer tools are unavailable on this page");
+    }
+  };
+
+  ipcMain.handle(DESKTOP_DEVELOPER_TOOLS_CHANNELS.getState, (event) => {
+    assertComputerUsePage(event);
+    return api.getState();
+  });
+  ipcMain.handle(
+    DESKTOP_DEVELOPER_TOOLS_CHANNELS.setEnabled,
+    (event, enabled: unknown) => {
+      assertComputerUsePage(event);
+      if (typeof enabled !== "boolean") {
+        throw new Error(
+          "Desktop developer tools enabled state must be a boolean",
+        );
+      }
+      return api.setEnabled(enabled);
+    },
+  );
+}

--- a/turbo/apps/desktop/src/desktop-developer-tools-ipc-channels.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-ipc-channels.ts
@@ -1,0 +1,5 @@
+export const DESKTOP_DEVELOPER_TOOLS_CHANNELS = {
+  getState: "desktop-developer-tools:get-state",
+  setEnabled: "desktop-developer-tools:set-enabled",
+  changed: "desktop-developer-tools:changed",
+} as const;

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -4,6 +4,7 @@ import type { DesktopComputerUseState } from "./computer-use-types";
 import { COMPUTER_USE_FEATURE_SWITCH_KEY } from "./computer-use-types";
 import type { DesktopAuthState } from "./desktop-bridge";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
+import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
 
 type IpcEvent = {
   readonly senderFrame?: {
@@ -128,6 +129,35 @@ describe("Desktop IPC boundary", () => {
     expect(api.completeSignIn).toHaveBeenCalledWith("desktop_token");
   });
 
+  it("protects developer tools handlers by renderer URL and validates payloads", async () => {
+    const { installDesktopDeveloperToolsIpc } =
+      await import("./desktop-developer-tools-electron");
+    const api = createDesktopDeveloperToolsApi();
+
+    installDesktopDeveloperToolsIpc(api, { rendererUrl });
+
+    await expect(
+      invokeIpc(DESKTOP_DEVELOPER_TOOLS_CHANNELS.getState, blockedAppUrl),
+    ).rejects.toThrow("Desktop developer tools are unavailable on this page");
+    await expect(
+      invokeIpc(
+        DESKTOP_DEVELOPER_TOOLS_CHANNELS.setEnabled,
+        rendererUrl,
+        "true",
+      ),
+    ).rejects.toThrow(
+      "Desktop developer tools enabled state must be a boolean",
+    );
+
+    await invokeIpc(
+      DESKTOP_DEVELOPER_TOOLS_CHANNELS.setEnabled,
+      rendererUrl,
+      true,
+    );
+
+    expect(api.setEnabled).toHaveBeenCalledWith(true);
+  });
+
   it("notifies only live windows when computer use state changes", async () => {
     const { notifyDesktopComputerUseChanged } =
       await import("./computer-use-electron");
@@ -154,6 +184,21 @@ describe("Desktop IPC boundary", () => {
 
     expect(liveWindow.webContents.send).toHaveBeenCalledWith(
       DESKTOP_AUTH_CHANNELS.changed,
+    );
+    expect(destroyedWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it("notifies only live windows when developer tools state changes", async () => {
+    const { notifyDesktopDeveloperToolsChanged } =
+      await import("./desktop-developer-tools-electron");
+    const liveWindow = createMockWindow({ destroyed: false });
+    const destroyedWindow = createMockWindow({ destroyed: true });
+    electronMock.windows.push(liveWindow, destroyedWindow);
+
+    notifyDesktopDeveloperToolsChanged();
+
+    expect(liveWindow.webContents.send).toHaveBeenCalledWith(
+      DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed,
     );
     expect(destroyedWindow.webContents.send).not.toHaveBeenCalled();
   });
@@ -215,6 +260,30 @@ function createDesktopAuthApi(): {
     openOrgSelection: vi.fn(async () => {}),
     signOut: vi.fn(async () => {}),
     completeSignIn: vi.fn(() => {}),
+  };
+}
+
+function createDesktopDeveloperToolsApi(): {
+  readonly getState: ReturnType<
+    typeof vi.fn<
+      () => { readonly available: boolean; readonly enabled: boolean }
+    >
+  >;
+  readonly setEnabled: ReturnType<
+    typeof vi.fn<
+      (enabled: boolean) => {
+        readonly available: boolean;
+        readonly enabled: boolean;
+      }
+    >
+  >;
+} {
+  const state = { available: true, enabled: false };
+  return {
+    getState: vi.fn(() => state),
+    setEnabled: vi.fn((enabled) => {
+      return { available: true, enabled };
+    }),
   };
 }
 

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -140,14 +140,14 @@ describe("desktop tray menu", () => {
     );
 
     expect(menu.map((item) => item.label).filter((label) => label)).toEqual([
-      "Show Main Window",
+      "Open Computer Use",
       "Workspace: Max & Zoe",
       "Computer Use: Online",
       "Keep Mac Awake",
       "No Recent Commands",
       "Quit",
     ]);
-    expect(findItem(menu, "Show Main Window")).toBeDefined();
+    expect(findItem(menu, "Open Computer Use")).toBeDefined();
     expect(findItem(menu, "Keep Mac Awake")).toStrictEqual({
       label: "Keep Mac Awake",
       type: "checkbox",

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -340,7 +340,7 @@ export function buildDesktopTrayMenuItems(
   actions: DesktopTrayMenuActions,
 ): readonly DesktopTrayMenuItem[] {
   return [
-    { label: "Show Main Window", click: actions.showMainWindow },
+    { label: "Open Computer Use", click: actions.showMainWindow },
     {
       label: authStatusLabel(state),
       submenu: buildAuthSubmenu(state, actions),

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -11,6 +11,7 @@ import {
   protocol,
   session,
   shell,
+  type MenuItemConstructorOptions,
 } from "electron";
 import {
   ComputerUseSnapshotStore,
@@ -64,6 +65,11 @@ import {
   notifyDesktopAuthChanged,
 } from "./desktop-auth-electron";
 import {
+  installDesktopDeveloperToolsIpc,
+  notifyDesktopDeveloperToolsChanged,
+} from "./desktop-developer-tools-electron";
+import type { DesktopDeveloperToolsState } from "./desktop-bridge";
+import {
   buildDesktopAuthConsumeUrl,
   buildDesktopAuthSelectOrgUrl,
   buildDesktopAuthStartUrl,
@@ -103,6 +109,8 @@ const desktopAuthSelectOrgUrl = buildDesktopAuthSelectOrgUrl(
 );
 const desktopAuthTokenUrl = buildDesktopAuthTokenUrl(config.webUrl);
 const localRendererUrl = desktopRendererUrl();
+const ZERO_DEBUG_FEATURE_SWITCH_KEY = "zeroDebug";
+const ZERO_FEATURE_SWITCHES_PATH = "/api/zero/feature-switches";
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const ELECTRON_ERR_ABORTED = -3;
 const COMPUTER_USE_QUIT_STOP_TIMEOUT_MS = 1_000;
@@ -124,6 +132,10 @@ let computerUseManualStopRequested = false;
 let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
+let developerToolsAvailable = false;
+let developerToolsEnabled = false;
+let developerToolsRefresh: Promise<void> | null = null;
+let developerToolsRefreshRequested = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
@@ -163,6 +175,92 @@ function notifyComputerUseChanged(): void {
 function notifyAuthChanged(): void {
   notifyDesktopAuthChanged();
   refreshDesktopTrayAuth();
+  refreshDeveloperToolsAvailabilityForState();
+}
+
+function notifyDeveloperToolsChanged(): void {
+  notifyDesktopDeveloperToolsChanged();
+  if (app.isReady()) {
+    applyApplicationMenu();
+  }
+}
+
+function getDesktopDeveloperToolsState(): DesktopDeveloperToolsState {
+  return {
+    available: developerToolsAvailable,
+    enabled: developerToolsAvailable && developerToolsEnabled,
+  };
+}
+
+function setDesktopDeveloperToolsEnabled(
+  enabled: boolean,
+): DesktopDeveloperToolsState {
+  const nextEnabled = developerToolsAvailable && enabled;
+  if (developerToolsEnabled !== nextEnabled) {
+    developerToolsEnabled = nextEnabled;
+    notifyDeveloperToolsChanged();
+  }
+  return getDesktopDeveloperToolsState();
+}
+
+function setDeveloperToolsAvailability(available: boolean): void {
+  const nextEnabled = available ? developerToolsEnabled : false;
+  if (
+    developerToolsAvailable === available &&
+    developerToolsEnabled === nextEnabled
+  ) {
+    return;
+  }
+  developerToolsAvailable = available;
+  developerToolsEnabled = nextEnabled;
+  notifyDeveloperToolsChanged();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function zeroDebugEnabledFromFeatureSwitches(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.switches)) {
+    return false;
+  }
+  return value.switches[ZERO_DEBUG_FEATURE_SWITCH_KEY] === true;
+}
+
+async function refreshDeveloperToolsAvailability(): Promise<void> {
+  const response = await getAuthSession().fetchWithSessionAuth(
+    new URL(ZERO_FEATURE_SWITCHES_PATH, desktopApiBaseUrl),
+  );
+  if (response.status === 401) {
+    setDeveloperToolsAvailability(false);
+    return;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Desktop developer tools feature switch failed: ${response.status}`,
+    );
+  }
+  const body: unknown = await response.json();
+  setDeveloperToolsAvailability(zeroDebugEnabledFromFeatureSwitches(body));
+}
+
+function refreshDeveloperToolsAvailabilityForState(): void {
+  if (developerToolsRefresh) {
+    developerToolsRefreshRequested = true;
+    return;
+  }
+  developerToolsRefresh = refreshDeveloperToolsAvailability()
+    .catch((error) => {
+      console.warn("Unable to refresh desktop developer tools state", error);
+      setDeveloperToolsAvailability(false);
+    })
+    .finally(() => {
+      developerToolsRefresh = null;
+      if (developerToolsRefreshRequested) {
+        developerToolsRefreshRequested = false;
+        refreshDeveloperToolsAvailabilityForState();
+      }
+    });
 }
 
 async function runAuthWindow(request: {
@@ -437,6 +535,16 @@ function installComputerUse(): void {
   );
 }
 
+function installDesktopDeveloperTools(): void {
+  installDesktopDeveloperToolsIpc(
+    {
+      getState: getDesktopDeveloperToolsState,
+      setEnabled: setDesktopDeveloperToolsEnabled,
+    },
+    { rendererUrl: localRendererUrl },
+  );
+}
+
 function refreshComputerUsePermissionsForState(): void {
   void refreshComputerUsePermissionState()
     .catch((error) => {
@@ -570,18 +678,31 @@ function requestDesktopQuit(): void {
 }
 
 function applyApplicationMenu(): void {
+  const appSubmenu: MenuItemConstructorOptions[] = [
+    { role: "about" },
+    { type: "separator" },
+  ];
+  if (developerToolsAvailable) {
+    appSubmenu.push({
+      label: "Developer Tools",
+      type: "checkbox",
+      checked: developerToolsEnabled,
+      click: () => {
+        setDesktopDeveloperToolsEnabled(!developerToolsEnabled);
+      },
+    });
+    appSubmenu.push({ type: "separator" });
+  }
+  appSubmenu.push({
+    label: `Quit ${config.identity.displayName}`,
+    accelerator: "CommandOrControl+Q",
+    click: requestDesktopQuit,
+  });
+
   const menu = Menu.buildFromTemplate([
     {
       label: config.identity.displayName,
-      submenu: [
-        { role: "about" },
-        { type: "separator" },
-        {
-          label: `Quit ${config.identity.displayName}`,
-          accelerator: "CommandOrControl+Q",
-          click: requestDesktopQuit,
-        },
-      ],
+      submenu: appSubmenu,
     },
     {
       label: "Edit",
@@ -1049,9 +1170,11 @@ if (!hasSingleInstanceLock) {
     });
     installKeepAwake();
     installComputerUse();
+    installDesktopDeveloperTools();
     refreshComputerUsePermissionsForState();
     const desktopAuthSession = getAuthSession();
     installDesktopAuth();
+    refreshDeveloperToolsAvailabilityForState();
     installTray();
     queueDesktopAuthCallbackArgv(process.argv);
 

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
-import type { DesktopAuthApi, DesktopComputerUseApi } from "./desktop-bridge";
+import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
+import type {
+  DesktopAuthApi,
+  DesktopComputerUseApi,
+  DesktopDeveloperToolsApi,
+} from "./desktop-bridge";
 
 type ExposeInMainWorld = (key: string, api: unknown) => void;
 type IpcInvoke = (channel: string, ...args: unknown[]) => Promise<unknown>;
@@ -64,17 +69,24 @@ beforeEach(() => {
 });
 
 describe("Desktop preload bridge", () => {
-  it("exposes the desktop auth and computer use APIs in the renderer", async () => {
+  it("exposes the desktop APIs in the renderer", async () => {
     await loadPreload();
 
     expect(
       electronMock.contextBridge.exposeInMainWorld.mock.calls.map(([key]) => {
         return key;
       }),
-    ).toStrictEqual(["vm0DesktopAuth", "vm0DesktopComputerUse"]);
+    ).toStrictEqual([
+      "vm0DesktopAuth",
+      "vm0DesktopComputerUse",
+      "vm0DesktopDeveloperTools",
+    ]);
     expect(exposedApi<DesktopAuthApi>("vm0DesktopAuth")).toBeTruthy();
     expect(
       exposedApi<DesktopComputerUseApi>("vm0DesktopComputerUse"),
+    ).toBeTruthy();
+    expect(
+      exposedApi<DesktopDeveloperToolsApi>("vm0DesktopDeveloperTools"),
     ).toBeTruthy();
   });
 
@@ -126,33 +138,65 @@ describe("Desktop preload bridge", () => {
     ]);
   });
 
-  it("cleans up auth and computer use IPC subscriptions", async () => {
+  it("routes developer tools API calls through IPC channels", async () => {
+    await loadPreload();
+    const developerTools = exposedApi<DesktopDeveloperToolsApi>(
+      "vm0DesktopDeveloperTools",
+    );
+
+    await developerTools.getState();
+    await developerTools.setEnabled(true);
+
+    expect(electronMock.ipcRenderer.invoke.mock.calls).toStrictEqual([
+      [DESKTOP_DEVELOPER_TOOLS_CHANNELS.getState],
+      [DESKTOP_DEVELOPER_TOOLS_CHANNELS.setEnabled, true],
+    ]);
+  });
+
+  it("cleans up auth, computer use, and developer tools IPC subscriptions", async () => {
     await loadPreload();
     const auth = exposedApi<DesktopAuthApi>("vm0DesktopAuth");
     const computerUse = exposedApi<DesktopComputerUseApi>(
       "vm0DesktopComputerUse",
     );
+    const developerTools = exposedApi<DesktopDeveloperToolsApi>(
+      "vm0DesktopDeveloperTools",
+    );
     const authChanged = vi.fn<() => void>();
     const computerUseChanged = vi.fn<() => void>();
+    const developerToolsChanged = vi.fn<() => void>();
 
     const unsubscribeAuth = auth.subscribe(authChanged);
     const unsubscribeComputerUse = computerUse.subscribe(computerUseChanged);
+    const unsubscribeDeveloperTools = developerTools.subscribe(
+      developerToolsChanged,
+    );
 
     electronMock.emit(DESKTOP_AUTH_CHANNELS.changed, { ignored: true });
     electronMock.emit(COMPUTER_USE_CHANNELS.changed, { ignored: true });
+    electronMock.emit(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed, {
+      ignored: true,
+    });
 
     expect(authChanged).toHaveBeenCalledOnce();
     expect(computerUseChanged).toHaveBeenCalledOnce();
+    expect(developerToolsChanged).toHaveBeenCalledOnce();
 
     const authListener = listenerFor(DESKTOP_AUTH_CHANNELS.changed);
     const computerUseListener = listenerFor(COMPUTER_USE_CHANNELS.changed);
+    const developerToolsListener = listenerFor(
+      DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed,
+    );
     unsubscribeAuth();
     unsubscribeComputerUse();
+    unsubscribeDeveloperTools();
     electronMock.emit(DESKTOP_AUTH_CHANNELS.changed);
     electronMock.emit(COMPUTER_USE_CHANNELS.changed);
+    electronMock.emit(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed);
 
     expect(authChanged).toHaveBeenCalledOnce();
     expect(computerUseChanged).toHaveBeenCalledOnce();
+    expect(developerToolsChanged).toHaveBeenCalledOnce();
     expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
       DESKTOP_AUTH_CHANNELS.changed,
       authListener,
@@ -160,6 +204,10 @@ describe("Desktop preload bridge", () => {
     expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
       COMPUTER_USE_CHANNELS.changed,
       computerUseListener,
+    );
+    expect(electronMock.ipcRenderer.off).toHaveBeenCalledWith(
+      DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed,
+      developerToolsListener,
     );
   });
 });

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -1,7 +1,12 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { DesktopAuthApi, DesktopComputerUseApi } from "./desktop-bridge";
+import type {
+  DesktopAuthApi,
+  DesktopComputerUseApi,
+  DesktopDeveloperToolsApi,
+} from "./desktop-bridge";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
+import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
 import type { DesktopComputerUseState } from "./computer-use-types";
 
 const desktopAuthApi: DesktopAuthApi = {
@@ -79,5 +84,30 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
   },
 };
 
+const desktopDeveloperToolsApi: DesktopDeveloperToolsApi = {
+  getState() {
+    return ipcRenderer.invoke(DESKTOP_DEVELOPER_TOOLS_CHANNELS.getState);
+  },
+  setEnabled(enabled) {
+    return ipcRenderer.invoke(
+      DESKTOP_DEVELOPER_TOOLS_CHANNELS.setEnabled,
+      enabled,
+    );
+  },
+  subscribe(callback: () => void): () => void {
+    const listener = (): void => {
+      callback();
+    };
+    ipcRenderer.on(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed, listener);
+    return () => {
+      ipcRenderer.off(DESKTOP_DEVELOPER_TOOLS_CHANNELS.changed, listener);
+    };
+  },
+};
+
 contextBridge.exposeInMainWorld("vm0DesktopAuth", desktopAuthApi);
 contextBridge.exposeInMainWorld("vm0DesktopComputerUse", desktopComputerUseApi);
+contextBridge.exposeInMainWorld(
+  "vm0DesktopDeveloperTools",
+  desktopDeveloperToolsApi,
+);

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -21,6 +21,8 @@ import type {
   DesktopAuthApi,
   DesktopAuthState,
   DesktopComputerUseApi,
+  DesktopDeveloperToolsApi,
+  DesktopDeveloperToolsState,
 } from "../desktop-bridge";
 import { App } from "./App";
 
@@ -41,6 +43,11 @@ const signedOutAuthState: DesktopAuthState = {
   status: "signed_out",
   user: null,
   organization: null,
+};
+
+const defaultDeveloperToolsState: DesktopDeveloperToolsState = {
+  available: false,
+  enabled: false,
 };
 
 function createComputerUseState({
@@ -225,23 +232,78 @@ function createAuthBridge(initialState: DesktopAuthState): {
   };
 }
 
+function createDeveloperToolsBridge(initialState: DesktopDeveloperToolsState): {
+  readonly api: DesktopDeveloperToolsApi;
+  readonly emitState: (nextState: DesktopDeveloperToolsState) => void;
+  readonly getState: ReturnType<
+    typeof vi.fn<DesktopDeveloperToolsApi["getState"]>
+  >;
+  readonly subscribe: ReturnType<
+    typeof vi.fn<DesktopDeveloperToolsApi["subscribe"]>
+  >;
+} {
+  let currentState = initialState;
+  const subscribers = new Set<() => void>();
+  const getState = vi.fn<DesktopDeveloperToolsApi["getState"]>(async () => {
+    return currentState;
+  });
+  const setEnabled = vi.fn<DesktopDeveloperToolsApi["setEnabled"]>(
+    async (enabled) => {
+      currentState = {
+        available: currentState.available,
+        enabled: currentState.available && enabled,
+      };
+      return currentState;
+    },
+  );
+  const subscribe = vi.fn<DesktopDeveloperToolsApi["subscribe"]>((callback) => {
+    subscribers.add(callback);
+    return () => {
+      subscribers.delete(callback);
+    };
+  });
+  const api: DesktopDeveloperToolsApi = {
+    getState,
+    setEnabled,
+    subscribe,
+  };
+
+  return {
+    api,
+    emitState: (nextState) => {
+      currentState = nextState;
+      for (const subscriber of subscribers) {
+        subscriber();
+      }
+    },
+    getState,
+    subscribe,
+  };
+}
+
 function installDesktopBridges({
   authState = signedInAuthState,
   computerUseState = createComputerUseState(),
+  developerToolsState = defaultDeveloperToolsState,
 }: {
   readonly authState?: DesktopAuthState;
   readonly computerUseState?: DesktopComputerUseState;
+  readonly developerToolsState?: DesktopDeveloperToolsState;
 } = {}): {
   readonly auth: ReturnType<typeof createAuthBridge>;
   readonly computerUse: ReturnType<typeof createComputerUseBridge>;
+  readonly developerTools: ReturnType<typeof createDeveloperToolsBridge>;
 } {
   const auth = createAuthBridge(authState);
   const computerUse = createComputerUseBridge(computerUseState);
+  const developerTools = createDeveloperToolsBridge(developerToolsState);
   window.vm0DesktopAuth = auth.api;
   window.vm0DesktopComputerUse = computerUse.api;
+  window.vm0DesktopDeveloperTools = developerTools.api;
   return {
     auth,
     computerUse,
+    developerTools,
   };
 }
 
@@ -265,6 +327,7 @@ afterEach(() => {
   cleanup();
   delete window.vm0DesktopAuth;
   delete window.vm0DesktopComputerUse;
+  delete window.vm0DesktopDeveloperTools;
   vi.clearAllMocks();
 });
 
@@ -306,6 +369,23 @@ describe("Desktop renderer bridge integration", () => {
 
     expect(await screen.findByText("Online")).toBeTruthy();
     expect(computerUse.subscribe).toHaveBeenCalled();
+  });
+
+  it("shows runtime details only after developer tools are enabled", async () => {
+    const { developerTools } = installDesktopBridges({
+      computerUseState: createComputerUseState({ status: "online" }),
+    });
+    renderDesktopApp();
+
+    expect(await screen.findByText("Online")).toBeTruthy();
+    expect(screen.queryByText("Runtime")).toBeNull();
+    expect(screen.queryByText("Command Log")).toBeNull();
+
+    developerTools.emitState({ available: true, enabled: true });
+
+    expect(await screen.findByText("Runtime")).toBeTruthy();
+    expect(await screen.findByText("Command Log")).toBeTruthy();
+    expect(developerTools.subscribe).toHaveBeenCalled();
   });
 
   it("delegates signed-out account actions to the auth bridge", async () => {

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -30,9 +30,11 @@ import {
 } from "../computer-use-types";
 import {
   computerUseData$,
+  developerToolsData$,
   desktopAuthData$,
   hasDesktopAuthBridge,
   hasDesktopComputerUseBridge,
+  hasDesktopDeveloperToolsBridge,
   openAccessibilitySettings$,
   openDesktopOrgSelection$,
   openDesktopSignIn$,
@@ -67,6 +69,17 @@ const STATUS_LABELS = {
   needs_organization: "Select workspace",
   disabled: "Disabled",
   error: "Error",
+} as const satisfies Record<HostStatus, string>;
+
+const COMPUTER_USE_STATUS_COPY = {
+  offline: "Computer Use is stopped on this Mac.",
+  connecting: "Starting Computer Use on this Mac.",
+  online: "This Mac is available for Zero computer use.",
+  recovering: "Computer Use is reconnecting automatically.",
+  unauthenticated: "Sign in to Zero before starting Computer Use.",
+  needs_organization: "Select a workspace before starting Computer Use.",
+  disabled: "Computer Use is disabled for this Mac.",
+  error: "Computer Use needs attention before it can continue.",
 } as const satisfies Record<HostStatus, string>;
 
 const COMMAND_STATUS_LABELS = {
@@ -787,6 +800,70 @@ function RuntimePanel({ state }: { readonly state: DesktopComputerUseState }) {
   );
 }
 
+function ComputerUseStatusPanel({
+  state,
+}: {
+  readonly state: DesktopComputerUseState;
+}) {
+  const [startLoadable, start] = useLoadableSet(startComputerUse$);
+  const [stopLoadable, stop] = useLoadableSet(stopComputerUse$);
+  const running =
+    state.host.status === "connecting" ||
+    state.host.status === "online" ||
+    state.host.status === "recovering";
+  const startDisabled =
+    running ||
+    state.host.status === "disabled" ||
+    startLoadable.state === "loading";
+  const stopDisabled =
+    (state.host.status !== "online" && state.host.status !== "recovering") ||
+    stopLoadable.state === "loading";
+
+  return (
+    <Panel title="Computer Use" icon={<IconActivityHeartbeat size={18} />}>
+      <div
+        className={`computer-use-status-card computer-use-status-${state.host.status}`}
+      >
+        <div className="computer-use-status-main">
+          <div className="computer-use-status-mark" aria-hidden="true">
+            <IconActivityHeartbeat size={26} />
+          </div>
+          <div className="computer-use-status-copy">
+            <span>Status</span>
+            <strong>{STATUS_LABELS[state.host.status]}</strong>
+            <p>{COMPUTER_USE_STATUS_COPY[state.host.status]}</p>
+          </div>
+        </div>
+        <div className="computer-use-status-action">
+          {running ? (
+            <IconButton
+              tone="danger"
+              icon={<IconPlayerStop size={15} />}
+              onClick={() => {
+                void stop();
+              }}
+              disabled={stopDisabled}
+            >
+              Stop
+            </IconButton>
+          ) : (
+            <IconButton
+              tone="primary"
+              icon={<IconPlayerPlay size={15} />}
+              onClick={() => {
+                void start();
+              }}
+              disabled={startDisabled}
+            >
+              Start
+            </IconButton>
+          )}
+        </div>
+      </div>
+    </Panel>
+  );
+}
+
 function RuntimeRecoveryAlert({
   state,
 }: {
@@ -1282,10 +1359,12 @@ function StartupLoadingScreen() {
 function ComputerUseContent({
   authLoading,
   authState,
+  developerToolsEnabled,
   state,
 }: {
   readonly authLoading: boolean;
   readonly authState: DesktopAuthState | null;
+  readonly developerToolsEnabled: boolean;
   readonly state: DesktopComputerUseState;
 }) {
   const authReady = hasReadyDesktopAuth(authState);
@@ -1301,8 +1380,13 @@ function ComputerUseContent({
           <PermissionsStepCard authReady={authReady} state={state} />
           {authReady && permissionsReady && (
             <>
-              <RuntimePanel state={state} />
-              <CommandLogPanel state={state} />
+              <ComputerUseStatusPanel state={state} />
+              {developerToolsEnabled && (
+                <>
+                  <RuntimePanel state={state} />
+                  <CommandLogPanel state={state} />
+                </>
+              )}
             </>
           )}
         </>
@@ -1314,9 +1398,15 @@ function ComputerUseContent({
 function ComputerUsePage() {
   const loadable = useLastLoadable(computerUseData$);
   const authLoadable = useLastLoadable(desktopAuthData$);
+  const developerToolsLoadable = useLastLoadable(developerToolsData$);
   const authState = authLoadable.state === "hasData" ? authLoadable.data : null;
   const authLoading = authLoadable.state === "loading";
   const authInitialLoading = authLoading && authState === null;
+  const developerToolsEnabled =
+    hasDesktopDeveloperToolsBridge() &&
+    developerToolsLoadable.state === "hasData" &&
+    developerToolsLoadable.data.available &&
+    developerToolsLoadable.data.enabled;
 
   if (!hasDesktopComputerUseBridge()) {
     return (
@@ -1335,6 +1425,7 @@ function ComputerUsePage() {
       <ComputerUseContent
         authLoading={authLoading}
         authState={authState}
+        developerToolsEnabled={developerToolsEnabled}
         state={loadable.data}
       />
     );

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -3,11 +3,18 @@ import type {
   DesktopAuthApi,
   DesktopAuthState,
   DesktopComputerUseApi,
+  DesktopDeveloperToolsApi,
+  DesktopDeveloperToolsState,
 } from "../desktop-bridge";
 import type { DesktopComputerUseState } from "../computer-use-types";
 
+const DEFAULT_DEVELOPER_TOOLS_STATE: DesktopDeveloperToolsState = {
+  available: false,
+  enabled: false,
+};
 const reloadComputerUseState$ = state(0);
 const reloadDesktopAuthState$ = state(0);
+const reloadDeveloperToolsState$ = state(0);
 
 function desktopComputerUseApi(): DesktopComputerUseApi {
   const api = window.vm0DesktopComputerUse;
@@ -25,12 +32,20 @@ function desktopAuthApi(): DesktopAuthApi {
   return api;
 }
 
+function desktopDeveloperToolsApi(): DesktopDeveloperToolsApi | null {
+  return window.vm0DesktopDeveloperTools ?? null;
+}
+
 export function hasDesktopComputerUseBridge(): boolean {
   return Boolean(window.vm0DesktopComputerUse);
 }
 
 export function hasDesktopAuthBridge(): boolean {
   return Boolean(window.vm0DesktopAuth);
+}
+
+export function hasDesktopDeveloperToolsBridge(): boolean {
+  return Boolean(window.vm0DesktopDeveloperTools);
 }
 
 export const computerUseData$ = computed(
@@ -44,6 +59,16 @@ export const desktopAuthData$ = computed((get): Promise<DesktopAuthState> => {
   get(reloadDesktopAuthState$);
   return desktopAuthApi().getState();
 });
+
+export const developerToolsData$ = computed(
+  (get): Promise<DesktopDeveloperToolsState> => {
+    get(reloadDeveloperToolsState$);
+    return (
+      desktopDeveloperToolsApi()?.getState() ??
+      Promise.resolve(DEFAULT_DEVELOPER_TOOLS_STATE)
+    );
+  },
+);
 
 const reloadComputerUse$ = command(({ set }) => {
   set(reloadComputerUseState$, (count) => {
@@ -62,6 +87,12 @@ const refreshDesktopAuth$ = command(({ set }) => {
   });
 });
 
+const reloadDeveloperTools$ = command(({ set }) => {
+  set(reloadDeveloperToolsState$, (count) => {
+    return count + 1;
+  });
+});
+
 export const setupComputerUseBridge$ = command(
   ({ set }, signal: AbortSignal) => {
     const unsubscribeComputerUse = desktopComputerUseApi().subscribe(() => {
@@ -71,17 +102,24 @@ export const setupComputerUseBridge$ = command(
       set(refreshDesktopAuth$);
       set(reloadComputerUse$);
     });
+    const unsubscribeDeveloperTools = desktopDeveloperToolsApi()?.subscribe(
+      () => {
+        set(reloadDeveloperTools$);
+      },
+    );
 
     signal.addEventListener(
       "abort",
       () => {
         unsubscribeComputerUse();
         unsubscribeAuth?.();
+        unsubscribeDeveloperTools?.();
       },
       { once: true },
     );
     set(refreshDesktopAuth$);
     set(refreshComputerUse$);
+    set(reloadDeveloperTools$);
   },
 );
 

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -274,6 +274,143 @@ button {
   gap: 6px;
 }
 
+.computer-use-status-card {
+  position: relative;
+  min-height: 156px;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 8px;
+  padding: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  overflow: hidden;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(248, 250, 252, 0.9)
+    ),
+    #f8fafc;
+}
+
+.computer-use-status-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+  background: #94a3b8;
+}
+
+.computer-use-status-online::before {
+  background: #12b76a;
+}
+
+.computer-use-status-connecting::before,
+.computer-use-status-recovering::before {
+  background: #2e90fa;
+}
+
+.computer-use-status-unauthenticated::before,
+.computer-use-status-needs_organization::before {
+  background: #f79009;
+}
+
+.computer-use-status-disabled::before,
+.computer-use-status-error::before {
+  background: #f04438;
+}
+
+.computer-use-status-main {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.computer-use-status-mark {
+  width: 58px;
+  height: 58px;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #475467;
+  background: #ffffff;
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.08);
+}
+
+.computer-use-status-online .computer-use-status-mark {
+  color: #067647;
+  background: #ecfdf3;
+}
+
+.computer-use-status-connecting .computer-use-status-mark,
+.computer-use-status-recovering .computer-use-status-mark {
+  color: #175cd3;
+  background: #eff8ff;
+}
+
+.computer-use-status-unauthenticated .computer-use-status-mark,
+.computer-use-status-needs_organization .computer-use-status-mark {
+  color: #b54708;
+  background: #fffaeb;
+}
+
+.computer-use-status-disabled .computer-use-status-mark,
+.computer-use-status-error .computer-use-status-mark {
+  color: #b42318;
+  background: #fef3f2;
+}
+
+.computer-use-status-copy {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.computer-use-status-copy span {
+  color: #667085;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.computer-use-status-copy strong {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  color: #202631;
+  font-size: 34px;
+  line-height: 1.1;
+  font-weight: 760;
+  letter-spacing: 0;
+}
+
+.computer-use-status-copy p {
+  max-width: 430px;
+  margin: 0;
+  color: #667085;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.computer-use-status-action {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+}
+
+.computer-use-status-action .button {
+  min-width: 118px;
+  min-height: 42px;
+  font-size: 15px;
+}
+
 .status-error-button {
   width: 24px;
   height: 24px;
@@ -1058,6 +1195,20 @@ button {
 
   .runtime-grid {
     grid-template-columns: 1fr;
+  }
+
+  .computer-use-status-card {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .computer-use-status-main {
+    align-items: flex-start;
+  }
+
+  .computer-use-status-action,
+  .computer-use-status-action .button {
+    width: 100%;
   }
 
   .permission-row {


### PR DESCRIPTION
## Summary
- productize the Desktop Computer Use main window with a large status card and primary Start/Stop controls
- gate Runtime and Command Log behind the macOS app-menu Developer Tools toggle when zeroDebug is enabled
- add desktop developer-tools IPC/preload state plumbing and renderer coverage

Closes #18039

## Validation
- pnpm -F @vm0/desktop test
- pnpm -F @vm0/desktop build
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint