### PR TITLE
docs: document guest-write-file run_cli contract

### DIFF
--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -175,7 +175,7 @@ where
             let _ = writeln!(stderr, "guest-write-file: {e}");
             let _ = writeln!(
                 stderr,
-                "usage: guest-write-file [--append | --create-parents] <path>"
+                "usage: guest-write-file [--append | --create-parents] [--] <path>"
             );
             return 2;
         }

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -1,4 +1,7 @@
-//! Direct guest file writer used by vsock-guest.
+//! Library entry point for the `guest-write-file` helper.
+//!
+//! The helper copies stdin to a target file using the CLI contract documented
+//! on [`run_cli`].
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
@@ -143,6 +146,25 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
     Ok(())
 }
 
+/// Runs the `guest-write-file` CLI.
+///
+/// `args` must contain the command-line arguments after the executable name,
+/// matching `std::env::args().skip(1)`. The accepted syntax is:
+///
+/// ```text
+/// guest-write-file [--append | --create-parents] <path>
+/// ```
+///
+/// Use `--` before `<path>` when the literal path begins with `-`. `stdin`
+/// provides the complete file content and `stderr` receives diagnostics.
+///
+/// By default, the target file is created or truncated before writing.
+/// `--append` appends to the target file and creates it only when the parent
+/// directory already exists. `--create-parents` creates missing parent
+/// directories before writing.
+///
+/// Returns process-style exit codes: `0` for success, `1` for runtime or write
+/// failures, and `2` for usage or argument errors.
 pub fn run_cli<I>(args: I, stdin: impl Read, mut stderr: impl Write) -> i32
 where
     I: IntoIterator<Item = String>,

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -152,7 +152,7 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// matching `std::env::args().skip(1)`. The accepted syntax is:
 ///
 /// ```text
-/// guest-write-file [--append | --create-parents] <path>
+/// guest-write-file [--append | --create-parents] [--] <path>
 /// ```
 ///
 /// Use `--` before `<path>` when the literal path begins with `-`. `stdin`

--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -1,11 +1,12 @@
 //! Direct guest file writer used by vsock-guest.
 //!
-//! Usage: `guest-write-file [--append | --create-parents] <path>`.
+//! Usage: `guest-write-file [--append | --create-parents] [--] <path>`.
 //!
 //! Content is read from stdin. Create mode truncates or creates the target.
 //! Append mode creates the target file when its parent already exists, matching
 //! shell `>>`, but does not create missing parents.
 //! Create-parents mode creates missing parent directories before writing.
+//! Use `--` before a path that begins with `-`.
 
 use std::io;
 

--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -5,6 +5,7 @@
 //! Content is read from stdin. Create mode truncates or creates the target.
 //! Append mode creates the target file when its parent already exists, matching
 //! shell `>>`, but does not create missing parents.
+//! Create-parents mode creates missing parent directories before writing.
 
 use std::io;
 

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -162,7 +162,9 @@ fn append_mode_rejects_create_parents() {
     let output = run_helper(&["--append", "--create-parents", path_str], b"hello");
 
     assert_eq!(output.status.code(), Some(2));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("cannot be used together"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot be used together"));
+    assert!(stderr.contains("usage: guest-write-file [--append | --create-parents] [--] <path>"));
     assert!(!path.exists());
 }
 


### PR DESCRIPTION
## Summary

- Add item-level rustdoc for `guest_write_file::run_cli` describing the public CLI contract.
- Keep crate-level and binary docs aligned with the same usage semantics.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --package guest-write-file --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-write-file`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-write-file --no-deps`
- Pre-commit hooks: `cargo-doc`, `cargo-clippy`, file-size checks, connector firewall index check

Closes #18184
