### PR TITLE
ci: clean stale keepalive runner state

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1641,55 +1641,17 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-          EVENT_NAME: ${{ github.event_name }}
           BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
           DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
-          KEEPALIVE_REF="${JOB_REF}-r${RUN_ID}-a${RUN_ATTEMPT}"
-          SVC="${KEEPALIVE_REF}-keepalive"
-          GROUP="vm0/keepalive-${KEEPALIVE_REF}"
+          SVC="${JOB_REF}-keepalive"
+          GROUP="vm0/keepalive-${JOB_REF}"
           RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
-          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${KEEPALIVE_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${JOB_REF}"
 
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "=== Cleaning previous isolated keep-alive attempts for this PR ==="
-            ssh "$REMOTE" bash -s -- "${JOB_REF}" "${SVC}" "keepalive-${KEEPALIVE_REF}" <<'REMOTE_SCRIPT'
-          set -euo pipefail
-          JOB_REF=$1; CURRENT_SVC=$2; CURRENT_GROUP_DIRNAME=$3
-
-          while read -r unit _; do
-            case "$unit" in
-              vm0-runner-${JOB_REF}-r*-a*-keepalive.service)
-                svc="${unit#vm0-runner-}"
-                svc="${svc%.service}"
-                if [ "$svc" != "$CURRENT_SVC" ]; then
-                  sudo systemctl stop "$unit" || true
-                  sudo systemctl reset-failed "$unit" || true
-                fi
-                ;;
-            esac
-          done < <(systemctl list-units "vm0-runner-${JOB_REF}-r*-a*-keepalive.service" --all --no-legend --plain || true)
-
-          if [ -d /var/lib/vm0-runner/runners ]; then
-            sudo find /var/lib/vm0-runner/runners \
-              -mindepth 1 -maxdepth 1 -type d \
-              -name "${JOB_REF}-r*-a*-keepalive" ! -name "$CURRENT_SVC" \
-              -exec rm -rf {} +
-          fi
-          if [ -d /var/lib/vm0-runner/groups/vm0 ]; then
-            sudo find /var/lib/vm0-runner/groups/vm0 \
-              -mindepth 1 -maxdepth 1 -type d \
-              -name "keepalive-${JOB_REF}-r*-a*" ! -name "$CURRENT_GROUP_DIRNAME" \
-              -exec rm -rf {} +
-          fi
-          REMOTE_SCRIPT
-          fi
-
-          echo "=== Cleaning existing keep-alive runner state for this run ==="
+          echo "=== Cleaning stale keep-alive runner state ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'
           set -euo pipefail
           BIN_DIR=$1; SVC=$2; GROUP_DIR=$3; RUNNER_DIR=$4

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1761,7 +1761,7 @@ jobs:
           echo "--- runner doctor --name $SVC (expect 0 warnings) ---"
           DOCTOR_OUT=$(sudo "$BIN_DIR/runner" doctor --name "$SVC" 2>&1 || true)
           echo "$DOCTOR_OUT"
-          if ! echo "$DOCTOR_OUT" | grep -q '^0 warning(s) found$'; then
+          if ! grep -q '^0 warning(s) found$' <<<"$DOCTOR_OUT"; then
             fail "runner doctor reported warnings with parked idle VMs — regression for #9552"
           fi
           echo "PASS: runner doctor clean with parked VMs"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1643,6 +1643,7 @@ jobs:
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          EVENT_NAME: ${{ github.event_name }}
           BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
           DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
@@ -1653,6 +1654,40 @@ jobs:
           GROUP="vm0/keepalive-${KEEPALIVE_REF}"
           RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
           GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${KEEPALIVE_REF}"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "=== Cleaning previous isolated keep-alive attempts for this PR ==="
+            ssh "$REMOTE" bash -s -- "${JOB_REF}" "${SVC}" "keepalive-${KEEPALIVE_REF}" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          JOB_REF=$1; CURRENT_SVC=$2; CURRENT_GROUP_DIRNAME=$3
+
+          while read -r unit _; do
+            case "$unit" in
+              vm0-runner-${JOB_REF}-r*-a*-keepalive.service)
+                svc="${unit#vm0-runner-}"
+                svc="${svc%.service}"
+                if [ "$svc" != "$CURRENT_SVC" ]; then
+                  sudo systemctl stop "$unit" || true
+                  sudo systemctl reset-failed "$unit" || true
+                fi
+                ;;
+            esac
+          done < <(systemctl list-units "vm0-runner-${JOB_REF}-r*-a*-keepalive.service" --all --no-legend --plain || true)
+
+          if [ -d /var/lib/vm0-runner/runners ]; then
+            sudo find /var/lib/vm0-runner/runners \
+              -mindepth 1 -maxdepth 1 -type d \
+              -name "${JOB_REF}-r*-a*-keepalive" ! -name "$CURRENT_SVC" \
+              -exec rm -rf {} +
+          fi
+          if [ -d /var/lib/vm0-runner/groups/vm0 ]; then
+            sudo find /var/lib/vm0-runner/groups/vm0 \
+              -mindepth 1 -maxdepth 1 -type d \
+              -name "keepalive-${JOB_REF}-r*-a*" ! -name "$CURRENT_GROUP_DIRNAME" \
+              -exec rm -rf {} +
+          fi
+          REMOTE_SCRIPT
+          fi
 
           echo "=== Cleaning existing keep-alive runner state for this run ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1684,6 +1684,7 @@ jobs:
 
           echo "=== Running keep-alive test ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
