### PR TITLE
fix: render fenced hosted site links as previews

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -59,6 +59,12 @@ type ExtractedPreviewUrl = {
   title?: string;
 };
 
+type OpenMarkdownFence = {
+  marker: "`" | "~";
+  length: number;
+  lines: string[];
+};
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -343,12 +349,13 @@ function hostedSitePublicSlug(hostname: string): string | null {
     return null;
   }
 
+  const normalizedHostname = hostname.toLowerCase();
   const suffix = `.${domain}`;
-  if (!hostname.endsWith(suffix)) {
+  if (!normalizedHostname.endsWith(suffix)) {
     return null;
   }
 
-  const slug = hostname.slice(0, -suffix.length);
+  const slug = normalizedHostname.slice(0, -suffix.length);
   return HOSTED_SITE_SLUG_PATTERN.test(slug) ? slug : null;
 }
 
@@ -466,6 +473,105 @@ function renderExtractedPreviewLine(
   }
 
   return { renderKind: "markdown", line };
+}
+
+function renderFencedHostedSitePreview(
+  contentLines: readonly string[],
+): ExtractedPreviewLineRender | null {
+  const nonEmptyLines = contentLines.filter((line) => {
+    return line.trim().length > 0;
+  });
+  if (nonEmptyLines.length !== 1) {
+    return null;
+  }
+
+  const line = nonEmptyLines[0]!;
+  const extracted = extractPreviewUrlFromLine(line);
+  if (!extracted || !isHostedSiteUrl(extracted.url)) {
+    return null;
+  }
+
+  const rendered = renderExtractedPreviewLine(extracted, line);
+  return rendered.renderKind === "preview" && rendered.preview.kind === "html"
+    ? rendered
+    : null;
+}
+
+type MarkdownFenceLineResult =
+  | {
+      kind: "pending";
+      openFence: OpenMarkdownFence | null;
+    }
+  | {
+      kind: "markdown";
+      openFence: null;
+      lines: readonly string[];
+    }
+  | {
+      kind: "preview";
+      openFence: null;
+      preview: {
+        filename: string;
+        url: string;
+        kind: BodyPreviewKind;
+      };
+    };
+
+function renderOpenMarkdownFence(
+  openFence: OpenMarkdownFence,
+  previews: boolean,
+): MarkdownFenceLineResult {
+  const renderedFence = previews
+    ? renderFencedHostedSitePreview(openFence.lines.slice(1))
+    : null;
+
+  if (renderedFence?.renderKind === "preview") {
+    return {
+      kind: "preview",
+      openFence: null,
+      preview: renderedFence.preview,
+    };
+  }
+
+  return { kind: "markdown", openFence: null, lines: openFence.lines };
+}
+
+function parseMarkdownFenceLine(
+  line: string,
+  openFence: OpenMarkdownFence | null,
+  previews: boolean,
+): MarkdownFenceLineResult | null {
+  const trimmedLine = line.trim();
+  const fenceMatch = trimmedLine.match(/^(`{3,}|~{3,})/);
+  if (!fenceMatch) {
+    if (!openFence) {
+      return null;
+    }
+
+    openFence.lines.push(line);
+    return { kind: "pending", openFence };
+  }
+
+  const fence = fenceMatch[1]!;
+  const marker = fence.startsWith("`") ? "`" : "~";
+  if (!openFence) {
+    return {
+      kind: "pending",
+      openFence: { marker, length: fence.length, lines: [line] },
+    };
+  }
+
+  if (openFence.marker !== marker || fence.length < openFence.length) {
+    openFence.lines.push(line);
+    return { kind: "pending", openFence };
+  }
+
+  const result = renderOpenMarkdownFence(openFence, previews);
+  if (result.kind === "markdown") {
+    return { ...result, lines: [...openFence.lines, line] };
+  }
+
+  return result;
 }
 
 function stripMarkdownLineDecorations(value: string): string {
@@ -703,10 +809,7 @@ export function parseBodyRenderBlocks(
   const keptLines: string[] = [];
   const markdownBuffer: string[] = [];
   let blockSequence = 0;
-  let openFence: {
-    marker: "`" | "~";
-    length: number;
-  } | null = null;
+  let openFence: OpenMarkdownFence | null = null;
   const nextBlockId = (type: BodyRenderBlock["type"]) => {
     blockSequence += 1;
     return `${type}-${blockSequence}`;
@@ -724,29 +827,37 @@ export function parseBodyRenderBlocks(
     markdownBuffer.length = 0;
   };
 
-  for (const [lineIndex, line] of lines.entries()) {
-    const trimmedLine = line.trim();
-    const fenceMatch = trimmedLine.match(/^(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const fence = fenceMatch[1];
-      const marker = fence.startsWith("`") ? "`" : "~";
-      if (
-        openFence &&
-        openFence.marker === marker &&
-        fence.length >= openFence.length
-      ) {
-        openFence = null;
-      } else if (!openFence) {
-        openFence = { marker, length: fence.length };
-      }
-      markdownBuffer.push(line);
-      keptLines.push(line);
-      continue;
-    }
+  const pushMarkdownLines = (nextLines: readonly string[]) => {
+    markdownBuffer.push(...nextLines);
+    keptLines.push(...nextLines);
+  };
 
-    if (openFence) {
-      markdownBuffer.push(line);
-      keptLines.push(line);
+  const pushPreviewBlock = (
+    preview: Extract<MarkdownFenceLineResult, { kind: "preview" }>["preview"],
+  ) => {
+    flushMarkdownBuffer();
+    blocks.push({
+      type: "preview",
+      id: nextBlockId("preview"),
+      preview,
+    });
+  };
+
+  const applyFenceLineResult = (result: MarkdownFenceLineResult) => {
+    openFence = result.openFence;
+    if (result.kind === "markdown") {
+      pushMarkdownLines(result.lines);
+      return;
+    }
+    if (result.kind === "preview") {
+      pushPreviewBlock(result.preview);
+    }
+  };
+
+  for (const [lineIndex, line] of lines.entries()) {
+    const fenceResult = parseMarkdownFenceLine(line, openFence, previews);
+    if (fenceResult) {
+      applyFenceLineResult(fenceResult);
       continue;
     }
 
@@ -785,10 +896,15 @@ export function parseBodyRenderBlocks(
     });
   }
 
+  if (openFence) {
+    applyFenceLineResult(renderOpenMarkdownFence(openFence, previews));
+  }
   flushMarkdownBuffer();
 
+  const cleanContent = keptLines.join("\n").trim();
+
   return {
-    cleanContent: keptLines.join("\n").trim(),
+    cleanContent,
     blocks,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -900,6 +900,9 @@ describe("zero artifact sidebar", () => {
     const jsonUrl = "https://cdn.vm7.io/artifacts/test/run-2/status.json";
     const htmlUrl = "https://cdn.vm7.io/artifacts/test/run-2/site.html";
     const hostedSiteUrl = "https://customer-launch-a1b2c3d4.sites.vm7.io";
+    const fencedHostedSiteUrl = "https://deck-summary-d09dae7b.sites.vm7.io";
+    const openFencedHostedSiteUrl =
+      "https://page-content-pack-d09dae7b.sites.vm7.io";
     const fileUrl = "/artifacts/test/run-2/archive.bin";
 
     setupChatThread({
@@ -913,6 +916,10 @@ describe("zero artifact sidebar", () => {
 ${videoUrl}
 \`\`\`
 
+\`\`\`text
+${fencedHostedSiteUrl}
+\`\`\`
+
 ${imageUrl}
 ${videoUrl}
 [Release notes](${markdownUrl})
@@ -920,11 +927,15 @@ ${videoUrl}
 ${jsonUrl}
 [Launch site](${htmlUrl})
 ${hostedSiteUrl}
-Download the archive here: ${fileUrl}.`,
+Download the archive here: ${fileUrl}.
+
+\`\`\`text
+${openFencedHostedSiteUrl}`,
     });
 
     await waitFor(() => {
       expect(screen.getByText("Table keeps URLs as text")).toBeInTheDocument();
+      expect(screen.getByText(videoUrl)).toBeInTheDocument();
       expect(screen.getByAltText("chart.png")).toBeInTheDocument();
       expect(screen.getByLabelText("Preview demo.mp4")).toBeInTheDocument();
       expect(screen.getByTestId("attachment-preview-markdown")).toHaveAttribute(
@@ -952,9 +963,22 @@ Download the archive here: ${fileUrl}.`,
         "Open html preview for Launch site",
       );
       expect(screen.getByText("Customer Launch")).toBeInTheDocument();
+      expect(screen.getByText("Deck Summary")).toBeInTheDocument();
+      expect(screen.getByText("Page Content Pack")).toBeInTheDocument();
+      const customerLaunchFrame = document.querySelector(
+        'iframe[title="Site preview for Customer Launch"]',
+      );
+      expect(customerLaunchFrame).toBeInTheDocument();
+      expect(customerLaunchFrame).toHaveAttribute(
+        "sandbox",
+        "allow-same-origin allow-scripts",
+      );
+      expect(
+        document.querySelector('iframe[title="Site preview for Deck Summary"]'),
+      ).toBeInTheDocument();
       expect(
         document.querySelector(
-          'iframe[title="Site preview for Customer Launch"]',
+          'iframe[title="Site preview for Page Content Pack"]',
         ),
       ).toBeInTheDocument();
       expect(screen.getByTestId("attachment-preview-file")).toHaveAttribute(

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1003,7 +1003,7 @@ function ArtifactIframeBody({
         focusOnMount={fullscreen}
         src={versionedSrc}
         title={`${filename} preview`}
-        sandbox="allow-scripts"
+        sandbox="allow-same-origin allow-scripts"
         className="h-full w-full border-0 bg-background"
         data-testid={`artifact-sidebar-body-${kind}`}
       />

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -756,7 +756,7 @@ function ArtifactDialogHtmlBody({
         focusOnMount
         src={src}
         title={`${filename} preview`}
-        sandbox="allow-scripts"
+        sandbox="allow-same-origin allow-scripts"
         scrolling="yes"
         className="block h-full w-full border-0 bg-background"
         data-testid="artifact-dialog-body-html"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-preview.tsx
@@ -258,7 +258,7 @@ function HtmlSitePreviewCard({
           <iframe
             src={publicUrl}
             title={`Site preview for ${title}`}
-            sandbox="allow-scripts"
+            sandbox="allow-same-origin allow-scripts"
             tabIndex={-1}
             loading="lazy"
             scrolling="no"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1345,7 +1345,7 @@ function ArtifactPreviewBadge({ file }: { file: ChatThreadArtifactFile }) {
         <iframe
           src={publicUrl}
           title={`${file.filename} artifact thumbnail`}
-          sandbox="allow-scripts"
+          sandbox="allow-same-origin allow-scripts"
           tabIndex={-1}
           loading="lazy"
           scrolling="no"


### PR DESCRIPTION
## Summary
- Render assistant hosted-site URLs inside single-line markdown code fences as HTML site previews
- Preserve regular code blocks and non-hosted-site fenced content as markdown
- Allow same-origin execution in HTML/site preview iframes so hosted-site CSS and JS assets load without opaque-origin CORS failures

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "renders inline previews from assistant artifact links"
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pre-commit: prettier, knip, turbo check-types