### PR TITLE
fix: restrict runner dnsmasq listener

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -434,13 +434,6 @@ async fn run_start_with_home(
     let kmsg_handle = kmsg_log::spawn(network_log_manager.clone())
         .map_err(|e| RunnerError::Internal(format!("kmsg monitor: {e}")))?;
 
-    // Reserve the DNS proxy port before netns setup so iptables can redirect
-    // to a stable value. dnsmasq starts after runtime creation, once the
-    // backend knows the runner-specific VM-facing interface pattern.
-    let dns_port_reservation =
-        dns::reserve_port().map_err(|e| RunnerError::Internal(format!("dns port: {e}")))?;
-    let dns_port = dns_port_reservation.port();
-
     // Resource budget from host resources + config.
     let host_cpus = host::cpu_count()?;
     let host_memory_mb = host::memory_mb()?;
@@ -513,47 +506,70 @@ async fn run_start_with_home(
         }
     };
 
-    // Build sandbox runtime with shared resources (netns and NBD device pools).
-    let mut runtime = runtime_provider
-        .create_runtime(sandbox::RuntimeConfig {
-            proxy_port: Some(mitm.port()),
-            dns_port: Some(dns_port),
-        })
-        .await
-        .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
+    // Build sandbox runtime with shared resources (netns and NBD device pools),
+    // then start dnsmasq once the backend exposes the runner-scoped veth
+    // interface pattern. If the reserved DNS port is claimed in the small
+    // release-before-dnsmasq-bind window, rebuild the runtime with a fresh port
+    // so all prewarmed namespace REDIRECT rules stay consistent.
+    const DNS_START_MAX_ATTEMPTS: usize = 3;
+    let mut dns_start_attempt = 1;
+    let (mut runtime, dns_handle) = loop {
+        let dns_port_reservation =
+            dns::reserve_port().map_err(|e| RunnerError::Internal(format!("dns port: {e}")))?;
+        let dns_port = dns_port_reservation.port();
+        let mut runtime = runtime_provider
+            .create_runtime(sandbox::RuntimeConfig {
+                proxy_port: Some(mitm.port()),
+                dns_port: Some(dns_port),
+            })
+            .await
+            .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
 
-    let Some(dns_interface_pattern) = runtime.dns_interface_pattern().await else {
-        memory_prefetch.cancel();
-        runtime.shutdown().await;
-        if let Err(e) = mitm.kill_now().await {
-            warn!(error = %e, "failed to kill proxy after DNS interface resolution failed");
-        }
-        kmsg_handle.stop().await;
-        memory_prefetch.drain().await;
-        return Err(RunnerError::Internal(
-            "sandbox runtime did not provide DNS interface pattern".into(),
-        ));
-    };
-
-    // Start DNS proxy (dnsmasq) for domain-level DNS interception and logging.
-    // Shares NetworkLogManager with kmsg — both use source IP (peer veth) as key.
-    let dns_handle = match dns::start_on_reserved_port(
-        dns_port_reservation,
-        dns_interface_pattern,
-        network_log_manager.clone(),
-    )
-    .await
-    {
-        Ok(handle) => handle,
-        Err(e) => {
+        let Some(dns_interface_pattern) = runtime.dns_interface_pattern().await else {
             memory_prefetch.cancel();
             runtime.shutdown().await;
-            if let Err(kill_error) = mitm.kill_now().await {
-                warn!(error = %kill_error, "failed to kill proxy after DNS startup failed");
+            if let Err(e) = mitm.kill_now().await {
+                warn!(error = %e, "failed to kill proxy after DNS interface resolution failed");
             }
             kmsg_handle.stop().await;
             memory_prefetch.drain().await;
-            return Err(RunnerError::Internal(format!("dns proxy: {e}")));
+            return Err(RunnerError::Internal(
+                "sandbox runtime did not provide DNS interface pattern".into(),
+            ));
+        };
+
+        match dns::start_on_reserved_port(
+            dns_port_reservation,
+            dns_interface_pattern,
+            network_log_manager.clone(),
+        )
+        .await
+        {
+            Ok(handle) => break (runtime, handle),
+            Err(e)
+                if e.kind() == std::io::ErrorKind::AddrInUse
+                    && dns_start_attempt < DNS_START_MAX_ATTEMPTS =>
+            {
+                warn!(
+                    attempt = dns_start_attempt,
+                    max_attempts = DNS_START_MAX_ATTEMPTS,
+                    port = dns_port,
+                    error = %e,
+                    "dns proxy port was claimed before dnsmasq could bind; retrying with a fresh runtime",
+                );
+                runtime.shutdown().await;
+                dns_start_attempt += 1;
+            }
+            Err(e) => {
+                memory_prefetch.cancel();
+                runtime.shutdown().await;
+                if let Err(kill_error) = mitm.kill_now().await {
+                    warn!(error = %kill_error, "failed to kill proxy after DNS startup failed");
+                }
+                kmsg_handle.stop().await;
+                memory_prefetch.drain().await;
+                return Err(RunnerError::Internal(format!("dns proxy: {e}")));
+            }
         }
     };
     let network_log_drain = NetworkLogDrainCoordinator::new(vec![

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -434,15 +434,12 @@ async fn run_start_with_home(
     let kmsg_handle = kmsg_log::spawn(network_log_manager.clone())
         .map_err(|e| RunnerError::Internal(format!("kmsg monitor: {e}")))?;
 
-    // Start DNS proxy (dnsmasq) for domain-level DNS interception and logging.
-    // Shares NetworkLogManager with kmsg — both use source IP (peer veth) as key.
-    let dns_handle = dns::start(network_log_manager.clone())
-        .await
-        .map_err(|e| RunnerError::Internal(format!("dns proxy: {e}")))?;
-    let network_log_drain = NetworkLogDrainCoordinator::new(vec![
-        kmsg_handle.drain_producer(),
-        dns_handle.drain_producer(),
-    ]);
+    // Reserve the DNS proxy port before netns setup so iptables can redirect
+    // to a stable value. dnsmasq starts after runtime creation, once the
+    // backend knows the runner-specific VM-facing interface pattern.
+    let dns_port_reservation =
+        dns::reserve_port().map_err(|e| RunnerError::Internal(format!("dns port: {e}")))?;
+    let dns_port = dns_port_reservation.port();
 
     // Resource budget from host resources + config.
     let host_cpus = host::cpu_count()?;
@@ -520,10 +517,49 @@ async fn run_start_with_home(
     let mut runtime = runtime_provider
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
-            dns_port: Some(dns_handle.port()),
+            dns_port: Some(dns_port),
         })
         .await
         .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
+
+    let Some(dns_interface_pattern) = runtime.dns_interface_pattern().await else {
+        memory_prefetch.cancel();
+        runtime.shutdown().await;
+        if let Err(e) = mitm.kill_now().await {
+            warn!(error = %e, "failed to kill proxy after DNS interface resolution failed");
+        }
+        kmsg_handle.stop().await;
+        memory_prefetch.drain().await;
+        return Err(RunnerError::Internal(
+            "sandbox runtime did not provide DNS interface pattern".into(),
+        ));
+    };
+
+    // Start DNS proxy (dnsmasq) for domain-level DNS interception and logging.
+    // Shares NetworkLogManager with kmsg — both use source IP (peer veth) as key.
+    let dns_handle = match dns::start_on_reserved_port(
+        dns_port_reservation,
+        dns_interface_pattern,
+        network_log_manager.clone(),
+    )
+    .await
+    {
+        Ok(handle) => handle,
+        Err(e) => {
+            memory_prefetch.cancel();
+            runtime.shutdown().await;
+            if let Err(kill_error) = mitm.kill_now().await {
+                warn!(error = %kill_error, "failed to kill proxy after DNS startup failed");
+            }
+            kmsg_handle.stop().await;
+            memory_prefetch.drain().await;
+            return Err(RunnerError::Internal(format!("dns proxy: {e}")));
+        }
+    };
+    let network_log_drain = NetworkLogDrainCoordinator::new(vec![
+        kmsg_handle.drain_producer(),
+        dns_handle.drain_producer(),
+    ]);
 
     let status = Arc::new(StatusTracker::new(
         paths.status(),

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -7,6 +7,7 @@
 //! Defense-in-depth:
 //! - Layer 1: iptables REDIRECT → dnsmasq port (working path, preserves source IP)
 //! - Layer 2: iptables DROP external UDP 53 / TCP 853 (bypass prevention)
+//! - Layer 3: dnsmasq binds only VM-facing veth interfaces (listener restriction)
 //!
 //! VM resolv.conf points to an external nameserver (e.g. 8.8.8.8) as a dummy
 //! target. The REDIRECT rule in PREROUTING intercepts all UDP 53 from the VM
@@ -518,6 +519,7 @@ fn dnsmasq_args(port: u16) -> Vec<String> {
         "--no-resolv".into(),
         "--port".into(),
         port.to_string(),
+        // VM host-side veth devices are created after dnsmasq starts.
         format!("--interface={DNSMASQ_VM_INTERFACE_PATTERN}"),
         "--bind-dynamic".into(),
         "--server".into(),

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -19,7 +19,7 @@
 use std::{borrow::Cow, process::Stdio};
 
 use chrono::{DateTime, Utc};
-use tokio::io::AsyncBufRead;
+use tokio::io::{AsyncBufRead, AsyncReadExt};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -29,8 +29,6 @@ use crate::network_log_drain::{
     run_drainable_line_reader,
 };
 use crate::network_log_manager::NetworkLogManager;
-
-const DNSMASQ_VM_INTERFACE_PATTERN: &str = "vm0-ve*";
 
 /// Handle to the dnsmasq process and its log monitor.
 pub struct DnsProxy {
@@ -98,8 +96,8 @@ impl Drop for DnsProxy {
     /// Kill dnsmasq and abort the log task if `stop()` was never called.
     ///
     /// Prevents orphaned dnsmasq processes when `run_start()` fails after
-    /// `dns::start()` (e.g., runtime creation error). Harmless if `stop()`
-    /// already ran — `start_kill` on an exited child is a no-op.
+    /// `start_on_reserved_port()` (e.g., live-runner publish error). Harmless
+    /// if `stop()` already ran — `start_kill` on an exited child is a no-op.
     fn drop(&mut self) {
         if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
@@ -109,18 +107,40 @@ impl Drop for DnsProxy {
     }
 }
 
-/// Find an available port by binding to port 0.
+/// Reserved TCP/UDP port for the runner-managed dnsmasq process.
+pub(crate) struct DnsPortReservation {
+    port: u16,
+    _tcp: std::net::TcpListener,
+    _udp: std::net::UdpSocket,
+}
+
+impl DnsPortReservation {
+    /// Return the reserved port.
+    pub(crate) fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+/// Reserve an available port by binding to port 0.
 ///
 /// Checks both TCP and UDP because dnsmasq binds both protocols.
-fn find_available_port() -> std::io::Result<u16> {
+pub(crate) fn reserve_port() -> std::io::Result<DnsPortReservation> {
     const MAX_PORT_PROBE_ATTEMPTS: usize = 64;
 
-    find_available_port_from(
+    reserve_port_from(
         (0..MAX_PORT_PROBE_ATTEMPTS).map(|_| std::net::TcpListener::bind("0.0.0.0:0")),
     )
 }
 
+#[cfg(test)]
 fn find_available_port_from<I>(tcp_candidates: I) -> std::io::Result<u16>
+where
+    I: IntoIterator<Item = std::io::Result<std::net::TcpListener>>,
+{
+    Ok(reserve_port_from(tcp_candidates)?.port())
+}
+
+fn reserve_port_from<I>(tcp_candidates: I) -> std::io::Result<DnsPortReservation>
 where
     I: IntoIterator<Item = std::io::Result<std::net::TcpListener>>,
 {
@@ -129,7 +149,13 @@ where
         let tcp = tcp?;
         let port = tcp.local_addr()?.port();
         match std::net::UdpSocket::bind(("0.0.0.0", port)) {
-            Ok(_udp) => return Ok(port),
+            Ok(udp) => {
+                return Ok(DnsPortReservation {
+                    port,
+                    _tcp: tcp,
+                    _udp: udp,
+                });
+            }
             Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
                 last_addr_in_use = Some(err);
             }
@@ -148,38 +174,26 @@ where
 /// Start dnsmasq and spawn a background task to parse its query log.
 ///
 /// dnsmasq listens on a dynamically allocated port and forwards to upstream DNS.
-/// Retries up to 3 times with a fresh port if the initial bind fails (TOCTOU race).
-pub async fn start(network_log_manager: NetworkLogManager) -> std::io::Result<DnsProxy> {
-    const MAX_ATTEMPTS: u32 = 3;
-    let mut last_err = None;
-    for attempt in 1..=MAX_ATTEMPTS {
-        let port = match find_available_port() {
-            Ok(p) => p,
-            Err(e) => {
-                warn!(attempt, error = %e, "failed to find available port");
-                last_err = Some(e);
-                continue;
-            }
-        };
-        match try_start(port, network_log_manager.clone()).await {
-            Ok(proxy) => return Ok(proxy),
-            Err(e) => {
-                if attempt < MAX_ATTEMPTS {
-                    warn!(port, attempt, error = %e, "dnsmasq failed to start, retrying with new port");
-                } else {
-                    warn!(port, attempt, error = %e, "dnsmasq failed to start, all attempts exhausted");
-                }
-                last_err = Some(e);
-            }
-        }
-    }
-    Err(last_err.unwrap_or_else(|| std::io::Error::other("dnsmasq failed to start")))
+/// The port is reserved before netns setup so iptables can redirect to a stable
+/// value, then released immediately before spawning dnsmasq.
+pub async fn start_on_reserved_port(
+    reservation: DnsPortReservation,
+    interface_pattern: String,
+    network_log_manager: NetworkLogManager,
+) -> std::io::Result<DnsProxy> {
+    let port = reservation.port();
+    drop(reservation);
+    try_start(port, &interface_pattern, network_log_manager).await
 }
 
 /// Try to start dnsmasq on the given port. Returns the proxy handle on success.
-async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io::Result<DnsProxy> {
+async fn try_start(
+    port: u16,
+    interface_pattern: &str,
+    network_log_manager: NetworkLogManager,
+) -> std::io::Result<DnsProxy> {
     let mut child = tokio::process::Command::new("dnsmasq")
-        .args(dnsmasq_args(port))
+        .args(dnsmasq_args(port, interface_pattern))
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -190,8 +204,9 @@ async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     match child.try_wait() {
         Ok(Some(status)) => {
+            let stderr = read_child_stderr_excerpt(&mut child).await;
             return Err(std::io::Error::other(format!(
-                "dnsmasq exited immediately with {status}"
+                "dnsmasq exited immediately with {status}{stderr}"
             )));
         }
         Err(e) => {
@@ -225,6 +240,22 @@ async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io
         drain,
         port,
     })
+}
+
+async fn read_child_stderr_excerpt(child: &mut tokio::process::Child) -> String {
+    let Some(mut stderr) = child.stderr.take() else {
+        return String::new();
+    };
+    let mut output = String::new();
+    if stderr.read_to_string(&mut output).await.is_err() {
+        return String::new();
+    }
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!(": {trimmed}")
+    }
 }
 
 /// Tail dnsmasq stderr and write DNS log entries to per-VM network JSONL.
@@ -513,14 +544,14 @@ fn network_log_row(entry: &DnsLogEntry<'_>, timestamp: DateTime<Utc>) -> serde_j
     json
 }
 
-fn dnsmasq_args(port: u16) -> Vec<String> {
+fn dnsmasq_args(port: u16, interface_pattern: &str) -> Vec<String> {
     vec![
         "--no-daemon".into(),
         "--no-resolv".into(),
         "--port".into(),
         port.to_string(),
         // VM host-side veth devices are created after dnsmasq starts.
-        format!("--interface={DNSMASQ_VM_INTERFACE_PATTERN}"),
+        format!("--interface={interface_pattern}"),
         "--bind-dynamic".into(),
         "--server".into(),
         "8.8.8.8".into(),
@@ -986,15 +1017,15 @@ mod tests {
 
     #[test]
     fn dnsmasq_args_restrict_listener_to_vm_interfaces() {
-        let args = dnsmasq_args(5353);
+        let args = dnsmasq_args(5353, "vm0-ve-0a-*");
 
-        assert!(args.contains(&"--interface=vm0-ve*".to_string()));
+        assert!(args.contains(&"--interface=vm0-ve-0a-*".to_string()));
         assert!(args.contains(&"--bind-dynamic".to_string()));
     }
 
     #[test]
     fn dnsmasq_args_preserve_port_upstream_and_logging_config() {
-        let args = dnsmasq_args(5353);
+        let args = dnsmasq_args(5353, "vm0-ve-0a-*");
 
         assert_eq!(
             args,
@@ -1003,7 +1034,7 @@ mod tests {
                 "--no-resolv",
                 "--port",
                 "5353",
-                "--interface=vm0-ve*",
+                "--interface=vm0-ve-0a-*",
                 "--bind-dynamic",
                 "--server",
                 "8.8.8.8",
@@ -1016,9 +1047,9 @@ mod tests {
     }
 
     #[test]
-    fn find_available_port_returns_nonzero() {
-        let port = find_available_port().unwrap();
-        assert!(port > 0);
+    fn reserve_port_returns_nonzero() {
+        let reservation = reserve_port().unwrap();
+        assert!(reservation.port() > 0);
     }
 
     fn bind_tcp_udp_pair() -> std::io::Result<(std::net::TcpListener, std::net::UdpSocket)> {

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -7,7 +7,8 @@
 //! Defense-in-depth:
 //! - Layer 1: iptables REDIRECT → dnsmasq port (working path, preserves source IP)
 //! - Layer 2: iptables DROP external UDP 53 / TCP 853 (bypass prevention)
-//! - Layer 3: dnsmasq binds only VM-facing veth interfaces (listener restriction)
+//! - Layer 3: dnsmasq binds to VM-facing veth interfaces instead of external
+//!   host interfaces (listener restriction)
 //!
 //! VM resolv.conf points to an external nameserver (e.g. 8.8.8.8) as a dummy
 //! target. The REDIRECT rule in PREROUTING intercepts all UDP 53 from the VM
@@ -1030,7 +1031,7 @@ mod tests {
     }
 
     #[test]
-    fn dnsmasq_args_restrict_listener_to_vm_interfaces() {
+    fn dnsmasq_args_restrict_listener_to_vm_interface_pattern() {
         let args = dnsmasq_args(5353, "vm0-ve-0a-*");
 
         assert!(args.contains(&"--interface=vm0-ve-0a-*".to_string()));

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -204,10 +204,8 @@ async fn try_start(
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     match child.try_wait() {
         Ok(Some(status)) => {
-            let stderr = read_child_stderr_excerpt(&mut child).await;
-            return Err(std::io::Error::other(format!(
-                "dnsmasq exited immediately with {status}{stderr}"
-            )));
+            let stderr = read_child_stderr(&mut child).await;
+            return Err(dnsmasq_immediate_exit_error(status, &stderr));
         }
         Err(e) => {
             let _ = child.kill().await;
@@ -242,7 +240,28 @@ async fn try_start(
     })
 }
 
-async fn read_child_stderr_excerpt(child: &mut tokio::process::Child) -> String {
+fn dnsmasq_immediate_exit_error(status: std::process::ExitStatus, stderr: &str) -> std::io::Error {
+    let trimmed = stderr.trim();
+    let message = if trimmed.is_empty() {
+        format!("dnsmasq exited immediately with {status}")
+    } else {
+        format!("dnsmasq exited immediately with {status}: {trimmed}")
+    };
+    std::io::Error::new(dnsmasq_immediate_exit_error_kind(trimmed), message)
+}
+
+fn dnsmasq_immediate_exit_error_kind(stderr: &str) -> std::io::ErrorKind {
+    if stderr
+        .to_ascii_lowercase()
+        .contains("address already in use")
+    {
+        std::io::ErrorKind::AddrInUse
+    } else {
+        std::io::ErrorKind::Other
+    }
+}
+
+async fn read_child_stderr(child: &mut tokio::process::Child) -> String {
     let Some(mut stderr) = child.stderr.take() else {
         return String::new();
     };
@@ -250,12 +269,7 @@ async fn read_child_stderr_excerpt(child: &mut tokio::process::Child) -> String 
     if stderr.read_to_string(&mut output).await.is_err() {
         return String::new();
     }
-    let trimmed = output.trim();
-    if trimmed.is_empty() {
-        String::new()
-    } else {
-        format!(": {trimmed}")
-    }
+    output
 }
 
 /// Tail dnsmasq stderr and write DNS log entries to per-VM network JSONL.
@@ -1043,6 +1057,28 @@ mod tests {
                 "--log-queries=extra",
                 "--log-facility=-",
             ]
+        );
+    }
+
+    #[test]
+    fn dnsmasq_immediate_exit_error_kind_detects_port_race() {
+        let stderr =
+            "dnsmasq: failed to create listening socket for 127.0.0.1: Address already in use";
+
+        assert_eq!(
+            dnsmasq_immediate_exit_error_kind(stderr),
+            std::io::ErrorKind::AddrInUse
+        );
+    }
+
+    #[test]
+    fn dnsmasq_immediate_exit_error_kind_keeps_non_port_errors_fatal() {
+        let stderr =
+            "dnsmasq: failed to create listening socket for 10.200.52.97: Too many open files";
+
+        assert_eq!(
+            dnsmasq_immediate_exit_error_kind(stderr),
+            std::io::ErrorKind::Other
         );
     }
 

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -29,6 +29,8 @@ use crate::network_log_drain::{
 };
 use crate::network_log_manager::NetworkLogManager;
 
+const DNSMASQ_VM_INTERFACE_PATTERN: &str = "vm0-ve*";
+
 /// Handle to the dnsmasq process and its log monitor.
 pub struct DnsProxy {
     cancel: CancellationToken,
@@ -175,21 +177,8 @@ pub async fn start(network_log_manager: NetworkLogManager) -> std::io::Result<Dn
 
 /// Try to start dnsmasq on the given port. Returns the proxy handle on success.
 async fn try_start(port: u16, network_log_manager: NetworkLogManager) -> std::io::Result<DnsProxy> {
-    let port_str = port.to_string();
-
     let mut child = tokio::process::Command::new("dnsmasq")
-        .args([
-            "--no-daemon",
-            "--no-resolv",
-            "--port",
-            &port_str,
-            "--server",
-            "8.8.8.8",
-            "--server",
-            "8.8.4.4",
-            "--log-queries=extra",
-            "--log-facility=-",
-        ])
+        .args(dnsmasq_args(port))
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -521,6 +510,23 @@ fn network_log_row(entry: &DnsLogEntry<'_>, timestamp: DateTime<Utc>) -> serde_j
     }
 
     json
+}
+
+fn dnsmasq_args(port: u16) -> Vec<String> {
+    vec![
+        "--no-daemon".into(),
+        "--no-resolv".into(),
+        "--port".into(),
+        port.to_string(),
+        format!("--interface={DNSMASQ_VM_INTERFACE_PATTERN}"),
+        "--bind-dynamic".into(),
+        "--server".into(),
+        "8.8.8.8".into(),
+        "--server".into(),
+        "8.8.4.4".into(),
+        "--log-queries=extra".into(),
+        "--log-facility=-".into(),
+    ]
 }
 
 #[cfg(test)]
@@ -974,6 +980,37 @@ mod tests {
         }
 
         fn consume(self: Pin<&mut Self>, _amt: usize) {}
+    }
+
+    #[test]
+    fn dnsmasq_args_restrict_listener_to_vm_interfaces() {
+        let args = dnsmasq_args(5353);
+
+        assert!(args.contains(&"--interface=vm0-ve*".to_string()));
+        assert!(args.contains(&"--bind-dynamic".to_string()));
+    }
+
+    #[test]
+    fn dnsmasq_args_preserve_port_upstream_and_logging_config() {
+        let args = dnsmasq_args(5353);
+
+        assert_eq!(
+            args,
+            vec![
+                "--no-daemon",
+                "--no-resolv",
+                "--port",
+                "5353",
+                "--interface=vm0-ve*",
+                "--bind-dynamic",
+                "--server",
+                "8.8.8.8",
+                "--server",
+                "8.8.4.4",
+                "--log-queries=extra",
+                "--log-facility=-",
+            ]
+        );
     }
 
     #[test]

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -111,7 +111,7 @@ impl Drop for DnsProxy {
 /// Reserved TCP/UDP port for the runner-managed dnsmasq process.
 pub(crate) struct DnsPortReservation {
     port: u16,
-    _tcp: std::net::TcpListener,
+    _tcp: ReservedTcpPort,
     _udp: std::net::UdpSocket,
 }
 
@@ -122,33 +122,51 @@ impl DnsPortReservation {
     }
 }
 
-/// Reserve an available port by binding to port 0.
+struct ReservedTcpPort {
+    port: u16,
+    _socket: tokio::net::TcpSocket,
+}
+
+impl ReservedTcpPort {
+    fn bind(port: u16) -> std::io::Result<Self> {
+        let socket = tokio::net::TcpSocket::new_v4()?;
+        socket.bind(std::net::SocketAddr::from(([0, 0, 0, 0], port)))?;
+        Ok(Self {
+            port: socket.local_addr()?.port(),
+            _socket: socket,
+        })
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+/// Reserve an available port by binding to port 0 without listening.
 ///
 /// Checks both TCP and UDP because dnsmasq binds both protocols.
 pub(crate) fn reserve_port() -> std::io::Result<DnsPortReservation> {
     const MAX_PORT_PROBE_ATTEMPTS: usize = 64;
 
-    reserve_port_from(
-        (0..MAX_PORT_PROBE_ATTEMPTS).map(|_| std::net::TcpListener::bind("0.0.0.0:0")),
-    )
+    reserve_port_from((0..MAX_PORT_PROBE_ATTEMPTS).map(|_| ReservedTcpPort::bind(0)))
 }
 
 #[cfg(test)]
 fn find_available_port_from<I>(tcp_candidates: I) -> std::io::Result<u16>
 where
-    I: IntoIterator<Item = std::io::Result<std::net::TcpListener>>,
+    I: IntoIterator<Item = std::io::Result<ReservedTcpPort>>,
 {
     Ok(reserve_port_from(tcp_candidates)?.port())
 }
 
 fn reserve_port_from<I>(tcp_candidates: I) -> std::io::Result<DnsPortReservation>
 where
-    I: IntoIterator<Item = std::io::Result<std::net::TcpListener>>,
+    I: IntoIterator<Item = std::io::Result<ReservedTcpPort>>,
 {
     let mut last_addr_in_use = None;
     for tcp in tcp_candidates {
         let tcp = tcp?;
-        let port = tcp.local_addr()?.port();
+        let port = tcp.port();
         match std::net::UdpSocket::bind(("0.0.0.0", port)) {
             Ok(udp) => {
                 return Ok(DnsPortReservation {
@@ -1089,13 +1107,13 @@ mod tests {
         assert!(reservation.port() > 0);
     }
 
-    fn bind_tcp_udp_pair() -> std::io::Result<(std::net::TcpListener, std::net::UdpSocket)> {
+    fn bind_tcp_udp_pair() -> std::io::Result<(ReservedTcpPort, std::net::UdpSocket)> {
         const MAX_PORT_PROBE_ATTEMPTS: usize = 64;
 
         let mut last_addr_in_use = None;
         for _ in 0..MAX_PORT_PROBE_ATTEMPTS {
-            let tcp = std::net::TcpListener::bind("0.0.0.0:0")?;
-            let port = tcp.local_addr()?.port();
+            let tcp = ReservedTcpPort::bind(0)?;
+            let port = tcp.port();
             match std::net::UdpSocket::bind(("0.0.0.0", port)) {
                 Ok(udp) => return Ok((tcp, udp)),
                 Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
@@ -1117,7 +1135,7 @@ mod tests {
     fn find_available_port_retries_when_udp_candidate_is_in_use() {
         let (busy_tcp, _busy_udp) = bind_tcp_udp_pair().unwrap();
         let (free_tcp, free_udp_probe) = bind_tcp_udp_pair().unwrap();
-        let free_port = free_tcp.local_addr().unwrap().port();
+        let free_port = free_tcp.port();
         drop(free_udp_probe);
 
         let port = find_available_port_from([Ok(busy_tcp), Ok(free_tcp)]).unwrap();

--- a/crates/sandbox-fc/src/network/pool/state.rs
+++ b/crates/sandbox-fc/src/network/pool/state.rs
@@ -19,7 +19,7 @@ use super::host::{
     NamespaceDeleteOutcome, NetnsLifecycleOps, acquire_pool_lock, create_single_namespace,
     enable_host_ip_forwarding, get_default_interface, reconcile_orphan_namespaces,
 };
-use super::naming::MAX_NAMESPACES;
+use super::naming::{MAX_NAMESPACES, format_hex_index};
 use super::types::{
     CheckedNetnsPoolConfig, NetnsInfo, NetnsLease, NetnsPoolConfig, NetnsReleaseOutcome,
 };
@@ -309,6 +309,11 @@ impl NetnsPoolState {
         let id = PendingId(self.next_pending_id);
         self.next_pending_id += 1;
         id
+    }
+
+    fn host_device_pattern(&self) -> String {
+        let pool_idx = format_hex_index(self.pool_index);
+        format!("vm0-ve-{pool_idx}-*")
     }
 
     fn creation_notifier(&self) -> CreationNotifier {
@@ -887,6 +892,11 @@ impl NetnsPoolInner {
         }
     }
 
+    async fn host_device_pattern(&self) -> String {
+        let state = self.state.lock().await;
+        state.host_device_pattern()
+    }
+
     #[cfg(test)]
     fn with_state_for_test<R>(&self, f: impl FnOnce(&mut NetnsPoolState) -> R) -> R {
         let mut state = self
@@ -1008,6 +1018,10 @@ impl NetnsPoolHandle {
     pub(crate) async fn cleanup(&self) -> Result<()> {
         self.inner.cleanup().await
     }
+
+    pub(crate) async fn host_device_pattern(&self) -> String {
+        self.inner.host_device_pattern().await
+    }
 }
 
 fn spawn_creation_worker<F>(id: PendingId, kind: NetnsKind, notifier: CreationNotifier, future: F)
@@ -1072,6 +1086,15 @@ mod tests {
 
     fn test_info(name: &str) -> NetnsInfo {
         NetnsInfo::new(name.into(), "test-ve".into(), "10.200.0.2".into())
+    }
+
+    #[tokio::test]
+    async fn host_device_pattern_scopes_to_pool_index() {
+        let mut pool = NetnsPoolState::inactive_for_test();
+        pool.pool_index = 10;
+        let handle = NetnsPoolHandle::from_state_for_test(pool);
+
+        assert_eq!(handle.host_device_pattern().await, "vm0-ve-0a-*");
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -109,6 +109,14 @@ impl SandboxRuntime for FirecrackerRuntime {
         Ok(Box::new(factory))
     }
 
+    async fn dns_interface_pattern(&self) -> Option<String> {
+        if self.dns_port.is_some() {
+            Some(self.netns_pool.host_device_pattern().await)
+        } else {
+            None
+        }
+    }
+
     async fn shutdown(&mut self) {
         // Clean up shared netns pool.
         if let Err(e) = self.netns_pool.cleanup().await {

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -25,6 +25,14 @@ pub trait SandboxRuntime: Send + Sync {
     /// The returned factory is fully initialized and ready to create sandboxes.
     async fn create_factory(&self, config: FactoryConfig) -> Result<Box<dyn SandboxFactory>>;
 
+    /// Return the host interface pattern that runner-managed DNS should bind.
+    ///
+    /// Backends that create VM-facing host interfaces can return a scoped
+    /// pattern here so dnsmasq avoids listening on unrelated host interfaces.
+    async fn dns_interface_pattern(&self) -> Option<String> {
+        None
+    }
+
     /// Release shared resources (network pools, device caches).
     async fn shutdown(&mut self);
 }


### PR DESCRIPTION
## Summary

- reserve the runner-managed DNS port before netns setup so iptables REDIRECT uses a stable target
- reserve TCP with a bind-only socket and UDP with a UDP socket, so the startup reservation window does not create a temporary externally reachable TCP listener
- expose a sandbox-runtime DNS interface hint and have Firecracker return its own netns pool pattern, e.g. `vm0-ve-0a-*`
- start dnsmasq after runtime/netns pool creation with `--interface=<pool-pattern> --bind-dynamic`
- avoid binding dnsmasq across unrelated runners' `vm0-ve*` interfaces, which can exhaust file descriptors on shared hosts
- retry runtime + dnsmasq startup only when dnsmasq reports `Address already in use`, covering the release-before-bind port race without masking persistent config/resource failures
- keep upstream resolver, logging, network-log drain, and startup cleanup behavior intact

Fixes #18277

## Validation

- `cargo fmt --all` from `crates/`
- `cargo test --manifest-path crates/Cargo.toml -p runner dns::tests::`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc network::pool::state::tests::host_device_pattern_scopes_to_pool_index`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `git diff --check`
- pre-commit hook also ran `cargo-fmt`, `cargo-clippy`, and `cargo-doc`
- dev-1 dnsmasq 2.90 smoke test: global `--interface=vm0-ve* --bind-dynamic` failed with `Too many open files` after matching many existing runner veth addresses; pool-scoped patterns like `--interface=vm0-ve-3f-* --bind-dynamic` started successfully and logged only `warning: interface vm0-ve-3f-* does not currently exist` when no matching interface existed

## Real runner validation before merge

The refreshed PR CI runner jobs should confirm the Linux-level behavior after the latest commit:

- dnsmasq starts with the current runner's pool-scoped `vm0-ve-{pool}-*` pattern
- VM DNS still resolves through the existing UDP/53 REDIRECT path after namespace creation
- non-VM traffic cannot use the selected dnsmasq port through public, VPC, or management interfaces
- socket inspection/probing confirms the dnsmasq port is not externally usable