### PR TITLE
feat: roll out chat draft + double-click rename switches, drop automation sidebar switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3048,37 +3048,6 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps the linked automation dropdown when the sidebar switch is off", async () => {
-    mockAutomationThread();
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${AUTOMATION_THREAD_ID}?automations=${AUTOMATION_THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatAutomationSidebar]: false },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Scheduled launch review")).toBeInTheDocument();
-      expect(buttonByLabel("Automations")).toBeInTheDocument();
-    });
-
-    click(buttonByLabel("Automations"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Launch review")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("Paused launch audit")).toBeInTheDocument();
-    expect(screen.getByText("Manual launch reminder")).toBeInTheDocument();
-    expect(screen.getByText("Automation inactive")).toBeInTheDocument();
-    expect(screen.queryByTestId("automation-sidebar")).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Close automations"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Run now")).not.toBeInTheDocument();
-    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
-  });
-
   it("shows linked automations from the chat header sidebar", async () => {
     mockAutomationThread();
     context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
@@ -3088,7 +3057,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${AUTOMATION_THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatAutomationSidebar]: true },
     });
 
     await waitFor(() => {
@@ -3141,7 +3109,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${AUTOMATION_THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatAutomationSidebar]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -421,7 +421,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("keeps sidebar double-click rename disabled by default", async () => {
+  it("renames a chat thread by double-clicking from the sidebar", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([
       createThread(EXISTING_THREAD_ID, "Release plan"),
@@ -431,30 +431,6 @@ describe("zero sidebar", () => {
     detachedSetupPage({
       context,
       path: `/chats/${EXISTING_THREAD_ID}`,
-    });
-
-    await waitFor(() => {
-      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
-    });
-
-    fireEvent.doubleClick(threadLinkByTitle("Release plan"));
-
-    expect(
-      screen.queryByRole("dialog", { name: "Rename chat" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("renames a chat thread by double-clicking from the sidebar when enabled", async () => {
-    prepareDefaultAgent();
-    mockSidebarThreadStory([
-      createThread(EXISTING_THREAD_ID, "Release plan"),
-      createThread(INCIDENT_THREAD_ID, "Incident notes"),
-    ]);
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${EXISTING_THREAD_ID}`,
-      featureSwitches: { [FeatureSwitchKey.ChatThreadDoubleClickRename]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -135,7 +135,6 @@ import {
   requestedUserPermissionGrantExpirationAlreadyApplies,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
-import { detachedNavigateTo$ } from "../../signals/route.ts";
 import {
   artifactFullscreen$,
   artifactInboxQuery$,
@@ -963,23 +962,6 @@ function GithubPrTrackingButton({
   );
 }
 
-// Second line shown under each automation in the legacy header dropdown: the
-// next upcoming run time, or a note that the automation is inactive when it has
-// been disabled.
-function automationMenuSubline(automation: HeaderAutomationEntry): string {
-  if (!automation.enabled) {
-    return "Automation inactive";
-  }
-  if (!automation.nextRunAt) {
-    return "No upcoming run";
-  }
-  const nextRun = new Date(automation.nextRunAt).toLocaleString("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
-  return `Next run ${nextRun}`;
-}
-
 function featureSwitchEnabled(
   features: Record<FeatureSwitchKey, boolean> | undefined,
   key: FeatureSwitchKey,
@@ -996,76 +978,20 @@ export function AutomationMenuButton({
   threadId: string;
   ariaLabel?: string;
 }) {
-  const navigate = useSet(detachedNavigateTo$);
   const reloadAutomations = useSet(reloadHeaderAutomationMenu$);
   const openAutomationSidebar = useSet(openHeaderAutomationSidebar$);
   const openThreadId = useGet(currentHeaderAutomationThreadId$);
   const automationsLoadable = useLastLoadable(headerAutomationMenu$);
   const lastResolvedAutomations = useLastResolved(headerAutomationMenu$);
-  const features = useLastResolved(featureSwitch$);
-  const automationSidebarEnabled = featureSwitchEnabled(
-    features,
-    FeatureSwitchKey.ChatAutomationSidebar,
-  );
   const allAutomations =
     automationsLoadable.state === "hasData"
       ? automationsLoadable.data
       : (lastResolvedAutomations ?? []);
   const automations = automationsForThread(allAutomations, threadId);
-  const open = automationSidebarEnabled && openThreadId === threadId;
+  const open = openThreadId === threadId;
 
   if (automations.length === 0) {
     return null;
-  }
-
-  if (!automationSidebarEnabled) {
-    return (
-      <DropdownMenu
-        onOpenChange={(dropdownOpen) => {
-          if (dropdownOpen) {
-            reloadAutomations();
-          }
-        }}
-      >
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors duration-150 hover:bg-accent hover:text-foreground"
-            aria-label={ariaLabel}
-          >
-            <IconClock size={18} />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-64">
-          {automations.map((automation) => {
-            return (
-              <DropdownMenuItem
-                key={automation.id}
-                onClick={() => {
-                  navigate("/automations/:automationId", {
-                    pathParams: { automationId: automation.id },
-                  });
-                }}
-                className="items-start gap-2"
-              >
-                <IconClock
-                  size={15}
-                  className="mt-0.5 shrink-0 text-muted-foreground"
-                />
-                <div className="flex min-w-0 flex-col">
-                  <span className="truncate">
-                    {automationDescription(automation)}
-                  </span>
-                  <span className="truncate text-xs text-muted-foreground">
-                    {automationMenuSubline(automation)}
-                  </span>
-                </div>
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
   }
 
   return (
@@ -2434,17 +2360,12 @@ export function ZeroChatThreadPage() {
     features,
     FeatureSwitchKey.PresentationHtmlPptxDownload,
   );
-  const automationSidebarEnabled = featureSwitchEnabled(
-    features,
-    FeatureSwitchKey.ChatAutomationSidebar,
-  );
   const activePresentationEditorUrl = presentationHtmlEditorEnabled
     ? presentationEditorUrl
     : null;
   const artifactPanelOpen =
     artifactRef !== null || artifactInboxThreadId !== null;
-  const automationPanelOpen =
-    automationSidebarEnabled && automationPanelThreadId !== null;
+  const automationPanelOpen = automationPanelThreadId !== null;
   const rightPanelOpen = artifactPanelOpen || automationPanelOpen;
   const { style: artifactPanelStyle, transition: artifactTransition } =
     artifactPanelLayout(

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -55,7 +55,6 @@ export enum FeatureSwitchKey {
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatInlineFeedback = "chatInlineFeedback",
   ChatSlashWorkflowCommands = "chatSlashWorkflowCommands",
-  ChatAutomationSidebar = "chatAutomationSidebar",
   ConnectorReconnectReasons = "connectorReconnectReasons",
   AutomationWebhookTriggers = "automationWebhookTriggers",
   AutomationMultiTrigger = "automationMultiTrigger",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -49,7 +49,7 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(true);
     expect(
-      isFeatureEnabled(FeatureSwitchKey.ChatThreadDoubleClickRename, {
+      isFeatureEnabled(FeatureSwitchKey.ChatTemplatePicker, {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
@@ -72,7 +72,7 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(false);
     expect(
-      isFeatureEnabled(FeatureSwitchKey.ChatThreadDoubleClickRename, {
+      isFeatureEnabled(FeatureSwitchKey.ChatTemplatePicker, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
@@ -126,9 +126,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowsViewer]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatThreadDoubleClickRename]).toBe(
-      true,
-    );
+    expect(staffOrgStates[FeatureSwitchKey.ChatTemplatePicker]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
 
@@ -138,9 +136,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowsViewer]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatThreadDoubleClickRename]).toBe(
-      false,
-    );
+    expect(otherOrgStates[FeatureSwitchKey.ChatTemplatePicker]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -254,14 +254,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Persist per-user, per-org drafts for the new agent chat page. When disabled, agent chat uses the local non-persisted draft path and does not call the agent draft endpoint.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatThreadDoubleClickRename]: {
     maintainer: "lancy@vm0.ai",
     description:
       "Open the existing chat rename dialog when a sidebar chat thread is double-clicked.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatTemplatePicker]: {
     maintainer: "linghan@vm0.ai",
@@ -315,12 +314,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable slash command suggestions for the current agent's workflows in the Zero chat composer.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
-  [FeatureSwitchKey.ChatAutomationSidebar]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Replace the chat header automation dropdown with the right-side Automation sidebar. While off, chat headers keep the legacy dropdown menu.",
-    enabled: true,
   },
   [FeatureSwitchKey.ConnectorReconnectReasons]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary

- **Full rollout** of the `agentChatDrafts` feature switch — set `enabled: true`.
- **Full rollout** of the `chatThreadDoubleClickRename` feature switch — set `enabled: true` and dropped the now-redundant `enabledOrgIdHashes` staff gate.
- **Removed** the `chatAutomationSidebar` feature switch entirely (it was already `enabled: true`):
  - Deleted the enum member and registry entry.
  - Inlined the sidebar-on path in `zero-chat-thread-page.tsx` and removed the legacy header automation dropdown (plus the now-unused `automationMenuSubline` helper and `detachedNavigateTo$` import).

## Tests
- `feature-switch.test.ts`: `chatThreadDoubleClickRename` is no longer org-gated, so the staff-org matrix assertions now use `chatTemplatePicker` (still staff-gated) to preserve coverage.
- `chat-lifecycle.test.tsx`: removed the legacy "dropdown when sidebar switch is off" test and dropped the now-redundant explicit `ChatAutomationSidebar: true` overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)