### PR TITLE
fix: restore stripe cli device auth

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -434,9 +434,6 @@ describe("CONN-02: OAuth device authorization", () => {
 
     const bdd = createBddApi(context);
     const actor = bdd.user();
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.StripeConnector]: true,
-    });
 
     const session = await connectorsApi.startDeviceAuth(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -34,6 +34,7 @@ import {
   mockGithubAppInstallProvider,
   mockSlackConnectorOAuth,
   mockSlockOAuthProvider,
+  mockStripeCliDashboardAuth,
   mockTestOAuthAuthCodeProvider,
   mockTestOAuthDeviceConnectorProvider,
   requestOauthCallbackRaw,
@@ -428,6 +429,80 @@ describe("CONN-02: OAuth device authorization", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
+  it("starts and completes the Stripe CLI device authorization method", async () => {
+    const stripeProvider = mockStripeCliDashboardAuth();
+
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.StripeConnector]: true,
+    });
+
+    const session = await connectorsApi.startDeviceAuth(
+      actor,
+      "stripe",
+      "cli",
+      { mode: "live" },
+    );
+    expect(session).toMatchObject({
+      type: "stripe",
+      status: "pending",
+      userCode: "STRIPE-CLI",
+      verificationUri:
+        "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI",
+      verificationUriComplete:
+        "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI",
+      expiresIn: 600,
+      interval: 1,
+    });
+    expect(stripeProvider.startBodies[0]?.get("client_version")).toBe("1.42.1");
+    expect(stripeProvider.startBodies[0]?.get("device_name")).toBe(
+      "vm0-stripe-connector",
+    );
+
+    mockNow(now() + 2000);
+    const poll = await connectorsApi.pollDeviceAuth(
+      actor,
+      "stripe",
+      session.sessionId,
+      session.sessionToken,
+    );
+    expect(poll.status).toBe("complete");
+    if (poll.status !== "complete") {
+      throw new Error(
+        `Expected complete Stripe device auth, got ${poll.status}`,
+      );
+    }
+    expect(poll.connector).toMatchObject({
+      type: "stripe",
+      authMethod: "cli",
+      externalId: "acct_bdd",
+      externalUsername: "BDD Stripe",
+      externalEmail: null,
+      oauthScopes: [],
+      connectionStatus: "connected",
+    });
+    expect(JSON.stringify(poll)).not.toContain("rk_live_api456");
+    expect(stripeProvider.pollCount()).toBe(1);
+    clearMockNow();
+
+    const listed = await connectorsApi.listConnectors(actor);
+    expect(connectorByType(listed.connectors, "stripe")?.id).toBe(
+      poll.connector.id,
+    );
+    expect(listed.connectorProvidedBindings).toContainEqual(
+      expect.objectContaining({
+        connectorType: "stripe",
+        authMethod: "cli",
+        namespace: "secrets",
+        name: "STRIPE_TOKEN",
+      }),
+    );
+
+    await connectorsApi.deleteConnectorByType(actor, "stripe");
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
   it("rejects device-auth starts through visible validation, grant, and availability boundaries", async () => {
     const testOauthProvider = mockTestOAuthDeviceConnectorProvider();
     const bdd = createBddApi(context);
@@ -540,7 +615,7 @@ describe("CONN-02: OAuth device authorization", () => {
     );
     expectApiError(stripeDeviceAuth.body);
     expect(stripeDeviceAuth.body.error.message).toBe(
-      "stripe connector does not support a device-auth grant",
+      "stripe cli device-auth start option mode must be one of: test, live",
     );
 
     const disabled = await connectorsApi.requestDeviceAuthStart(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -83,6 +83,11 @@ const SLOCK_DEVICE_CODE_URL = "https://api.slock.ai/api/auth/device/authorize";
 const SLOCK_TOKEN_URL = "https://api.slock.ai/api/auth/device/token";
 const SLOCK_USERINFO_URL = "https://api.slock.ai/api/auth/me";
 const SLOCK_SERVERS_URL = "https://api.slock.ai/api/servers";
+const STRIPE_CLI_AUTH_URL = "https://dashboard.stripe.com/stripecli/auth";
+const STRIPE_CLI_BROWSER_URL =
+  "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI";
+const STRIPE_CLI_POLL_URL =
+  "https://dashboard.stripe.com/stripecli/auth/poll-session";
 const TEST_OAUTH_USERINFO_URL =
   "http://localhost:3000/api/test/oauth-provider/userinfo";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";
@@ -824,6 +829,46 @@ export function mockSlockOAuthProvider(
   );
 
   return { accessToken };
+}
+
+interface StripeCliDashboardAuthMock {
+  readonly startBodies: URLSearchParams[];
+  readonly pollCount: () => number;
+}
+
+export function mockStripeCliDashboardAuth(): StripeCliDashboardAuthMock {
+  const startBodies: URLSearchParams[] = [];
+  let pollCount = 0;
+
+  server.use(
+    http.post(STRIPE_CLI_AUTH_URL, async ({ request }) => {
+      startBodies.push(new URLSearchParams(await request.text()));
+      return HttpResponse.json({
+        browser_url: STRIPE_CLI_BROWSER_URL,
+        poll_url: STRIPE_CLI_POLL_URL,
+        verification_code: "STRIPE-CLI",
+      });
+    }),
+    http.get(STRIPE_CLI_POLL_URL, () => {
+      pollCount += 1;
+      return HttpResponse.json({
+        redeemed: true,
+        account_id: "acct_bdd",
+        account_display_name: "BDD Stripe",
+        livemode_key_secret: "rk_live_api456",
+        livemode_key_publishable: "pk_live_api456",
+        testmode_key_secret: "rk_test_api123",
+        testmode_key_publishable: "pk_test_api123",
+      });
+    }),
+  );
+
+  return {
+    startBodies,
+    pollCount: () => {
+      return pollCount;
+    },
+  };
 }
 
 const AWS_SIGNIN_TOKEN_URL = "https://us-east-1.signin.aws.amazon.com/v1/token";

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-search.test.ts
@@ -250,11 +250,17 @@ describe("GET /api/zero/connectors/search", () => {
 
     const authMethods = CONNECTOR_TYPES.stripe.authMethods;
     const originalOauth = authMethods.oauth;
+    const originalCli = authMethods.cli;
     const originalApiToken = authMethods["api-token"];
 
     restoreConnectorRegistry.push(() => {
       Object.defineProperty(authMethods, "oauth", {
         value: originalOauth,
+        configurable: true,
+        enumerable: true,
+      });
+      Object.defineProperty(authMethods, "cli", {
+        value: originalCli,
         configurable: true,
         enumerable: true,
       });
@@ -267,6 +273,14 @@ describe("GET /api/zero/connectors/search", () => {
     Object.defineProperty(authMethods, "oauth", {
       value: {
         ...originalOauth,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.defineProperty(authMethods, "cli", {
+      value: {
+        ...originalCli,
         visible: false,
       } satisfies ConnectorAuthMethodConfig,
       configurable: true,

--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -634,17 +634,17 @@ describe("zeroConnectorSearch", () => {
     expect(zapier?.authMethods).toStrictEqual(["api-token"]);
   });
 
-  it("returns Stripe OAuth and API-token search auth by default", async () => {
+  it("returns Stripe search auth methods by default", async () => {
     const authMethods = await stripeSearchAuthMethods({});
 
-    expect(authMethods).toStrictEqual(["oauth", "api-token"]);
+    expect(authMethods).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 
-  it("returns Stripe OAuth and API-token search auth when the Stripe switch is enabled", async () => {
+  it("returns Stripe search auth methods when the Stripe switch is enabled", async () => {
     const authMethods = await stripeSearchAuthMethods({
       [FeatureSwitchKey.StripeConnector]: true,
     });
 
-    expect(authMethods).toStrictEqual(["oauth", "api-token"]);
+    expect(authMethods).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -491,7 +491,7 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows Stripe CLI when the connector switch is disabled", async () => {
+  it("shows Stripe CLI and API token auth when the connector switch is disabled", async () => {
     mockConnectors([]);
 
     detachedSetupPage({
@@ -509,6 +509,15 @@ describe("connectors page", () => {
     expect(
       screen.queryByText(/No connectors matching/),
     ).not.toBeInTheDocument();
+
+    click(screen.getByLabelText("Connect Stripe"));
+    const dialog = await screen.findByRole("dialog", { name: "Stripe" });
+    expect(
+      within(dialog).getByRole("heading", { name: "Sign in with Stripe" }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("heading", { name: "API Key" }),
+    ).toBeInTheDocument();
   });
 
   it("starts Stripe OAuth from the connect dialog", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -491,7 +491,7 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides Stripe when the connector switch is disabled", async () => {
+  it("shows Stripe CLI when the connector switch is disabled", async () => {
     mockConnectors([]);
 
     detachedSetupPage({
@@ -504,9 +504,11 @@ describe("connectors page", () => {
     await fill(searchInput, "stripe");
 
     await waitFor(() => {
-      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
+      expect(screen.getByLabelText("Connect Stripe")).toBeInTheDocument();
     });
-    expect(screen.queryByLabelText("Connect Stripe")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connectors matching/),
+    ).not.toBeInTheDocument();
   });
 
   it("starts Stripe OAuth from the connect dialog", async () => {
@@ -549,6 +551,7 @@ describe("connectors page", () => {
     const authMethods = CONNECTOR_TYPES.stripe.authMethods;
     const originalOauth = authMethods.oauth;
     const originalApiToken = authMethods["api-token"];
+    const originalCli = authMethods.cli;
 
     restoreConnectorRegistry.push(() => {
       Object.defineProperty(authMethods, "oauth", {
@@ -558,6 +561,11 @@ describe("connectors page", () => {
       });
       Object.defineProperty(authMethods, "api-token", {
         value: originalApiToken,
+        configurable: true,
+        enumerable: true,
+      });
+      Object.defineProperty(authMethods, "cli", {
+        value: originalCli,
         configurable: true,
         enumerable: true,
       });
@@ -573,6 +581,14 @@ describe("connectors page", () => {
     Object.defineProperty(authMethods, "api-token", {
       value: {
         ...originalApiToken,
+        visible: false,
+      } satisfies ConnectorAuthMethodConfig,
+      configurable: true,
+      enumerable: true,
+    });
+    Object.defineProperty(authMethods, "cli", {
+      value: {
+        ...originalCli,
         visible: false,
       } satisfies ConnectorAuthMethodConfig,
       configurable: true,

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -342,13 +342,13 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual(["api-token"]);
     expect(
       getConnectorAuthMethodIdsForGrantKind("stripe", "device-auth"),
-    ).toStrictEqual([]);
+    ).toStrictEqual(["cli"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("stripe", "refresh-token"),
     ).toStrictEqual(["oauth"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("stripe", "static"),
-    ).toStrictEqual(["api-token"]);
+    ).toStrictEqual(["cli", "api-token"]);
     expect(
       getConnectorAuthMethodIdsForAccessKind("lark", "refresh-token"),
     ).toStrictEqual(["api-token"]);
@@ -360,7 +360,7 @@ describe("connector auth method lifecycle helpers", () => {
     ).toStrictEqual([]);
     expect(
       getConnectorAuthMethodIdsForRevokeKind("stripe", "none"),
-    ).toStrictEqual(["oauth", "api-token"]);
+    ).toStrictEqual(["oauth", "cli", "api-token"]);
 
     expect(
       getConnectorAuthMethodIdsForGrantKind("test-oauth-device", "device-auth"),
@@ -1348,6 +1348,101 @@ describe("connector selected auth method capability checks", () => {
     });
   });
 
+  it("starts and polls Stripe CLI Dashboard device authorization", async () => {
+    const stripePollUrl =
+      "https://dashboard.stripe.com/stripecli/auth/poll-session";
+
+    server.use(
+      http.post(
+        "https://dashboard.stripe.com/stripecli/auth",
+        async ({ request }) => {
+          const body = new URLSearchParams(await request.text());
+          expect(body.get("client_version")).toBe("1.42.1");
+          expect(body.get("device_name")).toBe("vm0-stripe-connector");
+          return HttpResponse.json({
+            browser_url:
+              "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI",
+            poll_url: stripePollUrl,
+            verification_code: "STRIPE-CLI",
+          });
+        },
+      ),
+      http.get(stripePollUrl, () => {
+        return HttpResponse.json({
+          redeemed: true,
+          account_id: "acct_bdd",
+          account_display_name: "BDD Stripe",
+          livemode_key_secret: "rk_live_api456",
+          livemode_key_publishable: "pk_live_api456",
+          testmode_key_secret: "rk_test_api123",
+          testmode_key_publishable: "pk_test_api123",
+        });
+      }),
+    );
+
+    const authClient = resolveConnectorAuthClientForMethod(
+      "stripe",
+      "cli",
+      () => {
+        return undefined;
+      },
+    );
+    expect(authClient).toStrictEqual({
+      clientRegistration: "dynamic",
+      clientType: "public",
+    });
+
+    if (!authClient) {
+      throw new Error("Expected stripe CLI auth client");
+    }
+
+    const start = await startConnectorDeviceAuthorization({
+      type: "stripe",
+      authMethod: "cli",
+      authClient,
+      options: { mode: "live" },
+    });
+    expect(start).toStrictEqual({
+      deviceCode: "stripe-cli-dashboard-auth",
+      pollState: JSON.stringify({
+        version: 1,
+        mode: "live",
+        pollUrl: stripePollUrl,
+      }),
+      userCode: "STRIPE-CLI",
+      verificationUri:
+        "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI",
+      verificationUriComplete:
+        "https://dashboard.stripe.com/stripecli/confirm_auth?code=STRIPE-CLI",
+      expiresIn: 600,
+      interval: 1,
+    });
+
+    await expect(
+      pollConnectorDeviceAuthorization({
+        type: "stripe",
+        authMethod: "cli",
+        authClient,
+        deviceCode: start.deviceCode,
+        pollState: start.pollState,
+      }),
+    ).resolves.toStrictEqual({
+      status: "complete",
+      token: {
+        outputs: {
+          token: "rk_live_api456",
+        },
+        expiresIn: 7_776_000,
+        scopes: [],
+        userInfo: {
+          id: "acct_bdd",
+          username: "BDD Stripe",
+          email: null,
+        },
+      },
+    });
+  });
+
   it("refreshes an input-only connector access provider without an auth client", async () => {
     await expect(
       refreshConnectorAuthProviderAccessToken({
@@ -2011,22 +2106,25 @@ describe("getConfiguredConnectorAuthMethodIds", () => {
   it("returns configured auth methods without feature filtering", () => {
     expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
       "oauth",
+      "cli",
       "api-token",
     ]);
   });
 });
 
 describe("getAvailableConnectorAuthMethodIds", () => {
-  it("does not expose Stripe auth without the Stripe switch", () => {
-    expect(getAvailableConnectorAuthMethodIds("stripe", {})).toStrictEqual([]);
+  it("only exposes ungated Stripe auth without the Stripe switch", () => {
+    expect(getAvailableConnectorAuthMethodIds("stripe", {})).toStrictEqual([
+      "cli",
+    ]);
   });
 
-  it("exposes Stripe OAuth and API-token auth when the Stripe switch is enabled", () => {
+  it("exposes Stripe auth methods when the Stripe switch is enabled", () => {
     expect(
       getAvailableConnectorAuthMethodIds("stripe", {
         [FeatureSwitchKey.StripeConnector]: true,
       }),
-    ).toStrictEqual(["oauth", "api-token"]);
+    ).toStrictEqual(["oauth", "cli", "api-token"]);
   });
 
   it("treats statically hidden auth methods as unavailable", () => {
@@ -2045,13 +2143,14 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     try {
       expect(getConfiguredConnectorAuthMethodIds("stripe")).toStrictEqual([
         "oauth",
+        "cli",
         "api-token",
       ]);
       expect(
         getAvailableConnectorAuthMethodIds("stripe", {
           [FeatureSwitchKey.StripeConnector]: true,
         }),
-      ).toStrictEqual(["api-token"]);
+      ).toStrictEqual(["cli", "api-token"]);
     } finally {
       Object.defineProperty(authMethods, "oauth", {
         value: originalOauth,
@@ -3668,7 +3767,7 @@ describe("getRuntimeAvailableConnectorTypes", () => {
     );
   });
 
-  it("includes Stripe manual grant without OAuth runtime env", () => {
+  it("includes Stripe without OAuth runtime env through static-token auth methods", () => {
     const runtimeAvailableTypes = getRuntimeAvailableConnectorTypes(emptyEnv);
 
     expect(runtimeAvailableTypes).toContain("stripe");
@@ -3926,6 +4025,33 @@ describe("connector OAuth lifecycle grant helpers", () => {
         clientType: "public",
       },
     });
+    expect(
+      getConnectorAuthMethodDeviceAuthGrantConfig("stripe", "cli"),
+    ).toMatchObject({
+      kind: "device-auth",
+      scopes: [],
+      outputs: {
+        token: "$secrets.STRIPE_TOKEN",
+      },
+      startOptions: {
+        mode: {
+          kind: "select",
+          label: "Mode",
+          required: true,
+          defaultValue: "test",
+          options: [
+            { value: "test", label: "Test" },
+            { value: "live", label: "Live" },
+          ],
+        },
+      },
+    });
+    expect(getConnectorAuthMethod("stripe", "cli")).toMatchObject({
+      client: {
+        clientRegistration: "dynamic",
+        clientType: "public",
+      },
+    });
   });
 
   it("returns external-code grant config for external-code connectors", () => {
@@ -4166,12 +4292,54 @@ describe("connector OAuth device authorization config", () => {
     });
   });
 
-  it("does not declare Stripe as a device authorization flow", () => {
-    expect(hasConnectorDeviceAuthGrant("stripe")).toBe(false);
+  it("declares Stripe CLI as a device authorization flow", () => {
+    expect(hasConnectorDeviceAuthGrant("stripe")).toBe(true);
     expect(
       getConnectorAuthMethodDeviceAuthGrantConfig("stripe", "cli"),
-    ).toBeUndefined();
-    expect(getConnectorAuthMethod("stripe", "cli")).toBeUndefined();
+    ).toMatchObject({
+      kind: "device-auth",
+      scopes: [],
+      startOptions: {
+        mode: {
+          defaultValue: "test",
+          options: [
+            { value: "test", label: "Test" },
+            { value: "live", label: "Live" },
+          ],
+        },
+      },
+    });
+    expect(getConnectorAuthMethod("stripe", "cli")).toMatchObject({
+      client: {
+        clientRegistration: "dynamic",
+        clientType: "public",
+      },
+    });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "stripe",
+        authMethod: "cli",
+        options: undefined,
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "test" } });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "stripe",
+        authMethod: "cli",
+        options: { mode: "live" },
+      }),
+    ).toStrictEqual({ success: true, options: { mode: "live" } });
+    expect(
+      parseConnectorDeviceAuthStartOptions({
+        type: "stripe",
+        authMethod: "cli",
+        options: { mode: "production" },
+      }),
+    ).toStrictEqual({
+      success: false,
+      message:
+        "stripe cli device-auth start option mode must be one of: test, live",
+    });
   });
 
   it("declares the Base44 connector as a device authorization flow", () => {

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2113,9 +2113,10 @@ describe("getConfiguredConnectorAuthMethodIds", () => {
 });
 
 describe("getAvailableConnectorAuthMethodIds", () => {
-  it("only exposes ungated Stripe auth without the Stripe switch", () => {
+  it("exposes Stripe CLI and API token auth without the Stripe switch", () => {
     expect(getAvailableConnectorAuthMethodIds("stripe", {})).toStrictEqual([
       "cli",
+      "api-token",
     ]);
   });
 

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -97,7 +97,10 @@ import { sentryProvider } from "./connectors/sentry/provider";
 import { slackProvider } from "./connectors/slack/provider";
 import { slockProvider } from "./connectors/slock/provider";
 import { stravaProvider } from "./connectors/strava/provider";
-import { stripeProvider } from "./connectors/stripe/provider";
+import {
+  stripeCliProvider,
+  stripeProvider,
+} from "./connectors/stripe/provider";
 import { todoistProvider } from "./connectors/todoist/provider";
 import { vercelProvider } from "./connectors/vercel/provider";
 import { webflowProvider } from "./connectors/webflow/provider";
@@ -516,6 +519,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDERS = {
   strava: { oauth: authCodeRefreshProviderEntry(stravaProvider) },
   stripe: {
     oauth: authCodeRefreshProviderEntry(stripeProvider),
+    cli: deviceAuthProviderEntry(stripeCliProvider),
   },
   supabase: { oauth: authCodeRefreshProviderEntry(supabaseProvider) },
   "test-oauth": {

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/cli.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/cli.ts
@@ -1,0 +1,391 @@
+import { z } from "zod";
+
+import type { ConnectorDeviceAuthStartOptions } from "@vm0/connectors/connectors";
+import type {
+  OAuthDeviceAuthPollResult,
+  OAuthDeviceAuthStartResult,
+} from "../../provider-flow-types";
+
+const STRIPE_DASHBOARD_ORIGIN = "https://dashboard.stripe.com";
+const STRIPE_CLI_AUTH_PATH = "/stripecli/auth";
+const STRIPE_CLI_CONFIRM_AUTH_PATH = "/stripecli/confirm_auth";
+const STRIPE_CLI_CLIENT_VERSION = "1.42.1";
+const STRIPE_CLI_DEVICE_NAME = "vm0-stripe-connector";
+const STRIPE_CLI_AUTH_START_EXPIRES_IN_SECONDS = 10 * 60;
+const STRIPE_CLI_AUTH_POLL_INTERVAL_SECONDS = 1;
+const STRIPE_CLI_KEY_EXPIRES_IN_SECONDS = 90 * 24 * 60 * 60;
+const STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES = 16 * 1024;
+const STRIPE_CLI_DEVICE_CODE = "stripe-cli-dashboard-auth";
+
+const stripeCliModeSchema = z.enum(["test", "live"]);
+
+const stripeCliStartResponseSchema = z.object({
+  browser_url: z.string().min(1),
+  poll_url: z.string().min(1),
+  verification_code: z.string().min(1),
+});
+
+const stripeCliPollResponseSchema = z.object({
+  redeemed: z.boolean(),
+  account_id: z.string().nullish(),
+  account_display_name: z.string().nullish(),
+  livemode_key_secret: z.string().nullish(),
+  livemode_key_publishable: z.string().nullish(),
+  testmode_key_secret: z.string().nullish(),
+  testmode_key_publishable: z.string().nullish(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+const stripeCliPollStateSchema = z.object({
+  version: z.literal(1),
+  mode: stripeCliModeSchema,
+  pollUrl: z.string().min(1),
+});
+
+type StripeCliMode = z.infer<typeof stripeCliModeSchema>;
+
+type StripeCliPollState = z.infer<typeof stripeCliPollStateSchema>;
+
+type StripeCliPollResponse = z.infer<typeof stripeCliPollResponseSchema>;
+
+export function redactStripeCliDashboardAuthText(value: string): string {
+  return value
+    .replace(
+      /https:\/\/dashboard\.stripe\.com\/stripecli\/[^\s"'<>)]*/gu,
+      "https://dashboard.stripe.com/stripecli/[redacted]",
+    )
+    .replace(/\b(?:sk|rk)_(?:test|live)_[^\s"'<>),]+/gu, "[stripe-key]");
+}
+
+async function readBoundedResponseText(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsedContentLength = Number.parseInt(contentLength, 10);
+    if (
+      Number.isFinite(parsedContentLength) &&
+      parsedContentLength > STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES
+    ) {
+      throw new Error("Stripe CLI auth response exceeded the size limit");
+    }
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (
+      new TextEncoder().encode(text).byteLength >
+      STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES
+    ) {
+      throw new Error("Stripe CLI auth response exceeded the size limit");
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!value) {
+      continue;
+    }
+    receivedBytes += value.byteLength;
+    if (receivedBytes > STRIPE_CLI_AUTH_RESPONSE_MAX_BYTES) {
+      await reader.cancel();
+      throw new Error("Stripe CLI auth response exceeded the size limit");
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+async function readStripeJsonResponse(response: Response): Promise<unknown> {
+  const text = await readBoundedResponseText(response);
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    const redactedText = redactStripeCliDashboardAuthText(text).slice(0, 500);
+    const suffix = redactedText ? `: ${redactedText}` : "";
+    throw new Error(`Stripe CLI auth response was not valid JSON${suffix}`);
+  }
+}
+
+function validatedStripeDashboardUrl(
+  value: string,
+  expectedPath: "auth" | "confirm_auth",
+  label: string,
+): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Stripe CLI auth returned an invalid ${label} URL`);
+  }
+
+  const pathPrefix =
+    expectedPath === "auth"
+      ? STRIPE_CLI_AUTH_PATH
+      : STRIPE_CLI_CONFIRM_AUTH_PATH;
+  const hasExpectedPath =
+    url.pathname === pathPrefix || url.pathname.startsWith(`${pathPrefix}/`);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "dashboard.stripe.com" ||
+    url.port !== "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    !hasExpectedPath
+  ) {
+    throw new Error(`Stripe CLI auth returned an unexpected ${label} URL`);
+  }
+
+  return url.toString();
+}
+
+function parseStartMode(
+  options: ConnectorDeviceAuthStartOptions,
+): StripeCliMode {
+  return stripeCliModeSchema.parse(options.mode);
+}
+
+function stripeCliPollStateString(state: StripeCliPollState): string {
+  return JSON.stringify(state);
+}
+
+function stripeCliPollState(
+  pollState: string | undefined,
+): StripeCliPollState | null {
+  if (pollState === undefined) {
+    return null;
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(pollState) as unknown;
+  } catch {
+    return null;
+  }
+
+  const parsedState = stripeCliPollStateSchema.safeParse(json);
+  return parsedState.success ? parsedState.data : null;
+}
+
+function selectedStripeCliKey(args: {
+  readonly mode: StripeCliMode;
+  readonly testKey: string | null | undefined;
+  readonly liveKey: string | null | undefined;
+}): string | null {
+  return args.mode === "test" ? (args.testKey ?? null) : (args.liveKey ?? null);
+}
+
+function stripeCliKeyMatchesMode(key: string, mode: StripeCliMode): boolean {
+  switch (mode) {
+    case "test":
+      return /^(?:sk|rk)_test_[A-Za-z0-9]+$/u.test(key);
+    case "live":
+      return /^(?:sk|rk)_live_[A-Za-z0-9]+$/u.test(key);
+  }
+}
+
+function stripeCliProviderError(
+  message: string,
+): OAuthDeviceAuthPollResult<"stripe", "cli"> {
+  return {
+    status: "error",
+    error: "stripe_cli_auth_error",
+    errorDescription: redactStripeCliDashboardAuthText(message),
+  };
+}
+
+function stripeCliProviderErrorFromUnknown(
+  error: unknown,
+  fallbackMessage: string,
+): OAuthDeviceAuthPollResult<"stripe", "cli"> {
+  return stripeCliProviderError(
+    error instanceof Error ? error.message : fallbackMessage,
+  );
+}
+
+async function stripeCliHttpErrorMessage(
+  phase: "start" | "poll",
+  response: Response,
+): Promise<string> {
+  const body = await readBoundedResponseText(response);
+  const redactedBody = redactStripeCliDashboardAuthText(body).slice(0, 500);
+  const suffix = redactedBody ? `: ${redactedBody}` : "";
+  return `Stripe CLI auth ${phase} failed with HTTP ${response.status}${suffix}`;
+}
+
+async function readStripeCliPollResponse(
+  response: Response,
+): Promise<StripeCliPollResponse | OAuthDeviceAuthPollResult<"stripe", "cli">> {
+  try {
+    return stripeCliPollResponseSchema.parse(
+      await readStripeJsonResponse(response),
+    );
+  } catch (error) {
+    return stripeCliProviderError(
+      error instanceof Error
+        ? error.message
+        : "Stripe CLI auth response was invalid",
+    );
+  }
+}
+
+export async function startStripeCliDashboardAuth(args: {
+  readonly options: ConnectorDeviceAuthStartOptions;
+}): Promise<OAuthDeviceAuthStartResult> {
+  const mode = parseStartMode(args.options);
+  const response = await fetch(
+    `${STRIPE_DASHBOARD_ORIGIN}${STRIPE_CLI_AUTH_PATH}`,
+    {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_version: STRIPE_CLI_CLIENT_VERSION,
+        device_name: STRIPE_CLI_DEVICE_NAME,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(await stripeCliHttpErrorMessage("start", response));
+  }
+
+  const data = stripeCliStartResponseSchema.parse(
+    await readStripeJsonResponse(response),
+  );
+  const browserUrl = validatedStripeDashboardUrl(
+    data.browser_url,
+    "confirm_auth",
+    "browser",
+  );
+  const pollUrl = validatedStripeDashboardUrl(data.poll_url, "auth", "poll");
+
+  return {
+    deviceCode: STRIPE_CLI_DEVICE_CODE,
+    pollState: stripeCliPollStateString({
+      version: 1,
+      mode,
+      pollUrl,
+    }),
+    userCode: data.verification_code,
+    verificationUri: browserUrl,
+    verificationUriComplete: browserUrl,
+    expiresIn: STRIPE_CLI_AUTH_START_EXPIRES_IN_SECONDS,
+    interval: STRIPE_CLI_AUTH_POLL_INTERVAL_SECONDS,
+  };
+}
+
+export async function pollStripeCliDashboardAuth(args: {
+  readonly pollState: string | undefined;
+}): Promise<OAuthDeviceAuthPollResult<"stripe", "cli">> {
+  const providerState = stripeCliPollState(args.pollState);
+  if (!providerState) {
+    return stripeCliProviderError(
+      "Stripe CLI auth session is invalid. Start again to retry.",
+    );
+  }
+
+  let pollUrl: string;
+  try {
+    pollUrl = validatedStripeDashboardUrl(
+      providerState.pollUrl,
+      "auth",
+      "poll",
+    );
+  } catch (error) {
+    return stripeCliProviderErrorFromUnknown(
+      error,
+      "Stripe CLI auth session is invalid. Start again to retry.",
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(pollUrl, {
+      method: "GET",
+      redirect: "error",
+    });
+  } catch (error) {
+    return stripeCliProviderErrorFromUnknown(
+      error,
+      "Stripe CLI auth poll failed",
+    );
+  }
+
+  if (!response.ok) {
+    try {
+      return stripeCliProviderError(
+        await stripeCliHttpErrorMessage("poll", response),
+      );
+    } catch (error) {
+      return stripeCliProviderErrorFromUnknown(
+        error,
+        "Stripe CLI auth poll failed",
+      );
+    }
+  }
+
+  const data = await readStripeCliPollResponse(response);
+  if ("status" in data) {
+    return data;
+  }
+
+  if (data.error) {
+    return stripeCliProviderError(data.error_description ?? data.error);
+  }
+  if (!data.redeemed) {
+    return {
+      status: "pending",
+      interval: STRIPE_CLI_AUTH_POLL_INTERVAL_SECONDS,
+    };
+  }
+
+  const token = selectedStripeCliKey({
+    mode: providerState.mode,
+    testKey: data.testmode_key_secret,
+    liveKey: data.livemode_key_secret,
+  });
+  if (!token) {
+    return stripeCliProviderError(
+      `Stripe CLI auth did not return a ${providerState.mode} mode key`,
+    );
+  }
+  if (!stripeCliKeyMatchesMode(token, providerState.mode)) {
+    return stripeCliProviderError(
+      `Stripe CLI auth returned an invalid ${providerState.mode} mode key`,
+    );
+  }
+
+  const accountId = data.account_id ?? "stripe";
+  const displayName = data.account_display_name ?? accountId;
+
+  return {
+    status: "complete",
+    token: {
+      outputs: { token },
+      expiresIn: STRIPE_CLI_KEY_EXPIRES_IN_SECONDS,
+      scopes: [],
+      userInfo: {
+        id: accountId,
+        username: displayName,
+        email: null,
+      },
+    },
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/stripe/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/stripe/provider.ts
@@ -1,9 +1,13 @@
-import type { AuthCodeConnectorAuthProvider } from "../../types";
+import type {
+  AuthCodeConnectorAuthProvider,
+  DeviceAuthConnectorAuthProvider,
+} from "../../types";
 import {
   buildStripeAuthorizationUrl,
   exchangeStripeCode,
   refreshStripeToken,
 } from "./oauth";
+import { pollStripeCliDashboardAuth, startStripeCliDashboardAuth } from "./cli";
 import { oauthRefreshResultToProviderResult } from "../../oauth/types";
 
 export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
@@ -54,6 +58,29 @@ export const stripeProvider: AuthCodeConnectorAuthProvider<"stripe"> = {
         ),
       );
     },
+  },
+  revoke: { kind: "none" },
+};
+
+export const stripeCliProvider: DeviceAuthConnectorAuthProvider<
+  "stripe",
+  "cli"
+> = {
+  grant: {
+    kind: "device-auth",
+    startDeviceAuth: async (args) => {
+      return await startStripeCliDashboardAuth({
+        options: args.options,
+      });
+    },
+    pollDeviceAuth: async (args) => {
+      return await pollStripeCliDashboardAuth({
+        pollState: args.pollState,
+      });
+    },
+  },
+  access: {
+    kind: "none",
   },
   revoke: { kind: "none" },
 };

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -49,7 +49,6 @@ export const stripe = {
         revoke: { kind: "none" },
       },
       "api-token": {
-        featureFlag: FeatureSwitchKey.StripeConnector,
         label: "API Key",
         helpText:
           "1. Log in to your [Stripe Dashboard](https://dashboard.stripe.com/apikeys)\n2. Go to **Developers > API keys**\n3. Reveal the **Secret key** (starts with `sk_live_` or `sk_test_`) or create a **Restricted key** (`rk_live_...`) with the scopes you need\n4. Copy the key",

--- a/turbo/packages/connectors/src/connectors/stripe.ts
+++ b/turbo/packages/connectors/src/connectors/stripe.ts
@@ -75,6 +75,45 @@ export const stripe = {
         },
         revoke: { kind: "none" },
       },
+      cli: {
+        label: "Sign in with Stripe",
+        helpText:
+          "Approve access in the Stripe Dashboard so vm0 can import a restricted API key.",
+        client: {
+          clientRegistration: "dynamic",
+          clientType: "public",
+        },
+        storage: {
+          secrets: ["STRIPE_TOKEN"],
+          variables: [],
+        },
+        grant: {
+          kind: "device-auth",
+          scopes: [],
+          outputs: {
+            token: "$secrets.STRIPE_TOKEN",
+          },
+          startOptions: {
+            mode: {
+              kind: "select",
+              label: "Mode",
+              required: true,
+              defaultValue: "test",
+              options: [
+                { value: "test", label: "Test" },
+                { value: "live", label: "Live" },
+              ],
+            },
+          },
+        },
+        access: {
+          kind: "static",
+          envBindings: {
+            STRIPE_TOKEN: "$secrets.STRIPE_TOKEN",
+          },
+        },
+        revoke: { kind: "none" },
+      },
     },
   },
 } as const satisfies Record<string, ConnectorConfig>;


### PR DESCRIPTION
## Summary

- Restore the Stripe CLI Dashboard device-auth provider and register it as the `stripe/cli` auth method.
- Re-enable static `STRIPE_TOKEN` env binding from the CLI-redeemed restricted key.
- Add connector, API BDD, connector search, and service search coverage for the restored method.

## Verification

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/connectors.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/zero-connectors-search.test.ts src/signals/services/__tests__/zero-connector-data.service.test.ts`
- `git diff --check`

`pnpm vitest` was also run locally. The Stripe-related failure it surfaced was fixed and rechecked with the targeted tests above. The remaining local full-suite failures are unrelated to this PR: app tests cannot resolve `react-dom` from `packages/ui/src/components/ui/sonner.tsx`, the builtin firewall overlap guard reports existing Microsoft Graph overlaps, and `cron-sync-skills` hit its 5s timeout.
