### PR TITLE
feat: add runner local active input forwarding

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -689,7 +689,6 @@ jobs:
             --group "$GROUP" \
             --timeout 180 \
             --cli-agent-type claude-code \
-            --env USE_MOCK_CLAUDE=true \
             --prompt '@active-input-smoke:2' \
             --active-input 'after=1s,text=first' \
             --active-input 'after=2s,text=second' 2>&1); then

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -458,146 +458,6 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
-  runner-local-submit-env-smoke:
-    runs-on: ubuntu-latest
-    needs: [runner-build]
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup SSH via Cloudflare Tunnel
-        uses: ./.github/actions/setup-ssh-tunnel
-        with:
-          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
-          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-
-      - name: Test local submit with real Claude Code
-        env:
-          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
-          HOST: ${{ needs.runner-build.outputs.host }}
-          JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
-          BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
-          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
-          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "::error::CI_ANTHROPIC_API_KEY is required for real Claude local submit smoke"
-            exit 1
-          fi
-
-          REMOTE="${METAL_USER}@${HOST}"
-          {
-            # Keep the CI provider key off SSH/bash argv; the runner CLI still
-            # receives it through --secret-env because that is the behavior
-            # under test.
-            printf 'ANTHROPIC_API_KEY=%q\n' "$ANTHROPIC_API_KEY"
-            cat <<'REMOTE_SCRIPT'
-          set -euo pipefail
-
-          BIN_DIR=$1
-          JOB_REF=$2
-          ROOTFS_HASH=$3
-          SNAPSHOT_HASH=$4
-          OFFICIAL_RUNNER_SECRET=$5
-
-          SVC="${JOB_REF}-local-env"
-          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
-          GROUP="vm0/local-env-${JOB_REF}"
-          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-env-${JOB_REF}"
-
-          fail() {
-            echo "FAIL: $1" >&2
-            exit 1
-          }
-
-          print_service_logs() {
-            echo "--- ${SVC} service logs ---"
-            sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
-          }
-
-          cleanup() {
-            echo "--- Cleanup local env smoke runner ---"
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
-            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
-          }
-          trap cleanup EXIT
-
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
-          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
-
-          echo "--- Generating local runner config ---"
-          sudo "$BIN_DIR/runner" config \
-            --profile vm0/default \
-            --rootfs-hash "$ROOTFS_HASH" \
-            --snapshot-hash "$SNAPSHOT_HASH" \
-            --name "$SVC" \
-            --group "$GROUP" \
-            --runner-dirname "$SVC" \
-            --max-concurrent 1 \
-            --api-url https://not-a-real-server.test \
-            --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
-
-          echo "--- Starting local runner ---"
-          sudo "$BIN_DIR/runner" service start \
-            --name "$SVC" \
-            --config "$RUNNER_DIR/runner.yaml" \
-            --local
-
-          PROMPT='Compute 123+456 and reply with exactly: RESULT=<answer>'
-
-          echo "--- Submitting real Claude Code smoke job ---"
-          if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
-            --group "$GROUP" \
-            --timeout 180 \
-            --cli-agent-type claude-code \
-            --env ANTHROPIC_MODEL=claude-haiku-4-5 \
-            --secret-env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
-            --prompt "$PROMPT" 2>&1); then
-            echo "$SUBMIT_OUTPUT"
-            print_service_logs
-            fail "real Claude Code local submit smoke failed"
-          fi
-          echo "$SUBMIT_OUTPUT"
-
-          SUBMIT_JSON="$(awk '/^\{/{line=$0} END{print line}' <<<"$SUBMIT_OUTPUT")"
-          [ -n "$SUBMIT_JSON" ] || fail "local submit output did not include a JSON response"
-          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")"
-          [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
-          STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
-
-          print_failure_context() {
-            echo "--- Guest stdout stream tail ---"
-            sudo tail -200 "$STREAM_LOG" || true
-            print_service_logs
-          }
-
-          if sudo grep -q 'Using mock-claude for testing' "$STREAM_LOG"; then
-            print_failure_context
-            fail "real Claude Code smoke used mock Claude"
-          fi
-
-          echo "--- Real Claude Code result lines from guest stdout ---"
-          sudo grep -E 'RESULT=579|Claude Code Completed' "$STREAM_LOG" || true
-
-          sudo grep -q 'RESULT=579' "$STREAM_LOG" || {
-            print_failure_context
-            fail "real Claude Code did not return RESULT=579"
-          }
-
-          echo "PASS: local submit ran real Claude Code with Haiku and returned RESULT=579"
-          REMOTE_SCRIPT
-          } | ssh "$REMOTE" bash -s -- \
-            "$BIN_DIR" \
-            "$JOB_REF" \
-            "$DEFAULT_ROOTFS_HASH" \
-            "$DEFAULT_SNAPSHOT_HASH" \
-            "$OFFICIAL_RUNNER_SECRET"
-
   runner-local-active-input-smoke:
     runs-on: ubuntu-latest
     needs: [runner-build]
@@ -612,10 +472,11 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
-      - name: Test local active input with mock Claude
+      - name: Test local active input with real Claude Code
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           HOST: ${{ needs.runner-build.outputs.host }}
           JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
           BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
@@ -624,13 +485,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::CI_ANTHROPIC_API_KEY is required for real Claude active-input smoke"
+            exit 1
+          fi
+
           REMOTE="${METAL_USER}@${HOST}"
-          ssh "$REMOTE" bash -s -- \
-            "$BIN_DIR" \
-            "$JOB_REF" \
-            "$DEFAULT_ROOTFS_HASH" \
-            "$DEFAULT_SNAPSHOT_HASH" \
-            "$OFFICIAL_RUNNER_SECRET" <<'REMOTE_SCRIPT'
+          {
+            # Keep the CI provider key off SSH/bash argv; the runner CLI still
+            # receives it through --secret-env because that is the behavior
+            # under test.
+            printf 'ANTHROPIC_API_KEY=%q\n' "$ANTHROPIC_API_KEY"
+            cat <<'REMOTE_SCRIPT'
           set -euo pipefail
 
           BIN_DIR=$1
@@ -676,25 +542,28 @@ jobs:
             --api-url https://not-a-real-server.test \
             --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
-          echo "--- Starting local runner with mock Claude ---"
+          echo "--- Starting local runner ---"
           sudo "$BIN_DIR/runner" service start \
             --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" \
-            --local \
-            --env USE_MOCK_CLAUDE=true \
-            --env USE_MOCK_CODEX=true
+            --local
+
+          PROMPT='This is a CI smoke test for Claude Code active input. The initial prompt token is ci-initial-5k2. Run Bash command `sleep 3` before your final answer. During that sleep, two follow-up user messages will arrive, each containing one token. After the sleep and after reading both follow-up messages, reply with exactly RESULT=ci-initial-5k2+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
+          EXPECTED_RESULT='RESULT=ci-initial-5k2+ci-active-one-7f3+ci-active-two-9q4'
 
           echo "--- Submitting active-input smoke job ---"
           if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
             --group "$GROUP" \
             --timeout 180 \
             --cli-agent-type claude-code \
-            --prompt '@active-input-smoke:2' \
-            --active-input 'after=10ms,text=first' \
-            --active-input 'after=20ms,text=second' 2>&1); then
+            --env ANTHROPIC_MODEL=claude-haiku-4-5 \
+            --secret-env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+            --prompt "$PROMPT" \
+            --active-input 'after=1s,text=ci-active-one-7f3' \
+            --active-input 'after=2s,text=ci-active-two-9q4' 2>&1); then
             echo "$SUBMIT_OUTPUT"
             print_service_logs
-            fail "mock Claude active-input local submit smoke failed"
+            fail "real Claude Code active-input local submit smoke failed"
           fi
           echo "$SUBMIT_OUTPUT"
 
@@ -710,17 +579,27 @@ jobs:
             print_service_logs
           }
 
-          sudo grep -q 'Using mock-claude for testing' "$STREAM_LOG" || {
+          if sudo grep -q 'Using mock-claude for testing' "$STREAM_LOG"; then
             print_failure_context
-            fail "active-input smoke did not use mock Claude"
-          }
-          sudo grep -q 'RESULT=first+second' "$STREAM_LOG" || {
+            fail "real Claude Code active-input smoke used mock Claude"
+          fi
+
+          echo "--- Real Claude Code active-input result lines from guest stdout ---"
+          sudo grep -E 'RESULT=|filtered_replayed_initial_prompt|filtered_replayed_active_input|Claude Code Completed' "$STREAM_LOG" || true
+
+          sudo grep -F -q "$EXPECTED_RESULT" "$STREAM_LOG" || {
             print_failure_context
-            fail "mock Claude active-input smoke did not return RESULT=first+second"
+            fail "real Claude Code output did not include initial and active-input tokens"
           }
 
-          echo "PASS: local active input reached mock Claude and returned RESULT=first+second"
+          echo "PASS: local active input reached real Claude Code and returned ${EXPECTED_RESULT}"
           REMOTE_SCRIPT
+          } | ssh "$REMOTE" bash -s -- \
+            "$BIN_DIR" \
+            "$JOB_REF" \
+            "$DEFAULT_ROOTFS_HASH" \
+            "$DEFAULT_SNAPSHOT_HASH" \
+            "$OFFICIAL_RUNNER_SECRET"
 
   runner-benchmark:
     runs-on: ubuntu-latest
@@ -1906,7 +1785,6 @@ jobs:
       - api-contracts-rust-bindings
       - mitm-addon-test
       - runner-build
-      - runner-local-submit-env-smoke
       - runner-local-active-input-smoke
       - runner-benchmark
       - runner-exec
@@ -1957,7 +1835,6 @@ jobs:
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
-          check_result "runner-local-submit-env-smoke" "${{ needs.runner-local-submit-env-smoke.result }}" "true"
           check_result "runner-local-active-input-smoke" "${{ needs.runner-local-active-input-smoke.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -598,6 +598,131 @@ jobs:
             "$DEFAULT_SNAPSHOT_HASH" \
             "$OFFICIAL_RUNNER_SECRET"
 
