### PR TITLE
feat: add firewall metadata policy resolver

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -278,6 +278,15 @@ describe("firewall metadata", () => {
     expect(resolver.unknown()).toBe("ask");
   });
 
+  it("ignores inherited fields when resolving sparse overlay overrides", () => {
+    const resolver = createFirewallMetadataPolicyResolver(RESOLVER_METADATA, {
+      permissionOverrides: {},
+    });
+
+    expect(resolver.permission("toString")).toBe("allow");
+    expect(resolver.isPermissionOverridden("toString")).toBe(false);
+  });
+
   it("keeps metadata modules independent from runtime firewall modules", () => {
     const metadataRoot = path.resolve(
       import.meta.dirname,

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { CONNECTOR_TYPES, type ConnectorType } from "../connectors";
 import {
+  createFirewallMetadataPolicyResolver,
   expandFirewallMetadataDefaultPolicy,
   FIREWALL_PERMISSION_METADATA_SUMMARIES,
   getFirewallPermissionSummary,
@@ -13,8 +14,14 @@ import {
   permissionGrantsToFirewallPolicies,
   resolveFirewallMetadataPolicies,
 } from "../firewall-metadata";
-import type { FirewallPermissionMetadataPermission } from "../firewall-metadata";
-import type { FirewallConfig } from "../firewall-types";
+import type {
+  FirewallPermissionDetailMetadata,
+  FirewallPermissionMetadataPermission,
+} from "../firewall-metadata";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallConfig,
+} from "../firewall-types";
 import {
   getAllConnectorFirewalls,
   getDefaultFirewallPolicies,
@@ -149,6 +156,26 @@ function runtimeEntries(): [FirewallConnectorType, FirewallConfig][] {
   }) as [FirewallConnectorType, FirewallConfig][];
 }
 
+const RESOLVER_METADATA = {
+  type: "slack",
+  label: "Slack",
+  permissionCount: 4,
+  permissions: [
+    { name: "metadata-default-one" },
+    { name: "metadata-default-two" },
+    { name: "metadata-deny" },
+    { name: "metadata-ask" },
+  ],
+  defaultPolicy: {
+    permissionDefault: "allow",
+    permissionOverrides: {
+      deny: ["metadata-deny"],
+      ask: ["metadata-ask"],
+    },
+    unknownPolicy: "deny",
+  },
+} satisfies FirewallPermissionDetailMetadata;
+
 describe("firewall metadata", () => {
   it("keeps the public entrypoint summary-first", () => {
     const entrypoint = path.resolve(
@@ -159,12 +186,96 @@ describe("firewall metadata", () => {
 
     expect(staticImportSpecifiers(source).sort(compareStrings)).toStrictEqual([
       "../firewall-types",
+      "./policy-resolver",
       "./summary.generated",
+      "./types",
+    ]);
+    expect(exportFromSpecifiers(source).sort(compareStrings)).toStrictEqual([
+      "./policy-resolver",
       "./types",
     ]);
     expect(dynamicImportSpecifiers(source)).toStrictEqual([
       "./loader.generated",
     ]);
+  });
+
+  it("resolves metadata permission defaults and overrides", () => {
+    const resolver = createFirewallMetadataPolicyResolver(RESOLVER_METADATA);
+
+    expect(resolver.permission("metadata-default-one")).toBe("allow");
+    expect(resolver.permission("metadata-deny")).toBe("deny");
+    expect(resolver.permission("metadata-ask")).toBe("ask");
+    expect(resolver.permission("not-in-metadata")).toBe("allow");
+    expect(resolver.unknown()).toBe("deny");
+  });
+
+  it("applies sparse overlay precedence", () => {
+    const resolver = createFirewallMetadataPolicyResolver(RESOLVER_METADATA, {
+      permissionDefault: "deny",
+      permissionOverrides: {
+        "metadata-deny": "allow",
+        "metadata-ask": "ask",
+      },
+      unknownPolicy: "ask",
+    });
+
+    expect(resolver.permission("metadata-default-one")).toBe("deny");
+    expect(resolver.permission("metadata-deny")).toBe("allow");
+    expect(resolver.permission("metadata-ask")).toBe("ask");
+    expect(resolver.permission("not-in-metadata")).toBe("deny");
+    expect(resolver.unknown()).toBe("ask");
+  });
+
+  it("summarizes visible permission lists", () => {
+    const resolver = createFirewallMetadataPolicyResolver(RESOLVER_METADATA);
+
+    expect(
+      resolver.list(["metadata-default-one", "metadata-default-two"]),
+    ).toBe("allow");
+    expect(resolver.list(["metadata-default-one", "metadata-deny"])).toBe(
+      "mixed",
+    );
+    expect(resolver.list([])).toBe("mixed");
+  });
+
+  it("reports only effective sparse overlay changes as overrides", () => {
+    const redundant = createFirewallMetadataPolicyResolver(RESOLVER_METADATA, {
+      permissionDefault: "allow",
+      permissionOverrides: {
+        "metadata-deny": "deny",
+      },
+      unknownPolicy: "deny",
+    });
+
+    expect(redundant.isPermissionOverridden("metadata-default-one")).toBe(
+      false,
+    );
+    expect(redundant.isPermissionOverridden("metadata-deny")).toBe(false);
+    expect(redundant.isUnknownOverridden()).toBe(false);
+
+    const changed = createFirewallMetadataPolicyResolver(RESOLVER_METADATA, {
+      permissionDefault: "deny",
+      permissionOverrides: {
+        "metadata-deny": "allow",
+      },
+      unknownPolicy: "allow",
+    });
+
+    expect(changed.isPermissionOverridden("metadata-default-one")).toBe(true);
+    expect(changed.isPermissionOverridden("metadata-deny")).toBe(true);
+    expect(changed.isUnknownOverridden()).toBe(true);
+  });
+
+  it("keeps unknown endpoint policy separate from permission lookup", () => {
+    const resolver = createFirewallMetadataPolicyResolver(RESOLVER_METADATA, {
+      permissionOverrides: {
+        [UNKNOWN_PERMISSION_GRANT]: "allow",
+      },
+      unknownPolicy: "ask",
+    });
+
+    expect(resolver.permission(UNKNOWN_PERMISSION_GRANT)).toBe("allow");
+    expect(resolver.unknown()).toBe("ask");
   });
 
   it("keeps metadata modules independent from runtime firewall modules", () => {

--- a/turbo/packages/connectors/src/firewall-metadata/index.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/index.ts
@@ -4,6 +4,7 @@ import {
   type FirewallPolicy,
   type FirewallPolicyValue,
 } from "../firewall-types";
+import { createFirewallMetadataPolicyResolver } from "./policy-resolver";
 import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./summary.generated";
 import type {
   FirewallPermissionDetailMetadata,
@@ -11,6 +12,12 @@ import type {
 } from "./types";
 
 export { FIREWALL_PERMISSION_METADATA_SUMMARIES };
+export { createFirewallMetadataPolicyResolver };
+export type {
+  FirewallMetadataPolicyListState,
+  FirewallMetadataPolicyOverlay,
+  FirewallMetadataPolicyResolver,
+} from "./policy-resolver";
 export type {
   FirewallPermissionCategoryMetadata,
   FirewallPermissionDefaultPolicyMetadata,
@@ -75,28 +82,16 @@ export async function loadFirewallPermissionMetadata(
 export function expandFirewallMetadataDefaultPolicy(
   metadata: FirewallPermissionDetailMetadata,
 ): FirewallPolicy {
+  const resolver = createFirewallMetadataPolicyResolver(metadata);
   const policies: Record<string, FirewallPolicyValue> = {};
-  const overrides = metadata.defaultPolicy.permissionOverrides ?? {};
-  const overrideLookup = new Map<string, FirewallPolicyValue>();
-
-  for (const [policy, permissions] of Object.entries(overrides) as [
-    FirewallPolicyValue,
-    readonly string[],
-  ][]) {
-    for (const permission of permissions) {
-      overrideLookup.set(permission, policy);
-    }
-  }
 
   for (const permission of metadata.permissions) {
-    policies[permission.name] =
-      overrideLookup.get(permission.name) ??
-      metadata.defaultPolicy.permissionDefault;
+    policies[permission.name] = resolver.permission(permission.name);
   }
 
   return {
     policies,
-    unknownPolicy: metadata.defaultPolicy.unknownPolicy,
+    unknownPolicy: resolver.unknown(),
   };
 }
 

--- a/turbo/packages/connectors/src/firewall-metadata/policy-resolver.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/policy-resolver.ts
@@ -9,6 +9,10 @@ export interface FirewallMetadataPolicyOverlay {
 
 export type FirewallMetadataPolicyListState = FirewallPolicyValue | "mixed";
 
+/**
+ * Resolves generated metadata defaults with an optional sparse policy overlay.
+ * Permission name validation belongs to callers; unknown endpoints use unknown().
+ */
 export interface FirewallMetadataPolicyResolver {
   permission(name: string): FirewallPolicyValue;
   unknown(): FirewallPolicyValue;
@@ -39,6 +43,16 @@ function buildMetadataOverrideLookup(
   return lookup;
 }
 
+function getOwnPermissionOverride(
+  overrides: Readonly<Record<string, FirewallPolicyValue>> | undefined,
+  name: string,
+): FirewallPolicyValue | undefined {
+  if (!overrides || !Object.prototype.hasOwnProperty.call(overrides, name)) {
+    return undefined;
+  }
+  return overrides[name];
+}
+
 export function createFirewallMetadataPolicyResolver(
   metadata: FirewallPermissionDetailMetadata,
   overlay?: FirewallMetadataPolicyOverlay,
@@ -52,9 +66,8 @@ export function createFirewallMetadataPolicyResolver(
   }
 
   function permission(name: string): FirewallPolicyValue {
-    // Permission validation is owned by callers; unknown endpoints use unknown().
     return (
-      overlay?.permissionOverrides?.[name] ??
+      getOwnPermissionOverride(overlay?.permissionOverrides, name) ??
       overlay?.permissionDefault ??
       metadataPermission(name)
     );

--- a/turbo/packages/connectors/src/firewall-metadata/policy-resolver.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/policy-resolver.ts
@@ -1,0 +1,92 @@
+import type { FirewallPolicyValue } from "../firewall-types";
+import type { FirewallPermissionDetailMetadata } from "./types";
+
+export interface FirewallMetadataPolicyOverlay {
+  readonly permissionDefault?: FirewallPolicyValue;
+  readonly permissionOverrides?: Readonly<Record<string, FirewallPolicyValue>>;
+  readonly unknownPolicy?: FirewallPolicyValue;
+}
+
+export type FirewallMetadataPolicyListState = FirewallPolicyValue | "mixed";
+
+export interface FirewallMetadataPolicyResolver {
+  permission(name: string): FirewallPolicyValue;
+  unknown(): FirewallPolicyValue;
+  list(permissionNames: readonly string[]): FirewallMetadataPolicyListState;
+  isPermissionOverridden(name: string): boolean;
+  isUnknownOverridden(): boolean;
+}
+
+function buildMetadataOverrideLookup(
+  metadata: FirewallPermissionDetailMetadata,
+): ReadonlyMap<string, FirewallPolicyValue> {
+  const overrides = metadata.defaultPolicy.permissionOverrides;
+  const lookup = new Map<string, FirewallPolicyValue>();
+  if (!overrides) {
+    return lookup;
+  }
+
+  for (const permission of overrides.allow ?? []) {
+    lookup.set(permission, "allow");
+  }
+  for (const permission of overrides.deny ?? []) {
+    lookup.set(permission, "deny");
+  }
+  for (const permission of overrides.ask ?? []) {
+    lookup.set(permission, "ask");
+  }
+
+  return lookup;
+}
+
+export function createFirewallMetadataPolicyResolver(
+  metadata: FirewallPermissionDetailMetadata,
+  overlay?: FirewallMetadataPolicyOverlay,
+): FirewallMetadataPolicyResolver {
+  const metadataOverrides = buildMetadataOverrideLookup(metadata);
+
+  function metadataPermission(name: string): FirewallPolicyValue {
+    return (
+      metadataOverrides.get(name) ?? metadata.defaultPolicy.permissionDefault
+    );
+  }
+
+  function permission(name: string): FirewallPolicyValue {
+    // Permission validation is owned by callers; unknown endpoints use unknown().
+    return (
+      overlay?.permissionOverrides?.[name] ??
+      overlay?.permissionDefault ??
+      metadataPermission(name)
+    );
+  }
+
+  return {
+    permission,
+    unknown: () => {
+      return overlay?.unknownPolicy ?? metadata.defaultPolicy.unknownPolicy;
+    },
+    list: (permissionNames) => {
+      let first: FirewallPolicyValue | null = null;
+      for (const name of permissionNames) {
+        const current = permission(name);
+        if (first === null) {
+          first = current;
+          continue;
+        }
+        if (first !== current) {
+          return "mixed";
+        }
+      }
+      return first ?? "mixed";
+    },
+    isPermissionOverridden: (name) => {
+      return permission(name) !== metadataPermission(name);
+    },
+    isUnknownOverridden: () => {
+      return (
+        (overlay?.unknownPolicy ?? metadata.defaultPolicy.unknownPolicy) !==
+        metadata.defaultPolicy.unknownPolicy
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add a pure firewall metadata policy resolver for generated metadata plus optional sparse overlays.
- Export the resolver from `@vm0/connectors/firewall-metadata`.
- Keep existing materialized default-policy helpers compatible by delegating default expansion through the resolver.
- Cover precedence, list summaries, effective override detection, unknown endpoint separation, and metadata import boundaries.

Closes #18217

## Validation

- `pnpm -F @vm0/connectors test -- firewall-metadata`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm format`
- `pnpm check-types`
- `pnpm turbo run lint`
- `pnpm knip`
- `pnpm vitest` was run once; the full suite hit 9 unrelated 5s timeout/wait failures in API/platform tests. Each failed test was rerun isolated and passed:
  - `team-navigation.test.tsx -t "updates connector permission policies from an agent page"`
  - `zero-attachment-chips.test.tsx -t "opens media and file previews parsed from chat message links"`
  - `zero-connectors-page.test.tsx -t "filters connectors by integration keywords"`
  - `chat-callbacks.bdd.test.ts -t "starts a fresh session with prior web context when the queued model differs, without regenerating an existing title"`
  - `cron-sync-skills.test.ts` failed cases rerun individually
  - `github-integration.bdd.test.ts` failed cases rerun individually
