### PR TITLE
feat: restore stripe api-token connector auth method

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -250,6 +250,7 @@ describe("GET /api/zero/connectors/search", () => {
 
     const authMethods = CONNECTOR_TYPES.stripe.authMethods;
     const originalOauth = authMethods.oauth;
+    const originalApiToken = authMethods["api-token"];
 
     restoreConnectorRegistry.push(() => {
       Object.defineProperty(authMethods, "oauth", {
@@ -257,10 +258,23 @@ describe("GET /api/zero/connectors/search", () => {
         configurable: true,
         enumerable: true,
       });
+      Object.defineProperty(authMethods, "api-token", {
+        value: originalApiToken,
+        configurable: true,
+        enumerable: true,
+      });
     });
     Object.defineProperty(authMethods, "oauth", {
       value: {
         ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.defineProperty(authMethods, "api-token", {
+      value: {
+        ...originalApiToken,
         visible: false,
       } satisfies ConnectorAuthMethodConfig,
       configurable: true,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -634,17 +634,17 @@ describe("zeroConnectorSearch", () => {
     expect(zapier?.authMethods).toStrictEqual(["api-token"]);
   });
 
-  it("returns Stripe OAuth search auth by default", async () => {
+  it("returns Stripe OAuth and API-token search auth by default", async () => {
     const authMethods = await stripeSearchAuthMethods({});
 
-    expect(authMethods).toStrictEqual(["oauth"]);
+    expect(authMethods).toStrictEqual(["oauth", "api-token"]);
   });
 
-  it("returns Stripe OAuth search auth when the Stripe switch is enabled", async () => {
+  it("returns Stripe OAuth and API-token search auth when the Stripe switch is enabled", async () => {
     const authMethods = await stripeSearchAuthMethods({
       [FeatureSwitchKey.StripeConnector]: true,
     });
 
-    expect(authMethods).toStrictEqual(["oauth"]);
+    expect(authMethods).toStrictEqual(["oauth", "api-token"]);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -509,7 +509,7 @@ describe("connectors page", () => {
     expect(screen.queryByLabelText("Connect Stripe")).not.toBeInTheDocument();
   });
 
-  it("starts Stripe OAuth directly from the connector card", async () => {
+  it("starts Stripe OAuth from the connect dialog", async () => {
     mockConnectors([]);
     const authWindow = createMockAuthWindow();
     context.mocks.browser.open(authWindow);
@@ -534,20 +534,21 @@ describe("connectors page", () => {
     await fill(searchInput, "stripe");
     click(await screen.findByLabelText("Connect Stripe"));
 
+    const dialog = await screen.findByRole("dialog", { name: "Stripe" });
+    click(buttonByText("Connect", dialog));
+
     await waitFor(() => {
       expect(authWindow.location.href).toBe(
         "https://oauth.test/stripe/authorize",
       );
     });
-    expect(
-      screen.queryByRole("dialog", { name: "Stripe" }),
-    ).not.toBeInTheDocument();
   });
 
-  it("hides Stripe when its only auth method is statically hidden", async () => {
+  it("hides Stripe when all its auth methods are statically hidden", async () => {
     mockConnectors([]);
     const authMethods = CONNECTOR_TYPES.stripe.authMethods;
     const originalOauth = authMethods.oauth;
+    const originalApiToken = authMethods["api-token"];
 
     restoreConnectorRegistry.push(() => {
       Object.defineProperty(authMethods, "oauth", {
@@ -555,10 +556,23 @@ describe("connectors page", () => {
         configurable: true,
         enumerable: true,
       });
+      Object.defineProperty(authMethods, "api-token", {
+        value: originalApiToken,
+        configurable: true,
+        enumerable: true,
+      });
     });
     Object.defineProperty(authMethods, "oauth", {
       value: {
         ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.defineProperty(authMethods, "api-token", {
+      value: {
+        ...originalApiToken,
         visible: false,
       } satisfies ConnectorAuthMethodConfig,
       configurable: true,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -339,7 +339,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual(["oauth"]);
     expect(
       getConnectorAuthMethodIdsForGrantKind("stripe", "manual"),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["api-token"]);
     expect(
       getConnectorAuthMethodIdsForGrantKind("stripe", "device-auth"),
     ).toStrictEqual([]);
@@ -348,7 +348,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual(["oauth"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("stripe", "static"),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["api-token"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("lark", "refresh-token"),
     ).toStrictEqual(["api-token"]);
@@ -360,7 +360,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual([]);
     expect(
       getConnectorAuthMethodIdsForRevokeKind("stripe", "none"),
-    ).toStrictEqual(["oauth"]);
+    ).toStrictEqual(["oauth", "api-token"]);
 
     expect(
       getConnectorAuthMethodIdsForGrantKind("test-oauth-device", "device-auth"),
@@ -2011,6 +2011,7 @@ describe("getConfiguredConnectorAuthMethodIds", () => {
   it("returns configured auth methods without feature filtering", () => {
     expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
       "oauth",
+      "api-token",
     ]);
   });
 });
@@ -2020,12 +2021,12 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     expect(getAvailableConnectorAuthMethodIds("stripe", {})).toStrictEqual([]);
   });
 
-  it("exposes only Stripe OAuth auth when the Stripe switch is enabled", () => {
+  it("exposes Stripe OAuth and API-token auth when the Stripe switch is enabled", () => {
     expect(
       getAvailableConnectorAuthMethodIds("stripe", {
         [FeatureSwitchKey.StripeConnector]: true,
       }),
-    ).toStrictEqual(["oauth"]);
+    ).toStrictEqual(["oauth", "api-token"]);
   });
 
   it("treats statically hidden auth methods as unavailable", () => {
@@ -2044,12 +2045,13 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     try {
       expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
         "oauth",
+        "api-token",
       ]);
       expect(
         getAvailableConnectorAuthMethodIds("stripe", {
           [FeatureSwitchKey.StripeConnector]: true,
         }),
-      ).toStrictEqual([]);
+      ).toStrictEqual(["api-token"]);
     } finally {
       Object.defineProperty(authMethods, "oauth", {
         value: originalOauth,

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -48,6 +48,33 @@ export const stripe = {
         },
         revoke: { kind: "none" },
       },
+      "api-token": {
+        featureFlag: FeatureSwitchKey.StripeConnector,
+        label: "API Key",
+        helpText:
+          "1. Log in to your [Stripe Dashboard](https://dashboard.stripe.com/apikeys)\n2. Go to **Developers > API keys**\n3. Reveal the **Secret key** (starts with `sk_live_` or `sk_test_`) or create a **Restricted key** (`rk_live_...`) with the scopes you need\n4. Copy the key",
+        storage: {
+          secrets: ["STRIPE_TOKEN"],
+          variables: [],
+        },
+        grant: {
+          kind: "manual",
+          fields: {
+            STRIPE_TOKEN: {
+              label: "API Key",
+              required: true,
+              placeholder: "sk_live_...",
+            },
+          },
+        },
+        access: {
+          kind: "static",
+          envBindings: {
+            STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+          },
+        },
+        revoke: { kind: "none" },
+      },
     },
   },
 } as const satisfies Record<string, ConnectorConfig>;


### PR DESCRIPTION
## Problem

PR #18249 (`feat: use stripe connector oauth`) changed the Stripe connector to **OAuth-only**, removing the `api-token` (and `cli`) auth methods from the config.

But existing rows in the `connectors` table still carry `auth_method = 'api-token'`. At agent-run creation, the binding step (`agent-run-create.service.ts` → `connectorEnvBindingSets()`) does a hard lookup via `getConnectorAuthMethod()` / `getConnectorAuthMethodRuntimeMetadata()`, gets `undefined`, and throws:

```
Error: Invalid auth method "api-token" for stored connector "stripe"
```

The stale row slips through `allowedStoredConnectorRows()` (its credential status resolves to `available` because `token_expires_at` is `NULL`), then blows up at the binding step → **500**.

Sentry: [API-16](https://vm0.sentry.io/issues/7560485186/) — 12 events since 2026-06-18, first seen on release `f1977014`.

## Fix

Re-add the `api-token` (API Key) auth method to the Stripe connector, restoring the exact `manual` grant + `static` access (`STRIPE_TOKEN`) shape that was removed. It is gated behind the `StripeConnector` feature switch, consistent with `oauth`.

This makes `getConnectorAuthMethod("stripe", "api-token")` resolve again, so existing api-token connections bind cleanly instead of throwing, and the connect UI offers API Key alongside Sign in with Stripe.

## Scope notes

- Only the **api-token** form is restored (per request). The `cli` device-auth flow removed in #18249 is **not** re-added.
- There are still 2 stored Stripe rows with `auth_method = 'cli'` that will throw the same error until they are cleaned up or `cli` is restored separately. All affected rows (api-token + cli) live in VM0's internal org only — no external users impacted.

## Tests

Updated Stripe auth-method expectations in `connectors.test.ts`, `zero-connector-data.service.test.ts`, and `zero-connectors-search.test.ts` to reflect the restored method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)