+  runner-local-active-input-smoke:
+    runs-on: ubuntu-latest
+    needs: [runner-build]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Test local active input with mock Claude
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          HOST: ${{ needs.runner-build.outputs.host }}
+          JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+          BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+        run: |
+          set -euo pipefail
+
+          REMOTE="${METAL_USER}@${HOST}"
+          ssh "$REMOTE" bash -s -- \
+            "$BIN_DIR" \
+            "$JOB_REF" \
+            "$DEFAULT_ROOTFS_HASH" \
+            "$DEFAULT_SNAPSHOT_HASH" \
+            "$OFFICIAL_RUNNER_SECRET" <<'REMOTE_SCRIPT'
+          set -euo pipefail
+
+          BIN_DIR=$1
+          JOB_REF=$2
+          ROOTFS_HASH=$3
+          SNAPSHOT_HASH=$4
+          OFFICIAL_RUNNER_SECRET=$5
+
+          SVC="${JOB_REF}-local-active-input"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+          GROUP="vm0/local-active-input-${JOB_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-active-input-${JOB_REF}"
+
+          fail() {
+            echo "FAIL: $1" >&2
+            exit 1
+          }
+
+          print_service_logs() {
+            echo "--- ${SVC} service logs ---"
+            sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
+          }
+
+          cleanup() {
+            echo "--- Cleanup local active-input smoke runner ---"
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+          }
+          trap cleanup EXIT
+
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+
+          echo "--- Generating local runner config ---"
+          sudo "$BIN_DIR/runner" config \
+            --profile vm0/default \
+            --rootfs-hash "$ROOTFS_HASH" \
+            --snapshot-hash "$SNAPSHOT_HASH" \
+            --name "$SVC" \
+            --group "$GROUP" \
+            --runner-dirname "$SVC" \
+            --max-concurrent 1 \
+            --api-url https://not-a-real-server.test \
+            --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+          echo "--- Starting local runner with mock Claude ---"
+          sudo "$BIN_DIR/runner" service start \
+            --name "$SVC" \
+            --config "$RUNNER_DIR/runner.yaml" \
+            --local \
+            --env USE_MOCK_CLAUDE=true \
+            --env USE_MOCK_CODEX=true
+
+          echo "--- Submitting active-input smoke job ---"
+          if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
+            --group "$GROUP" \
+            --timeout 180 \
+            --cli-agent-type claude-code \
+            --env USE_MOCK_CLAUDE=true \
+            --prompt '@active-input-smoke:2' \
+            --active-input 'after=1s,text=first' \
+            --active-input 'after=2s,text=second' 2>&1); then
+            echo "$SUBMIT_OUTPUT"
+            print_service_logs
+            fail "mock Claude active-input local submit smoke failed"
+          fi
+          echo "$SUBMIT_OUTPUT"
+
+          SUBMIT_JSON="$(awk '/^\{/{line=$0} END{print line}' <<<"$SUBMIT_OUTPUT")"
+          [ -n "$SUBMIT_JSON" ] || fail "local submit output did not include a JSON response"
+          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")"
+          [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
+          STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
+
+          print_failure_context() {
+            echo "--- Guest stdout stream tail ---"
+            sudo tail -200 "$STREAM_LOG" || true
+            print_service_logs
+          }
+
+          sudo grep -q 'Using mock-claude for testing' "$STREAM_LOG" || {
+            print_failure_context
+            fail "active-input smoke did not use mock Claude"
+          }
+          sudo grep -q 'RESULT=first+second' "$STREAM_LOG" || {
+            print_failure_context
+            fail "mock Claude active-input smoke did not return RESULT=first+second"
+          }
+
+          echo "PASS: local active input reached mock Claude and returned RESULT=first+second"
+          REMOTE_SCRIPT
+
   runner-benchmark:
     runs-on: ubuntu-latest
     needs: [runner-build]
@@ -1783,6 +1908,7 @@ jobs:
       - mitm-addon-test
       - runner-build
       - runner-local-submit-env-smoke
+      - runner-local-active-input-smoke
       - runner-benchmark
       - runner-exec
       - runner-cancel
@@ -1833,6 +1959,7 @@ jobs:
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
           check_result "runner-local-submit-env-smoke" "${{ needs.runner-local-submit-env-smoke.result }}" "true"
+          check_result "runner-local-active-input-smoke" "${{ needs.runner-local-active-input-smoke.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"
           check_result "runner-cancel" "${{ needs.runner-cancel.result }}" "true"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -690,8 +690,8 @@ jobs:
             --timeout 180 \
             --cli-agent-type claude-code \
             --prompt '@active-input-smoke:2' \
-            --active-input 'after=1s,text=first' \
-            --active-input 'after=2s,text=second' 2>&1); then
+            --active-input 'after=10ms,text=first' \
+            --active-input 'after=20ms,text=second' 2>&1); then
             echo "$SUBMIT_OUTPUT"
             print_service_logs
             fail "mock Claude active-input local submit smoke failed"

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -23,6 +23,7 @@ pub struct ActiveInputFrame {
 pub enum ActiveInputControlOutcome {
     Accepted,
     Rejected { diagnostic: &'static str },
+    QueueFull { diagnostic: &'static str },
     Error { diagnostic: &'static str },
 }
 
@@ -421,7 +422,7 @@ impl ActiveInputController {
             };
         }
         if state.pending_by_uuid.len() >= ACTIVE_INPUT_QUEUE_CAPACITY {
-            return ActiveInputControlOutcome::Rejected {
+            return ActiveInputControlOutcome::QueueFull {
                 diagnostic: "active input queue is full",
             };
         }
@@ -446,7 +447,7 @@ impl ActiveInputController {
             Err(mpsc::error::TrySendError::Full(frame)) => {
                 state.forget_message_id(&frame.message_id);
                 state.remove_pending_by_uuid(&frame.uuid);
-                ActiveInputControlOutcome::Rejected {
+                ActiveInputControlOutcome::QueueFull {
                     diagnostic: "active input queue is full",
                 }
             }
@@ -689,7 +690,7 @@ mod tests {
 
         assert!(matches!(
             controller.handle_control_payload("overflow", br#"{"type":"active-input","text":"hello"}"#),
-            ActiveInputControlOutcome::Rejected { diagnostic } if diagnostic == "active input queue is full"
+            ActiveInputControlOutcome::QueueFull { diagnostic } if diagnostic == "active input queue is full"
         ));
     }
 

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -156,6 +156,10 @@ fn control_response_from_active_input(
             process_control_ipc::ControlResponseStatus::Rejected,
             diagnostic.to_owned(),
         ),
+        ActiveInputControlOutcome::QueueFull { diagnostic } => (
+            process_control_ipc::ControlResponseStatus::QueueFull,
+            diagnostic.to_owned(),
+        ),
         ActiveInputControlOutcome::Error { diagnostic } => (
             process_control_ipc::ControlResponseStatus::Error,
             diagnostic.to_owned(),

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -262,6 +262,73 @@ mod tests {
     }
 
     #[test]
+    fn control_task_reports_queue_full_when_active_input_backlog_is_full() {
+        let nonce = *b"1122334455667788";
+        let endpoint = process_control_ipc::endpoint_name(47, &nonce);
+        let listener = process_control_ipc::bind_abstract_listener(&endpoint).unwrap();
+        let shutdown = CancellationToken::new();
+        let worker_shutdown = shutdown.clone();
+        let stream_slot = Arc::new(Mutex::new(None));
+        let active_runtime = crate::active_input::ActiveInputRuntime::new_with_initial_prompt(
+            "control-test",
+            true,
+            "initial",
+        );
+        let active_input = active_runtime.controller();
+        let worker = thread::spawn({
+            let endpoint = endpoint.clone();
+            move || run_inner(&endpoint, worker_shutdown, stream_slot, active_input)
+        });
+
+        let mut stream =
+            process_control_ipc::accept_with_timeout(&listener, Duration::from_secs(1))
+                .expect("control task should connect");
+        process_control_ipc::read_hello(&mut stream).unwrap();
+
+        let mut accepted_count = 0;
+        let mut queue_full_response = None;
+        let mut unexpected_status = None;
+        for index in 0..32 {
+            let message_id = format!("msg-{index}");
+            process_control_ipc::write_request(
+                &mut stream,
+                &process_control_ipc::ControlRequest {
+                    message_id: message_id.clone(),
+                    payload: br#"{"type":"active-input","text":"hello"}"#.to_vec(),
+                },
+            )
+            .unwrap();
+
+            let response = process_control_ipc::read_response(&mut stream).unwrap();
+            assert_eq!(response.message_id, message_id);
+            match response.status {
+                process_control_ipc::ControlResponseStatus::Accepted => {
+                    accepted_count += 1;
+                }
+                process_control_ipc::ControlResponseStatus::QueueFull => {
+                    queue_full_response = Some(response);
+                    break;
+                }
+                status => {
+                    unexpected_status = Some(status);
+                    break;
+                }
+            }
+        }
+
+        shutdown.cancel();
+        drop(stream);
+        worker.join().unwrap().unwrap();
+
+        if let Some(status) = unexpected_status {
+            panic!("unexpected control response status: {status:?}");
+        }
+        let response = queue_full_response.expect("active input backlog should become full");
+        assert!(accepted_count > 0);
+        assert_eq!(response.diagnostic, "active input queue is full");
+    }
+
+    #[test]
     fn control_handle_join_wakes_idle_reader() {
         let nonce = *b"fedcba9876543210";
         let endpoint = process_control_ipc::endpoint_name(43, &nonce);

--- a/crates/process-control-ipc/src/codec.rs
+++ b/crates/process-control-ipc/src/codec.rs
@@ -17,6 +17,7 @@ const FRAME_RESPONSE: u8 = 0x03;
 const RESPONSE_ACCEPTED: u8 = 0x00;
 const RESPONSE_REJECTED: u8 = 0x01;
 const RESPONSE_ERROR: u8 = 0x02;
+const RESPONSE_QUEUE_FULL: u8 = 0x03;
 
 /// Write the required hello frame to a connected stream.
 ///
@@ -139,6 +140,7 @@ pub fn write_response(stream: &mut UnixStream, response: &ControlResponse) -> io
         ControlResponseStatus::Accepted => RESPONSE_ACCEPTED,
         ControlResponseStatus::Rejected => RESPONSE_REJECTED,
         ControlResponseStatus::Error => RESPONSE_ERROR,
+        ControlResponseStatus::QueueFull => RESPONSE_QUEUE_FULL,
     });
     payload.extend_from_slice(&(diagnostic.len() as u16).to_be_bytes());
     payload.extend_from_slice(diagnostic);
@@ -259,6 +261,7 @@ fn decode_response(payload: &[u8]) -> io::Result<ControlResponse> {
         RESPONSE_ACCEPTED => ControlResponseStatus::Accepted,
         RESPONSE_REJECTED => ControlResponseStatus::Rejected,
         RESPONSE_ERROR => ControlResponseStatus::Error,
+        RESPONSE_QUEUE_FULL => ControlResponseStatus::QueueFull,
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -377,6 +380,27 @@ mod tests {
         };
         write_response(&mut b, &response).unwrap();
         assert_eq!(read_response(&mut a).unwrap(), response);
+    }
+
+    #[test]
+    fn response_status_roundtrip() {
+        for status in [
+            ControlResponseStatus::Accepted,
+            ControlResponseStatus::Rejected,
+            ControlResponseStatus::QueueFull,
+            ControlResponseStatus::Error,
+        ] {
+            let (mut a, mut b) = UnixStream::pair().unwrap();
+            let response = ControlResponse {
+                message_id: "msg-1".to_string(),
+                status,
+                diagnostic: format!("{status:?}"),
+            };
+
+            write_response(&mut a, &response).unwrap();
+
+            assert_eq!(read_response(&mut b).unwrap(), response);
+        }
     }
 
     #[test]

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -139,6 +139,12 @@ pub enum ControlResponseStatus {
     /// the sink connection as broken.
     Rejected,
 
+    /// The control sink is temporarily full and the caller may retry later.
+    ///
+    /// `vsock-guest` maps this to the outer queue-full status without treating
+    /// the sink connection as broken.
+    QueueFull,
+
     /// The control sink failed while processing the request.
     ///
     /// `vsock-guest` maps this to the outer sink-error status. This status is

--- a/crates/process-control-ipc/src/lib.rs
+++ b/crates/process-control-ipc/src/lib.rs
@@ -41,6 +41,7 @@
 //! | 0x00   | accepted | sink handled the request |
 //! | 0x01   | rejected | sink understood the request but declined it |
 //! | 0x02   | error    | sink failed while processing the request |
+//! | 0x03   | queue-full | sink is temporarily full; caller may retry |
 //!
 //! ## Expected sequence
 //!

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use crate::ids::RunId;
+use crate::local_queue::{ActiveInputEntry, LocalQueue};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ActiveInputSource {
+    LocalQueue(LocalQueueActiveInputSource),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LocalQueueActiveInputSource {
+    pub(crate) group_dir: PathBuf,
+    pub(crate) run_id: RunId,
+}
+
+impl ActiveInputSource {
+    pub(crate) fn local_queue(group_dir: PathBuf, run_id: RunId) -> Self {
+        Self::LocalQueue(LocalQueueActiveInputSource { group_dir, run_id })
+    }
+
+    pub(crate) fn read_entries_sync(&self) -> Vec<ActiveInputEntry> {
+        match self {
+            Self::LocalQueue(source) => LocalQueue::new(source.group_dir.clone())
+                .read_active_input_entries_sync(source.run_id),
+        }
+    }
+}

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -3,6 +3,36 @@ use std::path::PathBuf;
 use crate::ids::RunId;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 
+/// Exec-control payloads are bounded by the guest-side process-control IPC
+/// frame limit.
+pub(crate) const ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES: usize = 1024 * 1024;
+
+#[derive(serde::Serialize)]
+pub(crate) struct ActiveInputPayload<'a> {
+    #[serde(rename = "type")]
+    payload_type: &'static str,
+    text: &'a str,
+}
+
+impl<'a> ActiveInputPayload<'a> {
+    pub(crate) fn new(text: &'a str) -> Self {
+        Self {
+            payload_type: "active-input",
+            text,
+        }
+    }
+
+    pub(crate) fn to_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+}
+
+pub(crate) fn active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {
+    ActiveInputPayload::new(text)
+        .to_vec()
+        .map(|payload| payload.len())
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ActiveInputSource {
     LocalQueue(LocalQueueActiveInputSource),

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -49,10 +49,13 @@ impl ActiveInputSource {
         Self::LocalQueue(LocalQueueActiveInputSource { group_dir, run_id })
     }
 
-    pub(crate) fn read_entries_sync(&self) -> Vec<ActiveInputEntry> {
+    pub(crate) fn read_entries_from_sequence_sync(
+        &self,
+        min_sequence: u64,
+    ) -> Vec<ActiveInputEntry> {
         match self {
             Self::LocalQueue(source) => LocalQueue::new(source.group_dir.clone())
-                .read_active_input_entries_sync(source.run_id),
+                .read_active_input_entries_from_sequence_sync(source.run_id, min_sequence),
         }
     }
 }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -731,6 +731,8 @@ mod tests {
 
     /// Serialize tests that mutate environment variables to prevent UB.
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    const TEST_QUEUE_WATCH_TIMEOUT: Duration = Duration::from_secs(5);
+    const TEST_QUEUE_WATCH_INTERVAL: Duration = Duration::from_millis(1);
 
     fn submit_queue_entry(group_dir: &Path, job_id: RunId) -> SubmitQueueEntry {
         SubmitQueueEntry::for_job(group_dir, crate::profile::DEFAULT_PROFILE, job_id).unwrap()
@@ -1012,6 +1014,8 @@ mod tests {
     ) -> (JobRequest, Vec<local_queue::ActiveInputEntry>) {
         let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile).unwrap();
         let queue = local_queue::LocalQueue::new(group_dir.clone());
+        let deadline = tokio::time::Instant::now() + TEST_QUEUE_WATCH_TIMEOUT;
+        let mut last_seen_inputs = 0;
         loop {
             if let Ok(entries) = std::fs::read_dir(&job_dir) {
                 for entry in entries.filter_map(Result::ok) {
@@ -1022,6 +1026,7 @@ mod tests {
                     let request: JobRequest =
                         serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
                     let inputs = queue.read_active_input_entries_sync(request.job_id);
+                    last_seen_inputs = last_seen_inputs.max(inputs.len());
                     if inputs.len() < expected_inputs {
                         continue;
                     }
@@ -1037,7 +1042,13 @@ mod tests {
                 }
             }
 
-            tokio::task::yield_now().await;
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "timed out waiting for {expected_inputs} local active inputs in {} (last seen: {last_seen_inputs})",
+                    job_dir.display()
+                );
+            }
+            tokio::time::sleep(TEST_QUEUE_WATCH_INTERVAL).await;
         }
     }
 

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -1708,6 +1708,14 @@ mod tests {
         std::fs::write(&queue.job, b"{}").unwrap();
         std::fs::write(&queue.cancel, b"").unwrap();
         std::fs::write(&queue.claim, b"").unwrap();
+        local_queue::LocalQueue::new(group_dir.to_path_buf())
+            .write_active_input_sync(&local_queue::ActiveInputEntry {
+                run_id: job_id,
+                sequence: 1,
+                message_id: "msg-1".to_string(),
+                text: "one".to_string(),
+            })
+            .unwrap();
 
         queue.abandon("timed out");
         let response: JobResponse =
@@ -1724,6 +1732,10 @@ mod tests {
             "abandoned cleanup must not delete files while a runner owns the claim"
         );
         assert!(queue.claim.exists());
+        assert!(
+            local_queue::run_inputs_dir(group_dir, job_id).exists(),
+            "abandoned cleanup must leave active inputs for claimed jobs"
+        );
     }
 
     #[test]
@@ -1738,6 +1750,14 @@ mod tests {
 
         std::fs::write(&queue.job, b"{}").unwrap();
         std::fs::write(&queue.cancel, b"").unwrap();
+        local_queue::LocalQueue::new(group_dir.to_path_buf())
+            .write_active_input_sync(&local_queue::ActiveInputEntry {
+                run_id: job_id,
+                sequence: 1,
+                message_id: "msg-1".to_string(),
+                text: "one".to_string(),
+            })
+            .unwrap();
 
         queue.abandon("timed out");
 
@@ -1747,6 +1767,10 @@ mod tests {
         assert!(
             !queue.claim.exists(),
             "abandoned cleanup should not create a temporary claim"
+        );
+        assert!(
+            !local_queue::run_inputs_dir(group_dir, job_id).exists(),
+            "abandoned cleanup should remove active inputs for unclaimed jobs"
         );
     }
 

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -30,6 +30,9 @@ const MAX_LOCAL_SUBMIT_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 /// Grace period after Ctrl+C to wait for the runner to write a `.result` file.
 const CANCEL_GRACE: Duration = Duration::from_secs(10);
 
+/// Local active input is only used by smoke tests, so keep producer fan-out bounded.
+const MAX_LOCAL_ACTIVE_INPUTS: usize = 16;
+
 #[derive(Args)]
 pub struct SubmitArgs {
     /// Runner group name (writes job to the group's local queue)
@@ -418,6 +421,11 @@ impl SubmitPlan {
         timeout: Duration,
         job_id: RunId,
     ) -> RunnerResult<Vec<DelayedActiveInput>> {
+        if values.len() > MAX_LOCAL_ACTIVE_INPUTS {
+            return Err(RunnerError::Config(format!(
+                "invalid --active-input: at most {MAX_LOCAL_ACTIVE_INPUTS} entries are supported"
+            )));
+        }
         values
             .iter()
             .enumerate()
@@ -1235,6 +1243,11 @@ mod tests {
                 "value={value}, got: {err}"
             );
         }
+
+        let too_many = vec!["after=1s,text=ok".to_string(); MAX_LOCAL_ACTIVE_INPUTS + 1];
+        let err =
+            SubmitPlan::parse_active_inputs(&too_many, Duration::from_secs(5), job_id).unwrap_err();
+        assert!(err.to_string().contains("active-input"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -59,6 +59,9 @@ pub struct SubmitArgs {
     /// Timeout in seconds waiting for a runner to complete the job (max: 24 hours)
     #[arg(long, default_value_t = DEFAULT_LOCAL_SUBMIT_TIMEOUT_SECS)]
     timeout: u64,
+    /// Delayed active input for local smoke tests (repeatable, format: after=1s,text=hello)
+    #[arg(long = "active-input")]
+    active_inputs: Vec<String>,
 }
 
 /// Detect the system timezone from the `TZ` env var or `/etc/timezone`.
@@ -97,6 +100,7 @@ struct PublishedMarker {
     ino: u64,
 }
 
+#[derive(Clone)]
 struct SubmitQueueEntry {
     job_id: RunId,
     group_dir: PathBuf,
@@ -124,6 +128,7 @@ impl SubmitQueueEntry {
     fn cleanup_completed(&self) {
         let jobs_removed = local_queue::LocalQueue::new(self.group_dir.clone())
             .remove_job_files_if_present(self.job_id);
+        self.cleanup_active_inputs();
         let _ = remove_file_if_exists(&self.cancel);
         let _ = remove_file_if_exists(&self.claim);
         if jobs_removed {
@@ -138,6 +143,7 @@ impl SubmitQueueEntry {
         let has_claim =
             local_queue::marker_file_exists(&self.claim, "local claim marker").unwrap_or(true);
         if jobs_removed && !has_claim {
+            self.cleanup_active_inputs();
             let _ = remove_file_if_exists(&self.claim);
             let _ = remove_file_if_exists(&self.cancel);
             if marker.is_some() {
@@ -151,6 +157,22 @@ impl SubmitQueueEntry {
     fn abandon(&self, error: &str) {
         let marker = write_abandoned_result_marker(&self.result, self.job_id, error);
         self.cleanup_abandoned(marker.as_ref());
+    }
+
+    fn cleanup_active_inputs(&self) {
+        local_queue::LocalQueue::new(self.group_dir.clone())
+            .cleanup_active_inputs_sync(self.job_id);
+    }
+
+    fn can_write_active_input(&self) -> bool {
+        if local_queue::private_file_has_content(&self.result, "local result file").unwrap_or(false)
+        {
+            return false;
+        }
+        if local_queue::marker_path_occupied(&self.claim, "local claim marker").unwrap_or(false) {
+            return true;
+        }
+        local_queue::marker_file_exists(&self.job, "local job file").unwrap_or(false)
     }
 }
 
@@ -250,6 +272,74 @@ struct SubmitPlan {
     queue: SubmitQueueEntry,
     timeout: Duration,
     request_json: Vec<u8>,
+    active_inputs: Vec<DelayedActiveInput>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DelayedActiveInput {
+    sequence: u64,
+    message_id: String,
+    after: Duration,
+    text: String,
+}
+
+struct ActiveInputProducer {
+    stop: tokio_util::sync::CancellationToken,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl ActiveInputProducer {
+    fn start(queue: SubmitQueueEntry, inputs: Vec<DelayedActiveInput>) -> Option<Self> {
+        if inputs.is_empty() {
+            return None;
+        }
+        let stop = tokio_util::sync::CancellationToken::new();
+        let mut tasks = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            let queue = queue.clone();
+            let stop = stop.clone();
+            tasks.push(tokio::spawn(async move {
+                tokio::select! {
+                    () = stop.cancelled() => {}
+                    () = tokio::time::sleep(input.after) => {
+                        if !queue.can_write_active_input() {
+                            return;
+                        }
+                        let entry = local_queue::ActiveInputEntry {
+                            run_id: queue.job_id,
+                            sequence: input.sequence,
+                            message_id: input.message_id,
+                            text: input.text,
+                        };
+                        let queue_state = local_queue::LocalQueue::new(queue.group_dir.clone());
+                        if let Err(error) = tokio::task::spawn_blocking(move || {
+                            queue_state.write_active_input_sync(&entry)
+                        })
+                        .await
+                        .unwrap_or_else(|error| Err(std::io::Error::other(error.to_string())))
+                            && error.kind() != std::io::ErrorKind::NotFound
+                        {
+                            eprintln!("warn: failed to write local active input: {error}");
+                        }
+                    }
+                }
+            }));
+        }
+        Some(Self { stop, tasks })
+    }
+
+    async fn stop(self) {
+        self.stop.cancel();
+        for mut task in self.tasks {
+            match tokio::time::timeout(Duration::from_secs(1), &mut task).await {
+                Ok(_) => {}
+                Err(_) => {
+                    task.abort();
+                    let _ = task.await;
+                }
+            }
+        }
+    }
 }
 
 enum SubmitOutcome {
@@ -269,6 +359,7 @@ impl SubmitPlan {
             env,
             secret_env,
             timeout,
+            active_inputs,
         } = args;
 
         crate::group::validate_or_err(&group)?;
@@ -297,6 +388,7 @@ impl SubmitPlan {
             .map_err(|e| RunnerError::Config(format!("create cancels dir: {e}")))?;
 
         let job_id = RunId::new_v4();
+        let active_inputs = Self::parse_active_inputs(&active_inputs, timeout, job_id)?;
         let request = JobRequest {
             job_id,
             prompt,
@@ -308,6 +400,7 @@ impl SubmitPlan {
             profile: Some(profile.clone()),
             session_id,
             feature_flags,
+            active_input: (!active_inputs.is_empty()).then_some(true),
         };
 
         let request_json = serde_json::to_vec(&request)
@@ -320,6 +413,93 @@ impl SubmitPlan {
             queue,
             timeout,
             request_json,
+            active_inputs,
+        })
+    }
+
+    fn parse_active_inputs(
+        values: &[String],
+        timeout: Duration,
+        job_id: RunId,
+    ) -> RunnerResult<Vec<DelayedActiveInput>> {
+        values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                Self::parse_active_input(value, index as u64 + 1, timeout, job_id)
+            })
+            .collect()
+    }
+
+    fn parse_active_input(
+        value: &str,
+        sequence: u64,
+        timeout: Duration,
+        job_id: RunId,
+    ) -> RunnerResult<DelayedActiveInput> {
+        let rest = value.strip_prefix("after=").ok_or_else(|| {
+            RunnerError::Config(
+                "invalid --active-input value: expected after=<duration>,text=<text>".to_string(),
+            )
+        })?;
+        let (after, text) = rest.split_once(",text=").ok_or_else(|| {
+            RunnerError::Config(
+                "invalid --active-input value: expected after=<duration>,text=<text>".to_string(),
+            )
+        })?;
+        let after = Self::parse_active_input_delay(after)?;
+        if after >= timeout {
+            return Err(RunnerError::Config(format!(
+                "invalid --active-input value: delay must be less than submit timeout ({timeout:?})"
+            )));
+        }
+        if text.is_empty() {
+            return Err(RunnerError::Config(
+                "invalid --active-input value: text must not be empty".to_string(),
+            ));
+        }
+        if text.contains('\0') {
+            return Err(RunnerError::Config(
+                "invalid --active-input value: text must not contain NUL characters".to_string(),
+            ));
+        }
+        Ok(DelayedActiveInput {
+            sequence,
+            message_id: format!("local-active-input-{job_id}-{sequence}"),
+            after,
+            text: text.to_owned(),
+        })
+    }
+
+    fn parse_active_input_delay(value: &str) -> RunnerResult<Duration> {
+        let (digits, unit) = if let Some(digits) = value.strip_suffix("ms") {
+            (digits, "ms")
+        } else if let Some(digits) = value.strip_suffix('s') {
+            (digits, "s")
+        } else {
+            return Err(RunnerError::Config(format!(
+                "invalid --active-input duration '{value}': expected positive integer ms or s"
+            )));
+        };
+        if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(RunnerError::Config(format!(
+                "invalid --active-input duration '{value}': expected positive integer"
+            )));
+        }
+        let amount = digits.parse::<u64>().map_err(|_| {
+            RunnerError::Config(format!(
+                "invalid --active-input duration '{value}': out of range"
+            ))
+        })?;
+        if amount == 0 {
+            return Err(RunnerError::Config(format!(
+                "invalid --active-input duration '{value}': must be greater than zero"
+            )));
+        }
+        Ok(if unit == "ms" {
+            Duration::from_millis(amount)
+        } else {
+            Duration::from_secs(amount)
         })
     }
 
@@ -446,6 +626,10 @@ impl SubmitPlan {
         Ok(())
     }
 
+    fn start_active_input_producer(&self) -> Option<ActiveInputProducer> {
+        ActiveInputProducer::start(self.queue.clone(), self.active_inputs.clone())
+    }
+
     async fn wait_for_result(&self) -> RunnerResult<SubmitOutcome> {
         let started_at = tokio::time::Instant::now();
 
@@ -529,7 +713,12 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
 async fn run_submit_with_home(args: SubmitArgs, home: HomePaths) -> RunnerResult<ExitCode> {
     let plan = SubmitPlan::from_args(args, home)?;
     plan.write_job_file()?;
-    match plan.wait_for_result().await? {
+    let producer = plan.start_active_input_producer();
+    let outcome = plan.wait_for_result().await;
+    if let Some(producer) = producer {
+        producer.stop().await;
+    }
+    match outcome? {
         SubmitOutcome::Completed(buf) => plan.finish_completed(&buf),
         SubmitOutcome::Cancelled => Ok(ExitCode::FAILURE),
     }
@@ -817,6 +1006,42 @@ mod tests {
         wait_for_job_and_write_result(group_dir, profile, 0, None).await
     }
 
+    async fn wait_for_active_inputs_and_write_success(
+        group_dir: std::path::PathBuf,
+        profile: String,
+        expected_inputs: usize,
+    ) -> (JobRequest, Vec<local_queue::ActiveInputEntry>) {
+        let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile).unwrap();
+        let queue = local_queue::LocalQueue::new(group_dir.clone());
+        loop {
+            if let Ok(entries) = std::fs::read_dir(&job_dir) {
+                for entry in entries.filter_map(Result::ok) {
+                    let path = entry.path();
+                    if path.extension().and_then(|ext| ext.to_str()) != Some("job") {
+                        continue;
+                    }
+                    let request: JobRequest =
+                        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+                    let inputs = queue.read_active_input_entries_sync(request.job_id);
+                    if inputs.len() < expected_inputs {
+                        continue;
+                    }
+                    let response = JobResponse {
+                        run_id: request.job_id,
+                        exit_code: 0,
+                        error: None,
+                    };
+                    let result_path = local_queue::result_path(&group_dir, request.job_id);
+                    std::fs::create_dir_all(result_path.parent().unwrap()).unwrap();
+                    std::fs::write(&result_path, serde_json::to_vec(&response).unwrap()).unwrap();
+                    return (request, inputs);
+                }
+            }
+
+            tokio::task::yield_now().await;
+        }
+    }
+
     fn submit_args_for_test() -> SubmitArgs {
         SubmitArgs {
             group: "test/group".into(),
@@ -828,6 +1053,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 1,
+            active_inputs: vec![],
         }
     }
 
@@ -853,6 +1079,7 @@ mod tests {
                 env: vec![],
                 secret_env: vec![],
                 timeout: 5,
+                active_inputs: vec![],
             },
             home,
         )
@@ -892,6 +1119,7 @@ mod tests {
                 env: vec![],
                 secret_env: vec![],
                 timeout: 5,
+                active_inputs: vec![],
             },
             home,
         )
@@ -925,6 +1153,7 @@ mod tests {
                 env: vec![],
                 secret_env: vec![],
                 timeout: 5,
+                active_inputs: vec![],
             },
             home,
         )
@@ -939,6 +1168,101 @@ mod tests {
         assert_eq!(request.session_id.as_deref(), Some("sess-123"));
         assert_eq!(flags.get("alpha"), Some(&true));
         assert_eq!(flags.get("beta"), Some(&false));
+    }
+
+    #[test]
+    fn parses_active_input_specs() {
+        let job_id = RunId::nil();
+        let parsed = SubmitPlan::parse_active_inputs(
+            &[
+                "after=1s,text=first".to_string(),
+                "after=250ms,text=second,with,commas".to_string(),
+            ],
+            Duration::from_secs(5),
+            job_id,
+        )
+        .unwrap();
+
+        assert_eq!(
+            parsed,
+            vec![
+                DelayedActiveInput {
+                    sequence: 1,
+                    message_id: format!("local-active-input-{job_id}-1"),
+                    after: Duration::from_secs(1),
+                    text: "first".to_string(),
+                },
+                DelayedActiveInput {
+                    sequence: 2,
+                    message_id: format!("local-active-input-{job_id}-2"),
+                    after: Duration::from_millis(250),
+                    text: "second,with,commas".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_active_input_specs() {
+        let job_id = RunId::nil();
+        for value in [
+            "text=missing-after",
+            "after=1m,text=bad-unit",
+            "after=0s,text=zero",
+            "after=1s,text=",
+            "after=5s,text=timeout",
+            "after=1s,text=bad\0nul",
+        ] {
+            let err = SubmitPlan::parse_active_inputs(
+                &[value.to_string()],
+                Duration::from_secs(5),
+                job_id,
+            )
+            .unwrap_err();
+
+            assert!(
+                err.to_string().contains("active-input"),
+                "value={value}, got: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn active_inputs_are_written_after_job_publication_and_cleaned_on_completion() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let group = "test/group";
+        let group_dir = home.groups_dir().join(group);
+        let watcher = tokio::spawn(wait_for_active_inputs_and_write_success(
+            group_dir.clone(),
+            crate::profile::DEFAULT_PROFILE.to_owned(),
+            2,
+        ));
+        let mut args = submit_args_for_test();
+        args.group = group.into();
+        args.timeout = 5;
+        args.active_inputs = vec![
+            "after=1ms,text=first".to_string(),
+            "after=2ms,text=second,with,comma".to_string(),
+        ];
+
+        let code = run_submit_with_home(args, home).await.unwrap();
+        let (request, inputs) = watcher.await.unwrap();
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(request.prompt, "hello");
+        assert_eq!(request.active_input, Some(true));
+        assert_eq!(
+            inputs
+                .iter()
+                .map(|entry| (entry.sequence, entry.text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(1, "first"), (2, "second,with,comma")]
+        );
+        assert!(
+            !local_queue::run_inputs_dir(&group_dir, request.job_id).exists(),
+            "completed submit cleanup should remove local active-input files"
+        );
     }
 
     #[tokio::test]
@@ -1087,6 +1411,7 @@ mod tests {
             timeout: Duration::ZERO,
             request_json: br#"{"secretEnvironment":{"ANTHROPIC_API_KEY":"sk-local-secret"}}"#
                 .to_vec(),
+            active_inputs: vec![],
         };
 
         plan.write_job_file().unwrap();
@@ -1113,6 +1438,7 @@ mod tests {
             queue,
             timeout: Duration::ZERO,
             request_json: b"{}".to_vec(),
+            active_inputs: vec![],
         };
 
         let err = plan.write_job_file().unwrap_err();
@@ -1145,6 +1471,7 @@ mod tests {
                 env: vec![],
                 secret_env: vec![],
                 timeout: 5,
+                active_inputs: vec![],
             },
             home,
         )
@@ -1185,6 +1512,7 @@ mod tests {
                 env: vec![],
                 secret_env: vec![],
                 timeout: 5,
+                active_inputs: vec![],
             },
             home,
         )
@@ -1219,6 +1547,7 @@ mod tests {
                 env: vec![],
                 secret_env: vec![],
                 timeout: 5,
+                active_inputs: vec![],
             },
             home,
         )
@@ -1696,6 +2025,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 1,
+            active_inputs: vec![],
         };
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -1718,6 +2048,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 0,
+            active_inputs: vec![],
         };
         // Should pass validation and fail later (HomePaths or timeout), not on profile.
         let dir = tempfile::tempdir().unwrap();
@@ -1740,6 +2071,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 1,
+            active_inputs: vec![],
         };
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -1759,6 +2091,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 1,
+            active_inputs: vec![],
         };
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
@@ -1783,6 +2116,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 0,
+            active_inputs: vec![],
         };
 
         let err = run_submit_with_home(args, home).await.unwrap_err();
@@ -1855,6 +2189,7 @@ mod tests {
             env: vec![],
             secret_env: vec![],
             timeout: 0,
+            active_inputs: vec![],
         };
 
         let err = run_submit_with_home(args, home).await.unwrap_err();

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -519,11 +519,14 @@ impl SubmitPlan {
         cli_agent_type: &str,
         active_inputs: &[String],
     ) -> RunnerResult<()> {
-        if active_inputs.is_empty() || matches!(cli_agent_type, "" | "claude-code") {
+        // Guest-agent treats unknown CLI_AGENT_TYPE values as Claude Code.
+        // Keep local submit validation aligned and only reject the known
+        // non-Claude framework.
+        if active_inputs.is_empty() || cli_agent_type != "codex" {
             return Ok(());
         }
         Err(RunnerError::Config(format!(
-            "invalid --active-input: active input is only supported with claude-code (got {cli_agent_type})"
+            "invalid --active-input: active input is not supported with {cli_agent_type}"
         )))
     }
 
@@ -1053,7 +1056,8 @@ mod tests {
                     }
                     let request: JobRequest =
                         serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-                    let inputs = queue.read_active_input_entries_sync(request.job_id);
+                    let inputs =
+                        queue.read_active_input_entries_from_sequence_sync(request.job_id, 0);
                     last_seen_inputs = last_seen_inputs.max(inputs.len());
                     if inputs.len() < expected_inputs {
                         continue;
@@ -1316,7 +1320,18 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(err.to_string().contains("only supported with claude-code"));
+        assert!(err.to_string().contains("not supported with codex"));
+    }
+
+    #[test]
+    fn accepts_active_input_for_custom_agent_that_defaults_to_claude() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let mut args = submit_args_for_test();
+        args.cli_agent_type = "custom-agent".to_string();
+        args.active_inputs = vec!["after=1ms,text=hello".to_string()];
+
+        SubmitPlan::from_args(args, home).unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -142,8 +142,10 @@ impl SubmitQueueEntry {
             .remove_job_files_if_present(self.job_id);
         let has_claim =
             local_queue::marker_file_exists(&self.claim, "local claim marker").unwrap_or(true);
-        if jobs_removed && !has_claim {
+        if !has_claim {
             self.cleanup_active_inputs();
+        }
+        if jobs_removed && !has_claim {
             let _ = remove_file_if_exists(&self.claim);
             let _ = remove_file_if_exists(&self.cancel);
             if marker.is_some() {
@@ -1837,6 +1839,33 @@ mod tests {
 
         queue.cleanup_abandoned(Some(&marker));
 
+        assert!(!queue.result.exists());
+        assert!(!queue.cancel.exists());
+        assert!(!queue.claim.exists());
+    }
+
+    #[test]
+    fn abandoned_cleanup_removes_unclaimed_active_inputs_when_job_already_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
+        std::fs::write(&queue.cancel, b"").unwrap();
+        let marker =
+            write_abandoned_result_marker(&queue.result, job_id, "local submit abandoned").unwrap();
+        local_queue::LocalQueue::new(group_dir.to_path_buf())
+            .write_active_input_sync(&local_queue::ActiveInputEntry {
+                run_id: job_id,
+                sequence: 1,
+                message_id: "msg-1".to_string(),
+                text: "one".to_string(),
+            })
+            .unwrap();
+
+        queue.cleanup_abandoned(Some(&marker));
+
+        assert!(!local_queue::run_inputs_dir(group_dir, job_id).exists());
         assert!(!queue.result.exists());
         assert!(!queue.cancel.exists());
         assert!(!queue.claim.exists());

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use clap::Args;
 
+use crate::active_input::{ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, active_input_payload_len};
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::local_queue::{self, JobRequest, JobResponse};
@@ -472,6 +473,16 @@ impl SubmitPlan {
             return Err(RunnerError::Config(
                 "invalid --active-input value: text must not contain NUL characters".to_string(),
             ));
+        }
+        let payload_len = active_input_payload_len(text).map_err(|e| {
+            RunnerError::Internal(format!(
+                "serialize active-input payload for validation: {e}"
+            ))
+        })?;
+        if payload_len > ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES {
+            return Err(RunnerError::Config(format!(
+                "invalid --active-input value: serialized payload must be <= {ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES} bytes"
+            )));
         }
         Ok(DelayedActiveInput {
             sequence,
@@ -1265,6 +1276,15 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("non-decreasing"));
+
+        let oversized_text = "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES);
+        let err = SubmitPlan::parse_active_inputs(
+            &[format!("after=1s,text={oversized_text}")],
+            Duration::from_secs(5),
+            job_id,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("serialized payload"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -426,13 +426,19 @@ impl SubmitPlan {
                 "invalid --active-input: at most {MAX_LOCAL_ACTIVE_INPUTS} entries are supported"
             )));
         }
-        values
-            .iter()
-            .enumerate()
-            .map(|(index, value)| {
-                Self::parse_active_input(value, index as u64 + 1, timeout, job_id)
-            })
-            .collect()
+        let mut inputs: Vec<DelayedActiveInput> = Vec::with_capacity(values.len());
+        for (index, value) in values.iter().enumerate() {
+            let input = Self::parse_active_input(value, index as u64 + 1, timeout, job_id)?;
+            if let Some(previous) = inputs.last()
+                && input.after < previous.after
+            {
+                return Err(RunnerError::Config(
+                    "invalid --active-input value: delays must be non-decreasing".to_string(),
+                ));
+            }
+            inputs.push(input);
+        }
+        Ok(inputs)
     }
 
     fn parse_active_input(
@@ -1193,8 +1199,8 @@ mod tests {
         let job_id = RunId::nil();
         let parsed = SubmitPlan::parse_active_inputs(
             &[
-                "after=1s,text=first".to_string(),
-                "after=250ms,text=second,with,commas".to_string(),
+                "after=250ms,text=first".to_string(),
+                "after=1s,text=second,with,commas".to_string(),
             ],
             Duration::from_secs(5),
             job_id,
@@ -1207,13 +1213,13 @@ mod tests {
                 DelayedActiveInput {
                     sequence: 1,
                     message_id: format!("local-active-input-{job_id}-1"),
-                    after: Duration::from_secs(1),
+                    after: Duration::from_millis(250),
                     text: "first".to_string(),
                 },
                 DelayedActiveInput {
                     sequence: 2,
                     message_id: format!("local-active-input-{job_id}-2"),
-                    after: Duration::from_millis(250),
+                    after: Duration::from_secs(1),
                     text: "second,with,commas".to_string(),
                 },
             ]
@@ -1248,6 +1254,17 @@ mod tests {
         let err =
             SubmitPlan::parse_active_inputs(&too_many, Duration::from_secs(5), job_id).unwrap_err();
         assert!(err.to_string().contains("active-input"));
+
+        let err = SubmitPlan::parse_active_inputs(
+            &[
+                "after=2s,text=first".to_string(),
+                "after=1s,text=second".to_string(),
+            ],
+            Duration::from_secs(5),
+            job_id,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("non-decreasing"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -31,8 +31,10 @@ const MAX_LOCAL_SUBMIT_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 /// Grace period after Ctrl+C to wait for the runner to write a `.result` file.
 const CANCEL_GRACE: Duration = Duration::from_secs(10);
 
-/// Local active input is only used by smoke tests, so keep producer fan-out bounded.
-const MAX_LOCAL_ACTIVE_INPUTS: usize = 16;
+/// Local active input is only used by smoke tests. Keep this at or below the
+/// guest-agent active-input queue capacity so rapid inputs cannot be rejected
+/// after the local job has already started.
+const MAX_LOCAL_ACTIVE_INPUTS: usize = 8;
 
 #[derive(Args)]
 pub struct SubmitArgs {

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -142,10 +142,8 @@ impl SubmitQueueEntry {
             .remove_job_files_if_present(self.job_id);
         let has_claim =
             local_queue::marker_file_exists(&self.claim, "local claim marker").unwrap_or(true);
-        if !has_claim {
-            self.cleanup_active_inputs();
-        }
         if jobs_removed && !has_claim {
+            self.cleanup_active_inputs();
             let _ = remove_file_if_exists(&self.claim);
             let _ = remove_file_if_exists(&self.cancel);
             if marker.is_some() {
@@ -719,6 +717,9 @@ async fn run_submit_with_home(args: SubmitArgs, home: HomePaths) -> RunnerResult
     let outcome = plan.wait_for_result().await;
     if let Some(producer) = producer {
         producer.stop().await;
+    }
+    if matches!(outcome, Err(_) | Ok(SubmitOutcome::Cancelled)) {
+        plan.queue.cleanup_abandoned(None);
     }
     match outcome? {
         SubmitOutcome::Completed(buf) => plan.finish_completed(&buf),
@@ -1864,6 +1865,35 @@ mod tests {
             .unwrap();
 
         queue.cleanup_abandoned(Some(&marker));
+
+        assert!(!local_queue::run_inputs_dir(group_dir, job_id).exists());
+        assert!(!queue.result.exists());
+        assert!(!queue.cancel.exists());
+        assert!(!queue.claim.exists());
+    }
+
+    #[test]
+    fn abandoned_cleanup_removes_late_unclaimed_active_inputs_after_job_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        std::fs::create_dir_all(queue.job.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
+        std::fs::write(&queue.job, b"{}").unwrap();
+        std::fs::write(&queue.cancel, b"").unwrap();
+
+        queue.abandon("timed out");
+        local_queue::LocalQueue::new(group_dir.to_path_buf())
+            .write_active_input_sync(&local_queue::ActiveInputEntry {
+                run_id: job_id,
+                sequence: 1,
+                message_id: "msg-1".to_string(),
+                text: "late".to_string(),
+            })
+            .unwrap();
+
+        queue.cleanup_abandoned(None);
 
         assert!(!local_queue::run_inputs_dir(group_dir, job_id).exists());
         assert!(!queue.result.exists());

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -372,6 +372,7 @@ impl SubmitPlan {
         let secret_environment = Self::parse_env_entries("--secret-env", &secret_env, false)?;
         Self::validate_disjoint_env_keys(&environment, &secret_environment)?;
         let timeout = Self::validate_timeout(timeout)?;
+        Self::validate_active_input_agent(&cli_agent_type, &active_inputs)?;
         let group_dir = home.groups_dir().join(&group);
         local_queue::ensure_profile_jobs_dir(&group_dir, &profile).map_err(|e| {
             RunnerError::Config(format!("create job dir for profile {profile}: {e}"))
@@ -512,6 +513,18 @@ impl SubmitPlan {
         } else {
             Duration::from_secs(amount)
         })
+    }
+
+    fn validate_active_input_agent(
+        cli_agent_type: &str,
+        active_inputs: &[String],
+    ) -> RunnerResult<()> {
+        if active_inputs.is_empty() || matches!(cli_agent_type, "" | "claude-code") {
+            return Ok(());
+        }
+        Err(RunnerError::Config(format!(
+            "invalid --active-input: active input is only supported with claude-code (got {cli_agent_type})"
+        )))
     }
 
     fn validate_timeout(timeout: u64) -> RunnerResult<Duration> {
@@ -1288,6 +1301,22 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("serialized payload"));
+    }
+
+    #[test]
+    fn rejects_active_input_for_non_claude_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let mut args = submit_args_for_test();
+        args.cli_agent_type = "codex".to_string();
+        args.active_inputs = vec!["after=1ms,text=hello".to_string()];
+
+        let err = match SubmitPlan::from_args(args, home) {
+            Ok(_) => panic!("codex active input should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(err.to_string().contains("only supported with claude-code"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -330,13 +330,9 @@ impl ActiveInputProducer {
 
     async fn stop(self) {
         self.stop.cancel();
-        for mut task in self.tasks {
-            match tokio::time::timeout(Duration::from_secs(1), &mut task).await {
-                Ok(_) => {}
-                Err(_) => {
-                    task.abort();
-                    let _ = task.await;
-                }
+        for task in self.tasks {
+            if let Err(error) = task.await {
+                eprintln!("warn: local active input producer task failed: {error}");
             }
         }
     }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -313,14 +313,16 @@ impl ActiveInputProducer {
                             text: input.text,
                         };
                         let queue_state = local_queue::LocalQueue::new(queue.group_dir.clone());
-                        if let Err(error) = tokio::task::spawn_blocking(move || {
+                        let write_result = tokio::task::spawn_blocking(move || {
                             queue_state.write_active_input_sync(&entry)
                         })
                         .await
-                        .unwrap_or_else(|error| Err(std::io::Error::other(error.to_string())))
-                            && error.kind() != std::io::ErrorKind::NotFound
-                        {
-                            eprintln!("warn: failed to write local active input: {error}");
+                        .unwrap_or_else(|error| Err(std::io::Error::other(error.to_string())));
+                        if let Err(error) = write_result {
+                            if error.kind() != std::io::ErrorKind::NotFound {
+                                eprintln!("warn: failed to write local active input: {error}");
+                            }
+                            return;
                         }
                     }
                 }
@@ -1385,6 +1387,50 @@ mod tests {
         assert!(
             !local_queue::run_inputs_dir(&group_dir, request.job_id).exists(),
             "completed submit cleanup should remove local active-input files"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_input_producer_stops_after_write_failure_to_preserve_sequence_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let job_id = RunId::new_v4();
+        let queue = submit_queue_entry(group_dir, job_id);
+        write_queue_job_file(group_dir, crate::profile::DEFAULT_PROFILE, job_id);
+        local_queue::ensure_run_inputs_dir(group_dir, job_id).unwrap();
+        std::fs::write(
+            local_queue::active_input_path(group_dir, job_id, 1),
+            b"not-json",
+        )
+        .unwrap();
+
+        let producer = ActiveInputProducer::start(
+            queue,
+            vec![
+                DelayedActiveInput {
+                    sequence: 1,
+                    message_id: "msg-1".to_string(),
+                    after: Duration::from_millis(1),
+                    text: "first".to_string(),
+                },
+                DelayedActiveInput {
+                    sequence: 2,
+                    message_id: "msg-2".to_string(),
+                    after: Duration::from_millis(1),
+                    text: "second".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+
+        tokio::time::timeout(TEST_QUEUE_WATCH_TIMEOUT, producer.task)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            !local_queue::active_input_path(group_dir, job_id, 2).exists(),
+            "producer should not create a sequence gap after an active-input write failure"
         );
     }
 

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -31,11 +31,6 @@ const MAX_LOCAL_SUBMIT_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 /// Grace period after Ctrl+C to wait for the runner to write a `.result` file.
 const CANCEL_GRACE: Duration = Duration::from_secs(10);
 
-/// Local active input is only used by smoke tests. Keep this at or below the
-/// guest-agent active-input queue capacity so rapid inputs cannot be rejected
-/// after the local job has already started.
-const MAX_LOCAL_ACTIVE_INPUTS: usize = 8;
-
 #[derive(Args)]
 pub struct SubmitArgs {
     /// Runner group name (writes job to the group's local queue)
@@ -291,7 +286,7 @@ struct DelayedActiveInput {
 
 struct ActiveInputProducer {
     stop: tokio_util::sync::CancellationToken,
-    tasks: Vec<tokio::task::JoinHandle<()>>,
+    task: tokio::task::JoinHandle<()>,
 }
 
 impl ActiveInputProducer {
@@ -300,14 +295,14 @@ impl ActiveInputProducer {
             return None;
         }
         let stop = tokio_util::sync::CancellationToken::new();
-        let mut tasks = Vec::with_capacity(inputs.len());
-        for input in inputs {
-            let queue = queue.clone();
-            let stop = stop.clone();
-            tasks.push(tokio::spawn(async move {
+        let stop_for_task = stop.clone();
+        let task = tokio::spawn(async move {
+            let started_at = tokio::time::Instant::now();
+            for input in inputs {
+                let sleep_for = input.after.saturating_sub(started_at.elapsed());
                 tokio::select! {
-                    () = stop.cancelled() => {}
-                    () = tokio::time::sleep(input.after) => {
+                    () = stop_for_task.cancelled() => return,
+                    () = tokio::time::sleep(sleep_for) => {
                         if !queue.can_write_active_input() {
                             return;
                         }
@@ -329,17 +324,15 @@ impl ActiveInputProducer {
                         }
                     }
                 }
-            }));
-        }
-        Some(Self { stop, tasks })
+            }
+        });
+        Some(Self { stop, task })
     }
 
     async fn stop(self) {
         self.stop.cancel();
-        for task in self.tasks {
-            if let Err(error) = task.await {
-                eprintln!("warn: local active input producer task failed: {error}");
-            }
+        if let Err(error) = self.task.await {
+            eprintln!("warn: local active input producer task failed: {error}");
         }
     }
 }
@@ -424,11 +417,6 @@ impl SubmitPlan {
         timeout: Duration,
         job_id: RunId,
     ) -> RunnerResult<Vec<DelayedActiveInput>> {
-        if values.len() > MAX_LOCAL_ACTIVE_INPUTS {
-            return Err(RunnerError::Config(format!(
-                "invalid --active-input: at most {MAX_LOCAL_ACTIVE_INPUTS} entries are supported"
-            )));
-        }
         let mut inputs: Vec<DelayedActiveInput> = Vec::with_capacity(values.len());
         for (index, value) in values.iter().enumerate() {
             let input = Self::parse_active_input(value, index as u64 + 1, timeout, job_id)?;
@@ -1240,6 +1228,24 @@ mod tests {
     }
 
     #[test]
+    fn parses_more_than_eight_active_input_specs() {
+        let job_id = RunId::nil();
+        let values = (1..=9)
+            .map(|sequence| format!("after={sequence}ms,text=input-{sequence}"))
+            .collect::<Vec<_>>();
+        let parsed =
+            SubmitPlan::parse_active_inputs(&values, Duration::from_secs(5), job_id).unwrap();
+
+        assert_eq!(parsed.len(), 9);
+        assert_eq!(parsed[8].sequence, 9);
+        assert_eq!(
+            parsed[8].message_id,
+            format!("local-active-input-{job_id}-9")
+        );
+        assert_eq!(parsed[8].text, "input-9");
+    }
+
+    #[test]
     fn rejects_invalid_active_input_specs() {
         let job_id = RunId::nil();
         for value in [
@@ -1262,11 +1268,6 @@ mod tests {
                 "value={value}, got: {err}"
             );
         }
-
-        let too_many = vec!["after=1s,text=ok".to_string(); MAX_LOCAL_ACTIVE_INPUTS + 1];
-        let err =
-            SubmitPlan::parse_active_inputs(&too_many, Duration::from_secs(5), job_id).unwrap_err();
-        assert!(err.to_string().contains("active-input"));
 
         let err = SubmitPlan::parse_active_inputs(
             &[
@@ -1298,15 +1299,31 @@ mod tests {
         let watcher = tokio::spawn(wait_for_active_inputs_and_write_success(
             group_dir.clone(),
             crate::profile::DEFAULT_PROFILE.to_owned(),
-            2,
+            9,
         ));
         let mut args = submit_args_for_test();
         args.group = group.into();
         args.timeout = 5;
-        args.active_inputs = vec![
-            "after=1ms,text=first".to_string(),
-            "after=2ms,text=second,with,comma".to_string(),
-        ];
+        args.active_inputs = (1..=9)
+            .map(|sequence| {
+                let text = if sequence == 2 {
+                    "second,with,comma".to_string()
+                } else {
+                    format!("input-{sequence}")
+                };
+                format!("after={sequence}ms,text={text}")
+            })
+            .collect();
+        let expected_inputs = (1..=9)
+            .map(|sequence| {
+                let text = if sequence == 2 {
+                    "second,with,comma".to_string()
+                } else {
+                    format!("input-{sequence}")
+                };
+                (sequence, text)
+            })
+            .collect::<Vec<_>>();
 
         let code = run_submit_with_home(args, home).await.unwrap();
         let (request, inputs) = watcher.await.unwrap();
@@ -1317,9 +1334,9 @@ mod tests {
         assert_eq!(
             inputs
                 .iter()
-                .map(|entry| (entry.sequence, entry.text.as_str()))
+                .map(|entry| (entry.sequence, entry.text.clone()))
                 .collect::<Vec<_>>(),
-            vec![(1, "first"), (2, "second,with,comma")]
+            expected_inputs
         );
         assert!(
             !local_queue::run_inputs_dir(&group_dir, request.job_id).exists(),

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -100,6 +100,7 @@ struct ExecutorInvocation {
     cancel: CancellationToken,
     sandbox_token: String,
     sandbox_prepared: Option<executor::SandboxPreparedNotifier>,
+    active_input_source: Option<crate::active_input::ActiveInputSource>,
 }
 
 struct ExecutorPhaseOutcome {
@@ -123,6 +124,7 @@ impl ExecutorInvocation {
             cancel,
             sandbox_token,
             sandbox_prepared,
+            active_input_source,
         } = self;
         let exec_config_for_panic = Arc::clone(&exec_config);
         let cancel_for_executor = cancel.clone();
@@ -131,12 +133,13 @@ impl ExecutorInvocation {
         // still reports completion and releases budget.
         let inner = tokio::spawn(async move {
             if let Some(idle_entry) = reuse_entry {
-                executor::execute_job_reuse(
+                executor::execute_job_reuse_with_active_input_source(
                     idle_entry,
                     context,
                     &exec_config,
                     &params,
                     cancel_for_executor,
+                    active_input_source,
                 )
                 .await
             } else {
@@ -150,7 +153,10 @@ impl ExecutorInvocation {
                     &exec_config,
                     &params,
                     cancel_for_executor,
-                    sandbox_prepared,
+                    executor::ExecutionHooks {
+                        sandbox_prepared,
+                        active_input_source,
+                    },
                 )
                 .await
             }
@@ -430,7 +436,7 @@ pub(super) fn spawn_job(
         reuse_result,
         active_cli_agent_session_guard,
     } = request;
-    let (context, completion_auth) = claimed.into_parts();
+    let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
     let cli_agent_session_id = if executor::validate_resume_session_id(&context).is_ok() {
         context.cli_agent_session_id().map(String::from)
@@ -518,6 +524,7 @@ pub(super) fn spawn_job(
         cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
         sandbox_prepared,
+        active_input_source,
     };
     let finalization = FinalizationPhase {
         run_id,

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -12,12 +12,33 @@ use crate::local_queue::ActiveInputEntry;
 const ACTIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
 const ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+const FIRST_ACTIVE_INPUT_SEQUENCE: u64 = 1;
 
 #[derive(serde::Serialize)]
 struct ActiveInputPayload<'a> {
     #[serde(rename = "type")]
     payload_type: &'static str,
     text: &'a str,
+}
+
+struct ForwardState {
+    seen_message_ids: HashSet<String>,
+    next_sequence: u64,
+}
+
+impl Default for ForwardState {
+    fn default() -> Self {
+        Self {
+            seen_message_ids: HashSet::new(),
+            next_sequence: FIRST_ACTIVE_INPUT_SEQUENCE,
+        }
+    }
+}
+
+impl ForwardState {
+    fn consume_sequence(&mut self) {
+        self.next_sequence = self.next_sequence.saturating_add(1);
+    }
 }
 
 pub(super) struct ActiveInputForwarder {
@@ -66,14 +87,14 @@ async fn run_forwarder(
     job_cancel: CancellationToken,
     stop: CancellationToken,
 ) {
-    let mut seen = HashSet::new();
+    let mut state = ForwardState::default();
     loop {
         tokio::select! {
             biased;
             () = stop.cancelled() => return,
             () = job_cancel.cancelled() => return,
             entries = read_entries(run_id, source.clone()) => {
-                forward_entries(run_id, &control, entries, &mut seen).await;
+                forward_entries(run_id, &control, entries, &mut state).await;
             }
         }
 
@@ -100,10 +121,17 @@ async fn forward_entries(
     run_id: RunId,
     control: &GuestProcessControlHandle,
     entries: Vec<ActiveInputEntry>,
-    seen: &mut HashSet<String>,
+    state: &mut ForwardState,
 ) {
     for entry in entries {
-        if seen.contains(&entry.message_id) {
+        if entry.sequence < state.next_sequence {
+            continue;
+        }
+        if entry.sequence > state.next_sequence {
+            break;
+        }
+        if state.seen_message_ids.contains(&entry.message_id) {
+            state.consume_sequence();
             continue;
         }
         let payload = ActiveInputPayload {
@@ -120,6 +148,7 @@ async fn forward_entries(
                     error = %error,
                     "failed to serialize active-input payload"
                 );
+                state.consume_sequence();
                 continue;
             }
         };
@@ -134,7 +163,8 @@ async fn forward_entries(
                     message_id = %entry.message_id,
                     "forwarded active input"
                 );
-                seen.insert(entry.message_id);
+                state.seen_message_ids.insert(entry.message_id);
+                state.consume_sequence();
             }
             Err(error) => {
                 let retry = should_retry_control_error(&error);
@@ -147,7 +177,8 @@ async fn forward_entries(
                     "failed to forward active input"
                 );
                 if !retry {
-                    seen.insert(entry.message_id);
+                    state.seen_message_ids.insert(entry.message_id);
+                    state.consume_sequence();
                 } else {
                     break;
                 }
@@ -164,4 +195,84 @@ fn should_retry_control_error(error: &std::io::Error) -> bool {
             | std::io::ErrorKind::TimedOut
             | std::io::ErrorKind::WouldBlock
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use sandbox::ProcessControlAck;
+
+    use super::*;
+
+    fn recording_control(calls: Arc<Mutex<Vec<String>>>) -> GuestProcessControlHandle {
+        GuestProcessControlHandle::new(move |message_id, _payload, _timeout| {
+            let calls = Arc::clone(&calls);
+            Box::pin(async move {
+                calls.lock().unwrap().push(message_id.clone());
+                Ok(ProcessControlAck { message_id })
+            })
+        })
+    }
+
+    fn entry(sequence: u64, message_id: &str, text: &str) -> ActiveInputEntry {
+        ActiveInputEntry {
+            run_id: RunId::nil(),
+            sequence,
+            message_id: message_id.to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_entries_waits_for_missing_earlier_sequence() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let control = recording_control(Arc::clone(&calls));
+        let mut state = ForwardState::default();
+
+        forward_entries(
+            RunId::nil(),
+            &control,
+            vec![entry(2, "msg-2", "second")],
+            &mut state,
+        )
+        .await;
+        assert!(calls.lock().unwrap().is_empty());
+
+        forward_entries(
+            RunId::nil(),
+            &control,
+            vec![entry(1, "msg-1", "first"), entry(2, "msg-2", "second")],
+            &mut state,
+        )
+        .await;
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["msg-1".to_string(), "msg-2".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_entries_consumes_duplicate_message_id_sequences() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let control = recording_control(Arc::clone(&calls));
+        let mut state = ForwardState::default();
+
+        forward_entries(
+            RunId::nil(),
+            &control,
+            vec![
+                entry(1, "msg-dup", "first"),
+                entry(2, "msg-dup", "duplicate"),
+                entry(3, "msg-3", "third"),
+            ],
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["msg-dup".to_string(), "msg-3".to_string()]
+        );
+    }
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -148,6 +148,8 @@ async fn forward_entries(
                 );
                 if !retry {
                     seen.insert(entry.message_id);
+                } else {
+                    break;
                 }
             }
         }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -1,0 +1,149 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
+use sandbox::GuestProcessControlHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::active_input::ActiveInputSource;
+use crate::ids::RunId;
+use crate::local_queue::ActiveInputEntry;
+
+const ACTIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
+const ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(serde::Serialize)]
+struct ActiveInputPayload<'a> {
+    #[serde(rename = "type")]
+    payload_type: &'static str,
+    text: &'a str,
+}
+
+pub(super) struct ActiveInputForwarder {
+    stop: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ActiveInputForwarder {
+    pub(super) fn start(
+        run_id: RunId,
+        source: Option<ActiveInputSource>,
+        control: Option<GuestProcessControlHandle>,
+        job_cancel: CancellationToken,
+    ) -> Option<Self> {
+        let (Some(source), Some(control)) = (source, control) else {
+            return None;
+        };
+        let stop = CancellationToken::new();
+        let stop_for_task = stop.clone();
+        let task = tokio::spawn(async move {
+            run_forwarder(run_id, source, control, job_cancel, stop_for_task).await;
+        });
+        Some(Self { stop, task })
+    }
+
+    pub(super) async fn stop(self) {
+        self.stop.cancel();
+        let mut task = self.task;
+        match tokio::time::timeout(ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT, &mut task).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                warn!(error = %error, "active-input forwarder task failed");
+            }
+            Err(_) => {
+                task.abort();
+                let _ = task.await;
+            }
+        }
+    }
+}
+
+async fn run_forwarder(
+    run_id: RunId,
+    source: ActiveInputSource,
+    control: GuestProcessControlHandle,
+    job_cancel: CancellationToken,
+    stop: CancellationToken,
+) {
+    let mut seen = HashSet::new();
+    loop {
+        tokio::select! {
+            biased;
+            () = stop.cancelled() => return,
+            () = job_cancel.cancelled() => return,
+            entries = read_entries(run_id, source.clone()) => {
+                forward_entries(run_id, &control, entries, &mut seen).await;
+            }
+        }
+
+        tokio::select! {
+            biased;
+            () = stop.cancelled() => return,
+            () = job_cancel.cancelled() => return,
+            () = tokio::time::sleep(ACTIVE_INPUT_POLL_INTERVAL) => {}
+        }
+    }
+}
+
+async fn read_entries(run_id: RunId, source: ActiveInputSource) -> Vec<ActiveInputEntry> {
+    match tokio::task::spawn_blocking(move || source.read_entries_sync()).await {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(run_id = %run_id, error = %error, "active-input reader task failed");
+            Vec::new()
+        }
+    }
+}
+
+async fn forward_entries(
+    run_id: RunId,
+    control: &GuestProcessControlHandle,
+    entries: Vec<ActiveInputEntry>,
+    seen: &mut HashSet<String>,
+) {
+    for entry in entries {
+        if !seen.insert(entry.message_id.clone()) {
+            continue;
+        }
+        let payload = ActiveInputPayload {
+            payload_type: "active-input",
+            text: &entry.text,
+        };
+        let bytes = match serde_json::to_vec(&payload) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    sequence = entry.sequence,
+                    message_id = %entry.message_id,
+                    error = %error,
+                    "failed to serialize active-input payload"
+                );
+                continue;
+            }
+        };
+        match control
+            .control(&entry.message_id, &bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
+            .await
+        {
+            Ok(_) => {
+                debug!(
+                    run_id = %run_id,
+                    sequence = entry.sequence,
+                    message_id = %entry.message_id,
+                    "forwarded active input"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    run_id = %run_id,
+                    sequence = entry.sequence,
+                    message_id = %entry.message_id,
+                    error = %error,
+                    "failed to forward active input"
+                );
+            }
+        }
+    }
+}

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -314,6 +314,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn forward_entries_retries_queue_full_before_forwarding_later_inputs() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let errors = Arc::new(Mutex::new(VecDeque::from([std::io::ErrorKind::WouldBlock])));
+        let control = recording_control_with_errors(Arc::clone(&calls), errors);
+        let mut state = ForwardState::default();
+
+        let entries = vec![entry(1, "msg-1", "first"), entry(2, "msg-2", "second")];
+        forward_entries(RunId::nil(), &control, entries.clone(), &mut state).await;
+        assert_eq!(calls.lock().unwrap().as_slice(), ["msg-1".to_string()]);
+
+        forward_entries(RunId::nil(), &control, entries, &mut state).await;
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            [
+                "msg-1".to_string(),
+                "msg-1".to_string(),
+                "msg-2".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn forward_entries_consumes_non_retryable_failure_and_continues() {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let errors = Arc::new(Mutex::new(VecDeque::from([

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -103,7 +103,7 @@ async fn forward_entries(
     seen: &mut HashSet<String>,
 ) {
     for entry in entries {
-        if !seen.insert(entry.message_id.clone()) {
+        if seen.contains(&entry.message_id) {
             continue;
         }
         let payload = ActiveInputPayload {
@@ -134,16 +134,32 @@ async fn forward_entries(
                     message_id = %entry.message_id,
                     "forwarded active input"
                 );
+                seen.insert(entry.message_id);
             }
             Err(error) => {
+                let retry = should_retry_control_error(&error);
                 warn!(
                     run_id = %run_id,
                     sequence = entry.sequence,
                     message_id = %entry.message_id,
                     error = %error,
+                    retry,
                     "failed to forward active input"
                 );
+                if !retry {
+                    seen.insert(entry.message_id);
+                }
             }
         }
     }
+}
+
+fn should_retry_control_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::NotConnected
+            | std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::WouldBlock
+    )
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -165,19 +165,25 @@ async fn forward_entries(
             }
             Err(error) => {
                 let retry = should_retry_control_error(&error);
-                warn!(
-                    run_id = %run_id,
-                    sequence = entry.sequence,
-                    message_id = %entry.message_id,
-                    error = %error,
-                    retry,
-                    "failed to forward active input"
-                );
-                if !retry {
+                if retry {
+                    debug!(
+                        run_id = %run_id,
+                        sequence = entry.sequence,
+                        message_id = %entry.message_id,
+                        error = %error,
+                        "active-input forward failed; will retry"
+                    );
+                    break;
+                } else {
+                    warn!(
+                        run_id = %run_id,
+                        sequence = entry.sequence,
+                        message_id = %entry.message_id,
+                        error = %error,
+                        "active-input forward failed; dropping input"
+                    );
                     state.seen_message_ids.insert(entry.message_id);
                     state.consume_sequence();
-                } else {
-                    break;
                 }
             }
         }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -5,7 +5,7 @@ use sandbox::GuestProcessControlHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-use crate::active_input::ActiveInputSource;
+use crate::active_input::{ActiveInputPayload, ActiveInputSource};
 use crate::ids::RunId;
 use crate::local_queue::ActiveInputEntry;
 
@@ -13,13 +13,6 @@ const ACTIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
 const ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
 const FIRST_ACTIVE_INPUT_SEQUENCE: u64 = 1;
-
-#[derive(serde::Serialize)]
-struct ActiveInputPayload<'a> {
-    #[serde(rename = "type")]
-    payload_type: &'static str,
-    text: &'a str,
-}
 
 struct ForwardState {
     seen_message_ids: HashSet<String>,
@@ -134,11 +127,8 @@ async fn forward_entries(
             state.consume_sequence();
             continue;
         }
-        let payload = ActiveInputPayload {
-            payload_type: "active-input",
-            text: &entry.text,
-        };
-        let bytes = match serde_json::to_vec(&payload) {
+        let payload = ActiveInputPayload::new(&entry.text);
+        let bytes = match payload.to_vec() {
             Ok(bytes) => bytes,
             Err(error) => {
                 warn!(

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::time::Duration;
 
 use sandbox::GuestProcessControlHandle;
@@ -12,10 +12,12 @@ use crate::local_queue::ActiveInputEntry;
 const ACTIVE_INPUT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
 const ACTIVE_INPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_secs(1);
+const ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY: usize = 1024;
 const FIRST_ACTIVE_INPUT_SEQUENCE: u64 = 1;
 
 struct ForwardState {
     seen_message_ids: HashSet<String>,
+    seen_message_id_order: VecDeque<String>,
     next_sequence: u64,
 }
 
@@ -23,6 +25,7 @@ impl Default for ForwardState {
     fn default() -> Self {
         Self {
             seen_message_ids: HashSet::new(),
+            seen_message_id_order: VecDeque::new(),
             next_sequence: FIRST_ACTIVE_INPUT_SEQUENCE,
         }
     }
@@ -31,6 +34,19 @@ impl Default for ForwardState {
 impl ForwardState {
     fn consume_sequence(&mut self) {
         self.next_sequence = self.next_sequence.saturating_add(1);
+    }
+
+    fn remember_message_id(&mut self, message_id: String) {
+        if !self.seen_message_ids.insert(message_id.clone()) {
+            return;
+        }
+        self.seen_message_id_order.push_back(message_id);
+        while self.seen_message_ids.len() > ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY {
+            let Some(oldest) = self.seen_message_id_order.pop_front() else {
+                break;
+            };
+            self.seen_message_ids.remove(&oldest);
+        }
     }
 }
 
@@ -160,7 +176,7 @@ async fn forward_entries(
                     message_id = %entry.message_id,
                     "forwarded active input"
                 );
-                state.seen_message_ids.insert(entry.message_id);
+                state.remember_message_id(entry.message_id);
                 state.consume_sequence();
             }
             Err(error) => {
@@ -182,7 +198,7 @@ async fn forward_entries(
                         error = %error,
                         "active-input forward failed; dropping input"
                     );
-                    state.seen_message_ids.insert(entry.message_id);
+                    state.remember_message_id(entry.message_id);
                     state.consume_sequence();
                 }
             }
@@ -294,6 +310,39 @@ mod tests {
         assert_eq!(
             calls.lock().unwrap().as_slice(),
             ["msg-dup".to_string(), "msg-3".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_entries_bounds_seen_message_id_cache() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let control = recording_control(Arc::clone(&calls));
+        let mut state = ForwardState::default();
+        let entries: Vec<_> = (0..=ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY)
+            .map(|index| {
+                entry(
+                    index as u64 + FIRST_ACTIVE_INPUT_SEQUENCE,
+                    &format!("msg-{index}"),
+                    "input",
+                )
+            })
+            .collect();
+
+        forward_entries(RunId::nil(), &control, entries, &mut state).await;
+
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY + 1
+        );
+        assert_eq!(
+            state.seen_message_ids.len(),
+            ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY
+        );
+        assert!(!state.seen_message_ids.contains("msg-0"));
+        assert!(
+            state
+                .seen_message_ids
+                .contains(&format!("msg-{ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY}"))
         );
     }
 

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -199,6 +199,7 @@ fn should_retry_control_error(error: &std::io::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
     use sandbox::ProcessControlAck;
@@ -210,6 +211,23 @@ mod tests {
             let calls = Arc::clone(&calls);
             Box::pin(async move {
                 calls.lock().unwrap().push(message_id.clone());
+                Ok(ProcessControlAck { message_id })
+            })
+        })
+    }
+
+    fn recording_control_with_errors(
+        calls: Arc<Mutex<Vec<String>>>,
+        errors: Arc<Mutex<VecDeque<std::io::ErrorKind>>>,
+    ) -> GuestProcessControlHandle {
+        GuestProcessControlHandle::new(move |message_id, _payload, _timeout| {
+            let calls = Arc::clone(&calls);
+            let errors = Arc::clone(&errors);
+            Box::pin(async move {
+                calls.lock().unwrap().push(message_id.clone());
+                if let Some(kind) = errors.lock().unwrap().pop_front() {
+                    return Err(std::io::Error::new(kind, "injected control error"));
+                }
                 Ok(ProcessControlAck { message_id })
             })
         })
@@ -273,6 +291,51 @@ mod tests {
         assert_eq!(
             calls.lock().unwrap().as_slice(),
             ["msg-dup".to_string(), "msg-3".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_entries_retries_sequence_before_forwarding_later_inputs() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let errors = Arc::new(Mutex::new(VecDeque::from([std::io::ErrorKind::TimedOut])));
+        let control = recording_control_with_errors(Arc::clone(&calls), errors);
+        let mut state = ForwardState::default();
+
+        let entries = vec![entry(1, "msg-1", "first"), entry(2, "msg-2", "second")];
+        forward_entries(RunId::nil(), &control, entries.clone(), &mut state).await;
+        assert_eq!(calls.lock().unwrap().as_slice(), ["msg-1".to_string()]);
+
+        forward_entries(RunId::nil(), &control, entries, &mut state).await;
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            [
+                "msg-1".to_string(),
+                "msg-1".to_string(),
+                "msg-2".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_entries_consumes_non_retryable_failure_and_continues() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let errors = Arc::new(Mutex::new(VecDeque::from([
+            std::io::ErrorKind::PermissionDenied,
+        ])));
+        let control = recording_control_with_errors(Arc::clone(&calls), errors);
+        let mut state = ForwardState::default();
+
+        forward_entries(
+            RunId::nil(),
+            &control,
+            vec![entry(1, "msg-1", "first"), entry(2, "msg-2", "second")],
+            &mut state,
+        )
+        .await;
+
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            ["msg-1".to_string(), "msg-2".to_string()]
         );
     }
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -82,11 +82,12 @@ async fn run_forwarder(
 ) {
     let mut state = ForwardState::default();
     loop {
+        let next_sequence = state.next_sequence;
         tokio::select! {
             biased;
             () = stop.cancelled() => return,
             () = job_cancel.cancelled() => return,
-            entries = read_entries(run_id, source.clone()) => {
+            entries = read_entries(run_id, source.clone(), next_sequence) => {
                 forward_entries(run_id, &control, entries, &mut state).await;
             }
         }
@@ -100,8 +101,14 @@ async fn run_forwarder(
     }
 }
 
-async fn read_entries(run_id: RunId, source: ActiveInputSource) -> Vec<ActiveInputEntry> {
-    match tokio::task::spawn_blocking(move || source.read_entries_sync()).await {
+async fn read_entries(
+    run_id: RunId,
+    source: ActiveInputSource,
+    min_sequence: u64,
+) -> Vec<ActiveInputEntry> {
+    match tokio::task::spawn_blocking(move || source.read_entries_from_sequence_sync(min_sequence))
+        .await
+    {
         Ok(entries) => entries,
         Err(error) => {
             warn!(run_id = %run_id, error = %error, "active-input reader task failed");

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -27,6 +27,7 @@ use super::{
     agent_exit_failure_message, job_terminal_wait_timeout, normalize_failure_exit_code,
     normalize_timeout_failure_exit_code,
 };
+use crate::active_input::ActiveInputSource;
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
@@ -121,13 +122,30 @@ pub(super) struct RunStart<'a> {
     pub(super) prev_storage: Option<&'a crate::storage_fingerprints::StorageFingerprints>,
 }
 
+pub(super) struct RunControls {
+    pub(super) cancel: CancellationToken,
+    pub(super) active_input_source: Option<ActiveInputSource>,
+}
+
+impl RunControls {
+    pub(super) fn new(
+        cancel: CancellationToken,
+        active_input_source: Option<ActiveInputSource>,
+    ) -> Self {
+        Self {
+            cancel,
+            active_input_source,
+        }
+    }
+}
+
 pub(super) async fn run_in_sandbox(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     config: &ExecutorConfig,
     start: RunStart<'_>,
     telemetry: &mut JobTelemetry,
-    cancel: CancellationToken,
+    controls: RunControls,
 ) -> RunnerResult<AgentExecutionResult> {
     run_in_sandbox_with_process_cancel_timeouts(
         sandbox,
@@ -135,7 +153,7 @@ pub(super) async fn run_in_sandbox(
         config,
         start,
         telemetry,
-        cancel,
+        controls,
         PROCESS_CANCEL_TIMEOUTS,
     )
     .await
@@ -147,9 +165,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     config: &ExecutorConfig,
     start: RunStart<'_>,
     telemetry: &mut JobTelemetry,
-    cancel: CancellationToken,
+    controls: RunControls,
     process_cancel_timeouts: ProcessCancelTimeouts,
 ) -> RunnerResult<AgentExecutionResult> {
+    let RunControls {
+        cancel,
+        active_input_source,
+    } = controls;
+
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
     if start.restore_guest_state {
@@ -265,6 +288,13 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // Claude Code process has a PID now — record end-to-end startup latency.
     record_api_latency("api_to_spawn", context, telemetry);
 
+    let active_input_forwarder = super::active_input::ActiveInputForwarder::start(
+        context.run_id,
+        active_input_source,
+        handle.control_handle(),
+        cancel.clone(),
+    );
+
     // Spawn background task to drain stdout chunks and write to the host stream log file.
     let host_log_path = config.log_paths.system_stream_log(context.run_id);
     let stream_task = handle
@@ -354,6 +384,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             }
         }
     };
+
+    if let Some(forwarder) = active_input_forwarder {
+        forwarder.stop().await;
+    }
 
     // Wait for streaming to finish (channel closes when process exits).
     // On cancel/timeout/crash the stream channel may not close — abort to

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -23,6 +23,7 @@ use futures_util::future::BoxFuture;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
 use tokio_util::sync::CancellationToken;
 
+mod active_input;
 mod agent_run;
 mod diagnostics;
 mod env;
@@ -34,7 +35,8 @@ mod telemetry;
 
 pub(crate) use guest_state::{fix_guest_clock, reseed_guest_entropy};
 
-use agent_run::ProcessCancelTimeouts;
+use crate::active_input::ActiveInputSource;
+use agent_run::{ProcessCancelTimeouts, RunControls};
 use env::validate_execution_context_before_sandbox;
 pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
@@ -175,6 +177,21 @@ impl SandboxPreparedNotifier {
 
     async fn notify(&self, run_id: RunId, sandbox_id: SandboxId) {
         (self.callback)(run_id, sandbox_id).await;
+    }
+}
+
+pub(crate) struct ExecutionHooks {
+    pub(crate) sandbox_prepared: Option<SandboxPreparedNotifier>,
+    pub(crate) active_input_source: Option<ActiveInputSource>,
+}
+
+impl ExecutionHooks {
+    #[cfg(test)]
+    fn none() -> Self {
+        Self {
+            sandbox_prepared: None,
+            active_input_source: None,
+        }
     }
 }
 
@@ -372,8 +389,16 @@ pub async fn execute_job(
     params: &JobParams,
     cancel: CancellationToken,
 ) -> (ExecuteOutcome, JobTelemetry) {
-    execute_job_with_prepared_notifier(factory, context, dispatch, config, params, cancel, None)
-        .await
+    execute_job_with_prepared_notifier(
+        factory,
+        context,
+        dispatch,
+        config,
+        params,
+        cancel,
+        ExecutionHooks::none(),
+    )
+    .await
 }
 
 pub(crate) async fn execute_job_with_prepared_notifier(
@@ -383,7 +408,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
-    sandbox_prepared: Option<SandboxPreparedNotifier>,
+    hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
@@ -417,8 +442,8 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             params,
             &mut telemetry,
             NewSandboxHooks {
-                cancel,
-                sandbox_prepared: sandbox_prepared.as_ref(),
+                controls: RunControls::new(cancel, hooks.active_input_source),
+                sandbox_prepared: hooks.sandbox_prepared.as_ref(),
             },
         )
         .await
@@ -446,12 +471,25 @@ pub(crate) async fn execute_job_with_prepared_notifier(
 /// [`JobTelemetry`] buffer — the caller (`spawn_job` in `cmd/start/job_spawn.rs`)
 /// must flush telemetry after firing `provider.complete`, matching the fresh
 /// sandbox path's completion ordering.
+#[cfg(test)]
 pub async fn execute_job_reuse(
     idle_sandbox: ReusableIdleSandbox,
     context: ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
+) -> (ExecuteOutcome, JobTelemetry) {
+    execute_job_reuse_with_active_input_source(idle_sandbox, context, config, params, cancel, None)
+        .await
+}
+
+pub(crate) async fn execute_job_reuse_with_active_input_source(
+    idle_sandbox: ReusableIdleSandbox,
+    context: ExecutionContext,
+    config: &ExecutorConfig,
+    params: &JobParams,
+    cancel: CancellationToken,
+    active_input_source: Option<ActiveInputSource>,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
@@ -595,7 +633,7 @@ pub async fn execute_job_reuse(
             config,
             &prev_storage,
             &mut telemetry,
-            cancel,
+            RunControls::new(cancel, active_input_source),
         )
         .await;
         outcome.workspace_promotable = workspace_image_promotable(

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -5,10 +5,9 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxConfig, SandboxFactory, SandboxId};
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use super::agent_run::{AgentExecutionResult, RunStart, run_in_sandbox};
+use super::agent_run::{AgentExecutionResult, RunControls, RunStart, run_in_sandbox};
 use super::diagnostics::{
     AgentStdoutStreamDiagnostics, append_stdout_stream_diagnostics_to_stream_log, copy_guest_logs,
     read_guest_cli_agent_session_id,
@@ -40,7 +39,7 @@ pub(super) async fn execute_new_sandbox(
     config: &ExecutorConfig,
     params: &JobParams,
     telemetry: &mut JobTelemetry,
-    cancel: CancellationToken,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> RunnerResult<ExecuteOutcome> {
     execute_new_sandbox_with_prepared_notifier(
         factory,
@@ -50,7 +49,7 @@ pub(super) async fn execute_new_sandbox(
         params,
         telemetry,
         NewSandboxHooks {
-            cancel,
+            controls: RunControls::new(cancel, None),
             sandbox_prepared: None,
         },
     )
@@ -71,7 +70,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         reuse_result,
     } = dispatch;
     let NewSandboxHooks {
-        cancel,
+        controls,
         sandbox_prepared,
     } = hooks;
     let mut workspace_image = prepare_workspace_image(
@@ -148,7 +147,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 .and_then(WorkspaceImageLease::previous_storage),
         },
         telemetry,
-        cancel,
+        controls,
     )
     .await;
     outcome.workspace_promotable = workspace_image_promotable(
@@ -172,7 +171,7 @@ pub(super) struct SandboxPrepareError {
 }
 
 pub(super) struct NewSandboxHooks<'a> {
-    pub(super) cancel: CancellationToken,
+    pub(super) controls: RunControls,
     pub(super) sandbox_prepared: Option<&'a SandboxPreparedNotifier>,
 }
 
@@ -396,7 +395,7 @@ pub(super) async fn execute_reused_sandbox(
     config: &ExecutorConfig,
     prev_storage: &crate::storage_fingerprints::StorageFingerprints,
     telemetry: &mut JobTelemetry,
-    cancel: CancellationToken,
+    controls: RunControls,
 ) -> ExecuteOutcome {
     info!(
         run_id = %context.run_id,
@@ -461,7 +460,7 @@ pub(super) async fn execute_reused_sandbox(
             prev_storage: Some(prev_storage),
         },
         telemetry,
-        cancel,
+        controls,
     )
     .await
 }
@@ -472,7 +471,7 @@ pub(super) async fn execute_prepared_sandbox_run(
     config: &ExecutorConfig,
     start: RunStart<'_>,
     telemetry: &mut JobTelemetry,
-    cancel: CancellationToken,
+    controls: RunControls,
 ) -> ExecuteOutcome {
     let PreparedSandboxRun {
         sandbox,
@@ -486,7 +485,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         config,
         start,
         telemetry,
-        cancel.clone(),
+        RunControls::new(controls.cancel.clone(), controls.active_input_source),
     )
     .await;
 
@@ -500,7 +499,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         config,
         context,
         &source_ip,
-        cancel.is_cancelled(),
+        controls.cancel.is_cancelled(),
         stdout_stream_diagnostics,
     )
     .await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -6,7 +6,7 @@ use api_contracts::generated::types::runners::storage::StorageManifest;
 use sandbox::{ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::MockSandboxFactory;
 
-use super::super::agent_run::{ProcessCancelTimeouts, RunStart, run_in_sandbox};
+use super::super::agent_run::{ProcessCancelTimeouts, RunControls, RunStart, run_in_sandbox};
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
 use super::super::storage::guest_download_command;
 use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT};
@@ -15,6 +15,8 @@ use super::support::{
     minimal_context, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
     test_executor_config, test_telemetry,
 };
+use crate::active_input::ActiveInputSource;
+use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::SandboxReuseResult;
 
@@ -57,7 +59,7 @@ async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
             prev_storage: None,
         },
         &mut telemetry,
-        cancel.clone(),
+        RunControls::new(cancel.clone(), None),
     )
     .await
     .unwrap();
@@ -109,7 +111,7 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
             prev_storage: Some(&prev_storage),
         },
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     )
     .await
     .unwrap();
@@ -121,6 +123,144 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
             .any(|call| call.cmd == guest_download_command()),
         "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_forwards_local_active_inputs_in_order_and_dedupes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let group_dir = dir.path().join("active-inputs");
+    let queue = LocalQueue::new(group_dir.clone());
+    for entry in [
+        ActiveInputEntry {
+            run_id: ctx.run_id,
+            sequence: 1,
+            message_id: "msg-dup".to_string(),
+            text: "first".to_string(),
+        },
+        ActiveInputEntry {
+            run_id: ctx.run_id,
+            sequence: 2,
+            message_id: "msg-dup".to_string(),
+            text: "duplicate".to_string(),
+        },
+        ActiveInputEntry {
+            run_id: ctx.run_id,
+            sequence: 3,
+            message_id: "msg-3".to_string(),
+            text: "third".to_string(),
+        },
+    ] {
+        queue.write_active_input_sync(&entry).unwrap();
+    }
+    let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(result.failure.is_none());
+    let calls = overrides.process_control_calls();
+    assert_eq!(
+        calls
+            .iter()
+            .map(|call| call.message_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["msg-dup", "msg-3"]
+    );
+    let payloads = calls
+        .iter()
+        .map(|call| serde_json::from_slice::<serde_json::Value>(&call.payload).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(payloads[0]["text"], "first");
+    assert_eq!(payloads[1]["text"], "third");
+}
+
+#[tokio::test]
+async fn run_in_sandbox_control_error_does_not_block_completion() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    overrides.push_process_control_error("simulated control error");
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let group_dir = dir.path().join("active-inputs");
+    LocalQueue::new(group_dir.clone())
+        .write_active_input_sync(&ActiveInputEntry {
+            run_id: ctx.run_id,
+            sequence: 1,
+            message_id: "msg-1".to_string(),
+            text: "first".to_string(),
+        })
+        .unwrap();
+    let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let run_task = tokio::spawn(async move {
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        )
+        .await
+    });
+
+    assert!(
+        overrides
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .await
+    );
+    wait_gate.notify_one();
+    let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert!(result.failure.is_none());
+    assert_eq!(overrides.process_control_calls().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -230,6 +230,14 @@ async fn run_in_sandbox_retries_active_input_after_control_error() {
             text: "first".to_string(),
         })
         .unwrap();
+    LocalQueue::new(group_dir.clone())
+        .write_active_input_sync(&ActiveInputEntry {
+            run_id: ctx.run_id,
+            sequence: 2,
+            message_id: "msg-2".to_string(),
+            text: "second".to_string(),
+        })
+        .unwrap();
     let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -252,7 +260,7 @@ async fn run_in_sandbox_retries_active_input_after_control_error() {
 
     assert!(
         overrides
-            .wait_for_process_control_calls(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .wait_for_process_control_calls(3, RUN_IN_SANDBOX_TEST_TIMEOUT)
             .await
     );
     wait_gate.notify_one();
@@ -269,7 +277,7 @@ async fn run_in_sandbox_retries_active_input_after_control_error() {
             .iter()
             .map(|call| call.message_id.as_str())
             .collect::<Vec<_>>(),
-        vec!["msg-1", "msg-1"]
+        vec!["msg-1", "msg-1", "msg-2"]
     );
 }
 

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -208,14 +208,17 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order_and_dedupes() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_control_error_does_not_block_completion() {
+async fn run_in_sandbox_retries_active_input_after_control_error() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let wait_gate = Arc::new(tokio::sync::Notify::new());
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&wait_gate),
     ));
-    overrides.push_process_control_error("simulated control error");
+    overrides.push_process_control_io_error(
+        std::io::ErrorKind::TimedOut,
+        "simulated transient control error",
+    );
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let group_dir = dir.path().join("active-inputs");
@@ -249,7 +252,7 @@ async fn run_in_sandbox_control_error_does_not_block_completion() {
 
     assert!(
         overrides
-            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .wait_for_process_control_calls(2, RUN_IN_SANDBOX_TEST_TIMEOUT)
             .await
     );
     wait_gate.notify_one();
@@ -260,7 +263,14 @@ async fn run_in_sandbox_control_error_does_not_block_completion() {
         .unwrap();
 
     assert!(result.failure.is_none());
-    assert_eq!(overrides.process_control_calls().len(), 1);
+    assert_eq!(
+        overrides
+            .process_control_calls()
+            .iter()
+            .map(|call| call.message_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["msg-1", "msg-1"]
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -177,7 +177,7 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
             prev_storage: None,
         },
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     )
     .await;
 
@@ -219,7 +219,7 @@ async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw
             prev_storage: None,
         },
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     ))
     .await;
 
@@ -271,7 +271,7 @@ async fn execute_prepared_sandbox_run_canonicalizes_codex_discovered_cli_agent_s
             prev_storage: None,
         },
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     ))
     .await;
 
@@ -317,7 +317,7 @@ async fn execute_prepared_sandbox_run_ignores_non_uuid_codex_discovered_cli_agen
             prev_storage: None,
         },
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     ))
     .await;
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -47,7 +47,7 @@ async fn execute_new_sandbox_notifies_after_successful_prepare() {
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
-            cancel: tokio_util::sync::CancellationToken::new(),
+            controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             sandbox_prepared: Some(&notifier),
         },
     )
@@ -89,7 +89,7 @@ async fn execute_new_sandbox_does_not_notify_before_start_failure() {
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
-            cancel: tokio_util::sync::CancellationToken::new(),
+            controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             sandbox_prepared: Some(&notifier),
         },
     )
@@ -134,7 +134,7 @@ async fn execute_new_sandbox_does_not_notify_after_post_start_prepare_failure() 
         &default_params(),
         &mut telemetry,
         NewSandboxHooks {
-            cancel: tokio_util::sync::CancellationToken::new(),
+            controls: RunControls::new(tokio_util::sync::CancellationToken::new(), None),
             sandbox_prepared: Some(&notifier),
         },
     )

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -14,7 +14,7 @@ use sandbox::{
 };
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
-use super::super::agent_run::RunStart;
+use super::super::agent_run::{RunControls, RunStart};
 use super::super::env::{guest_user_env_dir_path, guest_user_env_file_path};
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -145,7 +145,7 @@ async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_ag
         &config,
         &prev_storage,
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     )
     .await;
 
@@ -192,7 +192,7 @@ async fn execute_inner_proxy_unregister_failure_marks_successful_run_failed() {
             prev_storage: None,
         },
         &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     )
     .await;
 

--- a/crates/runner/src/executor/tests/support/execution.rs
+++ b/crates/runner/src/executor/tests/support/execution.rs
@@ -5,7 +5,7 @@ use sandbox_mock::MockSandboxFactory;
 use tokio_util::sync::CancellationToken;
 
 use super::super::super::agent_run::{
-    AgentExecutionResult, ProcessCancelTimeouts, RunStart,
+    AgentExecutionResult, ProcessCancelTimeouts, RunControls, RunStart,
     run_in_sandbox_with_process_cancel_timeouts,
 };
 use super::super::super::sandbox_run::execute_new_sandbox;
@@ -68,7 +68,7 @@ pub(in crate::executor::tests) fn spawn_run_in_sandbox_test_with_timeouts(
                 prev_storage: None,
             },
             &mut telemetry,
-            cancel,
+            RunControls::new(cancel, None),
             process_cancel_timeouts,
         )
         .await

--- a/crates/runner/src/local_queue/fs.rs
+++ b/crates/runner/src/local_queue/fs.rs
@@ -50,6 +50,43 @@ pub(crate) fn validate_cancels_dir(group_dir: &Path) -> io::Result<PathBuf> {
     Ok(dir)
 }
 
+pub(crate) fn ensure_run_inputs_dir(
+    group_dir: &Path,
+    run_id: crate::ids::RunId,
+) -> io::Result<PathBuf> {
+    ensure_group_dir(group_dir)?;
+    let inputs_dir = super::inputs_dir(group_dir);
+    ensure_queue_dir(&inputs_dir, "local queue inputs directory")?;
+    let run_dir = super::run_inputs_dir(group_dir, run_id);
+    ensure_queue_dir(&run_dir, "local queue run inputs directory")?;
+    Ok(run_dir)
+}
+
+pub(crate) fn validate_inputs_dir(group_dir: &Path) -> io::Result<PathBuf> {
+    validate_group_dir(group_dir)?;
+    let inputs_dir = super::inputs_dir(group_dir);
+    host_file::validate_dir(
+        &inputs_dir,
+        DirMode::Private,
+        "local queue inputs directory",
+    )?;
+    Ok(inputs_dir)
+}
+
+pub(crate) fn validate_run_inputs_dir(
+    group_dir: &Path,
+    run_id: crate::ids::RunId,
+) -> io::Result<PathBuf> {
+    validate_inputs_dir(group_dir)?;
+    let run_dir = super::run_inputs_dir(group_dir, run_id);
+    host_file::validate_dir(
+        &run_dir,
+        DirMode::Private,
+        "local queue run inputs directory",
+    )?;
+    Ok(run_dir)
+}
+
 pub(crate) fn ensure_group_dir(group_dir: &Path) -> io::Result<()> {
     host_file::ensure_dir(
         group_dir,

--- a/crates/runner/src/local_queue/mod.rs
+++ b/crates/runner/src/local_queue/mod.rs
@@ -7,13 +7,14 @@ mod types;
 
 pub(crate) use fs::{
     create_private_marker, ensure_cancels_dir, ensure_claims_dir, ensure_group_dir,
-    ensure_profile_jobs_dir, ensure_results_dir, marker_file_exists, marker_path_occupied,
-    open_private_new_file, private_file_has_content, read_private_file, validate_cancels_dir,
-    validate_claims_dir, validate_group_dir, write_private_file, write_private_marker,
+    ensure_profile_jobs_dir, ensure_results_dir, ensure_run_inputs_dir, marker_file_exists,
+    marker_path_occupied, open_private_new_file, private_file_has_content, read_private_file,
+    validate_cancels_dir, validate_claims_dir, validate_group_dir, validate_inputs_dir,
+    validate_run_inputs_dir, write_private_file, write_private_marker,
 };
 pub(crate) use paths::{
-    cancel_path, cancels_dir, claim_path, claims_dir, job_path, jobs_dir, profile_jobs_dir,
-    result_path, results_dir,
+    active_input_path, cancel_path, cancels_dir, claim_path, claims_dir, inputs_dir, job_path,
+    jobs_dir, profile_jobs_dir, result_path, results_dir, run_inputs_dir,
 };
 pub(crate) use state::{CancelTargetState, LocalClaimResult, LocalDiscoveredJob, LocalQueue};
-pub(crate) use types::{JobRequest, JobResponse};
+pub(crate) use types::{ActiveInputEntry, JobRequest, JobResponse};

--- a/crates/runner/src/local_queue/paths.rs
+++ b/crates/runner/src/local_queue/paths.rs
@@ -49,6 +49,18 @@ pub(crate) fn cancel_path(group_dir: &Path, run_id: RunId) -> PathBuf {
     cancels_dir(group_dir).join(format!("{run_id}.cancel"))
 }
 
+pub(crate) fn inputs_dir(group_dir: &Path) -> PathBuf {
+    group_dir.join("inputs")
+}
+
+pub(crate) fn run_inputs_dir(group_dir: &Path, run_id: RunId) -> PathBuf {
+    inputs_dir(group_dir).join(run_id.to_string())
+}
+
+pub(crate) fn active_input_path(group_dir: &Path, run_id: RunId, sequence: u64) -> PathBuf {
+    run_inputs_dir(group_dir, run_id).join(format!("{sequence:020}.json"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -536,6 +536,7 @@ impl LocalQueue {
     fn fail_claimed_job_sync_with_claim(&self, run_id: RunId, claim_file: &Path, error: String) {
         if self.write_result_sync(run_id, 1, Some(&error)) {
             let _ = self.remove_job_files_if_present(run_id);
+            self.cleanup_active_inputs_sync(run_id);
         }
         let _ = std::fs::remove_file(claim_file);
     }
@@ -828,6 +829,30 @@ mod tests {
         queue.cleanup_active_inputs_sync(run_id);
         queue.cleanup_active_inputs_sync(run_id);
 
+        assert!(!super::super::run_inputs_dir(group_dir, run_id).exists());
+    }
+
+    #[test]
+    fn fail_claimed_job_sync_cleans_active_inputs_after_terminal_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let run_id = RunId::new_v4();
+        let profile = crate::profile::DEFAULT_PROFILE;
+        let job_path = write_job_request(group_dir, run_id, profile);
+        queue
+            .write_active_input_sync(&ActiveInputEntry {
+                run_id,
+                sequence: 1,
+                message_id: "msg-1".to_string(),
+                text: "one".to_string(),
+            })
+            .unwrap();
+
+        queue.fail_claimed_job_sync(run_id, "failed before execution".to_string());
+
+        assert!(queue.result_file_has_content(run_id));
+        assert!(!job_path.exists());
         assert!(!super::super::run_inputs_dir(group_dir, run_id).exists());
     }
 

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -257,6 +257,12 @@ impl LocalQueue {
     }
 
     pub(crate) fn write_active_input_sync(&self, entry: &ActiveInputEntry) -> std::io::Result<()> {
+        if entry.sequence == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "local active input sequence must be greater than zero",
+            ));
+        }
         if entry.message_id.is_empty() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -283,16 +289,17 @@ impl LocalQueue {
             let _ = std::fs::remove_file(&tmp_path);
             return Err(e);
         }
-        if let Err(e) = std::fs::rename(&tmp_path, &final_path) {
+        if let Err(e) = std::fs::hard_link(&tmp_path, &final_path) {
             let _ = std::fs::remove_file(&tmp_path);
             return Err(std::io::Error::new(
                 e.kind(),
                 format!(
-                    "rename local active-input file {}: {e}",
+                    "publish local active-input file {}: {e}",
                     final_path.display()
                 ),
             ));
         }
+        let _ = std::fs::remove_file(&tmp_path);
         Ok(())
     }
 
@@ -867,6 +874,52 @@ mod tests {
             queue.read_active_input_entries_from_sequence_sync(run_id, 2),
             vec![entry_3]
         );
+    }
+
+    #[test]
+    fn active_input_write_rejects_duplicate_sequence_without_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let run_id = RunId::new_v4();
+        let original = ActiveInputEntry {
+            run_id,
+            sequence: 1,
+            message_id: "msg-1".to_string(),
+            text: "one".to_string(),
+        };
+        let duplicate = ActiveInputEntry {
+            run_id,
+            sequence: 1,
+            message_id: "msg-duplicate".to_string(),
+            text: "duplicate".to_string(),
+        };
+
+        queue.write_active_input_sync(&original).unwrap();
+        let error = queue.write_active_input_sync(&duplicate).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            queue.read_active_input_entries_from_sequence_sync(run_id, 0),
+            vec![original]
+        );
+    }
+
+    #[test]
+    fn active_input_write_rejects_zero_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = LocalQueue::new(dir.path().to_path_buf());
+
+        let error = queue
+            .write_active_input_sync(&ActiveInputEntry {
+                run_id: RunId::new_v4(),
+                sequence: 0,
+                message_id: "msg-0".to_string(),
+                text: "zero".to_string(),
+            })
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -296,7 +296,11 @@ impl LocalQueue {
         Ok(())
     }
 
-    pub(crate) fn read_active_input_entries_sync(&self, run_id: RunId) -> Vec<ActiveInputEntry> {
+    pub(crate) fn read_active_input_entries_from_sequence_sync(
+        &self,
+        run_id: RunId,
+        min_sequence: u64,
+    ) -> Vec<ActiveInputEntry> {
         let run_dir = super::run_inputs_dir(&self.group_dir, run_id);
         match std::fs::symlink_metadata(&run_dir) {
             Ok(_) => {
@@ -340,6 +344,9 @@ impl LocalQueue {
             else {
                 continue;
             };
+            if sequence < min_sequence {
+                continue;
+            }
             let Ok(bytes) = super::read_private_file(&path, "local active-input file") else {
                 continue;
             };
@@ -774,7 +781,7 @@ mod tests {
             0o600
         );
         assert_eq!(
-            queue.read_active_input_entries_sync(run_id),
+            queue.read_active_input_entries_from_sequence_sync(run_id, 0),
             vec![entry_2, entry_10]
         );
     }
@@ -829,7 +836,37 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(queue.read_active_input_entries_sync(run_id), vec![valid]);
+        assert_eq!(
+            queue.read_active_input_entries_from_sequence_sync(run_id, 0),
+            vec![valid]
+        );
+    }
+
+    #[test]
+    fn active_input_read_skips_entries_before_min_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let run_id = RunId::new_v4();
+        let entry_1 = ActiveInputEntry {
+            run_id,
+            sequence: 1,
+            message_id: "msg-1".to_string(),
+            text: "one".to_string(),
+        };
+        let entry_3 = ActiveInputEntry {
+            run_id,
+            sequence: 3,
+            message_id: "msg-3".to_string(),
+            text: "three".to_string(),
+        };
+        queue.write_active_input_sync(&entry_1).unwrap();
+        queue.write_active_input_sync(&entry_3).unwrap();
+
+        assert_eq!(
+            queue.read_active_input_entries_from_sequence_sync(run_id, 2),
+            vec![entry_3]
+        );
     }
 
     #[test]

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -257,6 +257,12 @@ impl LocalQueue {
     }
 
     pub(crate) fn write_active_input_sync(&self, entry: &ActiveInputEntry) -> std::io::Result<()> {
+        if entry.message_id.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "local active input message id must not be empty",
+            ));
+        }
         if entry.text.is_empty() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -340,7 +346,11 @@ impl LocalQueue {
             let Ok(input) = serde_json::from_slice::<ActiveInputEntry>(&bytes) else {
                 continue;
             };
-            if input.run_id != run_id || input.sequence != sequence || input.text.is_empty() {
+            if input.run_id != run_id
+                || input.sequence != sequence
+                || input.message_id.is_empty()
+                || input.text.is_empty()
+            {
                 continue;
             }
             parsed.push(input);
@@ -807,8 +817,36 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
+        std::fs::write(
+            run_dir.join("00000000000000000005.json"),
+            serde_json::to_vec(&ActiveInputEntry {
+                run_id,
+                sequence: 5,
+                message_id: String::new(),
+                text: "empty message id".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(queue.read_active_input_entries_sync(run_id), vec![valid]);
+    }
+
+    #[test]
+    fn active_input_write_rejects_empty_message_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = LocalQueue::new(dir.path().to_path_buf());
+
+        let error = queue
+            .write_active_input_sync(&ActiveInputEntry {
+                run_id: RunId::new_v4(),
+                sequence: 1,
+                message_id: String::new(),
+                text: "one".to_string(),
+            })
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
 
-use super::types::{JobRequest, JobResponse};
+use super::types::{ActiveInputEntry, JobRequest, JobResponse};
 use crate::ids::RunId;
 
 #[derive(Clone)]
@@ -58,6 +58,10 @@ enum JobFileScanMode {
 impl LocalQueue {
     pub(crate) fn new(group_dir: PathBuf) -> Self {
         Self { group_dir }
+    }
+
+    pub(crate) fn group_dir(&self) -> &Path {
+        &self.group_dir
     }
 
     pub(crate) fn discover_candidate_sync(
@@ -240,6 +244,7 @@ impl LocalQueue {
             if self.remove_job_files_if_present(run_id) {
                 let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
                 let _ = std::fs::remove_file(super::claim_path(&self.group_dir, run_id));
+                self.cleanup_active_inputs_sync(run_id);
             }
             return;
         }
@@ -248,6 +253,133 @@ impl LocalQueue {
         // last discover() scan but before the job actually finished).
         let _ = std::fs::remove_file(super::cancel_path(&self.group_dir, run_id));
         let _ = std::fs::remove_file(super::claim_path(&self.group_dir, run_id));
+        self.cleanup_active_inputs_sync(run_id);
+    }
+
+    pub(crate) fn write_active_input_sync(&self, entry: &ActiveInputEntry) -> std::io::Result<()> {
+        if entry.text.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "local active input text must not be empty",
+            ));
+        }
+        let run_dir = super::ensure_run_inputs_dir(&self.group_dir, entry.run_id)?;
+        let bytes = serde_json::to_vec(entry).map_err(std::io::Error::other)?;
+        let tmp_path = run_dir.join(format!(
+            "{:020}.{}.json.tmp",
+            entry.sequence,
+            RunId::new_v4()
+        ));
+        let final_path = super::active_input_path(&self.group_dir, entry.run_id, entry.sequence);
+        if let Err(e) =
+            super::write_private_file(&tmp_path, &bytes, "local active-input temporary file")
+        {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e);
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, &final_path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "rename local active-input file {}: {e}",
+                    final_path.display()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn read_active_input_entries_sync(&self, run_id: RunId) -> Vec<ActiveInputEntry> {
+        let run_dir = super::run_inputs_dir(&self.group_dir, run_id);
+        match std::fs::symlink_metadata(&run_dir) {
+            Ok(_) => {
+                if let Err(e) = super::validate_run_inputs_dir(&self.group_dir, run_id) {
+                    warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: invalid active-input directory");
+                    return Vec::new();
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) => {
+                warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: cannot stat active-input directory");
+                return Vec::new();
+            }
+        }
+
+        let entries = match std::fs::read_dir(&run_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) => {
+                warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: cannot read active-input directory");
+                return Vec::new();
+            }
+        };
+
+        let mut parsed = Vec::new();
+        for entry in entries.filter_map(Result::ok) {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(sequence) = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .and_then(|stem| stem.parse::<u64>().ok())
+            else {
+                continue;
+            };
+            let Ok(bytes) = super::read_private_file(&path, "local active-input file") else {
+                continue;
+            };
+            let Ok(input) = serde_json::from_slice::<ActiveInputEntry>(&bytes) else {
+                continue;
+            };
+            if input.run_id != run_id || input.sequence != sequence || input.text.is_empty() {
+                continue;
+            }
+            parsed.push(input);
+        }
+        parsed.sort_by_key(|entry| entry.sequence);
+        parsed
+    }
+
+    pub(crate) fn cleanup_active_inputs_sync(&self, run_id: RunId) {
+        let run_dir = super::run_inputs_dir(&self.group_dir, run_id);
+        match std::fs::symlink_metadata(&run_dir) {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                if let Err(e) = super::validate_run_inputs_dir(&self.group_dir, run_id) {
+                    warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: invalid active-input directory during cleanup");
+                    return;
+                }
+                if let Err(e) = std::fs::remove_dir_all(&run_dir)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: failed to clean active-input directory");
+                }
+            }
+            Ok(metadata) if metadata.file_type().is_file() => {
+                if let Err(e) = super::validate_inputs_dir(&self.group_dir) {
+                    warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: invalid active-input parent directory during cleanup");
+                    return;
+                }
+                if let Err(e) = std::fs::remove_file(&run_dir)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: failed to clean active-input file");
+                }
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                warn!(run_id = %run_id, path = %run_dir.display(), error = %e, "local: cannot stat active-input directory for cleanup");
+            }
+        }
     }
 
     pub(crate) fn collect_cancel_markers_sync(&self) -> Vec<LocalCancelMarker> {
@@ -550,6 +682,7 @@ mod tests {
             profile: Some(profile.to_owned()),
             session_id: Some("session-123".into()),
             feature_flags: None,
+            active_input: None,
         };
         std::fs::write(&job_path, serde_json::to_vec(&request).unwrap()).unwrap();
         job_path
@@ -596,6 +729,123 @@ mod tests {
         assert!(matches!(claim, LocalClaimResult::Claimed { .. }));
         assert_eq!(mode(&super::super::claims_dir(group_dir)), 0o700);
         assert_eq!(mode(&super::super::claim_path(group_dir, run_id)), 0o600);
+    }
+
+    #[test]
+    fn active_input_write_creates_private_files_and_reads_in_numeric_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let run_id = RunId::new_v4();
+        let entry_10 = ActiveInputEntry {
+            run_id,
+            sequence: 10,
+            message_id: "msg-10".to_string(),
+            text: "ten".to_string(),
+        };
+        let entry_2 = ActiveInputEntry {
+            run_id,
+            sequence: 2,
+            message_id: "msg-2".to_string(),
+            text: "two".to_string(),
+        };
+
+        queue.write_active_input_sync(&entry_10).unwrap();
+        queue.write_active_input_sync(&entry_2).unwrap();
+
+        assert_eq!(mode(&super::super::inputs_dir(group_dir)), 0o700);
+        assert_eq!(
+            mode(&super::super::run_inputs_dir(group_dir, run_id)),
+            0o700
+        );
+        assert_eq!(
+            mode(&super::super::active_input_path(group_dir, run_id, 2)),
+            0o600
+        );
+        assert_eq!(
+            queue.read_active_input_entries_sync(run_id),
+            vec![entry_2, entry_10]
+        );
+    }
+
+    #[test]
+    fn active_input_read_ignores_malformed_or_mismatched_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let run_id = RunId::new_v4();
+        let other_run_id = RunId::new_v4();
+        let valid = ActiveInputEntry {
+            run_id,
+            sequence: 1,
+            message_id: "msg-1".to_string(),
+            text: "one".to_string(),
+        };
+        queue.write_active_input_sync(&valid).unwrap();
+        let run_dir = super::super::run_inputs_dir(group_dir, run_id);
+        std::fs::write(run_dir.join("00000000000000000002.json"), b"not-json").unwrap();
+        std::fs::write(
+            run_dir.join("00000000000000000003.json"),
+            serde_json::to_vec(&ActiveInputEntry {
+                run_id: other_run_id,
+                sequence: 3,
+                message_id: "msg-3".to_string(),
+                text: "wrong run".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            run_dir.join("00000000000000000004.json"),
+            serde_json::to_vec(&ActiveInputEntry {
+                run_id,
+                sequence: 5,
+                message_id: "msg-5".to_string(),
+                text: "wrong sequence".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(queue.read_active_input_entries_sync(run_id), vec![valid]);
+    }
+
+    #[test]
+    fn active_input_cleanup_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path();
+        let queue = LocalQueue::new(group_dir.to_path_buf());
+        let run_id = RunId::new_v4();
+        queue
+            .write_active_input_sync(&ActiveInputEntry {
+                run_id,
+                sequence: 1,
+                message_id: "msg-1".to_string(),
+                text: "one".to_string(),
+            })
+            .unwrap();
+
+        queue.cleanup_active_inputs_sync(run_id);
+        queue.cleanup_active_inputs_sync(run_id);
+
+        assert!(!super::super::run_inputs_dir(group_dir, run_id).exists());
+    }
+
+    #[test]
+    fn active_input_cleanup_does_not_follow_inputs_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let group_dir = dir.path().join("group");
+        let target_dir = dir.path().join("target");
+        let run_id = RunId::new_v4();
+        std::fs::create_dir_all(&group_dir).unwrap();
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let target_file = target_dir.join(run_id.to_string());
+        std::fs::write(&target_file, b"do not delete").unwrap();
+        symlink(&target_dir, super::super::inputs_dir(&group_dir)).unwrap();
+
+        LocalQueue::new(group_dir).cleanup_active_inputs_sync(run_id);
+
+        assert!(target_file.exists());
     }
 
     #[test]

--- a/crates/runner/src/local_queue/types.rs
+++ b/crates/runner/src/local_queue/types.rs
@@ -23,6 +23,8 @@ pub(crate) struct JobRequest {
     pub(crate) session_id: Option<String>,
     #[serde(default)]
     pub(crate) feature_flags: Option<HashMap<String, bool>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) active_input: Option<bool>,
 }
 
 /// Job response written by the runner as a `{job_id}.result` file.
@@ -31,4 +33,14 @@ pub(crate) struct JobResponse {
     pub(crate) run_id: RunId,
     pub(crate) exit_code: i32,
     pub(crate) error: Option<String>,
+}
+
+/// Active input written by local producers for a claimed live run.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ActiveInputEntry {
+    pub(crate) run_id: RunId,
+    pub(crate) sequence: u64,
+    pub(crate) message_id: String,
+    pub(crate) text: String,
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,3 +1,4 @@
+mod active_input;
 mod axiom_layer;
 mod ca;
 mod cmd;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1492,8 +1492,9 @@ mod tests {
             ))
             .await
             .expect("claim should succeed");
-        let (context, completion_auth) = claimed.into_parts();
+        let (context, completion_auth, active_input_source) = claimed.into_parts();
         assert_eq!(context.sandbox_token, "claim-sandbox-token");
+        assert!(active_input_source.is_none());
 
         provider
             .complete(run_id, 0, None, None, None, completion_auth)
@@ -1578,8 +1579,10 @@ mod tests {
             ))
             .await
             .expect("second claim should succeed");
-        let (context_a, completion_auth_a) = claimed_a.into_parts();
-        let (context_b, completion_auth_b) = claimed_b.into_parts();
+        let (context_a, completion_auth_a, active_input_source_a) = claimed_a.into_parts();
+        let (context_b, completion_auth_b, active_input_source_b) = claimed_b.into_parts();
+        assert!(active_input_source_a.is_none());
+        assert!(active_input_source_b.is_none());
 
         provider
             .complete(context_b.run_id, 0, None, None, None, completion_auth_b)

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -231,7 +231,13 @@ impl JobProvider for LocalProvider {
             billable_firewalls: vec![],
             model_usage_provider: None,
         };
-        match ClaimedJob::local(run_id, context) {
+        let active_input_source = req.active_input.unwrap_or(false).then(|| {
+            crate::active_input::ActiveInputSource::local_queue(
+                self.queue.group_dir().to_path_buf(),
+                run_id,
+            )
+        });
+        match ClaimedJob::local_with_active_input_source(run_id, context, active_input_source) {
             Ok(claimed) => {
                 self.cancel_scanner.mark_owned_claim(run_id).await;
                 info!(run_id = %run_id, "local: job claimed");
@@ -402,12 +408,41 @@ mod tests {
         write_job_in_partition(dir, partition, job_id, prompt, profile);
     }
 
+    fn write_job_with_active_input(dir: &std::path::Path, job_id: RunId, prompt: &str) {
+        write_job_in_partition_with_active_input(
+            dir,
+            crate::profile::DEFAULT_PROFILE,
+            job_id,
+            prompt,
+            Some(crate::profile::DEFAULT_PROFILE),
+            Some(true),
+        );
+    }
+
     fn write_job_in_partition(
         dir: &std::path::Path,
         partition_profile: &str,
         job_id: RunId,
         prompt: &str,
         json_profile: Option<&str>,
+    ) {
+        write_job_in_partition_with_active_input(
+            dir,
+            partition_profile,
+            job_id,
+            prompt,
+            json_profile,
+            None,
+        );
+    }
+
+    fn write_job_in_partition_with_active_input(
+        dir: &std::path::Path,
+        partition_profile: &str,
+        job_id: RunId,
+        prompt: &str,
+        json_profile: Option<&str>,
+        active_input: Option<bool>,
     ) {
         let req = JobRequest {
             job_id,
@@ -420,6 +455,7 @@ mod tests {
             profile: json_profile.map(String::from),
             session_id: None,
             feature_flags: None,
+            active_input,
         };
         let json = serde_json::to_vec(&req).unwrap();
         let job_dir = local_queue::profile_jobs_dir(dir, partition_profile).unwrap();
@@ -448,6 +484,7 @@ mod tests {
             profile: Some(crate::profile::DEFAULT_PROFILE.into()),
             session_id: None,
             feature_flags: None,
+            active_input: None,
         };
         let json = serde_json::to_vec(&req).unwrap();
         let job_dir = local_queue::profile_jobs_dir(dir, crate::profile::DEFAULT_PROFILE).unwrap();
@@ -482,6 +519,7 @@ mod tests {
         assert_eq!(candidate.profile_name(), crate::profile::DEFAULT_PROFILE);
 
         let claimed = provider.claim(candidate).await.unwrap();
+        assert!(claimed.active_input_source().is_none());
         let ctx = claimed.context();
         assert_eq!(ctx.run_id, job_id);
         assert_eq!(ctx.prompt, "hello world");
@@ -497,6 +535,25 @@ mod tests {
             !job_path.exists(),
             "complete() should remove the completed local job file"
         );
+    }
+
+    #[tokio::test]
+    async fn claim_attaches_active_input_source_when_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let cancel = CancellationToken::new();
+        let provider = default_provider(dir.path(), cancel, empty_cancel_tokens());
+
+        let job_id = RunId::new_v4();
+        write_job_with_active_input(dir.path(), job_id, "hello with active input");
+
+        let candidate = provider.discover().await.unwrap();
+        let claimed = provider.claim(candidate).await.unwrap();
+
+        assert!(matches!(
+            claimed.active_input_source(),
+            Some(crate::active_input::ActiveInputSource::LocalQueue(source))
+                if source.run_id == job_id && source.group_dir == dir.path()
+        ));
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -18,6 +18,7 @@ use sandbox::SandboxId;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use crate::active_input::ActiveInputSource;
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 
@@ -111,6 +112,7 @@ impl JobCandidate {
 pub struct ClaimedJob {
     context: ExecutionContext,
     completion_auth: CompletionAuth,
+    active_input_source: Option<ActiveInputSource>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -144,26 +146,44 @@ impl ClaimedJob {
         Ok(Self {
             context,
             completion_auth,
+            active_input_source: None,
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn local(
         expected_run_id: RunId,
         context: ExecutionContext,
+    ) -> Result<Self, ClaimedJobRunIdMismatch> {
+        Self::local_with_active_input_source(expected_run_id, context, None)
+    }
+
+    pub(crate) fn local_with_active_input_source(
+        expected_run_id: RunId,
+        context: ExecutionContext,
+        active_input_source: Option<ActiveInputSource>,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
         Self::validate_run_id(expected_run_id, &context)?;
         Ok(Self {
             context,
             completion_auth: CompletionAuth::local(),
+            active_input_source,
         })
     }
 
-    pub(crate) fn into_parts(self) -> (ExecutionContext, CompletionAuth) {
-        (self.context, self.completion_auth)
+    pub(crate) fn into_parts(
+        self,
+    ) -> (ExecutionContext, CompletionAuth, Option<ActiveInputSource>) {
+        (self.context, self.completion_auth, self.active_input_source)
     }
 
     pub(crate) fn context(&self) -> &ExecutionContext {
         &self.context
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_input_source(&self) -> Option<&ActiveInputSource> {
+        self.active_input_source.as_ref()
     }
 }
 
@@ -324,9 +344,10 @@ mod tests {
 
         let claimed =
             ClaimedJob::api(run_id, minimal_context(run_id)).expect("matching context is valid");
-        let (context, completion_auth) = claimed.into_parts();
+        let (context, completion_auth, active_input_source) = claimed.into_parts();
 
         assert_eq!(context.run_id, run_id);
+        assert!(active_input_source.is_none());
         assert!(completion_auth.matches_sandbox_token_for_test(run_id, "sandbox-token"));
     }
 }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -540,7 +540,7 @@ pub struct MockSandboxOverrides {
     /// Wakes tests waiting for process-control calls to be recorded.
     process_control_notify: tokio::sync::Notify,
     /// FIFO queue of process-control errors consumed by control handles.
-    process_control_errors: Mutex<VecDeque<String>>,
+    process_control_errors: Mutex<VecDeque<(std::io::ErrorKind, String)>>,
     /// Whether a successful process cancel releases the configured
     /// `wait_process` gate. Tests can disable this to exercise bounded wait
     /// timeout paths after cancel is sent.
@@ -934,9 +934,18 @@ impl MockSandboxOverrides {
 
     /// Queue a process-control send error consumed by the next control handle.
     pub fn push_process_control_error(&self, message: impl Into<String>) {
+        self.push_process_control_io_error(std::io::ErrorKind::Other, message);
+    }
+
+    /// Queue a process-control send error with a specific I/O kind.
+    pub fn push_process_control_io_error(
+        &self,
+        kind: std::io::ErrorKind,
+        message: impl Into<String>,
+    ) {
         self.process_control_errors
             .lock_ignoring_poison()
-            .push_back(message.into());
+            .push_back((kind, message.into()));
     }
 
     /// Configure whether successful process cancellation releases a configured
@@ -1501,12 +1510,12 @@ impl Sandbox for MockSandbox {
                             },
                         );
                         overrides.process_control_notify.notify_waiters();
-                        if let Some(message) = overrides
+                        if let Some((kind, message)) = overrides
                             .process_control_errors
                             .lock_ignoring_poison()
                             .pop_front()
                         {
-                            return Err(std::io::Error::other(message));
+                            return Err(std::io::Error::new(kind, message));
                         }
                     }
                     Ok(ProcessControlAck { message_id })

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -189,6 +189,17 @@ pub struct ProcessCancelCall {
     pub timeout: Duration,
 }
 
+/// Captured process-control request fields recorded for test assertions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessControlCall {
+    /// Message id supplied to the process-control handle.
+    pub message_id: String,
+    /// Payload bytes supplied to the process-control handle.
+    pub payload: Vec<u8>,
+    /// Timeout supplied to the process-control handle.
+    pub timeout: Duration,
+}
+
 /// Captured `write_file` request fields recorded for test assertions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WriteFileCall {
@@ -523,6 +534,13 @@ pub struct MockSandboxOverrides {
     process_cancel_notify: tokio::sync::Notify,
     /// FIFO queue of process cancel errors consumed by cancel handles.
     process_cancel_errors: Mutex<VecDeque<String>>,
+    /// Recorded process-control calls across all sandboxes built from this
+    /// override set.
+    process_control_calls: Mutex<Vec<ProcessControlCall>>,
+    /// Wakes tests waiting for process-control calls to be recorded.
+    process_control_notify: tokio::sync::Notify,
+    /// FIFO queue of process-control errors consumed by control handles.
+    process_control_errors: Mutex<VecDeque<String>>,
     /// Whether a successful process cancel releases the configured
     /// `wait_process` gate. Tests can disable this to exercise bounded wait
     /// timeout paths after cancel is sent.
@@ -570,6 +588,9 @@ impl MockSandboxOverrides {
             process_cancel_calls: Mutex::new(Vec::new()),
             process_cancel_notify: tokio::sync::Notify::new(),
             process_cancel_errors: Mutex::new(VecDeque::new()),
+            process_control_calls: Mutex::new(Vec::new()),
+            process_control_notify: tokio::sync::Notify::new(),
+            process_control_errors: Mutex::new(VecDeque::new()),
             process_cancel_releases_wait_gate: Mutex::new(true),
             park_calls: Mutex::new(0),
             unpark_calls: Mutex::new(0),
@@ -865,6 +886,15 @@ impl MockSandboxOverrides {
         self.process_cancel_calls.lock_ignoring_poison().clone()
     }
 
+    /// Return recorded process-control calls across all sandboxes built from
+    /// this override set.
+    ///
+    /// The returned vector is a cloned snapshot in recorded order. Control
+    /// attempts are recorded before any queued control send error is returned.
+    pub fn process_control_calls(&self) -> Vec<ProcessControlCall> {
+        self.process_control_calls.lock_ignoring_poison().clone()
+    }
+
     /// Wait until at least `expected` process cancel calls have been recorded.
     pub async fn wait_for_process_cancel_calls(&self, expected: usize, timeout: Duration) -> bool {
         tokio::time::timeout(timeout, async {
@@ -880,9 +910,31 @@ impl MockSandboxOverrides {
         .is_ok()
     }
 
+    /// Wait until at least `expected` process-control calls have been recorded.
+    pub async fn wait_for_process_control_calls(&self, expected: usize, timeout: Duration) -> bool {
+        tokio::time::timeout(timeout, async {
+            loop {
+                let notified = self.process_control_notify.notified();
+                if self.process_control_calls.lock_ignoring_poison().len() >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
     /// Queue a process cancel send error consumed by the next cancel handle.
     pub fn push_process_cancel_error(&self, message: impl Into<String>) {
         self.process_cancel_errors
+            .lock_ignoring_poison()
+            .push_back(message.into());
+    }
+
+    /// Queue a process-control send error consumed by the next control handle.
+    pub fn push_process_control_error(&self, message: impl Into<String>) {
+        self.process_control_errors
             .lock_ignoring_poison()
             .push_back(message.into());
     }
@@ -1436,8 +1488,29 @@ impl Sandbox for MockSandbox {
             *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
         let control = (request.control == ProcessControlMode::Enabled).then(|| {
-            GuestProcessControlHandle::new(|message_id, _payload, _timeout| {
-                Box::pin(async move { Ok(ProcessControlAck { message_id }) })
+            let overrides = self.overrides.clone();
+            GuestProcessControlHandle::new(move |message_id, payload, timeout| {
+                let overrides = overrides.clone();
+                Box::pin(async move {
+                    if let Some(overrides) = overrides {
+                        overrides.process_control_calls.lock_ignoring_poison().push(
+                            ProcessControlCall {
+                                message_id: message_id.clone(),
+                                payload,
+                                timeout,
+                            },
+                        );
+                        overrides.process_control_notify.notify_waiters();
+                        if let Some(message) = overrides
+                            .process_control_errors
+                            .lock_ignoring_poison()
+                            .pop_front()
+                        {
+                            return Err(std::io::Error::other(message));
+                        }
+                    }
+                    Ok(ProcessControlAck { message_id })
+                })
             })
         });
         let process_cancel = self.overrides.as_ref().and_then(|overrides| {
@@ -3289,6 +3362,74 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ack.message_id, "msg-1");
+    }
+
+    #[tokio::test]
+    async fn process_control_calls_are_recorded_when_overrides_are_enabled() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
+        let handle = sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::Enabled,
+            })
+            .await
+            .unwrap();
+        let control = handle
+            .control_handle()
+            .expect("enabled control should expose a handle");
+
+        control
+            .control("msg-1", b"payload", Duration::from_millis(250))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            overrides.process_control_calls(),
+            vec![ProcessControlCall {
+                message_id: "msg-1".to_string(),
+                payload: b"payload".to_vec(),
+                timeout: Duration::from_millis(250),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn queued_process_control_errors_are_consumed_fifo() {
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.push_process_control_error("control failed");
+        let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
+        let handle = sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+                control: ProcessControlMode::Enabled,
+            })
+            .await
+            .unwrap();
+        let control = handle
+            .control_handle()
+            .expect("enabled control should expose a handle");
+
+        let err = control
+            .control("msg-1", b"payload-1", Duration::from_secs(1))
+            .await
+            .unwrap_err();
+        let ack = control
+            .control("msg-2", b"payload-2", Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        assert!(err.to_string().contains("control failed"));
+        assert_eq!(ack.message_id, "msg-2");
+        assert_eq!(overrides.process_control_calls().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/vsock-guest/src/exec_control/forward.rs
+++ b/crates/vsock-guest/src/exec_control/forward.rs
@@ -226,6 +226,11 @@ fn forward_to_connected_sink(
                 diagnostic: response.diagnostic,
                 sink_disposition: ControlSinkDisposition::Keep,
             },
+            ControlResponseStatus::QueueFull => ControlForwardOutcome {
+                status: ExecControlStatus::QueueFull,
+                diagnostic: response.diagnostic,
+                sink_disposition: ControlSinkDisposition::Keep,
+            },
             ControlResponseStatus::Error => ControlForwardOutcome {
                 status: ExecControlStatus::SinkError,
                 diagnostic: response.diagnostic,

--- a/crates/vsock-guest/src/exec_control/tests.rs
+++ b/crates/vsock-guest/src/exec_control/tests.rs
@@ -415,6 +415,18 @@ fn non_terminal_control_responses_do_not_close_sink() {
         .unwrap();
 
         let request = process_control_ipc::read_request(&mut stream).unwrap();
+        assert_eq!(request.message_id, "msg-queue-full");
+        process_control_ipc::write_response(
+            &mut stream,
+            &process_control_ipc::ControlResponse {
+                message_id: request.message_id,
+                status: process_control_ipc::ControlResponseStatus::QueueFull,
+                diagnostic: "pending inputs full".to_owned(),
+            },
+        )
+        .unwrap();
+
+        let request = process_control_ipc::read_request(&mut stream).unwrap();
         assert_eq!(request.message_id, "msg-error");
         process_control_ipc::write_response(
             &mut stream,
@@ -454,10 +466,20 @@ fn non_terminal_control_responses_do_not_close_sink() {
     assert_eq!(diagnostic, "denied");
 
     let payload =
-        vsock_proto::encode_exec_control(11, forward_nonce, "msg-error", b"payload", 5000).unwrap();
+        vsock_proto::encode_exec_control(11, forward_nonce, "msg-queue-full", b"payload", 5000)
+            .unwrap();
     handle_exec_control(22, &payload, &registry, &writer).unwrap();
     let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
     assert_eq!(seq, 22);
+    assert_eq!(status, ExecControlStatus::QueueFull);
+    assert_eq!(message_id, "msg-queue-full");
+    assert_eq!(diagnostic, "pending inputs full");
+
+    let payload =
+        vsock_proto::encode_exec_control(11, forward_nonce, "msg-error", b"payload", 5000).unwrap();
+    handle_exec_control(23, &payload, &registry, &writer).unwrap();
+    let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
+    assert_eq!(seq, 23);
     assert_eq!(status, ExecControlStatus::SinkError);
     assert_eq!(message_id, "msg-error");
     assert_eq!(diagnostic, "temporary error");
@@ -465,9 +487,9 @@ fn non_terminal_control_responses_do_not_close_sink() {
     let payload =
         vsock_proto::encode_exec_control(11, forward_nonce, "msg-after-error", b"payload", 5000)
             .unwrap();
-    handle_exec_control(23, &payload, &registry, &writer).unwrap();
+    handle_exec_control(24, &payload, &registry, &writer).unwrap();
     let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
-    assert_eq!(seq, 23);
+    assert_eq!(seq, 24);
     assert_eq!(status, ExecControlStatus::Delivered);
     assert_eq!(message_id, "msg-after-error");
     assert_eq!(diagnostic, "");


### PR DESCRIPTION
## Summary
- add a local queue active-input file protocol and opt-in `activeInput` job marker for `runner local submit`
- forward local active input through the sandbox process-control channel for fresh and reused runs
- extend sandbox-mock process-control assertions and add a metal-host smoke workflow for mock Claude active input

## Tests
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner -p sandbox-mock --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner active_input`
- `cargo test --manifest-path crates/Cargo.toml -p runner discover_claim_complete`
- `cargo test --manifest-path crates/Cargo.toml -p runner control_error`
- `cargo test --manifest-path crates/Cargo.toml -p runner sandbox_run`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`

Note: `actionlint` is not installed in this workspace, so workflow linting will rely on CI.

Fixes #18093