### PR TITLE
ci: update cloudflared to 2026.6.0

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -14,7 +14,7 @@ inputs:
   cloudflared-version:
     description: "cloudflared version to install"
     required: false
-    default: "2026.2.0"
+    default: "2026.6.0"
 
 runs:
   using: "composite"

--- a/scripts/cloudflared-ssh.sh
+++ b/scripts/cloudflared-ssh.sh
@@ -9,7 +9,7 @@
 #   CF_TUNNEL_ACCOUNT_ID  — Cloudflare account ID
 #
 # Usage:
-#   scripts/cloudflared-ssh.sh provision <host> [--domain vm3.ai] [--user ubuntu] [--version 2026.2.0]
+#   scripts/cloudflared-ssh.sh provision <host> [--domain vm3.ai] [--user ubuntu] [--version 2026.6.0]
 #   scripts/cloudflared-ssh.sh deprovision <host> [--domain vm3.ai] [--user ubuntu]
 #
 # Examples:
@@ -29,7 +29,7 @@ fi
 
 DEFAULT_DOMAIN="vm3.ai"
 DEFAULT_USER="ubuntu"
-DEFAULT_VERSION="2026.2.0"
+DEFAULT_VERSION="2026.6.0"
 
 log() { echo -e "\033[1;34m[cloudflared-ssh]\033[0m $1" >&2; }
 err() { echo -e "\033[1;31m[cloudflared-ssh]\033[0m $1" >&2; }
@@ -110,7 +110,7 @@ do_provision() {
     esac
   done
   if [[ -z "$host" ]]; then
-    err "Usage: $0 provision <host> [--domain vm3.ai] [--user ubuntu] [--version 2026.2.0]"
+    err "Usage: $0 provision <host> [--domain vm3.ai] [--user ubuntu] [--version 2026.6.0]"
     exit 1
   fi
 


### PR DESCRIPTION
## Summary
- update the GitHub Actions Cloudflare SSH setup default cloudflared version to 2026.6.0
- update the metal SSH tunnel provisioning default and usage text to 2026.6.0

## Validation
- `bash -n scripts/cloudflared-ssh.sh`
- `bash -n scripts/cf-ssh.sh`
- `bash -n .github/scripts/cloudflare-ssh-proxy.sh`
- `git diff --check`
- confirmed no remaining 2026.2.0 pins under `.github`, `scripts`, or `ansible`

## Notes
- local-1.aws.vm3.ai was upgraded manually to cloudflared 2026.6.0 and verified over direct SSH and Cloudflare Access SSH.