### PR TITLE
fix: retry permission action card loads

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -17,7 +17,7 @@ import { zeroOnboardingStatus$ } from "./zero-page/zero-onboarding.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { localStorageSignals } from "./external/local-storage.ts";
-import { retryAsync } from "./utils.ts";
+import { retryTransientLoad } from "./utils.ts";
 
 const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
 
@@ -43,7 +43,7 @@ function createAgentByIdFactory(): (
     const atom$ = computed(async (get) => {
       get(internalAgentByIdReload$);
       const client = get(zeroClient$)(zeroAgentsByIdContract);
-      const result = await retryAsync(() => {
+      const result = await retryTransientLoad(() => {
         return accept(client.get({ params: { id } }), [200], {
           toast: false,
         });

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -17,6 +17,7 @@ import { zeroOnboardingStatus$ } from "./zero-page/zero-onboarding.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { localStorageSignals } from "./external/local-storage.ts";
+import { retryAsync } from "./utils.ts";
 
 const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
 
@@ -42,8 +43,10 @@ function createAgentByIdFactory(): (
     const atom$ = computed(async (get) => {
       get(internalAgentByIdReload$);
       const client = get(zeroClient$)(zeroAgentsByIdContract);
-      const result = await accept(client.get({ params: { id } }), [200], {
-        toast: false,
+      const result = await retryAsync(() => {
+        return accept(client.get({ params: { id } }), [200], {
+          toast: false,
+        });
       });
       return result.body;
     });

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -4,7 +4,7 @@ import {
   loadFirewallPermissionMetadata,
   type FirewallPermissionDetailMetadata,
 } from "@vm0/connectors/firewall-metadata";
-import { retryAsync } from "./utils.ts";
+import { retryTransientLoad } from "./utils.ts";
 
 interface FirewallPermissionMetadataParams {
   readonly connectorType: string;
@@ -27,7 +27,7 @@ function createFirewallPermissionMetadataFactory(): (
       if (!isFirewallMetadataConnectorType(params.connectorType)) {
         return null;
       }
-      return await retryAsync(() => {
+      return await retryTransientLoad(() => {
         return loadFirewallPermissionMetadata(params.connectorType);
       });
     });

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -4,6 +4,7 @@ import {
   loadFirewallPermissionMetadata,
   type FirewallPermissionDetailMetadata,
 } from "@vm0/connectors/firewall-metadata";
+import { retryAsync } from "./utils.ts";
 
 interface FirewallPermissionMetadataParams {
   readonly connectorType: string;
@@ -26,7 +27,9 @@ function createFirewallPermissionMetadataFactory(): (
       if (!isFirewallMetadataConnectorType(params.connectorType)) {
         return null;
       }
-      return await loadFirewallPermissionMetadata(params.connectorType);
+      return await retryAsync(() => {
+        return loadFirewallPermissionMetadata(params.connectorType);
+      });
     });
     cache.set(key, atom$);
     return atom$;

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -18,6 +18,7 @@ import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
+import { retryAsync } from "../utils.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
 
 // ---------------------------------------------------------------------------
@@ -132,10 +133,13 @@ function createUserPermissionGrantsByAgentFactory(): (
     const atom$ = computed(async (get) => {
       get(internalUserPermissionGrantsReload$);
       const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-      const result = await accept(
-        client.list({ query: { agentId: params.agentId } }),
-        [200],
-      );
+      const result = await retryAsync(() => {
+        return accept(
+          client.list({ query: { agentId: params.agentId } }),
+          [200],
+          { toast: false },
+        );
+      });
       return result.body;
     });
     cache.set(key, atom$);

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -18,7 +18,7 @@ import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
-import { retryAsync } from "../utils.ts";
+import { retryTransientLoad } from "../utils.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
 
 // ---------------------------------------------------------------------------
@@ -133,7 +133,7 @@ function createUserPermissionGrantsByAgentFactory(): (
     const atom$ = computed(async (get) => {
       get(internalUserPermissionGrantsReload$);
       const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
-      const result = await retryAsync(() => {
+      const result = await retryTransientLoad(() => {
         return accept(
           client.list({ query: { agentId: params.agentId } }),
           [200],

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -282,6 +282,55 @@ export function toVoid<T>(p: Promise<T>): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Bounded async retry
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RETRY_DELAYS_MS = [250, 750] as const;
+
+function errorStatus(error: unknown): number | null {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof error.status === "number"
+  ) {
+    return error.status;
+  }
+  return null;
+}
+
+function isRetryableError(error: unknown): boolean {
+  const status = errorStatus(error);
+  if (status === null) {
+    return true;
+  }
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function runRetriedLoad<T>(load: () => Promise<T>): Promise<T> {
+  return Promise.resolve().then(load);
+}
+
+export async function retryAsync<T>(
+  load: () => Promise<T>,
+  delaysMs: readonly number[] = DEFAULT_RETRY_DELAYS_MS,
+): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    const result = await settle(runRetriedLoad(load));
+    if (result.ok) {
+      return result.value;
+    }
+    const delayMs = delaysMs[attempt];
+    if (delayMs === undefined || !isRetryableError(result.error)) {
+      throw result.error;
+    }
+    attempt += 1;
+    await delay(IN_VITEST ? 0 : delayMs);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Polling loop with fibonacci backoff
 // ---------------------------------------------------------------------------
 const FIB_DELAYS_MS = [

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -282,19 +282,20 @@ export function toVoid<T>(p: Promise<T>): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Bounded async retry
+// Bounded async load retry
 // ---------------------------------------------------------------------------
 
 const DEFAULT_RETRY_DELAYS_MS = [250, 750] as const;
 
 function errorStatus(error: unknown): number | null {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "status" in error &&
-    typeof error.status === "number"
-  ) {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  if ("status" in error && typeof error.status === "number") {
     return error.status;
+  }
+  if ("statusCode" in error && typeof error.statusCode === "number") {
+    return error.statusCode;
   }
   return null;
 }
@@ -311,9 +312,13 @@ function runRetriedLoad<T>(load: () => Promise<T>): Promise<T> {
   return Promise.resolve().then(load);
 }
 
-export async function retryAsync<T>(
+/**
+ * Retry idempotent read/lazy-load operations that can fail on transient
+ * network or chunk-loading errors. Do not wrap mutations: `load` may run more
+ * than once.
+ */
+export async function retryTransientLoad<T>(
   load: () => Promise<T>,
-  delaysMs: readonly number[] = DEFAULT_RETRY_DELAYS_MS,
 ): Promise<T> {
   let attempt = 0;
   while (true) {
@@ -321,7 +326,7 @@ export async function retryAsync<T>(
     if (result.ok) {
       return result.value;
     }
-    const delayMs = delaysMs[attempt];
+    const delayMs = DEFAULT_RETRY_DELAYS_MS[attempt];
     if (delayMs === undefined || !isRetryableError(result.error)) {
       throw result.error;
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -212,7 +212,7 @@ describe("chat message action cards", () => {
     ).toBeInTheDocument();
 
     await waitForButtonByText("Confirm", permissionCard);
-    expect(listRequests).toBeGreaterThanOrEqual(2);
+    expect(listRequests).toBe(2);
     expect(
       within(permissionCard).queryByText("Failed to load permissions"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -149,6 +149,90 @@ describe("chat message action cards", () => {
     });
   });
 
+  it("automatically retries permission action loading before showing an error", async () => {
+    const user = userEvent.setup({ delay: null });
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=gmail.modify&action=allow&expiresIn=1h`;
+    let listRequests = 0;
+    let capturedBody: unknown = null;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      listRequests += 1;
+      if (listRequests === 1) {
+        throw new Error("temporary permission grant load failure");
+      }
+      return respond(200, []);
+    });
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.upsert,
+      ({ body, respond }) => {
+        capturedBody = body;
+        return respond(200, {
+          agentId: body.agentId,
+          connectorRef: body.connectorRef,
+          permission: body.permission,
+          action: body.action,
+          expiresAt: "2026-06-09T12:00:00.000Z",
+          createdAt: "2026-06-09T11:00:00Z",
+          updatedAt: "2026-06-09T11:01:00Z",
+        });
+      },
+    );
+
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-permission-load-retry`,
+      threadTitle: "Permission load retry",
+      chatMessages: [
+        {
+          id: "msg-user-permission-load-retry",
+          role: "user",
+          content: "Allow Gmail modification",
+          runId: "run-permission-load-retry",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-permission-load-retry-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-permission-load-retry",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-permission-load-retry`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    expect(
+      within(permissionCard).getByText("Gmail permissions"),
+    ).toBeInTheDocument();
+    expect(
+      within(permissionCard).getByText("Allow gmail.modify"),
+    ).toBeInTheDocument();
+
+    await waitForButtonByText("Confirm", permissionCard);
+    expect(listRequests).toBeGreaterThanOrEqual(2);
+    expect(
+      within(permissionCard).queryByText("Failed to load permissions"),
+    ).not.toBeInTheDocument();
+
+    await confirmPermissionAction(user, permissionCard);
+
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Permissions updated"),
+      ).toBeInTheDocument();
+      expect(capturedBody).toMatchObject({
+        agentId: AGENT_ID,
+        connectorRef: "gmail",
+        permission: "gmail.modify",
+        action: "allow",
+        expiresIn: "1h",
+      });
+    });
+  });
+
   it("lets users change permission duration before confirming", async () => {
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -233,6 +233,54 @@ describe("chat message action cards", () => {
     });
   });
 
+  it("does not retry non-transient permission action loading failures", async () => {
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=gmail.modify&action=allow&expiresIn=1h`;
+    let listRequests = 0;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      listRequests += 1;
+      return respond(403, {
+        error: {
+          code: "FORBIDDEN",
+          message: "Forbidden",
+        },
+      });
+    });
+
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-permission-load-forbidden`,
+      threadTitle: "Permission load forbidden",
+      chatMessages: [
+        {
+          id: "msg-user-permission-load-forbidden",
+          role: "user",
+          content: "Allow Gmail modification",
+          runId: "run-permission-load-forbidden",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-permission-load-forbidden-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-permission-load-forbidden",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-permission-load-forbidden`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitFor(() => {
+      expect(
+        buttonByText("Failed to load permissions", permissionCard),
+      ).toBeDisabled();
+    });
+    expect(listRequests).toBe(1);
+  });
+
   it("lets users change permission duration before confirming", async () => {
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;


### PR DESCRIPTION
## Summary
- add bounded retry for permission action card read paths
- retry firewall permission metadata dynamic loads and agent/grant reads on transient failures
- keep permanent 4xx load failures non-retryable
- add integration tests covering transient recovery and permanent failure behavior

Fixes #18296

## Tests
- cd turbo && pnpm -F @vm0/app check-types
- cd turbo && pnpm -F @vm0/app lint
- cd turbo && pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/permission-allow/__tests__/permission-allow-page.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx
- git diff --check
- pre-commit: prettier, knip, turbo check-types