### PR TITLE
test: assert runner main loop shutdown results

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop.rs
@@ -868,11 +868,12 @@ async fn shutdown_drains_memory_prefetch_before_stopped() {
     release_tx
         .send(())
         .expect("runner should still be waiting for prefetch release");
-    let result = tokio::time::timeout(Duration::from_secs(5), run_handle)
-        .await
-        .expect("run should finish after memory prefetch drains")
-        .expect("task should not panic");
-    assert!(result.is_ok());
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "run should finish after memory prefetch drains",
+    )
+    .await;
     wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
 }
 
@@ -931,11 +932,12 @@ async fn drain_then_resume_keeps_jobs_running() {
     // Tear down hard — the shared gate would otherwise block the
     // second job's natural completion during Draining.
     env.trigger_stopping().await;
-    let result = tokio::time::timeout(Duration::from_secs(5), run_handle)
-        .await
-        .expect("run should exit within 5s after hard shutdown")
-        .expect("task should not panic");
-    assert!(result.is_ok());
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "run should exit within 5s after hard shutdown",
+    )
+    .await;
 }
 
 /// Regression guard for the unified reactor's Draining-entry state.
@@ -1055,7 +1057,12 @@ async fn heartbeat_fires_while_draining() {
 
     // Tear down hard — the gate would block natural completion.
     env.trigger_stopping().await;
-    let _ = tokio::time::timeout(Duration::from_secs(5), run_handle).await;
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should exit within 5s after Draining heartbeat check",
+    )
+    .await;
 }
 
 /// Invariant: heartbeat ticks must fire while the unified reactor is
@@ -1426,7 +1433,12 @@ async fn claim_after_stopping_sent_cancels_new_job() {
         *v = RunnerMode::Stopping;
     });
     env.cancel.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(5), run_handle).await;
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "run should exit within 5s after Stopping notification",
+    )
+    .await;
 }
 
 /// SIGUSR2 received while Stopping is committed is ignored — the
@@ -1626,7 +1638,12 @@ async fn draining_auto_stop_preserves_concurrent_resume() {
 
     // Tear down cleanly.
     env.trigger_stopping().await;
-    let _ = tokio::time::timeout(Duration::from_secs(5), run_handle).await;
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should exit within 5s after concurrent resume race",
+    )
+    .await;
 }
 
 // -----------------------------------------------------------------------

--- a/crates/runner/src/cmd/start/tests/support/jobs.rs
+++ b/crates/runner/src/cmd/start/tests/support/jobs.rs
@@ -1,5 +1,6 @@
 use super::super::super::*;
 use super::env::MockRunEnv;
+use super::wait::assert_run_exits_within;
 use crate::provider::JobCandidate;
 use crate::test_fixtures::execution_context_for_test;
 
@@ -30,11 +31,12 @@ pub(in super::super) async fn shutdown(
 ) {
     env.drain();
     env.cancel.cancel();
-    let result = tokio::time::timeout(Duration::from_secs(10), run_handle)
-        .await
-        .expect("run should finish within 10s")
-        .expect("task should not panic");
-    assert!(result.is_ok());
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(10),
+        "run should finish within 10s",
+    )
+    .await;
 }
 
 /// ExecutionContext with a resume_session for idle pool testing.

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -35,11 +35,16 @@ pub(in super::super) async fn assert_run_exits_within(
     timeout: Duration,
     timeout_msg: &str,
 ) {
-    match tokio::time::timeout(timeout, run_handle).await {
+    let mut run_handle = run_handle;
+    match tokio::time::timeout(timeout, &mut run_handle).await {
         Ok(Ok(Ok(()))) => {}
         Ok(Ok(Err(e))) => panic!("run() returned error: {e}"),
         Ok(Err(e)) => panic!("task panicked: {e}"),
-        Err(_) => panic!("{timeout_msg}"),
+        Err(_) => {
+            run_handle.abort();
+            let _ = tokio::time::timeout(Duration::from_secs(1), run_handle).await;
+            panic!("{timeout_msg}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace ignored main-loop shutdown timeout waits with assert_run_exits_within so timeout, panic, and runner errors fail the test
- Reuse the same helper for nearby direct run_handle joins and the shared test shutdown helper
- Abort the runner task after a shutdown assertion timeout so failing tests do not leave a detached run task behind
- Keep the change test-only; no runner production behavior changes

Closes #18246

## Testing
- cargo test --manifest-path crates/Cargo.toml -p runner heartbeat_fires_while_draining
- cargo test --manifest-path crates/Cargo.toml -p runner claim_after_stopping_sent_cancels_new_job
- cargo test --manifest-path crates/Cargo.toml -p runner draining_auto_stop_preserves_concurrent_resume
- cargo test --manifest-path crates/Cargo.toml -p runner shutdown_drains_memory_prefetch_before_stopped
- cargo test --manifest-path crates/Cargo.toml -p runner drain_then_resume_keeps_jobs_running
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::budget
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::failure_recovery
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests
- cargo fmt --manifest-path crates/runner/Cargo.toml --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- lefthook pre-commit: cargo-fmt, cargo-clippy, cargo-doc
- lefthook commit-msg: commitlint
