### PR TITLE
refactor: migrate sandbox-fc exec capture to structured results

### DIFF
--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -20,6 +20,7 @@ use super::protocol::{
 };
 use crate::exec_result_compat::{
     captured_exec_output_bytes, legacy_exit_code_for_exec_termination, reject_stream_overflow,
+    validate_legacy_exec_capture_timeout,
 };
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::park_coordinator::ParkCoordinator;
@@ -433,6 +434,12 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
 
     let timeout_ms = request.timeout_secs.saturating_mul(1000);
     let env: &[(&str, &str)] = &[];
+
+    if let Err(e) = validate_legacy_exec_capture_timeout(timeout_ms) {
+        return ExecResponse::Error {
+            error: format!("exec failed: {e}"),
+        };
+    }
 
     let result = vsock
         .exec_operation_capture(vsock_host::ExecCaptureRequest {

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -18,6 +18,9 @@ use super::protocol::{
     ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
     TerminateStatus, read_frame, write_frame,
 };
+use crate::exec_result_compat::{
+    captured_exec_output_bytes, legacy_exit_code_for_exec_termination, reject_stream_overflow,
+};
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::park_coordinator::ParkCoordinator;
 
@@ -432,7 +435,7 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
     let env: &[(&str, &str)] = &[];
 
     let result = vsock
-        .exec_capture(vsock_host::ExecCaptureRequest {
+        .exec_operation_capture(vsock_host::ExecCaptureRequest {
             command: &request.command,
             timeout_ms,
             env,
@@ -444,20 +447,41 @@ async fn execute(request: ExecRequest, guest_operations: &GuestOperationStartGat
             stdin_bytes: None,
             wait_timeout: Duration::from_millis(timeout_ms as u64 + CONTROL_SOCKET_OVERHEAD_MS),
         })
-        .await;
+        .await
+        .and_then(exec_response_from_operation_result);
 
     match result {
-        Ok(result) => ExecResponse::Success {
-            exit_code: result.exit_code,
-            stdout: BASE64.encode(&result.stdout),
-            stderr: BASE64.encode(&result.stderr),
-            stdout_truncated: result.stdout_truncated,
-            stderr_truncated: result.stderr_truncated,
-        },
+        Ok(response) => response,
         Err(e) => ExecResponse::Error {
             error: format!("exec failed: {e}"),
         },
     }
+}
+
+fn exec_response_from_operation_result(
+    result: vsock_host::ExecOperationResult,
+) -> io::Result<ExecResponse> {
+    reject_stream_overflow(&result)?;
+
+    let vsock_host::ExecOperationResult {
+        termination,
+        stdout,
+        stderr,
+        diagnostic,
+        ..
+    } = result;
+
+    let (stdout, stdout_truncated) = captured_exec_output_bytes("stdout", stdout)?;
+    let (mut stderr, stderr_truncated) = captured_exec_output_bytes("stderr", stderr)?;
+    let exit_code = legacy_exit_code_for_exec_termination(termination, &mut stderr, &diagnostic);
+
+    Ok(ExecResponse::Success {
+        exit_code,
+        stdout: BASE64.encode(stdout),
+        stderr: BASE64.encode(stderr),
+        stdout_truncated,
+        stderr_truncated,
+    })
 }
 
 fn control_start_error(error: GuestOperationStartError) -> String {

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -713,6 +713,41 @@ async fn control_exec_rejects_when_policy_gate_is_closing() {
 }
 
 #[tokio::test]
+async fn control_exec_rejects_zero_timeout_without_guest_exec() {
+    let (exec_seen_tx, mut exec_seen_rx) = oneshot::channel();
+    let fixture =
+        VsockExecFixture::connect(|vsock_base| mock_guest_records_exec(vsock_base, exec_seen_tx))
+            .await;
+    let mut handle = fixture.spawn_server();
+    let request = ExecRequest {
+        command: "echo should-not-run".into(),
+        timeout_secs: 0,
+        sudo: false,
+    };
+    let response = send_exec(&fixture.sock_path, &request, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    match response {
+        ExecResponse::Error { error } => {
+            assert_eq!(
+                error,
+                "exec failed: exec requires a positive timeout; use supervised exec for unbounded commands"
+            );
+        }
+        ExecResponse::Success { .. } => panic!("expected zero-timeout validation error"),
+    }
+    assert!(
+        exec_seen_rx.try_recv().is_err(),
+        "control exec should not send a guest command with zero timeout"
+    );
+
+    handle.shutdown().await;
+    fixture.guest_task.abort();
+    let _ = fixture.guest_task.await;
+}
+
+#[tokio::test]
 async fn control_exec_terminal_guest_error_completes_vsock_operation() {
     let fixture = VsockExecFixture::connect(|vsock_base| {
         mock_guest_errors_exec(vsock_base, "guest refused exec")

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 
 use base64::Engine;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::{mpsc, oneshot};
 use vsock_host::{ExecOwnedCapturedOutput, NormalOperationFenceRejection, VsockHost};
 use vsock_proto::{
@@ -702,8 +703,8 @@ async fn control_exec_rejects_when_policy_gate_is_closing() {
         ExecResponse::Success { .. } => panic!("expected gate-closed error"),
     }
     assert!(
-        exec_seen_rx.try_recv().is_err(),
-        "control exec should not send a guest command while the gate is closing"
+        matches!(exec_seen_rx.try_recv(), Err(TryRecvError::Empty)),
+        "control exec should not send a guest command while the gate is closing or drop the mock guest"
     );
 
     handle.shutdown().await;
@@ -738,8 +739,8 @@ async fn control_exec_rejects_zero_timeout_without_guest_exec() {
         ExecResponse::Success { .. } => panic!("expected zero-timeout validation error"),
     }
     assert!(
-        exec_seen_rx.try_recv().is_err(),
-        "control exec should not send a guest command with zero timeout"
+        matches!(exec_seen_rx.try_recv(), Err(TryRecvError::Empty)),
+        "control exec should not send a guest command with zero timeout or drop the mock guest"
     );
 
     handle.shutdown().await;

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -2,15 +2,19 @@ use super::*;
 
 use std::future::Future;
 
+use base64::Engine;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
-use vsock_host::{NormalOperationFenceRejection, VsockHost};
-use vsock_proto::{Decoder, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage};
+use vsock_host::{ExecOwnedCapturedOutput, NormalOperationFenceRejection, VsockHost};
+use vsock_proto::{
+    Decoder, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_PING, MSG_PONG, MSG_READY, RawMessage,
+};
 
 use crate::control::{
     ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
     TerminateStatus, send_exec, send_terminate,
 };
+use crate::exec_result_compat::EXEC_TIMEOUT_EXIT_CODE;
 use crate::park_coordinator::{
     CoordinatorState, DirtyReason, ParkCoordinator, PrepareParkEvidence,
 };
@@ -112,6 +116,47 @@ fn exec_request(command: &str) -> ExecRequest {
     }
 }
 
+fn control_exec_result(
+    termination: ExecTermination,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    diagnostic: &str,
+) -> vsock_host::ExecOperationResult {
+    vsock_host::ExecOperationResult {
+        termination,
+        duration_ms: 10,
+        stdout: ExecOwnedCapturedOutput::Captured {
+            bytes: stdout,
+            truncated: true,
+        },
+        stderr: ExecOwnedCapturedOutput::Captured {
+            bytes: stderr,
+            truncated: false,
+        },
+        diagnostic: diagnostic.to_string(),
+        stream_overflowed: false,
+    }
+}
+
+fn expect_exec_success(response: ExecResponse) -> (i32, Vec<u8>, Vec<u8>, bool, bool) {
+    match response {
+        ExecResponse::Success {
+            exit_code,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+        } => (
+            exit_code,
+            BASE64.decode(stdout).expect("stdout should decode"),
+            BASE64.decode(stderr).expect("stderr should decode"),
+            stdout_truncated,
+            stderr_truncated,
+        ),
+        ExecResponse::Error { error } => panic!("expected success response, got error: {error}"),
+    }
+}
+
 fn test_gate(guest: GuestState) -> GuestOperationStartGate {
     GuestOperationStartGate::new(guest, ParkCoordinator::new())
 }
@@ -145,6 +190,114 @@ fn bind_test_server(
     guest_operations: GuestOperationStartGate,
 ) -> io::Result<BoundControlServer> {
     bind_server(sock_path, guest_operations, test_termination_handle())
+}
+
+#[test]
+fn control_exec_result_preserves_ordinary_exit_compatibility() {
+    let response = exec_response_from_operation_result(control_exec_result(
+        ExecTermination::Exited { exit_code: 7 },
+        b"out".to_vec(),
+        b"err".to_vec(),
+        "ignored",
+    ))
+    .expect("ordinary exit should convert");
+
+    let (exit_code, stdout, stderr, stdout_truncated, stderr_truncated) =
+        expect_exec_success(response);
+    assert_eq!(exit_code, 7);
+    assert_eq!(stdout, b"out");
+    assert_eq!(stderr, b"err");
+    assert!(stdout_truncated);
+    assert!(!stderr_truncated);
+}
+
+#[test]
+fn control_exec_result_preserves_terminal_state_compatibility_mapping() {
+    for (termination, diagnostic, expected_code, expected_stderr) in [
+        (
+            ExecTermination::TimedOut,
+            "",
+            EXEC_TIMEOUT_EXIT_CODE,
+            "Timeout",
+        ),
+        (
+            ExecTermination::Cancelled,
+            "cancel diagnostic",
+            1,
+            "Cancelled\ncancel diagnostic",
+        ),
+        (
+            ExecTermination::StartFailed,
+            "spawn failed",
+            1,
+            "spawn failed",
+        ),
+        (
+            ExecTermination::WaitFailed,
+            "wait failed",
+            1,
+            "stderr clue\nwait failed",
+        ),
+    ] {
+        let stderr = if matches!(termination, ExecTermination::WaitFailed) {
+            b"stderr clue".to_vec()
+        } else {
+            Vec::new()
+        };
+        let response = exec_response_from_operation_result(control_exec_result(
+            termination,
+            Vec::new(),
+            stderr,
+            diagnostic,
+        ))
+        .expect("terminal state should convert to compatibility response");
+
+        let (exit_code, _, stderr, _, _) = expect_exec_success(response);
+        assert_eq!(exit_code, expected_code);
+        assert_eq!(String::from_utf8(stderr).unwrap(), expected_stderr);
+    }
+}
+
+#[test]
+fn control_exec_result_rejects_invalid_capture_state() {
+    let overflow = exec_response_from_operation_result(vsock_host::ExecOperationResult {
+        stream_overflowed: true,
+        ..control_exec_result(
+            ExecTermination::Exited { exit_code: 0 },
+            Vec::new(),
+            Vec::new(),
+            "",
+        )
+    })
+    .expect_err("stream overflow should fail");
+    assert_eq!(overflow.kind(), io::ErrorKind::InvalidData);
+    assert!(overflow.to_string().contains("overflowed a stream queue"));
+
+    let stdout_discarded = exec_response_from_operation_result(vsock_host::ExecOperationResult {
+        stdout: ExecOwnedCapturedOutput::Discarded,
+        ..control_exec_result(
+            ExecTermination::Exited { exit_code: 0 },
+            Vec::new(),
+            Vec::new(),
+            "",
+        )
+    })
+    .expect_err("discarded stdout should fail");
+    assert_eq!(stdout_discarded.kind(), io::ErrorKind::InvalidData);
+    assert!(stdout_discarded.to_string().contains("discarded stdout"));
+
+    let stderr_discarded = exec_response_from_operation_result(vsock_host::ExecOperationResult {
+        stderr: ExecOwnedCapturedOutput::Discarded,
+        ..control_exec_result(
+            ExecTermination::Exited { exit_code: 0 },
+            Vec::new(),
+            Vec::new(),
+            "",
+        )
+    })
+    .expect_err("discarded stderr should fail");
+    assert_eq!(stderr_discarded.kind(), io::ErrorKind::InvalidData);
+    assert!(stderr_discarded.to_string().contains("discarded stderr"));
 }
 
 async fn recv_termination_request(

--- a/crates/sandbox-fc/src/exec_result_compat.rs
+++ b/crates/sandbox-fc/src/exec_result_compat.rs
@@ -30,7 +30,7 @@ pub(crate) fn captured_exec_output_bytes(
     }
 }
 
-pub(crate) fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
+fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
     if diagnostic.is_empty() {
         return;
     }

--- a/crates/sandbox-fc/src/exec_result_compat.rs
+++ b/crates/sandbox-fc/src/exec_result_compat.rs
@@ -1,0 +1,68 @@
+use std::io;
+
+use vsock_host::{ExecOperationResult, ExecOwnedCapturedOutput};
+use vsock_proto::ExecTermination;
+
+/// Exit code historically used for timed-out guest exec operations.
+pub(crate) const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
+
+pub(crate) fn reject_stream_overflow(result: &ExecOperationResult) -> io::Result<()> {
+    if result.stream_overflowed {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "exec capture unexpectedly overflowed a stream queue",
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn captured_exec_output_bytes(
+    name: &str,
+    output: ExecOwnedCapturedOutput,
+) -> io::Result<(Vec<u8>, bool)> {
+    match output {
+        ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
+        ExecOwnedCapturedOutput::Discarded => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("exec result discarded {name} for capture request"),
+        )),
+    }
+}
+
+pub(crate) fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
+    if diagnostic.is_empty() {
+        return;
+    }
+    if !stderr.is_empty() && !stderr.ends_with(b"\n") {
+        stderr.push(b'\n');
+    }
+    stderr.extend_from_slice(diagnostic.as_bytes());
+}
+
+pub(crate) fn legacy_exit_code_for_exec_termination(
+    termination: ExecTermination,
+    stderr: &mut Vec<u8>,
+    diagnostic: &str,
+) -> i32 {
+    match termination {
+        ExecTermination::Exited { exit_code } => exit_code,
+        ExecTermination::TimedOut => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Timeout");
+            }
+            EXEC_TIMEOUT_EXIT_CODE
+        }
+        ExecTermination::Cancelled => {
+            if stderr.is_empty() {
+                stderr.extend_from_slice(b"Cancelled");
+            }
+            append_diagnostic(stderr, diagnostic);
+            1
+        }
+        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
+            append_diagnostic(stderr, diagnostic);
+            1
+        }
+    }
+}

--- a/crates/sandbox-fc/src/exec_result_compat.rs
+++ b/crates/sandbox-fc/src/exec_result_compat.rs
@@ -6,6 +6,17 @@ use vsock_proto::ExecTermination;
 /// Exit code historically used for timed-out guest exec operations.
 pub(crate) const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 
+pub(crate) fn validate_legacy_exec_capture_timeout(timeout_ms: u32) -> io::Result<()> {
+    if timeout_ms == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "exec requires a positive timeout; use supervised exec for unbounded commands",
+        ));
+    }
+
+    Ok(())
+}
+
 pub(crate) fn reject_stream_overflow(result: &ExecOperationResult) -> io::Result<()> {
     if result.stream_overflowed {
         return Err(io::Error::new(

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -30,6 +30,7 @@ mod config;
 pub mod control;
 mod cow_cleanup;
 mod cow_pool;
+mod exec_result_compat;
 mod factory;
 mod guest_operations;
 mod leaked_resources;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -37,6 +37,7 @@ use crate::control;
 use crate::exec_result_compat::EXEC_TIMEOUT_EXIT_CODE;
 use crate::exec_result_compat::{
     captured_exec_output_bytes, legacy_exit_code_for_exec_termination, reject_stream_overflow,
+    validate_legacy_exec_capture_timeout,
 };
 use crate::factory::InvariantConfig;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
@@ -2089,12 +2090,7 @@ impl Sandbox for FirecrackerSandbox {
             operation,
             || Self::validate_exec_env_keys(operation, request.env),
             |guest| async move {
-                if timeout_ms == 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "exec requires a positive timeout; use supervised exec for unbounded commands",
-                    ));
-                }
+                validate_legacy_exec_capture_timeout(timeout_ms)?;
                 guest
                     .exec_operation_capture(vsock_host::ExecCaptureRequest {
                         command: request.cmd,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -33,6 +33,11 @@ use crate::api::ApiClient;
 use crate::balloon;
 use crate::config::{FirecrackerConfig, FirecrackerDeviceRateLimits};
 use crate::control;
+#[cfg(test)]
+use crate::exec_result_compat::EXEC_TIMEOUT_EXIT_CODE;
+use crate::exec_result_compat::{
+    captured_exec_output_bytes, legacy_exit_code_for_exec_termination, reject_stream_overflow,
+};
 use crate::factory::InvariantConfig;
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::leaked_resources::LeakedResources;
@@ -48,9 +53,6 @@ use crate::process::{ChildExitNotifier, kill_process_group};
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Timeout for receiving a process start acknowledgement from the guest.
 const PROCESS_START_ACK_TIMEOUT: Duration = Duration::from_secs(30);
-/// Exit code returned by guest exec timeout handling.
-const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
-
 /// Timeout for graceful shutdown via vsock.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -1613,29 +1615,6 @@ fn captured_output_bytes(output: ExecOwnedCapturedOutput) -> (Vec<u8>, bool) {
     }
 }
 
-fn captured_exec_output_bytes(
-    name: &str,
-    output: ExecOwnedCapturedOutput,
-) -> io::Result<(Vec<u8>, bool)> {
-    match output {
-        ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
-        ExecOwnedCapturedOutput::Discarded => Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("exec result discarded {name} for capture request"),
-        )),
-    }
-}
-
-fn append_diagnostic(stderr: &mut Vec<u8>, diagnostic: &str) {
-    if diagnostic.is_empty() {
-        return;
-    }
-    if !stderr.is_empty() && !stderr.ends_with(b"\n") {
-        stderr.push(b'\n');
-    }
-    stderr.extend_from_slice(diagnostic.as_bytes());
-}
-
 fn process_termination_kind(termination: ExecTermination) -> ProcessTerminationKind {
     match termination {
         ExecTermination::Exited { .. } => ProcessTerminationKind::Exited,
@@ -1646,42 +1625,10 @@ fn process_termination_kind(termination: ExecTermination) -> ProcessTerminationK
     }
 }
 
-fn legacy_exit_code_for_exec_termination(
-    termination: ExecTermination,
-    stderr: &mut Vec<u8>,
-    diagnostic: &str,
-) -> i32 {
-    match termination {
-        ExecTermination::Exited { exit_code } => exit_code,
-        ExecTermination::TimedOut => {
-            if stderr.is_empty() {
-                stderr.extend_from_slice(b"Timeout");
-            }
-            EXEC_TIMEOUT_EXIT_CODE
-        }
-        ExecTermination::Cancelled => {
-            if stderr.is_empty() {
-                stderr.extend_from_slice(b"Cancelled");
-            }
-            append_diagnostic(stderr, diagnostic);
-            1
-        }
-        ExecTermination::StartFailed | ExecTermination::WaitFailed => {
-            append_diagnostic(stderr, diagnostic);
-            1
-        }
-    }
-}
-
 fn bounded_exec_result_to_exec_result(
     result: vsock_host::ExecOperationResult,
 ) -> io::Result<ExecResult> {
-    if result.stream_overflowed {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "exec capture unexpectedly overflowed a stream queue",
-        ));
-    }
+    reject_stream_overflow(&result)?;
 
     let termination = process_termination_kind(result.termination);
     let (stdout, stdout_truncated) = captured_exec_output_bytes("stdout", result.stdout)?;

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::future::Future;
+use std::io;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -8,9 +9,11 @@ use std::time::Duration;
 use tokio::io::AsyncBufReadExt;
 use tokio::task::JoinHandle;
 use tracing::info;
+use vsock_proto::ExecTermination;
 
 use crate::api::ApiClient;
 use crate::config::SnapshotConfig;
+use crate::exec_result_compat::{captured_exec_output_bytes, reject_stream_overflow};
 use crate::factory::InvariantConfig;
 use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process::kill_process_group;
@@ -323,7 +326,7 @@ async fn run_with_firecracker(
     //      are fast. The snapshot captures memory + disk state, so caches
     //      populated here persist across restores.
     let prewarm_result = guest
-        .exec_capture(vsock_host::ExecCaptureRequest {
+        .exec_operation_capture(vsock_host::ExecCaptureRequest {
             command: inv.prewarm_script,
             timeout_ms: 30_000,
             env: &[],
@@ -337,14 +340,7 @@ async fn run_with_firecracker(
         })
         .await
         .map_err(|e| SnapshotError::Setup(format!("pre-warm exec: {e}")))?;
-    if prewarm_result.exit_code != 0 {
-        let stderr = String::from_utf8_lossy(&prewarm_result.stderr);
-        return Err(SnapshotError::Setup(format!(
-            "pre-warm failed (exit code {}): {}",
-            prewarm_result.exit_code,
-            stderr.trim(),
-        )));
-    }
+    validate_prewarm_exec_result(prewarm_result)?;
     info!("pre-warm complete");
 
     // 10. Pause VM.
@@ -373,6 +369,62 @@ async fn run_with_firecracker(
     info!(output_dir = %config.output_dir.display(), "snapshot creation complete");
 
     Ok(output.snapshot_config(&config.id))
+}
+
+fn validate_prewarm_exec_result(
+    result: vsock_host::ExecOperationResult,
+) -> Result<(), SnapshotError> {
+    let (termination, stderr, diagnostic) = prewarm_exec_result_parts(result)
+        .map_err(|e| SnapshotError::Setup(format!("pre-warm exec: {e}")))?;
+    let stderr = String::from_utf8_lossy(&stderr);
+    let stderr = stderr.trim();
+
+    match termination {
+        ExecTermination::Exited { exit_code: 0 } => Ok(()),
+        ExecTermination::Exited { exit_code } => Err(SnapshotError::Setup(format!(
+            "pre-warm failed (exit code {exit_code}): {stderr}",
+        ))),
+        termination => {
+            let detail = prewarm_failure_detail(stderr, &diagnostic);
+            if detail.is_empty() {
+                Err(SnapshotError::Setup(format!(
+                    "pre-warm failed (termination {termination:?})"
+                )))
+            } else {
+                Err(SnapshotError::Setup(format!(
+                    "pre-warm failed (termination {termination:?}): {detail}"
+                )))
+            }
+        }
+    }
+}
+
+fn prewarm_exec_result_parts(
+    result: vsock_host::ExecOperationResult,
+) -> io::Result<(ExecTermination, Vec<u8>, String)> {
+    reject_stream_overflow(&result)?;
+
+    let vsock_host::ExecOperationResult {
+        termination,
+        stdout,
+        stderr,
+        diagnostic,
+        ..
+    } = result;
+
+    let _ = captured_exec_output_bytes("stdout", stdout)?;
+    let (stderr, _) = captured_exec_output_bytes("stderr", stderr)?;
+    Ok((termination, stderr, diagnostic))
+}
+
+fn prewarm_failure_detail(stderr: &str, diagnostic: &str) -> String {
+    let diagnostic = diagnostic.trim();
+    match (stderr.is_empty(), diagnostic.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => stderr.to_string(),
+        (true, false) => diagnostic.to_string(),
+        (false, false) => format!("{stderr}; diagnostic: {diagnostic}"),
+    }
 }
 
 async fn configure_snapshot_vm(
@@ -441,6 +493,115 @@ mod tests {
             memory_mb: 512,
             workspace_disk_mb: 1024,
         }
+    }
+
+    fn prewarm_result(
+        termination: ExecTermination,
+        stderr: Vec<u8>,
+        diagnostic: &str,
+    ) -> vsock_host::ExecOperationResult {
+        vsock_host::ExecOperationResult {
+            termination,
+            duration_ms: 10,
+            stdout: vsock_host::ExecOwnedCapturedOutput::Captured {
+                bytes: Vec::new(),
+                truncated: false,
+            },
+            stderr: vsock_host::ExecOwnedCapturedOutput::Captured {
+                bytes: stderr,
+                truncated: false,
+            },
+            diagnostic: diagnostic.to_string(),
+            stream_overflowed: false,
+        }
+    }
+
+    fn expect_prewarm_setup_error(result: Result<(), SnapshotError>) -> String {
+        match result {
+            Ok(()) => panic!("expected prewarm setup error"),
+            Err(SnapshotError::Setup(message)) => message,
+            Err(other) => panic!("expected prewarm setup error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prewarm_exec_result_accepts_exited_zero() {
+        validate_prewarm_exec_result(prewarm_result(
+            ExecTermination::Exited { exit_code: 0 },
+            Vec::new(),
+            "",
+        ))
+        .expect("zero exit should succeed");
+    }
+
+    #[test]
+    fn prewarm_exec_result_preserves_nonzero_exit_wording() {
+        let message = expect_prewarm_setup_error(validate_prewarm_exec_result(prewarm_result(
+            ExecTermination::Exited { exit_code: 7 },
+            b"prewarm failed\n".to_vec(),
+            "ignored",
+        )));
+
+        assert_eq!(message, "pre-warm failed (exit code 7): prewarm failed");
+    }
+
+    #[test]
+    fn prewarm_exec_result_reports_structured_terminal_states() {
+        for (termination, diagnostic, expected) in [
+            (ExecTermination::TimedOut, "", "TimedOut"),
+            (ExecTermination::Cancelled, "cancelled by host", "Cancelled"),
+            (ExecTermination::StartFailed, "spawn failed", "StartFailed"),
+            (ExecTermination::WaitFailed, "wait failed", "WaitFailed"),
+        ] {
+            let message = expect_prewarm_setup_error(validate_prewarm_exec_result(prewarm_result(
+                termination,
+                b"stderr clue".to_vec(),
+                diagnostic,
+            )));
+
+            assert!(message.contains(expected), "got: {message}");
+            assert!(message.contains("stderr clue"), "got: {message}");
+            if !diagnostic.is_empty() {
+                assert!(message.contains(diagnostic), "got: {message}");
+            }
+        }
+    }
+
+    #[test]
+    fn prewarm_exec_result_rejects_invalid_capture_state() {
+        let overflow = expect_prewarm_setup_error(validate_prewarm_exec_result(
+            vsock_host::ExecOperationResult {
+                stream_overflowed: true,
+                ..prewarm_result(ExecTermination::Exited { exit_code: 0 }, Vec::new(), "")
+            },
+        ));
+        assert!(overflow.contains("pre-warm exec"), "got: {overflow}");
+        assert!(
+            overflow.contains("overflowed a stream queue"),
+            "got: {overflow}"
+        );
+
+        let stdout_discarded = expect_prewarm_setup_error(validate_prewarm_exec_result(
+            vsock_host::ExecOperationResult {
+                stdout: vsock_host::ExecOwnedCapturedOutput::Discarded,
+                ..prewarm_result(ExecTermination::Exited { exit_code: 0 }, Vec::new(), "")
+            },
+        ));
+        assert!(
+            stdout_discarded.contains("discarded stdout"),
+            "got: {stdout_discarded}"
+        );
+
+        let stderr_discarded = expect_prewarm_setup_error(validate_prewarm_exec_result(
+            vsock_host::ExecOperationResult {
+                stderr: vsock_host::ExecOwnedCapturedOutput::Discarded,
+                ..prewarm_result(ExecTermination::Exited { exit_code: 0 }, Vec::new(), "")
+            },
+        ));
+        assert!(
+            stderr_discarded.contains("discarded stderr"),
+            "got: {stderr_discarded}"
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -568,6 +568,31 @@ mod tests {
     }
 
     #[test]
+    fn prewarm_exec_result_reports_terminal_state_without_detail() {
+        let message = expect_prewarm_setup_error(validate_prewarm_exec_result(prewarm_result(
+            ExecTermination::TimedOut,
+            Vec::new(),
+            "",
+        )));
+
+        assert_eq!(message, "pre-warm failed (termination TimedOut)");
+    }
+
+    #[test]
+    fn prewarm_exec_result_reports_terminal_state_with_diagnostic_only() {
+        let message = expect_prewarm_setup_error(validate_prewarm_exec_result(prewarm_result(
+            ExecTermination::StartFailed,
+            Vec::new(),
+            "spawn failed",
+        )));
+
+        assert_eq!(
+            message,
+            "pre-warm failed (termination StartFailed): spawn failed"
+        );
+    }
+
+    #[test]
     fn prewarm_exec_result_rejects_invalid_capture_state() {
         let overflow = expect_prewarm_setup_error(validate_prewarm_exec_result(
             vsock_host::ExecOperationResult {


### PR DESCRIPTION
## Summary
- Replace sandbox-fc direct `VsockHost::exec_capture` usage with `exec_operation_capture` plus local compatibility conversion.
- Share legacy exec result mapping for sandbox exec and control exec responses so external contracts remain unchanged.
- Preserve snapshot pre-warm success handling while reporting structured terminal states and invalid capture states clearly.

Fixes #18237

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::runtime`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::server`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo check --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`