### PR TITLE
test(mitm-addon): propagate worker thread failures

### DIFF
--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -7,6 +7,7 @@ import pytest
 
 import mitm_addon
 import usage
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
 
 
 class TestDoneHook:
@@ -90,13 +91,22 @@ class TestDoneHook:
             mitm_addon._handle_runner_usage_flush_signal(0, None)
             assert runner_flush_started.wait(timeout=1)
 
-            done_thread = threading.Thread(target=mitm_addon.done)
-            done_thread.start()
-            assert lock.blocking_acquire_started.wait(timeout=1)
-            assert not shutdown_called.is_set()
+            done_thread = ThreadUnderTest(target=mitm_addon.done)
+            try:
+                done_thread.start()
+                wait_for_event(
+                    lock.blocking_acquire_started,
+                    timeout=1,
+                    threads=(done_thread,),
+                    message="done did not wait for the runner flush lock",
+                )
+                assert not shutdown_called.is_set()
 
-            release_runner_flush.set()
-            done_thread.join(timeout=1)
+                release_runner_flush.set()
+                done_thread.join_and_raise(timeout=1)
+            finally:
+                release_runner_flush.set()
+                done_thread.join(timeout=1)
 
         assert not done_thread.is_alive()
         assert calls == [

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -1,10 +1,10 @@
 """Tests for the asynchronous JSONL writer state machine."""
 
-import queue
 import threading
 from unittest.mock import patch
 
 import jsonl_writer
+from tests.thread_helpers import ThreadUnderTest
 
 
 def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
@@ -28,8 +28,7 @@ def test_flush_prunes_completed_path_state(tmp_path):
     log_path = str(tmp_path / "net.jsonl")
     append_started = threading.Event()
     release_append = threading.Event()
-    flush_thread: threading.Thread | None = None
-    flush_errors: queue.SimpleQueue[Exception] = queue.SimpleQueue()
+    flush_thread: ThreadUnderTest | None = None
     original_append_lines = jsonl_writer._append_lines
 
     def append_lines(path: str, content: bytes) -> None:
@@ -37,34 +36,33 @@ def test_flush_prunes_completed_path_state(tmp_path):
         release_append.wait()
         original_append_lines(path, content)
 
-    def flush_log_path() -> None:
-        try:
-            jsonl_writer.flush_log_path(log_path)
-        except Exception as exc:
-            flush_errors.put(exc)
-
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
             jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
             assert append_started.wait(timeout=1)
 
-            flush_thread = threading.Thread(target=flush_log_path, daemon=True)
+            flush_thread = ThreadUnderTest(
+                target=lambda: jsonl_writer.flush_log_path(log_path),
+                daemon=True,
+            )
             flush_thread.start()
 
             with jsonl_writer._condition:
-                assert jsonl_writer._condition.wait_for(
+                flush_waiter_registered = jsonl_writer._condition.wait_for(
                     lambda: jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 1,
                     timeout=1,
                 )
+            if not flush_waiter_registered:
+                flush_thread.raise_if_failed()
+            assert flush_waiter_registered
         finally:
             release_append.set()
             if flush_thread is not None:
                 flush_thread.join(timeout=1)
 
     assert flush_thread is not None
+    flush_thread.raise_if_failed()
     assert not flush_thread.is_alive()
-    if not flush_errors.empty():
-        raise flush_errors.get_nowait()
 
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
@@ -76,8 +74,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     log_path = str(tmp_path / "net.jsonl")
     append_started = threading.Event()
     release_append = threading.Event()
-    flush_threads: list[threading.Thread] = []
-    flush_errors: queue.SimpleQueue[Exception] = queue.SimpleQueue()
+    flush_threads: list[ThreadUnderTest] = []
     original_append_lines = jsonl_writer._append_lines
 
     def append_lines(path: str, content: bytes) -> None:
@@ -85,39 +82,36 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
         release_append.wait()
         original_append_lines(path, content)
 
-    def flush_log_path() -> None:
-        try:
-            jsonl_writer.flush_log_path(log_path)
-        except Exception as exc:
-            flush_errors.put(exc)
-
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
             jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
             assert append_started.wait(timeout=1)
 
             flush_threads = [
-                threading.Thread(target=flush_log_path, daemon=True),
-                threading.Thread(target=flush_log_path, daemon=True),
+                ThreadUnderTest(target=lambda: jsonl_writer.flush_log_path(log_path), daemon=True),
+                ThreadUnderTest(target=lambda: jsonl_writer.flush_log_path(log_path), daemon=True),
             ]
             for thread in flush_threads:
                 thread.start()
 
             with jsonl_writer._condition:
-                assert jsonl_writer._condition.wait_for(
+                flush_waiters_registered = jsonl_writer._condition.wait_for(
                     lambda: jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 2,
                     timeout=1,
                 )
+            if not flush_waiters_registered:
+                for thread in flush_threads:
+                    thread.raise_if_failed()
+            assert flush_waiters_registered
         finally:
             release_append.set()
             for thread in flush_threads:
                 thread.join(timeout=1)
 
     for thread in flush_threads:
+        thread.raise_if_failed()
         assert not thread.is_alive()
 
-    if not flush_errors.empty():
-        raise flush_errors.get_nowait()
     assert log_path not in jsonl_writer._accepted_by_path
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -61,7 +61,7 @@ def test_flush_prunes_completed_path_state(tmp_path):
                 flush_thread.join(timeout=1)
 
     assert flush_thread is not None
-    flush_thread.raise_if_failed()
+    flush_thread.join_and_raise(timeout=0)
     assert not flush_thread.is_alive()
 
     assert log_path not in jsonl_writer._accepted_by_path
@@ -109,7 +109,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
                 thread.join(timeout=1)
 
     for thread in flush_threads:
-        thread.raise_if_failed()
+        thread.join_and_raise(timeout=0)
         assert not thread.is_alive()
 
     assert log_path not in jsonl_writer._accepted_by_path

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -3,7 +3,6 @@
 import json
 import os
 import queue
-import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +13,7 @@ from tests.registry_helpers import (
     pin_mtime,
     write_simple_registry,
 )
+from tests.thread_helpers import ThreadUnderTest
 
 
 class TestLoadRegistry:
@@ -239,10 +239,11 @@ class TestLoadRegistry:
             with patch.object(registry.ctx, "log", log, create=True):
                 results.put(registry.load_registry_state(str(path)))
 
-        thread = threading.Thread(target=load_state, daemon=True)
+        thread = ThreadUnderTest(target=load_state, daemon=True)
         thread.start()
         thread.join(1)
 
+        thread.raise_if_failed()
         assert not thread.is_alive(), "registry load blocked on FIFO"
         state = results.get_nowait()
         assert isinstance(state, registry.RegistryUnavailable)

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -241,9 +241,8 @@ class TestLoadRegistry:
 
         thread = ThreadUnderTest(target=load_state, daemon=True)
         thread.start()
-        thread.join(1)
+        thread.join_and_raise(1)
 
-        thread.raise_if_failed()
         assert not thread.is_alive(), "registry load blocked on FIFO"
         state = results.get_nowait()
         assert isinstance(state, registry.RegistryUnavailable)

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -13,6 +13,7 @@ import logging_utils
 import mitm_addon
 import usage
 from tests.pending_helpers import assert_pending
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 from tests.usage_helpers import install_recording_usage_timer
 
@@ -399,16 +400,24 @@ class TestRunnerUsageFlushSignal:
             [event(source_key="source-1")],
             proxy_log_path,
         )
-        timer_thread = threading.Thread(target=timers[0].callback)
-        timer_thread_started = False
+        timer_thread = ThreadUnderTest(target=timers[0].callback)
 
         try:
             timer_thread.start()
-            timer_thread_started = True
-            assert timer_enqueue_started.wait(timeout=1)
+            wait_for_event(
+                timer_enqueue_started,
+                timeout=1,
+                threads=(timer_thread,),
+                message="timer enqueue did not start",
+            )
 
             mitm_addon._handle_runner_usage_flush_signal(0, None)
-            assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+            wait_for_event(
+                flush_owner_lock.blocking_acquire_started,
+                timeout=1,
+                threads=(timer_thread,),
+                message="runner flush did not wait for the active timer flush",
+            )
             state_before_release = json.loads(runner_usage_flush_files.pending_path.read_text())
             assert "flushRequestId" not in state_before_release
 
@@ -422,7 +431,7 @@ class TestRunnerUsageFlushSignal:
             assert len(timers) == 2
 
             release_timer_enqueue.set()
-            timer_thread.join(timeout=1)
+            timer_thread.join_and_raise(timeout=1)
             wait_for_usage_flush_worker_to_stop()
 
             assert not timer_thread.is_alive()
@@ -437,8 +446,7 @@ class TestRunnerUsageFlushSignal:
             )
         finally:
             release_timer_enqueue.set()
-            if timer_thread_started:
-                timer_thread.join(timeout=1)
+            timer_thread.join(timeout=1)
             wait_for_usage_flush_worker_to_stop()
 
     def test_signal_retries_failed_active_timer_flush_before_ack_snapshot(
@@ -482,21 +490,29 @@ class TestRunnerUsageFlushSignal:
             except OSError as exc:
                 timer_errors.append(str(exc))
 
-        timer_thread = threading.Thread(target=timer_flush)
-        timer_thread_started = False
+        timer_thread = ThreadUnderTest(target=timer_flush)
 
         try:
             timer_thread.start()
-            timer_thread_started = True
-            assert first_enqueue_started.wait(timeout=1)
+            wait_for_event(
+                first_enqueue_started,
+                timeout=1,
+                threads=(timer_thread,),
+                message="first timer enqueue did not start",
+            )
 
             mitm_addon._handle_runner_usage_flush_signal(0, None)
-            assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+            wait_for_event(
+                flush_owner_lock.blocking_acquire_started,
+                timeout=1,
+                threads=(timer_thread,),
+                message="runner flush did not wait for the failed active timer flush",
+            )
             state_before_release = json.loads(runner_usage_flush_files.pending_path.read_text())
             assert "flushRequestId" not in state_before_release
 
             release_first_enqueue.set()
-            timer_thread.join(timeout=1)
+            timer_thread.join_and_raise(timeout=1)
             wait_for_usage_flush_worker_to_stop()
 
             assert not timer_thread.is_alive()
@@ -515,8 +531,7 @@ class TestRunnerUsageFlushSignal:
             )
         finally:
             release_first_enqueue.set()
-            if timer_thread_started:
-                timer_thread.join(timeout=1)
+            timer_thread.join(timeout=1)
             wait_for_usage_flush_worker_to_stop()
 
     def test_signal_during_active_flush_runs_follow_up_flush(self):

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -68,6 +68,33 @@ def test_wait_for_event_raises_worker_failure_before_timeout_message():
     assert not thread.is_alive()
 
 
+def test_wait_for_event_raises_worker_failure_even_when_event_is_set():
+    event = threading.Event()
+    finished = threading.Event()
+
+    def signal_then_fail() -> None:
+        try:
+            event.set()
+            raise RuntimeError("worker failed after event")
+        finally:
+            finished.set()
+
+    thread = ThreadUnderTest(target=signal_then_fail)
+    thread.start()
+    assert finished.wait(timeout=1)
+
+    with pytest.raises(RuntimeError, match="worker failed after event"):
+        wait_for_event(
+            event,
+            timeout=1,
+            threads=(thread,),
+            message="event was not signaled",
+        )
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+
 def test_join_and_raise_propagates_base_exception_subclasses():
     class WorkerAbort(BaseException):
         pass

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+import builtins
 import threading
 import traceback
 
 import pytest
 
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
+
+_base_exception_group = getattr(builtins, "BaseExceptionGroup", None)
 
 
 def test_join_and_raise_propagates_worker_assertion_with_traceback():
@@ -130,6 +134,53 @@ def test_join_and_raise_propagates_keyboard_interrupt_from_worker():
     thread.start()
 
     with pytest.raises(KeyboardInterrupt):
+        thread.join_and_raise(timeout=1)
+
+    assert not thread.is_alive()
+
+
+def test_join_and_raise_propagates_asyncio_cancelled_error_from_worker():
+    def cancel_worker() -> None:
+        raise asyncio.CancelledError
+
+    thread = ThreadUnderTest(target=cancel_worker)
+    thread.start()
+
+    with pytest.raises(asyncio.CancelledError):
+        thread.join_and_raise(timeout=1)
+
+    assert not thread.is_alive()
+
+
+def test_join_and_raise_propagates_generator_exit_from_worker():
+    def close_worker() -> None:
+        raise GeneratorExit
+
+    thread = ThreadUnderTest(target=close_worker)
+    thread.start()
+
+    with pytest.raises(GeneratorExit):
+        thread.join_and_raise(timeout=1)
+
+    assert not thread.is_alive()
+
+
+@pytest.mark.skipif(
+    _base_exception_group is None,
+    reason="BaseExceptionGroup was added in Python 3.11",
+)
+def test_join_and_raise_propagates_base_exception_group_from_worker():
+    base_exception_group = _base_exception_group
+    assert isinstance(base_exception_group, type)
+    assert issubclass(base_exception_group, BaseException)
+
+    def group_worker() -> None:
+        raise base_exception_group("worker group", [KeyboardInterrupt()])
+
+    thread = ThreadUnderTest(target=group_worker)
+    thread.start()
+
+    with pytest.raises(base_exception_group, match="worker group"):
         thread.join_and_raise(timeout=1)
 
     assert not thread.is_alive()

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -108,6 +108,33 @@ def test_join_and_raise_propagates_pytest_outcome_failures():
     assert not thread.is_alive()
 
 
+def test_join_and_raise_propagates_system_exit_from_worker():
+    def exit_worker() -> None:
+        raise SystemExit(7)
+
+    thread = ThreadUnderTest(target=exit_worker)
+    thread.start()
+
+    with pytest.raises(SystemExit) as exc_info:
+        thread.join_and_raise(timeout=1)
+
+    assert exc_info.value.code == 7
+    assert not thread.is_alive()
+
+
+def test_join_and_raise_propagates_keyboard_interrupt_from_worker():
+    def interrupt_worker() -> None:
+        raise KeyboardInterrupt
+
+    thread = ThreadUnderTest(target=interrupt_worker)
+    thread.start()
+
+    with pytest.raises(KeyboardInterrupt):
+        thread.join_and_raise(timeout=1)
+
+    assert not thread.is_alive()
+
+
 def test_join_and_raise_fails_when_thread_is_still_running():
     started = threading.Event()
     release = threading.Event()

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -132,3 +132,10 @@ def test_join_and_raise_fails_when_thread_is_still_running():
         thread.join(timeout=1)
 
     assert not thread.is_alive()
+
+
+def test_join_and_raise_fails_when_thread_was_not_started():
+    thread = ThreadUnderTest(target=lambda: None)
+
+    with pytest.raises(AssertionError, match="thread was not started"):
+        thread.join_and_raise(timeout=1)

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -95,17 +95,14 @@ def test_wait_for_event_raises_worker_failure_even_when_event_is_set():
     assert not thread.is_alive()
 
 
-def test_join_and_raise_propagates_base_exception_subclasses():
-    class WorkerAbort(BaseException):
-        pass
+def test_join_and_raise_propagates_pytest_outcome_failures():
+    def fail_worker() -> None:
+        pytest.fail("worker pytest failure")
 
-    def abort_worker() -> None:
-        raise WorkerAbort("abort")
-
-    thread = ThreadUnderTest(target=abort_worker)
+    thread = ThreadUnderTest(target=fail_worker)
     thread.start()
 
-    with pytest.raises(WorkerAbort, match="abort"):
+    with pytest.raises(pytest.fail.Exception, match="worker pytest failure"):
         thread.join_and_raise(timeout=1)
 
     assert not thread.is_alive()

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -1,0 +1,84 @@
+"""Tests for thread helper failure propagation."""
+
+from __future__ import annotations
+
+import threading
+import traceback
+
+import pytest
+
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
+
+
+def test_join_and_raise_propagates_worker_assertion_with_traceback():
+    def fail_in_worker() -> None:
+        raise AssertionError("worker assertion failed")
+
+    thread = ThreadUnderTest(target=fail_in_worker)
+    thread.start()
+
+    with pytest.raises(AssertionError, match="worker assertion failed") as exc_info:
+        thread.join_and_raise(timeout=1)
+
+    captured_traceback = exc_info.value.__traceback__
+    assert captured_traceback is not None
+    traceback_functions = [frame.name for frame in traceback.extract_tb(captured_traceback)]
+    assert "fail_in_worker" in traceback_functions
+    assert not thread.is_alive()
+
+
+def test_raise_if_failed_reports_completed_worker_failure_without_joining_first():
+    finished = threading.Event()
+
+    def fail_then_signal() -> None:
+        try:
+            raise RuntimeError("worker failed")
+        finally:
+            finished.set()
+
+    thread = ThreadUnderTest(target=fail_then_signal)
+    thread.start()
+    assert finished.wait(timeout=1)
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        thread.raise_if_failed()
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+
+def test_wait_for_event_raises_worker_failure_before_timeout_message():
+    event = threading.Event()
+
+    def fail_without_signaling() -> None:
+        raise RuntimeError("worker failed before event")
+
+    thread = ThreadUnderTest(target=fail_without_signaling)
+    thread.start()
+
+    with pytest.raises(RuntimeError, match="worker failed before event"):
+        wait_for_event(
+            event,
+            timeout=1,
+            threads=(thread,),
+            message="event was not signaled",
+        )
+
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+
+def test_join_and_raise_propagates_base_exception_subclasses():
+    class WorkerAbort(BaseException):
+        pass
+
+    def abort_worker() -> None:
+        raise WorkerAbort("abort")
+
+    thread = ThreadUnderTest(target=abort_worker)
+    thread.start()
+
+    with pytest.raises(WorkerAbort, match="abort"):
+        thread.join_and_raise(timeout=1)
+
+    assert not thread.is_alive()

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -139,3 +139,17 @@ def test_join_and_raise_fails_when_thread_was_not_started():
 
     with pytest.raises(AssertionError, match="thread was not started"):
         thread.join_and_raise(timeout=1)
+
+
+def test_wait_for_event_fails_when_worker_thread_was_not_started():
+    event = threading.Event()
+    thread = ThreadUnderTest(target=lambda: None)
+    event.set()
+
+    with pytest.raises(AssertionError, match="thread was not started"):
+        wait_for_event(
+            event,
+            timeout=1,
+            threads=(thread,),
+            message="event was not signaled",
+        )

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -82,3 +82,26 @@ def test_join_and_raise_propagates_base_exception_subclasses():
         thread.join_and_raise(timeout=1)
 
     assert not thread.is_alive()
+
+
+def test_join_and_raise_fails_when_thread_is_still_running():
+    started = threading.Event()
+    release = threading.Event()
+
+    def wait_until_released() -> None:
+        started.set()
+        release.wait()
+
+    thread = ThreadUnderTest(target=wait_until_released)
+
+    try:
+        thread.start()
+        assert started.wait(timeout=1)
+
+        with pytest.raises(AssertionError, match="thread did not finish before timeout"):
+            thread.join_and_raise(timeout=0)
+    finally:
+        release.set()
+        thread.join(timeout=1)
+
+    assert not thread.is_alive()

--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
-import builtins
 import threading
 import traceback
 
 import pytest
 
 from tests.thread_helpers import ThreadUnderTest, wait_for_event
-
-_base_exception_group = getattr(builtins, "BaseExceptionGroup", None)
 
 
 def test_join_and_raise_propagates_worker_assertion_with_traceback():
@@ -112,6 +108,22 @@ def test_join_and_raise_propagates_pytest_outcome_failures():
     assert not thread.is_alive()
 
 
+def test_join_and_raise_propagates_custom_base_exception_from_worker():
+    class WorkerAbort(BaseException):
+        pass
+
+    def abort_worker() -> None:
+        raise WorkerAbort("worker aborted")
+
+    thread = ThreadUnderTest(target=abort_worker)
+    thread.start()
+
+    with pytest.raises(WorkerAbort, match="worker aborted"):
+        thread.join_and_raise(timeout=1)
+
+    assert not thread.is_alive()
+
+
 def test_join_and_raise_propagates_system_exit_from_worker():
     def exit_worker() -> None:
         raise SystemExit(7)
@@ -134,53 +146,6 @@ def test_join_and_raise_propagates_keyboard_interrupt_from_worker():
     thread.start()
 
     with pytest.raises(KeyboardInterrupt):
-        thread.join_and_raise(timeout=1)
-
-    assert not thread.is_alive()
-
-
-def test_join_and_raise_propagates_asyncio_cancelled_error_from_worker():
-    def cancel_worker() -> None:
-        raise asyncio.CancelledError
-
-    thread = ThreadUnderTest(target=cancel_worker)
-    thread.start()
-
-    with pytest.raises(asyncio.CancelledError):
-        thread.join_and_raise(timeout=1)
-
-    assert not thread.is_alive()
-
-
-def test_join_and_raise_propagates_generator_exit_from_worker():
-    def close_worker() -> None:
-        raise GeneratorExit
-
-    thread = ThreadUnderTest(target=close_worker)
-    thread.start()
-
-    with pytest.raises(GeneratorExit):
-        thread.join_and_raise(timeout=1)
-
-    assert not thread.is_alive()
-
-
-@pytest.mark.skipif(
-    _base_exception_group is None,
-    reason="BaseExceptionGroup was added in Python 3.11",
-)
-def test_join_and_raise_propagates_base_exception_group_from_worker():
-    base_exception_group = _base_exception_group
-    assert isinstance(base_exception_group, type)
-    assert issubclass(base_exception_group, BaseException)
-
-    def group_worker() -> None:
-        raise base_exception_group("worker group", [KeyboardInterrupt()])
-
-    thread = ThreadUnderTest(target=group_worker)
-    thread.start()
-
-    with pytest.raises(base_exception_group, match="worker group"):
         thread.join_and_raise(timeout=1)
 
     assert not thread.is_alive()

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -8,6 +8,7 @@ import pytest
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_current_pending
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
 from tests.usage_buffer_helpers import RecordingEnqueue, event, flush_log_entries
 from tests.usage_helpers import RecordingTimer, install_recording_usage_timer
 
@@ -129,34 +130,50 @@ def test_shutdown_flush_waits_for_active_timer_flush_and_drains_live_usage(tmp_p
         shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
         shutdown_returned.set()
 
-    timer_thread = threading.Thread(target=timers[0].callback)
-    timer_thread.start()
-    assert timer_enqueue_started.wait(timeout=1)
+    timer_thread = ThreadUnderTest(target=timers[0].callback)
+    shutdown_thread = ThreadUnderTest(target=shutdown_flush)
 
-    shutdown_thread = threading.Thread(target=shutdown_flush)
-    shutdown_thread.start()
-    assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
-    assert not shutdown_returned.is_set()
-    assert enqueue_call_count == 1
+    try:
+        timer_thread.start()
+        wait_for_event(
+            timer_enqueue_started,
+            timeout=1,
+            threads=(timer_thread,),
+            message="timer enqueue did not start",
+        )
 
-    release_timer_enqueue.set()
-    timer_thread.join(timeout=1)
-    shutdown_thread.join(timeout=1)
+        shutdown_thread.start()
+        wait_for_event(
+            flush_owner_lock.blocking_acquire_started,
+            timeout=1,
+            threads=(timer_thread, shutdown_thread),
+            message="shutdown flush did not block on the active timer flush",
+        )
+        assert not shutdown_returned.is_set()
+        assert enqueue_call_count == 1
 
-    assert not timer_thread.is_alive()
-    assert not shutdown_thread.is_alive()
-    assert shutdown_returned.is_set()
-    assert shutdown_results == [1]
-    assert enqueued_runs == ["run-1", "run-2"]
-    assert len(timers) == 2
-    assert timers[1].cancelled is True
-    assert_current_pending(
-        pending_path,
-        flows=0,
-        buffered=0,
-        reports=0,
-        flush_request_id="shutdown-wait-drained",
-    )
+        release_timer_enqueue.set()
+        timer_thread.join_and_raise(timeout=1)
+        shutdown_thread.join_and_raise(timeout=1)
+
+        assert not timer_thread.is_alive()
+        assert not shutdown_thread.is_alive()
+        assert shutdown_returned.is_set()
+        assert shutdown_results == [1]
+        assert enqueued_runs == ["run-1", "run-2"]
+        assert len(timers) == 2
+        assert timers[1].cancelled is True
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="shutdown-wait-drained",
+        )
+    finally:
+        release_timer_enqueue.set()
+        timer_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
 
 
 def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(tmp_path):
@@ -205,35 +222,51 @@ def test_shutdown_flush_retries_active_timer_failure_without_rescheduling_timer(
         shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
         shutdown_returned.set()
 
-    timer_thread = threading.Thread(target=timer_flush)
-    timer_thread.start()
-    assert first_enqueue_started.wait(timeout=1)
+    timer_thread = ThreadUnderTest(target=timer_flush)
+    shutdown_thread = ThreadUnderTest(target=shutdown_flush)
 
-    shutdown_thread = threading.Thread(target=shutdown_flush)
-    shutdown_thread.start()
-    assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
-    assert not shutdown_returned.is_set()
+    try:
+        timer_thread.start()
+        wait_for_event(
+            first_enqueue_started,
+            timeout=1,
+            threads=(timer_thread,),
+            message="first timer enqueue did not start",
+        )
 
-    release_first_enqueue.set()
-    timer_thread.join(timeout=1)
-    shutdown_thread.join(timeout=1)
+        shutdown_thread.start()
+        wait_for_event(
+            flush_owner_lock.blocking_acquire_started,
+            timeout=1,
+            threads=(timer_thread, shutdown_thread),
+            message="shutdown flush did not block on the failed active timer flush",
+        )
+        assert not shutdown_returned.is_set()
 
-    assert not timer_thread.is_alive()
-    assert not shutdown_thread.is_alive()
-    assert timer_errors == ["timer failed"]
-    assert shutdown_results == [1]
-    assert enqueued_run_ids == ["run-1", "run-1"]
-    assert enqueued_idempotency_keys[0] == enqueued_idempotency_keys[1]
-    assert len(timers) == 2
-    assert timers[0].cancelled is True
-    assert timers[1].cancelled is True
-    assert_current_pending(
-        pending_path,
-        flows=0,
-        buffered=0,
-        reports=0,
-        flush_request_id="shutdown-retry-drained",
-    )
+        release_first_enqueue.set()
+        timer_thread.join_and_raise(timeout=1)
+        shutdown_thread.join_and_raise(timeout=1)
+
+        assert not timer_thread.is_alive()
+        assert not shutdown_thread.is_alive()
+        assert timer_errors == ["timer failed"]
+        assert shutdown_results == [1]
+        assert enqueued_run_ids == ["run-1", "run-1"]
+        assert enqueued_idempotency_keys[0] == enqueued_idempotency_keys[1]
+        assert len(timers) == 2
+        assert timers[0].cancelled is True
+        assert timers[1].cancelled is True
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="shutdown-retry-drained",
+        )
+    finally:
+        release_first_enqueue.set()
+        timer_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
 
 
 def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(tmp_path):
@@ -273,45 +306,61 @@ def test_shutdown_flush_drains_usage_deferred_by_threshold_flush_while_waiting(t
         shutdown_results.append(usage.flush_usage_events(trigger="shutdown"))
         shutdown_returned.set()
 
-    timer_thread = threading.Thread(target=timers[0].callback)
-    timer_thread.start()
-    assert timer_enqueue_started.wait(timeout=1)
+    timer_thread = ThreadUnderTest(target=timers[0].callback)
+    shutdown_thread = ThreadUnderTest(target=shutdown_flush)
 
-    shutdown_thread = threading.Thread(target=shutdown_flush)
-    shutdown_thread.start()
-    assert flush_owner_lock.blocking_acquire_started.wait(timeout=1)
+    try:
+        timer_thread.start()
+        wait_for_event(
+            timer_enqueue_started,
+            timeout=1,
+            threads=(timer_thread,),
+            message="timer enqueue did not start",
+        )
 
-    usage.buffer_usage_events(
-        "https://api.test/api/webhooks/agent/usage-event",
-        "token-a",
-        "run-2",
-        [
-            event(source_key=f"source-deferred-{index}", category=f"category-{index}")
-            for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS)
-        ],
-        str(tmp_path / "proxy.jsonl"),
-    )
-    assert not shutdown_returned.is_set()
-    assert len(timers) == 2
+        shutdown_thread.start()
+        wait_for_event(
+            flush_owner_lock.blocking_acquire_started,
+            timeout=1,
+            threads=(timer_thread, shutdown_thread),
+            message="shutdown flush did not block on the active timer flush",
+        )
 
-    release_timer_enqueue.set()
-    timer_thread.join(timeout=1)
-    shutdown_thread.join(timeout=1)
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-2",
+            [
+                event(source_key=f"source-deferred-{index}", category=f"category-{index}")
+                for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS)
+            ],
+            str(tmp_path / "proxy.jsonl"),
+        )
+        assert not shutdown_returned.is_set()
+        assert len(timers) == 2
 
