### PR TITLE
test: split oversized automation schedule settings test in two

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automation-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automation-detail-page.test.tsx
@@ -326,7 +326,7 @@ describe("zero automation detail page", () => {
     });
   });
 
-  it("updates automation schedule settings", async () => {
+  it("updates automation to a loop schedule", async () => {
     mockAutomationDetailStory();
 
     detachedSetupPage({ context, path: `/automations/${automationId}` });
@@ -351,6 +351,29 @@ describe("zero automation detail page", () => {
     selectOptionByLabel("Every", "60 minutes");
     expect(screen.getByText("60 minutes")).toBeInTheDocument();
 
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    click(buttonByText("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Automation updated")).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue(/Team morning brief/u)).toBeInTheDocument();
+  });
+
+  it("updates automation to a one-time schedule", async () => {
+    mockAutomationDetailStory();
+
+    detachedSetupPage({ context, path: `/automations/${automationId}` });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Morning brief" }),
+      ).toBeInTheDocument();
+    });
+
     selectOptionByLabel("Time", "Once");
     fireEvent.change(screen.getByLabelText("Date"), {
       target: { value: "2099-06-12" },
@@ -373,7 +396,6 @@ describe("zero automation detail page", () => {
     await waitFor(() => {
       expect(screen.getByText("Automation updated")).toBeInTheDocument();
     });
-    expect(screen.getByDisplayValue(/Team morning brief/u)).toBeInTheDocument();
   });
 
   it("shows the trigger section when automation multi trigger is enabled", async () => {


### PR DESCRIPTION
## Problem

CI run [27749755814](https://github.com/vm0-ai/vm0/actions/runs/27749755814) failed on `test-app (8)`:

```
src/views/zero-page/__tests__/zero-automation-detail-page.test.tsx (10 tests | 1 failed) 19596ms
 × updates automation schedule settings 5045ms
   Error: Test timed out in 5000ms.
   ❯ zero-automation-detail-page.test.tsx:329:3
```

The other failing shards in that run (`test-app (4)`, `(6)`) were just fail-fast cancellations triggered by this one timeout.

## Diagnosis: oversized test, not a floating promise

- The failure is a clean `Test timed out in 5000ms` at the `it()` body — **not** a teardown `DOMException` or cross-test leak, which is how floating-promise bugs surface (per the `ccstate` skill docs).
- It clocked **5045ms**, barely over the default 5000ms timeout — the signature of a test sitting right at the boundary.
- The save path (`handleSave`) and the zero-page views use `detach(..., Reason.DomCallback)` correctly with no empty `.catch(() => {})` smells.

The single test crammed **three** scenarios into one case — rename, switch to a **Loop** interval, and switch to a **Once** date/time/timezone schedule — performing ~6 Radix `Select` open/close cycles (including the expensive full-timezone-list select) on top of the page mount.

## Fix

Split into two focused tests that each exercise one schedule type:

- `updates automation to a loop schedule` — rename + Loop interval + save
- `updates automation to a one-time schedule` — Once date/time/timezone + save

Coverage is unchanged; each test now stays well under the default timeout. No production code changed; no tests skipped.