### PR TITLE
fix: support local onboarding proxy and usage popover

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -9,7 +9,7 @@ CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VM0_API_URL=https://api.vm7.ai:8443
 VM0_WEB_URL=https://www.vm7.ai:8443
 APP_URL=https://app.vm7.ai:8443
-PAID_ONBOARDING_URL=https://so.vm7.ai:8441
+PAID_ONBOARDING_URL=https://so.vm7.ai:8443
 
 # Optional: Atom redeem service for onboarding codes
 ATOM_URL=https://atom.vm7.ai:8442/

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -638,7 +638,7 @@ describe("POST /api/zero/billing/checkout", () => {
   });
 
   it("accepts successUrl on the configured paid-onboarding origin", async () => {
-    mockEnv("PAID_ONBOARDING_URL", "https://so.vm7.ai:8441");
+    mockEnv("PAID_ONBOARDING_URL", "https://so.vm7.ai:8443");
 
     const fixture = await trackedPendingSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
@@ -656,8 +656,8 @@ describe("POST /api/zero/billing/checkout", () => {
         body: {
           tier: "pro",
           trialDays: 7,
-          successUrl: "https://so.vm7.ai:8441/onboarding?billing=pro",
-          cancelUrl: "https://so.vm7.ai:8441/onboarding?billing=canceled",
+          successUrl: "https://so.vm7.ai:8443/onboarding?billing=pro",
+          cancelUrl: "https://so.vm7.ai:8443/onboarding?billing=canceled",
         },
         headers: { authorization: "Bearer clerk-session" },
       }),

--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -2,8 +2,8 @@
 # Use 1Password CLI to inject secrets: ./scripts/sync-env.sh
 VITE_CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VITE_API_URL=http://localhost:3000
-VITE_PAID_ONBOARDING_URL=https://so.vm7.ai:8441
-VITE_PAID_ONBOARDING_DOMAIN=
+VITE_PAID_ONBOARDING_URL=https://so.vm7.ai:8443
+VITE_PAID_ONBOARDING_DOMAIN=api.vm7.ai:8443
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
 VITE_STATIC_ASSETS_BASE_URL=https://static.vm7.io
 VITE_ZERO_HOST_DOMAIN=sites.vm7.io

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -29,8 +29,8 @@ vi.mock("@clerk/clerk-js", () => {
 vi.hoisted(() => {
   vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", "test_key");
   vi.stubEnv("VITE_API_URL", "http://localhost:3000");
-  vi.stubEnv("VITE_PAID_ONBOARDING_URL", "https://so.vm7.ai:8441");
-  vi.stubEnv("VITE_PAID_ONBOARDING_DOMAIN", "pr-123-api.vm6.ai");
+  vi.stubEnv("VITE_PAID_ONBOARDING_URL", "https://so.vm7.ai:8443");
+  vi.stubEnv("VITE_PAID_ONBOARDING_DOMAIN", "api.vm7.ai:8443");
   vi.stubEnv("VITE_ZERO_HOST_DOMAIN", "sites.vm7.io");
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1620,7 +1620,9 @@ describe("chat lifecycle", () => {
       },
     });
 
-    const credit = await screen.findByLabelText("Credit usage 24,234");
+    const credit = await waitFor(() => {
+      return buttonByLabel("Credit usage 24,234");
+    });
     const actions = credit.closest('[data-testid="chat-message-actions"]');
     expect(actions).not.toBeNull();
     const copy = within(actions as HTMLElement).getByLabelText("Copy message");
@@ -1629,9 +1631,6 @@ describe("chat lifecycle", () => {
     ).toBeTruthy();
 
     click(credit);
-    expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
-
-    fireEvent.pointerEnter(credit);
 
     await waitFor(() => {
       expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
@@ -1650,11 +1649,13 @@ describe("chat lifecycle", () => {
       expect(screen.queryByText("moonshot")).not.toBeInTheDocument();
     });
 
-    fireEvent.pointerDown(credit, { button: 0 });
-    expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
-      1,
-    );
-    fireEvent.click(credit);
+    click(credit);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
+    });
+
+    click(credit);
 
     await waitFor(() => {
       expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
@@ -1663,15 +1664,6 @@ describe("chat lifecycle", () => {
       expect(screen.getAllByText("Kimi K2.5").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("1,234").length).toBeGreaterThanOrEqual(1);
     });
-
-    fireEvent.pointerLeave(credit);
-
-    await waitFor(() => {
-      expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
-    });
-
-    click(credit);
-    expect(screen.queryByText("Credit usage")).not.toBeInTheDocument();
   });
 
   it("shows generation usage with model names only", async () => {
@@ -1733,7 +1725,7 @@ describe("chat lifecycle", () => {
     });
 
     const credit = await screen.findByLabelText("Credit usage 1,976");
-    fireEvent.pointerEnter(credit);
+    click(credit);
 
     await waitFor(() => {
       expect(screen.getAllByText("Credit usage").length).toBeGreaterThanOrEqual(
@@ -1901,7 +1893,7 @@ describe("chat lifecycle", () => {
     ).not.toBeInTheDocument();
 
     const connectorCredit = await screen.findByLabelText("Credit usage 108");
-    fireEvent.pointerEnter(connectorCredit);
+    click(connectorCredit);
 
     await waitFor(() => {
       expect(screen.getAllByText("X").length).toBeGreaterThanOrEqual(1);
@@ -2004,7 +1996,7 @@ describe("chat lifecycle", () => {
     ).resolves.toBeInTheDocument();
     const connectorCredit = await screen.findByLabelText("Credit usage 108");
 
-    fireEvent.pointerEnter(connectorCredit);
+    click(connectorCredit);
 
     await waitFor(() => {
       expect(screen.getByText("Connector usage is ready.")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -74,12 +74,12 @@ describe("zero onboarding", () => {
 
     await waitFor(() => {
       const url = new URL(window.location.href);
-      expect(url.origin).toBe("https://so.vm7.ai:8441");
+      expect(url.origin).toBe("https://so.vm7.ai:8443");
       expect(url.pathname).toBe("/onboarding/2afcf6");
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");
-      expect(url.searchParams.get("domain")).toBe("pr-123-api.vm6.ai");
+      expect(url.searchParams.get("domain")).toBe("api.vm7.ai:8443");
     });
   });
 
@@ -94,12 +94,12 @@ describe("zero onboarding", () => {
 
     await waitFor(() => {
       const url = new URL(window.location.href);
-      expect(url.origin).toBe("https://so.vm7.ai:8441");
+      expect(url.origin).toBe("https://so.vm7.ai:8443");
       expect(url.pathname).toBe("/onboarding/2afcf6");
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");
-      expect(url.searchParams.get("domain")).toBe("pr-123-api.vm6.ai");
+      expect(url.searchParams.get("domain")).toBe("api.vm7.ai:8443");
     });
   });
 
@@ -122,12 +122,12 @@ describe("zero onboarding", () => {
 
     await waitFor(() => {
       const url = new URL(window.location.href);
-      expect(url.origin).toBe("https://so.vm7.ai:8441");
+      expect(url.origin).toBe("https://so.vm7.ai:8443");
       expect(url.pathname).toBe("/onboarding/2afcf6");
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");
-      expect(url.searchParams.get("domain")).toBe("pr-123-api.vm6.ai");
+      expect(url.searchParams.get("domain")).toBe("api.vm7.ai:8443");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -58,8 +58,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Popover,
-  PopoverAnchor,
   PopoverContent,
+  PopoverTrigger,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -6158,46 +6158,20 @@ function UsageChip({
 }) {
   const total = formatCredits(usage.totalCredits);
   const displayRows = buildRunUsageDisplayRows(usage);
-  const showTooltip = () => {
-    setOpen(true);
-  };
-  const hideTooltip = () => {
-    setOpen(false);
-  };
 
   return (
-    <Popover open={open}>
-      <PopoverAnchor asChild>
-        <span
-          tabIndex={0}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
           className="inline-flex h-7 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground/70 hover:bg-accent hover:text-foreground transition-colors duration-150"
           aria-label={`${ariaLabel} ${total}`}
-          onFocus={showTooltip}
-          onBlur={hideTooltip}
-          onPointerDown={(event) => {
-            event.preventDefault();
-          }}
-          onClick={(event) => {
-            event.preventDefault();
-          }}
-          onMouseEnter={showTooltip}
-          onMouseLeave={hideTooltip}
-          onPointerEnter={showTooltip}
-          onPointerLeave={hideTooltip}
         >
           <IconCoins size={17} stroke={1.5} />
           <span>{total}</span>
-        </span>
-      </PopoverAnchor>
-      <PopoverContent
-        side="bottom"
-        align={contentAlign}
-        className="w-72 p-3"
-        onPointerEnter={showTooltip}
-        onPointerLeave={hideTooltip}
-        onMouseEnter={showTooltip}
-        onMouseLeave={hideTooltip}
-      >
+        </button>
+      </PopoverTrigger>
+      <PopoverContent side="bottom" align={contentAlign} className="w-72 p-3">
         <div className="flex items-center justify-between gap-3 text-sm font-medium">
           <span>{title}</span>
           <span>{total}</span>

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -37,7 +37,7 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 
 # Optional: Paid-onboarding origin
-PAID_ONBOARDING_URL=https://so.vm7.ai:8441
+PAID_ONBOARDING_URL=https://so.vm7.ai:8443
 
 # Optional: Vercel preview proxy bypass
 VERCEL_AUTOMATION_BYPASS_SECRET=

--- a/turbo/apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/turbo/apps/web/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -9,6 +9,7 @@ import { buildSignupRedirectUrl } from "../../../src/lib/adAttribution";
 import {
   getAllowedRedirectOrigins,
   getAppUrl,
+  getPaidOnboardingUrl,
 } from "../../../src/lib/zero/url";
 
 export function SignUpClient() {
@@ -18,6 +19,7 @@ export function SignUpClient() {
     getAppUrl(),
     searchParams.toString(),
     getAllowedRedirectOrigins(),
+    getPaidOnboardingUrl(),
   );
 
   return (

--- a/turbo/apps/web/src/__tests__/adAttribution.test.ts
+++ b/turbo/apps/web/src/__tests__/adAttribution.test.ts
@@ -236,6 +236,32 @@ describe("buildSignupRedirectUrl", () => {
     expect(url.searchParams.get("vm0_source")).toBe("presentation");
   });
 
+  it("rewrites staging SO onboarding redirects to the configured paid-onboarding origin", () => {
+    const redirectUrl = buildSignupRedirectUrl(
+      "https://app.vm7.ai:8443",
+      "redirect_url=https%3A%2F%2Fstaging-so.vm6.ai%2Fonboarding%2F2afcf6%3Fdomain%3Dstaging-api.vm6.ai%26prompt%3Dhello",
+      ["https://app.vm7.ai:8443", "https://so.vm7.ai:8443"],
+      "https://so.vm7.ai:8443",
+    );
+    const url = new URL(redirectUrl);
+
+    expect(url.origin).toBe("https://so.vm7.ai:8443");
+    expect(url.pathname).toBe("/onboarding/2afcf6");
+    expect(url.searchParams.get("domain")).toBe("staging-api.vm6.ai");
+    expect(url.searchParams.get("prompt")).toBe("hello");
+  });
+
+  it("does not rewrite staging SO redirects to production paid-onboarding", () => {
+    const redirectUrl = buildSignupRedirectUrl(
+      "https://app.vm0.ai",
+      "redirect_url=https%3A%2F%2Fstaging-so.vm6.ai%2Fonboarding%2F2afcf6",
+      ["https://app.vm0.ai", "https://so.vm0.ai"],
+      "https://so.vm0.ai",
+    );
+
+    expect(redirectUrl).toBe("https://app.vm0.ai");
+  });
+
   it("ignores a disallowed redirect_url and keeps the attributed app fallback", () => {
     const redirectUrl = buildSignupRedirectUrl(
       "https://app.vm0.ai",

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -272,9 +272,14 @@ export function buildSignupRedirectUrl(
   appUrl: string,
   signUpSearch: string,
   allowedRedirectOrigins: readonly string[] = [appUrl],
+  paidOnboardingUrl?: string,
 ): string {
   const params = new URLSearchParams(signUpSearch);
-  const redirectUrl = readAllowedRedirectUrl(params, allowedRedirectOrigins);
+  const redirectUrl = readAllowedRedirectUrl(
+    params,
+    allowedRedirectOrigins,
+    paidOnboardingUrl,
+  );
   if (redirectUrl) {
     return redirectUrl;
   }
@@ -291,6 +296,7 @@ export function buildSignupRedirectUrl(
 function readAllowedRedirectUrl(
   params: URLSearchParams,
   allowedRedirectOrigins: readonly string[],
+  paidOnboardingUrl: string | undefined,
 ): string | null {
   const rawRedirectUrl = params.get("redirect_url");
   if (!rawRedirectUrl) {
@@ -298,13 +304,49 @@ function readAllowedRedirectUrl(
   }
 
   try {
-    const redirectUrl = new URL(rawRedirectUrl);
+    const redirectUrl = normalizePaidOnboardingRedirectUrl(
+      new URL(rawRedirectUrl),
+      paidOnboardingUrl,
+    );
     return isAllowedRedirectOrigin(redirectUrl, allowedRedirectOrigins)
       ? redirectUrl.toString()
       : null;
   } catch {
     return null;
   }
+}
+
+function normalizePaidOnboardingRedirectUrl(
+  redirectUrl: URL,
+  paidOnboardingUrl: string | undefined,
+): URL {
+  if (!paidOnboardingUrl || !isKnownStagingSoOnboardingRedirect(redirectUrl)) {
+    return redirectUrl;
+  }
+
+  const paidUrl = new URL(paidOnboardingUrl);
+  if (isVm0ProductionOrigin(paidUrl)) {
+    return redirectUrl;
+  }
+
+  const normalized = new URL(redirectUrl.toString());
+  normalized.protocol = paidUrl.protocol;
+  normalized.host = paidUrl.host;
+  return normalized;
+}
+
+function isKnownStagingSoOnboardingRedirect(redirectUrl: URL): boolean {
+  return (
+    redirectUrl.protocol === "https:" &&
+    (redirectUrl.hostname === "staging-so.vm6.ai" ||
+      redirectUrl.hostname.endsWith("-so.vm6.ai")) &&
+    (redirectUrl.pathname === "/onboarding" ||
+      redirectUrl.pathname.startsWith("/onboarding/"))
+  );
+}
+
+function isVm0ProductionOrigin(url: URL): boolean {
+  return url.hostname === "vm0.ai" || url.hostname.endsWith(".vm0.ai");
 }
 
 function isAllowedRedirectOrigin(

--- a/turbo/apps/web/src/lib/zero/url.ts
+++ b/turbo/apps/web/src/lib/zero/url.ts
@@ -4,13 +4,17 @@ export function getAppUrl(): string {
   return env().NEXT_PUBLIC_APP_URL;
 }
 
+export function getPaidOnboardingUrl(): string | undefined {
+  return env().NEXT_PUBLIC_PAID_ONBOARDING_URL;
+}
+
 // Origins Clerk is allowed to redirect back to after sign-in/sign-up. Always
 // includes the app; optionally includes the paid-onboarding origin (so.vm0.ai)
 // when configured per environment, so a paid onboarding flow hosted on a
 // sibling *.vm0.ai subdomain can run auth on www and return to itself.
 export function getAllowedRedirectOrigins(): string[] {
   const appUrl = getAppUrl();
-  const paidOnboardingUrl = env().NEXT_PUBLIC_PAID_ONBOARDING_URL;
+  const paidOnboardingUrl = getPaidOnboardingUrl();
   const origins = paidOnboardingUrl ? [appUrl, paidOnboardingUrl] : [appUrl];
 
   // Any vm6.ai app/web preview is staging-only. Allow the whole *.vm6.ai

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -38,6 +38,16 @@ api.vm7.ai:8443 {
 	reverse_proxy localhost:3001
 }
 
+# Paid onboarding surface proxied to the shared staging SO deployment.
+so.vm7.ai:8443 {
+	tls {
+		dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
+	}
+	reverse_proxy https://staging-so.vm6.ai {
+		header_up Host staging-so.vm6.ai
+	}
+}
+
 # HTTP redirects to HTTPS
 http://vm7.ai:8080 {
 	redir https://www.vm7.ai:8443{uri} permanent
@@ -53,4 +63,8 @@ http://app.vm7.ai:8080 {
 
 http://api.vm7.ai:8080 {
 	redir https://api.vm7.ai:8443{uri} permanent
+}
+
+http://so.vm7.ai:8080 {
+	redir https://so.vm7.ai:8443{uri} permanent
 }

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -9,7 +9,7 @@ This package provides a Caddy-based reverse proxy that enables HTTPS for local d
 ## Features
 
 - **Automatic HTTPS** via Let's Encrypt (no manual certificate management)
-- **Multiple domains**: www.vm7.ai, app.vm7.ai, api.vm7.ai
+- **Multiple domains**: www.vm7.ai, app.vm7.ai, api.vm7.ai, so.vm7.ai
 - **Automatic HTTP to HTTPS redirect**
 - **WebSocket support** for hot module replacement
 - **Shared certificate cache** across devcontainers via Docker volume
@@ -20,9 +20,9 @@ This package provides a Caddy-based reverse proxy that enables HTTPS for local d
 Browser
   ↓
 Caddy Proxy (HTTPS: 8443, HTTP: 8080)
-  ↓              ↓              ↓
-Web App        App            API
-(port 3000)    (port 3002)    (port 3001)
+  ↓              ↓              ↓              ↓
+Web App        App            API            SO staging
+(port 3000)    (port 3002)    (port 3001)    (staging-so.vm6.ai)
 ```
 
 ## Quick Start
@@ -58,6 +58,7 @@ On first start, Caddy will automatically obtain a Let's Encrypt certificate (~30
 - Web: https://www.vm7.ai:8443
 - App: https://app.vm7.ai:8443
 - API: https://api.vm7.ai:8443
+- SO: https://so.vm7.ai:8443
 
 Direct access (HTTP only):
 
@@ -83,6 +84,7 @@ The `Caddyfile` defines:
 | www.vm7.ai:8443 | 8443 | localhost:3000 (Next.js web) |
 | app.vm7.ai:8443 | 8443 | localhost:3002 (Vite app)    |
 | api.vm7.ai:8443 | 8443 | localhost:3001 (Hono API)    |
+| so.vm7.ai:8443  | 8443 | staging-so.vm6.ai            |
 | vm7.ai:8443     | 8443 | Redirect to www.vm7.ai:8443  |
 
 ## Scripts
@@ -108,7 +110,7 @@ pkill -f caddy
 In DevContainer, this should be automatic. If not:
 
 ```bash
-echo "127.0.0.1 vm7.ai www.vm7.ai app.vm7.ai api.vm7.ai" | sudo tee -a /etc/hosts
+echo "127.0.0.1 vm7.ai www.vm7.ai app.vm7.ai api.vm7.ai so.vm7.ai" | sudo tee -a /etc/hosts
 ```
 
 ## File Structure

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -74,6 +74,7 @@ setTimeout(() => {
   console.log("   Web:       https://www.vm7.ai:8443");
   console.log("   App:       https://app.vm7.ai:8443");
   console.log("   API:       https://api.vm7.ai:8443");
+  console.log("   SO:        https://so.vm7.ai:8443");
   console.log("\n💡 Make sure your applications are running:");
   console.log("   Web:       pnpm --filter web dev (port 3000)");
   console.log("   App:       pnpm --filter @vm0/app dev (port 3002)");

--- a/turbo/scripts/dev-server-check.sh
+++ b/turbo/scripts/dev-server-check.sh
@@ -11,7 +11,7 @@ fi
 check_port() {
   local label="$1"
   local url="$2"
-  if curl -k -s --connect-timeout 3 --resolve "$(echo "$url" | sed 's|https://||;s|/.*||'):127.0.0.1" "$url" > /dev/null 2>&1; then
+  if curl -f -k -s --connect-timeout 3 --max-time 10 --resolve "$(echo "$url" | sed 's|https://||;s|/.*||'):127.0.0.1" "$url" > /dev/null 2>&1; then
     echo "$label | running"
   else
     echo "$label | not started"
@@ -21,3 +21,4 @@ check_port() {
 check_port "Web:      https://www.vm7.ai:8443"      "https://www.vm7.ai:8443/"
 check_port "App:      https://app.vm7.ai:8443"  "https://app.vm7.ai:8443/"
 check_port "API:      https://api.vm7.ai:8443"  "https://api.vm7.ai:8443/health"
+check_port "SO:       https://so.vm7.ai:8443"   "https://so.vm7.ai:8443/onboarding/2afcf6"


### PR DESCRIPTION
## Summary
- add local `so.vm7.ai:8443` proxy for paid onboarding against staging SO
- normalize local signup onboarding redirects back to the configured local SO origin
- make the chat usage popover trigger work on mobile by using a real popover trigger button
- tighten dev server status checks so timeouts and HTTP errors are reported correctly

## Tests
- `pnpm check-types` via pre-commit
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/zero-onboarding.test.tsx`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts`
- `pnpm -F web exec vitest run src/__tests__/adAttribution.test.ts src/lib/zero/url.test.ts`
- `pnpm dev:status`