### PR TITLE
fix: improve computer use dialog spacing

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4083,7 +4083,7 @@ function ComputerUseDownloadDialog({
               <DialogTitle className="text-xl leading-7">
                 Connect your computer
               </DialogTitle>
-              <DialogDescription className="mt-2 leading-6">
+              <DialogDescription className="mt-3 leading-6">
                 Download Zero Computer Use for macOS, then open it to let Zero
                 use your desktop.
               </DialogDescription>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4073,7 +4073,7 @@ function ComputerUseDownloadDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md gap-5">
+      <DialogContent className="max-w-md gap-5 pt-4">
         <DialogHeader>
           <div className="flex items-start gap-4 pr-8">
             <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border bg-gray-50 text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4079,7 +4079,7 @@ function ComputerUseDownloadDialog({
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-gray-50 text-muted-foreground">
               <IconDeviceDesktop size={18} stroke={1.5} />
             </div>
-            <div className="min-w-0 space-y-1 text-left">
+            <div className="min-w-0 space-y-2 text-left">
               <DialogTitle>Connect your computer</DialogTitle>
               <DialogDescription>
                 Download Zero Computer Use for macOS, then open it to let Zero

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4073,22 +4073,24 @@ function ComputerUseDownloadDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md gap-5">
         <DialogHeader>
-          <div className="flex items-start gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-gray-50 text-muted-foreground">
-              <IconDeviceDesktop size={18} stroke={1.5} />
+          <div className="flex items-start gap-4 pr-8">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border bg-gray-50 text-muted-foreground">
+              <IconDeviceDesktop size={20} stroke={1.5} />
             </div>
-            <div className="min-w-0 space-y-2 text-left">
-              <DialogTitle>Connect your computer</DialogTitle>
-              <DialogDescription>
+            <div className="min-w-0 text-left">
+              <DialogTitle className="text-xl leading-7">
+                Connect your computer
+              </DialogTitle>
+              <DialogDescription className="mt-2 leading-6">
                 Download Zero Computer Use for macOS, then open it to let Zero
                 use your desktop.
               </DialogDescription>
             </div>
           </div>
         </DialogHeader>
-        <Button asChild className="mt-2 w-full">
+        <Button asChild size="lg" className="w-full">
           <a
             href={downloadUrl}
             target="_blank"


### PR DESCRIPTION
## Summary
- Refine the Computer Use download dialog layout so the icon, title, description, close control, and CTA have clearer hierarchy
- Align the computer icon with the close button by matching the dialog top padding to the shared close button offset
- Lower the description text slightly so the title and body copy have clearer separation
- Use the larger modal button size for a stronger primary action

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "opens the Computer Use download dialog from the chat composer"`
- Alignment check: computer icon top and close button top both measured at `106px` in the screenshot harness (`delta = 0`)
- Latest screenshot: https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/fda86c69-50b2-4989-9417-c9d9b0ed200d/computer-use-dialog-description-lower.png
- Close hover screenshot: https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/cffab6f7-9f0e-43cc-8e59-8f9e82b59d01/computer-use-dialog-layout-v2-close-hover.png