### PR TITLE
fix(desktop): clarify computer use capture failures

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -2126,63 +2126,35 @@ func currentConsoleSessionUnavailable() -> Bool {
     return onConsole == false
 }
 
-func targetWindowLabel(appName: String, target: WindowTarget) -> String {
-    let title = target.title.map { " \"\($0)\"" } ?? ""
-    return "\(appName) window\(title) \(target.windowNumber)"
-}
-
 func targetWindowScreenshotFailureMessage(appName: String, target: WindowTarget) -> String {
-    let label = targetWindowLabel(appName: appName, target: target)
-    let base = "Zero has Screen Recording permission, but macOS could not capture the selected \(label)."
-    let retry = "Ask the user to bring that window to the current desktop, keep it visible and unminimized, then retry."
-
-    if currentConsoleSessionUnavailable() {
-        return "\(base) The Mac appears to be locked or not on the active console. Ask the user to unlock the Mac and retry."
+    let isConsoleSessionUnavailable = currentConsoleSessionUnavailable()
+    let record: TargetWindowScreenshotFailureRecord?
+    if isConsoleSessionUnavailable {
+        record = nil
+    } else {
+        record = cgWindowRecord(windowNumber: target.windowNumber).map { record in
+            TargetWindowScreenshotFailureRecord(
+                ownerPID: (record[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+                frame: cgWindowBounds(record[kCGWindowBounds as String]),
+                alpha: cgWindowAlpha(record[kCGWindowAlpha as String]),
+                isOnScreen: cgWindowIsOnScreen(record[kCGWindowIsOnscreen as String]),
+                layer: (record[kCGWindowLayer as String] as? NSNumber)?.intValue
+            )
+        }
     }
-
-    guard let record = cgWindowRecord(windowNumber: target.windowNumber) else {
-        return "\(base) The target window disappeared before capture, likely because the app closed, reopened, or replaced the window. \(retry)"
-    }
-
-    if let ownerPID = (record[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
-       ownerPID != target.pid
-    {
-        return "\(base) The target window id now belongs to another process, so the previous window is stale. \(retry)"
-    }
-
-    let freshFrame = cgWindowBounds(record[kCGWindowBounds as String])
-    if let freshFrame, freshFrame.width <= 0 || freshFrame.height <= 0 {
-        return "\(base) macOS reports the target window has no drawable size. \(retry)"
-    }
-
-    let alpha = cgWindowAlpha(record[kCGWindowAlpha as String])
-    if alpha <= 0.01 {
-        return "\(base) macOS reports the target window is hidden or fully transparent. \(retry)"
-    }
-
-    let isOnScreen = cgWindowIsOnScreen(record[kCGWindowIsOnscreen as String])
-    if target.onCurrentSpace == false && !isOnScreen {
-        let currentSpace = target.currentSpaceId.map(String.init) ?? "unknown"
-        let windowSpaces = formatSpaceIds(target.spaceIds)
-        return "\(base) The target window is on another macOS Space (current Space \(currentSpace), window Spaces \(windowSpaces)) and is not visible on screen. \(retry)"
-    }
-
-    if !isOnScreen {
-        return "\(base) macOS reports the target window is not visible on screen, which usually means it is minimized, hidden, offscreen, or on another Space. \(retry)"
-    }
-
-    if target.onCurrentSpace == false {
-        let currentSpace = target.currentSpaceId.map(String.init) ?? "unknown"
-        let windowSpaces = formatSpaceIds(target.spaceIds)
-        return "\(base) macOS reports the target window is on another Space (current Space \(currentSpace), window Spaces \(windowSpaces)). \(retry)"
-    }
-
-    let layer = (record[kCGWindowLayer as String] as? NSNumber)?.intValue
-    if let layer, layer != 0 {
-        return "\(base) macOS reports the selected window is not a normal app window layer. \(retry)"
-    }
-
-    return "\(base) The window still exists and appears visible, so this is likely a transient WindowServer capture failure or a protected/rapidly changing window. Retry once; if it keeps happening, ask the user to restart Zero Desktop and keep the target window visible."
+    return ComputerUseHelperCore.targetWindowScreenshotFailureMessage(
+        appName: appName,
+        target: TargetWindowScreenshotFailureTarget(
+            pid: target.pid,
+            windowNumber: target.windowNumber,
+            title: target.title,
+            onCurrentSpace: target.onCurrentSpace,
+            currentSpaceId: target.currentSpaceId,
+            spaceIds: target.spaceIds
+        ),
+        record: record,
+        currentConsoleSessionUnavailable: isConsoleSessionUnavailable
+    )
 }
 
 func visualPointerWindowStack() -> [VisualPointerStackWindow] {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1118,7 +1118,7 @@ enum BackgroundWindowScreenshot {
         return unsafeBitCast(symbol, to: CreateImageFn.self)
     }()
 
-    static func capture(windowNumber: Int) throws -> WindowScreenshot {
+    static func capture(target: WindowTarget, appName: String) throws -> WindowScreenshot {
         guard let createImage else {
             throw HelperFailure(
                 code: "screen_recording_unavailable",
@@ -1129,12 +1129,12 @@ enum BackgroundWindowScreenshot {
         guard let image = createImage(
             .null,
             CGWindowListOption.optionIncludingWindow.rawValue,
-            CGWindowID(windowNumber),
+            CGWindowID(target.windowNumber),
             imageOptions.rawValue
         )?.takeRetainedValue() else {
             throw HelperFailure(
                 code: "screen_recording_unavailable",
-                message: "Unable to capture target window screenshot"
+                message: targetWindowScreenshotFailureMessage(appName: appName, target: target)
             )
         }
         let scaledImage = scaledForTransport(image)
@@ -2101,6 +2101,88 @@ func cgWindowAlpha(_ value: Any?) -> Double {
         return value
     }
     return 1
+}
+
+func cgWindowRecord(windowNumber: Int) -> [String: Any]? {
+    guard let rawList = CGWindowListCopyWindowInfo(
+        .optionIncludingWindow,
+        CGWindowID(windowNumber)
+    ) as? [[String: Any]] else {
+        return nil
+    }
+    return rawList.first
+}
+
+func currentConsoleSessionUnavailable() -> Bool {
+    guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else {
+        return false
+    }
+    if boolValue(session["CGSSessionScreenIsLocked"]) == true {
+        return true
+    }
+    let onConsole =
+        boolValue(session["kCGSSessionOnConsoleKey"]) ??
+        boolValue(session["CGSSessionOnConsoleKey"])
+    return onConsole == false
+}
+
+func targetWindowLabel(appName: String, target: WindowTarget) -> String {
+    let title = target.title.map { " \"\($0)\"" } ?? ""
+    return "\(appName) window\(title) \(target.windowNumber)"
+}
+
+func targetWindowScreenshotFailureMessage(appName: String, target: WindowTarget) -> String {
+    let label = targetWindowLabel(appName: appName, target: target)
+    let base = "Zero has Screen Recording permission, but macOS could not capture the selected \(label)."
+    let retry = "Ask the user to bring that window to the current desktop, keep it visible and unminimized, then retry."
+
+    if currentConsoleSessionUnavailable() {
+        return "\(base) The Mac appears to be locked or not on the active console. Ask the user to unlock the Mac and retry."
+    }
+
+    guard let record = cgWindowRecord(windowNumber: target.windowNumber) else {
+        return "\(base) The target window disappeared before capture, likely because the app closed, reopened, or replaced the window. \(retry)"
+    }
+
+    if let ownerPID = (record[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+       ownerPID != target.pid
+    {
+        return "\(base) The target window id now belongs to another process, so the previous window is stale. \(retry)"
+    }
+
+    let freshFrame = cgWindowBounds(record[kCGWindowBounds as String])
+    if let freshFrame, freshFrame.width <= 0 || freshFrame.height <= 0 {
+        return "\(base) macOS reports the target window has no drawable size. \(retry)"
+    }
+
+    let alpha = cgWindowAlpha(record[kCGWindowAlpha as String])
+    if alpha <= 0.01 {
+        return "\(base) macOS reports the target window is hidden or fully transparent. \(retry)"
+    }
+
+    let isOnScreen = cgWindowIsOnScreen(record[kCGWindowIsOnscreen as String])
+    if target.onCurrentSpace == false && !isOnScreen {
+        let currentSpace = target.currentSpaceId.map(String.init) ?? "unknown"
+        let windowSpaces = formatSpaceIds(target.spaceIds)
+        return "\(base) The target window is on another macOS Space (current Space \(currentSpace), window Spaces \(windowSpaces)) and is not visible on screen. \(retry)"
+    }
+
+    if !isOnScreen {
+        return "\(base) macOS reports the target window is not visible on screen, which usually means it is minimized, hidden, offscreen, or on another Space. \(retry)"
+    }
+
+    if target.onCurrentSpace == false {
+        let currentSpace = target.currentSpaceId.map(String.init) ?? "unknown"
+        let windowSpaces = formatSpaceIds(target.spaceIds)
+        return "\(base) macOS reports the target window is on another Space (current Space \(currentSpace), window Spaces \(windowSpaces)). \(retry)"
+    }
+
+    let layer = (record[kCGWindowLayer as String] as? NSNumber)?.intValue
+    if let layer, layer != 0 {
+        return "\(base) macOS reports the selected window is not a normal app window layer. \(retry)"
+    }
+
+    return "\(base) The window still exists and appears visible, so this is likely a transient WindowServer capture failure or a protected/rapidly changing window. Retry once; if it keeps happening, ask the user to restart Zero Desktop and keep the target window visible."
 }
 
 func visualPointerWindowStack() -> [VisualPointerStackWindow] {
@@ -3719,7 +3801,10 @@ func handleAppState(_ request: [String: Any], session: ComputerUseRuntimeSession
     if response["windowTitle"] == nil, let windowTitle = target.title {
         response["windowTitle"] = windowTitle
     }
-    let screenshot = try BackgroundWindowScreenshot.capture(windowNumber: target.windowNumber)
+    let screenshot = try BackgroundWindowScreenshot.capture(
+        target: target,
+        appName: runningApp.localizedName ?? appName
+    )
     let sourceName = target.title ??
         (elements.first?["name"] as? String) ??
         runningApp.localizedName ??

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/TargetWindowScreenshotFailurePolicy.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelperCore/TargetWindowScreenshotFailurePolicy.swift
@@ -1,0 +1,116 @@
+import CoreGraphics
+
+public struct TargetWindowScreenshotFailureTarget: Sendable, Equatable {
+    public let pid: Int32
+    public let windowNumber: Int
+    public let title: String?
+    public let onCurrentSpace: Bool?
+    public let currentSpaceId: UInt64?
+    public let spaceIds: [UInt64]?
+
+    public init(
+        pid: Int32,
+        windowNumber: Int,
+        title: String?,
+        onCurrentSpace: Bool?,
+        currentSpaceId: UInt64?,
+        spaceIds: [UInt64]?
+    ) {
+        self.pid = pid
+        self.windowNumber = windowNumber
+        self.title = title
+        self.onCurrentSpace = onCurrentSpace
+        self.currentSpaceId = currentSpaceId
+        self.spaceIds = spaceIds
+    }
+}
+
+public struct TargetWindowScreenshotFailureRecord: Sendable, Equatable {
+    public let ownerPID: Int32?
+    public let frame: CGRect?
+    public let alpha: Double
+    public let isOnScreen: Bool
+    public let layer: Int?
+
+    public init(
+        ownerPID: Int32?,
+        frame: CGRect?,
+        alpha: Double,
+        isOnScreen: Bool,
+        layer: Int?
+    ) {
+        self.ownerPID = ownerPID
+        self.frame = frame
+        self.alpha = alpha
+        self.isOnScreen = isOnScreen
+        self.layer = layer
+    }
+}
+
+public func targetWindowScreenshotFailureMessage(
+    appName: String,
+    target: TargetWindowScreenshotFailureTarget,
+    record: TargetWindowScreenshotFailureRecord?,
+    currentConsoleSessionUnavailable: Bool
+) -> String {
+    let label = targetWindowScreenshotFailureLabel(appName: appName, target: target)
+    let base = "Zero has Screen Recording permission, but macOS could not capture the selected \(label)."
+    let retry = "Ask the user to bring that window to the current desktop, keep it visible and unminimized, then retry."
+
+    if currentConsoleSessionUnavailable {
+        return "\(base) The Mac appears to be locked or not on the active console. Ask the user to unlock the Mac and retry."
+    }
+
+    guard let record else {
+        return "\(base) The target window disappeared before capture, likely because the app closed, reopened, or replaced the window. \(retry)"
+    }
+
+    if let ownerPID = record.ownerPID, ownerPID != target.pid {
+        return "\(base) The target window id now belongs to another process, so the previous window is stale. \(retry)"
+    }
+
+    if let freshFrame = record.frame, freshFrame.width <= 0 || freshFrame.height <= 0 {
+        return "\(base) macOS reports the target window has no drawable size. \(retry)"
+    }
+
+    if record.alpha <= 0.01 {
+        return "\(base) macOS reports the target window is hidden or fully transparent. \(retry)"
+    }
+
+    if target.onCurrentSpace == false && !record.isOnScreen {
+        let currentSpace = target.currentSpaceId.map(String.init) ?? "unknown"
+        let windowSpaces = targetWindowScreenshotFailureSpaceIds(target.spaceIds)
+        return "\(base) The target window is on another macOS Space (current Space \(currentSpace), window Spaces \(windowSpaces)) and is not visible on screen. \(retry)"
+    }
+
+    if !record.isOnScreen {
+        return "\(base) macOS reports the target window is not visible on screen, which usually means it is minimized, hidden, offscreen, or on another Space. \(retry)"
+    }
+
+    if target.onCurrentSpace == false {
+        let currentSpace = target.currentSpaceId.map(String.init) ?? "unknown"
+        let windowSpaces = targetWindowScreenshotFailureSpaceIds(target.spaceIds)
+        return "\(base) macOS reports the target window is on another Space (current Space \(currentSpace), window Spaces \(windowSpaces)). \(retry)"
+    }
+
+    if let layer = record.layer, layer != 0 {
+        return "\(base) macOS reports the selected window is not a normal app window layer. \(retry)"
+    }
+
+    return "\(base) The window still exists and appears visible, so this is likely a transient WindowServer capture failure or a protected/rapidly changing window. Retry once; if it keeps happening, ask the user to restart Zero Desktop and keep the target window visible."
+}
+
+private func targetWindowScreenshotFailureLabel(
+    appName: String,
+    target: TargetWindowScreenshotFailureTarget
+) -> String {
+    let title = target.title.map { " \"\($0)\"" } ?? ""
+    return "\(appName) window\(title) \(target.windowNumber)"
+}
+
+private func targetWindowScreenshotFailureSpaceIds(_ spaceIds: [UInt64]?) -> String {
+    guard let spaceIds, !spaceIds.isEmpty else {
+        return "unknown"
+    }
+    return spaceIds.map(String.init).joined(separator: ", ")
+}

--- a/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/TargetWindowScreenshotFailurePolicyTests.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Tests/ComputerUseHelperCoreTests/TargetWindowScreenshotFailurePolicyTests.swift
@@ -1,0 +1,158 @@
+import CoreGraphics
+import Testing
+
+@testable import ComputerUseHelperCore
+
+struct TargetWindowScreenshotFailurePolicyTests {
+    private func target(
+        pid: Int32 = 100,
+        windowNumber: Int = 42,
+        title: String? = "Compose",
+        onCurrentSpace: Bool? = true,
+        currentSpaceId: UInt64? = 7,
+        spaceIds: [UInt64]? = [7]
+    ) -> TargetWindowScreenshotFailureTarget {
+        TargetWindowScreenshotFailureTarget(
+            pid: pid,
+            windowNumber: windowNumber,
+            title: title,
+            onCurrentSpace: onCurrentSpace,
+            currentSpaceId: currentSpaceId,
+            spaceIds: spaceIds
+        )
+    }
+
+    private func record(
+        ownerPID: Int32? = 100,
+        frame: CGRect? = CGRect(x: 0, y: 0, width: 400, height: 300),
+        alpha: Double = 1,
+        isOnScreen: Bool = true,
+        layer: Int? = 0
+    ) -> TargetWindowScreenshotFailureRecord {
+        TargetWindowScreenshotFailureRecord(
+            ownerPID: ownerPID,
+            frame: frame,
+            alpha: alpha,
+            isOnScreen: isOnScreen,
+            layer: layer
+        )
+    }
+
+    private func message(
+        target: TargetWindowScreenshotFailureTarget? = nil,
+        record: TargetWindowScreenshotFailureRecord,
+        currentConsoleSessionUnavailable: Bool = false
+    ) -> String {
+        targetWindowScreenshotFailureMessage(
+            appName: "Safari",
+            target: target ?? self.target(),
+            record: record,
+            currentConsoleSessionUnavailable: currentConsoleSessionUnavailable
+        )
+    }
+
+    @Test
+    func includesAppTitleAndWindowNumberInDiagnosticSubject() {
+        #expect(message(record: record()).contains("selected Safari window \"Compose\" 42"))
+    }
+
+    @Test
+    func reportsLockedOrInactiveConsoleBeforeInspectingWindowState() {
+        let result = targetWindowScreenshotFailureMessage(
+            appName: "Safari",
+            target: target(),
+            record: nil,
+            currentConsoleSessionUnavailable: true
+        )
+
+        #expect(result.contains("locked or not on the active console"))
+        #expect(result.contains("unlock the Mac and retry"))
+    }
+
+    @Test
+    func reportsDisappearedWindowWhenWindowServerHasNoRecord() {
+        let result = targetWindowScreenshotFailureMessage(
+            appName: "Safari",
+            target: target(),
+            record: nil,
+            currentConsoleSessionUnavailable: false
+        )
+
+        #expect(result.contains("target window disappeared before capture"))
+        #expect(result.contains("app closed, reopened, or replaced the window"))
+    }
+
+    @Test
+    func reportsStaleWindowWhenOwnerPidChanged() {
+        let result = message(record: record(ownerPID: 200))
+
+        #expect(result.contains("window id now belongs to another process"))
+        #expect(result.contains("previous window is stale"))
+    }
+
+    @Test
+    func reportsWindowWithNoDrawableSize() {
+        let result = message(record: record(frame: CGRect(x: 0, y: 0, width: 0, height: 300)))
+
+        #expect(result.contains("no drawable size"))
+    }
+
+    @Test
+    func reportsHiddenOrTransparentWindow() {
+        let result = message(record: record(alpha: 0.01))
+
+        #expect(result.contains("hidden or fully transparent"))
+    }
+
+    @Test
+    func reportsOtherSpaceAndNotVisibleWhenBothSignalsArePresent() {
+        let result = message(
+            target: target(onCurrentSpace: false, currentSpaceId: 3, spaceIds: [9, 10]),
+            record: record(isOnScreen: false)
+        )
+
+        #expect(result.contains("on another macOS Space"))
+        #expect(result.contains("current Space 3"))
+        #expect(result.contains("window Spaces 9, 10"))
+        #expect(result.contains("not visible on screen"))
+    }
+
+    @Test
+    func reportsOffscreenWindowWhenSpaceMetadataDoesNotIdentifyAnotherSpace() {
+        let result = message(
+            target: target(onCurrentSpace: nil, currentSpaceId: nil, spaceIds: nil),
+            record: record(isOnScreen: false)
+        )
+
+        #expect(result.contains("not visible on screen"))
+        #expect(result.contains("minimized, hidden, offscreen, or on another Space"))
+    }
+
+    @Test
+    func reportsOtherSpaceWhenWindowIsStillOnScreen() {
+        let result = message(
+            target: target(onCurrentSpace: false, currentSpaceId: 3, spaceIds: [9]),
+            record: record(isOnScreen: true)
+        )
+
+        #expect(result.contains("on another Space"))
+        #expect(result.contains("current Space 3"))
+        #expect(result.contains("window Spaces 9"))
+    }
+
+    @Test
+    func reportsNonNormalWindowLayer() {
+        let result = message(record: record(layer: 27))
+
+        #expect(result.contains("not a normal app window layer"))
+    }
+
+    @Test
+    func reportsTransientWindowServerFailureWhenWindowAppearsCapturable() {
+        let result = message(record: record())
+
+        #expect(result.contains("still exists and appears visible"))
+        #expect(result.contains("transient WindowServer capture failure"))
+        #expect(result.contains("protected/rapidly changing window"))
+    }
+}


### PR DESCRIPTION
## Summary

- replace the generic target-window screenshot failure message with natural-language guidance for agents
- diagnose stale windows, locked sessions, off-Space/offscreen windows, hidden windows, abnormal layers, and transient WindowServer failures
- keep the existing `screen_recording_unavailable` code for compatibility while making the `message` actionable

## Validation

- `git diff --check`
- `pnpm -F @vm0/desktop test:native` (skips on Linux by package script)

Note: native Swift build/test could not be run in this Linux agent runtime because `swift` is not installed; macOS CI should validate the helper build.
