### PR TITLE
test: refactor parking cleanup assertions

### DIFF
--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -212,7 +212,6 @@ async fn release_destroy_and_wait_for_successful_completion(
     destroy_gate: &MockLifecycleGate,
     run_id: RunId,
     completion_message: &str,
-    no_error_message: Option<&str>,
 ) {
     destroy_gate.release_one();
     let completion = env
@@ -221,9 +220,10 @@ async fn release_destroy_and_wait_for_successful_completion(
         .await
         .expect(completion_message);
     assert_eq!(completion.exit_code, 0);
-    if let Some(message) = no_error_message {
-        assert!(completion.error.is_none(), "{message}");
-    }
+    assert!(
+        completion.error.is_none(),
+        "parking cleanup should not rewrite job result"
+    );
 }
 
 async fn assert_post_destroy_cleanup(
@@ -338,7 +338,6 @@ async fn assert_workspace_cache_after_late_cancellation(
         &destroy_gate,
         run_id,
         "job should complete after destroy finishes",
-        Some("late cleanup cancellation should not rewrite job result"),
     )
     .await;
 
@@ -429,7 +428,6 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
         &destroy_gate,
         run_id,
         "job should complete after rejected VM destroy",
-        None,
     )
     .await;
 
@@ -501,7 +499,6 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
         &destroy_gate,
         run_id,
         "job should complete after destroy finishes",
-        None,
     )
     .await;
 
@@ -572,7 +569,6 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
         &destroy_gate,
         run_id,
         "job should complete after destroy finishes",
-        Some("late cleanup cancellation should not rewrite job result"),
     )
     .await;
 
@@ -640,7 +636,6 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
         &destroy_gate,
         run_id,
         "job should complete after destroy finishes",
-        Some("late cleanup cancellation should not rewrite job result"),
     )
     .await;
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, mock_run_config_with_overrides, push_job, seed_idle_pool, shutdown,
-    test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
+    MockRunEnv, context_with_session, mock_run_config_with_overrides, push_job, seed_idle_pool,
+    shutdown, test_profiles, wait_budget_count, wait_cancel_handle, wait_cancel_token_removed,
     wait_workspace_cache_sessions,
 };
 use super::support::assert_no_completion_for_run;
@@ -179,6 +179,68 @@ enum LateCancellationPoint {
     BeforeIdlePoolTransfer,
 }
 
