### PR TITLE
fix: run guest download for cached instruction normalization

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -18,7 +18,7 @@ use super::diagnostics::{
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{fix_guest_clock, reseed_guest_entropy, sync_guest_timezone};
 use super::session_restore::restore_session;
-use super::storage::{download_storages, filter_unchanged_storages};
+use super::storage::{download_storages, filter_unchanged_storages, guest_download_has_work};
 use super::telemetry::record_api_latency;
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
@@ -166,11 +166,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             Some(prev) => filter_unchanged_storages(&guest_manifest, prev),
             None => guest_manifest,
         };
-        // Short-circuit: skip the vsock exec if every entry was filtered out
-        // and there are no paths to clean up.
-        let has_work = effective.storages.iter().any(|s| s.archive_url.is_some())
-            || effective.artifacts.iter().any(|a| a.archive_url.is_some())
-            || !effective.cleanup_paths.is_empty();
+        // Short-circuit: skip the vsock exec if no downloads, cleanup, or
+        // guest-side instruction normalization remain.
+        let has_work = guest_download_has_work(&effective);
         if !has_work {
             info!(run_id = %context.run_id, "all storages unchanged, skipping download");
         }

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -113,6 +113,16 @@ pub(super) fn filter_unchanged_storages(
     }
 }
 
+pub(super) fn guest_download_has_work(manifest: &GuestDownloadManifest) -> bool {
+    manifest.storages.iter().any(|s| s.archive_url.is_some())
+        || manifest.artifacts.iter().any(|a| a.archive_url.is_some())
+        || !manifest.cleanup_paths.is_empty()
+        || manifest
+            .storages
+            .iter()
+            .any(|s| s.instructions_target_filename.is_some())
+}
+
 /// Download storage volumes into the guest.
 pub(super) fn guest_download_command() -> String {
     format!("{} {}", guest::DOWNLOAD_BIN, guest::STORAGE_MANIFEST)

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -1,17 +1,21 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use api_contracts::generated::types::runners::storage::StorageManifest;
 use sandbox::{ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::MockSandboxFactory;
 
 use super::super::agent_run::{ProcessCancelTimeouts, RunStart, run_in_sandbox};
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
+use super::super::storage::guest_download_command;
 use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT};
 use super::support::{
-    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox,
+    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
     minimal_context, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
     test_executor_config, test_telemetry,
 };
+use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::SandboxReuseResult;
 
 #[tokio::test]
@@ -66,6 +70,56 @@ async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
             chunk_truncated: true,
             stream_overflowed: false,
         }
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    let mut storage = api_storage(
+        "instructions",
+        "/home/user/.codex",
+        "v1",
+        "https://example.com/instructions.tar.gz",
+    );
+    storage.instructions_target_filename = Some("AGENTS.md".into());
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![storage],
+        artifacts: vec![],
+    });
+    let prev_storage = StorageFingerprints {
+        storages: HashMap::from([(
+            "/home/user/.codex".into(),
+            StorageFingerprint::new("instructions", "v1"),
+        )]),
+        artifacts: HashMap::new(),
+    };
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: Some(&prev_storage),
+        },
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let exec_calls = sandbox.exec_calls();
+    assert!(
+        exec_calls
+            .iter()
+            .any(|call| call.cmd == guest_download_command()),
+        "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
 }
 

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -9,6 +9,7 @@ use super::super::guest_runtime_dir;
 use super::super::storage::{
     download_storages, filter_unchanged_storages, format_command_output_excerpt,
     format_guest_download_failure, guest_download_command, guest_download_env,
+    guest_download_has_work,
 };
 use super::support::{minimal_context, sandbox_write_file_error};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
@@ -229,6 +230,65 @@ fn art_fp(mount: &str, name: &str, ver: &str) -> HashMap<String, StorageFingerpr
     let mut m = HashMap::new();
     m.insert(mount.into(), fp(name, ver));
     m
+}
+
+// -----------------------------------------------------------------------
+// guest_download_has_work tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn guest_download_has_work_detects_instruction_normalization_without_archives() {
+    let mut storage = guest_storage("/home/user/.codex", "instructions", "v1", None);
+    storage.instructions_target_filename = Some("AGENTS.md".into());
+    let manifest = GuestDownloadManifest {
+        storages: vec![storage],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+    };
+
+    assert!(guest_download_has_work(&manifest));
+}
+
+#[test]
+fn guest_download_has_work_skips_fully_empty_cached_manifest() {
+    let mut storage = guest_storage("/home/user/.codex", "instructions", "v1", None);
+    storage.cached = true;
+    let manifest = GuestDownloadManifest {
+        storages: vec![storage],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+    };
+
+    assert!(!guest_download_has_work(&manifest));
+}
+
+#[test]
+fn guest_download_has_work_detects_archive_urls_and_cleanup_paths() {
+    let storage_work = GuestDownloadManifest {
+        storages: vec![guest_storage(
+            "/data",
+            "data",
+            "v1",
+            Some("https://s3/data"),
+        )],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+    };
+    assert!(guest_download_has_work(&storage_work));
+
+    let artifact_work = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![guest_art("workspace", "v1", Some("https://s3/workspace"))],
+        cleanup_paths: vec![],
+    };
+    assert!(guest_download_has_work(&artifact_work));
+
+    let cleanup_work = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![],
+        cleanup_paths: vec!["/old".into()],
+    };
+    assert!(guest_download_has_work(&cleanup_work));
 }
 
 #[test]
@@ -585,6 +645,37 @@ fn filter_unchanged_storage_sets_cached_true() {
     let result = filter_unchanged_storages(&manifest, &prev);
     assert!(result.storages[0].cached);
     assert!(result.storages[0].archive_url.is_none());
+}
+
+#[test]
+fn filter_unchanged_storage_leaves_instruction_normalization_work() {
+    let mut storage = guest_storage(
+        "/home/user/.codex",
+        "instructions",
+        "v1",
+        Some("https://s3/instructions"),
+    );
+    storage.instructions_target_filename = Some("AGENTS.md".into());
+    let manifest = GuestDownloadManifest {
+        storages: vec![storage],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::from([("/home/user/.codex".into(), fp("instructions", "v1"))]),
+        artifacts: HashMap::new(),
+    };
+
+    let result = filter_unchanged_storages(&manifest, &prev);
+
+    assert!(result.storages[0].cached);
+    assert!(result.storages[0].archive_url.is_none());
+    assert_eq!(
+        result.storages[0].instructions_target_filename.as_deref(),
+        Some("AGENTS.md")
+    );
+    assert!(result.cleanup_paths.is_empty());
+    assert!(guest_download_has_work(&result));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- include pending storage instruction normalization in the runner guest-download work gate
- keep unchanged storage archives filtered to `archiveUrl: null`, so cached archives are not downloaded again
- add focused runner tests and an executor regression for cached instruction normalization

Closes #18241

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --package runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_runs_guest_download_for_cached_instruction_normalization`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_tests`
- pre-commit hook: `cargo-doc`, `cargo-clippy`
