### PR TITLE
fix: lock desktop main window size

### DIFF
--- a/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildDesktopMainWindowSizeOptions,
   hideDockForHiddenMainWindow,
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
@@ -7,6 +8,18 @@ import {
 import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
 
 describe("desktop window lifecycle", () => {
+  it("uses a fixed main window size", () => {
+    expect(buildDesktopMainWindowSizeOptions()).toStrictEqual({
+      width: 1024,
+      height: 700,
+      minWidth: 1024,
+      minHeight: 700,
+      resizable: false,
+      maximizable: false,
+      fullscreenable: false,
+    });
+  });
+
   it("uses integrated macOS window chrome", () => {
     expect(buildDesktopWindowChromeOptions("darwin")).toStrictEqual({
       titleBarStyle: "hiddenInset",

--- a/turbo/apps/desktop/src/desktop-window-lifecycle.ts
+++ b/turbo/apps/desktop/src/desktop-window-lifecycle.ts
@@ -11,6 +11,32 @@ interface DockController {
   readonly show: () => Promise<void>;
 }
 
+type MainWindowSizeOptions = Pick<
+  Electron.BrowserWindowConstructorOptions,
+  | "width"
+  | "height"
+  | "minWidth"
+  | "minHeight"
+  | "resizable"
+  | "maximizable"
+  | "fullscreenable"
+>;
+
+const MAIN_WINDOW_WIDTH = 1024;
+const MAIN_WINDOW_HEIGHT = 700;
+
+export function buildDesktopMainWindowSizeOptions(): MainWindowSizeOptions {
+  return {
+    width: MAIN_WINDOW_WIDTH,
+    height: MAIN_WINDOW_HEIGHT,
+    minWidth: MAIN_WINDOW_WIDTH,
+    minHeight: MAIN_WINDOW_HEIGHT,
+    resizable: false,
+    maximizable: false,
+    fullscreenable: false,
+  };
+}
+
 export function shouldHideMainWindowOnClose(params: {
   readonly platform: NodeJS.Platform;
   readonly isQuitting: boolean;

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -88,6 +88,7 @@ import {
   type DesktopAuthCallback,
 } from "./desktop-auth";
 import {
+  buildDesktopMainWindowSizeOptions,
   hideDockForHiddenMainWindow,
   shouldHideMainWindowOnClose,
   showAndFocusWindow,
@@ -910,10 +911,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
   await showDockForActiveMainWindow();
   const window = new BrowserWindow({
     ...browserWindowOptions(),
-    width: 1280,
-    height: 900,
-    minWidth: 1024,
-    minHeight: 700,
+    ...buildDesktopMainWindowSizeOptions(),
   });
 
   mainWindow = window;


### PR DESCRIPTION
## Summary
- lock the Desktop main window to the existing minimum size
- disable resizing, maximizing, and fullscreen for the main client window
- add coverage for the main window size policy

## Validation
- pnpm -F @vm0/desktop exec vitest run src/desktop-window-lifecycle.test.ts
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop lint
- pnpm exec prettier --check apps/desktop/src/desktop-window-lifecycle.ts apps/desktop/src/main.ts apps/desktop/src/desktop-window-lifecycle.test.ts
- pnpm -F @vm0/desktop build:electron