### PR TITLE
fix(maskdb): align connector with unified mk_ scoped token model

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/maskdb_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/maskdb_0.py
@@ -12,7 +12,69 @@ JSON_PART = r"""{
         }
       },
       "base": "https://api.maskdb.ai",
-      "permissions": []
+      "permissions": [
+        {
+          "description": "Run read-only structured queries (results masked).",
+          "name": "db:query",
+          "rules": [
+            "POST /v1/databases/{db}/query"
+          ]
+        },
+        {
+          "description": "List databases, tables, masked schema, and indexes.",
+          "name": "db:metadata",
+          "rules": [
+            "GET /v1/databases",
+            "GET /v1/databases/{db}/tables",
+            "GET /v1/databases/{db}/tables/{table}/schema",
+            "GET /v1/databases/{db}/tables/{table}/indexes"
+          ]
+        },
+        {
+          "description": "Register/remove databases and read the raw (unmasked) schema.",
+          "name": "db:manage",
+          "rules": [
+            "POST /v1/databases",
+            "DELETE /v1/databases/{db}",
+            "GET /v1/databases/{db}/schema"
+          ]
+        },
+        {
+          "description": "Read a database's masking policy.",
+          "name": "policy:read",
+          "rules": [
+            "GET /v1/databases/{db}/policy"
+          ]
+        },
+        {
+          "description": "Change a database's masking policy (can unmask columns).",
+          "name": "policy:write",
+          "rules": [
+            "PUT /v1/databases/{db}/policy"
+          ]
+        },
+        {
+          "description": "Mint child tokens (scoped subsets).",
+          "name": "token:mint",
+          "rules": [
+            "POST /v1/tokens"
+          ]
+        },
+        {
+          "description": "List tokens.",
+          "name": "token:read",
+          "rules": [
+            "GET /v1/tokens"
+          ]
+        },
+        {
+          "description": "Revoke tokens.",
+          "name": "token:revoke",
+          "rules": [
+            "DELETE /v1/tokens/{id}"
+          ]
+        }
+      ]
     }
   ],
   "name": "maskdb"

--- a/turbo/packages/connectors/src/connectors/maskdb.ts
+++ b/turbo/packages/connectors/src/connectors/maskdb.ts
@@ -8,9 +8,9 @@ export const maskdb = {
       "Connect maskdb to run read-only, structured queries against a masked Postgres database. Sensitive columns are returned masked and can never be used to filter or sort.",
     authMethods: {
       "api-token": {
-        label: "Agent Token",
+        label: "Token",
         helpText:
-          "1. Open your [maskdb dashboard](https://github.com/e7h4n/maskdb)\n2. Create or copy a maskdb **agent token** (read-only data plane). It starts with `mk_agent_`\n3. Paste the agent token here",
+          "1. Open your [maskdb dashboard](https://github.com/e7h4n/maskdb)\n2. Mint a maskdb token with the `db:query` and `db:metadata` scopes (read-only). It starts with `mk_`\n3. Paste the token here",
         storage: {
           secrets: ["MASKDB_TOKEN"],
           variables: [],
@@ -19,10 +19,9 @@ export const maskdb = {
           kind: "manual",
           fields: {
             MASKDB_TOKEN: {
-              label: "Agent Token",
+              label: "Token",
               required: true,
-              placeholder:
-                "mk_agent_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc",
+              placeholder: "mk_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc",
             },
           },
         },

--- a/turbo/packages/firewalls-generator/src/maskdb.ts
+++ b/turbo/packages/firewalls-generator/src/maskdb.ts
@@ -5,14 +5,87 @@
  *
  * maskdb authenticates with a single Bearer token (a scoped read-only token):
  *   - `Authorization: Bearer <token>` → MASKDB_TOKEN (secret)
+ *
+ * Permission groups mirror maskdb's own token scopes, so the connector firewall
+ * only lets a token reach the endpoints its capability needs. A reader
+ * connector (db:query + db:metadata) can never hit the control-plane endpoints
+ * (register/remove DB, change policy, mint tokens) even if a broader token is
+ * pasted in.
  */
 
 import { writeOutput } from "./codegen";
 
 const DOCS_URL = "https://github.com/e7h4n/maskdb";
 // Format: mk_ prefix + 43 url-safe base64 chars
-const PLACEHOLDER_VALUE =
-  "mk_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc";
+const PLACEHOLDER_VALUE = "mk_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc";
+
+// Permission groups named after maskdb scopes. Each rule is `METHOD /path`
+// relative to the API base; `{…}` segments are path parameters.
+const PERMISSIONS: { name: string; description: string; rules: string[] }[] = [
+  {
+    name: "db:query",
+    description: "Run read-only structured queries (results masked).",
+    rules: ["POST /v1/databases/{db}/query"],
+  },
+  {
+    name: "db:metadata",
+    description: "List databases, tables, masked schema, and indexes.",
+    rules: [
+      "GET /v1/databases",
+      "GET /v1/databases/{db}/tables",
+      "GET /v1/databases/{db}/tables/{table}/schema",
+      "GET /v1/databases/{db}/tables/{table}/indexes",
+    ],
+  },
+  {
+    name: "db:manage",
+    description: "Register/remove databases and read the raw (unmasked) schema.",
+    rules: [
+      "POST /v1/databases",
+      "DELETE /v1/databases/{db}",
+      "GET /v1/databases/{db}/schema",
+    ],
+  },
+  {
+    name: "policy:read",
+    description: "Read a database's masking policy.",
+    rules: ["GET /v1/databases/{db}/policy"],
+  },
+  {
+    name: "policy:write",
+    description: "Change a database's masking policy (can unmask columns).",
+    rules: ["PUT /v1/databases/{db}/policy"],
+  },
+  {
+    name: "token:mint",
+    description: "Mint child tokens (scoped subsets).",
+    rules: ["POST /v1/tokens"],
+  },
+  {
+    name: "token:read",
+    description: "List tokens.",
+    rules: ["GET /v1/tokens"],
+  },
+  {
+    name: "token:revoke",
+    description: "Revoke tokens.",
+    rules: ["DELETE /v1/tokens/{id}"],
+  },
+];
+
+function renderPermissionGroups(): string[] {
+  const out: string[] = [];
+  for (const p of PERMISSIONS) {
+    out.push("        {");
+    out.push(`          name: ${JSON.stringify(p.name)},`);
+    out.push(`          description: ${JSON.stringify(p.description)},`);
+    out.push("          rules: [");
+    for (const r of p.rules) out.push(`            ${JSON.stringify(r)},`);
+    out.push("          ],");
+    out.push("        },");
+  }
+  return out;
+}
 
 function generateTypeScript(): string {
   const lines: string[] = [
@@ -38,7 +111,9 @@ function generateTypeScript(): string {
     '          Authorization: "Bearer ${{ secrets.MASKDB_TOKEN }}",',
     "        },",
     "      },",
-    "      permissions: [],",
+    "      permissions: [",
+    ...renderPermissionGroups(),
+    "      ],",
     "    },",
     "  ],",
     "} as const satisfies FirewallConfig;",

--- a/turbo/packages/firewalls-generator/src/maskdb.ts
+++ b/turbo/packages/firewalls-generator/src/maskdb.ts
@@ -39,7 +39,8 @@ const PERMISSIONS: { name: string; description: string; rules: string[] }[] = [
   },
   {
     name: "db:manage",
-    description: "Register/remove databases and read the raw (unmasked) schema.",
+    description:
+      "Register/remove databases and read the raw (unmasked) schema.",
     rules: [
       "POST /v1/databases",
       "DELETE /v1/databases/{db}",

--- a/turbo/packages/firewalls-generator/src/maskdb.ts
+++ b/turbo/packages/firewalls-generator/src/maskdb.ts
@@ -3,16 +3,16 @@
  *
  * Data source: https://github.com/e7h4n/maskdb
  *
- * maskdb authenticates with a single Bearer token (a read-only agent token):
+ * maskdb authenticates with a single Bearer token (a scoped read-only token):
  *   - `Authorization: Bearer <token>` → MASKDB_TOKEN (secret)
  */
 
 import { writeOutput } from "./codegen";
 
 const DOCS_URL = "https://github.com/e7h4n/maskdb";
-// Format: mk_agent_ prefix + 43 url-safe base64 chars
+// Format: mk_ prefix + 43 url-safe base64 chars
 const PLACEHOLDER_VALUE =
-  "mk_agent_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc";
+  "mk_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc";
 
 function generateTypeScript(): string {
   const lines: string[] = [


### PR DESCRIPTION
maskdb's auth changed from two token classes (`mk_agent_`/`mk_admin_`) to **one token class** (`mk_`) with granular scopes. This updates the merged connector:
- placeholder `mk_agent_…` → `mk_CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLoc` (mk_ + 43 base64url)
- field/method label "Agent Token" → "Token"
- help text: mint a token with `db:query` + `db:metadata` scopes (read-only)
- generator comments updated

Follow-up to #18320.