### PR TITLE
fix: use standard floating ui for usage details

### DIFF
--- a/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
+++ b/turbo/apps/platform/src/views/usage-page/__tests__/usage-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { zeroUsageInsightContract } from "@vm0/core";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -158,24 +158,31 @@ describe("/usage page", () => {
       expect(screen.getByText("Roadmap Review")).toBeInTheDocument();
     });
 
-    const chart = creditsTotals().querySelector("svg");
-    if (!(chart instanceof SVGSVGElement)) {
-      throw new Error("usage chart not found");
+    const usageDetailTriggers = queryAllByRoleFast(
+      "button",
+      creditsTotals(),
+    ).filter((button) => {
+      return button
+        .getAttribute("aria-label")
+        ?.startsWith("Show usage details for ");
+    });
+    const latestUsageDetailTrigger =
+      usageDetailTriggers[usageDetailTriggers.length - 1];
+    if (!latestUsageDetailTrigger) {
+      throw new Error("latest usage detail trigger not found");
     }
-    fireEvent.mouseMove(chart, { clientX: 300, clientY: 80 });
+    click(latestUsageDetailTrigger);
 
     await waitFor(() => {
-      expect(within(creditsTotals()).getByText("Chat:")).toBeInTheDocument();
-      expect(within(creditsTotals()).getByText("Slack:")).toBeInTheDocument();
-      expect(within(creditsTotals()).getByText("Email:")).toBeInTheDocument();
+      expect(screen.getByText("Chat:")).toBeInTheDocument();
+      expect(screen.getByText("Slack:")).toBeInTheDocument();
+      expect(screen.getByText("Email:")).toBeInTheDocument();
     });
 
-    fireEvent.mouseLeave(chart);
+    click(latestUsageDetailTrigger);
 
     await waitFor(() => {
-      expect(
-        within(creditsTotals()).queryByText("Chat:"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Chat:")).not.toBeInTheDocument();
     });
 
     click(tabByText("Agent"));

--- a/turbo/apps/platform/src/views/usage-page/components/usage-insight-bar-chart.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/usage-insight-bar-chart.tsx
@@ -3,7 +3,14 @@ import type {
   UsageInsightBucket,
   UsageInsightResponse,
 } from "@vm0/api-contracts/contracts/zero-usage-insight";
-import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@vm0/ui";
 import {
   chartTooltip$,
   chartWidth$,
@@ -102,6 +109,20 @@ function formatBucketLabel(ts: string, range: string): string {
   });
 }
 
+function createChartXScale(
+  bucketCount: number,
+  width: number,
+): (index: number) => number {
+  const drawW = width - CHART_PADDING.left - CHART_PADDING.right;
+  const spacing = bucketCount > 1 ? drawW / (bucketCount - 1) : 0;
+  return (index: number) => {
+    if (bucketCount <= 1) {
+      return CHART_PADDING.left + drawW / 2;
+    }
+    return CHART_PADDING.left + index * spacing;
+  };
+}
+
 function niceStep(range: number, targetTicks: number): number {
   const rough = range / targetTicks;
   const pow = Math.pow(10, Math.floor(Math.log10(rough)));
@@ -193,24 +214,13 @@ function useChartResizeRef(setWidth: (w: number) => void) {
 
 // --- Tooltip ---
 
-const TOOLTIP_ESTIMATED_WIDTH = 200;
-const TOOLTIP_ESTIMATED_HEIGHT = 90;
-
-function ChartTooltip({
+function ChartTooltipContent({
   data,
-  containerWidth,
   range,
 }: {
   data: ChartTooltipData;
-  containerWidth: number;
   range: string;
 }) {
-  const flipLeft = data.x + 12 + TOOLTIP_ESTIMATED_WIDTH > containerWidth;
-  const flipTop = data.y < TOOLTIP_ESTIMATED_HEIGHT;
-  const left = flipLeft ? data.x - 12 : data.x + 12;
-  const top = flipTop ? data.y + 12 : data.y - 8;
-  const translateX = flipLeft ? "-100%" : "0";
-  const translateY = flipTop ? "0" : "-100%";
   // Lines are drawn per-category from y=0 (not stacked), so a synthetic Total
   // wouldn't correspond to anything visible. List per-category values that
   // match the dots on each line.
@@ -219,13 +229,15 @@ function ChartTooltip({
   });
 
   return (
-    <div
-      className="pointer-events-none absolute z-10 rounded-md border border-border bg-popover px-3 py-2 text-xs shadow-md"
-      style={{
-        left,
-        top,
-        transform: `translate(${translateX}, ${translateY})`,
+    <PopoverContent
+      side="top"
+      align="center"
+      sideOffset={8}
+      collisionPadding={12}
+      onOpenAutoFocus={(event) => {
+        event.preventDefault();
       }}
+      className="w-auto max-w-[min(16rem,calc(100vw-2rem))] px-3 py-2 text-xs"
     >
       <div className="font-medium text-foreground mb-1">
         {formatBucketLabel(data.ts, range)}
@@ -250,6 +262,104 @@ function ChartTooltip({
           );
         })
       )}
+    </PopoverContent>
+  );
+}
+
+function buildChartTooltipData({
+  bucket,
+  index,
+  stackOrder,
+  xScale,
+}: {
+  bucket: UsageInsightBucket;
+  index: number;
+  stackOrder: readonly string[];
+  xScale: (index: number) => number;
+}): ChartTooltipData {
+  return {
+    x: xScale(index),
+    y: CHART_PADDING.top,
+    ts: bucket.ts,
+    values: stackOrder.map((key, colorIndex) => {
+      return {
+        label: key,
+        value: valueAt(bucket, key),
+        color: colorFor(colorIndex),
+      };
+    }),
+  };
+}
+
+function ChartTooltipHitAreas({
+  buckets,
+  range,
+  stackOrder,
+  tooltip,
+  width,
+  setTooltip,
+}: {
+  buckets: UsageInsightBucket[];
+  range: string;
+  stackOrder: readonly string[];
+  tooltip: ChartTooltipData | null;
+  width: number;
+  setTooltip: (data: ChartTooltipData | null) => void;
+}) {
+  const xScale = createChartXScale(buckets.length, width);
+  return (
+    <div
+      className="absolute left-0 top-0 w-full"
+      style={{ height: CHART_HEIGHT }}
+    >
+      {buckets.map((bucket, index) => {
+        const data = buildChartTooltipData({
+          bucket,
+          index,
+          stackOrder,
+          xScale,
+        });
+        const previousMidpoint =
+          index === 0 ? 0 : (xScale(index - 1) + data.x) / 2;
+        const nextMidpoint =
+          index === buckets.length - 1
+            ? width
+            : (data.x + xScale(index + 1)) / 2;
+        const open = tooltip?.ts === bucket.ts;
+
+        return (
+          <Popover
+            key={bucket.ts}
+            open={open}
+            onOpenChange={(nextOpen) => {
+              if (nextOpen) {
+                setTooltip(data);
+              } else {
+                setTooltip(null);
+              }
+            }}
+          >
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                aria-label={`Show usage details for ${formatBucketLabel(bucket.ts, range)}`}
+                className="absolute top-0 h-full cursor-crosshair rounded-sm bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-[-2px]"
+                style={{
+                  left: previousMidpoint,
+                  width: Math.max(1, nextMidpoint - previousMidpoint),
+                }}
+                onMouseEnter={() => {
+                  setTooltip(data);
+                }}
+                onMouseLeave={() => {
+                  setTooltip(null);
+                }}
+              />
+            </PopoverTrigger>
+            <ChartTooltipContent data={data} range={range} />
+          </Popover>
+        );
+      })}
     </div>
   );
 }
@@ -284,14 +394,9 @@ function buildScales(
   const yMax = yTicks[yTicks.length - 1] ?? maxValue;
   const drawW = width - CHART_PADDING.left - CHART_PADDING.right;
   const drawH = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom;
-  const spacing = buckets.length > 1 ? drawW / (buckets.length - 1) : 0;
+  const xScale = createChartXScale(buckets.length, width);
   return {
-    xScale: (i: number) => {
-      if (buckets.length <= 1) {
-        return CHART_PADDING.left + drawW / 2;
-      }
-      return CHART_PADDING.left + i * spacing;
-    },
+    xScale,
     yScale: (v: number) => {
       return CHART_PADDING.top + drawH - (v / yMax) * drawH;
     },
@@ -456,8 +561,6 @@ function ChartSvg({
   range,
   hoveredKey,
   tooltip,
-  onMouseMove,
-  onMouseLeave,
 }: {
   buckets: UsageInsightBucket[];
   stackOrder: readonly string[];
@@ -465,18 +568,10 @@ function ChartSvg({
   range: string;
   hoveredKey: string | null;
   tooltip: ChartTooltipData | null;
-  onMouseMove: (e: React.MouseEvent<SVGSVGElement>) => void;
-  onMouseLeave: () => void;
 }) {
   const scales = buildScales(buckets, stackOrder, width);
   return (
-    <svg
-      width={width}
-      height={CHART_HEIGHT}
-      className="select-none"
-      onMouseMove={onMouseMove}
-      onMouseLeave={onMouseLeave}
-    >
+    <svg width={width} height={CHART_HEIGHT} className="select-none">
       <ChartGrid
         buckets={buckets}
         width={width}
@@ -532,51 +627,6 @@ export function UsageInsightBarChart({
 
   const { stackOrder, keyTotals } = buildStackOrder(buckets);
 
-  const drawW = width - CHART_PADDING.left - CHART_PADDING.right;
-  const spacing = buckets.length > 1 ? drawW / (buckets.length - 1) : 0;
-
-  const xScale = (i: number) => {
-    if (buckets.length <= 1) {
-      return CHART_PADDING.left + drawW / 2;
-    }
-    return CHART_PADDING.left + i * spacing;
-  };
-
-  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const mx = e.clientX - rect.left;
-    const my = e.clientY - rect.top;
-
-    let closestIdx = 0;
-    let closestDist = Infinity;
-    for (let i = 0; i < buckets.length; i++) {
-      const dist = Math.abs(xScale(i) - mx);
-      if (dist < closestDist) {
-        closestDist = dist;
-        closestIdx = i;
-      }
-    }
-
-    const bucket = buckets[closestIdx];
-    if (!bucket) {
-      return;
-    }
-
-    const values = stackOrder.map((key, i) => {
-      return {
-        label: key,
-        value: valueAt(bucket, key),
-        color: colorFor(i),
-      };
-    });
-
-    setTooltip({ x: xScale(closestIdx), y: my, ts: bucket.ts, values });
-  };
-
-  const handleMouseLeave = () => {
-    setTooltip(null);
-  };
-
   return (
     <section
       aria-label="Credits totals"
@@ -609,13 +659,16 @@ export function UsageInsightBarChart({
               range={range}
               hoveredKey={hoveredKey}
               tooltip={tooltip}
-              onMouseMove={handleMouseMove}
-              onMouseLeave={handleMouseLeave}
             />
           </div>
-          {tooltip && (
-            <ChartTooltip data={tooltip} containerWidth={width} range={range} />
-          )}
+          <ChartTooltipHitAreas
+            buckets={buckets}
+            stackOrder={stackOrder}
+            width={width}
+            range={range}
+            tooltip={tooltip}
+            setTooltip={setTooltip}
+          />
         </div>
       )}
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -733,6 +733,12 @@ describe("zero artifact sidebar", () => {
       expect(screen.getByText("Download")).toBeInTheDocument();
       expect(screen.getByText("Connect Google Drive")).toBeInTheDocument();
     });
+    await user.hover(menuItemByText("Connect Google Drive"));
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Connect Google Drive to upload artifacts").length,
+      ).toBeGreaterThan(0);
+    });
 
     click(menuItemByText("Download"));
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -390,24 +390,22 @@ function GoogleDriveMenuItem({
   }
 
   return (
-    <div className="group/google-drive-connect relative">
-      <ArtifactDownloadMenuItem
-        className="text-muted-foreground"
-        onClick={syncOrConnect}
-      >
-        <IconBrandGoogleDrive size={14} stroke={1.5} />
-        Connect Google Drive
-      </ArtifactDownloadMenuItem>
-      <div
-        role="tooltip"
-        className={cn(
-          "pointer-events-none absolute right-full top-1/2 z-[10001] mr-2 -translate-y-1/2 translate-x-1 whitespace-nowrap rounded-md border border-border/70 bg-popover px-2 py-1 text-xs text-popover-foreground opacity-0 shadow-md transition-[opacity,transform] duration-[180ms] ease",
-          "group-hover/google-drive-connect:translate-x-0 group-hover/google-drive-connect:opacity-100 group-focus-within/google-drive-connect:translate-x-0 group-focus-within/google-drive-connect:opacity-100",
-        )}
-      >
-        {CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP}
-      </div>
-    </div>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ArtifactDownloadMenuItem
+            className="text-muted-foreground"
+            onClick={syncOrConnect}
+          >
+            <IconBrandGoogleDrive size={14} stroke={1.5} />
+            Connect Google Drive
+          </ArtifactDownloadMenuItem>
+        </TooltipTrigger>
+        <TooltipContent side="left" className={ARTIFACT_FLOATING_LAYER_CLASS}>
+          {CONNECT_GOOGLE_DRIVE_ARTIFACT_UPLOAD_TOOLTIP}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace the usage insight chart's hand-positioned hover tooltip with standard Popover primitives anchored to bucket hit areas.
- Replace the Google Drive download menu's CSS-only hover tooltip with the shared Tooltip component.
- Update platform tests to cover the chart bucket trigger and Google Drive tooltip behavior.

## Why

These two interactions rendered floating UI manually, which bypassed the platform's standard Radix/shadcn components and left the chart dependent on mouse movement only.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/usage-page/__tests__/usage-page.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `pnpm -F @vm0/app run --if-present lint`
- `pnpm -F @vm0/app run --if-present check-types`
- pre-commit: prettier, knip, full `pnpm check-types`
