### PR TITLE
refactor(mitm-addon): centralize responses event prefilter

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_probe.py
+++ b/crates/runner/mitm-addon/src/usage/json_probe.py
@@ -26,6 +26,7 @@ class TopLevelStringFieldProbeResult:
 
     status: TopLevelStringFieldProbeStatus
     value: str | None = None
+    field_seen: bool = False
 
 
 @dataclass(frozen=True)
@@ -86,12 +87,13 @@ def probe_top_level_string_field(
         if key == field_name:
             if body[i] != ord('"'):
                 return TopLevelStringFieldProbeResult(
-                    "non_string" if _is_json_value_start(body[i]) else "invalid"
+                    "non_string" if _is_json_value_start(body[i]) else "invalid",
+                    field_seen=True,
                 )
             value_result = _read_json_string(body, i, max_bytes=max_string_bytes)
             if value_result.status != "ok":
-                return TopLevelStringFieldProbeResult(value_result.status)
-            return TopLevelStringFieldProbeResult("found", value_result.value)
+                return TopLevelStringFieldProbeResult(value_result.status, field_seen=True)
+            return TopLevelStringFieldProbeResult("found", value_result.value, field_seen=True)
 
         skip_result = _skip_json_value(
             body,

--- a/crates/runner/mitm-addon/src/usage/json_probe.py
+++ b/crates/runner/mitm-addon/src/usage/json_probe.py
@@ -1,0 +1,391 @@
+"""Bounded JSON prefix probing helpers."""
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+TopLevelStringFieldProbeStatus = Literal[
+    "found",
+    "not_found",
+    "incomplete",
+    "invalid",
+    "non_string",
+    "bound_exceeded",
+]
+
+_JSON_CONTROL_CHAR_MAX = 0x20
+_JSON_HEX_BYTES = frozenset(b"0123456789abcdefABCDEF")
+_JSON_WHITESPACE = b" \t\r\n"
+_UTF8_SURROGATE_MIN = 0xD800
+_UTF8_SURROGATE_MAX = 0xDFFF
+
+
+@dataclass(frozen=True)
+class TopLevelStringFieldProbeResult:
+    """Result of probing a JSON object for a top-level string field."""
+
+    status: TopLevelStringFieldProbeStatus
+    value: str | None = None
+
+
+@dataclass(frozen=True)
+class _IndexResult:
+    status: Literal["ok", "incomplete", "invalid", "bound_exceeded"]
+    index: int = 0
+
+
+@dataclass(frozen=True)
+class _StringResult:
+    status: Literal["ok", "incomplete", "invalid", "bound_exceeded"]
+    value: str | None = None
+    index: int = 0
+
+
+def probe_top_level_string_field(
+    body: bytes,
+    field_name: str = "type",
+    *,
+    max_depth: int = 256,
+    max_key_bytes: int = 1024,
+    max_string_bytes: int = 1024,
+) -> TopLevelStringFieldProbeResult:
+    """Probe a bounded JSON object prefix for the first top-level string field."""
+
+    _validate_positive_int("max_depth", max_depth)
+    _validate_positive_int("max_key_bytes", max_key_bytes)
+    _validate_positive_int("max_string_bytes", max_string_bytes)
+
+    i = _skip_json_whitespace(body, 0)
+    if i >= len(body):
+        return TopLevelStringFieldProbeResult("incomplete")
+    if body[i] != ord("{"):
+        return TopLevelStringFieldProbeResult("invalid")
+
+    i = _skip_json_whitespace(body, i + 1)
+    if i >= len(body):
+        return TopLevelStringFieldProbeResult("incomplete")
+    if body[i] == ord("}"):
+        return _finish_not_found_object(body, i + 1)
+
+    while i < len(body):
+        key_result = _read_json_string(body, i, max_bytes=max_key_bytes)
+        if key_result.status != "ok":
+            return TopLevelStringFieldProbeResult(key_result.status)
+        key = key_result.value
+        if key is None:
+            return TopLevelStringFieldProbeResult("invalid")
+        i = _skip_json_whitespace(body, key_result.index)
+        if i >= len(body):
+            return TopLevelStringFieldProbeResult("incomplete")
+        if body[i] != ord(":"):
+            return TopLevelStringFieldProbeResult("invalid")
+        i = _skip_json_whitespace(body, i + 1)
+        if i >= len(body):
+            return TopLevelStringFieldProbeResult("incomplete")
+
+        if key == field_name:
+            if body[i] != ord('"'):
+                return TopLevelStringFieldProbeResult(
+                    "non_string" if _is_json_value_start(body[i]) else "invalid"
+                )
+            value_result = _read_json_string(body, i, max_bytes=max_string_bytes)
+            if value_result.status != "ok":
+                return TopLevelStringFieldProbeResult(value_result.status)
+            return TopLevelStringFieldProbeResult("found", value_result.value)
+
+        skip_result = _skip_json_value(
+            body,
+            i,
+            depth=1,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+            max_string_bytes=max_string_bytes,
+        )
+        if skip_result.status != "ok":
+            return TopLevelStringFieldProbeResult(skip_result.status)
+        i = _skip_json_whitespace(body, skip_result.index)
+        if i >= len(body):
+            return TopLevelStringFieldProbeResult("incomplete")
+        if body[i] == ord("}"):
+            return _finish_not_found_object(body, i + 1)
+        if body[i] != ord(","):
+            return TopLevelStringFieldProbeResult("invalid")
+        i = _skip_json_whitespace(body, i + 1)
+        if i >= len(body):
+            return TopLevelStringFieldProbeResult("incomplete")
+
+    return TopLevelStringFieldProbeResult("incomplete")
+
+
+def _validate_positive_int(name: str, value: int) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+def _skip_json_whitespace(body: bytes, i: int) -> int:
+    while i < len(body) and body[i] in _JSON_WHITESPACE:
+        i += 1
+    return i
+
+
+def _finish_not_found_object(body: bytes, i: int) -> TopLevelStringFieldProbeResult:
+    i = _skip_json_whitespace(body, i)
+    if i == len(body):
+        return TopLevelStringFieldProbeResult("not_found")
+    return TopLevelStringFieldProbeResult("invalid")
+
+
+def _scan_json_string_end(
+    body: bytes,
+    i: int,
+    *,
+    max_bytes: int,
+) -> _IndexResult:
+    if i >= len(body) or body[i] != ord('"'):
+        return _IndexResult("invalid")
+    i += 1
+    raw_bytes = 0
+    while i < len(body):
+        b = body[i]
+        if b == ord('"'):
+            return _IndexResult("ok", i + 1)
+        raw_bytes += 1
+        if raw_bytes > max_bytes:
+            return _IndexResult("bound_exceeded")
+        if b == ord("\\"):
+            i += 1
+            if i >= len(body):
+                return _IndexResult("incomplete")
+            escape = body[i]
+            raw_bytes += 1
+            if raw_bytes > max_bytes:
+                return _IndexResult("bound_exceeded")
+            if escape == ord("u"):
+                if i + 4 >= len(body):
+                    return _IndexResult("incomplete")
+                if any(hex_byte not in _JSON_HEX_BYTES for hex_byte in body[i + 1 : i + 5]):
+                    return _IndexResult("invalid")
+                raw_bytes += 4
+                if raw_bytes > max_bytes:
+                    return _IndexResult("bound_exceeded")
+                i += 5
+                continue
+            if escape not in b'"\\/bfnrt':
+                return _IndexResult("invalid")
+            i += 1
+            continue
+        if b < _JSON_CONTROL_CHAR_MAX:
+            return _IndexResult("invalid")
+        i += 1
+    return _IndexResult("incomplete")
+
+
+def _read_json_string(body: bytes, i: int, *, max_bytes: int) -> _StringResult:
+    end_result = _scan_json_string_end(body, i, max_bytes=max_bytes)
+    if end_result.status != "ok":
+        return _StringResult(end_result.status)
+    try:
+        value = json.loads(body[i : end_result.index].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return _StringResult("invalid")
+    if not isinstance(value, str) or _contains_surrogate(value):
+        return _StringResult("invalid")
+    return _StringResult("ok", value, end_result.index)
+
+
+def _skip_json_string(body: bytes, i: int, *, max_bytes: int) -> _IndexResult:
+    string_result = _read_json_string(body, i, max_bytes=max_bytes)
+    if string_result.status != "ok":
+        return _IndexResult(string_result.status)
+    return _IndexResult("ok", string_result.index)
+
+
+def _skip_json_number(body: bytes, i: int) -> _IndexResult:
+    if i < len(body) and body[i] == ord("-"):
+        i += 1
+    if i >= len(body):
+        return _IndexResult("incomplete")
+
+    if body[i] == ord("0"):
+        i += 1
+        if i < len(body) and ord("0") <= body[i] <= ord("9"):
+            return _IndexResult("invalid")
+    elif ord("1") <= body[i] <= ord("9"):
+        i += 1
+        while i < len(body) and ord("0") <= body[i] <= ord("9"):
+            i += 1
+    else:
+        return _IndexResult("invalid")
+
+    if i < len(body) and body[i] == ord("."):
+        i += 1
+        if i >= len(body):
+            return _IndexResult("incomplete")
+        if not ord("0") <= body[i] <= ord("9"):
+            return _IndexResult("invalid")
+        while i < len(body) and ord("0") <= body[i] <= ord("9"):
+            i += 1
+
+    if i < len(body) and body[i] in b"eE":
+        i += 1
+        if i < len(body) and body[i] in b"+-":
+            i += 1
+        if i >= len(body):
+            return _IndexResult("incomplete")
+        if not ord("0") <= body[i] <= ord("9"):
+            return _IndexResult("invalid")
+        while i < len(body) and ord("0") <= body[i] <= ord("9"):
+            i += 1
+
+    if i >= len(body):
+        return _IndexResult("incomplete")
+    return _IndexResult("ok", i)
+
+
+def _skip_json_array(
+    body: bytes,
+    i: int,
+    *,
+    depth: int,
+    max_depth: int,
+    max_key_bytes: int,
+    max_string_bytes: int,
+) -> _IndexResult:
+    if depth >= max_depth:
+        return _IndexResult("bound_exceeded")
+    i = _skip_json_whitespace(body, i + 1)
+    if i >= len(body):
+        return _IndexResult("incomplete")
+    if body[i] == ord("]"):
+        return _IndexResult("ok", i + 1)
+
+    while i < len(body):
+        value_result = _skip_json_value(
+            body,
+            i,
+            depth=depth + 1,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+            max_string_bytes=max_string_bytes,
+        )
+        if value_result.status != "ok":
+            return value_result
+        i = _skip_json_whitespace(body, value_result.index)
+        if i >= len(body):
+            return _IndexResult("incomplete")
+        if body[i] == ord("]"):
+            return _IndexResult("ok", i + 1)
+        if body[i] != ord(","):
+            return _IndexResult("invalid")
+        i = _skip_json_whitespace(body, i + 1)
+        if i >= len(body):
+            return _IndexResult("incomplete")
+    return _IndexResult("incomplete")
+
+
+def _skip_json_object(
+    body: bytes,
+    i: int,
+    *,
+    depth: int,
+    max_depth: int,
+    max_key_bytes: int,
+    max_string_bytes: int,
+) -> _IndexResult:
+    if depth >= max_depth:
+        return _IndexResult("bound_exceeded")
+    i = _skip_json_whitespace(body, i + 1)
+    if i >= len(body):
+        return _IndexResult("incomplete")
+    if body[i] == ord("}"):
+        return _IndexResult("ok", i + 1)
+
+    while i < len(body):
+        key_result = _skip_json_string(body, i, max_bytes=max_key_bytes)
+        if key_result.status != "ok":
+            return key_result
+        i = _skip_json_whitespace(body, key_result.index)
+        if i >= len(body):
+            return _IndexResult("incomplete")
+        if body[i] != ord(":"):
+            return _IndexResult("invalid")
+        i = _skip_json_whitespace(body, i + 1)
+        if i >= len(body):
+            return _IndexResult("incomplete")
+        value_result = _skip_json_value(
+            body,
+            i,
+            depth=depth + 1,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+            max_string_bytes=max_string_bytes,
+        )
+        if value_result.status != "ok":
+            return value_result
+        i = _skip_json_whitespace(body, value_result.index)
+        if i >= len(body):
+            return _IndexResult("incomplete")
+        if body[i] == ord("}"):
+            return _IndexResult("ok", i + 1)
+        if body[i] != ord(","):
+            return _IndexResult("invalid")
+        i = _skip_json_whitespace(body, i + 1)
+        if i >= len(body):
+            return _IndexResult("incomplete")
+    return _IndexResult("incomplete")
+
+
+def _skip_json_value(
+    body: bytes,
+    i: int,
+    *,
+    depth: int,
+    max_depth: int,
+    max_key_bytes: int,
+    max_string_bytes: int,
+) -> _IndexResult:
+    i = _skip_json_whitespace(body, i)
+    if i >= len(body):
+        return _IndexResult("incomplete")
+    b = body[i]
+    if b == ord('"'):
+        return _skip_json_string(body, i, max_bytes=max_string_bytes)
+    if b == ord("{"):
+        return _skip_json_object(
+            body,
+            i,
+            depth=depth,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+            max_string_bytes=max_string_bytes,
+        )
+    if b == ord("["):
+        return _skip_json_array(
+            body,
+            i,
+            depth=depth,
+            max_depth=max_depth,
+            max_key_bytes=max_key_bytes,
+            max_string_bytes=max_string_bytes,
+        )
+    if b == ord("-") or ord("0") <= b <= ord("9"):
+        return _skip_json_number(body, i)
+    for literal in (b"true", b"false", b"null"):
+        if body.startswith(literal, i):
+            end = i + len(literal)
+            if end == len(body):
+                return _IndexResult("incomplete")
+            return _IndexResult("ok", end)
+        if literal.startswith(body[i:]):
+            return _IndexResult("incomplete")
+    return _IndexResult("invalid")
+
+
+def _is_json_value_start(b: int) -> bool:
+    return b in b'{["tfn-' or ord("0") <= b <= ord("9")
+
+
+def _contains_surrogate(value: str) -> bool:
+    return any(_UTF8_SURROGATE_MIN <= ord(ch) <= _UTF8_SURROGATE_MAX for ch in value)

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -108,6 +108,20 @@ def _classify_responses_event_name(event_name: str) -> _ResponsesEventTypeClassi
     return _RESPONSES_EVENT_UNKNOWN
 
 
+def _resolved_event_type(
+    event_type: _ResponsesEventTypeClassification,
+) -> _ResponsesEventTypeClassification:
+    if event_type == _RESPONSES_EVENT_PENDING:
+        return _RESPONSES_EVENT_UNKNOWN
+    return event_type
+
+
+def _resolved_event_type_from_prefix(
+    prefix: bytearray,
+) -> _ResponsesEventTypeClassification:
+    return _resolved_event_type(_classify_responses_event_type(bytes(prefix)))
+
+
 def _is_known_terminal_usage_event(value: object) -> bool:
     return isinstance(value, str) and value in _RESPONSES_TERMINAL_USAGE_EVENTS
 
@@ -237,12 +251,16 @@ def _store_sse_result_values(
     target: dict,
     *,
     event_name: str | None,
+    data_event_type: _ResponsesEventTypeClassification | None = None,
 ) -> None:
     data_type = values.get(("type",))
-    if _is_known_non_usage_event(event_name) or _is_known_non_usage_event(data_type):
+    if _is_known_non_usage_event(event_name) or data_event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
         return
     event_identity = event_name if event_name is not None else data_type
-    is_known_terminal_usage_event = _is_known_terminal_usage_event(event_identity)
+    is_known_terminal_usage_event = (
+        _is_known_terminal_usage_event(event_identity)
+        or data_event_type == _RESPONSES_EVENT_TERMINAL
+    )
 
     prefix = ("response",) if _has_response_wrapper_values(values) else ()
     source: dict = {}
@@ -277,6 +295,8 @@ class _OpenAIResponsesSseUsageHandler:
         self._usage = usage
         self._extractor: JsonSelectiveExtractor | None = None
         self._eventless_prefix: bytearray | None = None
+        self._named_event_prefix: bytearray | None = None
+        self._data_event_type: _ResponsesEventTypeClassification | None = None
         self._discard_eventless_event = False
         self._on_parse_error = on_parse_error
 
@@ -288,12 +308,15 @@ class _OpenAIResponsesSseUsageHandler:
         if event_name is None:
             self._eventless_prefix = bytearray()
             return
+        if not _is_known_terminal_usage_event(event_name):
+            self._named_event_prefix = bytearray()
         self._start_full_extractor()
 
     def on_data(self, chunk: bytes) -> None:
         if self._discard_eventless_event:
             return
         if self._extractor is not None:
+            self._feed_named_event_prefix(chunk)
             self._extractor.feed(chunk)
             return
         if self._eventless_prefix is not None:
@@ -304,16 +327,25 @@ class _OpenAIResponsesSseUsageHandler:
 
     def on_event_end(self, event_name: str | None) -> None:
         if self._eventless_prefix is not None:
+            self._data_event_type = _resolved_event_type_from_prefix(self._eventless_prefix)
             extractor = self._start_full_extractor()
             extractor.feed(bytes(self._eventless_prefix))
             self._eventless_prefix = None
+        if self._named_event_prefix is not None and self._data_event_type is None:
+            self._data_event_type = _resolved_event_type_from_prefix(self._named_event_prefix)
         extractor = self._extractor
+        data_event_type = self._data_event_type
         self._reset_event_state()
         if extractor is None:
             return
         result = extractor.finish()
         if result.complete:
-            _store_sse_result_values(result.values, self._usage, event_name=event_name)
+            _store_sse_result_values(
+                result.values,
+                self._usage,
+                event_name=event_name,
+                data_event_type=data_event_type,
+            )
             return
         if (
             event_name is not None
@@ -329,6 +361,8 @@ class _OpenAIResponsesSseUsageHandler:
     def _reset_event_state(self) -> None:
         self._extractor = None
         self._eventless_prefix = None
+        self._named_event_prefix = None
+        self._data_event_type = None
         self._discard_eventless_event = False
 
     def _start_full_extractor(self) -> JsonSelectiveExtractor:
@@ -359,9 +393,31 @@ class _OpenAIResponsesSseUsageHandler:
         if not should_fallback:
             return
 
+        self._data_event_type = _resolved_event_type(event_type)
         self._fallback_eventless_prefix_to_full_extractor()
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
+
+    def _feed_named_event_prefix(self, chunk: bytes) -> None:
+        prefix = self._named_event_prefix
+        if prefix is None or self._data_event_type is not None:
+            return
+
+        remaining = max(_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES - len(prefix), 0)
+        captured_len = min(len(chunk), remaining)
+        if captured_len:
+            prefix.extend(chunk[:captured_len])
+
+        event_type = _classify_responses_event_type(bytes(prefix))
+        if (
+            event_type == _RESPONSES_EVENT_PENDING
+            and captured_len == len(chunk)
+            and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
+        ):
+            return
+
+        self._data_event_type = _resolved_event_type(event_type)
+        self._named_event_prefix = None
 
     def _fallback_eventless_prefix_to_full_extractor(self) -> None:
         prefix = self._eventless_prefix
@@ -469,7 +525,8 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
     ``event:`` / ``data:`` envelope, so reuse the SSE field map and event gate
     directly.
     """
-    if _classify_responses_event_type(body) == _RESPONSES_EVENT_KNOWN_NON_USAGE:
+    event_type = _classify_responses_event_type(body)
+    if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
         return None
 
     extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
@@ -479,7 +536,7 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
         return None
 
     usage: dict = {}
-    _store_sse_result_values(result.values, usage, event_name=None)
+    _store_sse_result_values(result.values, usage, event_name=None, data_event_type=event_type)
     if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
         return None
     return usage

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -86,10 +86,13 @@ _RESPONSES_RESPONSE_SCALAR_FIELDS = {
     ("usage", "input_tokens_details", "cached_tokens"): ScalarField("int", max_bytes=64),
 }
 
-_RESPONSES_SSE_SCALAR_FIELDS = {
-    ("type",): ScalarField("string", max_bytes=1024),
+_RESPONSES_SSE_RESPONSE_SCALAR_FIELDS = {
     **_RESPONSES_RESPONSE_SCALAR_FIELDS,
     **{("response", *path): field for path, field in _RESPONSES_RESPONSE_SCALAR_FIELDS.items()},
+}
+_RESPONSES_SSE_SCALAR_FIELDS = {
+    ("type",): ScalarField("string", max_bytes=1024),
+    **_RESPONSES_SSE_RESPONSE_SCALAR_FIELDS,
 }
 
 
@@ -324,15 +327,15 @@ class _OpenAIResponsesSseUsageHandler:
             self._eventless_prefix = bytearray()
             return
         self._named_event_prefix = bytearray()
-        self._start_full_extractor()
 
     def on_data(self, chunk: bytes) -> None:
         if self._discard_eventless_event or self._discard_named_event:
             return
         if self._extractor is not None:
-            if self._feed_named_event_prefix(chunk):
-                return
             self._extractor.feed(chunk)
+            return
+        if self._named_event_prefix is not None:
+            self._feed_named_event_data(chunk)
             return
         if self._eventless_prefix is not None:
             self._feed_eventless_data(chunk)
@@ -343,11 +346,14 @@ class _OpenAIResponsesSseUsageHandler:
     def on_event_end(self, event_name: str | None) -> None:
         if self._eventless_prefix is not None:
             self._data_event_type = _resolved_data_event_type_from_prefix(self._eventless_prefix)
-            extractor = self._start_full_extractor()
+            extractor = self._start_full_extractor(include_type=self._data_event_type is None)
             extractor.feed(bytes(self._eventless_prefix))
             self._eventless_prefix = None
         if self._named_event_prefix is not None and self._data_event_type is None:
             self._data_event_type = _resolved_data_event_type_from_prefix(self._named_event_prefix)
+            extractor = self._start_full_extractor(include_type=self._data_event_type is None)
+            extractor.feed(bytes(self._named_event_prefix))
+            self._named_event_prefix = None
         extractor = self._extractor
         data_event_type = self._data_event_type
         self._reset_event_state()
@@ -381,8 +387,11 @@ class _OpenAIResponsesSseUsageHandler:
         self._discard_eventless_event = False
         self._discard_named_event = False
 
-    def _start_full_extractor(self) -> JsonSelectiveExtractor:
-        self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
+    def _start_full_extractor(self, *, include_type: bool = True) -> JsonSelectiveExtractor:
+        scalar_fields = (
+            _RESPONSES_SSE_SCALAR_FIELDS if include_type else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
+        )
+        self._extractor = JsonSelectiveExtractor(scalar_fields=scalar_fields)
         return self._extractor
 
     def _feed_eventless_data(self, chunk: bytes) -> None:
@@ -411,14 +420,16 @@ class _OpenAIResponsesSseUsageHandler:
             return
 
         self._data_event_type = _resolved_data_event_type(event_type)
-        self._fallback_eventless_prefix_to_full_extractor()
+        self._fallback_eventless_prefix_to_full_extractor(
+            include_type=self._data_event_type is None
+        )
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 
-    def _feed_named_event_prefix(self, chunk: bytes) -> bool:
+    def _feed_named_event_data(self, chunk: bytes) -> None:
         prefix = self._named_event_prefix
-        if prefix is None or self._data_event_type is not None:
-            return False
+        if prefix is None:
+            return
 
         remaining = max(_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES - len(prefix), 0)
         captured_len = min(len(chunk), remaining)
@@ -431,20 +442,30 @@ class _OpenAIResponsesSseUsageHandler:
             and captured_len == len(chunk)
             and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
         ):
-            return False
+            return
 
-        self._data_event_type = _resolved_data_event_type(event_type)
-        self._named_event_prefix = None
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
+            self._named_event_prefix = None
             self._extractor = None
             self._discard_named_event = True
-            return True
-        return False
+            return
 
-    def _fallback_eventless_prefix_to_full_extractor(self) -> None:
+        self._data_event_type = _resolved_data_event_type(event_type)
+        self._fallback_named_prefix_to_full_extractor(include_type=self._data_event_type is None)
+        if self._extractor is not None and captured_len < len(chunk):
+            self._extractor.feed(chunk[captured_len:])
+
+    def _fallback_eventless_prefix_to_full_extractor(self, *, include_type: bool) -> None:
         prefix = self._eventless_prefix
         self._eventless_prefix = None
-        extractor = self._start_full_extractor()
+        extractor = self._start_full_extractor(include_type=include_type)
+        if prefix:
+            extractor.feed(bytes(prefix))
+
+    def _fallback_named_prefix_to_full_extractor(self, *, include_type: bool) -> None:
+        prefix = self._named_event_prefix
+        self._named_event_prefix = None
+        extractor = self._start_full_extractor(include_type=include_type)
         if prefix:
             extractor.feed(bytes(prefix))
 
@@ -551,7 +572,13 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
     if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
         return None
 
-    extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
+    data_event_type = _resolved_data_event_type(event_type)
+    scalar_fields = (
+        _RESPONSES_SSE_SCALAR_FIELDS
+        if data_event_type is None
+        else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
+    )
+    extractor = JsonSelectiveExtractor(scalar_fields=scalar_fields)
     extractor.feed(body)
     result = extractor.finish()
     if not result.complete:
@@ -562,7 +589,7 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
         result.values,
         usage,
         event_name=None,
-        data_event_type=_resolved_data_event_type(event_type),
+        data_event_type=data_event_type,
     )
     if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
         return None

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -312,6 +312,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._named_event_prefix: bytearray | None = None
         self._data_event_type: _ResponsesEventTypeClassification | None = None
         self._discard_eventless_event = False
+        self._discard_named_event = False
         self._on_parse_error = on_parse_error
 
     def should_capture_event(self, event_name: str | None) -> bool:
@@ -326,10 +327,11 @@ class _OpenAIResponsesSseUsageHandler:
         self._start_full_extractor()
 
     def on_data(self, chunk: bytes) -> None:
-        if self._discard_eventless_event:
+        if self._discard_eventless_event or self._discard_named_event:
             return
         if self._extractor is not None:
-            self._feed_named_event_prefix(chunk)
+            if self._feed_named_event_prefix(chunk):
+                return
             self._extractor.feed(chunk)
             return
         if self._eventless_prefix is not None:
@@ -377,6 +379,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._named_event_prefix = None
         self._data_event_type = None
         self._discard_eventless_event = False
+        self._discard_named_event = False
 
     def _start_full_extractor(self) -> JsonSelectiveExtractor:
         self._extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)
@@ -412,10 +415,10 @@ class _OpenAIResponsesSseUsageHandler:
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 
-    def _feed_named_event_prefix(self, chunk: bytes) -> None:
+    def _feed_named_event_prefix(self, chunk: bytes) -> bool:
         prefix = self._named_event_prefix
         if prefix is None or self._data_event_type is not None:
-            return
+            return False
 
         remaining = max(_RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES - len(prefix), 0)
         captured_len = min(len(chunk), remaining)
@@ -428,10 +431,15 @@ class _OpenAIResponsesSseUsageHandler:
             and captured_len == len(chunk)
             and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
         ):
-            return
+            return False
 
         self._data_event_type = _resolved_data_event_type(event_type)
         self._named_event_prefix = None
+        if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
+            self._extractor = None
+            self._discard_named_event = True
+            return True
+        return False
 
     def _fallback_eventless_prefix_to_full_extractor(self) -> None:
         prefix = self._eventless_prefix

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -18,7 +18,6 @@ model-provider usage billing:
   usage into a per-flow accumulator.
 """
 
-import json
 from collections.abc import Callable
 from typing import Literal, TypeGuard
 
@@ -27,6 +26,7 @@ from mitmproxy import http
 import body_decoding
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
+from .json_probe import probe_top_level_string_field
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import (
     MODEL_USAGE_CATEGORY_CACHE_READ,
@@ -42,15 +42,24 @@ from .sse import SseUsageScanner
 _RESPONSES_TERMINAL_USAGE_EVENTS = frozenset(
     ("response.completed", "response.done", "response.incomplete", "response.failed")
 )
+_RESPONSES_KNOWN_NON_USAGE_EVENTS = frozenset(
+    (
+        "response.created",
+        "response.in_progress",
+        "response.output_text.delta",
+        "response.refusal.delta",
+        "response.function_call_arguments.delta",
+        "response.code_interpreter_call.code.delta",
+    )
+)
 _SseUsageParseErrorCallback = Callable[[str, str], None]
-_ResponsesEventTypeClassification = Literal["terminal", "non_terminal", "unknown"]
+_ResponsesEventTypeClassification = Literal["terminal", "known_non_usage", "unknown", "pending"]
 _RESPONSES_EVENT_TERMINAL: _ResponsesEventTypeClassification = "terminal"
-_RESPONSES_EVENT_NON_TERMINAL: _ResponsesEventTypeClassification = "non_terminal"
+_RESPONSES_EVENT_KNOWN_NON_USAGE: _ResponsesEventTypeClassification = "known_non_usage"
 _RESPONSES_EVENT_UNKNOWN: _ResponsesEventTypeClassification = "unknown"
-_JSON_CONTROL_CHAR_MAX = 0x20
+_RESPONSES_EVENT_PENDING: _ResponsesEventTypeClassification = "pending"
 _JSON_PREFILTER_MAX_DEPTH = 256
 _JSON_PREFILTER_MAX_STRING_BYTES = 1024
-_JSON_HEX_BYTES = frozenset(b"0123456789abcdefABCDEF")
 # Eventless SSE frames normally expose ``type`` near the top of the JSON body.
 # After this bounded prefix, fall back to the full streaming extractor so rare
 # terminal frames with late ``type`` fields still report usage.
@@ -77,225 +86,34 @@ _RESPONSES_SSE_SCALAR_FIELDS = {
 }
 
 
-def _skip_json_whitespace(body: bytes, i: int) -> int:
-    while i < len(body) and body[i] in b" \t\r\n":
-        i += 1
-    return i
-
-
-def _scan_json_string_end(
-    body: bytes,
-    i: int,
-    *,
-    max_string_bytes: int | None = None,
-) -> int | None:
-    if i >= len(body) or body[i] != ord('"'):
-        return None
-    i += 1
-    raw_bytes = 0
-    while i < len(body):
-        b = body[i]
-        if b == ord('"'):
-            return i + 1
-        raw_bytes += 1
-        if max_string_bytes is not None and raw_bytes > max_string_bytes:
-            return None
-        if b == ord("\\"):
-            i += 1
-            if i >= len(body):
-                return None
-            escape = body[i]
-            raw_bytes += 1
-            if max_string_bytes is not None and raw_bytes > max_string_bytes:
-                return None
-            if escape == ord("u"):
-                if i + 4 >= len(body):
-                    return None
-                if any(hex_byte not in _JSON_HEX_BYTES for hex_byte in body[i + 1 : i + 5]):
-                    return None
-                raw_bytes += 4
-                if max_string_bytes is not None and raw_bytes > max_string_bytes:
-                    return None
-                i += 5
-                continue
-            if escape not in b'"\\/bfnrt':
-                return None
-            i += 1
-            continue
-        if b < _JSON_CONTROL_CHAR_MAX:
-            return None
-        i += 1
-    return None
-
-
-def _read_json_string(body: bytes, i: int) -> tuple[str, int] | None:
-    end = _scan_json_string_end(
+def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
+    result = probe_top_level_string_field(
         body,
-        i,
+        "type",
+        max_depth=_JSON_PREFILTER_MAX_DEPTH,
         max_string_bytes=_JSON_PREFILTER_MAX_STRING_BYTES,
     )
-    if end is None:
-        return None
-    try:
-        value = json.loads(body[i:end].decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return None
-    if not isinstance(value, str):
-        return None
-    return value, end
-
-
-def _skip_json_number(body: bytes, i: int) -> int | None:
-    if i < len(body) and body[i] == ord("-"):
-        i += 1
-    if i >= len(body):
-        return None
-
-    if body[i] == ord("0"):
-        i += 1
-        if i < len(body) and ord("0") <= body[i] <= ord("9"):
-            return None
-    elif ord("1") <= body[i] <= ord("9"):
-        i += 1
-        while i < len(body) and ord("0") <= body[i] <= ord("9"):
-            i += 1
-    else:
-        return None
-
-    if i < len(body) and body[i] == ord("."):
-        i += 1
-        if i >= len(body) or not ord("0") <= body[i] <= ord("9"):
-            return None
-        while i < len(body) and ord("0") <= body[i] <= ord("9"):
-            i += 1
-
-    if i < len(body) and body[i] in b"eE":
-        i += 1
-        if i < len(body) and body[i] in b"+-":
-            i += 1
-        if i >= len(body) or not ord("0") <= body[i] <= ord("9"):
-            return None
-        while i < len(body) and ord("0") <= body[i] <= ord("9"):
-            i += 1
-
-    return i
-
-
-def _skip_json_array(body: bytes, i: int, depth: int) -> int | None:
-    if depth >= _JSON_PREFILTER_MAX_DEPTH:
-        return None
-    i = _skip_json_whitespace(body, i + 1)
-    if i < len(body) and body[i] == ord("]"):
-        return i + 1
-
-    while i < len(body):
-        next_i = _skip_json_value(body, i, depth + 1)
-        if next_i is None:
-            return None
-        i = next_i
-        i = _skip_json_whitespace(body, i)
-        if i >= len(body):
-            return None
-        if body[i] == ord("]"):
-            return i + 1
-        if body[i] != ord(","):
-            return None
-        i = _skip_json_whitespace(body, i + 1)
-    return None
-
-
-def _skip_json_object(body: bytes, i: int, depth: int) -> int | None:
-    if depth >= _JSON_PREFILTER_MAX_DEPTH:
-        return None
-    i = _skip_json_whitespace(body, i + 1)
-    if i < len(body) and body[i] == ord("}"):
-        return i + 1
-
-    while i < len(body):
-        key = _scan_json_string_end(body, i)
-        if key is None:
-            return None
-        i = _skip_json_whitespace(body, key)
-        if i >= len(body) or body[i] != ord(":"):
-            return None
-        i = _skip_json_whitespace(body, i + 1)
-        next_i = _skip_json_value(body, i, depth + 1)
-        if next_i is None:
-            return None
-        i = next_i
-        i = _skip_json_whitespace(body, i)
-        if i >= len(body):
-            return None
-        if body[i] == ord("}"):
-            return i + 1
-        if body[i] != ord(","):
-            return None
-        i = _skip_json_whitespace(body, i + 1)
-    return None
-
-
-def _skip_json_value(body: bytes, i: int, depth: int = 0) -> int | None:
-    i = _skip_json_whitespace(body, i)
-    if i >= len(body):
-        return None
-    b = body[i]
-    if b == ord('"'):
-        return _scan_json_string_end(body, i)
-    if b == ord("{"):
-        return _skip_json_object(body, i, depth)
-    if b == ord("["):
-        return _skip_json_array(body, i, depth)
-    if b == ord("-") or ord("0") <= b <= ord("9"):
-        return _skip_json_number(body, i)
-    for literal in (b"true", b"false", b"null"):
-        if body.startswith(literal, i):
-            return i + len(literal)
-    return None
-
-
-def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassification:
-    i = _skip_json_whitespace(body, 0)
-    if i >= len(body) or body[i] != ord("{"):
+    if result.status == "incomplete":
+        return _RESPONSES_EVENT_PENDING
+    if result.status != "found" or result.value is None:
         return _RESPONSES_EVENT_UNKNOWN
-    i = _skip_json_whitespace(body, i + 1)
-    if i < len(body) and body[i] == ord("}"):
-        return _RESPONSES_EVENT_UNKNOWN
+    return _classify_responses_event_name(result.value)
 
-    while i < len(body):
-        key_result = _read_json_string(body, i)
-        if key_result is None:
-            return _RESPONSES_EVENT_UNKNOWN
-        key, i = key_result
 
-        i = _skip_json_whitespace(body, i)
-        if i >= len(body) or body[i] != ord(":"):
-            return _RESPONSES_EVENT_UNKNOWN
-        i = _skip_json_whitespace(body, i + 1)
-
-        if key == "type":
-            type_result = _read_json_string(body, i)
-            if type_result is None:
-                return _RESPONSES_EVENT_UNKNOWN
-            event_type, _end = type_result
-            # Responses event JSON is expected to have one top-level type. Stop
-            # at the first conforming type so common delta frames stay cheap.
-            if event_type in _RESPONSES_TERMINAL_USAGE_EVENTS:
-                return _RESPONSES_EVENT_TERMINAL
-            return _RESPONSES_EVENT_NON_TERMINAL
-
-        i = _skip_json_value(body, i)
-        if i is None:
-            return _RESPONSES_EVENT_UNKNOWN
-        i = _skip_json_whitespace(body, i)
-        if i >= len(body):
-            return _RESPONSES_EVENT_UNKNOWN
-        if body[i] == ord("}"):
-            return _RESPONSES_EVENT_UNKNOWN
-        if body[i] != ord(","):
-            return _RESPONSES_EVENT_UNKNOWN
-        i = _skip_json_whitespace(body, i + 1)
-
+def _classify_responses_event_name(event_name: str) -> _ResponsesEventTypeClassification:
+    if event_name in _RESPONSES_TERMINAL_USAGE_EVENTS:
+        return _RESPONSES_EVENT_TERMINAL
+    if event_name in _RESPONSES_KNOWN_NON_USAGE_EVENTS:
+        return _RESPONSES_EVENT_KNOWN_NON_USAGE
     return _RESPONSES_EVENT_UNKNOWN
+
+
+def _is_known_terminal_usage_event(value: object) -> bool:
+    return isinstance(value, str) and value in _RESPONSES_TERMINAL_USAGE_EVENTS
+
+
+def _is_known_non_usage_event(value: object) -> bool:
+    return isinstance(value, str) and value in _RESPONSES_KNOWN_NON_USAGE_EVENTS
 
 
 def _is_usage_quantity(value: object) -> TypeGuard[int]:
@@ -317,6 +135,13 @@ def _has_positive_usage_quantity(values: dict) -> bool:
     for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
         value = values.get(category)
         if _is_usage_quantity(value) and value > 0:
+            return True
+    return False
+
+
+def _has_usage_quantity(values: dict) -> bool:
+    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
+        if _is_usage_quantity(values.get(category)):
             return True
     return False
 
@@ -414,15 +239,16 @@ def _store_sse_result_values(
     event_name: str | None,
 ) -> None:
     data_type = values.get(("type",))
-    if (
-        event_name not in _RESPONSES_TERMINAL_USAGE_EVENTS
-        and data_type not in _RESPONSES_TERMINAL_USAGE_EVENTS
-    ):
+    if _is_known_non_usage_event(event_name) or _is_known_non_usage_event(data_type):
         return
+    event_identity = event_name if event_name is not None else data_type
+    is_known_terminal_usage_event = _is_known_terminal_usage_event(event_identity)
 
     prefix = ("response",) if _has_response_wrapper_values(values) else ()
     source: dict = {}
     _store_response_values(values, source, prefix)
+    if not is_known_terminal_usage_event and not _has_usage_quantity(source):
+        return
     merge_openai_responses_usage_result(target, source)
 
 
@@ -455,7 +281,7 @@ class _OpenAIResponsesSseUsageHandler:
         self._on_parse_error = on_parse_error
 
     def should_capture_event(self, event_name: str | None) -> bool:
-        return event_name is None or event_name in _RESPONSES_TERMINAL_USAGE_EVENTS
+        return event_name is None or not _is_known_non_usage_event(event_name)
 
     def on_event_start(self, event_name: str | None) -> None:
         self._reset_event_state()
@@ -520,13 +346,13 @@ class _OpenAIResponsesSseUsageHandler:
             prefix.extend(chunk[:captured_len])
 
         event_type = _classify_responses_event_type(bytes(prefix))
-        if event_type == _RESPONSES_EVENT_NON_TERMINAL:
+        if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
             self._eventless_prefix = None
             self._discard_eventless_event = True
             return
 
         should_fallback = (
-            event_type == _RESPONSES_EVENT_TERMINAL
+            event_type in (_RESPONSES_EVENT_TERMINAL, _RESPONSES_EVENT_UNKNOWN)
             or captured_len < len(chunk)
             or len(prefix) >= _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
         )
@@ -643,7 +469,7 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
     ``event:`` / ``data:`` envelope, so reuse the SSE field map and event gate
     directly.
     """
-    if _classify_responses_event_type(body) == _RESPONSES_EVENT_NON_TERMINAL:
+    if _classify_responses_event_type(body) == _RESPONSES_EVENT_KNOWN_NON_USAGE:
         return None
 
     extractor = JsonSelectiveExtractor(scalar_fields=_RESPONSES_SSE_SCALAR_FIELDS)

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -53,10 +53,17 @@ _RESPONSES_KNOWN_NON_USAGE_EVENTS = frozenset(
     )
 )
 _SseUsageParseErrorCallback = Callable[[str, str], None]
-_ResponsesEventTypeClassification = Literal["terminal", "known_non_usage", "unknown", "pending"]
+_ResponsesEventTypeClassification = Literal[
+    "terminal",
+    "known_non_usage",
+    "unknown",
+    "unresolved",
+    "pending",
+]
 _RESPONSES_EVENT_TERMINAL: _ResponsesEventTypeClassification = "terminal"
 _RESPONSES_EVENT_KNOWN_NON_USAGE: _ResponsesEventTypeClassification = "known_non_usage"
 _RESPONSES_EVENT_UNKNOWN: _ResponsesEventTypeClassification = "unknown"
+_RESPONSES_EVENT_UNRESOLVED: _ResponsesEventTypeClassification = "unresolved"
 _RESPONSES_EVENT_PENDING: _ResponsesEventTypeClassification = "pending"
 _JSON_PREFILTER_MAX_DEPTH = 256
 _JSON_PREFILTER_MAX_STRING_BYTES = 1024
@@ -96,7 +103,9 @@ def _classify_responses_event_type(body: bytes) -> _ResponsesEventTypeClassifica
     if result.status == "incomplete":
         return _RESPONSES_EVENT_PENDING
     if result.status != "found" or result.value is None:
-        return _RESPONSES_EVENT_UNKNOWN
+        if result.field_seen:
+            return _RESPONSES_EVENT_UNKNOWN
+        return _RESPONSES_EVENT_UNRESOLVED
     return _classify_responses_event_name(result.value)
 
 
@@ -108,18 +117,18 @@ def _classify_responses_event_name(event_name: str) -> _ResponsesEventTypeClassi
     return _RESPONSES_EVENT_UNKNOWN
 
 
-def _resolved_event_type(
+def _resolved_data_event_type(
     event_type: _ResponsesEventTypeClassification,
-) -> _ResponsesEventTypeClassification:
-    if event_type == _RESPONSES_EVENT_PENDING:
-        return _RESPONSES_EVENT_UNKNOWN
+) -> _ResponsesEventTypeClassification | None:
+    if event_type in (_RESPONSES_EVENT_PENDING, _RESPONSES_EVENT_UNRESOLVED):
+        return None
     return event_type
 
 
-def _resolved_event_type_from_prefix(
+def _resolved_data_event_type_from_prefix(
     prefix: bytearray,
-) -> _ResponsesEventTypeClassification:
-    return _resolved_event_type(_classify_responses_event_type(bytes(prefix)))
+) -> _ResponsesEventTypeClassification | None:
+    return _resolved_data_event_type(_classify_responses_event_type(bytes(prefix)))
 
 
 def _is_known_terminal_usage_event(value: object) -> bool:
@@ -254,12 +263,17 @@ def _store_sse_result_values(
     data_event_type: _ResponsesEventTypeClassification | None = None,
 ) -> None:
     data_type = values.get(("type",))
-    if _is_known_non_usage_event(event_name) or data_event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
+    if (
+        _is_known_non_usage_event(event_name)
+        or data_event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE
+        or (data_event_type is None and _is_known_non_usage_event(data_type))
+    ):
         return
     event_identity = event_name if event_name is not None else data_type
     is_known_terminal_usage_event = (
         _is_known_terminal_usage_event(event_identity)
         or data_event_type == _RESPONSES_EVENT_TERMINAL
+        or (data_event_type is None and _is_known_terminal_usage_event(data_type))
     )
 
     prefix = ("response",) if _has_response_wrapper_values(values) else ()
@@ -308,8 +322,7 @@ class _OpenAIResponsesSseUsageHandler:
         if event_name is None:
             self._eventless_prefix = bytearray()
             return
-        if not _is_known_terminal_usage_event(event_name):
-            self._named_event_prefix = bytearray()
+        self._named_event_prefix = bytearray()
         self._start_full_extractor()
 
     def on_data(self, chunk: bytes) -> None:
@@ -327,12 +340,12 @@ class _OpenAIResponsesSseUsageHandler:
 
     def on_event_end(self, event_name: str | None) -> None:
         if self._eventless_prefix is not None:
-            self._data_event_type = _resolved_event_type_from_prefix(self._eventless_prefix)
+            self._data_event_type = _resolved_data_event_type_from_prefix(self._eventless_prefix)
             extractor = self._start_full_extractor()
             extractor.feed(bytes(self._eventless_prefix))
             self._eventless_prefix = None
         if self._named_event_prefix is not None and self._data_event_type is None:
-            self._data_event_type = _resolved_event_type_from_prefix(self._named_event_prefix)
+            self._data_event_type = _resolved_data_event_type_from_prefix(self._named_event_prefix)
         extractor = self._extractor
         data_event_type = self._data_event_type
         self._reset_event_state()
@@ -386,14 +399,15 @@ class _OpenAIResponsesSseUsageHandler:
             return
 
         should_fallback = (
-            event_type in (_RESPONSES_EVENT_TERMINAL, _RESPONSES_EVENT_UNKNOWN)
+            event_type
+            in (_RESPONSES_EVENT_TERMINAL, _RESPONSES_EVENT_UNKNOWN, _RESPONSES_EVENT_UNRESOLVED)
             or captured_len < len(chunk)
             or len(prefix) >= _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
         )
         if not should_fallback:
             return
 
-        self._data_event_type = _resolved_event_type(event_type)
+        self._data_event_type = _resolved_data_event_type(event_type)
         self._fallback_eventless_prefix_to_full_extractor()
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
@@ -416,7 +430,7 @@ class _OpenAIResponsesSseUsageHandler:
         ):
             return
 
-        self._data_event_type = _resolved_event_type(event_type)
+        self._data_event_type = _resolved_data_event_type(event_type)
         self._named_event_prefix = None
 
     def _fallback_eventless_prefix_to_full_extractor(self) -> None:
@@ -536,7 +550,12 @@ def extract_openai_responses_usage_from_event_json(body: bytes) -> dict | None:
         return None
 
     usage: dict = {}
-    _store_sse_result_values(result.values, usage, event_name=None, data_event_type=event_type)
+    _store_sse_result_values(
+        result.values,
+        usage,
+        event_name=None,
+        data_event_type=_resolved_data_event_type(event_type),
+    )
     if not any(category in usage for category in _OPENAI_RESPONSES_USAGE_CATEGORIES):
         return None
     return usage

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -59,6 +59,7 @@ def test_probe_reports_non_string_field_value():
 
     assert result.status == "non_string"
     assert result.value is None
+    assert result.field_seen
 
 
 def test_probe_reports_invalid_json_prefix():
@@ -66,6 +67,7 @@ def test_probe_reports_invalid_json_prefix():
 
     assert result.status == "invalid"
     assert result.value is None
+    assert not result.field_seen
 
 
 def test_probe_reports_invalid_utf8_in_skipped_string():
@@ -80,6 +82,7 @@ def test_probe_reports_bound_exceeded_for_oversized_value():
 
     assert result.status == "bound_exceeded"
     assert result.value is None
+    assert result.field_seen
 
 
 def test_probe_reports_bound_exceeded_for_oversized_skipped_value():
@@ -90,6 +93,7 @@ def test_probe_reports_bound_exceeded_for_oversized_skipped_value():
 
     assert result.status == "bound_exceeded"
     assert result.value is None
+    assert not result.field_seen
 
 
 def test_probe_reports_bound_exceeded_for_depth_limit():

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -1,0 +1,109 @@
+"""Tests for bounded JSON prefix probing helpers."""
+
+from usage.json_probe import probe_top_level_string_field
+
+
+def test_probe_finds_top_level_string_field_without_scanning_rest():
+    result = probe_top_level_string_field(
+        b'{"type":"response.completed","payload":' + b"x" * 100_000
+    )
+
+    assert result.status == "found"
+    assert result.value == "response.completed"
+
+
+def test_probe_ignores_nested_fields_with_same_name():
+    result = probe_top_level_string_field(
+        b'{"metadata":{"type":"nested","items":[{"type":"also_nested"}]},"type":"top_level"}'
+    )
+
+    assert result.status == "found"
+    assert result.value == "top_level"
+
+
+def test_probe_ignores_field_name_inside_string_payload():
+    result = probe_top_level_string_field(
+        b'{"text":"payload mentions \\"type\\":\\"response.completed\\"",'
+        b'"type":"response.output_text.delta"}'
+    )
+
+    assert result.status == "found"
+    assert result.value == "response.output_text.delta"
+
+
+def test_probe_uses_first_duplicate_top_level_field():
+    result = probe_top_level_string_field(
+        b'{"type":"response.output_text.delta","type":"response.completed"}'
+    )
+
+    assert result.status == "found"
+    assert result.value == "response.output_text.delta"
+
+
+def test_probe_reports_incomplete_prefix_before_field_value_completes():
+    result = probe_top_level_string_field(b'{"type":"response.comp')
+
+    assert result.status == "incomplete"
+    assert result.value is None
+
+
+def test_probe_reports_not_found_when_complete_object_has_no_field():
+    result = probe_top_level_string_field(b'{"metadata":{"type":"nested"}}')
+
+    assert result.status == "not_found"
+    assert result.value is None
+
+
+def test_probe_reports_non_string_field_value():
+    result = probe_top_level_string_field(b'{"type":123}')
+
+    assert result.status == "non_string"
+    assert result.value is None
+
+
+def test_probe_reports_invalid_json_prefix():
+    result = probe_top_level_string_field(b'{"type" "response.completed"}')
+
+    assert result.status == "invalid"
+    assert result.value is None
+
+
+def test_probe_reports_invalid_utf8_in_skipped_string():
+    result = probe_top_level_string_field(b'{"padding":"\x80","type":"response.completed"}')
+
+    assert result.status == "invalid"
+    assert result.value is None
+
+
+def test_probe_reports_bound_exceeded_for_oversized_value():
+    result = probe_top_level_string_field(b'{"type":"abcdef"}', max_string_bytes=4)
+
+    assert result.status == "bound_exceeded"
+    assert result.value is None
+
+
+def test_probe_reports_bound_exceeded_for_oversized_skipped_value():
+    result = probe_top_level_string_field(
+        b'{"padding":"' + b"x" * 12 + b'","type":"response.completed"}',
+        max_string_bytes=8,
+    )
+
+    assert result.status == "bound_exceeded"
+    assert result.value is None
+
+
+def test_probe_reports_bound_exceeded_for_depth_limit():
+    result = probe_top_level_string_field(
+        b'{"metadata":{"nested":true},"type":"response.completed"}',
+        max_depth=1,
+    )
+
+    assert result.status == "bound_exceeded"
+    assert result.value is None
+
+
+def test_probe_supports_custom_field_name():
+    result = probe_top_level_string_field(b'{"kind":"target","type":"ignored"}', "kind")
+
+    assert result.status == "found"
+    assert result.value == "target"

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -163,6 +163,45 @@ def test_returns_none_for_non_usage_event_type():
     assert extract_openai_responses_usage_from_event_json(body) is None
 
 
+def test_unknown_event_type_with_usage_extracts_usage():
+    body = json.dumps(
+        {
+            "type": "response.future_terminal",
+            "response": {
+                "id": "resp_future",
+                "model": "gpt-5.6",
+                "usage": {
+                    "input_tokens": 15,
+                    "output_tokens": 9,
+                    "input_tokens_details": {"cached_tokens": 4},
+                },
+            },
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "message_id": "resp_future",
+        "model": "gpt-5.6",
+        "tokens.input": 11,
+        "tokens.output": 9,
+        "tokens.cache_read": 4,
+    }
+
+
+def test_known_non_usage_event_with_usage_fields_is_ignored():
+    body = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "response": {
+                "model": "gpt-5.6",
+                "usage": {"input_tokens": 15, "output_tokens": 9},
+            },
+        }
+    ).encode()
+
+    assert extract_openai_responses_usage_from_event_json(body) is None
+
+
 def test_non_terminal_event_skips_full_usage_extractor(monkeypatch):
     def fail_extractor(**_kwargs):
         raise AssertionError("full extractor should not run for non-terminal events")

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -266,6 +266,18 @@ def test_duplicate_top_level_unknown_type_keeps_first_type_boundary():
     }
 
 
+def test_late_known_non_usage_event_type_is_ignored():
+    assert (
+        extract_openai_responses_usage_from_event_json(
+            b'{"padding":"'
+            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b'","type":"response.output_text.delta",'
+            + b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
+        )
+        is None
+    )
+
+
 def test_terminal_event_type_after_skipped_fields_still_extracts_usage():
     body = json.dumps(
         {

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -254,6 +254,18 @@ def test_duplicate_top_level_type_uses_first_type_boundary(monkeypatch):
     )
 
 
+def test_duplicate_top_level_unknown_type_keeps_first_type_boundary():
+    assert extract_openai_responses_usage_from_event_json(
+        b'{"type":"response.future_terminal",'
+        b'"type":"response.output_text.delta",'
+        b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
+    ) == {
+        "model": "gpt-5.6",
+        "tokens.input": 9,
+        "tokens.output": 4,
+    }
+
+
 def test_terminal_event_type_after_skipped_fields_still_extracts_usage():
     body = json.dumps(
         {

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -363,6 +363,18 @@ def test_oversized_type_falls_back_to_full_extractor(monkeypatch):
     }
 
 
+def test_oversized_unknown_type_with_usage_extracts_usage():
+    assert extract_openai_responses_usage_from_event_json(
+        b'{"type":"'
+        + b"x" * 2048
+        + b'","response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
+    ) == {
+        "model": "gpt-5.6",
+        "tokens.input": 9,
+        "tokens.output": 4,
+    }
+
+
 def test_returns_none_for_malformed_json():
     assert extract_openai_responses_usage_from_event_json(b'{"type":"response.completed"') is None
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -161,6 +161,21 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
+    def test_named_terminal_event_with_oversized_type_extracts_usage(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.completed\n"
+            b'data: {"type":"'
+            + b"x" * 2048
+            + b'","response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.6",
+            "tokens.input": 9,
+            "tokens.output": 4,
+        }
+
     def test_eventless_duplicate_unknown_type_keeps_first_type_boundary(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -127,6 +127,35 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
+    def test_eventless_duplicate_unknown_type_keeps_first_type_boundary(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"type":"response.future_terminal",'
+            b'"type":"response.output_text.delta",'
+            b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.6",
+            "tokens.input": 9,
+            "tokens.output": 4,
+        }
+
+    def test_named_duplicate_unknown_type_keeps_first_type_boundary(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.future_terminal\n"
+            b'data: {"type":"response.future_terminal",'
+            b'"type":"response.output_text.delta",'
+            b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.6",
+            "tokens.input": 9,
+            "tokens.output": 4,
+        }
+
     def test_named_unknown_malformed_event_does_not_report_parse_error(self):
         parse_errors: list[tuple[str, str]] = []
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -90,6 +90,70 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.4-mini"
         assert usage["tokens.input"] == 3
 
+    def test_eventless_unknown_event_type_with_usage_extracts_usage(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"type":"response.future_terminal","response":{"id":"resp_future",'
+            b'"model":"gpt-5.6","usage":{"input_tokens":11,"output_tokens":7}}}\n\n'
+        )
+
+        assert usage == {
+            "message_id": "resp_future",
+            "model": "gpt-5.6",
+            "tokens.input": 11,
+            "tokens.output": 7,
+        }
+
+    def test_named_unknown_event_type_with_usage_extracts_usage(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.future_terminal\n"
+            b'data: {"type":"response.future_terminal","response":{"model":"gpt-5.6",'
+            b'"usage":{"output_tokens":12}}}\n\n'
+        )
+
+        assert usage == {
+            "model": "gpt-5.6",
+            "tokens.output": 12,
+        }
+
+    def test_named_unknown_event_with_known_non_usage_type_is_ignored(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.future_terminal\n"
+            b'data: {"type":"response.output_text.delta","response":{"model":"gpt-5.6",'
+            b'"usage":{"output_tokens":12}}}\n\n'
+        )
+
+        assert usage == {}
+
+    def test_named_unknown_malformed_event_does_not_report_parse_error(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
+        parse(
+            b"event: response.future_terminal\n"
+            b'data: {"type":"response.future_terminal","response":{"model":"gpt'
+        )
+        parse.finish()
+
+        assert usage == {}
+        assert parse_errors == []
+
+    def test_known_non_usage_eventless_usage_fields_are_ignored(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"type":"response.output_text.delta","response":{"model":"gpt-5.6",'
+            b'"usage":{"input_tokens":11,"output_tokens":7}}}\n\n'
+        )
+
+        assert usage == {}
+
     def test_eventless_non_terminal_skips_large_delta_before_full_extraction(self, monkeypatch):
         real_extractor = openai_responses.JsonSelectiveExtractor
         fed_chunks: list[bytes] = []

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -127,6 +127,16 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
+    def test_named_terminal_event_with_known_non_usage_type_is_ignored(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.completed\n"
+            b'data: {"type":"response.output_text.delta","response":{"model":"gpt-5.6",'
+            b'"usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+        )
+
+        assert usage == {}
+
     def test_eventless_duplicate_unknown_type_keeps_first_type_boundary(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(
@@ -140,6 +150,31 @@ class TestOpenAIResponsesSseUsageExtractor:
             "tokens.input": 9,
             "tokens.output": 4,
         }
+
+    def test_eventless_late_known_non_usage_type_is_ignored(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b'data: {"padding":"'
+            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b'","type":"response.output_text.delta",'
+            + b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
+            + b"\n\n"
+        )
+
+        assert usage == {}
+
+    def test_named_late_known_non_usage_type_is_ignored(self):
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(
+            b"event: response.completed\n"
+            b'data: {"padding":"'
+            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b'","type":"response.output_text.delta",'
+            + b'"response":{"model":"gpt-5.6","usage":{"input_tokens":9,"output_tokens":4}}}'
+            + b"\n\n"
+        )
+
+        assert usage == {}
 
     def test_named_duplicate_unknown_type_keeps_first_type_boundary(self):
         parse, usage = create_openai_responses_sse_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -127,6 +127,30 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
+    def test_named_unknown_event_with_known_non_usage_type_stops_full_extraction(self, monkeypatch):
+        real_extractor = openai_responses.JsonSelectiveExtractor
+        fed_chunks: list[bytes] = []
+
+        class TrackingExtractor:
+            def __init__(self, **kwargs):
+                self._inner = real_extractor(**kwargs)
+
+            def feed(self, chunk: bytes) -> None:
+                fed_chunks.append(chunk)
+                self._inner.feed(chunk)
+
+            def finish(self):
+                return self._inner.finish()
+
+        monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", TrackingExtractor)
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        large_delta = b'{"type":"response.output_text.delta","delta":"' + b"x" * 100_000 + b'"}'
+        parse(b"event: response.future_delta\n")
+        parse(b"data: " + large_delta + b"\n\n")
+
+        assert usage == {}
+        assert large_delta not in b"".join(fed_chunks)
+
     def test_named_terminal_event_with_known_non_usage_type_is_ignored(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(


### PR DESCRIPTION
## Summary
- add a bounded provider-neutral top-level JSON string probe for Responses event prefiltering
- replace the local Responses JSON scanner with probe-backed event policy
- treat unknown Responses event types conservatively so complete usage payloads are not dropped

Fixes #18170

## Tests
- cd crates/runner/mitm-addon && ruff format --check src tests
- cd crates/runner/mitm-addon && ruff check src tests
- cd crates/runner/mitm-addon && basedpyright src tests
- cd crates/runner/mitm-addon && pytest tests/
