### PR TITLE
feat: silently cache chat history

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -110,6 +110,15 @@ export async function publishThreadListChanged(userId: string): Promise<void> {
   await publishUserSignal([userId], "threadListChanged");
 }
 
+export async function publishChatThreadRunFinished(args: {
+  readonly userId: string;
+  readonly threadId: string;
+}): Promise<void> {
+  await publishUserSignal([args.userId], "chatThreadRunFinished", {
+    threadId: args.threadId,
+  });
+}
+
 /**
  * Notify a chat thread's UI that its linked automation set changed (created,
  * deleted, enabled, or disabled). The chat-thread header automation menu

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -323,6 +323,19 @@ function lifecycleMarkers(
   });
 }
 
+function publishedChatThreadRunFinished(threadId: string): boolean {
+  return context.mocks.ably.publish.mock.calls.some((call) => {
+    const payload = call[1];
+    return (
+      call[0] === "chatThreadRunFinished" &&
+      payload !== null &&
+      typeof payload === "object" &&
+      "threadId" in payload &&
+      payload.threadId === threadId
+    );
+  });
+}
+
 function assistantEvent(
   sequenceNumber: number,
   text: string,
@@ -468,6 +481,11 @@ describe("CHAT-02: completed chat callback", () => {
         generationType: "website",
       },
     ]);
+    await expect
+      .poll(() => {
+        return publishedChatThreadRunFinished(first.threadId);
+      })
+      .toBe(true);
 
     const recommender = assistantMessages(after.messages).find((message) => {
       return (
@@ -838,6 +856,11 @@ describe("CHAT-02: failed chat callbacks", () => {
         `chatThreadRunCreated:${threadId}`,
         null,
       );
+      await expect
+        .poll(() => {
+          return publishedChatThreadRunFinished(run.threadId);
+        })
+        .toBe(true);
     }
     const reportRunId = runIds[2];
     if (!threadId || !reportRunId) {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -34,6 +34,7 @@ import { waitUntil } from "../context/wait-until";
 import { getDatasetName, queryAxiomDirect } from "../external/axiom";
 import { writeDb$, type Db } from "../external/db";
 import {
+  publishChatThreadRunFinished,
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
@@ -213,6 +214,7 @@ interface ChatThreadForRunRow {
   readonly chatThreadId: string;
   readonly userId: string;
   readonly orgId: string;
+  readonly triggerSource: string;
 }
 
 interface ChatRunInfo {
@@ -455,6 +457,7 @@ async function insertAssistantErrorMessage(args: {
   readonly prompt: string;
   readonly threadId: string;
   readonly userId: string;
+  readonly publishRunFinished: boolean;
   readonly lifecycleEvent: "failed" | "cancelled";
   readonly getFormattedError: () => Promise<string>;
 }): Promise<boolean> {
@@ -490,6 +493,12 @@ async function insertAssistantErrorMessage(args: {
     `chatThreadMessageCreated:${args.threadId}`,
   );
   await publishThreadListChanged(args.userId);
+  if (args.publishRunFinished) {
+    await publishChatThreadRunFinished({
+      userId: args.userId,
+      threadId: args.threadId,
+    });
+  }
   await sendUserPushNotifications({
     db: args.db,
     userId: args.userId,
@@ -507,6 +516,7 @@ async function insertRunLifecycleMarker(args: {
   readonly runId: string;
   readonly threadId: string;
   readonly userId: string;
+  readonly publishRunFinished: boolean;
   readonly event: "completed" | "cancelled";
   readonly recommendedFollowups?: ChatMessageRecommendedFollowups;
 }): Promise<boolean> {
@@ -557,6 +567,12 @@ async function insertRunLifecycleMarker(args: {
     `chatThreadMessageCreated:${args.threadId}`,
   );
   await publishThreadListChanged(args.userId);
+  if (args.publishRunFinished) {
+    await publishChatThreadRunFinished({
+      userId: args.userId,
+      threadId: args.threadId,
+    });
+  }
   return true;
 }
 
@@ -654,6 +670,7 @@ async function handleCompletedChatCallback(args: {
       runId: args.runId,
       threadId: args.chatThread.chatThreadId,
       userId: args.chatThread.userId,
+      publishRunFinished: args.chatThread.triggerSource === "web",
       event: "completed",
       recommendedFollowups,
     });
@@ -712,6 +729,7 @@ async function handleFailedChatCallback(args: {
     prompt: args.run.prompt,
     threadId: args.chatThread.chatThreadId,
     userId: args.chatThread.userId,
+    publishRunFinished: args.chatThread.triggerSource === "web",
     lifecycleEvent,
     getFormattedError: args.getFormattedError,
   });
@@ -1155,6 +1173,7 @@ async function chatThreadForRunFromDb(
       chatThreadId: zeroRuns.chatThreadId,
       userId: chatThreads.userId,
       orgId: agentRuns.orgId,
+      triggerSource: zeroRuns.triggerSource,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
@@ -1169,6 +1188,7 @@ async function chatThreadForRunFromDb(
     chatThreadId: row.chatThreadId,
     userId: row.userId,
     orgId: row.orgId,
+    triggerSource: row.triggerSource,
   };
 }
 

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -4,7 +4,11 @@ import { platformRealtimeTokenContract } from "@vm0/api-contracts/contracts/real
 import { afterEach, describe, expect, it } from "vitest";
 
 import { clearMockedAuth, mockUser } from "../../__tests__/mock-auth.ts";
-import { setupRealtime$, setAblyLoop$ } from "../realtime.ts";
+import {
+  setupRealtime$,
+  setAblyLoop$,
+  setAblyPayloadLoop$,
+} from "../realtime.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
@@ -137,6 +141,37 @@ describe("realtime signals", () => {
     context.mocks.ably.triggerReconnect();
     await waitFor(() => {
       expect(runs).toBe(2);
+    });
+
+    subscriber.abort(abortError("test done"));
+    await expect(loopPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("passes Ably payloads to payload loops", async () => {
+    mockSignedInUser();
+    const topic = "test:payload";
+    const subscriber = new AbortController();
+    const payloads: unknown[] = [];
+    const loop$ = command((_ctx, payload: unknown, _signal: AbortSignal) => {
+      payloads.push(payload);
+      return false;
+    });
+
+    await context.store.set(setupRealtime$, context.signal);
+    const loopPromise = context.store.set(
+      setAblyPayloadLoop$,
+      topic,
+      loop$,
+      subscriber.signal,
+    );
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+    });
+    context.mocks.ably.trigger(topic, { threadId: "thread-1" });
+
+    await waitFor(() => {
+      expect(payloads).toStrictEqual([{ threadId: "thread-1" }]);
     });
 
     subscriber.abort(abortError("test done"));

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { PagedChatMessage } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  chatThreadMessagesContract,
+  type PagedChatMessage,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import {
   clearMockedAuth,
   mockOrganization,
@@ -16,15 +19,59 @@ const idbStoreMock = vi.hoisted(() => {
     }
     return Promise.resolve(cachedMessages.slice(-limit));
   });
+  const messageExists = vi.fn((_threadId: string, messageId: string) => {
+    return Promise.resolve(
+      cachedMessages.some((message) => {
+        return (
+          typeof message === "object" &&
+          message !== null &&
+          "id" in message &&
+          message.id === messageId
+        );
+      }),
+    );
+  });
+  const upsertMessages = vi.fn((_threadId: string, messages: unknown[]) => {
+    for (const message of messages) {
+      if (
+        typeof message !== "object" ||
+        message === null ||
+        !("id" in message)
+      ) {
+        continue;
+      }
+      const index = cachedMessages.findIndex((cached) => {
+        return (
+          typeof cached === "object" &&
+          cached !== null &&
+          "id" in cached &&
+          cached.id === message.id
+        );
+      });
+      if (index === -1) {
+        cachedMessages.push(message);
+      } else {
+        cachedMessages[index] = message;
+      }
+    }
+    return Promise.resolve();
+  });
 
   return {
     readLatest,
+    messageExists,
+    upsertMessages,
+    getMessages() {
+      return cachedMessages;
+    },
     setMessages(messages: unknown[]) {
       cachedMessages = messages;
     },
     reset() {
       cachedMessages = [];
       readLatest.mockClear();
+      messageExists.mockClear();
+      upsertMessages.mockClear();
     },
   };
 });
@@ -35,17 +82,13 @@ vi.mock("../../external/idb-message-store.ts", () => {
       return {
         readStore: {
           readLatest: idbStoreMock.readLatest,
-          messageExists: () => {
-            return Promise.resolve(false);
-          },
+          messageExists: idbStoreMock.messageExists,
           readBefore: () => {
             return Promise.resolve([]);
           },
         },
         writeStore: {
-          upsertMessages: () => {
-            return Promise.resolve();
-          },
+          upsertMessages: idbStoreMock.upsertMessages,
         },
       };
     },
@@ -53,7 +96,7 @@ vi.mock("../../external/idb-message-store.ts", () => {
 });
 
 function message(index: number): PagedChatMessage {
-  const id = `m${index.toString().padStart(3, "0")}`;
+  const id = `00000000-0000-4000-8000-${index.toString().padStart(12, "0")}`;
   return {
     id,
     role: index % 2 === 0 ? "assistant" : "user",
@@ -100,5 +143,35 @@ describe("createIdbCachedDataSource initial page cache", () => {
 
     expect(idbStoreMock.readLatest.mock.calls[0]?.length).toBe(1);
     expect(ids(initialPage.messages)).toStrictEqual(ids(cachedMessages));
+  });
+
+  it("warms latest messages from the cached cursor until the remote reaches the end", async () => {
+    mockUser({ id: "user_1", fullName: "Test User" }, { token: "token" });
+    mockOrganization({
+      activeOrg: { id: "org_1", name: "Test Org" },
+      memberships: [{ id: "org_1" }],
+    });
+
+    const threadId = "00000000-0000-4000-8000-000000000999";
+    idbStoreMock.setMessages([message(1)]);
+    const seenSinceIds: (string | undefined)[] = [];
+    ctx.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
+      seenSinceIds.push(query.sinceId);
+      if (query.sinceId === message(1).id) {
+        return respond(200, { messages: range(2, 51) });
+      }
+      return respond(200, { messages: range(52, 53) });
+    });
+
+    const { warmLatestChatThreadMessages$ } =
+      await import("../idb-cached-chat-thread-data-source.ts");
+
+    await ctx.store.set(warmLatestChatThreadMessages$, threadId, ctx.signal);
+
+    expect(seenSinceIds).toStrictEqual([message(1).id, message(51).id]);
+    expect(idbStoreMock.upsertMessages).toHaveBeenCalledTimes(2);
+    expect(ids(idbStoreMock.getMessages() as PagedChatMessage[])).toStrictEqual(
+      ids(range(1, 53)),
+    );
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/background-chat-thread-cache.ts
+++ b/turbo/apps/platform/src/signals/chat-page/background-chat-thread-cache.ts
@@ -1,0 +1,56 @@
+import { command } from "ccstate";
+import { setAblyPayloadLoop$ } from "../realtime.ts";
+import { logger } from "../log.ts";
+import {
+  currentLeftThread$,
+  currentRightThread$,
+} from "./chat-thread-panes.ts";
+import { warmLatestChatThreadMessages$ } from "./idb-cached-chat-thread-data-source.ts";
+
+const L = logger("BackgroundChatThreadCache");
+const CHAT_THREAD_RUN_FINISHED_TOPIC = "chatThreadRunFinished";
+
+function threadIdFromRunFinishedPayload(payload: unknown): string | null {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    !("threadId" in payload)
+  ) {
+    return null;
+  }
+
+  const threadId = (payload as { readonly threadId: unknown }).threadId;
+  return typeof threadId === "string" ? threadId : null;
+}
+
+const warmFinishedThread$ = command(
+  async ({ get, set }, payload: unknown, signal: AbortSignal) => {
+    const threadId = threadIdFromRunFinishedPayload(payload);
+    if (!threadId) {
+      L.warn("runFinished:invalidPayload", { payload });
+      return false;
+    }
+
+    const leftThreadId = get(currentLeftThread$)?.threadId;
+    const rightThreadId = get(currentRightThread$)?.threadId;
+    if (threadId === leftThreadId || threadId === rightThreadId) {
+      L.debug("runFinished:threadOpen", { threadId });
+      return false;
+    }
+
+    await set(warmLatestChatThreadMessages$, threadId, signal);
+    signal.throwIfAborted();
+    return false;
+  },
+);
+
+export const subscribeBackgroundChatThreadRunFinished$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    await set(
+      setAblyPayloadLoop$,
+      CHAT_THREAD_RUN_FINISHED_TOPIC,
+      warmFinishedThread$,
+      signal,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -85,6 +85,11 @@ export type { DraftSignals } from "../zero-page/chat-draft.ts";
 const L = logger("ChatThread");
 
 const QUEUED_RUN_MARKER_EVENT_ID = "queue:queued";
+const SILENT_HISTORY_BACKFILL_INTERVAL_MS = 100;
+
+export interface LoadHistoryResult {
+  hasMore: boolean;
+}
 
 function isRecallControlMessage(msg: PagedChatMessage): boolean {
   return (
@@ -529,7 +534,7 @@ export interface ChatThreadSignals {
   latestRunStatus$: Computed<Promise<string | null>>;
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
-  loadHistory$: Command<Promise<void>, [AbortSignal]>;
+  loadHistory$: Command<Promise<LoadHistoryResult>, [AbortSignal]>;
   subscribeChatThread$: Command<Promise<void>, [AbortSignal]>;
   // ── Thinking indicator ───────────────────────────────────────────────────
   blockColors$: Computed<[string, string, string]>;
@@ -1114,40 +1119,6 @@ function createInitialPage(dataSource: ChatThreadDataSource) {
   return dataSource.initialPage$;
 }
 
-function createBackfillHistoryBoundaryCommand({
-  threadId,
-  initialPage$,
-  loadedHistoryHasMore$,
-  dataSource,
-}: {
-  threadId: string;
-  initialPage$: Computed<Promise<InitialPage>>;
-  loadedHistoryHasMore$: State<boolean | null>;
-  dataSource: ChatThreadDataSource;
-}) {
-  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const initial = await get(initialPage$);
-    signal.throwIfAborted();
-    if (!initial.needsHistoryBackfill) {
-      return;
-    }
-
-    const beforeId = initial.messages[0]?.id;
-    if (!beforeId) {
-      set(loadedHistoryHasMore$, false);
-      return;
-    }
-
-    const result = await set(
-      dataSource.listMessagesBefore$,
-      { threadId, beforeId },
-      signal,
-    );
-    signal.throwIfAborted();
-    set(loadedHistoryHasMore$, result.messages.length > 0 || result.hasMore);
-  });
-}
-
 interface ChatMessageProjectionEntry {
   message: PagedChatMessage;
   optimisticUserMessageAssociation?: OptimisticChatMessageEntry["optimisticUserMessageAssociation"];
@@ -1433,14 +1404,7 @@ function createPagedMessages(
       return loadedHistoryHasMore;
     }
     const initial = await get(initialPage$);
-    return initial.hasHistoryBefore;
-  });
-
-  const backfillHistoryBoundary$ = createBackfillHistoryBoundaryCommand({
-    threadId,
-    initialPage$,
-    loadedHistoryHasMore$,
-    dataSource,
+    return initial.hasHistoryBefore || initial.needsHistoryBackfill === true;
   });
 
   const fetchNextPage$ = createFetchNextPageCommand({
@@ -1486,7 +1450,6 @@ function createPagedMessages(
     hasOlderHistory$,
     latestRunStatus$,
     fetchNextPage$,
-    backfillHistoryBoundary$,
     refreshLatestMessages$,
     loadHistory$,
   };
@@ -1508,44 +1471,49 @@ function createLoadHistoryCommand({
   loadedHistoryHasMore$: State<boolean | null>;
   knownServerMessageIds$: KnownServerMessageIds$;
   dataSource: ChatThreadDataSource;
-}): Command<Promise<void>, [AbortSignal]> {
-  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const thread = await get(threadData$);
-    signal.throwIfAborted();
-    if (!thread) {
-      set(loadedHistoryHasMore$, false);
-      return;
-    }
-
-    const beforeId = await get(earliestChatMessageId$);
-    signal.throwIfAborted();
-    if (!beforeId) {
-      set(loadedHistoryHasMore$, false);
-      return;
-    }
-
-    const result = await set(
-      dataSource.listMessagesBefore$,
-      { threadId, beforeId },
-      signal,
-    );
-    signal.throwIfAborted();
-    set(reconcileOptimisticChatMessages$, {
-      threadId,
-      messages: result.messages,
-    });
-    set(knownServerMessageIds$, (prev) => {
-      return addKnownServerMessageIds(prev, result.messages);
-    });
-
-    set(historyMessages$, (prev) => {
-      if (result.messages.length === 0) {
-        return prev;
+}): Command<Promise<LoadHistoryResult>, [AbortSignal]> {
+  return command(
+    async ({ get, set }, signal: AbortSignal): Promise<LoadHistoryResult> => {
+      const thread = await get(threadData$);
+      signal.throwIfAborted();
+      if (!thread) {
+        set(loadedHistoryHasMore$, false);
+        return { hasMore: false };
       }
-      return [...result.messages, ...prev];
-    });
-    set(loadedHistoryHasMore$, result.hasMore);
-  });
+
+      const beforeId = await get(earliestChatMessageId$);
+      signal.throwIfAborted();
+      if (!beforeId) {
+        set(loadedHistoryHasMore$, false);
+        return { hasMore: false };
+      }
+
+      const result = await set(
+        dataSource.listMessagesBefore$,
+        { threadId, beforeId },
+        signal,
+      );
+      signal.throwIfAborted();
+      set(reconcileOptimisticChatMessages$, {
+        threadId,
+        messages: result.messages,
+      });
+      set(knownServerMessageIds$, (prev) => {
+        return addKnownServerMessageIds(prev, result.messages);
+      });
+
+      set(historyMessages$, (prev) => {
+        if (result.messages.length === 0) {
+          return prev;
+        }
+        return [...result.messages, ...prev];
+      });
+      set(loadedHistoryHasMore$, result.hasMore);
+      return {
+        hasMore: result.hasMore,
+      };
+    },
+  );
 }
 
 function createArtifacts(
@@ -1661,11 +1629,50 @@ function createLatestRunStatus(
 
 function createLoadHistoryWithPrependScroll(
   recordScrollHeightForPrepend$: Command<void, []>,
-  loadPagedHistory$: Command<Promise<void>, [AbortSignal]>,
+  loadPagedHistory$: Command<Promise<LoadHistoryResult>, [AbortSignal]>,
 ) {
-  return command(async ({ set }, signal: AbortSignal): Promise<void> => {
-    set(recordScrollHeightForPrepend$);
-    await set(loadPagedHistory$, signal);
+  return command(
+    async ({ set }, signal: AbortSignal): Promise<LoadHistoryResult> => {
+      set(recordScrollHeightForPrepend$);
+      return await set(loadPagedHistory$, signal);
+    },
+  );
+}
+
+function createSilentBackfillHistoryCommand({
+  groupedChatMessages$,
+  hasOlderHistory$,
+  loadHistory$,
+}: {
+  groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
+  hasOlderHistory$: Computed<Promise<boolean>>;
+  loadHistory$: Command<Promise<LoadHistoryResult>, [AbortSignal]>;
+}) {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    let initialMessagesResolved = false;
+
+    await setLoop(
+      async (sig) => {
+        if (!initialMessagesResolved) {
+          await get(groupedChatMessages$);
+          sig.throwIfAborted();
+          initialMessagesResolved = true;
+          return false;
+        }
+
+        const hasOlderHistory = await get(hasOlderHistory$);
+        sig.throwIfAborted();
+        if (!hasOlderHistory) {
+          return true;
+        }
+
+        const result = await set(loadHistory$, sig);
+        sig.throwIfAborted();
+        return !result.hasMore;
+      },
+      SILENT_HISTORY_BACKFILL_INTERVAL_MS,
+      signal,
+    );
   });
 }
 
@@ -1682,7 +1689,7 @@ interface RunTrackingDeps {
   rawMessages$: Computed<Promise<ChatMessageProjectionEntry[]>>;
   initialPage$: Computed<Promise<InitialPage>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
-  backfillHistoryBoundary$: Command<Promise<void>, [AbortSignal]>;
+  silentBackfillHistory$: Command<Promise<void>, [AbortSignal]>;
   refreshLatestMessages$: Command<Promise<void>, [AbortSignal]>;
   autoScroll$: Command<void, []>;
   dataSource: ChatThreadDataSource;
@@ -1742,7 +1749,7 @@ function createRunTracking({
   rawMessages$,
   initialPage$,
   fetchNextPage$,
-  backfillHistoryBoundary$,
+  silentBackfillHistory$,
   refreshLatestMessages$,
   autoScroll$,
   dataSource,
@@ -1834,7 +1841,7 @@ function createRunTracking({
 
     L.debug("subscribeChatThread$ subscribeRealtime$ start", { threadId });
     await Promise.all([
-      set(backfillHistoryBoundary$, signal),
+      set(silentBackfillHistory$, signal),
       set(markThreadReadIfNeeded$, signal),
       set(subscribeComputerUseHostsChanged$, signal),
       set(
@@ -2438,7 +2445,6 @@ export function createChatThreadSignals(
     hasOlderHistory$,
     latestRunStatus$,
     fetchNextPage$,
-    backfillHistoryBoundary$,
     refreshLatestMessages$,
     loadHistory$: loadPagedHistory$,
   } = createPagedMessages(threadId, threadData$, dataSource);
@@ -2447,6 +2453,11 @@ export function createChatThreadSignals(
     recordScrollHeightForPrepend$,
     loadPagedHistory$,
   );
+  const silentBackfillHistory$ = createSilentBackfillHistoryCommand({
+    groupedChatMessages$,
+    hasOlderHistory$,
+    loadHistory$,
+  });
 
   const { queueDraftSync$, cancelDraftSync$, flushDraftClear$ } =
     createDraftSync(threadId, draft, dataSource);
@@ -2459,7 +2470,7 @@ export function createChatThreadSignals(
     rawMessages$,
     initialPage$,
     fetchNextPage$,
-    backfillHistoryBoundary$,
+    silentBackfillHistory$,
     refreshLatestMessages$,
     autoScroll$: scrollSignals.autoScroll$,
     dataSource,

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -20,6 +20,10 @@ const L = logger("ChatIdbCache");
 const MESSAGE_PAGE_SIZE = 50;
 
 type Stores = ReturnType<typeof createIdbMessageStores>;
+type ListMessagesAfterResult = {
+  messages: PagedChatMessage[];
+  reachedEnd: boolean;
+};
 
 interface CachedMessageReadStore {
   readBefore(
@@ -219,6 +223,64 @@ function createListMessagesAfter(
     },
   );
 }
+
+export const warmLatestChatThreadMessages$ = command(
+  async ({ get, set }, threadId: string, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    const userId = clerk.user?.id;
+    const orgId = clerk.organization?.id;
+
+    if (!userId || !orgId) {
+      L.debug("warmLatest:noAuth", { threadId });
+      return;
+    }
+
+    const stores = createIdbMessageStores(userId, orgId);
+    const latest = await stores.readStore.readLatest(threadId, 1, signal);
+    signal.throwIfAborted();
+
+    const remote = createRemoteChatThreadDataSource(threadId);
+    const listMessagesAfter$ = createListMessagesAfter(remote, (uid, oid) => {
+      if (uid === userId && oid === orgId) {
+        return stores;
+      }
+      return createIdbMessageStores(uid, oid);
+    });
+
+    let sinceId = latest[0]?.id;
+    let pages = 0;
+    while (!signal.aborted) {
+      const result: ListMessagesAfterResult = await set(
+        listMessagesAfter$,
+        { threadId, sinceId },
+        signal,
+      );
+      signal.throwIfAborted();
+      pages += 1;
+
+      L.debug("warmLatest:page", {
+        threadId,
+        sinceId: sinceId ?? null,
+        count: result.messages.length,
+        reachedEnd: result.reachedEnd,
+        pages,
+      });
+
+      if (result.messages.length > 0) {
+        const nextSinceId = result.messages[result.messages.length - 1]!.id;
+        if (nextSinceId === sinceId) {
+          break;
+        }
+        sinceId = nextSinceId;
+      }
+
+      if (result.reachedEnd) {
+        break;
+      }
+    }
+  },
+);
 
 function createSubscribeRealtime(remote: ChatThreadDataSource) {
   return command(

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -145,6 +145,133 @@ const runWithChannel$ = command(
   },
 );
 
+const runPayloadNotification$ = command(
+  async (
+    { set },
+    loopCommand$: Command<Promise<boolean> | boolean, [unknown, AbortSignal]>,
+    payload: unknown,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
+    try {
+      const done = await set(loopCommand$, payload, signal);
+      signal.throwIfAborted();
+      return done;
+    } catch (error) {
+      signal.throwIfAborted();
+      throwIfAbort(error);
+      L.warn(`transient error in ably payload notification`, error);
+      return false;
+    }
+  },
+);
+
+const runWithChannelPayload$ = command(
+  async (
+    { set },
+    channel: RealtimeChannel,
+    topic: string,
+    loopCommand$: Command<Promise<boolean> | boolean, [unknown, AbortSignal]>,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    signal.throwIfAborted();
+    let deferred = createDeferredPromise(signal);
+    const pendingPayloads: unknown[] = [];
+
+    const pokeLoop = () => {
+      deferred.resolve(true);
+      deferred = createDeferredPromise(signal);
+    };
+
+    const callback = (message: InboundMessage) => {
+      L.debug("got payload message from topic", topic, message);
+      pendingPayloads.push(message.data);
+      pokeLoop();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      L.debug("tab visible, poking payload loop", topic);
+      pokeLoop();
+    };
+    let subscribed = false;
+    let registeredPoke = false;
+
+    const cleanup = () => {
+      set(subscriberPokeRegistry$, (prev) => {
+        if (!registeredPoke) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.delete(pokeLoop);
+        return next;
+      });
+      registeredPoke = false;
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      if (subscribed) {
+        subscribed = false;
+        channel.unsubscribe(topic, callback);
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange, {
+      signal,
+    });
+    set(subscriberPokeRegistry$, (prev) => {
+      const next = new Set(prev);
+      next.add(pokeLoop);
+      return next;
+    });
+    registeredPoke = true;
+    signal.addEventListener("abort", cleanup, { once: true });
+
+    // eslint-disable-next-line no-restricted-syntax -- Ably can close during app teardown while a channel attach is in flight; suppress only that terminal close race.
+    try {
+      await channel.subscribe(topic, callback);
+      signal.throwIfAborted();
+      subscribed = true;
+      L.debug("subscribed to payload topic: " + topic);
+
+      while (!signal.aborted) {
+        await deferred.promise;
+        signal.throwIfAborted();
+
+        while (pendingPayloads.length > 0) {
+          const payload = pendingPayloads.shift();
+          const done = await set(
+            runPayloadNotification$,
+            loopCommand$,
+            payload,
+            signal,
+          );
+          signal.throwIfAborted();
+          if (done) {
+            cleanup();
+            return;
+          }
+        }
+      }
+    } catch (error) {
+      signal.throwIfAborted();
+      throwIfAbort(error);
+      if (isAblyConnectionClosedError(error)) {
+        L.debug(
+          "Ably connection closed before payload subscription completed",
+          {
+            topic,
+          },
+        );
+        return;
+      }
+      throw error;
+    } finally {
+      signal.removeEventListener("abort", cleanup);
+      cleanup();
+    }
+  },
+);
+
 /**
  * Initialize the Ably realtime client and subscribe to the user's channel.
  * Call once during app bootstrap, after Clerk auth is ready.
@@ -250,20 +377,17 @@ export const setupRealtime$ = command(
   },
 );
 
-export const setAblyLoop$ = command(
+const userChannel$ = command(
   async (
     { get, set },
     topic: string,
-    loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>,
     signal: AbortSignal,
-  ) => {
+  ): Promise<RealtimeChannel> => {
     signal.throwIfAborted();
 
-    let channel = get(internalUserChannel$);
+    const channel = get(internalUserChannel$);
     if (channel) {
-      await set(runWithChannel$, channel, topic, loopCommand$, signal);
-      signal.throwIfAborted();
-      return;
+      return channel;
     }
 
     const channelDeferred = createDeferredPromise<RealtimeChannel>(signal);
@@ -287,11 +411,38 @@ export const setAblyLoop$ = command(
       return [...prev, pendingSubscription];
     });
 
-    channel = await channelDeferred.promise.finally(() => {
+    const connectedChannel = await channelDeferred.promise.finally(() => {
       signal.removeEventListener("abort", removePendingSubscription);
     });
     signal.throwIfAborted();
+    return connectedChannel;
+  },
+);
+
+export const setAblyLoop$ = command(
+  async (
+    { set },
+    topic: string,
+    loopCommand$: Command<Promise<boolean> | boolean, [AbortSignal]>,
+    signal: AbortSignal,
+  ) => {
+    const channel = await set(userChannel$, topic, signal);
+    signal.throwIfAborted();
     await set(runWithChannel$, channel, topic, loopCommand$, signal);
+    signal.throwIfAborted();
+  },
+);
+
+export const setAblyPayloadLoop$ = command(
+  async (
+    { set },
+    topic: string,
+    loopCommand$: Command<Promise<boolean> | boolean, [unknown, AbortSignal]>,
+    signal: AbortSignal,
+  ) => {
+    const channel = await set(userChannel$, topic, signal);
+    signal.throwIfAborted();
+    await set(runWithChannelPayload$, channel, topic, loopCommand$, signal);
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "./error-boundary.tsx";
 import { Router } from "./router.tsx";
 import { VM0ClerkProvider } from "./clerk/clerk-provider.tsx";
 import { subscribeThreadListChanged$ } from "../signals/chat-thread-list-reload.ts";
+import { subscribeBackgroundChatThreadRunFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
 import { IN_VITEST } from "../env.ts";
@@ -17,6 +18,10 @@ export const setupRouter = (
 ) => {
   const signal = store.get(rootSignal$);
   detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
+  detach(
+    store.set(subscribeBackgroundChatThreadRunFinished$, signal),
+    Reason.Daemon,
+  );
   render(
     <StrictMode>
       <StoreProvider value={store}>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2681,12 +2681,14 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("loads older chat history from the thread control", async () => {
+  it("silently loads older chat history after rendering latest messages", async () => {
     const olderReply = "Earlier launch notes from last week.";
+    const beforeHistoryGate = context.mocks.deferred<void>();
 
     mockChatLifecycle(context, {
       threadId: HISTORY_THREAD_ID,
       threadTitle: "History review",
+      beforeHistoryGate: beforeHistoryGate.promise,
       historyMessages: [
         {
           role: "assistant",
@@ -2715,24 +2717,26 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Current launch risks are ready."),
       ).toBeInTheDocument();
-      expect(buttonByText("Load history")).toBeInTheDocument();
     });
+    expect(queryButtonByText("Load history")).toBeNull();
     expect(screen.queryByText(olderReply)).not.toBeInTheDocument();
 
-    click(buttonByText("Load history"));
+    beforeHistoryGate.resolve();
 
     await waitFor(() => {
       expect(screen.getByText(olderReply)).toBeInTheDocument();
-      expect(queryButtonByText("Load history")).not.toBeInTheDocument();
+      expect(queryButtonByText("Load history")).toBeNull();
     });
   });
 
   it("keeps chat scroll controls visible while browsing older messages", async () => {
     const resizeObserver = mockResizeObserver();
     const olderReply = "Scroll back to the planning notes.";
+    const beforeHistoryGate = context.mocks.deferred<void>();
     mockChatLifecycle(context, {
       threadId: "scroll-history-thread",
       threadTitle: "Scroll history",
+      beforeHistoryGate: beforeHistoryGate.promise,
       historyMessages: [
         {
           role: "assistant",
@@ -2751,16 +2755,24 @@ describe("chat lifecycle", () => {
 
     detachedSetupPage({ context, path: "/chats/scroll-history-thread" });
 
+    let scrollContainer: HTMLElement | undefined;
     await waitFor(() => {
-      expect(screen.getByText("Visible launch update 7")).toBeInTheDocument();
-      expect(buttonByText("Load history")).toBeInTheDocument();
+      scrollContainer = chatScrollContainer();
+      expect(scrollContainer).toBeInTheDocument();
     });
-
-    const scrollContainer = chatScrollContainer();
+    if (scrollContainer === undefined) {
+      throw new Error("Chat scroll container not found");
+    }
     setScrollMetrics(scrollContainer, {
       scrollHeight: 1200,
       clientHeight: 300,
     });
+
+    await waitFor(() => {
+      expect(screen.getByText("Visible launch update 7")).toBeInTheDocument();
+      expect(queryButtonByText("Load history")).toBeNull();
+    });
+
     scrollContainer.scrollTop = 900;
     fireEvent.scroll(scrollContainer);
     fireEvent.wheel(scrollContainer);
@@ -2790,7 +2802,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(composer, { key: "ArrowUp" });
     expect(scrollContainer.scrollTop).toBe(420);
 
-    click(buttonByText("Load history"));
+    beforeHistoryGate.resolve();
     await waitFor(() => {
       expect(screen.getByText(olderReply)).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -346,6 +346,11 @@ export function mockChatLifecycle(
      * keep the new-thread optimistic view mounted while interacting with it.
      */
     sendGate?: Promise<void>;
