### PR TITLE
refactor: carry sandbox exec termination state

### DIFF
--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
-use sandbox::ExecResult;
+use sandbox::{ExecResult, ProcessTerminationKind};
 use sandbox_mock::MockSandbox;
 
 use super::super::GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
@@ -91,13 +91,14 @@ async fn download_storages_nonzero_exit_code() {
 #[test]
 fn guest_download_failure_output_redacts_url_queries() {
     let result = ExecResult {
-            exit_code: 1,
-            stdout: Vec::new(),
-            stderr: b"HTTP transport error for archiveUrl=https://storage.example/archive.tar.gz?X-Amz-Signature=secret"
-                .to_vec(),
-            stdout_truncated: false,
-            stderr_truncated: true,
-        };
+        termination: ProcessTerminationKind::Exited,
+        exit_code: 1,
+        stdout: Vec::new(),
+        stderr: b"HTTP transport error for archiveUrl=https://storage.example/archive.tar.gz?X-Amz-Signature=secret"
+            .to_vec(),
+        stdout_truncated: false,
+        stderr_truncated: true,
+    };
 
     let msg = format_guest_download_failure(&result);
 
@@ -119,6 +120,7 @@ fn guest_download_failure_redacts_url_query_before_excerpting() {
         - suffix.len();
     let query = format!("{query_key}{secret_value}{}", "a".repeat(padding_len));
     let result = ExecResult {
+        termination: ProcessTerminationKind::Exited,
         exit_code: 1,
         stdout: Vec::new(),
         stderr: format!("{prefix}{query}{suffix}").into_bytes(),

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1613,6 +1613,19 @@ fn captured_output_bytes(output: ExecOwnedCapturedOutput) -> (Vec<u8>, bool) {
     }
 }
 
+fn captured_exec_output_bytes(
+    name: &str,
+    output: ExecOwnedCapturedOutput,
+) -> io::Result<(Vec<u8>, bool)> {
+    match output {
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
+        ExecOwnedCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("exec result discarded {name} for capture request"),
+        )),
+    }
+}
+
 fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
     if diagnostic.is_empty() {
         return;
@@ -1623,19 +1636,67 @@ fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
     stderr.extend_from_slice(diagnostic.as_bytes());
 }
 
