### PR TITLE
fix(desktop): guide automation permission failures

### DIFF
--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -174,6 +174,7 @@ export interface ComputerUseCommandFailure {
     readonly code:
       | "permission_denied"
       | "accessibility_unavailable"
+      | "automation_permission_denied"
       | "element_action_unsupported"
       | "element_not_editable"
       | "window_unavailable"

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./computer-use-host";
 import type {
   ComputerUseCommand,
+  ComputerUseCommandFailure,
   ComputerUseCommandExecutionResult,
 } from "./computer-use-accessibility";
 import type { ComputerUsePermissionState } from "./computer-use-types";
@@ -57,6 +58,10 @@ function createRuntime(
       command: ComputerUseCommand,
       permissions: ComputerUsePermissionState,
     ) => Promise<ComputerUseCommandExecutionResult>;
+    readonly onCommandFailure?: (args: {
+      readonly command: ComputerUseCommand;
+      readonly failure: ComputerUseCommandFailure;
+    }) => void;
   } = {},
 ) {
   const sessionFetch =
@@ -88,6 +93,9 @@ function createRuntime(
       }
       return { status: "succeeded", result: {} };
     },
+    ...(options.onCommandFailure
+      ? { onCommandFailure: options.onCommandFailure }
+      : {}),
   });
   return { runtime, sessionFetch, hostFetch };
 }
