### PR TITLE
refactor: classify chunked write helper exec results

### DIFF
--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -10,12 +10,12 @@ use vsock_proto::{
 use crate::{ConnectionState, Shared, normal_operation_transition_error};
 
 use super::diagnostics::exec_terminal_log_lifecycle;
-use super::exec_operation_protocol_error;
 use super::state::{ExecCaptureState, ExecOperation, ExecOperationLifecycle};
 use super::types::{
     ExecControlAck, ExecControlGuestStatus, ExecControlOutcome, ExecOperationResult,
     ExecOutputEvent, ExecOwnedCapturedOutput,
 };
+use super::{exec_operation_guest_error, exec_operation_protocol_error};
 
 fn validate_output(
     operation: &mut ExecOperation,
@@ -385,7 +385,7 @@ fn dispatch_error(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Resu
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
                 let err = vsock_proto::decode_error(msg.payload)
-                    .map(|message| io::Error::other(message.to_string()))
+                    .map(|message| exec_operation_guest_error(message.to_string()))
                     .map_err(exec_operation_protocol_error)?;
                 let Some(operation) = operations.take(msg.seq) else {
                     return Ok(false);

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -23,12 +23,13 @@ pub(crate) use dispatch::dispatch_incoming_frame;
 pub(crate) use handle::ExecOperationCancelOnDropGuard;
 pub(crate) use start::{
     append_diagnostic, exec_capture_on_shared, exec_capture_on_shared_with_write_observer,
-    exec_capture_with_composite_on_shared_and_observer,
-    exec_cleanup_untracked_on_shared_with_write_observer,
-    exec_cleanup_with_composite_on_shared_and_observer, exec_on_shared,
-    exec_operation_capture_on_shared, exec_operation_capture_on_shared_with_write_observer,
-    exec_operation_stream_on_shared, exec_operation_stream_with_composite_on_shared_and_observer,
-    start_exec_operation_on_shared, start_supervised_exec_on_shared,
+    exec_on_shared, exec_operation_capture_on_shared,
+    exec_operation_capture_on_shared_with_write_observer,
+    exec_operation_capture_with_composite_on_shared_and_observer,
+    exec_operation_cleanup_untracked_on_shared_with_write_observer,
+    exec_operation_cleanup_with_composite_on_shared_and_observer, exec_operation_stream_on_shared,
+    exec_operation_stream_with_composite_on_shared_and_observer, start_exec_operation_on_shared,
+    start_supervised_exec_on_shared,
 };
 pub(crate) use state::Operations;
 

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -1,5 +1,5 @@
-use std::io;
 use std::time::Duration;
+use std::{fmt, io};
 
 mod diagnostics;
 mod dispatch;
@@ -49,6 +49,27 @@ const EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT: Duration = Duration::fr
 const EXEC_OPERATION_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const EXEC_OPERATION_FRAME_WRITE_STARTED: u8 = 1;
 const EXEC_OPERATION_FRAME_WRITE_COMPLETED: u8 = 2;
+
+#[derive(Debug)]
+struct ExecOperationGuestError(String);
+
+impl fmt::Display for ExecOperationGuestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ExecOperationGuestError {}
+
+fn exec_operation_guest_error(message: String) -> io::Error {
+    io::Error::other(ExecOperationGuestError(message))
+}
+
+pub(crate) fn error_is_exec_operation_guest_error(error: &io::Error) -> bool {
+    error
+        .get_ref()
+        .is_some_and(|error| error.is::<ExecOperationGuestError>())
+}
 
 fn exec_operation_protocol_error(error: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, error.to_string())

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -519,15 +519,15 @@ pub(crate) async fn exec_on_shared(
     .await
 }
 
-pub(crate) async fn exec_cleanup_untracked_on_shared_with_write_observer(
+pub(crate) async fn exec_operation_cleanup_untracked_on_shared_with_write_observer(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
     env: &[(&str, &str)],
     sudo: bool,
     write_observer: FrameWriteObserver,
-) -> io::Result<ExecResult> {
-    let result = exec_operation_capture_on_shared_with_tracking(
+) -> io::Result<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking(
         shared,
         ExecCaptureRequest {
             timeout_ms,
@@ -544,11 +544,10 @@ pub(crate) async fn exec_cleanup_untracked_on_shared_with_write_observer(
         ExecOperationTracking::Untracked,
         write_observer,
     )
-    .await?;
-    operation_result_to_legacy_exec_result(result)
+    .await
 }
 
-pub(crate) async fn exec_cleanup_with_composite_on_shared_and_observer(
+pub(crate) async fn exec_operation_cleanup_with_composite_on_shared_and_observer(
     shared: &Arc<Shared>,
     command: &str,
     timeout_ms: u32,
@@ -556,8 +555,8 @@ pub(crate) async fn exec_cleanup_with_composite_on_shared_and_observer(
     sudo: bool,
     normal_operation: &mut CompositeNormalOperation,
     write_observer: FrameWriteObserver,
-) -> io::Result<ExecResult> {
-    let result = exec_operation_capture_on_shared_with_tracking(
+) -> io::Result<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking(
         shared,
         ExecCaptureRequest {
             timeout_ms,
@@ -574,24 +573,22 @@ pub(crate) async fn exec_cleanup_with_composite_on_shared_and_observer(
         ExecOperationTracking::Composite(normal_operation),
         write_observer,
     )
-    .await?;
-    operation_result_to_legacy_exec_result(result)
+    .await
 }
 
-pub(crate) async fn exec_capture_with_composite_on_shared_and_observer(
+pub(crate) async fn exec_operation_capture_with_composite_on_shared_and_observer(
     shared: &Arc<Shared>,
     request: ExecCaptureRequest<'_>,
     normal_operation: &mut CompositeNormalOperation,
     write_observer: FrameWriteObserver,
-) -> io::Result<ExecResult> {
-    let result = exec_operation_capture_on_shared_with_tracking(
+) -> io::Result<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking(
         shared,
         request,
         ExecOperationTracking::Composite(normal_operation),
         write_observer,
     )
-    .await?;
-    operation_result_to_legacy_exec_result(result)
+    .await
 }
 
 pub(crate) async fn exec_capture_on_shared(

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
-use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+use std::{fmt, io};
 
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT};
 
@@ -13,7 +13,7 @@ use crate::{
     request_on_shared_with_composite_operation_and_observer,
 };
 
-use super::{file_operation_error_is_terminal, normalize_file_exec_stderr, shell_quote};
+use super::{normalize_file_exec_stderr, shell_quote};
 
 /// Maximum content per write_file message. Leaves headroom below
 /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
@@ -30,6 +30,27 @@ const CLEANUP_EXEC_TIMEOUT_MS: u32 = 1000;
 enum WriteFileChunkTracking<'a> {
     Tracked,
     Composite(&'a mut CompositeNormalOperation),
+}
+
+#[derive(Debug)]
+struct WriteFileGuestError(String);
+
+impl fmt::Display for WriteFileGuestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for WriteFileGuestError {}
+
+fn write_file_guest_error(message: impl Into<String>) -> io::Error {
+    io::Error::other(WriteFileGuestError(message.into()))
+}
+
+fn error_is_write_file_guest_error(error: &io::Error) -> bool {
+    error
+        .get_ref()
+        .is_some_and(|error| error.is::<WriteFileGuestError>())
 }
 
 struct ChunkedWriteCleanupGuard {
@@ -393,7 +414,7 @@ impl VsockHost {
 
         if let Err(error) = result {
             // Best-effort cleanup of the temp file.
-            let terminal_error = file_operation_error_is_terminal(&error);
+            let terminal_error = error_is_write_file_guest_error(&error);
             let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
             if terminal_error && cleanup_result.is_ok() {
                 normal_operation.complete()?;
@@ -484,7 +505,7 @@ impl VsockHost {
         if resp.msg_type == MSG_ERROR {
             let msg = vsock_proto::decode_error(&resp.payload)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-            return Err(io::Error::other(msg));
+            return Err(write_file_guest_error(msg));
         }
 
         if resp.msg_type != MSG_WRITE_FILE_RESULT {
@@ -498,7 +519,7 @@ impl VsockHost {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
         if !success {
-            return Err(io::Error::other(error));
+            return Err(write_file_guest_error(error));
         }
 
         Ok(())

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -423,8 +423,8 @@ impl VsockHost {
             return Err(error);
         }
 
-        // Atomic rename temp → target.
-        let mv_cmd = format!("mv -f -- {quoted_tmp} {}", shell_quote(path));
+        // `-T` keeps directory targets from being treated as destination directories.
+        let mv_cmd = format!("mv -fT -- {quoted_tmp} {}", shell_quote(path));
         let rename_result =
             exec_operation::exec_operation_capture_with_composite_on_shared_and_observer(
                 &self.shared,

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -4,15 +4,16 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use vsock_proto::{MSG_ERROR, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT};
+use vsock_proto::{ExecTermination, MSG_ERROR, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT};
 
 use crate::{
-    CompositeNormalOperation, ExecCaptureRequest, ExecResult, FrameWriteObserver, Shared,
-    VsockHost, exec_operation, normal_request_on_shared_with_write_observer,
+    CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput,
+    FrameWriteObserver, Shared, VsockHost, exec_operation,
+    normal_request_on_shared_with_write_observer,
     request_on_shared_with_composite_operation_and_observer,
 };
 
-use super::{file_operation_error_is_terminal, shell_quote};
+use super::{file_operation_error_is_terminal, normalize_file_exec_stderr, shell_quote};
 
 /// Maximum content per write_file message. Leaves headroom below
 /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
@@ -71,7 +72,7 @@ impl ChunkedWriteCleanupGuard {
 
         let result = if let Some(shared) = self.shared.as_ref() {
             cleanup_timeout(
-                exec_operation::exec_cleanup_with_composite_on_shared_and_observer(
+                exec_operation::exec_operation_cleanup_with_composite_on_shared_and_observer(
                     shared,
                     &self.command,
                     CLEANUP_EXEC_TIMEOUT_MS,
@@ -83,7 +84,7 @@ impl ChunkedWriteCleanupGuard {
                 CLEANUP_EXEC_TIMEOUT_MS,
             )
             .await
-            .and_then(validate_cleanup_result)
+            .and_then(|result| validate_cleanup_result(result).map_err(|err| err.error))
         } else {
             Ok(())
         };
@@ -94,25 +95,186 @@ impl ChunkedWriteCleanupGuard {
     }
 }
 
-async fn cleanup_timeout<F>(cleanup: F, timeout_ms: u32) -> io::Result<ExecResult>
+async fn cleanup_timeout<F>(cleanup: F, timeout_ms: u32) -> io::Result<ExecOperationResult>
 where
-    F: Future<Output = io::Result<ExecResult>>,
+    F: Future<Output = io::Result<ExecOperationResult>>,
 {
     tokio::time::timeout(Duration::from_millis(timeout_ms as u64), cleanup)
         .await
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "cleanup command timed out"))?
 }
 
-fn validate_cleanup_result(result: ExecResult) -> io::Result<()> {
-    if result.exit_code == 0 {
-        return Ok(());
+struct WriteHelperExecError {
+    error: io::Error,
+    terminal_proven: bool,
+}
+
+impl WriteHelperExecError {
+    fn terminal(error: io::Error) -> Self {
+        Self {
+            error,
+            terminal_proven: true,
+        }
     }
 
-    Err(io::Error::other(format!(
-        "cleanup command failed with exit code {}: {}",
-        result.exit_code,
-        String::from_utf8_lossy(&result.stderr)
-    )))
+    fn unproven(error: io::Error) -> Self {
+        Self {
+            error,
+            terminal_proven: false,
+        }
+    }
+
+    fn from_exec_wait(error: io::Error) -> Self {
+        if file_operation_error_is_terminal(&error) {
+            Self::terminal(error)
+        } else {
+            Self::unproven(error)
+        }
+    }
+}
+
+fn write_helper_exec_output(
+    context: &str,
+    result: ExecOperationResult,
+) -> Result<(ExecTermination, Vec<u8>, String), WriteHelperExecError> {
+    if result.stream_overflowed {
+        return Err(WriteHelperExecError::unproven(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{context} exec operation unexpectedly overflowed a stream queue"),
+        )));
+    }
+
+    let ExecOperationResult {
+        termination,
+        stdout,
+        stderr,
+        diagnostic,
+        ..
+    } = result;
+    let _stdout = write_helper_exec_captured_output(context, "stdout", stdout)?;
+    let (stderr, stderr_truncated) = write_helper_exec_captured_output(context, "stderr", stderr)?;
+
+    Ok((
+        termination,
+        normalize_file_exec_stderr(stderr, stderr_truncated),
+        diagnostic,
+    ))
+}
+
+fn write_helper_exec_captured_output(
+    context: &str,
+    name: &str,
+    output: ExecOwnedCapturedOutput,
+) -> Result<(Vec<u8>, bool), WriteHelperExecError> {
+    match output {
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
+        ExecOwnedCapturedOutput::Discarded => Err(WriteHelperExecError::unproven(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{context} exec result discarded {name} for capture request"),
+        ))),
+    }
+}
+
+fn write_helper_terminal_message(prefix: String, stderr: &[u8], diagnostic: &str) -> String {
+    let mut details = Vec::new();
+    if !stderr.is_empty() {
+        details.push(format!("stderr: {}", String::from_utf8_lossy(stderr)));
+    }
+    if !diagnostic.is_empty() {
+        details.push(format!("diagnostic: {diagnostic}"));
+    }
+    if details.is_empty() {
+        prefix
+    } else {
+        format!("{prefix}: {}", details.join("; "))
+    }
+}
+
+fn validate_cleanup_result(result: ExecOperationResult) -> Result<(), WriteHelperExecError> {
+    let (termination, stderr, diagnostic) = write_helper_exec_output("cleanup command", result)?;
+    match termination {
+        ExecTermination::Exited { exit_code: 0 } => Ok(()),
+        ExecTermination::Exited { exit_code } => {
+            Err(WriteHelperExecError::terminal(io::Error::other(format!(
+                "cleanup command failed with exit code {exit_code}: {}",
+                String::from_utf8_lossy(&stderr)
+            ))))
+        }
+        ExecTermination::TimedOut => Err(WriteHelperExecError::terminal(io::Error::new(
+            io::ErrorKind::TimedOut,
+            write_helper_terminal_message(
+                "cleanup command timed out".to_string(),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+        ExecTermination::Cancelled => Err(WriteHelperExecError::terminal(io::Error::other(
+            write_helper_terminal_message(
+                "cleanup command was cancelled".to_string(),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+        ExecTermination::StartFailed => Err(WriteHelperExecError::terminal(io::Error::other(
+            write_helper_terminal_message(
+                "cleanup command exec start failed".to_string(),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+        ExecTermination::WaitFailed => Err(WriteHelperExecError::terminal(io::Error::other(
+            write_helper_terminal_message(
+                "cleanup command exec wait failed".to_string(),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+    }
+}
+
+fn validate_rename_result(
+    path: &str,
+    result: ExecOperationResult,
+) -> Result<(), WriteHelperExecError> {
+    let (termination, stderr, diagnostic) = write_helper_exec_output("rename command", result)?;
+    match termination {
+        ExecTermination::Exited { exit_code: 0 } => Ok(()),
+        ExecTermination::Exited { exit_code } => {
+            Err(WriteHelperExecError::terminal(io::Error::other(format!(
+                "failed to rename temp file to {path} with exit code {exit_code}: {}",
+                String::from_utf8_lossy(&stderr)
+            ))))
+        }
+        ExecTermination::TimedOut => Err(WriteHelperExecError::terminal(io::Error::new(
+            io::ErrorKind::TimedOut,
+            write_helper_terminal_message(
+                format!("rename command timed out while moving temp file to {path}"),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+        ExecTermination::Cancelled => Err(WriteHelperExecError::terminal(io::Error::other(
+            write_helper_terminal_message(
+                format!("rename command was cancelled while moving temp file to {path}"),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+        ExecTermination::StartFailed => Err(WriteHelperExecError::terminal(io::Error::other(
+            write_helper_terminal_message(
+                format!("rename command exec start failed while moving temp file to {path}"),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+        ExecTermination::WaitFailed => Err(WriteHelperExecError::terminal(io::Error::other(
+            write_helper_terminal_message(
+                format!("rename command exec wait failed while moving temp file to {path}"),
+                &stderr,
+                &diagnostic,
+            ),
+        ))),
+    }
 }
 
 impl Drop for ChunkedWriteCleanupGuard {
@@ -130,7 +292,7 @@ impl Drop for ChunkedWriteCleanupGuard {
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 let _ = cleanup_timeout(
-                    exec_operation::exec_cleanup_untracked_on_shared_with_write_observer(
+                    exec_operation::exec_operation_cleanup_untracked_on_shared_with_write_observer(
                         &shared,
                         &command,
                         CLEANUP_EXEC_TIMEOUT_MS,
@@ -241,49 +403,40 @@ impl VsockHost {
 
         // Atomic rename temp → target.
         let mv_cmd = format!("mv -f -- {quoted_tmp} {}", shell_quote(path));
-        match exec_operation::exec_capture_with_composite_on_shared_and_observer(
-            &self.shared,
-            ExecCaptureRequest {
-                command: &mv_cmd,
-                timeout_ms: HELPER_EXEC_TIMEOUT_MS,
-                env: &[],
-                sudo,
-                label: "write-file-rename",
-                stdout_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
-                stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
-                expected_exit_codes: &[],
-                stdin_bytes: None,
-                wait_timeout: Duration::from_millis(HELPER_EXEC_TIMEOUT_MS as u64 + 5000),
-            },
-            &mut normal_operation,
-            write_observer,
-        )
-        .await
-        {
-            Ok(r) if r.exit_code == 0 => {
+        let rename_result =
+            exec_operation::exec_operation_capture_with_composite_on_shared_and_observer(
+                &self.shared,
+                ExecCaptureRequest {
+                    command: &mv_cmd,
+                    timeout_ms: HELPER_EXEC_TIMEOUT_MS,
+                    env: &[],
+                    sudo,
+                    label: "write-file-rename",
+                    stdout_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+                    stderr_limit_bytes: exec_operation::SMALL_EXEC_CAPTURE_LIMIT_BYTES,
+                    expected_exit_codes: &[],
+                    stdin_bytes: None,
+                    wait_timeout: Duration::from_millis(HELPER_EXEC_TIMEOUT_MS as u64 + 5000),
+                },
+                &mut normal_operation,
+                write_observer,
+            )
+            .await
+            .map_err(WriteHelperExecError::from_exec_wait)
+            .and_then(|result| validate_rename_result(path, result));
+        match rename_result {
+            Ok(()) => {
                 cleanup_guard.disarm();
                 normal_operation.complete()?;
                 Ok(())
             }
-            Ok(r) => {
-                let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
-                let error = io::Error::other(format!(
-                    "failed to rename temp file to {path}: {}",
-                    String::from_utf8_lossy(&r.stderr),
-                ));
-                if cleanup_result.is_ok() {
-                    normal_operation.complete()?;
-                }
-                Err(error)
-            }
-            Err(e) => {
+            Err(err) => {
                 // Connection likely broken — short timeout to avoid blocking.
-                let terminal_error = file_operation_error_is_terminal(&e);
                 let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
-                if terminal_error && cleanup_result.is_ok() {
+                if err.terminal_proven && cleanup_result.is_ok() {
                     normal_operation.complete()?;
                 }
-                Err(e)
+                Err(err.error)
             }
         }
     }

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -125,7 +125,7 @@ impl WriteHelperExecError {
     }
 
     fn from_exec_wait(error: io::Error) -> Self {
-        if file_operation_error_is_terminal(&error) {
+        if exec_operation::error_is_exec_operation_guest_error(&error) {
             Self::terminal(error)
         } else {
             Self::unproven(error)

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -13,7 +13,7 @@ use crate::{
     request_on_shared_with_composite_operation_and_observer,
 };
 
-use super::{normalize_file_exec_stderr, shell_quote};
+use super::{normalize_file_exec_stderr, shell_quote, validate_guest_file_path};
 
 /// Maximum content per write_file message. Leaves headroom below
 /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
@@ -364,6 +364,7 @@ impl VsockHost {
         sudo: bool,
         write_observer: FrameWriteObserver,
     ) -> io::Result<()> {
+        validate_guest_file_path(path)?;
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
             return self
                 .write_file_chunk(

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -431,7 +431,8 @@ impl VsockHost {
                 Ok(())
             }
             Err(err) => {
-                // Connection likely broken — short timeout to avoid blocking.
+                // Terminal proof only releases the tracker after cleanup also
+                // succeeds; unproven helper failures remain fail-closed.
                 let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
                 if err.terminal_proven && cleanup_result.is_ok() {
                     normal_operation.complete()?;

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -211,6 +211,41 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
 }
 
 #[tokio::test]
+async fn write_file_rejects_invalid_path_before_sending_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    for path in ["", "/tmp/has\0nul"] {
+        let err = host
+            .write_file_with_write_observer(
+                path,
+                b"hello",
+                false,
+                FrameWriteObserver::new({
+                    let write_start_count = Arc::clone(&write_start_count);
+                    move || {
+                        write_start_count.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                }),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn write_file_observer_error_cleans_pending_without_sending_frame() {
     let (host, guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -840,6 +840,54 @@ async fn write_file_chunked_rename_guest_timeout_cleans_up_and_releases_tracker(
     fixture.assert_readiness(NormalOperationReadiness::Idle);
 }
 
+#[tokio::test]
+async fn write_file_chunked_rename_observer_error_keeps_tracker_fail_closed() {
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let content = ChunkedWriteFixture::two_chunk_content();
+    let write_task = {
+        let host = Arc::clone(&fixture.host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/big.bin",
+                &content,
+                false,
+                FrameWriteObserver::new(move || {
+                    if write_start_count.fetch_add(1, Ordering::SeqCst) == 2 {
+                        return Err(io::Error::other("rename observer failed"));
+                    }
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
+
+    let second = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("rename observer failed"));
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 3);
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
+
+    let cleanup = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
+        .await
+        .expect("cleanup retry was not sent after rename observer error");
+    send_exec_result(
+        &mut fixture.guest,
+        cleanup.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+}
+
 async fn assert_rename_terminal_failure_reports(
     termination: ExecTermination,
     stderr: &'static [u8],

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -224,6 +224,40 @@ async fn write_file_chunked_rejects_invalid_path_before_cleanup_or_write() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_rejects_invalid_guest_path_before_cleanup_or_write() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let content = vec![0u8; file_impl::test_support::WRITE_FILE_CHUNK_LIMIT + 1];
+
+    let err = host
+        .write_file_with_write_observer(
+            "/tmp/has\0nul",
+            &content,
+            false,
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_eq!(operation_count(&host), 0);
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn write_file_chunked_rejects_temp_path_overflow_before_cleanup_or_write() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -745,6 +745,42 @@ async fn write_file_chunked_error_response_cleans_up_and_releases_tracker() {
 }
 
 #[tokio::test]
+async fn write_file_chunked_chunk_observer_error_keeps_tracker_fail_closed() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let content = ChunkedWriteFixture::two_chunk_content();
+
+    let err = host
+        .write_file_with_write_observer(
+            "/tmp/big.bin",
+            &content,
+            false,
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Err(io::Error::other("chunk observer failed"))
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("chunk observer failed"));
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("observer error must not send write_file frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after observer error: {err}"),
+    }
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
 async fn write_file_chunked_unexpected_response_keeps_tracker_fail_closed() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -133,6 +133,16 @@ fn helper_exec_capture_policy() -> ExecOutputPolicy {
     }
 }
 
+async fn drive_two_chunk_write_to_rename(fixture: &mut ChunkedWriteFixture) -> ExecStartFrame {
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
+
+    let second = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, second.seq()).await;
+
+    fixture.expect_rename().await
+}
+
 #[tokio::test]
 async fn write_file_chunked_cancelled_before_first_frame_write_does_not_cleanup() {
     let (host, mut guest) = setup_host_and_guest().await;
@@ -338,6 +348,7 @@ async fn write_file_chunked_quotes_target_path_with_single_quote() {
 
     let err = write_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("permission denied"));
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
 }
 
 #[tokio::test]
@@ -796,6 +807,92 @@ async fn write_file_chunked_rename_error_response_cleans_up_and_releases_tracker
 }
 
 #[tokio::test]
+async fn write_file_chunked_rename_guest_timeout_cleans_up_and_releases_tracker() {
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
+
+    let rename = drive_two_chunk_write_to_rename(&mut fixture).await;
+    send_exec_result(
+        &mut fixture.guest,
+        rename.seq(),
+        ExecTermination::TimedOut,
+        &[],
+        b"mv timed out",
+    )
+    .await;
+
+    let cleanup = fixture.expect_cleanup().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
+    send_exec_result(
+        &mut fixture.guest,
+        cleanup.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    let message = err.to_string();
+    assert!(message.contains("rename command timed out"));
+    assert!(message.contains("mv timed out"));
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
+}
+
+async fn assert_rename_terminal_failure_reports(
+    termination: ExecTermination,
+    stderr: &'static [u8],
+    expected_message: &'static str,
+) {
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
+
+    let rename = drive_two_chunk_write_to_rename(&mut fixture).await;
+    send_exec_result(&mut fixture.guest, rename.seq(), termination, &[], stderr).await;
+
+    let cleanup = fixture.expect_cleanup().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
+    send_exec_result(
+        &mut fixture.guest,
+        cleanup.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    let message = err.to_string();
+    let stderr_text = String::from_utf8_lossy(stderr);
+    assert!(message.contains(expected_message), "{message}");
+    assert!(message.contains(stderr_text.as_ref()), "{message}");
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
+}
+
+#[tokio::test]
+async fn write_file_chunked_rename_terminal_failures_report_distinct_errors() {
+    assert_rename_terminal_failure_reports(
+        ExecTermination::Cancelled,
+        b"guest cancelled rename",
+        "rename command was cancelled",
+    )
+    .await;
+    assert_rename_terminal_failure_reports(
+        ExecTermination::StartFailed,
+        b"spawn failed",
+        "rename command exec start failed",
+    )
+    .await;
+    assert_rename_terminal_failure_reports(
+        ExecTermination::WaitFailed,
+        b"wait failed",
+        "rename command exec wait failed",
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
@@ -816,6 +913,44 @@ async fn write_file_chunked_cleanup_error_retries_untracked_on_drop() {
     let retry = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
         .await
         .expect("cleanup retry was not sent after cleanup error");
+    send_exec_result(
+        &mut fixture.guest,
+        retry.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn write_file_chunked_cleanup_guest_timeout_retries_untracked_on_drop() {
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
+
+    let first = fixture.expect_chunk().await;
+    send_write_file_success(&mut fixture.guest, first.seq()).await;
+
+    let second = fixture.expect_chunk().await;
+    send_write_file_failure(&mut fixture.guest, second.seq(), "disk full").await;
+
+    let cleanup = fixture.expect_cleanup().await;
+    send_exec_result(
+        &mut fixture.guest,
+        cleanup.seq(),
+        ExecTermination::TimedOut,
+        &[],
+        b"cleanup timed out",
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
+
+    let retry = tokio::time::timeout(Duration::from_secs(2), fixture.expect_cleanup())
+        .await
+        .expect("cleanup retry was not sent after timed out cleanup");
     send_exec_result(
         &mut fixture.guest,
         retry.seq(),

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -101,7 +101,7 @@ impl ChunkedWriteFixture {
 
     fn expected_rename_command(&self) -> String {
         format!(
-            "mv -f -- {} {}",
+            "mv -fT -- {} {}",
             shell_quote_for_test(self.temp_path()),
             shell_quote_for_test(self.target_path)
         )
@@ -445,7 +445,7 @@ async fn write_file_chunked_concurrent_writes_to_same_target_use_distinct_temp_p
                     .iter()
                     .find_map(|(temp_path, (_marker, chunk_count))| {
                         let expected_command = format!(
-                            "mv -f -- {} {}",
+                            "mv -fT -- {} {}",
                             shell_quote_for_test(temp_path),
                             shell_quote_for_test(target_path)
                         );
@@ -576,7 +576,7 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
         match decoded.label {
             "write-file-rename" => {
                 let expected_command = format!(
-                    "mv -f -- {} {}",
+                    "mv -fT -- {} {}",
                     shell_quote_for_test(success_temp),
                     shell_quote_for_test(target_path)
                 );

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -1,4 +1,5 @@
 use crate::support::{Harness, shell_quote};
+use std::fs;
 
 #[test]
 fn shell_quote_escapes_single_quotes() {
@@ -163,6 +164,39 @@ async fn test_write_file_chunked() {
         .flatten()
         .any(|entry| entry.path().to_string_lossy().starts_with(&temp_prefix));
     assert!(!temp_remains, "temp file was not cleaned up");
+    h.finish();
+}
+
+#[tokio::test]
+async fn test_write_file_chunked_directory_target_fails() {
+    let h = Harness::new().await;
+
+    let target_dir = h.dir.join("chunked-target-dir");
+    fs::create_dir(&target_dir).expect("create target directory");
+    let target_dir_str = target_dir.to_string_lossy().to_string();
+    let content = vec![0xCD; 16 * 1024 * 1024];
+
+    h.host()
+        .write_file(&target_dir_str, &content, false)
+        .await
+        .expect_err("chunked write_file should fail when target is a directory");
+
+    assert!(target_dir.is_dir());
+    let nested_entries = fs::read_dir(&target_dir)
+        .expect("read target directory")
+        .count();
+    assert_eq!(
+        nested_entries, 0,
+        "temp file must not be moved into target directory"
+    );
+
+    let temp_prefix = format!("{target_dir_str}.vm0tmp-");
+    let sibling_temp_remains = fs::read_dir(target_dir.parent().unwrap())
+        .expect("read parent directory")
+        .flatten()
+        .any(|entry| entry.path().to_string_lossy().starts_with(&temp_prefix));
+    assert!(!sibling_temp_remains, "temp file was not cleaned up");
+
     h.finish();
 }
 


### PR DESCRIPTION
## Summary

- migrate chunked `write_file` rename and cleanup helper exec paths to consume `ExecOperationResult`
- classify helper outcomes locally as terminal-proven success, terminal-proven failure, or unproven failure before tracker decisions
- keep guest terminal timeout/cancel/start/wait failures distinct in write errors while preserving cleanup retry and fail-closed behavior
- remove now-unused crate-internal legacy composite cleanup/capture wrappers

Closes #18163

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::write_chunked`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::write`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- pre-commit hook: cargo fmt, cargo doc, cargo clippy