+fn process_termination_kind(termination: ExecTermination) -> ProcessTerminationKind {
+    match termination {
+        ExecTermination::Exited { .. } => ProcessTerminationKind::Exited,
+        ExecTermination::TimedOut => ProcessTerminationKind::TimedOut,
+        ExecTermination::Cancelled => ProcessTerminationKind::Cancelled,
+        ExecTermination::StartFailed => ProcessTerminationKind::StartFailed,
+        ExecTermination::WaitFailed => ProcessTerminationKind::WaitFailed,
+    }
+}
+
+fn bounded_exec_result_to_exec_result(
+    result: vsock_host::ExecOperationResult,
+) -> io::Result<ExecResult> {
+    if result.stream_overflowed {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "exec capture unexpectedly overflowed a stream queue",
+        ));
+    }
+
+    let termination = process_termination_kind(result.termination);
+    let (stdout, stdout_truncated) = captured_exec_output_bytes("stdout", result.stdout)?;
+    let (mut stderr, stderr_truncated) = captured_exec_output_bytes("stderr", result.stderr)?;
+    let exit_code = match result.termination {
+        ExecTermination::Exited { exit_code } => exit_code,
+        ExecTermination::TimedOut => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Timeout");
+            }
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        ExecTermination::Cancelled => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Cancelled");
+            }
+            append_diagnostic(&mut stderr, &result.diagnostic);
+            1
+        }
+        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
+            append_diagnostic(&mut stderr, &result.diagnostic);
+            1
+        }
+    };
+
+    Ok(ExecResult {
+        termination,
+        exit_code,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+    })
+}
+
 fn supervised_exec_result_to_process_exit(
     pid: u32,
     result: vsock_host::ExecOperationResult,
 ) -> ProcessExit {
     let (stdout, stdout_truncated) = captured_output_bytes(result.stdout);
     let (mut stderr, stderr_truncated) = captured_output_bytes(result.stderr);
-    let termination = match result.termination {
-        ExecTermination::Exited { .. } => ProcessTerminationKind::Exited,
-        ExecTermination::TimedOut => ProcessTerminationKind::TimedOut,
-        ExecTermination::Cancelled => ProcessTerminationKind::Cancelled,
-        ExecTermination::StartFailed => ProcessTerminationKind::StartFailed,
-        ExecTermination::WaitFailed => ProcessTerminationKind::WaitFailed,
-    };
+    let termination = process_termination_kind(result.termination);
     let exit_code = match result.termination {
         ExecTermination::Exited { exit_code } => exit_code,
         ExecTermination::TimedOut => {
@@ -2090,8 +2151,14 @@ impl Sandbox for FirecrackerSandbox {
             operation,
             || Self::validate_exec_env_keys(operation, request.env),
             |guest| async move {
+                if timeout_ms == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "exec requires a positive timeout; use supervised exec for unbounded commands",
+                    ));
+                }
                 guest
-                    .exec_capture(vsock_host::ExecCaptureRequest {
+                    .exec_operation_capture(vsock_host::ExecCaptureRequest {
                         command: request.cmd,
                         timeout_ms,
                         env: request.env,
@@ -2104,13 +2171,7 @@ impl Sandbox for FirecrackerSandbox {
                         wait_timeout: Duration::from_millis(timeout_ms as u64 + 5000),
                     })
                     .await
-                    .map(|result| ExecResult {
-                        exit_code: result.exit_code,
-                        stdout: result.stdout,
-                        stderr: result.stderr,
-                        stdout_truncated: result.stdout_truncated,
-                        stderr_truncated: result.stderr_truncated,
-                    })
+                    .and_then(bounded_exec_result_to_exec_result)
             },
         )
         .await
@@ -5218,6 +5279,145 @@ mod tests {
             ExecOutputPolicy::Capture { limit_bytes: 13 }
         );
         assert_eq!(process_stream_queue_capacity(output), None);
+    }
+
+    #[test]
+    fn bounded_exec_result_to_exec_result_preserves_terminal_metadata() {
+        let result = bounded_exec_result_to_exec_result(vsock_host::ExecOperationResult {
+            termination: ExecTermination::Exited { exit_code: 7 },
+            duration_ms: 10,
+            stdout: ExecOwnedCapturedOutput::Captured {
+                bytes: b"out".to_vec(),
+                truncated: true,
+            },
+            stderr: ExecOwnedCapturedOutput::Captured {
+                bytes: b"err".to_vec(),
+                truncated: false,
+            },
+            diagnostic: "ignored on ordinary exit".to_string(),
+            stream_overflowed: false,
+        })
+        .expect("bounded exec result should convert");
+
+        assert_eq!(result.termination, ProcessTerminationKind::Exited);
+        assert_eq!(result.exit_code, 7);
+        assert_eq!(result.stdout, b"out");
+        assert_eq!(result.stderr, b"err");
+        assert!(result.stdout_truncated);
+        assert!(!result.stderr_truncated);
+    }
+
+    #[test]
+    fn bounded_exec_result_to_exec_result_maps_terminal_edge_states() {
+        for (termination, diagnostic, expected_code, expected_stderr, expected_termination) in [
+            (
+                ExecTermination::TimedOut,
+                "",
+                EXEC_TIMEOUT_EXIT_CODE,
+                "Timeout",
+                ProcessTerminationKind::TimedOut,
+            ),
+            (
+                ExecTermination::Cancelled,
+                "cancel diagnostic",
+                1,
+                "Cancelled\ncancel diagnostic",
+                ProcessTerminationKind::Cancelled,
+            ),
+            (
+                ExecTermination::StartFailed,
+                "spawn failed",
+                1,
+                "spawn failed",
+                ProcessTerminationKind::StartFailed,
+            ),
+            (
+                ExecTermination::WaitFailed,
+                "wait failed",
+                1,
+                "wait failed",
+                ProcessTerminationKind::WaitFailed,
+            ),
+        ] {
+            let result = bounded_exec_result_to_exec_result(vsock_host::ExecOperationResult {
+                termination,
+                duration_ms: 10,
+                stdout: ExecOwnedCapturedOutput::Captured {
+                    bytes: Vec::new(),
+                    truncated: false,
+                },
+                stderr: ExecOwnedCapturedOutput::Captured {
+                    bytes: Vec::new(),
+                    truncated: false,
+                },
+                diagnostic: diagnostic.to_string(),
+                stream_overflowed: false,
+            })
+            .expect("bounded exec result should convert");
+
+            assert_eq!(result.exit_code, expected_code);
+            assert_eq!(result.termination, expected_termination);
+            assert_eq!(String::from_utf8(result.stderr).unwrap(), expected_stderr);
+        }
+    }
+
+    #[test]
+    fn bounded_exec_result_to_exec_result_rejects_invalid_capture_state() {
+        let overflow = match bounded_exec_result_to_exec_result(vsock_host::ExecOperationResult {
+            termination: ExecTermination::Exited { exit_code: 0 },
+            duration_ms: 10,
+            stdout: ExecOwnedCapturedOutput::Captured {
+                bytes: Vec::new(),
+                truncated: false,
+            },
+            stderr: ExecOwnedCapturedOutput::Captured {
+                bytes: Vec::new(),
+                truncated: false,
+            },
+            diagnostic: String::new(),
+            stream_overflowed: true,
+        }) {
+            Ok(_) => panic!("bounded capture should reject stream overflow"),
+            Err(error) => error,
+        };
+        assert_eq!(overflow.kind(), io::ErrorKind::InvalidData);
+        assert!(overflow.to_string().contains("overflowed a stream queue"));
+
+        let stdout_discarded =
+            match bounded_exec_result_to_exec_result(vsock_host::ExecOperationResult {
+                termination: ExecTermination::Exited { exit_code: 0 },
+                duration_ms: 10,
+                stdout: ExecOwnedCapturedOutput::Discarded,
+                stderr: ExecOwnedCapturedOutput::Captured {
+                    bytes: Vec::new(),
+                    truncated: false,
+                },
+                diagnostic: String::new(),
+                stream_overflowed: false,
+            }) {
+                Ok(_) => panic!("bounded capture should reject discarded stdout"),
+                Err(error) => error,
+            };
+        assert_eq!(stdout_discarded.kind(), io::ErrorKind::InvalidData);
+        assert!(stdout_discarded.to_string().contains("discarded stdout"));
+
+        let stderr_discarded =
+            match bounded_exec_result_to_exec_result(vsock_host::ExecOperationResult {
+                termination: ExecTermination::Exited { exit_code: 0 },
+                duration_ms: 10,
+                stdout: ExecOwnedCapturedOutput::Captured {
+                    bytes: Vec::new(),
+                    truncated: false,
+                },
+                stderr: ExecOwnedCapturedOutput::Discarded,
+                diagnostic: String::new(),
+                stream_overflowed: false,
+            }) {
+                Ok(_) => panic!("bounded capture should reject discarded stderr"),
+                Err(error) => error,
+            };
+        assert_eq!(stderr_discarded.kind(), io::ErrorKind::InvalidData);
+        assert!(stderr_discarded.to_string().contains("discarded stderr"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1646,6 +1646,33 @@ fn process_termination_kind(termination: ExecTermination) -> ProcessTerminationK
     }
 }
 
+fn legacy_exit_code_for_exec_termination(
+    termination: ExecTermination,
+    stderr: &mut Vec<u8>,
+    diagnostic: &str,
+) -> i32 {
+    match termination {
+        ExecTermination::Exited { exit_code } => exit_code,
+        ExecTermination::TimedOut => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Timeout");
+            }
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        ExecTermination::Cancelled => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Cancelled");
+            }
+            append_diagnostic(stderr, diagnostic);
+            1
+        }
+        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
+            append_diagnostic(stderr, diagnostic);
+            1
+        }
+    }
+}
+
 fn bounded_exec_result_to_exec_result(
     result: vsock_host::ExecOperationResult,
 ) -> io::Result<ExecResult> {
@@ -1659,26 +1686,8 @@ fn bounded_exec_result_to_exec_result(
     let termination = process_termination_kind(result.termination);
     let (stdout, stdout_truncated) = captured_exec_output_bytes("stdout", result.stdout)?;
     let (mut stderr, stderr_truncated) = captured_exec_output_bytes("stderr", result.stderr)?;
-    let exit_code = match result.termination {
-        ExecTermination::Exited { exit_code } => exit_code,
-        ExecTermination::TimedOut => {
-            if stderr.is_empty() {
-                stderr.extend_from_slice(b"Timeout");
-            }
-            EXEC_TIMEOUT_EXIT_CODE
-        }
-        ExecTermination::Cancelled => {
-            if stderr.is_empty() {
-                stderr.extend_from_slice(b"Cancelled");
-            }
-            append_diagnostic(&mut stderr, &result.diagnostic);
-            1
-        }
-        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
-            append_diagnostic(&mut stderr, &result.diagnostic);
-            1
-        }
-    };
+    let exit_code =
+        legacy_exit_code_for_exec_termination(result.termination, &mut stderr, &result.diagnostic);
 
     Ok(ExecResult {
         termination,
@@ -1697,26 +1706,8 @@ fn supervised_exec_result_to_process_exit(
     let (stdout, stdout_truncated) = captured_output_bytes(result.stdout);
     let (mut stderr, stderr_truncated) = captured_output_bytes(result.stderr);
     let termination = process_termination_kind(result.termination);
-    let exit_code = match result.termination {
-        ExecTermination::Exited { exit_code } => exit_code,
-        ExecTermination::TimedOut => {
-            if stderr.is_empty() {
-                stderr.extend_from_slice(b"Timeout");
-            }
-            EXEC_TIMEOUT_EXIT_CODE
-        }
-        ExecTermination::Cancelled => {
-            if stderr.is_empty() {
-                stderr.extend_from_slice(b"Cancelled");
-            }
-            append_diagnostic(&mut stderr, &result.diagnostic);
-            1
-        }
-        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
-            append_diagnostic(&mut stderr, &result.diagnostic);
-            1
-        }
-    };
+    let exit_code =
+        legacy_exit_code_for_exec_termination(result.termination, &mut stderr, &result.diagnostic);
 
     ProcessExit {
         pid,
@@ -5309,10 +5300,18 @@ mod tests {
 
     #[test]
     fn bounded_exec_result_to_exec_result_maps_terminal_edge_states() {
-        for (termination, diagnostic, expected_code, expected_stderr, expected_termination) in [
+        for (
+            termination,
+            diagnostic,
+            input_stderr,
+            expected_code,
+            expected_stderr,
+            expected_termination,
+        ) in [
             (
                 ExecTermination::TimedOut,
                 "",
+                Vec::new(),
                 EXEC_TIMEOUT_EXIT_CODE,
                 "Timeout",
                 ProcessTerminationKind::TimedOut,
@@ -5320,6 +5319,7 @@ mod tests {
             (
                 ExecTermination::Cancelled,
                 "cancel diagnostic",
+                Vec::new(),
                 1,
                 "Cancelled\ncancel diagnostic",
                 ProcessTerminationKind::Cancelled,
@@ -5327,6 +5327,7 @@ mod tests {
             (
                 ExecTermination::StartFailed,
                 "spawn failed",
+                Vec::new(),
                 1,
                 "spawn failed",
                 ProcessTerminationKind::StartFailed,
@@ -5334,8 +5335,9 @@ mod tests {
             (
                 ExecTermination::WaitFailed,
                 "wait failed",
+                b"stderr clue".to_vec(),
                 1,
-                "wait failed",
+                "stderr clue\nwait failed",
                 ProcessTerminationKind::WaitFailed,
             ),
         ] {
@@ -5347,7 +5349,7 @@ mod tests {
                     truncated: false,
                 },
                 stderr: ExecOwnedCapturedOutput::Captured {
-                    bytes: Vec::new(),
+                    bytes: input_stderr,
                     truncated: false,
                 },
                 diagnostic: diagnostic.to_string(),

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1068,13 +1068,7 @@ impl MockSandbox {
 }
 
 fn default_exec_result() -> ExecResult {
-    ExecResult {
-        exit_code: 0,
-        stdout: Vec::new(),
-        stderr: Vec::new(),
-        stdout_truncated: false,
-        stderr_truncated: false,
-    }
+    ExecResult::new(0, Vec::new(), Vec::new())
 }
 
 fn apply_exec_output_limits(mut result: ExecResult, limits: ExecOutputLimits) -> ExecResult {
@@ -1195,6 +1189,7 @@ impl Sandbox for MockSandbox {
             {
                 let m = matchers.remove(idx);
                 Ok(ExecResult {
+                    termination: ProcessTerminationKind::Exited,
                     exit_code: m.exit_code,
                     stdout: m.stdout,
                     stderr: m.stderr,
@@ -1931,6 +1926,7 @@ mod tests {
             })
             .await;
         let exec = result.unwrap();
+        assert_eq!(exec.termination, ProcessTerminationKind::Exited);
         assert_eq!(exec.exit_code, 0);
         assert!(exec.stdout.is_empty());
     }
@@ -2062,6 +2058,7 @@ mod tests {
     async fn sandbox_queued_exec_results() {
         let sandbox = MockSandbox::new("test-1");
         sandbox.push_exec_result(Ok(ExecResult {
+            termination: ProcessTerminationKind::WaitFailed,
             exit_code: 42,
             stdout: b"out".to_vec(),
             stderr: b"err".to_vec(),
@@ -2085,6 +2082,7 @@ mod tests {
 
         // First call returns queued result.
         let r1 = sandbox.exec(&req).await.unwrap();
+        assert_eq!(r1.termination, ProcessTerminationKind::WaitFailed);
         assert_eq!(r1.exit_code, 42);
         assert_eq!(r1.stdout, b"out");
 
@@ -2094,6 +2092,7 @@ mod tests {
 
         // Third call falls back to default (exit 0).
         let r3 = sandbox.exec(&req).await.unwrap();
+        assert_eq!(r3.termination, ProcessTerminationKind::Exited);
         assert_eq!(r3.exit_code, 0);
     }
 
@@ -2472,6 +2471,7 @@ mod tests {
         assert!(result.stdout_truncated);
         assert_eq!(result.stderr, b"stde");
         assert!(result.stderr_truncated);
+        assert_eq!(result.termination, ProcessTerminationKind::Exited);
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2058,10 +2058,18 @@ mod tests {
     async fn sandbox_queued_exec_results() {
         let sandbox = MockSandbox::new("test-1");
         sandbox.push_exec_result(Ok(ExecResult {
-            termination: ProcessTerminationKind::WaitFailed,
+            termination: ProcessTerminationKind::Exited,
             exit_code: 42,
             stdout: b"out".to_vec(),
             stderr: b"err".to_vec(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        }));
+        sandbox.push_exec_result(Ok(ExecResult {
+            termination: ProcessTerminationKind::WaitFailed,
+            exit_code: 1,
+            stdout: Vec::new(),
+            stderr: b"wait failed".to_vec(),
             stdout_truncated: false,
             stderr_truncated: false,
         }));
@@ -2082,18 +2090,24 @@ mod tests {
 
         // First call returns queued result.
         let r1 = sandbox.exec(&req).await.unwrap();
-        assert_eq!(r1.termination, ProcessTerminationKind::WaitFailed);
+        assert_eq!(r1.termination, ProcessTerminationKind::Exited);
         assert_eq!(r1.exit_code, 42);
         assert_eq!(r1.stdout, b"out");
 
-        // Second call returns queued error.
-        let r2 = sandbox.exec(&req).await;
-        assert!(r2.is_err());
+        // Second call preserves a queued non-exited terminal state.
+        let r2 = sandbox.exec(&req).await.unwrap();
+        assert_eq!(r2.termination, ProcessTerminationKind::WaitFailed);
+        assert_eq!(r2.exit_code, 1);
+        assert_eq!(r2.stderr, b"wait failed");
 
-        // Third call falls back to default (exit 0).
-        let r3 = sandbox.exec(&req).await.unwrap();
-        assert_eq!(r3.termination, ProcessTerminationKind::Exited);
-        assert_eq!(r3.exit_code, 0);
+        // Third call returns queued error.
+        let r3 = sandbox.exec(&req).await;
+        assert!(r3.is_err());
+
+        // Fourth call falls back to default (exit 0).
+        let r4 = sandbox.exec(&req).await.unwrap();
+        assert_eq!(r4.termination, ProcessTerminationKind::Exited);
+        assert_eq!(r4.exit_code, 0);
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -104,7 +104,13 @@ fn duration_ms(timeout: Duration) -> u32 {
 
 /// Result of a bounded command execution.
 pub struct ExecResult {
-    /// Process exit code, or a synthetic code for timeout/cancel failures.
+    /// Structured terminal state reported by the provider.
+    ///
+    /// This is the semantic terminal state. The `exit_code` field remains as a
+    /// temporary legacy projection while callers migrate to structured handling.
+    pub termination: ProcessTerminationKind,
+    /// Process exit code, or a synthetic compatibility code for timeout, cancel,
+    /// start, and wait failures.
     pub exit_code: i32,
     /// Captured stdout bytes, capped by the requested output limit.
     pub stdout: Vec<u8>,
@@ -117,8 +123,10 @@ pub struct ExecResult {
 }
 
 impl ExecResult {
+    /// Construct an ordinary exited-process result.
     pub fn new(exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
         Self {
+            termination: ProcessTerminationKind::Exited,
             exit_code,
             stdout,
             stderr,
@@ -658,6 +666,18 @@ mod tests {
                 queue_capacity: ProcessOutputMode::DEFAULT_QUEUE_CAPACITY,
             }
         );
+    }
+
+    #[test]
+    fn exec_result_new_defaults_to_exited() {
+        let result = ExecResult::new(7, b"out".to_vec(), b"err".to_vec());
+
+        assert_eq!(result.termination, ProcessTerminationKind::Exited);
+        assert_eq!(result.exit_code, 7);
+        assert_eq!(result.stdout, b"out");
+        assert_eq!(result.stderr, b"err");
+        assert!(!result.stdout_truncated);
+        assert!(!result.stderr_truncated);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add structured `termination` to `sandbox::ExecResult` while keeping legacy `exit_code` compatibility fields.
- Route Firecracker bounded `Sandbox::exec` through `exec_operation_capture` and centralize conversion from structured vsock terminal results.
- Update sandbox mocks and focused tests to preserve terminal state through defaults, queues, and output truncation.

Closes #18235.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox exec_result_new_defaults_to_exited`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock sandbox_exec`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock sandbox_default_exec_succeeds`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock sandbox_queued_exec_results`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc bounded_exec_result_to_exec_result`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_download_failure`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- pre-commit hook: cargo fmt, cargo doc, cargo clippy