@@ -497,6 +505,73 @@ describe("ComputerUseHostRuntime", () => {
     expect(entries).toHaveLength(20);
     expect(entries[0]?.commandId).toBe("cmd-25");
     expect(entries.at(-1)?.commandId).toBe("cmd-6");
+
+    await runtime.stop();
+  });
+
+  it("notifies command failures without moving the runtime offline", async () => {
+    vi.useFakeTimers();
+    const command: ComputerUseCommand = {
+      id: "cmd-1",
+      kind: "element.set_value",
+      payload: { app: "com.google.Chrome", value: "https://example.com" },
+    };
+    const failure: ComputerUseCommandFailure = {
+      status: "failed",
+      error: {
+        code: "automation_permission_denied",
+        message:
+          "Not authorized to send Apple events to Google Chrome. (-1743)",
+      },
+    };
+    let nextCalls = 0;
+    const hostFetch = vi.fn<ComputerUseHostFetch>(async (url) => {
+      if (url.endsWith("/api/zero/computer-use/heartbeat")) {
+        return jsonResponse({ ok: true, hostId: "host-1" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/next")) {
+        nextCalls++;
+        return nextCalls === 1
+          ? jsonResponse({ status: "command", command })
+          : jsonResponse({ status: "idle" });
+      }
+      if (url.endsWith("/api/zero/computer-use/host/commands/cmd-1/complete")) {
+        return jsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected host request: ${url}`);
+    });
+    const executeCommand = vi.fn<
+      (
+        command: ComputerUseCommand,
+        permissions: ComputerUsePermissionState,
+      ) => Promise<ComputerUseCommandExecutionResult>
+    >(async () => failure);
+    const onCommandFailure =
+      vi.fn<
+        (args: {
+          readonly command: ComputerUseCommand;
+          readonly failure: ComputerUseCommandFailure;
+        }) => void
+      >();
+    const { runtime } = createRuntime({
+      hostFetch,
+      executeCommand,
+      onCommandFailure,
+    });
+
+    await runtime.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(onCommandFailure).toHaveBeenCalledWith({ command, failure });
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      lastError: null,
+    });
+    expect(runtime.getState().localCommandLog[0]).toMatchObject({
+      commandId: "cmd-1",
+      status: "failed",
+      error: failure.error,
+    });
 
     await runtime.stop();
   });

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import type {
   ComputerUseCommand,
+  ComputerUseCommandFailure,
   ComputerUseCommandExecutionResult,
 } from "./computer-use-accessibility";
 import { SUPPORTED_COMPUTER_USE_CAPABILITIES } from "./computer-use-accessibility";
@@ -55,6 +56,10 @@ interface ComputerUseHostRuntimeOptions {
     command: ComputerUseCommand,
     permissions: ComputerUsePermissionState,
   ) => Promise<ComputerUseCommandExecutionResult>;
+  readonly onCommandFailure?: (args: {
+    readonly command: ComputerUseCommand;
+    readonly failure: ComputerUseCommandFailure;
+  }) => void;
   readonly onChange?: () => void;
   readonly setTimeout?: typeof setTimeout;
   readonly clearTimeout?: typeof clearTimeout;
@@ -227,6 +232,9 @@ export class ComputerUseHostRuntime {
   private readonly hostFetchRequest: ComputerUseHostFetch;
   private readonly getPermissions: ComputerUseHostRuntimeOptions["getPermissions"];
   private readonly executeCommand: ComputerUseHostRuntimeOptions["executeCommand"];
+  private readonly onCommandFailure: NonNullable<
+    ComputerUseHostRuntimeOptions["onCommandFailure"]
+  >;
   private readonly onChange: () => void;
   private readonly scheduleTimeout: typeof setTimeout;
   private readonly clearScheduledTimeout: typeof clearTimeout;
@@ -257,6 +265,7 @@ export class ComputerUseHostRuntime {
     this.hostFetchRequest = options.hostFetch;
     this.getPermissions = options.getPermissions;
     this.executeCommand = options.executeCommand;
+    this.onCommandFailure = options.onCommandFailure ?? (() => {});
     this.onChange = options.onChange ?? (() => {});
     this.scheduleTimeout = options.setTimeout ?? setTimeout;
     this.clearScheduledTimeout = options.clearTimeout ?? clearTimeout;
@@ -848,6 +857,9 @@ export class ComputerUseHostRuntime {
       completedAt: new Date(completedAtMs).toISOString(),
       durationMs: completedAtMs - startedAtMs,
     });
+    if (completed.status === "failed") {
+      this.onCommandFailure({ command: body.command, failure: completed });
+    }
     if (!this.running || !this.hostToken) {
       return;
     }

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -549,6 +549,10 @@ describe("computer use native backend", () => {
   it.each([
     ["app_not_found", "Unable to open Things: Unable to find application"],
     ["app_open_failed", "Unable to open Things"],
+    [
+      "automation_permission_denied",
+      "Not authorized to send Apple events to Google Chrome. (-1743)",
+    ],
     ["element_action_unsupported", "Element does not support a primary click"],
     [
       "element_not_editable",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -185,6 +185,7 @@ function responseErrorCode(value: unknown): ComputerUseNativeErrorCode {
   if (
     value === "permission_denied" ||
     value === "accessibility_unavailable" ||
+    value === "automation_permission_denied" ||
     value === "element_action_unsupported" ||
     value === "element_not_editable" ||
     value === "window_unavailable" ||

--- a/turbo/apps/desktop/src/desktop-automation-permission.test.ts
+++ b/turbo/apps/desktop/src/desktop-automation-permission.test.ts
@@ -1,0 +1,124 @@
+import type { MessageBoxOptions } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ComputerUseCommand,
+  ComputerUseCommandFailure,
+} from "./computer-use-accessibility";
+import {
+  MAC_AUTOMATION_SETTINGS_URL,
+  buildAutomationPermissionDialogOptions,
+  createAutomationPermissionDeniedPrompt,
+} from "./desktop-automation-permission";
+
+const automationFailure: ComputerUseCommandFailure = {
+  status: "failed",
+  error: {
+    code: "automation_permission_denied",
+    message: "Not authorized to send Apple events to Google Chrome. (-1743)",
+  },
+};
+
+function command(app: string): ComputerUseCommand {
+  return {
+    id: "cmd-1",
+    kind: "element.set_value",
+    payload: {
+      app,
+      value: "https://example.com",
+    },
+  };
+}
+
+describe("desktop automation permission prompt", () => {
+  it("builds a dialog that opens the macOS Automation settings pane", () => {
+    const options = buildAutomationPermissionDialogOptions(
+      "Zero Computer Use",
+      "Google Chrome",
+    );
+
+    expect(options).toMatchObject({
+      type: "warning",
+      buttons: ["Open Automation Settings", "Not Now"],
+      defaultId: 0,
+      cancelId: 1,
+      title: "Browser Automation Permission Required",
+      message: "Allow Zero Computer Use to control Google Chrome",
+    });
+    expect(options.detail).toContain(
+      "System Settings > Privacy & Security > Automation",
+    );
+    expect(MAC_AUTOMATION_SETTINGS_URL).toBe(
+      "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation",
+    );
+  });
+
+  it("opens Automation settings when the user accepts the prompt", async () => {
+    const showDialog = vi.fn<(options: MessageBoxOptions) => Promise<number>>(
+      async () => 0,
+    );
+    const openAutomationSettings = vi.fn<() => void>();
+    const prompt = createAutomationPermissionDeniedPrompt({
+      sourceLabel: "Zero Computer Use",
+      showDialog,
+      openAutomationSettings,
+    });
+
+    prompt({
+      command: command("com.google.Chrome"),
+      failure: automationFailure,
+    });
+    await vi.waitFor(() => {
+      expect(openAutomationSettings).toHaveBeenCalledOnce();
+    });
+
+    expect(showDialog).toHaveBeenCalledOnce();
+    expect(showDialog.mock.calls[0]?.[0].message).toBe(
+      "Allow Zero Computer Use to control Google Chrome",
+    );
+  });
+
+  it("does not prompt more than once per target app", async () => {
+    const showDialog = vi.fn<(options: MessageBoxOptions) => Promise<number>>(
+      async () => 1,
+    );
+    const openAutomationSettings = vi.fn<() => void>();
+    const prompt = createAutomationPermissionDeniedPrompt({
+      sourceLabel: "Zero Computer Use",
+      showDialog,
+      openAutomationSettings,
+    });
+    const chromeCommand = command("com.google.Chrome");
+
+    prompt({ command: chromeCommand, failure: automationFailure });
+    prompt({ command: chromeCommand, failure: automationFailure });
+
+    await vi.waitFor(() => {
+      expect(showDialog).toHaveBeenCalledOnce();
+    });
+    expect(openAutomationSettings).not.toHaveBeenCalled();
+  });
+
+  it("ignores unrelated command failures", () => {
+    const showDialog = vi.fn<(options: MessageBoxOptions) => Promise<number>>(
+      async () => 0,
+    );
+    const openAutomationSettings = vi.fn<() => void>();
+    const prompt = createAutomationPermissionDeniedPrompt({
+      sourceLabel: "Zero Computer Use",
+      showDialog,
+      openAutomationSettings,
+    });
+    const failure: ComputerUseCommandFailure = {
+      status: "failed",
+      error: {
+        code: "screen_recording_unavailable",
+        message: "macOS Screen Recording permission is required",
+      },
+    };
+
+    prompt({ command: command("com.google.Chrome"), failure });
+
+    expect(showDialog).not.toHaveBeenCalled();
+    expect(openAutomationSettings).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-automation-permission.ts
+++ b/turbo/apps/desktop/src/desktop-automation-permission.ts
@@ -19,7 +19,7 @@ interface AutomationPermissionPromptOptions {
   readonly onError?: (error: unknown) => void;
 }
 
-export interface AutomationPermissionDeniedNotification {
+interface AutomationPermissionDeniedNotification {
   readonly command: ComputerUseCommand;
   readonly failure: ComputerUseCommandFailure;
 }

--- a/turbo/apps/desktop/src/desktop-automation-permission.ts
+++ b/turbo/apps/desktop/src/desktop-automation-permission.ts
@@ -1,0 +1,103 @@
+import type { MessageBoxOptions } from "electron";
+import type {
+  ComputerUseCommand,
+  ComputerUseCommandFailure,
+} from "./computer-use-accessibility";
+
+export const MAC_AUTOMATION_SETTINGS_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation";
+
+interface AutomationPermissionTarget {
+  readonly key: string;
+  readonly label: string;
+}
+
+interface AutomationPermissionPromptOptions {
+  readonly sourceLabel: string;
+  readonly showDialog: (options: MessageBoxOptions) => Promise<number>;
+  readonly openAutomationSettings: () => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+export interface AutomationPermissionDeniedNotification {
+  readonly command: ComputerUseCommand;
+  readonly failure: ComputerUseCommandFailure;
+}
+
+const AUTOMATION_TARGET_LABELS = Object.freeze<Record<string, string>>({
+  "com.apple.safari": "Safari",
+  "com.google.chrome": "Google Chrome",
+});
+
+function commandApp(command: ComputerUseCommand): string | null {
+  const value = command.payload.app;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function automationPermissionTarget(
+  command: ComputerUseCommand,
+): AutomationPermissionTarget {
+  const app = commandApp(command);
+  if (!app) {
+    return { key: "target-app", label: "the target app" };
+  }
+
+  const key = app.toLowerCase();
+  return {
+    key,
+    label: AUTOMATION_TARGET_LABELS[key] ?? app,
+  };
+}
+
+export function buildAutomationPermissionDialogOptions(
+  sourceLabel: string,
+  targetLabel: string,
+): MessageBoxOptions {
+  return {
+    type: "warning",
+    buttons: ["Open Automation Settings", "Not Now"],
+    defaultId: 0,
+    cancelId: 1,
+    title: "Browser Automation Permission Required",
+    message: `Allow ${sourceLabel} to control ${targetLabel}`,
+    detail:
+      "Open System Settings > Privacy & Security > Automation and allow " +
+      `${sourceLabel} to control ${targetLabel}.`,
+  };
+}
+
+export function createAutomationPermissionDeniedPrompt(
+  options: AutomationPermissionPromptOptions,
+): (notification: AutomationPermissionDeniedNotification) => void {
+  const promptedTargets = new Set<string>();
+
+  return ({ command, failure }) => {
+    if (failure.error.code !== "automation_permission_denied") {
+      return;
+    }
+
+    const target = automationPermissionTarget(command);
+    if (promptedTargets.has(target.key)) {
+      return;
+    }
+    promptedTargets.add(target.key);
+
+    void options
+      .showDialog(
+        buildAutomationPermissionDialogOptions(
+          options.sourceLabel,
+          target.label,
+        ),
+      )
+      .then((response) => {
+        if (response === 0) {
+          options.openAutomationSettings();
+        }
+      })
+      .catch((error: unknown) => {
+        options.onError?.(error);
+      });
+  };
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -18,6 +18,10 @@ import {
   executeComputerUseCommand,
 } from "./computer-use-accessibility";
 import {
+  MAC_AUTOMATION_SETTINGS_URL,
+  createAutomationPermissionDeniedPrompt,
+} from "./desktop-automation-permission";
+import {
   installComputerUseIpc,
   notifyDesktopComputerUseChanged,
 } from "./computer-use-electron";
@@ -144,6 +148,22 @@ const computerUseNativeBackend = createComputerUseNativeBackend({
   onRuntimeError: captureDesktopNativeHelperError,
 });
 setComputerUsePermissionNativeBackend(computerUseNativeBackend);
+const automationPermissionPrompt = createAutomationPermissionDeniedPrompt({
+  sourceLabel: config.identity.displayName,
+  showDialog: async (options) => {
+    const window = currentDialogWindow();
+    const result = window
+      ? await dialog.showMessageBox(window, options)
+      : await dialog.showMessageBox(options);
+    return result.response;
+  },
+  openAutomationSettings: () => {
+    openExternal(MAC_AUTOMATION_SETTINGS_URL);
+  },
+  onError: (error) => {
+    console.error("Automation permission prompt failed", error);
+  },
+});
 const computerUseAutoStart = new DesktopComputerUseAutoStartSupervisor({
   getState: getComputerUseBridgeState,
   start: async () => {
@@ -485,6 +505,7 @@ async function startComputerUseRuntime(
           snapshotStore: computerUseSnapshotStore,
         });
       },
+      onCommandFailure: automationPermissionPrompt,
       onChange: notifyComputerUseChanged,
     });
   }
@@ -724,14 +745,17 @@ function applyApplicationMenu(): void {
   Menu.setApplicationMenu(menu);
 }
 
+function currentDialogWindow(): BrowserWindow | undefined {
+  return mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
+    ? mainWindow
+    : undefined;
+}
+
 async function confirmDesktopQuit(): Promise<boolean> {
   const options = buildDesktopQuitConfirmationOptions(
     config.identity.displayName,
   );
-  const window =
-    mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
-      ? mainWindow
-      : undefined;
+  const window = currentDialogWindow();
   const result = window
     ? await dialog.showMessageBox(window, options)
     : await dialog.showMessageBox(options);


### PR DESCRIPTION
## Summary
- preserve native `automation_permission_denied` command failures instead of normalizing them to accessibility errors
- show a one-time macOS Automation permission prompt for the target app after a denied browser automation command
- open System Settings > Privacy & Security > Automation from the prompt

## Tests
- `pnpm format`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop exec vitest run src/desktop-automation-permission.test.ts src/computer-use-host.test.ts src/computer-use-native.test.ts`
- `pnpm -F @vm0/desktop build`

Addresses #18128