-    assert not timer_thread.is_alive()
-    assert not shutdown_thread.is_alive()
-    assert shutdown_results == [1]
-    assert enqueued_run_ids == ["run-1", "run-2"]
-    assert len(timers) == 2
-    assert timers[0].cancelled is True
-    assert timers[1].cancelled is True
-    assert_current_pending(
-        pending_path,
-        flows=0,
-        buffered=0,
-        reports=0,
-        flush_request_id="shutdown-threshold-drained",
-    )
+        release_timer_enqueue.set()
+        timer_thread.join_and_raise(timeout=1)
+        shutdown_thread.join_and_raise(timeout=1)
+
+        assert not timer_thread.is_alive()
+        assert not shutdown_thread.is_alive()
+        assert shutdown_results == [1]
+        assert enqueued_run_ids == ["run-1", "run-2"]
+        assert len(timers) == 2
+        assert timers[0].cancelled is True
+        assert timers[1].cancelled is True
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="shutdown-threshold-drained",
+        )
+    finally:
+        release_timer_enqueue.set()
+        timer_thread.join(timeout=1)
+        shutdown_thread.join(timeout=1)
 
 
 def test_shutdown_flush_drains_live_usage_buffered_during_own_enqueue(tmp_path):

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -64,6 +64,8 @@ def wait_for_event(
     message: str = "event was not set before timeout",
 ) -> None:
     if event.wait(timeout=timeout):
