### PR TITLE
refactor: classify runner helper exec termination

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -27,6 +27,7 @@ use super::{
     agent_exit_failure_message, job_terminal_wait_timeout, normalize_failure_exit_code,
     normalize_timeout_failure_exit_code,
 };
+use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
@@ -455,7 +456,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         };
         match sandbox.exec(&dmesg_req).await {
-            Ok(dmesg) if dmesg_indicates_oom(&String::from_utf8_lossy(&dmesg.stdout)) => {
+            Ok(dmesg)
+                if helper_exec_succeeded(&dmesg)
+                    && dmesg_indicates_oom(&String::from_utf8_lossy(&dmesg.stdout)) =>
+            {
                 warn!(run_id = %context.run_id, "OOM kill detected via dmesg");
                 // Return exit code 1 with descriptive message instead of raw 137,
                 // so callers see a clear error rather than an opaque signal code.
@@ -467,6 +471,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             }
             Err(e) => {
                 warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
+            }
+            Ok(dmesg) if !helper_exec_succeeded(&dmesg) => {
+                warn!(
+                    run_id = %context.run_id,
+                    termination = helper_exec_termination_label(&dmesg),
+                    exit_code = dmesg.exit_code,
+                    "dmesg OOM check helper failed"
+                );
             }
             _ => {}
         }

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -19,6 +19,7 @@ use super::{
     ResourceFailureKind, SMALL_GUEST_FILE_MAX_BYTES, STDOUT_STREAM_LIMIT_MARKER,
     STDOUT_STREAM_OVERFLOW_MARKER, SandboxReuseResult, guest_runtime_path,
 };
+use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::ids::RunId;
 use crate::paths::{LogPaths, diagnostic_session_fingerprint};
 use crate::types::ExecutionContext;
@@ -312,7 +313,10 @@ pub(super) async fn collect_agent_abnormal_exit_diagnostics(
         Ok(result) => {
             let stdout = String::from_utf8_lossy(&result.stdout);
             let stderr = String::from_utf8_lossy(&result.stderr);
-            let resource_diagnostics = parse_agent_abnormal_exit_resource_diagnostics(&stdout);
+            let diagnostic_succeeded = helper_exec_succeeded(&result);
+            let resource_diagnostics = diagnostic_succeeded
+                .then(|| parse_agent_abnormal_exit_resource_diagnostics(&stdout))
+                .flatten();
             let resource_failure_kind = resource_diagnostics
                 .and_then(|diagnostics| diagnostics.failure_kind)
                 .map(ResourceFailureKind::as_str);
@@ -331,6 +335,8 @@ pub(super) async fn collect_agent_abnormal_exit_diagnostics(
                 sandbox_id = %sandbox_id,
                 sandbox_reuse_result = reuse_result.as_wire(),
                 exit_code,
+                diagnostic_termination = helper_exec_termination_label(&result),
+                diagnostic_succeeded,
                 diagnostic_exit_code = result.exit_code,
                 diagnostic_stdout_len = result.stdout.len(),
                 diagnostic_stderr_len = result.stderr.len(),

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -4,11 +4,11 @@ use api_contracts::generated::constants::model_provider_env::placeholders as mod
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
 use super::session_restore::{canonical_codex_thread_id, is_valid_session_id};
-use super::storage::format_guest_exec_failure;
 use super::{
     DEFAULT_EXEC_TIMEOUT, GUEST_USER_ENV_DIR_NAME, GUEST_USER_ENV_FILENAME, RunnerError,
     RunnerResult, guest_runtime_dir, guest_runtime_path,
 };
+use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
@@ -270,8 +270,8 @@ pub(super) async fn write_user_env_file(
             output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
-    if mkdir_result.exit_code != 0 {
-        return Err(RunnerError::Internal(format_guest_exec_failure(
+    if !helper_exec_succeeded(&mkdir_result) {
+        return Err(RunnerError::Internal(format_helper_exec_failure(
             "user env directory creation",
             &mkdir_result,
         )));
@@ -291,8 +291,8 @@ pub(super) async fn write_user_env_file(
             output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
-    if chmod_result.exit_code != 0 {
-        return Err(RunnerError::Internal(format_guest_exec_failure(
+    if !helper_exec_succeeded(&chmod_result) {
+        return Err(RunnerError::Internal(format_helper_exec_failure(
             "user env file permission update",
             &chmod_result,
         )));

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -2,9 +2,11 @@
 
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
-use super::storage::format_command_output_excerpt;
-use super::storage::format_guest_exec_failure;
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
+use crate::helper_exec::{
+    format_command_output_excerpt, format_helper_exec_failure, helper_exec_succeeded,
+    helper_exec_termination_label,
+};
 use crate::types::ExecutionContext;
 
 pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
@@ -26,8 +28,8 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
             output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
-    if result.exit_code != 0 {
-        return Err(RunnerError::Internal(format_guest_exec_failure(
+    if !helper_exec_succeeded(&result) {
+        return Err(RunnerError::Internal(format_helper_exec_failure(
             "guest clock sync",
             &result,
         )));
@@ -64,11 +66,10 @@ pub(crate) async fn reseed_guest_entropy(sandbox: &dyn Sandbox) -> RunnerResult<
         })
         .await?;
 
-    if result.exit_code != 0 {
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        return Err(RunnerError::Internal(format!(
-            "guest-reseed failed (exit code {}): {stderr}",
-            result.exit_code
+    if !helper_exec_succeeded(&result) {
+        return Err(RunnerError::Internal(format_helper_exec_failure(
+            "guest-reseed",
+            &result,
         )));
     }
 
@@ -119,7 +120,7 @@ pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &Executi
         })
         .await
     {
-        Ok(result) if result.exit_code != 0 => {
+        Ok(result) if !helper_exec_succeeded(&result) => {
             let stderr_excerpt =
                 format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
             let stdout_excerpt =
@@ -127,6 +128,7 @@ pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &Executi
             tracing::warn!(
                 run_id = %context.run_id,
                 tz = %tz,
+                termination = helper_exec_termination_label(&result),
                 exit_code = result.exit_code,
                 stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
                 stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -80,7 +80,6 @@ const AGENT_ENV_KEY_DIAGNOSTIC_LIMIT: usize = 128;
 const AGENT_ENV_KEY_MAX_CHARS: usize = 128;
 const SMALL_GUEST_FILE_MAX_BYTES: u64 = 64 * 1024;
 const GUEST_LOG_COPY_MAX_BYTES: u64 = 64 * 1024 * 1024;
-const GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES: usize = 8 * 1024;
 const STDOUT_STREAM_LIMIT_MARKER: &[u8] =
     b"[vm0] stdout stream reached the guest stream limit; later output was omitted\n";
 const STDOUT_STREAM_OVERFLOW_MARKER: &[u8] =

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -3,8 +3,8 @@
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox, SandboxError};
 use tracing::{info, warn};
 
-use super::storage::format_guest_exec_failure;
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
+use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -250,9 +250,9 @@ fi"#;
             output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
         })
         .await?;
-    if result.exit_code != 0 {
+    if !helper_exec_succeeded(&result) {
         return Err(RunnerError::Internal(redact_session_restore_diagnostic(
-            format_guest_exec_failure("codex session cleanup", &result),
+            format_helper_exec_failure("codex session cleanup", &result),
             &[session_id],
             session_path,
         )));

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -3,10 +3,8 @@
 use sandbox::{EXEC_OUTPUT_LIMIT_1_MIB, ExecRequest, Sandbox};
 use tracing::info;
 
-use super::{
-    DEFAULT_EXEC_TIMEOUT, GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES, RunnerError, RunnerResult,
-    guest_runtime_dir,
-};
+use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult, guest_runtime_dir};
+use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::guest;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
@@ -168,7 +166,7 @@ pub(super) async fn download_storages(
         })
         .await?;
 
-    if result.exit_code != 0 {
+    if !helper_exec_succeeded(&result) {
         return Err(RunnerError::Internal(format_guest_download_failure(
             &result,
         )));
@@ -177,121 +175,5 @@ pub(super) async fn download_storages(
 }
 
 pub(super) fn format_guest_download_failure(result: &sandbox::ExecResult) -> String {
-    format_guest_exec_failure("storage download", result)
-}
-
-pub(super) fn format_guest_exec_failure(operation: &str, result: &sandbox::ExecResult) -> String {
-    let mut message = format!("{operation} failed (exit code {})", result.exit_code);
-
-    if let Some(stderr) =
-        format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated)
-    {
-        message.push_str("; ");
-        message.push_str(&stderr);
-    }
-    if let Some(stdout) =
-        format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated)
-    {
-        message.push_str("; ");
-        message.push_str(&stdout);
-    }
-
-    message
-}
-
-pub(super) fn format_command_output_excerpt(
-    label: &str,
-    bytes: &[u8],
-    sandbox_truncated: bool,
-) -> Option<String> {
-    if bytes.is_empty() {
-        return None;
-    }
-
-    // Redact before excerpting so a suffix cannot start inside a URL query and expose it.
-    let output = String::from_utf8_lossy(bytes);
-    let output = sanitize_command_output_for_diagnostic(output.trim());
-    let output = output.trim();
-    let (excerpt, omitted_prefix) = diagnostic_output_excerpt(output);
-    let excerpt = excerpt.trim();
-    if excerpt.is_empty() {
-        return None;
-    }
-
-    let mut qualifiers = Vec::new();
-    if omitted_prefix {
-        qualifiers.push("last 8192 bytes");
-    } else {
-        qualifiers.push("captured");
-    }
-    if sandbox_truncated {
-        qualifiers.push("sandbox-truncated");
-    }
-
-    Some(format!("{label} ({}): {excerpt}", qualifiers.join(", ")))
-}
-
-fn diagnostic_output_excerpt(input: &str) -> (&str, bool) {
-    if input.len() <= GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES {
-        return (input, false);
-    }
-
-    let mut start = input.len() - GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
-    while !input.is_char_boundary(start) {
-        start += 1;
-    }
-    (&input[start..], true)
-}
-
-fn sanitize_command_output_for_diagnostic(input: &str) -> String {
-    redact_url_query_strings(input)
-}
-
-fn redact_url_query_strings(input: &str) -> String {
-    let mut redacted = String::with_capacity(input.len());
-    let mut cursor = 0;
-
-    while cursor < input.len() {
-        let Some(scheme) = url_scheme_at(input, cursor) else {
-            let Some(ch) = input[cursor..].chars().next() else {
-                break;
-            };
-            redacted.push(ch);
-            cursor += ch.len_utf8();
-            continue;
-        };
-
-        let url_start = cursor;
-        let url_body_start = url_start + scheme.len();
-        let url_end = find_url_token_end(input, url_body_start);
-        let Some(query_offset) = input[url_body_start..url_end].find('?') else {
-            redacted.push_str(&input[url_start..url_end]);
-            cursor = url_end;
-            continue;
-        };
-
-        let query_start = url_body_start + query_offset;
-        let query_value_start = query_start + '?'.len_utf8();
-        redacted.push_str(&input[url_start..query_value_start]);
-        redacted.push_str("<redacted>");
-        cursor = url_end;
-    }
-
-    redacted.push_str(&input[cursor..]);
-    redacted
-}
-
-fn url_scheme_at(input: &str, index: usize) -> Option<&'static str> {
-    ["https://", "http://"].into_iter().find(|scheme| {
-        input[index..]
-            .get(..scheme.len())
-            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(scheme))
-    })
-}
-
-fn find_url_token_end(input: &str, start: usize) -> usize {
-    input[start..]
-        .char_indices()
-        .find_map(|(index, ch)| ch.is_whitespace().then_some(start + index))
-        .unwrap_or(input.len())
+    format_helper_exec_failure("storage download", result)
 }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -4,11 +4,13 @@ use api_contracts::generated::constants::model_provider_env::placeholders as mod
 use api_contracts::generated::types::runners::storage::{
     ArtifactEntryMissingRootPolicy, StorageManifest,
 };
-use sandbox::SandboxId;
+use sandbox::{ExecResult, ProcessTerminationKind, SandboxId};
+use sandbox_mock::MockSandbox;
 
 use super::super::env::{
     HostEnv, build_env_json_with_host_env, build_user_env_json, is_runner_owned_env_key,
     validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
+    write_user_env_file,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
@@ -826,6 +828,33 @@ fn build_env_json_user_vars_cannot_override_system() {
     assert!(!env.contains_key("CUSTOM"));
     assert_eq!(user_env.get("CUSTOM").unwrap(), "value");
     assert!(!user_env.contains_key("VM0_PROMPT"));
+}
+
+#[tokio::test]
+async fn write_user_env_file_fails_on_non_exited_mkdir_result() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ProcessTerminationKind::Cancelled,
+        exit_code: 0,
+        stdout: Vec::new(),
+        stderr: b"cancelled".to_vec(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+    let run_id = RunId::nil();
+    let user_env = HashMap::from([("CUSTOM_ENV".to_string(), "value".to_string())]);
+
+    let err = write_user_env_file(&sandbox, run_id, &user_env)
+        .await
+        .unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message
+            .contains("user env directory creation failed (cancelled; compatibility exit code 0)"),
+        "got: {message}"
+    );
+    assert!(sandbox.write_file_calls().is_empty());
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -1,4 +1,4 @@
-use sandbox::{ExecResult, Sandbox};
+use sandbox::{ExecResult, ProcessTerminationKind, Sandbox};
 use sandbox_mock::MockSandbox;
 use tracing::Level;
 use tracing_subscriber::prelude::*;
@@ -41,6 +41,35 @@ async fn fix_guest_clock_fails_on_nonzero_exit() {
     );
     assert!(
         message.contains("stderr (captured): date stderr"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("stdout (captured): date stdout"),
+        "got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn fix_guest_clock_fails_on_non_exited_zero_exit_code() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ProcessTerminationKind::WaitFailed,
+        exit_code: 0,
+        stdout: b"date stdout".to_vec(),
+        stderr: b"wait failed".to_vec(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+
+    let result = fix_guest_clock(&sandbox).await;
+
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("guest clock sync failed (wait failed; compatibility exit code 0)"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("stderr (captured): wait failed"),
         "got: {message}"
     );
     assert!(
@@ -213,6 +242,10 @@ async fn sync_guest_timezone_logs_nonzero_exit() {
         Some("America/New_York")
     );
     assert_eq!(event.fields.get("exit_code").map(String::as_str), Some("2"));
+    assert_eq!(
+        event.fields.get("termination").map(String::as_str),
+        Some("exited")
+    );
     assert!(
         event
             .fields
@@ -225,6 +258,44 @@ async fn sync_guest_timezone_logs_nonzero_exit() {
             .fields
             .get("stdout_excerpt")
             .is_some_and(|value| value.contains("timezone stdout")),
+        "event={event:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn sync_guest_timezone_logs_non_exited_zero_exit_code() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ProcessTerminationKind::StartFailed,
+        exit_code: 0,
+        stdout: b"timezone stdout".to_vec(),
+        stderr: b"start failed".to_vec(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("America/New_York".into());
+
+    let events = capture_sync_guest_timezone_events(&sandbox, &ctx).await;
+    let event = events
+        .iter()
+        .find(|event| {
+            event.level == Level::WARN
+                && event.fields.get("message").map(String::as_str)
+                    == Some("failed to set guest timezone")
+        })
+        .unwrap_or_else(|| panic!("missing timezone warning; events={events:#?}"));
+
+    assert_eq!(
+        event.fields.get("termination").map(String::as_str),
+        Some("start_failed")
+    );
+    assert_eq!(event.fields.get("exit_code").map(String::as_str), Some("0"));
+    assert!(
+        event
+            .fields
+            .get("stderr_excerpt")
+            .is_some_and(|value| value.contains("start failed")),
         "event={event:#?}"
     );
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -100,6 +100,48 @@ async fn execute_inner_appends_stream_limit_marker_after_oom_rewrite() {
 }
 
 #[tokio::test]
+async fn execute_inner_ignores_non_exited_dmesg_oom_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, EXIT_SIGKILL, Vec::new(), Vec::new()));
+    overrides.add_exec_result_matcher(
+        "dmesg",
+        ExecResult {
+            termination: ProcessTerminationKind::TimedOut,
+            exit_code: 0,
+            stdout: b"Out of memory: Killed process 1234".to_vec(),
+            stderr: b"Timeout".to_vec(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        },
+    );
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(outcome.exit_code(), EXIT_SIGKILL);
+    assert_eq!(failure.error.as_str(), "Agent exited with code 137");
+    assert!(failure.resource_diagnostics.is_none());
+}
+
+#[tokio::test]
 async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -715,6 +757,48 @@ async fn execute_inner_abnormal_exit_collects_guest_diagnostics() {
     assert!(call.sudo);
     assert!(call.stdin_bytes.is_none());
     assert_eq!(call.output_limits, EXEC_OUTPUT_LIMIT_64_KIB);
+}
+
+#[tokio::test]
+async fn execute_inner_ignores_non_exited_abnormal_exit_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, 126, Vec::new(), Vec::new()));
+    overrides.add_exec_result_matcher(
+        "guest-agent-binary",
+        ExecResult {
+            termination: ProcessTerminationKind::WaitFailed,
+            exit_code: 0,
+            stdout: b"/dev/root       7.8G  7.4G   20K 100% /\n/dev/vdb         16G   24K   15G   1% /home/user/workspace\nMem:            3934        3310         255           0         552         624\n".to_vec(),
+            stderr: b"wait failed".to_vec(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        },
+    );
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+    let ctx = minimal_context();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(failure.exit_code, 126);
+    assert_eq!(failure.error, "Agent exited with code 126");
+    assert!(failure.resource_diagnostics.is_none());
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -396,6 +396,50 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
 }
 
 #[tokio::test]
+async fn restore_session_redacts_non_exited_codex_cleanup_failure_output() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let session_id_no_dashes = session_id.replace('-', "");
+    let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
+    let session = ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        session_history: format!(
+            "{}\n",
+            serde_json::json!({
+                "timestamp": "2026-06-04T07:18:08.001Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "timestamp": "2026-06-04T07:18:08.000Z",
+                },
+            }),
+        ),
+    };
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: sandbox::ProcessTerminationKind::WaitFailed,
+        exit_code: 0,
+        stdout: format!("stdout includes {session_id_no_dashes}").into_bytes(),
+        stderr: format!("find: {session_path}: Permission denied").into_bytes(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("codex session cleanup failed (wait failed; compatibility exit code 0)")
+    );
+    assert!(message.contains("[redacted-session-path]"));
+    assert!(message.contains("[redacted-session-id]"));
+    assert!(!message.contains(session_id));
+    assert!(!message.contains(&session_id_no_dashes));
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
 async fn restore_session_redacts_claude_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -4,14 +4,13 @@ use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootP
 use sandbox::{ExecResult, ProcessTerminationKind};
 use sandbox_mock::MockSandbox;
 
-use super::super::GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES;
 use super::super::guest_runtime_dir;
 use super::super::storage::{
-    download_storages, filter_unchanged_storages, format_command_output_excerpt,
-    format_guest_download_failure, guest_download_command, guest_download_env,
-    guest_download_has_work,
+    download_storages, filter_unchanged_storages, format_guest_download_failure,
+    guest_download_command, guest_download_env, guest_download_has_work,
 };
 use super::support::{minimal_context, sandbox_write_file_error};
+use crate::helper_exec::{HELPER_EXEC_OUTPUT_EXCERPT_BYTES, format_command_output_excerpt};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry};
 
@@ -89,6 +88,34 @@ async fn download_storages_nonzero_exit_code() {
     assert!(msg.contains("stdout (captured): stdout clue"));
 }
 
+#[tokio::test]
+async fn download_storages_fails_on_non_exited_zero_exit_code() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ProcessTerminationKind::TimedOut,
+        exit_code: 0,
+        stdout: b"partial stdout".to_vec(),
+        stderr: b"Timeout".to_vec(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+    let ctx = minimal_context();
+    let manifest = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+    };
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+
+    assert!(msg.contains("storage download failed (timed out; compatibility exit code 0)"));
+    assert!(msg.contains("stderr (captured): Timeout"));
+    assert!(msg.contains("stdout (captured): partial stdout"));
+}
+
 #[test]
 fn guest_download_failure_output_redacts_url_queries() {
     let result = ExecResult {
@@ -115,7 +142,7 @@ fn guest_download_failure_redacts_url_query_before_excerpting() {
     let secret_value = "secret-value-that-must-not-leak";
     let suffix = " download failed";
     let boundary_offset = "X-Amz-".len();
-    let padding_len = GUEST_DOWNLOAD_FAILURE_OUTPUT_BYTES + boundary_offset
+    let padding_len = HELPER_EXEC_OUTPUT_EXCERPT_BYTES + boundary_offset
         - query_key.len()
         - secret_value.len()
         - suffix.len();

--- a/crates/runner/src/helper_exec.rs
+++ b/crates/runner/src/helper_exec.rs
@@ -1,0 +1,293 @@
+use sandbox::{ExecResult, ProcessTerminationKind};
+
+pub(crate) const HELPER_EXEC_OUTPUT_EXCERPT_BYTES: usize = 8 * 1024;
+
+pub(crate) fn helper_exec_succeeded(result: &ExecResult) -> bool {
+    result.termination == ProcessTerminationKind::Exited && result.exit_code == 0
+}
+
+pub(crate) fn helper_exec_termination_label(result: &ExecResult) -> &'static str {
+    match result.termination {
+        ProcessTerminationKind::Exited => "exited",
+        ProcessTerminationKind::TimedOut => "timed_out",
+        ProcessTerminationKind::Cancelled => "cancelled",
+        ProcessTerminationKind::StartFailed => "start_failed",
+        ProcessTerminationKind::WaitFailed => "wait_failed",
+    }
+}
+
+pub(crate) fn format_helper_exec_failure(operation: &str, result: &ExecResult) -> String {
+    let mut message = match result.termination {
+        ProcessTerminationKind::Exited => {
+            format!("{operation} failed (exit code {})", result.exit_code)
+        }
+        ProcessTerminationKind::TimedOut => format!(
+            "{operation} failed (timed out; compatibility exit code {})",
+            result.exit_code
+        ),
+        ProcessTerminationKind::Cancelled => format!(
+            "{operation} failed (cancelled; compatibility exit code {})",
+            result.exit_code
+        ),
+        ProcessTerminationKind::StartFailed => format!(
+            "{operation} failed (start failed; compatibility exit code {})",
+            result.exit_code
+        ),
+        ProcessTerminationKind::WaitFailed => format!(
+            "{operation} failed (wait failed; compatibility exit code {})",
+            result.exit_code
+        ),
+    };
+
+    if let Some(stderr) =
+        format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated)
+    {
+        message.push_str("; ");
+        message.push_str(&stderr);
+    }
+    if let Some(stdout) =
+        format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated)
+    {
+        message.push_str("; ");
+        message.push_str(&stdout);
+    }
+
+    message
+}
+
+pub(crate) fn format_command_output_excerpt(
+    label: &str,
+    bytes: &[u8],
+    sandbox_truncated: bool,
+) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    // Redact before excerpting so a suffix cannot start inside a URL query and expose it.
+    let output = String::from_utf8_lossy(bytes);
+    let output = sanitize_command_output_for_diagnostic(output.trim());
+    let output = output.trim();
+    let (excerpt, omitted_prefix) = diagnostic_output_excerpt(output);
+    let excerpt = excerpt.trim();
+    if excerpt.is_empty() {
+        return None;
+    }
+
+    let mut qualifiers = Vec::new();
+    if omitted_prefix {
+        qualifiers.push("last 8192 bytes");
+    } else {
+        qualifiers.push("captured");
+    }
+    if sandbox_truncated {
+        qualifiers.push("sandbox-truncated");
+    }
+
+    Some(format!("{label} ({}): {excerpt}", qualifiers.join(", ")))
+}
+
+fn diagnostic_output_excerpt(input: &str) -> (&str, bool) {
+    if input.len() <= HELPER_EXEC_OUTPUT_EXCERPT_BYTES {
+        return (input, false);
+    }
+
+    let mut start = input.len() - HELPER_EXEC_OUTPUT_EXCERPT_BYTES;
+    while !input.is_char_boundary(start) {
+        start += 1;
+    }
+    (&input[start..], true)
+}
+
+fn sanitize_command_output_for_diagnostic(input: &str) -> String {
+    redact_url_query_strings(input)
+}
+
+fn redact_url_query_strings(input: &str) -> String {
+    let mut redacted = String::with_capacity(input.len());
+    let mut cursor = 0;
+
+    while cursor < input.len() {
+        let Some(scheme) = url_scheme_at(input, cursor) else {
+            let Some(ch) = input[cursor..].chars().next() else {
+                break;
+            };
+            redacted.push(ch);
+            cursor += ch.len_utf8();
+            continue;
+        };
+
+        let url_start = cursor;
+        let url_body_start = url_start + scheme.len();
+        let url_end = find_url_token_end(input, url_body_start);
+        let Some(query_offset) = input[url_body_start..url_end].find('?') else {
+            redacted.push_str(&input[url_start..url_end]);
+            cursor = url_end;
+            continue;
+        };
+
+        let query_start = url_body_start + query_offset;
+        let query_value_start = query_start + '?'.len_utf8();
+        redacted.push_str(&input[url_start..query_value_start]);
+        redacted.push_str("<redacted>");
+        cursor = url_end;
+    }
+
+    redacted.push_str(&input[cursor..]);
+    redacted
+}
+
+fn url_scheme_at(input: &str, index: usize) -> Option<&'static str> {
+    ["https://", "http://"].into_iter().find(|scheme| {
+        input[index..]
+            .get(..scheme.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(scheme))
+    })
+}
+
+fn find_url_token_end(input: &str, start: usize) -> usize {
+    input[start..]
+        .char_indices()
+        .find_map(|(index, ch)| ch.is_whitespace().then_some(start + index))
+        .unwrap_or(input.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exec_result(termination: ProcessTerminationKind, exit_code: i32) -> ExecResult {
+        ExecResult {
+            termination,
+            exit_code,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        }
+    }
+
+    #[test]
+    fn helper_exec_success_requires_exited_zero() {
+        assert!(helper_exec_succeeded(&exec_result(
+            ProcessTerminationKind::Exited,
+            0,
+        )));
+        assert!(!helper_exec_succeeded(&exec_result(
+            ProcessTerminationKind::Exited,
+            1,
+        )));
+        assert!(!helper_exec_succeeded(&exec_result(
+            ProcessTerminationKind::TimedOut,
+            0,
+        )));
+        assert!(!helper_exec_succeeded(&exec_result(
+            ProcessTerminationKind::Cancelled,
+            0,
+        )));
+        assert!(!helper_exec_succeeded(&exec_result(
+            ProcessTerminationKind::StartFailed,
+            0,
+        )));
+        assert!(!helper_exec_succeeded(&exec_result(
+            ProcessTerminationKind::WaitFailed,
+            0,
+        )));
+    }
+
+    #[test]
+    fn exited_failure_keeps_exit_code_wording() {
+        let result = exec_result(ProcessTerminationKind::Exited, 2);
+
+        let message = format_helper_exec_failure("guest clock sync", &result);
+
+        assert_eq!(message, "guest clock sync failed (exit code 2)");
+    }
+
+    #[test]
+    fn terminal_state_failures_include_compatibility_exit_code() {
+        for (termination, expected) in [
+            (
+                ProcessTerminationKind::TimedOut,
+                "storage download failed (timed out; compatibility exit code 124)",
+            ),
+            (
+                ProcessTerminationKind::Cancelled,
+                "storage download failed (cancelled; compatibility exit code 1)",
+            ),
+            (
+                ProcessTerminationKind::StartFailed,
+                "storage download failed (start failed; compatibility exit code 1)",
+            ),
+            (
+                ProcessTerminationKind::WaitFailed,
+                "storage download failed (wait failed; compatibility exit code 1)",
+            ),
+        ] {
+            let exit_code = if termination == ProcessTerminationKind::TimedOut {
+                124
+            } else {
+                1
+            };
+            let result = exec_result(termination, exit_code);
+
+            assert_eq!(
+                format_helper_exec_failure("storage download", &result),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn failure_formatting_preserves_excerpts_and_truncation_markers() {
+        let mut result = exec_result(ProcessTerminationKind::TimedOut, 124);
+        result.stdout = b"stdout clue".to_vec();
+        result.stderr = b"stderr clue".to_vec();
+        result.stderr_truncated = true;
+
+        let message = format_helper_exec_failure("storage download", &result);
+
+        assert!(message.contains("storage download failed (timed out"));
+        assert!(message.contains("stderr (captured, sandbox-truncated): stderr clue"));
+        assert!(message.contains("stdout (captured): stdout clue"));
+    }
+
+    #[test]
+    fn command_output_redaction_handles_urls_before_excerpting() {
+        let prefix = "archiveUrl=https://storage.example/archive.tar.gz?";
+        let secret = "X-Amz-Signature=secret-value-that-must-not-leak";
+        let padding_len =
+            HELPER_EXEC_OUTPUT_EXCERPT_BYTES + "X-Amz-".len() - secret.len() - " done".len();
+        let output = format!("{prefix}{secret}{} done", "a".repeat(padding_len));
+
+        let excerpt = format_command_output_excerpt("stderr", output.as_bytes(), false).unwrap();
+
+        assert!(excerpt.contains("archive.tar.gz?<redacted>"));
+        assert!(!excerpt.contains("X-Amz-Signature"));
+        assert!(!excerpt.contains("secret-value-that-must-not-leak"));
+    }
+
+    #[test]
+    fn termination_label_is_stable_for_logs() {
+        assert_eq!(
+            helper_exec_termination_label(&exec_result(ProcessTerminationKind::Exited, 0)),
+            "exited"
+        );
+        assert_eq!(
+            helper_exec_termination_label(&exec_result(ProcessTerminationKind::TimedOut, 124)),
+            "timed_out"
+        );
+        assert_eq!(
+            helper_exec_termination_label(&exec_result(ProcessTerminationKind::Cancelled, 1)),
+            "cancelled"
+        );
+        assert_eq!(
+            helper_exec_termination_label(&exec_result(ProcessTerminationKind::StartFailed, 1)),
+            "start_failed"
+        );
+        assert_eq!(
+            helper_exec_termination_label(&exec_result(ProcessTerminationKind::WaitFailed, 1)),
+            "wait_failed"
+        );
+    }
+}

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -7,6 +7,7 @@ mod dns;
 mod error;
 mod executor;
 mod group;
+mod helper_exec;
 mod host;
 mod host_env;
 mod host_file;

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -4,6 +4,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 
 const WORKSPACE_MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const WORKSPACE_DEVICE: &str = "/dev/vdb";
@@ -43,18 +44,13 @@ async fn run_workspace_drive_command(
         })
         .await
         .map_err(RunnerError::from)?;
-    if result.exit_code == 0 {
+    if helper_exec_succeeded(&result) {
         return Ok(());
     }
 
-    let stderr = String::from_utf8_lossy(&result.stderr);
-    let stdout = String::from_utf8_lossy(&result.stdout);
-    Err(RunnerError::Internal(format!(
-        "{operation} failed for {diagnostic_id} with exit code {}: stderr={} stdout={}",
-        result.exit_code,
-        stderr.trim(),
-        stdout.trim()
-    )))
+    let mut message = format_helper_exec_failure(operation, &result);
+    message.push_str(&format!("; diagnostic id: {diagnostic_id}"));
+    Err(RunnerError::Internal(message))
 }
 
 fn shell_quote(value: &str) -> String {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -126,6 +126,11 @@ pub struct ExecMatcher {
     pub stderr: Vec<u8>,
 }
 
+struct ExecMatcherResult {
+    pattern: String,
+    result: ExecResult,
+}
+
 /// Captured `exec` request fields recorded for test assertions.
 ///
 /// The record intentionally keeps environment variable names but not their
@@ -450,7 +455,7 @@ enum BlockingGate {
 pub struct MockSandboxOverrides {
     /// Pattern-matched exec results. First matching pattern wins and is
     /// consumed (one-shot).
-    exec_matchers: Mutex<Vec<ExecMatcher>>,
+    exec_matchers: Mutex<Vec<ExecMatcherResult>>,
     /// Recorded exec calls across all sandboxes built from this override set.
     exec_calls: Mutex<Vec<ExecCall>>,
     /// Recorded write_file calls across all sandboxes built from this override set.
@@ -625,7 +630,32 @@ impl MockSandboxOverrides {
 
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
-        self.exec_matchers.lock_ignoring_poison().push(matcher);
+        self.exec_matchers
+            .lock_ignoring_poison()
+            .push(ExecMatcherResult {
+                pattern: matcher.pattern,
+                result: ExecResult {
+                    termination: ProcessTerminationKind::Exited,
+                    exit_code: matcher.exit_code,
+                    stdout: matcher.stdout,
+                    stderr: matcher.stderr,
+                    stdout_truncated: false,
+                    stderr_truncated: false,
+                },
+            });
+    }
+
+    /// Register a pattern matcher that returns the supplied full exec result.
+    ///
+    /// Use this when a test needs a non-ordinary terminal state such as timeout,
+    /// cancel, start failure, or wait failure.
+    pub fn add_exec_result_matcher(&self, pattern: impl Into<String>, result: ExecResult) {
+        self.exec_matchers
+            .lock_ignoring_poison()
+            .push(ExecMatcherResult {
+                pattern: pattern.into(),
+                result,
+            });
     }
 
     /// Return recorded exec calls across all sandboxes built from this
@@ -1187,15 +1217,7 @@ impl Sandbox for MockSandbox {
                 .iter()
                 .position(|m| request.cmd.contains(&m.pattern))
             {
-                let m = matchers.remove(idx);
-                Ok(ExecResult {
-                    termination: ProcessTerminationKind::Exited,
-                    exit_code: m.exit_code,
-                    stdout: m.stdout,
-                    stderr: m.stderr,
-                    stdout_truncated: false,
-                    stderr_truncated: false,
-                })
+                Ok(matchers.remove(idx).result)
             } else {
                 self.exec_results
                     .lock_ignoring_poison()


### PR DESCRIPTION
## Summary

- add a runner helper exec classifier that treats only `Exited(0)` as success
- move shared helper failure formatting and output excerpt redaction out of storage
- migrate runner helper exec callers for storage, guest state, env setup, session restore, workspace mount, and diagnostics
- extend sandbox-mock so tests can return structured non-Exited exec results

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner helper_exec`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_state_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner env_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_restore_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner execution_diagnostics`
- `cargo test --manifest-path crates/Cargo.toml -p runner diagnostics_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_mount`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`

Closes #18236