### PR TITLE
fix: skip previews inside markdown code blocks

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -59,12 +59,6 @@ type ExtractedPreviewUrl = {
   title?: string;
 };
 
-type OpenMarkdownFence = {
-  marker: "`" | "~";
-  length: number;
-  lines: string[];
-};
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -475,105 +469,6 @@ function renderExtractedPreviewLine(
   return { renderKind: "markdown", line };
 }
 
-function renderFencedHostedSitePreview(
-  contentLines: readonly string[],
-): ExtractedPreviewLineRender | null {
-  const nonEmptyLines = contentLines.filter((line) => {
-    return line.trim().length > 0;
-  });
-  if (nonEmptyLines.length !== 1) {
-    return null;
-  }
-
-  const line = nonEmptyLines[0]!;
-  const extracted = extractPreviewUrlFromLine(line);
-  if (!extracted || !isHostedSiteUrl(extracted.url)) {
-    return null;
-  }
-
-  const rendered = renderExtractedPreviewLine(extracted, line);
-  return rendered.renderKind === "preview" && rendered.preview.kind === "html"
-    ? rendered
-    : null;
-}
-
-type MarkdownFenceLineResult =
-  | {
-      kind: "pending";
-      openFence: OpenMarkdownFence | null;
-    }
-  | {
-      kind: "markdown";
-      openFence: null;
-      lines: readonly string[];
-    }
-  | {
-      kind: "preview";
-      openFence: null;
-      preview: {
-        filename: string;
-        url: string;
-        kind: BodyPreviewKind;
-      };
-    };
-
-function renderOpenMarkdownFence(
-  openFence: OpenMarkdownFence,
-  previews: boolean,
-): MarkdownFenceLineResult {
-  const renderedFence = previews
-    ? renderFencedHostedSitePreview(openFence.lines.slice(1))
-    : null;
-
-  if (renderedFence?.renderKind === "preview") {
-    return {
-      kind: "preview",
-      openFence: null,
-      preview: renderedFence.preview,
-    };
-  }
-
-  return { kind: "markdown", openFence: null, lines: openFence.lines };
-}
-
-function parseMarkdownFenceLine(
-  line: string,
-  openFence: OpenMarkdownFence | null,
-  previews: boolean,
-): MarkdownFenceLineResult | null {
-  const trimmedLine = line.trim();
-  const fenceMatch = trimmedLine.match(/^(`{3,}|~{3,})/);
-  if (!fenceMatch) {
-    if (!openFence) {
-      return null;
-    }
-
-    openFence.lines.push(line);
-    return { kind: "pending", openFence };
-  }
-
-  const fence = fenceMatch[1]!;
-  const marker = fence.startsWith("`") ? "`" : "~";
-  if (!openFence) {
-    return {
-      kind: "pending",
-      openFence: { marker, length: fence.length, lines: [line] },
-    };
-  }
-
-  if (openFence.marker !== marker || fence.length < openFence.length) {
-    openFence.lines.push(line);
-    return { kind: "pending", openFence };
-  }
-
-  const result = renderOpenMarkdownFence(openFence, previews);
-  if (result.kind === "markdown") {
-    return { ...result, lines: [...openFence.lines, line] };
-  }
-
-  return result;
-}
-
 function stripMarkdownLineDecorations(value: string): string {
   let candidate = value
     .trim()
@@ -809,7 +704,10 @@ export function parseBodyRenderBlocks(
   const keptLines: string[] = [];
   const markdownBuffer: string[] = [];
   let blockSequence = 0;
-  let openFence: OpenMarkdownFence | null = null;
+  let openFence: {
+    marker: "`" | "~";
+    length: number;
+  } | null = null;
   const nextBlockId = (type: BodyRenderBlock["type"]) => {
     blockSequence += 1;
     return `${type}-${blockSequence}`;
@@ -827,37 +725,29 @@ export function parseBodyRenderBlocks(
     markdownBuffer.length = 0;
   };
 
-  const pushMarkdownLines = (nextLines: readonly string[]) => {
-    markdownBuffer.push(...nextLines);
-    keptLines.push(...nextLines);
-  };
-
-  const pushPreviewBlock = (
-    preview: Extract<MarkdownFenceLineResult, { kind: "preview" }>["preview"],
-  ) => {
-    flushMarkdownBuffer();
-    blocks.push({
-      type: "preview",
-      id: nextBlockId("preview"),
-      preview,
-    });
-  };
-
-  const applyFenceLineResult = (result: MarkdownFenceLineResult) => {
-    openFence = result.openFence;
-    if (result.kind === "markdown") {
-      pushMarkdownLines(result.lines);
-      return;
-    }
-    if (result.kind === "preview") {
-      pushPreviewBlock(result.preview);
-    }
-  };
-
   for (const [lineIndex, line] of lines.entries()) {
-    const fenceResult = parseMarkdownFenceLine(line, openFence, previews);
-    if (fenceResult) {
-      applyFenceLineResult(fenceResult);
+    const trimmedLine = line.trim();
+    const fenceMatch = trimmedLine.match(/^(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const fence = fenceMatch[1];
+      const marker = fence.startsWith("`") ? "`" : "~";
+      if (
+        openFence &&
+        openFence.marker === marker &&
+        fence.length >= openFence.length
+      ) {
+        openFence = null;
+      } else if (!openFence) {
+        openFence = { marker, length: fence.length };
+      }
+      markdownBuffer.push(line);
+      keptLines.push(line);
+      continue;
+    }
+
+    if (openFence) {
+      markdownBuffer.push(line);
+      keptLines.push(line);
       continue;
     }
 
@@ -896,9 +786,6 @@ export function parseBodyRenderBlocks(
     });
   }
 
-  if (openFence) {
-    applyFenceLineResult(renderOpenMarkdownFence(openFence, previews));
-  }
   flushMarkdownBuffer();
 
   const cleanContent = keptLines.join("\n").trim();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -936,6 +936,8 @@ ${openFencedHostedSiteUrl}`,
     await waitFor(() => {
       expect(screen.getByText("Table keeps URLs as text")).toBeInTheDocument();
       expect(screen.getByText(videoUrl)).toBeInTheDocument();
+      expect(screen.getByText(fencedHostedSiteUrl)).toBeInTheDocument();
+      expect(screen.getByText(openFencedHostedSiteUrl)).toBeInTheDocument();
       expect(screen.getByAltText("chart.png")).toBeInTheDocument();
       expect(screen.getByLabelText("Preview demo.mp4")).toBeInTheDocument();
       expect(screen.getByTestId("attachment-preview-markdown")).toHaveAttribute(
@@ -963,8 +965,8 @@ ${openFencedHostedSiteUrl}`,
         "Open html preview for Launch site",
       );
       expect(screen.getByText("Customer Launch")).toBeInTheDocument();
-      expect(screen.getByText("Deck Summary")).toBeInTheDocument();
-      expect(screen.getByText("Page Content Pack")).toBeInTheDocument();
+      expect(screen.queryByText("Deck Summary")).not.toBeInTheDocument();
+      expect(screen.queryByText("Page Content Pack")).not.toBeInTheDocument();
       const customerLaunchFrame = document.querySelector(
         'iframe[title="Site preview for Customer Launch"]',
       );
@@ -974,13 +976,10 @@ ${openFencedHostedSiteUrl}`,
         "allow-same-origin allow-scripts",
       );
       expect(
-        document.querySelector('iframe[title="Site preview for Deck Summary"]'),
-      ).toBeInTheDocument();
-      expect(
         document.querySelector(
           'iframe[title="Site preview for Page Content Pack"]',
         ),
-      ).toBeInTheDocument();
+      ).not.toBeInTheDocument();
       expect(screen.getByTestId("attachment-preview-file")).toHaveAttribute(
         "aria-label",
         "Download archive.bin",


### PR DESCRIPTION
## Summary
- Stop extracting hosted-site previews from markdown code fences
- Keep URLs inside closed and unclosed code blocks rendered as code text
- Preserve previews for normal assistant artifact/site links outside code blocks

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "renders inline previews from assistant artifact links"
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pre-commit: prettier, knip, turbo check-types