+async fn wait_lifecycle_gate_entered(gate: &MockLifecycleGate, message: &str) {
+    assert_eq!(
+        gate.wait_entered(1, Duration::from_secs(5))
+            .await
+            .expect(message),
+        1
+    );
+}
+
+fn assert_destroy_in_flight(
+    counter: &sandbox_mock::MockSandboxOverrides,
+    budget: &ResourceBudget,
+    expected_budget_count: usize,
+    destroy_message: &str,
+    budget_message: &str,
+) {
+    assert_eq!(counter.destroy_call_count(), 1, "{destroy_message}");
+    assert_eq!(
+        budget.allocated().2,
+        expected_budget_count,
+        "{budget_message}"
+    );
+}
+
+async fn assert_idle_pool_len(idle_pool: &SharedIdlePool, expected_len: usize, message: &str) {
+    assert_eq!(idle_pool.lock().await.len(), expected_len, "{message}");
+}
+
+async fn release_destroy_and_wait_for_successful_completion(
+    env: &MockRunEnv,
+    destroy_gate: &MockLifecycleGate,
+    run_id: RunId,
+    completion_message: &str,
+    no_error_message: Option<&str>,
+) {
+    destroy_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect(completion_message);
+    assert_eq!(completion.exit_code, 0);
+    if let Some(message) = no_error_message {
+        assert!(completion.error.is_none(), "{message}");
+    }
+}
+
+async fn assert_post_destroy_cleanup(
+    budget: &ResourceBudget,
+    idle_pool: &SharedIdlePool,
+    cancel_tokens: Option<&SharedRunCancellationMap>,
+    run_id: RunId,
+    expected_budget_count: usize,
+    expected_idle_len: usize,
+) {
+    wait_budget_count(budget, expected_budget_count, Duration::from_secs(2)).await;
+    if let Some(cancel_tokens) = cancel_tokens {
+        wait_cancel_token_removed(cancel_tokens, run_id, Duration::from_secs(2)).await;
+    }
+    assert_eq!(idle_pool.lock().await.len(), expected_idle_len);
+}
+
 async fn assert_workspace_cache_after_late_cancellation(
     session_id: &str,
     cancellation_point: LateCancellationPoint,
@@ -235,10 +297,7 @@ async fn assert_workspace_cache_after_late_cancellation(
 
     counter.clear_wait_process_lifecycle_gate();
     wait_gate.release_one();
-    park_gate
-        .wait_entered(1, Duration::from_secs(5))
-        .await
-        .expect("sandbox park should enter gate");
+    wait_lifecycle_gate_entered(&park_gate, "sandbox park should enter gate").await;
 
     match cancellation_point {
         LateCancellationPoint::DuringPark => {
@@ -256,15 +315,17 @@ async fn assert_workspace_cache_after_late_cancellation(
         }
     }
 
-    destroy_gate
-        .wait_entered(1, Duration::from_secs(5))
-        .await
-        .expect("cancelled parked sandbox should enter destroy gate");
-    assert_eq!(counter.destroy_call_count(), 1);
-    assert_eq!(
-        budget.allocated().2,
+    wait_lifecycle_gate_entered(
+        &destroy_gate,
+        "cancelled parked sandbox should enter destroy gate",
+    )
+    .await;
+    assert_destroy_in_flight(
+        &counter,
+        &budget,
         1,
-        "cancelled VM must retain budget while destroy is in-flight"
+        "cancelled VM should be sent to destroy exactly once",
+        "cancelled VM must retain budget while destroy is in-flight",
     );
     assert_no_completion_for_run(
         &env,
@@ -272,21 +333,16 @@ async fn assert_workspace_cache_after_late_cancellation(
         "provider.complete must wait until cancelled VM destroy finishes",
     );
 
-    destroy_gate.release_one();
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect("job should complete after destroy finishes");
-    assert_eq!(completion.exit_code, 0);
-    assert!(
-        completion.error.is_none(),
-        "late cleanup cancellation should not rewrite job result"
-    );
+    release_destroy_and_wait_for_successful_completion(
+        &env,
+        &destroy_gate,
+        run_id,
+        "job should complete after destroy finishes",
+        Some("late cleanup cancellation should not rewrite job result"),
+    )
+    .await;
 
-    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
-    wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(2)).await;
-    assert_eq!(idle_pool.lock().await.len(), 0);
+    assert_post_destroy_cleanup(&budget, &idle_pool, Some(&cancel_tokens), run_id, 0, 0).await;
     wait_workspace_cache_sessions(&workspace_cache, &[session_id], Duration::from_secs(2)).await;
 
     shutdown(&env, run_handle).await;
@@ -354,22 +410,13 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
         Some(context_with_session(run_id, "sess-rejected")),
     );
 
-    assert_eq!(
-        destroy_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("pool-full destroy should enter gate"),
-        1
-    );
-    assert_eq!(
-        counter.destroy_call_count(),
-        1,
-        "rejected VM should be sent to destroy"
-    );
-    assert_eq!(
-        budget.allocated().2,
+    wait_lifecycle_gate_entered(&destroy_gate, "pool-full destroy should enter gate").await;
+    assert_destroy_in_flight(
+        &counter,
+        &budget,
         2,
-        "rejected active VM must retain its budget while destroy is in-flight"
+        "rejected VM should be sent to destroy",
+        "rejected active VM must retain its budget while destroy is in-flight",
     );
     assert_no_completion_for_run(
         &env,
@@ -377,13 +424,14 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
         "provider.complete must wait until rejected VM destroy finishes",
     );
 
-    destroy_gate.release_one();
-    let c = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(c.is_some(), "job should complete after rejected VM destroy");
-    assert_eq!(c.unwrap().exit_code, 0);
+    release_destroy_and_wait_for_successful_completion(
+        &env,
+        &destroy_gate,
+        run_id,
+        "job should complete after rejected VM destroy",
+        None,
+    )
+    .await;
 
     wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
     let pool = idle_pool.lock().await;
@@ -416,13 +464,7 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
         Some(context_with_session(run_id, "sess-race-rejected")),
     );
 
-    assert_eq!(
-        park_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("sandbox park should enter gate"),
-        1
-    );
+    wait_lifecycle_gate_entered(&park_gate, "sandbox park should enter gate").await;
     assert_eq!(counter.park_call_count(), 1);
     assert_eq!(env.parking_gate.state(), ParkingState::Open);
 
@@ -430,44 +472,40 @@ async fn parking_gate_closing_after_sandbox_park_rejects_and_waits_for_destroy()
     assert_eq!(env.parking_gate.state(), ParkingState::SoftDraining);
 
     park_gate.release_one();
-    assert_eq!(
-        destroy_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("rejected parked sandbox should enter destroy gate"),
-        1
-    );
-    assert_eq!(
-        counter.destroy_call_count(),
+    wait_lifecycle_gate_entered(
+        &destroy_gate,
+        "rejected parked sandbox should enter destroy gate",
+    )
+    .await;
+    assert_destroy_in_flight(
+        &counter,
+        &budget,
         1,
-        "rejected VM should be sent to destroy exactly once"
+        "rejected VM should be sent to destroy exactly once",
+        "rejected VM must retain budget while destroy is in-flight",
     );
-    assert_eq!(
-        budget.allocated().2,
-        1,
-        "rejected VM must retain budget while destroy is in-flight"
-    );
-    assert_eq!(
-        idle_pool.lock().await.len(),
+    assert_idle_pool_len(
+        &idle_pool,
         0,
-        "closed gate must reject the candidate instead of parking it"
-    );
+        "closed gate must reject the candidate instead of parking it",
+    )
+    .await;
     assert_no_completion_for_run(
         &env,
         run_id,
         "provider.complete must wait until rejected VM destroy finishes",
     );
 
-    destroy_gate.release_one();
-    let c = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(c.is_some(), "job should complete after destroy finishes");
-    assert_eq!(c.unwrap().exit_code, 0);
+    release_destroy_and_wait_for_successful_completion(
+        &env,
+        &destroy_gate,
+        run_id,
+        "job should complete after destroy finishes",
+        None,
+    )
+    .await;
 
-    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
-    assert_eq!(idle_pool.lock().await.len(), 0);
+    assert_post_destroy_cleanup(&budget, &idle_pool, None, run_id, 0, 0).await;
 
     shutdown(&env, run_handle).await;
 }
@@ -496,13 +534,7 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     );
     let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    assert_eq!(
-        park_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("sandbox park should enter gate"),
-        1
-    );
+    wait_lifecycle_gate_entered(&park_gate, "sandbox park should enter gate").await;
     let pool_guard = idle_pool.lock().await;
     park_gate.release_one();
     env.start_observer
@@ -511,41 +543,40 @@ async fn cancellation_while_waiting_for_idle_pool_lock_destroys_instead_of_parki
     cancel_handle.cancel().await;
     drop(pool_guard);
 
-    assert_eq!(
-        destroy_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("cancelled lock-waiting sandbox should enter destroy gate"),
-        1
-    );
-    assert_eq!(
-        counter.destroy_call_count(),
+    wait_lifecycle_gate_entered(
+        &destroy_gate,
+        "cancelled lock-waiting sandbox should enter destroy gate",
+    )
+    .await;
+    assert_destroy_in_flight(
+        &counter,
+        &budget,
         1,
-        "cancelled VM should be sent to destroy exactly once"
+        "cancelled VM should be sent to destroy exactly once",
+        "cancelled VM must retain budget while destroy is in-flight",
     );
-    assert_eq!(
-        budget.allocated().2,
-        1,
-        "cancelled VM must retain budget while destroy is in-flight"
-    );
-    assert_eq!(
-        idle_pool.lock().await.len(),
+    assert_idle_pool_len(
+        &idle_pool,
         0,
-        "cancelled VM must not enter the idle pool after waiting for the lock"
+        "cancelled VM must not enter the idle pool after waiting for the lock",
+    )
+    .await;
+    assert_no_completion_for_run(
+        &env,
+        run_id,
+        "provider.complete must wait until cancelled VM destroy finishes",
     );
 
-    destroy_gate.release_one();
-    let c = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect("job should complete after destroy finishes");
-    assert_eq!(c.exit_code, 0);
-    assert!(c.error.is_none());
+    release_destroy_and_wait_for_successful_completion(
+        &env,
+        &destroy_gate,
+        run_id,
+        "job should complete after destroy finishes",
+        Some("late cleanup cancellation should not rewrite job result"),
+    )
+    .await;
 
-    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
-    wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(2)).await;
-    assert_eq!(idle_pool.lock().await.len(), 0);
+    assert_post_destroy_cleanup(&budget, &idle_pool, Some(&cancel_tokens), run_id, 0, 0).await;
 
     shutdown(&env, run_handle).await;
 }
@@ -574,61 +605,46 @@ async fn cancellation_during_sandbox_park_destroys_instead_of_parking() {
     );
     let cancel_handle = wait_cancel_handle(&cancel_tokens, run_id, Duration::from_secs(5)).await;
 
-    assert_eq!(
-        park_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("sandbox park should enter gate"),
-        1
-    );
+    wait_lifecycle_gate_entered(&park_gate, "sandbox park should enter gate").await;
     assert_eq!(counter.park_call_count(), 1);
 
     cancel_handle.cancel().await;
     park_gate.release_one();
 
-    assert_eq!(
-        destroy_gate
-            .wait_entered(1, Duration::from_secs(5))
-            .await
-            .expect("cancelled parked sandbox should enter destroy gate"),
-        1
-    );
-    assert_eq!(
-        counter.destroy_call_count(),
+    wait_lifecycle_gate_entered(
+        &destroy_gate,
+        "cancelled parked sandbox should enter destroy gate",
+    )
+    .await;
+    assert_destroy_in_flight(
+        &counter,
+        &budget,
         1,
-        "cancelled VM should be sent to destroy exactly once"
+        "cancelled VM should be sent to destroy exactly once",
+        "cancelled VM must retain budget while destroy is in-flight",
     );
-    assert_eq!(
-        budget.allocated().2,
-        1,
-        "cancelled VM must retain budget while destroy is in-flight"
-    );
-    assert_eq!(
-        idle_pool.lock().await.len(),
+    assert_idle_pool_len(
+        &idle_pool,
         0,
-        "cancelled VM must not enter the idle pool after park returns"
-    );
+        "cancelled VM must not enter the idle pool after park returns",
+    )
+    .await;
     assert_no_completion_for_run(
         &env,
         run_id,
         "provider.complete must wait until cancelled VM destroy finishes",
     );
 
-    destroy_gate.release_one();
-    let c = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    let c = c.expect("job should complete after destroy finishes");
-    assert_eq!(c.exit_code, 0);
-    assert!(
-        c.error.is_none(),
-        "late cleanup cancellation should not rewrite job result"
-    );
+    release_destroy_and_wait_for_successful_completion(
+        &env,
+        &destroy_gate,
+        run_id,
+        "job should complete after destroy finishes",
+        Some("late cleanup cancellation should not rewrite job result"),
+    )
+    .await;
 
-    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
-    wait_cancel_token_removed(&cancel_tokens, run_id, Duration::from_secs(2)).await;
-    assert_eq!(idle_pool.lock().await.len(), 0);
+    assert_post_destroy_cleanup(&budget, &idle_pool, Some(&cancel_tokens), run_id, 0, 0).await;
 
     shutdown(&env, run_handle).await;
 }


### PR DESCRIPTION
## Summary

- add local helpers for repeated parking cleanup gate, destroy, completion, and post-destroy assertions
- keep race-specific timing visible in each test body
- reuse the helpers across full-run parking cleanup scenarios without introducing a broad harness

Closes #18243

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner parking_cleanup`
- pre-commit Rust hooks during commit (`cargo-fmt`, `cargo-doc`, `cargo-clippy`)
