### PR TITLE
fix: equalize work-fold header spacing in zero chat

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3021,7 +3021,7 @@ function CompletedWorkFoldRow({
 }) {
   const label = completedWorkLabel(groups);
   return (
-    <div data-chat-completed-work-fold className="-mx-2 @[900px]:-mb-2.5">
+    <div data-chat-completed-work-fold className="-mx-2 @[900px]:-mb-[15px]">
       <button
         type="button"
         aria-expanded={expanded}


### PR DESCRIPTION
## Problem

In the Zero web chat, the vertical gap **above** an assistant message body (between the "Worked for NNs" work-fold header and the text) was visibly larger than the gap **below** it (between the text and the action toolbar icons). The two should be consistent.

## Root cause

The box-level spacing is already symmetric (~12px both sides). The visible asymmetry comes from the "Worked for NNs" row being a `min-h-9` button with vertically-centered text, which leaves extra empty space below the header text and pushes the perceived gap wider than the compact icon row below the body.

## Fix

Tighten the work-fold row's negative bottom margin from `@[900px]:-mb-2.5` (-10px) to `@[900px]:-mb-[15px]` to compensate for the button height, so the header to body gap matches the body to toolbar gap. The change only affects messages that render the work-fold header.

Verified by reproducing the exact DOM/spacing in an isolated page: both gaps measure equal after the change. Please eyeball on the PR preview to confirm at production fonts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)