### PR TITLE
fix: restore hidden stripe api-token runtime support

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11,6 +11,9 @@ import {
   type FirewallApi,
 } from "@vm0/connectors/firewall-types";
 import { getConnectorFirewall } from "@vm0/connectors/firewalls";
+import { connectors } from "@vm0/db/schema/connector";
+import { secrets as secretTable } from "@vm0/db/schema/secret";
+import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -18,6 +21,7 @@ import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now, nowDate } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
 import { assistantMessageIdForRunEvent } from "../../services/assistant-message-id";
 import {
   createBddApi,
@@ -35,6 +39,7 @@ import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { encryptSecretForTests } from "./helpers/encrypt-secret";
 
 /**
  * RUN-01..04 and CHAIN-RUN: successful run dispatch and lifecycle.
@@ -996,6 +1001,65 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.requestCancelRun(actor, withHost.runId, [200]);
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
+  });
+
+  it("creates runs with legacy hidden Stripe API-token connectors", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled actor to belong to an org");
+    }
+    const writeDb = createStore().set(writeDb$);
+
+    await writeDb.insert(connectors).values({
+      orgId: actor.orgId,
+      userId: actor.userId,
+      type: "stripe",
+      authMethod: "api-token",
+    });
+    await writeDb.insert(secretTable).values({
+      orgId: actor.orgId,
+      userId: actor.userId,
+      name: "STRIPE_TOKEN",
+      encryptedValue: encryptSecretForTests("sk_test_bdd_legacy"),
+      type: "connector",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["stripe"]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use legacy stripe api token",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(run.status).toBe("pending");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("ignores stored connectors with removed auth methods when creating runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled actor to belong to an org");
+    }
+    const writeDb = createStore().set(writeDb$);
+
+    await writeDb.insert(connectors).values({
+      orgId: actor.orgId,
+      userId: actor.userId,
+      type: "stripe",
+      authMethod: "cli",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["stripe"]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "ignore removed stripe auth method",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(run.status).toBe("pending");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("uses Figma personal access tokens in the X-Figma-Token firewall header", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1782,6 +1782,10 @@ function allowedStoredConnectorRows(
     return (
       (!allowedConnectorTypes ||
         allowedConnectorTypes.includes(row.connectorType)) &&
+      getConnectorAuthMethodRuntimeMetadata(
+        row.connectorType,
+        row.authMethod,
+      ) !== undefined &&
       storedConnectorRuntimeCredentialStatus(row, now) === "available"
     );
   });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -339,7 +339,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual(["oauth"]);
     expect(
       getConnectorAuthMethodIdsForGrantKind("stripe", "manual"),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["api-token"]);
     expect(
       getConnectorAuthMethodIdsForGrantKind("stripe", "device-auth"),
     ).toStrictEqual([]);
@@ -348,7 +348,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual(["oauth"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("stripe", "static"),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["api-token"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("lark", "refresh-token"),
     ).toStrictEqual(["api-token"]);
@@ -360,7 +360,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual([]);
     expect(
       getConnectorAuthMethodIdsForRevokeKind("stripe", "none"),
-    ).toStrictEqual(["oauth"]);
+    ).toStrictEqual(["oauth", "api-token"]);
 
     expect(
       getConnectorAuthMethodIdsForGrantKind("test-oauth-device", "device-auth"),
@@ -2011,6 +2011,7 @@ describe("getConfiguredConnectorAuthMethodIds", () => {
   it("returns configured auth methods without feature filtering", () => {
     expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
       "oauth",
+      "api-token",
     ]);
   });
 });
@@ -2026,6 +2027,11 @@ describe("getAvailableConnectorAuthMethodIds", () => {
         [FeatureSwitchKey.StripeConnector]: true,
       }),
     ).toStrictEqual(["oauth"]);
+    expect(getConnectorAuthMethod("stripe", "api-token")).toMatchObject({
+      visible: false,
+      grant: { kind: "manual" },
+      access: { kind: "static" },
+    });
   });
 
   it("treats statically hidden auth methods as unavailable", () => {
@@ -2044,6 +2050,7 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     try {
       expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
         "oauth",
+        "api-token",
       ]);
       expect(
         getAvailableConnectorAuthMethodIds("stripe", {
@@ -2278,6 +2285,15 @@ describe("getConnectorAuthMethodAccessMetadata", () => {
       kind: "static",
       envBindings: {
         OPENAI_TOKEN: "$secrets.OPENAI_TOKEN",
+      },
+      platformSecrets: [],
+    });
+    expect(
+      getConnectorAuthMethodAccessMetadata("stripe", "api-token"),
+    ).toStrictEqual({
+      kind: "static",
+      envBindings: {
+        STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
       },
       platformSecrets: [],
     });
@@ -2778,6 +2794,25 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
           source: {
             kind: "connector-secret",
             name: "OPENAI_TOKEN",
+          },
+        },
+      ],
+    });
+    expect(
+      getConnectorAuthMethodRuntimeMetadata("stripe", "api-token"),
+    ).toStrictEqual({
+      storage: {
+        secrets: ["STRIPE_TOKEN"],
+        variables: [],
+      },
+      runtimeBindings: [
+        {
+          envName: "STRIPE_TOKEN",
+          valueRef: "$secrets.STRIPE_TOKEN",
+          optional: false,
+          source: {
+            kind: "connector-secret",
+            name: "STRIPE_TOKEN",
           },
         },
       ],

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -1483,6 +1483,9 @@ function hasRuntimeAvailableAuthMethod(
 ): boolean {
   for (const authMethod of getConfiguredConnectorAuthMethodIds(type)) {
     const method = getConnectorAuthMethod(type, authMethod);
+    if (method?.visible === false) {
+      continue;
+    }
     switch (method?.grant.kind) {
       case "auth-code":
       case "external-code":

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -48,6 +48,33 @@ export const stripe = {
         },
         revoke: { kind: "none" },
       },
+      "api-token": {
+        visible: false,
+        label: "API Key",
+        helpText:
+          "Connect with a Stripe secret or restricted API key. This auth method is retained for existing stored connector credentials.",
+        storage: {
+          secrets: ["STRIPE_TOKEN"],
+          variables: [],
+        },
+        grant: {
+          kind: "manual",
+          fields: {
+            STRIPE_TOKEN: {
+              label: "API Key",
+              required: true,
+              placeholder: "sk_live_...",
+            },
+          },
+        },
+        access: {
+          kind: "static",
+          envBindings: {
+            STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+          },
+        },
+        revoke: { kind: "none" },
+      },
     },
   },
 } as const satisfies Record<string, ConnectorConfig>;


### PR DESCRIPTION
## Summary
- Restore Stripe `api-token` as a hidden legacy auth method so stored connector rows can still resolve runtime metadata and inject `STRIPE_TOKEN`.
- Keep hidden auth methods out of runtime-available connector candidates so the connector UI/search remains OAuth-only.
- Filter stored connector rows whose auth method no longer has runtime metadata, preventing removed legacy methods such as Stripe `cli` from crashing create run.

## Tests
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "legacy hidden Stripe|removed auth methods"`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts -t "Stripe OAuth search"`
- `pnpm exec prettier --check apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts packages/connectors/src/connectors/stripe.ts packages/connectors/src/connector-utils.ts packages/connectors/src/__tests__/connectors.test.ts`
- `git diff --check`