### PR TITLE
perf(guest-agent): resolve session markers at checkpoint time

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -379,13 +379,25 @@ async fn create_checkpoint_impl_with_artifacts(
     }
     record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
 
-    // Read session history. The history-path file's content is either a
-    // literal jsonl path (Claude) or a `CODEX_SEARCH:{dir}:{id}` marker
-    // (codex) — `session_history::read_session_history` abstracts the
-    // difference and decompresses zstd-compressed codex sessions.
+    // Read session history. The persisted or derived marker payload is either
+    // a literal jsonl path (Claude) or a `CODEX_SEARCH:{dir}:{id}` marker
+    // (codex) — `session_history` abstracts the difference and decompresses
+    // zstd-compressed codex sessions.
     let history_read_start = std::time::Instant::now();
+    let history_marker_payload =
+        match crate::session_metadata::resolve_history_marker_payload(&cli_agent_session_id) {
+            Ok(payload) => payload,
+            Err(e) => {
+                return Err(fail(
+                    mode,
+                    "session_history_read",
+                    history_read_start,
+                    e.to_string(),
+                ));
+            }
+        };
     let history_bytes =
-        match session_history::read_session_history(paths::session_history_path_file()) {
+        match session_history::read_session_history_from_payload(&history_marker_payload) {
             Ok(b) => b,
             Err(e) => {
                 return Err(fail(

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -438,6 +438,7 @@ async fn execute_cli_inner(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut failure_diagnostic = None;
+    let mut session_metadata_capture = events::SessionMetadataCapture::new();
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             stdin_write_result = async {
@@ -559,7 +560,7 @@ async fn execute_cli_inner(
                             // Capture checkpoint metadata and register any
                             // event-local session identifier before logging
                             // terminal diagnostics from the same event.
-                            events::capture_session_metadata(&event, masker);
+                            session_metadata_capture.capture_event(&event, masker);
                             // Print Claude Code final result to stdout if applicable.
                             if behavior.handles_claude_result_event(&event) {
                                 claude_result = Some(ClaudeResultSummary::from_event(&event));

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -10,10 +10,10 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
+use crate::session_metadata;
 use agent_diagnostics::FailureReason;
 use guest_common::{log_error, log_info};
 use serde_json::{Map, Value, json};
-use std::path::{Component, Path};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const FAILURE_DIAGNOSTIC_MAX_BYTES: usize = 4096;
@@ -45,7 +45,8 @@ pub async fn send_event(
     seq: u32,
     masker: &SecretMasker,
 ) -> Result<(), AgentError> {
-    capture_session_metadata(&event, masker);
+    let mut capture = SessionMetadataCapture::new();
+    capture.capture_event(&event, masker);
 
     if !http.has_api() {
         return Ok(());
@@ -351,70 +352,109 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
     results
 }
 
-/// Capture or repair the session metadata files needed by checkpoint.
+/// Capture session metadata files needed by checkpoint.
 ///
 /// Both frameworks emit a single id-bearing event near the top of their
 /// JSONL stream:
 /// - Claude Code: `{type: system, subtype: init, session_id: <uuid>}`
 /// - Codex:       `{type: thread.started, thread_id: <uuid>}`
 ///
+/// Ordinary events only seed the masker from an existing session id once; they
+/// do not repair the history marker. Checkpoint resolves missing markers when
+/// it consumes session metadata.
+///
 /// The on-disk format of `session_history_path_file()` differs by framework:
 /// - Claude: literal `~/.claude/projects/-{cwd}/{session_id}.jsonl` path.
 /// - Codex: `CODEX_SEARCH:{sessions_dir}:{thread_id}` marker — codex
 ///   doesn't write the session file until turn-completion, so resolution
 ///   is deferred to checkpoint time.
-pub(crate) fn capture_session_metadata(event: &Value, masker: &SecretMasker) {
-    register_event_session_identifier(event, masker);
+pub(crate) struct SessionMetadataCapture {
+    existing_session_id_seeded: bool,
+}
 
-    let parsed = match Framework::from_env() {
-        Framework::ClaudeCode => extract_claude_session_id(event),
-        Framework::Codex => extract_codex_thread_id(event),
-    };
-    let Some((session_id, history_path_payload)) = parsed else {
-        repair_missing_session_history_marker_from_existing_session(masker);
-        return;
-    };
-    masker.add_sensitive_value(&session_id);
+impl SessionMetadataCapture {
+    pub(crate) fn new() -> Self {
+        Self {
+            existing_session_id_seeded: false,
+        }
+    }
 
-    // Idempotency: only the first id-bearing event of the run wins, but allow
-    // a retry of the same session to repair a missing history marker after a
-    // partial metadata write.
-    match std::fs::read_to_string(paths::session_id_file()) {
-        Ok(existing_session_id) => {
-            let existing_session_id = existing_session_id.trim();
-            if !existing_session_id.is_empty() {
-                masker.add_sensitive_value(existing_session_id);
+    pub(crate) fn capture_event(&mut self, event: &Value, masker: &SecretMasker) {
+        register_event_session_identifier(event, masker);
+
+        let parsed = match Framework::from_env() {
+            Framework::ClaudeCode => extract_claude_session_id(event),
+            Framework::Codex => extract_codex_thread_id(event),
+        };
+        let Some((session_id, history_path_payload)) = parsed else {
+            self.seed_existing_session_id(masker);
+            return;
+        };
+        masker.add_sensitive_value(&session_id);
+
+        // Idempotency: only the first id-bearing event of the run wins, but allow
+        // a retry of the same session to repair a missing history marker after a
+        // partial metadata write.
+        match std::fs::read_to_string(paths::session_id_file()) {
+            Ok(existing_session_id) => {
+                let existing_session_id = existing_session_id.trim();
+                if !existing_session_id.is_empty() {
+                    masker.add_sensitive_value(existing_session_id);
+                    self.existing_session_id_seeded = true;
+                }
+                if existing_session_id == session_id {
+                    session_metadata::ensure_history_marker_payload(&history_path_payload);
+                }
+                return;
             }
-            if existing_session_id == session_id {
-                ensure_session_history_marker(&history_path_payload);
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                log_error!(
+                    LOG_TAG,
+                    "Failed to read existing session ID from {}: {e}",
+                    paths::session_id_file()
+                );
+                return;
             }
+        }
+
+        log_info!(LOG_TAG, "Captured session ID");
+        match paths::write_private(paths::session_id_file(), &session_id) {
+            Ok(()) => log_info!(
+                LOG_TAG,
+                "Session ID written to {}",
+                paths::session_id_file()
+            ),
+            Err(e) => log_error!(
+                LOG_TAG,
+                "Failed to write session ID to {}: {e}",
+                paths::session_id_file()
+            ),
+        }
+        session_metadata::write_session_history_marker(&history_path_payload);
+    }
+
+    fn seed_existing_session_id(&mut self, masker: &SecretMasker) {
+        if self.existing_session_id_seeded {
             return;
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
-            log_error!(
+        self.existing_session_id_seeded = true;
+
+        match std::fs::read_to_string(paths::session_id_file()) {
+            Ok(session_id) => {
+                let session_id = session_id.trim();
+                if !session_id.is_empty() {
+                    masker.add_sensitive_value(session_id);
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => log_error!(
                 LOG_TAG,
                 "Failed to read existing session ID from {}: {e}",
                 paths::session_id_file()
-            );
-            return;
+            ),
         }
     }
-
-    log_info!(LOG_TAG, "Captured session ID");
-    match paths::write_private(paths::session_id_file(), &session_id) {
-        Ok(()) => log_info!(
-            LOG_TAG,
-            "Session ID written to {}",
-            paths::session_id_file()
-        ),
-        Err(e) => log_error!(
-            LOG_TAG,
-            "Failed to write session ID to {}: {e}",
-            paths::session_id_file()
-        ),
-    }
-    write_session_history_marker(&history_path_payload);
 }
 
 pub(crate) fn register_event_session_identifier(event: &Value, masker: &SecretMasker) {
@@ -434,91 +474,11 @@ fn string_field<'a>(event: &'a Value, field: &str) -> Option<&'a str> {
         .filter(|value| !value.is_empty())
 }
 
-fn repair_missing_session_history_marker_from_existing_session(masker: &SecretMasker) {
-    if !should_write_session_history_marker() {
-        return;
-    }
-    let session_id = match std::fs::read_to_string(paths::session_id_file()) {
-        Ok(session_id) => session_id.trim().to_string(),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
-        Err(e) => {
-            log_error!(
-                LOG_TAG,
-                "Failed to read existing session ID from {}: {e}",
-                paths::session_id_file()
-            );
-            return;
-        }
-    };
-    if session_id.is_empty() {
-        return;
-    }
-    masker.add_sensitive_value(&session_id);
-    if let Some(history_path_payload) = history_path_payload_for_session_id(&session_id) {
-        write_session_history_marker(&history_path_payload);
-    }
-}
-
-fn ensure_session_history_marker(history_path_payload: &str) {
-    if should_write_session_history_marker() {
-        write_session_history_marker(history_path_payload);
-    }
-}
-
-fn should_write_session_history_marker() -> bool {
-    match std::fs::read_to_string(paths::session_history_path_file()) {
-        Ok(existing) => existing.trim().is_empty(),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
-        Err(e) => {
-            log_error!(
-                LOG_TAG,
-                "Failed to read existing session history marker from {}: {e}",
-                paths::session_history_path_file()
-            );
-            false
-        }
-    }
-}
-
-fn write_session_history_marker(history_path_payload: &str) {
-    match paths::write_private(paths::session_history_path_file(), history_path_payload) {
-        Ok(()) => log_info!(
-            LOG_TAG,
-            "Session history marker written to {} ({})",
-            paths::session_history_path_file(),
-            session_history_marker_kind(history_path_payload)
-        ),
-        Err(e) => log_error!(
-            LOG_TAG,
-            "Failed to write session history marker to {}: {e}",
-            paths::session_history_path_file()
-        ),
-    }
-}
-
-fn session_history_marker_kind(history_path_payload: &str) -> &'static str {
-    if crate::session_history::is_codex_marker(history_path_payload) {
-        "codex"
-    } else {
-        "claude"
-    }
-}
-
-fn history_path_payload_for_session_id(session_id: &str) -> Option<String> {
-    match Framework::from_env() {
-        Framework::ClaudeCode => claude_history_path_payload(session_id),
-        Framework::Codex => {
-            let thread_id = crate::session_history::canonical_codex_thread_id(session_id)?;
-            Some(codex_history_marker_payload(&thread_id))
-        }
-    }
-}
-
 /// Claude variant — matches `system/init` and computes the project-scoped
 /// jsonl path under `$HOME/.claude/projects/-{cwd}/`.
 fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
     let session_id = raw_claude_session_id(event)?;
-    let history_path_payload = claude_history_path_payload(session_id)?;
+    let history_path_payload = session_metadata::claude_history_path_payload(session_id)?;
 
     Some((session_id.to_string(), history_path_payload))
 }
@@ -532,42 +492,12 @@ fn raw_claude_session_id(event: &Value) -> Option<&str> {
     string_field(event, "session_id")
 }
 
-fn claude_history_path_payload(session_id: &str) -> Option<String> {
-    if !is_valid_session_history_id(session_id) {
-        return None;
-    }
-
-    let home = env::home_dir();
-    let project_name = paths::CANONICAL_WORKING_DIR
-        .strip_prefix('/')
-        .unwrap_or(paths::CANONICAL_WORKING_DIR)
-        .replace('/', "-");
-    Some(format!(
-        "{home}/.claude/projects/-{project_name}/{session_id}.jsonl"
-    ))
-}
-
-fn is_valid_session_history_id(session_id: &str) -> bool {
-    if session_id.is_empty()
-        || session_id == "."
-        || session_id == ".."
-        || session_id.contains('/')
-        || session_id.contains('\\')
-        || session_id.chars().any(char::is_control)
-    {
-        return false;
-    }
-
-    let mut components = Path::new(session_id).components();
-    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
-}
-
 /// Codex variant — matches `thread.started` and emits a session-history
 /// marker pointing at `${HOME}/.codex/sessions` plus the thread_id.
 fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
     let thread_id = raw_codex_thread_id(event)?;
     let thread_id = crate::session_history::canonical_codex_thread_id(thread_id)?;
-    let marker = codex_history_marker_payload(&thread_id);
+    let marker = session_metadata::codex_history_marker_payload(&thread_id);
 
     Some((thread_id, marker))
 }
@@ -578,11 +508,6 @@ fn raw_codex_thread_id(event: &Value) -> Option<&str> {
         return None;
     }
     string_field(event, "thread_id")
-}
-
-fn codex_history_marker_payload(thread_id: &str) -> String {
-    let sessions_dir = format!("{}/.codex/sessions", env::home_dir());
-    crate::session_history::codex_marker_payload(Path::new(&sessions_dir), thread_id)
 }
 
 #[cfg(test)]
@@ -1309,7 +1234,7 @@ mod tests {
         );
     }
 
-    // Note: end-to-end coverage of `capture_session_metadata` (including both
+    // Note: end-to-end coverage of session metadata capture (including both
     // the Claude `system/init` branch and the codex `thread.started`
     // branch) lives in the integration test suites:
     //   - `tests/integration.rs::send_event_extracts_claude_session_id`

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -431,6 +431,7 @@ impl SessionMetadataCapture {
                 paths::session_id_file()
             ),
         }
+        self.existing_session_id_seeded = true;
         session_metadata::write_session_history_marker(&history_path_payload);
     }
 

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -19,6 +19,7 @@ pub mod metrics;
 mod nofollow_fs;
 pub mod paths;
 pub mod session_history;
+pub mod session_metadata;
 pub mod telemetry;
 pub mod timing;
 mod urls;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -11,6 +11,7 @@ use guest_agent::http::HttpClient;
 use guest_agent::masker;
 use guest_agent::metrics;
 use guest_agent::paths;
+use guest_agent::session_metadata;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use agent_diagnostics::{
@@ -544,16 +545,12 @@ fn session_history_unavailable(status: SessionHistoryStatus) -> bool {
 }
 
 fn claude_history_target_status() -> SessionHistoryStatus {
-    let raw = match std::fs::read_to_string(paths::session_history_path_file()) {
-        Ok(raw) => raw,
-        Err(e) if e.kind() == ErrorKind::NotFound => return SessionHistoryStatus::Missing,
+    let marker = match session_metadata::resolve_history_marker_payload_for_diagnostics() {
+        Ok(Some(marker)) => marker,
+        Ok(None) => return SessionHistoryStatus::Missing,
         Err(_) => return SessionHistoryStatus::Unknown,
     };
-    let target = raw.trim();
-    if target.is_empty() {
-        return SessionHistoryStatus::Missing;
-    }
-    history_target_status(Path::new(target))
+    history_target_status(Path::new(&marker))
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -57,9 +57,15 @@ pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
     let raw = std::fs::read_to_string(path_file).map_err(|e| {
         AgentError::Checkpoint(format!("Failed to read history-path file {path_file}: {e}"))
     })?;
-    let trimmed = raw.trim();
+    read_session_history_from_payload(raw.trim())
+}
 
-    if let Some((sessions_dir, thread_id)) = decode_marker(trimmed) {
+/// Read session history bytes from an already-resolved marker payload.
+///
+/// The payload is either a literal path (Claude) or a
+/// `CODEX_SEARCH:{dir}:{id}` marker (codex).
+pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>, AgentError> {
+    if let Some((sessions_dir, thread_id)) = decode_marker(payload) {
         return read_codex_session_history(&sessions_dir, thread_id)?.ok_or_else(|| {
             AgentError::Checkpoint(format!(
                 "Codex session file not found under {}",
@@ -68,7 +74,7 @@ pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
         });
     }
 
-    let session_path = PathBuf::from(trimmed);
+    let session_path = PathBuf::from(payload);
     read_history_bytes(&session_path)
 }
 

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -9,8 +9,10 @@
 //!   CLI only writes the session file out at turn-completion time, so we
 //!   defer resolution until checkpoint time when the file is on disk.
 //!
-//! `read_session_history` is the single entry point used by `checkpoint.rs`.
-//! It returns the history bytes, decompressing legacy `.zst` files when needed.
+//! `read_session_history` is the file-backed entry point. Checkpoint resolves
+//! missing marker payloads first, then calls `read_session_history_from_payload`.
+//! Both paths return history bytes, decompressing legacy `.zst` files when
+//! needed.
 //!
 //! See parent epic #11386, sub-issue #11419 for the design rationale.
 //!

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -1,0 +1,151 @@
+//! Session metadata capture and resolution helpers.
+//!
+//! Event capture writes run-scoped metadata files. Checkpoint and diagnostics
+//! resolve missing history markers from the stored session id when needed.
+
+use crate::env;
+use crate::env::Framework;
+use crate::error::AgentError;
+use crate::paths;
+use crate::session_history;
+use guest_common::{log_error, log_info};
+use std::io;
+use std::path::{Component, Path};
+
+const LOG_TAG: &str = "sandbox:guest-agent";
+
+pub(crate) fn history_marker_payload_for_session_id(session_id: &str) -> Option<String> {
+    match Framework::from_env() {
+        Framework::ClaudeCode => claude_history_path_payload(session_id),
+        Framework::Codex => {
+            let thread_id = session_history::canonical_codex_thread_id(session_id)?;
+            Some(codex_history_marker_payload(&thread_id))
+        }
+    }
+}
+
+pub(crate) fn claude_history_path_payload(session_id: &str) -> Option<String> {
+    if !is_valid_session_history_id(session_id) {
+        return None;
+    }
+
+    let home = env::home_dir();
+    let project_name = paths::CANONICAL_WORKING_DIR
+        .strip_prefix('/')
+        .unwrap_or(paths::CANONICAL_WORKING_DIR)
+        .replace('/', "-");
+    Some(format!(
+        "{home}/.claude/projects/-{project_name}/{session_id}.jsonl"
+    ))
+}
+
+pub(crate) fn codex_history_marker_payload(thread_id: &str) -> String {
+    let sessions_dir = format!("{}/.codex/sessions", env::home_dir());
+    session_history::codex_marker_payload(Path::new(&sessions_dir), thread_id)
+}
+
+pub(crate) fn is_valid_session_history_id(session_id: &str) -> bool {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || session_id.contains('/')
+        || session_id.contains('\\')
+        || session_id.chars().any(char::is_control)
+    {
+        return false;
+    }
+
+    let mut components = Path::new(session_id).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
+pub(crate) fn session_history_marker_kind(history_path_payload: &str) -> &'static str {
+    if session_history::is_codex_marker(history_path_payload) {
+        "codex"
+    } else {
+        "claude"
+    }
+}
+
+pub(crate) fn read_existing_history_marker_payload() -> io::Result<Option<String>> {
+    match std::fs::read_to_string(paths::session_history_path_file()) {
+        Ok(existing) => {
+            let existing = existing.trim();
+            if existing.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(existing.to_string()))
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+pub(crate) fn ensure_history_marker_payload(history_path_payload: &str) {
+    match read_existing_history_marker_payload() {
+        Ok(Some(_)) => {}
+        Ok(None) => write_session_history_marker(history_path_payload),
+        Err(e) => log_error!(
+            LOG_TAG,
+            "Failed to read existing session history marker from {}: {e}",
+            paths::session_history_path_file()
+        ),
+    }
+}
+
+pub(crate) fn resolve_history_marker_payload(session_id: &str) -> Result<String, AgentError> {
+    match read_existing_history_marker_payload() {
+        Ok(Some(payload)) => return Ok(payload),
+        Ok(None) => {}
+        Err(e) => {
+            return Err(AgentError::Checkpoint(format!(
+                "Failed to read history-path file {}: {e}",
+                paths::session_history_path_file()
+            )));
+        }
+    }
+
+    let payload = history_marker_payload_for_session_id(session_id).ok_or_else(|| {
+        AgentError::Checkpoint(
+            "Failed to derive session history marker from session ID".to_string(),
+        )
+    })?;
+    write_session_history_marker(&payload);
+    Ok(payload)
+}
+
+pub fn resolve_history_marker_payload_for_diagnostics() -> io::Result<Option<String>> {
+    if let Some(payload) = read_existing_history_marker_payload()? {
+        return Ok(Some(payload));
+    }
+
+    match std::fs::read_to_string(paths::session_id_file()) {
+        Ok(session_id) => {
+            let session_id = session_id.trim();
+            if session_id.is_empty() {
+                Ok(None)
+            } else {
+                Ok(history_marker_payload_for_session_id(session_id))
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+pub(crate) fn write_session_history_marker(history_path_payload: &str) {
+    match paths::write_private(paths::session_history_path_file(), history_path_payload) {
+        Ok(()) => log_info!(
+            LOG_TAG,
+            "Session history marker written to {} ({})",
+            paths::session_history_path_file(),
+            session_history_marker_kind(history_path_payload)
+        ),
+        Err(e) => log_error!(
+            LOG_TAG,
+            "Failed to write session history marker to {}: {e}",
+            paths::session_history_path_file()
+        ),
+    }
+}

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -16,17 +16,19 @@
 //!
 //! # Coverage
 //!
-//! - End-to-end `send_event` → `capture_session_metadata` → marker write for the
+//! - End-to-end `send_event` → session metadata capture → marker write for the
 //!   codex `thread.started` event shape.
-//! - Marker repair after a partial metadata write.
+//! - Checkpoint metadata remains repairable after a partial metadata write.
 //! - Invalid/non-Codex events do not persist Codex session metadata.
 
 mod common;
 
 use common::SystemLogOverrideGuard;
+use httpmock::prelude::*;
 use serde_json::json;
 use std::path::Path;
 use std::sync::{LazyLock, Mutex, Once};
+use std::time::Duration;
 
 use guest_agent::masker::SecretMasker;
 
@@ -57,7 +59,7 @@ fn setup_env_once() {
 }
 
 /// Serialise tests — they share both LazyLock state and the run-id-scoped
-/// runtime metadata files written by `capture_session_metadata`.
+/// runtime metadata files written by session metadata capture.
 static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 macro_rules! http_client {
@@ -79,11 +81,41 @@ fn send_event_for_test(
 }
 
 /// Wipe the per-run session-id / history-path files so each test starts
-/// from a clean slate. `capture_session_metadata` is idempotent (first id wins),
+/// from a clean slate. Session metadata capture is idempotent (first id wins),
 /// so leaving stale files would mask real failures.
 fn reset_session_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+}
+
+fn write_codex_session_file(thread_id: &str, history: &str) -> Result<(), String> {
+    let id_no_dashes = thread_id.replace('-', "");
+    let path = Path::new(guest_agent::env::home_dir())
+        .join(".codex")
+        .join("sessions")
+        .join("2026")
+        .join("06")
+        .join("18")
+        .join(format!("rollout-2026-06-18T10-00-00-{id_no_dashes}.jsonl"));
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("session path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("create codex session dir {}: {e}", parent.display()))?;
+    std::fs::write(&path, history)
+        .map_err(|e| format!("write codex session history {}: {e}", path.display()))?;
+    Ok(())
+}
+
+fn checkpoint_http_client(
+    server: &MockServer,
+) -> Result<guest_agent::http::HttpClient, guest_agent::error::AgentError> {
+    guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        Duration::ZERO,
+    )
 }
 
 #[test]
@@ -181,7 +213,7 @@ fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
 }
 
 #[test]
-fn send_event_repairs_missing_codex_history_marker_after_later_event() {
+fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
 
@@ -209,13 +241,71 @@ fn send_event_repairs_missing_codex_history_marker_after_later_event() {
         let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())
             .expect("session id kept");
         assert_eq!(stored_id, thread_id);
-        let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
-            .expect("history marker repaired");
-        assert!(
-            marker.ends_with(&format!(":{thread_id}")),
-            "repaired marker should point at the existing thread id, got: {marker}"
-        );
+        if seed_empty_marker {
+            assert_eq!(
+                std::fs::read_to_string(guest_agent::paths::session_history_path_file()).unwrap(),
+                "",
+                "ordinary events must not repair empty history markers"
+            );
+        } else {
+            assert!(
+                !Path::new(guest_agent::paths::session_history_path_file()).exists(),
+                "ordinary events must not create missing history markers"
+            );
+        }
+        assert_eq!(masker.mask_string(thread_id), "***");
     }
+}
+
+#[test]
+fn recovery_checkpoint_derives_missing_codex_history_marker() {
+    setup_env_once();
+    let _guard = TEST_MUTEX.lock().unwrap();
+    reset_session_files();
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let history = r#"{"type":"thread.started"}"#.to_string() + "\n";
+    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), thread_id)
+        .expect("seed existing session id");
+    write_codex_session_file(thread_id, &history).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+    let server = MockServer::start();
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/codex-derived-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/codex-derived-history-upload")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{thread_id}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "codex-derived-checkpoint"}));
+    });
+
+    let http = checkpoint_http_client(&server).expect("build http client");
+    let result = runtime.block_on(guest_agent::checkpoint::create_recovery_checkpoint(&http));
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls(1);
+    upload_mock.assert_calls(1);
+    checkpoint_mock.assert_calls(1);
 }
 
 #[test]

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -5,16 +5,21 @@ use serde_json::json;
 fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), String> {
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
         .map_err(|e| format!("write session id: {e}"))?;
-    let marker = guest_agent::session_metadata::resolve_history_marker_payload_for_diagnostics()
-        .map_err(|e| format!("derive Claude history marker: {e}"))?
-        .ok_or_else(|| "derive Claude history marker from session id".to_string())?;
-    let history_path = std::path::Path::new(&marker);
+    let project_name = guest_agent::paths::CANONICAL_WORKING_DIR
+        .strip_prefix('/')
+        .unwrap_or(guest_agent::paths::CANONICAL_WORKING_DIR)
+        .replace('/', "-");
+    let history_path = std::path::Path::new(guest_agent::env::home_dir())
+        .join(".claude")
+        .join("projects")
+        .join(format!("-{project_name}"))
+        .join(format!("{session_id}.jsonl"));
     let parent = history_path
         .parent()
         .ok_or_else(|| format!("history path has no parent: {}", history_path.display()))?;
     std::fs::create_dir_all(parent)
         .map_err(|e| format!("create history dir {}: {e}", parent.display()))?;
-    std::fs::write(history_path, history)
+    std::fs::write(&history_path, history)
         .map_err(|e| format!("write history {}: {e}", history_path.display()))?;
     Ok(())
 }

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -2,6 +2,23 @@ use crate::support::*;
 use httpmock::prelude::*;
 use serde_json::json;
 
+fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), String> {
+    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
+        .map_err(|e| format!("write session id: {e}"))?;
+    let marker = guest_agent::session_metadata::resolve_history_marker_payload_for_diagnostics()
+        .map_err(|e| format!("derive Claude history marker: {e}"))?
+        .ok_or_else(|| "derive Claude history marker from session id".to_string())?;
+    let history_path = std::path::Path::new(&marker);
+    let parent = history_path
+        .parent()
+        .ok_or_else(|| format!("history path has no parent: {}", history_path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("create history dir {}: {e}", parent.display()))?;
+    std::fs::write(history_path, history)
+        .map_err(|e| format!("write history {}: {e}", history_path.display()))?;
+    Ok(())
+}
+
 // =========================================================================
 // Recovery checkpoint
 // =========================================================================
@@ -57,6 +74,82 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
+}
+
+async fn assert_recovery_checkpoint_derives_claude_history_marker(
+    seed_empty_marker: bool,
+    upload_path: &str,
+) -> Result<(), String> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let session_id = if seed_empty_marker {
+        "derived-empty-marker-session"
+    } else {
+        "derived-missing-marker-session"
+    };
+    let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
+    if seed_empty_marker {
+        guest_agent::paths::write_private(guest_agent::paths::session_history_path_file(), "")
+            .map_err(|e| format!("write empty history marker: {e}"))?;
+    }
+    write_derived_claude_history(session_id, &history)?;
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url(upload_path),
+                "existing": false
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path(upload_path)
+            .header("Content-Type", "application/octet-stream")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(format!(r#"{{"cliAgentSessionId":"{session_id}"}}"#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-derived-history"}));
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_derives_missing_claude_history_marker() {
+    assert_recovery_checkpoint_derives_claude_history_marker(
+        false,
+        "/test/derived-missing-history-upload",
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_derives_empty_claude_history_marker() {
+    assert_recovery_checkpoint_derives_claude_history_marker(
+        true,
+        "/test/derived-empty-history-upload",
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -130,12 +223,42 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
 }
 
 #[tokio::test]
-async fn recovery_checkpoint_skips_when_history_marker_is_missing() {
+async fn recovery_checkpoint_skips_when_derived_history_is_missing() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
     let _files_guard = SessionCheckpointFilesGuard::new();
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "missing-history")
+        .unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_rejects_invalid_session_id_without_marker() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "../unsafe-session")
         .unwrap();
 
     let prepare_mock = server.mock(|when, then| {

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -249,7 +249,7 @@ async fn send_event_keeps_existing_session_metadata() {
 }
 
 #[tokio::test]
-async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
+async fn send_event_seeds_existing_claude_session_id_without_repairing_history_marker() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
@@ -286,11 +286,18 @@ async fn send_event_repairs_missing_claude_history_marker_after_later_event() {
             session_id,
             "later events must keep the existing session id"
         );
-        let history = std::fs::read_to_string(hist_file).unwrap();
-        assert!(
-            history.ends_with(&format!("/{session_id}.jsonl")),
-            "repaired history marker should point at the existing session id, got: {history}"
-        );
+        if seed_empty_marker {
+            assert_eq!(
+                std::fs::read_to_string(hist_file).unwrap(),
+                "",
+                "ordinary events must not repair empty history markers"
+            );
+        } else {
+            assert!(
+                !std::path::Path::new(hist_file).exists(),
+                "ordinary events must not create missing history markers"
+            );
+        }
         assert_eq!(masker.mask_string(session_id), "***");
     }
 


### PR DESCRIPTION
## Summary
- move missing session-history marker recovery out of ordinary event processing into a shared session metadata resolver
- let checkpoint derive missing or empty marker payloads from the stored session id before reading session history
- keep CLI event capture on the hot path limited to id-bearing metadata plus one-time masker seeding, with Claude and Codex coverage

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`

Closes #18274
