### PR TITLE
fix: add visual text coverage verification prompt

### DIFF
--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts
@@ -88,6 +88,9 @@ describe("zero generate source-backed artifact commands", () => {
       expect(stdout).toContain(
         "The hosted URL is the preview and user-accessible view for this static HTML artifact.",
       );
+      expect(stdout).toContain(
+        "Check that shapes, charts, images, or decorative graphics do not cover readable text",
+      );
     },
   );
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -73,6 +73,9 @@ describe("zero generate presentation command", () => {
     expect(stdout).toContain("establish the deck's arc");
     expect(stdout).toContain("Vary slide forms across the deck");
     expect(stdout).toContain("Each slide carries one idea");
+    expect(stdout).toContain(
+      "Check that shapes, charts, images, or decorative graphics do not cover readable text",
+    );
   });
 
   it("should reject slide counts outside the supported range", async () => {

--- a/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/html-artifact-authoring.ts
@@ -248,6 +248,7 @@ export function createHtmlArtifactAuthoringPacket(
     "- Open the HTML locally and verify it is nonblank.",
     "- Check that keyboard/click interactions work when present.",
     "- Check that text does not overflow or overlap at desktop and mobile viewport sizes.",
+    "- Check that shapes, charts, images, or decorative graphics do not cover readable text at desktop and mobile viewport sizes.",
     "- Run the final hosting command only after the artifact looks correct.",
     "",
     "## Publish",


### PR DESCRIPTION
## Summary
- Add a shared HTML artifact verification reminder that shapes, charts, images, or decorative graphics must not cover readable text
- Keep the existing text overflow/overlap check while making the visual coverage check apply beyond presentations
- Cover the prompt in both source-backed artifact and presentation CLI tests

## Tests
- pnpm -F @vm0/cli test src/commands/zero/generate/__tests__/presentation.test.ts src/commands/zero/generate/__tests__/artifacts.test.ts
- pnpm exec prettier --check apps/cli/src/commands/zero/shared/html-artifact-authoring.ts apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts apps/cli/src/commands/zero/generate/__tests__/artifacts.test.ts