### PR TITLE
fix: show user image attachments before text

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -284,6 +284,45 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("shows user image attachments before the text bubble in chat history", async () => {
+    const imageUrl = "https://cdn.vm7.io/artifacts/test/photo/photo.png";
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-image-then-text",
+          role: "user",
+          content: "Review this image",
+          attachFiles: [
+            {
+              id: "attachment-photo",
+              filename: "photo.png",
+              contentType: "image/png",
+              size: 2048,
+              url: imageUrl,
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const image = await screen.findByAltText("photo.png");
+    const preview = image.closest("a");
+    const text = await screen.findByText("Review this image");
+    const textBubble = text.closest(".zero-chat-bubble-user");
+
+    expect(preview).not.toBeNull();
+    expect(textBubble).not.toBeNull();
+    expect(preview?.closest(".zero-chat-bubble-user")).toBeNull();
+    expect(
+      preview!.compareDocumentPosition(textBubble!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("opens persisted audio, video, and document attachments from chat history", async () => {
     const audioUrl =
       "https://cdn.vm7.io/artifacts/test/attachment-audio/briefing.mp3";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5497,7 +5497,7 @@ function UserMessageAttachments({
   }
 
   return (
-    <div className="border-t border-foreground/10 px-3 py-2.5 flex flex-wrap gap-2">
+    <div className="mb-2 flex max-w-[85%] flex-wrap justify-end gap-2">
       {attachments.map((a) => {
         if (a.isImage) {
           return (
@@ -5811,8 +5811,12 @@ function PagedUserMessage({
           <UserMessageGenerationTemplate
             generationTemplate={message.generationTemplate}
           />
-          <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden">
-            {bodyBlocks.length > 0 && (
+          <UserMessageAttachments
+            attachments={allAttachments}
+            onImageClick={openLightbox}
+          />
+          {bodyBlocks.length > 0 && (
+            <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden">
               <div className="px-4 py-3">
                 <BodyContentBlocks
                   blocks={bodyBlocks}
@@ -5821,12 +5825,8 @@ function PagedUserMessage({
                   markdownMediaPreview={false}
                 />
               </div>
-            )}
-            <UserMessageAttachments
-              attachments={allAttachments}
-              onImageClick={openLightbox}
-            />
-          </div>
+            </div>
+          )}
           <UserMessageActions
             canCopy={canCopy}
             copied={copied}


### PR DESCRIPTION
## Summary
- render user message attachments as a separate block before the text bubble
- only render the user text bubble when message text exists
- add regression coverage for image attachments appearing before text and outside the text bubble

## Tests
- pnpm -F @vm0/app test src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint