### PR TITLE
fix: dismiss inline feedback toolbar when a click clears the selection

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3606,6 +3606,53 @@ describe("chat lifecycle", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("dismisses the inline feedback toolbar when a click clears the selection", async () => {
+    const assistantReply = "The rollout dates are unclear in this summary.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-dismiss-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-dismiss",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-dismiss-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-dismiss",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatInlineFeedback]: true },
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+
+    // Click inside the selection: in a real browser mouseup fires first and the
+    // selection collapses right after. Mirror that order so the deferred read
+    // sees the cleared selection and dismisses the toolbar.
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    window.getSelection()?.removeAllRanges();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+    });
+  });
+
   it("sends inline feedback with selected template and draft attachments", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -29,14 +29,33 @@ function selectionListenersRef(
     if (!element) {
       return;
     }
-    document.addEventListener("mouseup", capture);
+    // A mouse click inside an existing selection collapses it *after* the
+    // mouseup event fires, so reading the selection synchronously here would
+    // still see the stale range and keep the toolbar floating once the
+    // highlight is gone. Defer the read to the next tick so the selection has
+    // settled — clicking to clear the selection then dismisses the toolbar.
+    let captureTimerId: number | null = null;
+    const captureDeferred = () => {
+      if (captureTimerId !== null) {
+        window.clearTimeout(captureTimerId);
+      }
+      captureTimerId = window.setTimeout(() => {
+        captureTimerId = null;
+        capture();
+      }, 0);
+    };
+    document.addEventListener("mouseup", captureDeferred);
     document.addEventListener("keyup", capture);
     document.addEventListener("scroll", dismissOnScroll, {
       capture: true,
       passive: true,
     });
     detachListeners = () => {
-      document.removeEventListener("mouseup", capture);
+      if (captureTimerId !== null) {
+        window.clearTimeout(captureTimerId);
+        captureTimerId = null;
+      }
+      document.removeEventListener("mouseup", captureDeferred);
       document.removeEventListener("keyup", capture);
       document.removeEventListener("scroll", dismissOnScroll, {
         capture: true,


### PR DESCRIPTION
## Summary

Fixes #18230 — the inline feedback "pill" (Copy | Provide feedback) stayed floating over an assistant message after the user clicked to clear the text selection.

## Root cause

A mouse **click inside an existing selection collapses it _after_ the `mouseup` event fires**. The selection toolbar reads `window.getSelection()` synchronously in its `mouseup` handler, so at that moment the stale (still non-collapsed) range is read and the toolbar is re-opened — right before the browser clears the selection. The highlight disappears but the toolbar lingers.

This also explains why Radix's own outside-click close didn't help: `pointerdown` closes the popover, then our synchronous `mouseup` re-captures the still-live selection and reopens it.

## Fix

Defer the `mouseup` selection read to the next tick (`setTimeout(…, 0)`) so the selection has settled before we read it. When a click clears the selection, the deferred read sees the collapsed selection and dismisses the toolbar. Normal drag-to-select is unaffected (the range is present after the drag completes). The pending timer is cleared on listener detach.

## Test

Added a regression test in `chat-lifecycle.test.tsx` that selects assistant text, asserts the toolbar shows, then simulates a click that clears the selection (mouseup, then collapse) and asserts the toolbar dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)