### PR TITLE
fix: use figma pat firewall header

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -998,6 +998,72 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(drained.body.concurrency.active).toBe(0);
   });
 
+  it("uses Figma personal access tokens in the X-Figma-Token firewall header", async () => {
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await connectors.connectManualGrant(actor, "figma", "api-token", {
+      FIGMA_TOKEN: "figd_bdd",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["figma"]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use figma personal access token",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    await expect
+      .poll(
+        async () => {
+          return (await api.pollRunner(runnerGroup)).body.job?.runId;
+        },
+        { timeout: 10_000 },
+      )
+      .toBe(run.runId);
+    const claim = await api.claimRunnerJob(run.runId);
+    const figmaTokenPlaceholder = connectorPlaceholder("figma", "FIGMA_TOKEN");
+    const figmaTokenTemplate = ["$", "{{ secrets.FIGMA_TOKEN }}"].join("");
+
+    expect(claim.environment?.FIGMA_TOKEN).toBe(figmaTokenPlaceholder);
+    expect(claim.secretConnectorMap).toMatchObject({ FIGMA_TOKEN: "figma" });
+
+    const figmaEntry = findFirewallEntry(claim.firewalls, "figma");
+    expect(figmaEntry?.kind).toBe("inline");
+    expect(
+      inlineFirewallApis(claim.firewalls, "figma")[0]?.auth.headers,
+    ).toStrictEqual({
+      "X-Figma-Token": figmaTokenTemplate,
+    });
+
+    if (!claim.encryptedSecrets) {
+      throw new Error("Expected the figma claim to carry encrypted secrets");
+    }
+    const resolved = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          "X-Figma-Token": figmaTokenTemplate,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected the figma firewall auth to resolve");
+    }
+    expect(resolved.body.headers).toStrictEqual({
+      "X-Figma-Token": "figd_bdd",
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  }, 15_000);
+
   it("keeps refresh-owned connector secrets out of the sandbox environment", async () => {
     const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -40,6 +40,7 @@ import {
   getConnectorFirewall,
   getDefaultFirewallPolicies,
   isFirewallConnectorType,
+  type FirewallConnectorType,
 } from "@vm0/connectors/firewalls";
 import { getModelProviderRefreshMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
 import {
@@ -399,6 +400,7 @@ interface ConnectorRuntimeContext {
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly connectorTypes: readonly ConnectorType[];
+  readonly connectorAuthMethods: Partial<Record<ConnectorType, string>>;
   readonly storedEnvironment: Record<string, string> | undefined;
 }
 
@@ -1740,6 +1742,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     vars: undefined,
     secretConnectorMap: undefined,
     connectorTypes: [],
+    connectorAuthMethods: {},
     storedEnvironment: undefined,
   };
 }
@@ -2037,6 +2040,11 @@ async function loadStoredConnectorContext(
       connectorTypes: allowedConnectorRows.map((row) => {
         return row.connectorType;
       }),
+      connectorAuthMethods: Object.fromEntries(
+        allowedConnectorRows.map((row) => {
+          return [row.connectorType, row.authMethod];
+        }),
+      ),
       storedEnvironment: compactRecord(resolved.environment),
     };
   });
@@ -2228,6 +2236,44 @@ function inlineFirewallEntry(
   return { kind: "inline", firewall: runtimeFirewall(firewall) };
 }
 
+interface RuntimeConnectorFirewall {
+  readonly firewall: ExpandedFirewallConfig;
+  readonly inline: boolean;
+}
+
+const FIGMA_API_TOKEN_TEMPLATE = ["$", "{{ secrets.FIGMA_TOKEN }}"].join("");
+const FIGMA_API_TOKEN_AUTH_HEADERS = Object.freeze({
+  "X-Figma-Token": FIGMA_API_TOKEN_TEMPLATE,
+});
+
+function figmaApiTokenFirewall(
+  firewall: ExpandedFirewallConfig,
+): ExpandedFirewallConfig {
+  return {
+    ...firewall,
+    apis: firewall.apis.map((api) => {
+      return {
+        ...api,
+        auth: {
+          ...api.auth,
+          headers: FIGMA_API_TOKEN_AUTH_HEADERS,
+        },
+      };
+    }),
+  };
+}
+
+function runtimeConnectorFirewall(
+  type: FirewallConnectorType,
+  authMethod: string | undefined,
+): RuntimeConnectorFirewall {
+  const firewall = getConnectorFirewall(type);
+  if (type === "figma" && authMethod === "api-token") {
+    return { firewall: figmaApiTokenFirewall(firewall), inline: true };
+  }
+  return { firewall, inline: false };
+}
+
 function applyConnectorPolicies(
   connectorFirewalls: readonly ExpandedFirewallConfig[],
   policies: FirewallPolicies | undefined,
@@ -2308,21 +2354,37 @@ function buildPermissionManifest(args: {
   readonly vars: Record<string, string> | undefined;
   readonly connectorVars?: Record<string, string>;
   readonly connectorTypes?: readonly ConnectorType[];
+  readonly connectorAuthMethods?: Partial<Record<ConnectorType, string>>;
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
 }): PermissionManifest | undefined {
   const connectorTypes =
     args.connectorTypes ??
     Object.keys(args.permissionPolicies ?? {}).filter(isFirewallConnectorType);
   const connectorBaseUrlVars = mergeRecords(args.vars, args.connectorVars);
-  const connectorFirewalls = connectorTypes
+  const runtimeConnectorFirewalls = connectorTypes
     .filter(isFirewallConnectorType)
     .map((type) => {
-      return getConnectorFirewall(type);
+      return runtimeConnectorFirewall(type, args.connectorAuthMethods?.[type]);
     });
+  const connectorFirewalls = runtimeConnectorFirewalls.map(({ firewall }) => {
+    return firewall;
+  });
+  const inlineConnectorFirewallNames = new Set(
+    runtimeConnectorFirewalls
+      .filter(({ inline }) => {
+        return inline;
+      })
+      .map(({ firewall }) => {
+        return firewall.name;
+      }),
+  );
   const connectorManifest = applyConnectorPolicies(
     connectorFirewalls,
     args.permissionPolicies,
     (firewall) => {
+      if (inlineConnectorFirewallNames.has(firewall.name)) {
+        return inlineFirewallEntry(firewall);
+      }
       return builtinFirewallEntry(firewall, connectorBaseUrlVars);
     },
     defaultBuiltinConnectorPolicyForFirewall,
@@ -3129,6 +3191,7 @@ async function buildStoredExecutionContext(args: {
     vars: args.body.vars,
     connectorVars: args.connectorContext.vars,
     connectorTypes: args.connectorContext.connectorTypes,
+    connectorAuthMethods: args.connectorContext.connectorAuthMethods,
     customConnectorFirewalls: args.customConnectorContext.firewalls,
   });
   const executionSecrets = buildStoredExecutionSecrets({
@@ -3889,6 +3952,7 @@ function validateRunEnvironmentReferences(args: {
     vars: args.body.vars,
     connectorVars: args.connectorContext.vars,
     connectorTypes: args.connectorContext.connectorTypes,
+    connectorAuthMethods: args.connectorContext.connectorAuthMethods,
     customConnectorFirewalls: args.customConnectorContext.firewalls,
   });
   const validationSecrets = buildStoredExecutionSecrets({


### PR DESCRIPTION
## Summary
- mount an inline Figma firewall for api-token connections that sends PATs via X-Figma-Token
- preserve the existing OAuth Bearer builtin firewall for Figma OAuth connections
- add run-lifecycle coverage for Figma PAT firewall auth resolution

## Testing
- pnpm exec prettier --write apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
- NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm -F api lint
- NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm -F api check-types
- PGTZ=UTC DATABASE_URL=\"postgresql://postgres@localhost:5432/vm0_test\" pnpm exec vitest run apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t \"uses Figma personal access tokens in the X-Figma-Token firewall header\"