### PR TITLE
fix(mitm-addon): report eventless OpenAI SSE parse errors

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -346,12 +346,12 @@ class _OpenAIResponsesSseUsageHandler:
     def on_event_end(self, event_name: str | None) -> None:
         if self._eventless_prefix is not None:
             self._data_event_type = _resolved_data_event_type_from_prefix(self._eventless_prefix)
-            extractor = self._start_full_extractor(include_type=self._data_event_type is None)
+            extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
             extractor.feed(bytes(self._eventless_prefix))
             self._eventless_prefix = None
         if self._named_event_prefix is not None and self._data_event_type is None:
             self._data_event_type = _resolved_data_event_type_from_prefix(self._named_event_prefix)
-            extractor = self._start_full_extractor(include_type=self._data_event_type is None)
+            extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
             extractor.feed(bytes(self._named_event_prefix))
             self._named_event_prefix = None
         extractor = self._extractor
@@ -399,6 +399,9 @@ class _OpenAIResponsesSseUsageHandler:
         self._extractor = JsonSelectiveExtractor(scalar_fields=scalar_fields)
         return self._extractor
 
+    def _should_include_type_scalar(self) -> bool:
+        return self._data_event_type is None or self._on_parse_error is not None
+
     def _feed_eventless_data(self, chunk: bytes) -> None:
         prefix = self._eventless_prefix
         if prefix is None:
@@ -426,7 +429,7 @@ class _OpenAIResponsesSseUsageHandler:
 
         self._data_event_type = _resolved_data_event_type(event_type)
         self._fallback_eventless_prefix_to_full_extractor(
-            include_type=self._data_event_type is None
+            include_type=self._should_include_type_scalar()
         )
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
@@ -456,7 +459,9 @@ class _OpenAIResponsesSseUsageHandler:
             return
 
         self._data_event_type = _resolved_data_event_type(event_type)
-        self._fallback_named_prefix_to_full_extractor(include_type=self._data_event_type is None)
+        self._fallback_named_prefix_to_full_extractor(
+            include_type=self._should_include_type_scalar()
+        )
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -368,13 +368,18 @@ class _OpenAIResponsesSseUsageHandler:
                 data_event_type=data_event_type,
             )
             return
+        event_type = event_name
+        if event_type is None:
+            data_type = extractor.observed_scalar_for_diagnostics(("type",))
+            if isinstance(data_type, str):
+                event_type = data_type
         if (
-            event_name is not None
-            and event_name in _RESPONSES_TERMINAL_USAGE_EVENTS
+            event_type is not None
+            and event_type in _RESPONSES_TERMINAL_USAGE_EVENTS
             and result.error
             and self._on_parse_error is not None
         ):
-            self._on_parse_error(event_name, result.error)
+            self._on_parse_error(event_type, result.error)
 
     def on_event_discard(self, event_name: str | None) -> None:
         self._reset_event_state()

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -345,7 +345,9 @@ class TestModelProviderSseUsage:
         assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
-    def test_full_pipeline_openai_eventless_incomplete_sse_does_not_warn(self, tmp_path, real_flow):
+    def test_full_pipeline_openai_eventless_incomplete_terminal_sse_warns(
+        self, tmp_path, real_flow
+    ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)
         response_stream(flow)(
@@ -355,7 +357,11 @@ class TestModelProviderSseUsage:
         webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
-        assert _model_sse_parse_warnings(flow) == []
+        _assert_single_model_sse_parse_warning(
+            flow,
+            usage_protocol="openai_responses_sse",
+            event="response.completed",
+        )
 
     def test_full_pipeline_openai_non_terminal_incomplete_sse_does_not_warn(
         self, tmp_path, real_flow

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -345,8 +345,9 @@ class TestModelProviderSseUsage:
         assert webhook.request_count == 0
         assert _model_sse_parse_warnings(flow) == []
 
+    @pytest.mark.parametrize("hook_name", ["response", "error"])
     def test_full_pipeline_openai_eventless_incomplete_terminal_sse_warns(
-        self, tmp_path, real_flow
+        self, tmp_path, real_flow, hook_name
     ):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)
@@ -354,7 +355,11 @@ class TestModelProviderSseUsage:
             b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt'
         )
 
-        webhook = self._run_response(flow)
+        if hook_name == "error":
+            flow.error = Error("connection reset by peer")
+            webhook = self._run_error(flow)
+        else:
+            webhook = self._run_response(flow)
 
         assert webhook.request_count == 0
         _assert_single_model_sse_parse_warning(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -314,6 +314,40 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 5
 
+    def test_eventless_incomplete_terminal_reports_parse_error(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
+        parse(b'data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt')
+        parse.finish()
+
+        assert usage == {}
+        assert len(parse_errors) == 1
+        event, error = parse_errors[0]
+        assert event == "response.completed"
+        assert isinstance(error, str)
+        assert error
+
+    def test_eventless_incomplete_non_terminal_stays_quiet(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
+        parse(b'data: {"type":"response.output_text.delta","delta":"hello')
+        parse.finish()
+
+        assert usage == {}
+        assert parse_errors == []
+
     def test_eventless_type_after_prefix_bound_falls_back_to_full_extraction(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -371,6 +371,25 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert isinstance(error, str)
         assert error
 
+    def test_eventless_incomplete_non_terminal_after_prefix_bound_stays_quiet(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
+        parse(
+            b'data: {"padding":"'
+            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b'","type":"response.output_text.delta","delta":"hello'
+        )
+        parse.finish()
+
+        assert usage == {}
+        assert parse_errors == []
+
     def test_eventless_incomplete_duplicate_type_does_not_use_stale_terminal_type(self):
         parse_errors: list[tuple[str, str]] = []
 

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -348,6 +348,46 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage == {}
         assert parse_errors == []
 
+    def test_eventless_incomplete_terminal_after_prefix_bound_reports_parse_error(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
+        parse(
+            b'data: {"padding":"'
+            + b"x" * (openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES + 1)
+            + b'","type":"response.completed","response":{"model":"gpt'
+        )
+        parse.finish()
+
+        assert usage == {}
+        assert len(parse_errors) == 1
+        event, error = parse_errors[0]
+        assert event == "response.completed"
+        assert isinstance(error, str)
+        assert error
+
+    def test_eventless_incomplete_duplicate_type_does_not_use_stale_terminal_type(self):
+        parse_errors: list[tuple[str, str]] = []
+
+        def record_parse_error(event: str, error: str) -> None:
+            parse_errors.append((event, error))
+
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            on_parse_error=record_parse_error
+        )
+        parse(
+            b'data: {"type":"response.completed","type":"response.output_text.delta","delta":"hello'
+        )
+        parse.finish()
+
+        assert usage == {}
+        assert parse_errors == []
+
     def test_eventless_type_after_prefix_bound_falls_back_to_full_extraction(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         parse(


### PR DESCRIPTION
## Summary

- infer OpenAI Responses SSE parse diagnostics from eventless JSON `type` when incomplete terminal frames truncate after the event type
- keep incomplete JSON out of billing data and keep non-terminal eventless frames quiet
- add parser and full pipeline regressions for eventless terminal warning behavior

Fixes #18196

## Verification

```bash
cd crates/runner/mitm-addon
.venv/bin/python -m pytest tests/test_openai_responses_sse.py tests/test_model_provider_sse_usage.py
.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check .
.venv/bin/basedpyright -p .
```
