### PR TITLE
fix(desktop): handle auth window close cleanup

### DIFF
--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -967,15 +967,18 @@ function waitForAuthConsumeWindow(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let settled = false;
+    let closed = false;
     const timeout = setTimeout(() => {
       rejectAuth(new Error("Desktop auth consume timed out"));
     }, 30_000);
 
     const cleanup = (): void => {
       clearTimeout(timeout);
-      window.webContents.off("did-navigate", handleNavigation);
-      window.webContents.off("did-fail-load", handleLoadFailure);
-      window.off("closed", handleClosed);
+      if (!closed && !window.isDestroyed()) {
+        window.webContents.off("did-navigate", handleNavigation);
+        window.webContents.off("did-fail-load", handleLoadFailure);
+        window.off("closed", handleClosed);
+      }
     };
 
     const resolveAuth = (): void => {
@@ -1043,6 +1046,7 @@ function waitForAuthConsumeWindow(
     };
 
     const handleClosed = (): void => {
+      closed = true;
       rejectAuth(new Error("Desktop auth consume window closed"));
     };
 


### PR DESCRIPTION
## Summary
- avoid touching auth consume window `webContents` after the window has closed
- keep normal listener cleanup for live auth windows that complete, fail, or time out

## Root cause
Closing the Switch workspace auth window emits `closed` after Electron has destroyed the `BrowserWindow`/`webContents`. The cleanup path then tried to remove `webContents` listeners unconditionally, which raised `TypeError: Object has been destroyed` in the main process.

## Validation
- `pnpm format`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop test`
- `pnpm -F @vm0/desktop build:electron`
- `git diff --check`