+          set -euo pipefail
           BIN_DIR=$1; JOB_REF=$2
           RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-keepalive"
           SVC="${JOB_REF}-keepalive"
@@ -1706,6 +1707,7 @@ jobs:
           cleanup() {
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            wait_for_unit_inactive
             sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
           }
           trap cleanup EXIT

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1709,7 +1709,7 @@ jobs:
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit or local queue files for this isolated run name.
+          # Clean up any residual transient unit or local queue files for this keep-alive runner.
           # stop() returns Ok when no service exists, so no need for || true.
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
           wait_for_unit_inactive

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1641,16 +1641,20 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
           DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
-          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-keepalive"
-          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${JOB_REF}"
-          SVC="${JOB_REF}-keepalive"
+          KEEPALIVE_REF="${JOB_REF}-r${RUN_ID}-a${RUN_ATTEMPT}"
+          SVC="${KEEPALIVE_REF}-keepalive"
+          GROUP="vm0/keepalive-${KEEPALIVE_REF}"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${KEEPALIVE_REF}"
 
-          echo "=== Cleaning stale keep-alive runner state ==="
+          echo "=== Cleaning existing keep-alive runner state for this run ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'
           set -euo pipefail
           BIN_DIR=$1; SVC=$2; GROUP_DIR=$3; RUNNER_DIR=$4
@@ -1675,22 +1679,18 @@ jobs:
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
-            --name ${JOB_REF}-keepalive \
-            --group vm0/keepalive-${JOB_REF} \
-            --runner-dirname ${JOB_REF}-keepalive \
+            --name ${SVC} \
+            --group ${GROUP} \
+            --runner-dirname ${SVC} \
             --max-concurrent 2 \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
           echo "=== Running keep-alive test ==="
-          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
+          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP}" "${RUNNER_DIR}" "${GROUP_DIR}" <<'REMOTE_SCRIPT'
           set -euo pipefail
-          BIN_DIR=$1; JOB_REF=$2
-          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-keepalive"
-          SVC="${JOB_REF}-keepalive"
+          BIN_DIR=$1; SVC=$2; GROUP=$3; RUNNER_DIR=$4; GROUP_DIR=$5
           UNIT="vm0-runner-${SVC}.service"
-          GROUP="vm0/keepalive-${JOB_REF}"
-          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${JOB_REF}"
           SESSION_ID="e2e-keepalive-test-session"
 
           fail() { echo "FAIL: $1"; exit 1; }
@@ -1712,7 +1712,7 @@ jobs:
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit or local queue files from a previous CI run.
+          # Clean up any residual transient unit or local queue files for this isolated run name.
           # stop() returns Ok when no service exists, so no need for || true.
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
           wait_for_unit_inactive

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1646,6 +1646,28 @@ jobs:
           DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-keepalive"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${JOB_REF}"
+          SVC="${JOB_REF}-keepalive"
+
+          echo "=== Cleaning stale keep-alive runner state ==="
+          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${SVC}" "${GROUP_DIR}" "${RUNNER_DIR}" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+          BIN_DIR=$1; SVC=$2; GROUP_DIR=$3; RUNNER_DIR=$4
+          UNIT="vm0-runner-${SVC}.service"
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+          for _ in $(seq 1 30); do
+            if ! sudo systemctl is-active --quiet "$UNIT"; then
+              break
+            fi
+            sleep 1
+          done
+          if sudo systemctl is-active --quiet "$UNIT"; then
+            echo "FAIL: ${UNIT} is still active after cleanup stop" >&2
+            exit 1
+          fi
+          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+          REMOTE_SCRIPT
 
           echo "=== Generating config ==="
           # shellcheck disable=SC2029
@@ -1665,20 +1687,34 @@ jobs:
           BIN_DIR=$1; JOB_REF=$2
           RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-keepalive"
           SVC="${JOB_REF}-keepalive"
+          UNIT="vm0-runner-${SVC}.service"
           GROUP="vm0/keepalive-${JOB_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/keepalive-${JOB_REF}"
           SESSION_ID="e2e-keepalive-test-session"
 
           fail() { echo "FAIL: $1"; exit 1; }
+          wait_for_unit_inactive() {
+            for _ in $(seq 1 30); do
+              if ! sudo systemctl is-active --quiet "$UNIT"; then
+                return 0
+              fi
+              sleep 1
+            done
+            fail "$UNIT is still active after stop"
+          }
 
           cleanup() {
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
           }
           trap cleanup EXIT
 