+    /**
+     * Promise the paged history handler awaits before responding to beforeId.
+     * Lets tests prove the latest-message view renders before silent backfill.
+     */
+    beforeHistoryGate?: Promise<void>;
     onRunCreate?: (body: {
       prompt?: string;
       clientMessageId?: string;
@@ -535,6 +540,7 @@ export function mockChatLifecycle(
     const sinceId = query.sinceId;
     const beforeId = query.beforeId;
     const limit = query.limit ?? 50;
+    const beforeHistoryGate = options?.beforeHistoryGate ?? Promise.resolve();
 
     const assistantId = `msg-assistant-run-v${assistantVersion}`;
 
@@ -604,19 +610,21 @@ export function mockChatLifecycle(
     }
 
     if (beforeId) {
-      const beforeIndex = pagedMessages.findIndex((message) => {
-        return message.id === beforeId;
-      });
-      if (beforeIndex <= 0) {
-        return respond(200, { messages: [], hasHistoryBefore: false });
-      }
-      const olderMessages = pagedMessages.slice(
-        Math.max(0, beforeIndex - limit),
-        beforeIndex,
-      );
-      return respond(200, {
-        messages: olderMessages,
-        hasHistoryBefore: beforeIndex - olderMessages.length > 0,
+      return beforeHistoryGate.then(() => {
+        const beforeIndex = pagedMessages.findIndex((message) => {
+          return message.id === beforeId;
+        });
+        if (beforeIndex <= 0) {
+          return respond(200, { messages: [], hasHistoryBefore: false });
+        }
+        const olderMessages = pagedMessages.slice(
+          Math.max(0, beforeIndex - limit),
+          beforeIndex,
+        );
+        return respond(200, {
+          messages: olderMessages,
+          hasHistoryBefore: beforeIndex - olderMessages.length > 0,
+        });
       });
     }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2529,20 +2529,14 @@ function ChatThreadMessagesMain({
   activeGroups,
   sessionError,
   skeletonVisible,
-  hasOlderHistory,
-  loadingHistory,
   messagesLoading,
-  onLoadHistory,
 }: {
   thread: ChatThreadSignals;
   groups: GroupedChatMessageGroup[];
   activeGroups: GroupedChatMessageGroup[];
   sessionError: string | null;
   skeletonVisible: boolean;
-  hasOlderHistory: boolean;
-  loadingHistory: boolean;
   messagesLoading: boolean;
-  onLoadHistory: (event: ReactMouseEvent<HTMLButtonElement>) => void;
 }) {
   const showEmptyState =
     !sessionError &&
@@ -2561,18 +2555,6 @@ function ChatThreadMessagesMain({
         className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible"
         style={{ visibility: skeletonVisible ? "hidden" : "visible" }}
       >
-        {!sessionError && !skeletonVisible && hasOlderHistory && (
-          <div className="flex justify-center">
-            <button
-              type="button"
-              disabled={loadingHistory}
-              onClick={onLoadHistory}
-              className="inline-flex h-8 items-center rounded-lg border border-border bg-background px-3 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Load history
-            </button>
-          </div>
-        )}
         {sessionError && (
           <div className="flex-1 flex items-center justify-center py-16">
             <div className="flex items-center gap-2 text-destructive">
@@ -3057,10 +3039,6 @@ function useChatThreadKeyDownFactory() {
 
 function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const groupsLoadable = useLastLoadable(thread.groupedChatMessages$);
-  const hasOlderHistory = useLastResolved(thread.hasOlderHistory$) ?? false;
-  const [loadHistoryLoadable, loadHistory] = useLoadableSet(
-    thread.loadHistory$,
-  );
   const threadDataLoadable = useLastLoadable(thread.threadData$);
   const sessionError = resolveSessionError(threadDataLoadable, groupsLoadable);
   const messagesLoading = groupsLoadable.state === "loading";
@@ -3068,14 +3046,9 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const { activeGroups } = splitQueuedMessagesForThinkingIndicator(groups);
   const setScrollContainer = useSet(thread.setScrollContainer$);
   const skeletonVisible = useGet(thread.skeletonVisible$);
-  const loadingHistory = loadHistoryLoadable.state === "loading";
-  const pageSignal = useGet(pageSignal$);
   const features = useLastResolved(featureSwitch$);
   const inlineFeedbackEnabled =
     features?.[FeatureSwitchKey.ChatInlineFeedback] ?? false;
-  const onLoadHistory = onDomEventFn(() => {
-    return loadHistory(pageSignal);
-  });
   const githubPrTrackingOpen = useGithubPrTrackingOpen(
     thread,
     threadDataLoadable,
@@ -3103,10 +3076,7 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
                 activeGroups={activeGroups}
                 sessionError={sessionError}
                 skeletonVisible={skeletonVisible}
-                hasOlderHistory={hasOlderHistory}
-                loadingHistory={loadingHistory}
                 messagesLoading={messagesLoading}
-                onLoadHistory={onLoadHistory}
               />
             </div>
             <ChatThreadSkeletonOverlay


### PR DESCRIPTION
## Summary
- remove the manual chat history load button and silently backfill older history after the latest messages render
- preserve the existing prepend-scroll compensation path so history backfill does not shift the viewport
- publish a user-level `chatThreadRunFinished` event for finished web chat runs and silently warm hidden thread messages into IndexedDB
- reuse the existing IDB `upsertMessages` path so foreground and background message fetches are idempotent

## Validation
- pnpm prettier --check apps/api/src/signals/external/realtime.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/platform/src/signals/__tests__/realtime.test.ts apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts apps/platform/src/signals/chat-page/background-chat-thread-cache.ts apps/platform/src/signals/realtime.ts apps/platform/src/views/main.tsx
- pnpm -F @vm0/app exec vitest run src/signals/__tests__/realtime.test.ts src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F api check-types
- pnpm -F @vm0/app lint
- pnpm -F api lint
- pre-commit hook: pnpm check-types, pnpm knip, prettier

Full test suite will run in CI.