+        for thread in threads:
+            thread.raise_if_failed()
         return
 
     for thread in threads:

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -33,6 +33,8 @@ class ThreadUnderTest:
     def join_and_raise(self, timeout: float | None = None) -> None:
         self.join(timeout=timeout)
         self.raise_if_failed()
+        if self.is_alive():
+            raise AssertionError("thread did not finish before timeout")
 
     def raise_if_failed(self) -> None:
         failure = self._failure

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -32,9 +32,10 @@ class ThreadUnderTest:
 
     def join_and_raise(self, timeout: float | None = None) -> None:
         self.join(timeout=timeout)
-        self.raise_if_failed()
         if self.is_alive():
+            self.raise_if_failed()
             raise AssertionError("thread did not finish before timeout")
+        self.raise_if_failed()
 
     def raise_if_failed(self) -> None:
         failure = self._failure

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -6,6 +6,8 @@ import threading
 from collections.abc import Callable, Sequence
 from types import TracebackType
 
+import pytest
+
 
 class ThreadUnderTest:
     """Run a short-lived test target and re-raise worker failures on demand."""
@@ -55,7 +57,14 @@ class ThreadUnderTest:
     def _run(self) -> None:
         try:
             self._target()
-        except BaseException as exc:
+        # Pytest outcome exceptions inherit directly from BaseException, so
+        # include them explicitly without catching interpreter control flow.
+        except (
+            Exception,
+            pytest.fail.Exception,
+            pytest.skip.Exception,
+            pytest.xfail.Exception,
+        ) as exc:
             self._failure = (exc, exc.__traceback__)
 
     def _raise_if_not_started(self) -> None:

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -31,8 +31,7 @@ class ThreadUnderTest:
             self._thread.join(timeout=timeout)
 
     def join_and_raise(self, timeout: float | None = None) -> None:
-        if not self._started:
-            raise AssertionError("thread was not started")
+        self._raise_if_not_started()
         self.join(timeout=timeout)
         if self.is_alive():
             self.raise_if_failed()
@@ -40,6 +39,7 @@ class ThreadUnderTest:
         self.raise_if_failed()
 
     def raise_if_failed(self) -> None:
+        self._raise_if_not_started()
         failure = self._failure
         if failure is None:
             return
@@ -57,6 +57,10 @@ class ThreadUnderTest:
             self._target()
         except BaseException as exc:
             self._failure = (exc, exc.__traceback__)
+
+    def _raise_if_not_started(self) -> None:
+        if not self._started:
+            raise AssertionError("thread was not started")
 
 
 def wait_for_event(

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -1,0 +1,70 @@
+"""Helpers for short-lived test-owned threads."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Sequence
+from types import TracebackType
+
+
+class ThreadUnderTest:
+    """Run a short-lived test target and re-raise worker failures on demand."""
+
+    def __init__(
+        self,
+        *,
+        target: Callable[[], None],
+        name: str | None = None,
+        daemon: bool | None = None,
+    ) -> None:
+        self._target = target
+        self._exception: BaseException | None = None
+        self._traceback: TracebackType | None = None
+        self._started = False
+        self._thread = threading.Thread(target=self._run, name=name, daemon=daemon)
+
+    def start(self) -> None:
+        self._thread.start()
+        self._started = True
+
+    def join(self, timeout: float | None = None) -> None:
+        if self._started:
+            self._thread.join(timeout=timeout)
+
+    def join_and_raise(self, timeout: float | None = None) -> None:
+        self.join(timeout=timeout)
+        self.raise_if_failed()
+
+    def raise_if_failed(self) -> None:
+        if self._exception is None:
+            return
+
+        raise self._exception.with_traceback(self._traceback)
+
+    def is_alive(self) -> bool:
+        if not self._started:
+            return False
+        return self._thread.is_alive()
+
+    def _run(self) -> None:
+        try:
+            self._target()
+        except BaseException as exc:
+            self._exception = exc
+            self._traceback = exc.__traceback__
+
+
+def wait_for_event(
+    event: threading.Event,
+    *,
+    timeout: float,
+    threads: Sequence[ThreadUnderTest] = (),
+    message: str = "event was not set before timeout",
+) -> None:
+    if event.wait(timeout=timeout):
+        return
+
+    for thread in threads:
+        thread.raise_if_failed()
+
+    raise AssertionError(message)

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -18,8 +18,7 @@ class ThreadUnderTest:
         daemon: bool | None = None,
     ) -> None:
         self._target = target
-        self._exception: BaseException | None = None
-        self._traceback: TracebackType | None = None
+        self._failure: tuple[BaseException, TracebackType | None] | None = None
         self._started = False
         self._thread = threading.Thread(target=self._run, name=name, daemon=daemon)
 
@@ -36,10 +35,12 @@ class ThreadUnderTest:
         self.raise_if_failed()
 
     def raise_if_failed(self) -> None:
-        if self._exception is None:
+        failure = self._failure
+        if failure is None:
             return
 
-        raise self._exception.with_traceback(self._traceback)
+        exception, traceback = failure
+        raise exception.with_traceback(traceback)
 
     def is_alive(self) -> bool:
         if not self._started:
@@ -50,8 +51,7 @@ class ThreadUnderTest:
         try:
             self._target()
         except BaseException as exc:
-            self._exception = exc
-            self._traceback = exc.__traceback__
+            self._failure = (exc, exc.__traceback__)
 
 
 def wait_for_event(

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -2,11 +2,32 @@
 
 from __future__ import annotations
 
+import asyncio
+import builtins
 import threading
 from collections.abc import Callable, Sequence
 from types import TracebackType
 
 import pytest
+
+_base_exception_group = getattr(builtins, "BaseExceptionGroup", None)
+_BASE_EXCEPTION_GROUPS: tuple[type[BaseException], ...]
+if isinstance(_base_exception_group, type) and issubclass(_base_exception_group, BaseException):
+    _BASE_EXCEPTION_GROUPS = (_base_exception_group,)
+else:
+    _BASE_EXCEPTION_GROUPS = ()
+
+_THREAD_FAILURE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    Exception,
+    pytest.fail.Exception,
+    pytest.skip.Exception,
+    pytest.xfail.Exception,
+    asyncio.CancelledError,
+    GeneratorExit,
+    KeyboardInterrupt,
+    SystemExit,
+    *_BASE_EXCEPTION_GROUPS,
+)
 
 
 class ThreadUnderTest:
@@ -58,16 +79,9 @@ class ThreadUnderTest:
         try:
             self._target()
         # Thread targets run outside pytest's main exception capture. Include
-        # pytest outcomes and interpreter-control exceptions explicitly so a
+        # pytest outcomes and thread-contained BaseException leaves so a
         # terminated worker cannot look like a clean exit to join_and_raise().
-        except (
-            Exception,
-            pytest.fail.Exception,
-            pytest.skip.Exception,
-            pytest.xfail.Exception,
-            SystemExit,
-            KeyboardInterrupt,
-        ) as exc:
+        except _THREAD_FAILURE_EXCEPTIONS as exc:
             self._failure = (exc, exc.__traceback__)
 
     def _raise_if_not_started(self) -> None:

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -57,13 +57,16 @@ class ThreadUnderTest:
     def _run(self) -> None:
         try:
             self._target()
-        # Pytest outcome exceptions inherit directly from BaseException, so
-        # include them explicitly without catching interpreter control flow.
+        # Thread targets run outside pytest's main exception capture. Include
+        # pytest outcomes and interpreter-control exceptions explicitly so a
+        # terminated worker cannot look like a clean exit to join_and_raise().
         except (
             Exception,
             pytest.fail.Exception,
             pytest.skip.Exception,
             pytest.xfail.Exception,
+            SystemExit,
+            KeyboardInterrupt,
         ) as exc:
             self._failure = (exc, exc.__traceback__)
 

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -31,6 +31,8 @@ class ThreadUnderTest:
             self._thread.join(timeout=timeout)
 
     def join_and_raise(self, timeout: float | None = None) -> None:
+        if not self._started:
+            raise AssertionError("thread was not started")
         self.join(timeout=timeout)
         if self.is_alive():
             self.raise_if_failed()

--- a/crates/runner/mitm-addon/tests/thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/thread_helpers.py
@@ -2,32 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-import builtins
 import threading
 from collections.abc import Callable, Sequence
 from types import TracebackType
-
-import pytest
-
-_base_exception_group = getattr(builtins, "BaseExceptionGroup", None)
-_BASE_EXCEPTION_GROUPS: tuple[type[BaseException], ...]
-if isinstance(_base_exception_group, type) and issubclass(_base_exception_group, BaseException):
-    _BASE_EXCEPTION_GROUPS = (_base_exception_group,)
-else:
-    _BASE_EXCEPTION_GROUPS = ()
-
-_THREAD_FAILURE_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    Exception,
-    pytest.fail.Exception,
-    pytest.skip.Exception,
-    pytest.xfail.Exception,
-    asyncio.CancelledError,
-    GeneratorExit,
-    KeyboardInterrupt,
-    SystemExit,
-    *_BASE_EXCEPTION_GROUPS,
-)
 
 
 class ThreadUnderTest:
@@ -78,10 +55,10 @@ class ThreadUnderTest:
     def _run(self) -> None:
         try:
             self._target()
-        # Thread targets run outside pytest's main exception capture. Include
-        # pytest outcomes and thread-contained BaseException leaves so a
-        # terminated worker cannot look like a clean exit to join_and_raise().
-        except _THREAD_FAILURE_EXCEPTIONS as exc:
+        # Thread targets run outside pytest's main exception capture. Capture
+        # every worker termination so join_and_raise() cannot see a failed
+        # worker as a clean exit.
+        except BaseException as exc:
             self._failure = (exc, exc.__traceback__)
 
     def _raise_if_not_started(self) -> None:


### PR DESCRIPTION
## Summary
- add ThreadUnderTest and wait_for_event helpers that capture worker-thread exceptions and re-raise them in the main pytest thread
- migrate short-lived mitm-addon worker-thread tests for shutdown timers, runner flush signals, done hook shutdown, JSONL flushes, and FIFO registry loading
- leave long-lived helper server threads unchanged

## Testing
- /tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_thread_helpers.py tests/test_usage_buffer_timer_shutdown.py tests/test_runner_usage_flush_signal.py tests/test_done_hook.py tests/test_jsonl_writer.py tests/test_registry_loading.py -q
- /tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/ -q
- /tmp/vm0-mitm-addon-venv/bin/ruff format --check .
- /tmp/vm0-mitm-addon-venv/bin/ruff check .
- /tmp/vm0-mitm-addon-venv/bin/basedpyright -p . --pythonpath /tmp/vm0-mitm-addon-venv/bin/python
- git diff --check

Closes #18248