-          # Clean up any residual transient unit from a previous CI run.
+          # Clean up any residual transient unit or local queue files from a previous CI run.
           # stop() returns Ok when no service exists, so no need for || true.
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          wait_for_unit_inactive
+          sudo rm -rf "$GROUP_DIR"
 
           # Start transient runner service
           echo "--- Starting runner ---"
@@ -1730,6 +1766,8 @@ jobs:
 
           # Stop transient service (drains idle pool)
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          wait_for_unit_inactive
+          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
           trap - EXIT
 
           echo "=== Keep-alive test passed ==="

--- a/ansible/playbooks/cleanup-crates-runner.yml
+++ b/ansible/playbooks/cleanup-crates-runner.yml
@@ -72,37 +72,9 @@
       command: systemctl stop vm0-runner-{{ job_ref }}-keepalive.service
       ignore_errors: true
 
-    - name: Find isolated keepalive transient services
-      shell: >
-        systemctl list-units 'vm0-runner-{{ job_ref }}-r*-a*-keepalive.service' --all --no-legend --plain
-        | awk '{print $1}'
-        | grep -E '^vm0-runner-{{ job_ref }}-r[0-9]+-a[0-9]+-keepalive\.service$' || true
-      register: isolated_keepalive_services
-      changed_when: false
-      ignore_errors: true
-
-    - name: Stop isolated keepalive transient services
-      command: systemctl stop {{ item }}
-      loop: "{{ isolated_keepalive_services.stdout_lines | default([]) }}"
-      ignore_errors: true
-
     - name: Reload systemd daemon
       command: systemctl daemon-reload
       ignore_errors: true
-
-    - name: Find isolated keepalive runner directories
-      find:
-        paths: "{{ base_dir }}/runners"
-        file_type: directory
-        patterns: "{{ job_ref }}-r*-a*-keepalive"
-      register: isolated_keepalive_runner_dirs
-
-    - name: Find isolated keepalive group directories
-      find:
-        paths: "{{ base_dir }}/groups/vm0"
-        file_type: directory
-        patterns: "keepalive-{{ job_ref }}-r*-a*"
-      register: isolated_keepalive_group_dirs
 
     - name: Remove directories
       file:
@@ -125,9 +97,3 @@
         - "{{ base_dir }}/groups/vm0/benchmark-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/upgrade-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/keepalive-{{ job_ref }}"
-
-    - name: Remove isolated keepalive directories
-      file:
-        path: "{{ item.path }}"
-        state: absent
-      loop: "{{ (isolated_keepalive_runner_dirs.files | default([])) + (isolated_keepalive_group_dirs.files | default([])) }}"

--- a/ansible/playbooks/cleanup-crates-runner.yml
+++ b/ansible/playbooks/cleanup-crates-runner.yml
@@ -72,9 +72,37 @@
       command: systemctl stop vm0-runner-{{ job_ref }}-keepalive.service
       ignore_errors: true
 
+    - name: Find isolated keepalive transient services
+      shell: >
+        systemctl list-units 'vm0-runner-{{ job_ref }}-r*-a*-keepalive.service' --all --no-legend --plain
+        | awk '{print $1}'
+        | grep -E '^vm0-runner-{{ job_ref }}-r[0-9]+-a[0-9]+-keepalive\.service$' || true
+      register: isolated_keepalive_services
+      changed_when: false
+      ignore_errors: true
+
+    - name: Stop isolated keepalive transient services
+      command: systemctl stop {{ item }}
+      loop: "{{ isolated_keepalive_services.stdout_lines | default([]) }}"
+      ignore_errors: true
+
     - name: Reload systemd daemon
       command: systemctl daemon-reload
       ignore_errors: true
+
+    - name: Find isolated keepalive runner directories
+      find:
+        paths: "{{ base_dir }}/runners"
+        file_type: directory
+        patterns: "{{ job_ref }}-r*-a*-keepalive"
+      register: isolated_keepalive_runner_dirs
+
+    - name: Find isolated keepalive group directories
+      find:
+        paths: "{{ base_dir }}/groups/vm0"
+        file_type: directory
+        patterns: "keepalive-{{ job_ref }}-r*-a*"
+      register: isolated_keepalive_group_dirs
 
     - name: Remove directories
       file:
@@ -97,3 +125,9 @@
         - "{{ base_dir }}/groups/vm0/benchmark-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/upgrade-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/keepalive-{{ job_ref }}"
+
+    - name: Remove isolated keepalive directories
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ (isolated_keepalive_runner_dirs.files | default([])) + (isolated_keepalive_group_dirs.files | default([])) }}"


### PR DESCRIPTION
## Summary
- keep the existing stable keep-alive runner name and group
- stop the keep-alive runner before regenerating config and wait until systemd reports it inactive
- remove the keep-alive local queue and runner directory before and after the test
- make the remote keep-alive script fail fast so service-start failures cannot continue against stale state
- avoid a pipefail false positive in the runner doctor output check

## Verification
- git diff --check
- python3 YAML parse for .github/workflows/crates.yml
- extracted keep-alive workflow run script and ran bash -n
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/crates.yml