### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -112,7 +112,7 @@ CACHE_TMP_TAR=""
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
 CLAUDE_CODE_VERSION="2.1.181"
-CODEX_CLI_VERSION="0.140.0"
+CODEX_CLI_VERSION="0.141.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.28.0"


### PR DESCRIPTION
## Summary
- Updated `@openai/codex` in `crates/runner/scripts/build-template.sh` from `0.140.0` to `0.141.0`.

## Version checks
- Go: kept `1.26.4` (latest stable from go.dev).
- Claude Code: kept `2.1.181` (latest npm release and matching standalone distribution version).
- `@googleworkspace/cli`: kept `0.22.5` (latest npm release).
- `@xdevplatform/xurl`: kept `1.0.3` (latest npm release).
- `agent-browser`: kept `0.28.0` (latest npm release).
- `pnpm`: kept `11.7.0` (latest npm release).
- Node.js: kept NodeSource `24.x` because Node.js `24` is the current LTS line.
- PostgreSQL: kept major `18`, the latest supported stable major line.