### PR TITLE
fix: escape html in user chat messages

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -1,8 +1,9 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { StoreProvider } from "ccstate-react";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -11,6 +12,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { Markdown } from "../markdown.tsx";
 
 const context = testContext();
 
@@ -68,6 +70,17 @@ async function openSettingsDialog(): Promise<HTMLElement> {
 }
 
 describe("assistant markdown", () => {
+  it("escapes html-like source when requested", () => {
+    const { container } = render(
+      <StoreProvider value={context.store}>
+        <Markdown source="<span> 123 </span>" escapeHtml />
+      </StoreProvider>,
+    );
+
+    expect(screen.getByText("<span> 123 </span>")).toBeInTheDocument();
+    expect(container.querySelector(".wmde-markdown span")).toBeNull();
+  });
+
   it("renders formatted text and follows theme changes", async () => {
     mockThread("**bold text**");
 

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -360,22 +360,33 @@ const MEDIA_MARKDOWN_COMPONENTS = {
   img: MediaImageRenderer,
 } as const;
 
+function escapeHtmlTags(source: string): string {
+  return source.replace(/[<>]/g, (char) => {
+    return char === "<" ? "&lt;" : "&gt;";
+  });
+}
+
 export function Markdown({
   className,
   style,
   mediaPreview = false,
   mathEnabled = false,
+  escapeHtml = false,
+  source,
   remarkPlugins,
   rehypePlugins,
   ...rest
 }: MarkdownPreviewProps & {
   mediaPreview?: boolean;
   mathEnabled?: boolean;
+  escapeHtml?: boolean;
 }) {
   const theme = useGet(theme$);
   const components = mediaPreview
     ? MEDIA_MARKDOWN_COMPONENTS
     : PLAIN_MARKDOWN_COMPONENTS;
+  const renderedSource =
+    escapeHtml && typeof source === "string" ? escapeHtmlTags(source) : source;
   return (
     <MarkdownPreview
       className={`min-w-0 max-w-full !bg-transparent !text-foreground text-sm ${className ?? ""}`}
@@ -400,6 +411,7 @@ export function Markdown({
         mathEnabled ? [rehypeKatex, ...(rehypePlugins ?? [])] : rehypePlugins
       }
       components={components}
+      source={renderedSource}
       {...rest}
     />
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1010,6 +1010,33 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("renders user html-like text literally", async () => {
+    const threadId = "thread-user-html-like-text";
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [
+        {
+          role: "user",
+          content: "<span> 123 </span>",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const userBubble = await waitFor(() => {
+      const bubble = document.querySelector(".zero-chat-bubble-user");
+      expect(bubble).toBeInstanceOf(HTMLElement);
+      expect(
+        within(bubble as HTMLElement).getByText("<span> 123 </span>"),
+      ).toBeInTheDocument();
+      return bubble as HTMLElement;
+    });
+
+    expect(userBubble.querySelector("span")).toBeNull();
+  });
+
   it("recalls a queued follow-up while an optimistic new thread settles", async () => {
     const user = userEvent.setup({ delay: null });
     const sendGate = context.mocks.deferred<void>();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4193,11 +4193,13 @@ function BodyContentBlocks({
   blocks,
   openLightbox,
   hardBreaks,
+  escapeMarkdownHtml = false,
   markdownMediaPreview = true,
 }: {
   blocks: BodyRenderBlock[];
   openLightbox: (url: string) => void;
   hardBreaks: boolean;
+  escapeMarkdownHtml?: boolean;
   markdownMediaPreview?: boolean;
 }) {
   const openVideoLightbox = useSet(openAttachmentVideoLightbox$);
@@ -4216,6 +4218,7 @@ function BodyContentBlocks({
               }
               mediaPreview={markdownMediaPreview}
               mathEnabled
+              escapeHtml={escapeMarkdownHtml}
               style={{ fontSize: "inherit", lineHeight: "inherit" }}
             />
           );
@@ -5818,6 +5821,7 @@ function PagedUserMessage({
                   blocks={bodyBlocks}
                   openLightbox={openLightbox}
                   hardBreaks
+                  escapeMarkdownHtml
                   markdownMediaPreview={false}
                 />
               </div>


### PR DESCRIPTION
## Summary
- escape HTML-like tags when rendering user chat message markdown
- keep assistant markdown rendering behavior unchanged
- add regression coverage for literal user text like `<span> 123 </span>`

## Verification
- `pnpm exec vitest run src/views/components/__tests__/markdown.test.tsx -t "escapes html-like source when requested"`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "renders user html-like text literally"`
- `pnpm --dir turbo --filter @vm0/app check-types`
- `pnpm exec prettier --check apps/platform/src/views/components/markdown.tsx apps/platform/src/views/components/__tests__/markdown.test.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm exec eslint src/views/components/markdown.tsx src/views/components/__tests__/markdown.test.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0`