### PR TITLE
fix(api): harden network log reads

### DIFF
--- a/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getApiTestMocks } from "../../../__tests__/mocks";
+
+describe("queryAxiomDirect", () => {
+  it("keeps the Axiom match timestamp when event data contains _time", async () => {
+    const { queryAxiomDirect } =
+      await vi.importActual<typeof import("../axiom")>("../axiom");
+    const mocks = getApiTestMocks();
+    mocks.axiom.query.mockResolvedValue({
+      matches: [
+        {
+          _time: "2026-06-10T11:00:00Z",
+          data: {
+            _time: "not-a-timestamp",
+            host: "api.example.com",
+          },
+        },
+      ],
+    });
+
+    const rows = await queryAxiomDirect(
+      "['vm0-sandbox-telemetry-network-dev']",
+    );
+
+    expect(rows).toStrictEqual([
+      {
+        _time: "2026-06-10T11:00:00Z",
+        host: "api.example.com",
+      },
+    ]);
+  });
+});

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -119,7 +119,7 @@ export async function queryAxiomDirect<T = Record<string, unknown>>(
   const result = await client.query(apl, axiomOptions);
   return (
     result.matches?.map((m) => {
-      return { _time: m._time, ...m.data } as T;
+      return { ...m.data, _time: m._time } as T;
     }) ?? []
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1808,11 +1808,6 @@ describe("RUN-04: agent run telemetry families", () => {
         port: 443,
         firewall_error: "connector_not_configured",
       },
-      {
-        timestamp: "2026-06-10T12:02:00Z",
-        type: "dns",
-        dns_event: "reply",
-      },
     ];
 
     expect(agentNetwork.body).toStrictEqual({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1246,7 +1246,7 @@ interface AxiomQueryRows {
   readonly events?: readonly Record<string, unknown>[];
   readonly systemLogs?: readonly Record<string, unknown>[];
   readonly metrics?: readonly Record<string, unknown>[];
-  readonly network?: readonly Record<string, unknown>[];
+  readonly network?: readonly unknown[];
   readonly runContext?: readonly Record<string, unknown>[];
 }
 
@@ -1318,6 +1318,58 @@ function agentEvent(
     eventType: "assistant",
     eventData: { type: "assistant", text },
   };
+}
+
+function networkHardeningRows(
+  runId: string,
+  userId: string,
+): readonly unknown[] {
+  return [
+    "not-a-network-log-row",
+    {
+      _time: 123,
+      runId,
+      userId,
+      type: "http",
+      action: "ALLOW",
+      host: "missing-time.example.com",
+    },
+    {
+      _time: "2026-06-10T12:00:00Z",
+      runId,
+      userId,
+      type: "http",
+      action: "MAYBE",
+      host: 42,
+      port: "443",
+      status: "200",
+      browser_user_agent: "true",
+      firewall_params: { owner: "vm0-ai", broken: 5 },
+      connector_diagnostic_env_names: ["FAL_TOKEN", 5],
+      auth_resolved_secrets: ["TOKEN", null],
+      request_headers: { host: "api.example.com", broken: false },
+      request_body_encoding: "utf-16",
+      request_body_truncated: "false",
+      response_body_encoding: "binary",
+    },
+    {
+      _time: "2026-06-10T12:01:00Z",
+      runId,
+      userId,
+      type: "http",
+      action: "BLOCK",
+      host: "blocked.example.com",
+      port: 443,
+      firewall_error: "connector_not_configured",
+    },
+    {
+      _time: "2026-06-10T12:02:00Z",
+      runId,
+      userId,
+      type: "dns",
+      dns_event: "reply",
+    },
+  ];
 }
 
 describe("RUN-04: agent run telemetry families", () => {
@@ -1701,6 +1753,76 @@ describe("RUN-04: agent run telemetry families", () => {
     expectApiError(memberTelemetry.body);
 
     await api.requestCancelRun(actor, pendingRun.runId, [200]);
+  });
+
+  it("hardens network log rows consistently across agent and zero read APIs", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-network-hardening");
+    const agentRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "agent network hardening",
+    });
+    const zeroRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "zero network hardening",
+    });
+
+    dispatchAxiomQueries({
+      [agentRun.runId]: {
+        network: networkHardeningRows(agentRun.runId, actor.userId),
+      },
+      [zeroRun.runId]: {
+        network: networkHardeningRows(zeroRun.runId, actor.userId),
+      },
+    });
+
+    const agentNetwork = await reads.requestRunNetworkLogs(
+      actor,
+      agentRun.runId,
+      { limit: 4, order: "asc" },
+      [200],
+    );
+    const zeroNetwork = await reads.requestZeroRunNetworkLogs(
+      actor,
+      zeroRun.runId,
+      { limit: 4, order: "asc" },
+      [200],
+    );
+    if (agentNetwork.status !== 200 || zeroNetwork.status !== 200) {
+      throw new Error("Expected both network log reads to succeed");
+    }
+
+    const expectedNetworkLogs = [
+      {
+        timestamp: "2026-06-10T12:00:00Z",
+        type: "http",
+        firewall_params: { owner: "vm0-ai" },
+        request_headers: { host: "api.example.com" },
+        response_body_encoding: "binary",
+      },
+      {
+        timestamp: "2026-06-10T12:01:00Z",
+        type: "http",
+        action: "BLOCK",
+        host: "blocked.example.com",
+        port: 443,
+        firewall_error: "connector_not_configured",
+      },
+      {
+        timestamp: "2026-06-10T12:02:00Z",
+        type: "dns",
+        dns_event: "reply",
+      },
+    ];
+
+    expect(agentNetwork.body).toStrictEqual({
+      networkLogs: expectedNetworkLogs,
+      hasMore: true,
+    });
+    expect(zeroNetwork.body).toStrictEqual({
+      networkLogs: expectedNetworkLogs,
+      hasMore: true,
+    });
   });
 
   it("maps zero run context, network, events, and runner metadata from axiom snapshots", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-telemetry.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-telemetry.service.ts
@@ -448,10 +448,8 @@ ${systemTelemetrySinceFilter(params.since)}
 
     const events = (await get(queryAxiom(apl))).slice();
     const hasMore = events.length > params.limit;
-    const networkLogs = sanitizeAxiomNetworkEvents(events).slice(
-      0,
-      params.limit,
-    );
+    const pageEvents = hasMore ? events.slice(0, params.limit) : events;
+    const networkLogs = sanitizeAxiomNetworkEvents(pageEvents);
 
     return {
       networkLogs,

--- a/turbo/apps/api/src/signals/services/agent-run-telemetry.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-telemetry.service.ts
@@ -1,19 +1,16 @@
 import { computed, type Computed } from "ccstate";
-import {
-  networkLogActionSchema,
-  type AgentEventsResponse,
-  type AxiomNetworkEvent,
-  type EventsResponse,
-  type MetricsResponse,
-  type NetworkLogEntry,
-  type NetworkLogsResponse,
-  type RunEvent,
-  type RunResult,
-  type RunState,
-  type RunStatus,
-  type SystemLogResponse,
-  type TelemetryMetric,
-  type TelemetryResponse,
+import type {
+  AgentEventsResponse,
+  EventsResponse,
+  MetricsResponse,
+  NetworkLogsResponse,
+  RunEvent,
+  RunResult,
+  RunState,
+  RunStatus,
+  SystemLogResponse,
+  TelemetryMetric,
+  TelemetryResponse,
 } from "@vm0/api-contracts/contracts/runs";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -27,6 +24,7 @@ import {
   waitForRunEventWatermarkVisible,
 } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
+import { sanitizeAxiomNetworkEvents } from "./network-log-sanitizer";
 
 interface AgentComposeContent {
   readonly agent?: { readonly framework?: string };
@@ -157,87 +155,6 @@ function systemTelemetrySinceFilter(since: number | undefined): string {
   return since
     ? `| where _time > datetime("${new Date(since).toISOString()}")`
     : "";
-}
-
-function optionalAxiomField<T>(value: T | null | undefined): T | undefined {
-  return value ?? undefined;
-}
-
-function optionalAxiomStringRecord(
-  value: Readonly<Record<string, unknown>> | null | undefined,
-): Record<string, string> | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).filter((entry): entry is [string, string] => {
-      return typeof entry[1] === "string";
-    }),
-  );
-}
-
-function networkActionValue(
-  value: unknown,
-): NetworkLogEntry["action"] | undefined {
-  const parsed = networkLogActionSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
-}
-
-function networkLogFromAxiom(event: AxiomNetworkEvent): NetworkLogEntry {
-  return {
-    timestamp: event._time,
-    type: optionalAxiomField(event.type),
-    action: networkActionValue(event.action),
-    host: optionalAxiomField(event.host),
-    port: optionalAxiomField(event.port),
-    method: optionalAxiomField(event.method),
-    url: optionalAxiomField(event.url),
-    status: optionalAxiomField(event.status),
-    latency_ms: optionalAxiomField(event.latency_ms),
-    request_size: optionalAxiomField(event.request_size),
-    response_size: optionalAxiomField(event.response_size),
-    browser_user_agent: optionalAxiomField(event.browser_user_agent),
-    dns_event: optionalAxiomField(event.dns_event),
-    dns_query_type: optionalAxiomField(event.dns_query_type),
-    dns_result: optionalAxiomField(event.dns_result),
-    dns_serial: optionalAxiomField(event.dns_serial),
-    firewall_base: optionalAxiomField(event.firewall_base),
-    firewall_name: optionalAxiomField(event.firewall_name),
-    firewall_permission: optionalAxiomField(event.firewall_permission),
-    firewall_rule_match: optionalAxiomField(event.firewall_rule_match),
-    firewall_params: optionalAxiomStringRecord(event.firewall_params),
-    firewall_billable: optionalAxiomField(event.firewall_billable),
-    firewall_error: optionalAxiomField(event.firewall_error),
-    connector_diagnostic_type: optionalAxiomField(
-      event.connector_diagnostic_type,
-    ),
-    connector_diagnostic_reason: optionalAxiomField(
-      event.connector_diagnostic_reason,
-    ),
-    connector_diagnostic_env_names: optionalAxiomField(
-      event.connector_diagnostic_env_names,
-    ),
-    connector_diagnostic_base: optionalAxiomField(
-      event.connector_diagnostic_base,
-    ),
-    auth_resolved_secrets: optionalAxiomField(event.auth_resolved_secrets),
-    auth_refreshed_connectors: optionalAxiomField(
-      event.auth_refreshed_connectors,
-    ),
-    auth_refreshed_secrets: optionalAxiomField(event.auth_refreshed_secrets),
-    auth_cache_hit: optionalAxiomField(event.auth_cache_hit),
-    auth_url_rewrite: optionalAxiomField(event.auth_url_rewrite),
-    error: optionalAxiomField(event.error),
-    request_headers: optionalAxiomStringRecord(event.request_headers),
-    request_body: optionalAxiomField(event.request_body),
-    request_body_encoding: optionalAxiomField(event.request_body_encoding),
-    request_body_truncated: optionalAxiomField(event.request_body_truncated),
-    response_headers: optionalAxiomStringRecord(event.response_headers),
-    response_body: optionalAxiomField(event.response_body),
-    response_body_encoding: optionalAxiomField(event.response_body_encoding),
-    response_body_truncated: optionalAxiomField(event.response_body_truncated),
-  };
 }
 
 function verifyRunOwnership(
@@ -529,14 +446,15 @@ ${systemTelemetrySinceFilter(params.since)}
 | order by _time ${params.order}
 | limit ${params.limit + 1}`;
 
-    const events = (
-      await get(queryAxiom(apl))
-    ).slice() as unknown as AxiomNetworkEvent[];
+    const events = (await get(queryAxiom(apl))).slice();
     const hasMore = events.length > params.limit;
-    const records = hasMore ? events.slice(0, params.limit) : events;
+    const networkLogs = sanitizeAxiomNetworkEvents(events).slice(
+      0,
+      params.limit,
+    );
 
     return {
-      networkLogs: records.map(networkLogFromAxiom),
+      networkLogs,
       hasMore,
     };
   });

--- a/turbo/apps/api/src/signals/services/network-log-sanitizer.ts
+++ b/turbo/apps/api/src/signals/services/network-log-sanitizer.ts
@@ -1,0 +1,150 @@
+import {
+  networkLogActionSchema,
+  networkLogEntrySchema,
+  type NetworkLogEntry,
+} from "@vm0/api-contracts/contracts/runs";
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function stringArrayValue(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = value.filter((item): item is string => {
+    return typeof item === "string";
+  });
+  return strings.length === value.length ? strings : undefined;
+}
+
+function stringRecordValue(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => {
+      return typeof entry[1] === "string";
+    },
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function networkActionValue(
+  value: unknown,
+): NetworkLogEntry["action"] | undefined {
+  const parsed = networkLogActionSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function networkBodyEncodingValue(value: unknown): string | undefined {
+  const isUtf8 =
+    typeof value === "string" &&
+    value.length === 5 &&
+    value.slice(0, 3) === "utf" &&
+    value[3] === "-" &&
+    value[4] === "8";
+  if (isUtf8 || value === "base64" || value === "binary") {
+    return value;
+  }
+  return undefined;
+}
+
+function omitUndefined(record: UnknownRecord): UnknownRecord {
+  return Object.fromEntries(
+    Object.entries(record).filter((entry) => {
+      return entry[1] !== undefined;
+    }),
+  );
+}
+
+function sanitizeAxiomNetworkEvent(event: unknown): NetworkLogEntry | null {
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const timestamp = stringValue(event._time);
+  if (timestamp === undefined) {
+    return null;
+  }
+
+  const candidate = omitUndefined({
+    timestamp,
+    type: stringValue(event.type),
+    action: networkActionValue(event.action),
+    host: stringValue(event.host),
+    port: numberValue(event.port),
+    method: stringValue(event.method),
+    url: stringValue(event.url),
+    status: numberValue(event.status),
+    latency_ms: numberValue(event.latency_ms),
+    request_size: numberValue(event.request_size),
+    response_size: numberValue(event.response_size),
+    browser_user_agent: booleanValue(event.browser_user_agent),
+    dns_event: stringValue(event.dns_event),
+    dns_query_type: stringValue(event.dns_query_type),
+    dns_result: stringValue(event.dns_result),
+    dns_serial: stringValue(event.dns_serial),
+    firewall_base: stringValue(event.firewall_base),
+    firewall_name: stringValue(event.firewall_name),
+    firewall_permission: stringValue(event.firewall_permission),
+    firewall_rule_match: stringValue(event.firewall_rule_match),
+    firewall_params: stringRecordValue(event.firewall_params),
+    firewall_billable: booleanValue(event.firewall_billable),
+    firewall_error: stringValue(event.firewall_error),
+    connector_diagnostic_type: stringValue(event.connector_diagnostic_type),
+    connector_diagnostic_reason: stringValue(event.connector_diagnostic_reason),
+    connector_diagnostic_env_names: stringArrayValue(
+      event.connector_diagnostic_env_names,
+    ),
+    connector_diagnostic_base: stringValue(event.connector_diagnostic_base),
+    auth_resolved_secrets: stringArrayValue(event.auth_resolved_secrets),
+    auth_refreshed_connectors: stringArrayValue(
+      event.auth_refreshed_connectors,
+    ),
+    auth_refreshed_secrets: stringArrayValue(event.auth_refreshed_secrets),
+    auth_cache_hit: booleanValue(event.auth_cache_hit),
+    auth_url_rewrite: booleanValue(event.auth_url_rewrite),
+    error: stringValue(event.error),
+    request_headers: stringRecordValue(event.request_headers),
+    request_body: stringValue(event.request_body),
+    request_body_encoding: networkBodyEncodingValue(
+      event.request_body_encoding,
+    ),
+    request_body_truncated: booleanValue(event.request_body_truncated),
+    response_headers: stringRecordValue(event.response_headers),
+    response_body: stringValue(event.response_body),
+    response_body_encoding: networkBodyEncodingValue(
+      event.response_body_encoding,
+    ),
+    response_body_truncated: booleanValue(event.response_body_truncated),
+  });
+
+  const parsed = networkLogEntrySchema.safeParse(candidate);
+  return parsed.success ? parsed.data : null;
+}
+
+export function sanitizeAxiomNetworkEvents(
+  events: readonly unknown[],
+): NetworkLogEntry[] {
+  return events.flatMap((event) => {
+    const networkLog = sanitizeAxiomNetworkEvent(event);
+    return networkLog ? [networkLog] : [];
+  });
+}

--- a/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
@@ -1,12 +1,9 @@
 import { computed, type Computed } from "ccstate";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
-import {
-  networkLogActionSchema,
-  type AgentEventsResponse,
-  type AxiomNetworkEvent,
-  type NetworkLogEntry,
-  type NetworkLogsResponse,
-  type RunEvent,
+import type {
+  AgentEventsResponse,
+  NetworkLogsResponse,
+  RunEvent,
 } from "@vm0/api-contracts/contracts/runs";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -19,10 +16,10 @@ import {
   waitForRunEventWatermarkVisible,
 } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
+import { sanitizeAxiomNetworkEvents } from "./network-log-sanitizer";
 import { normalizeRunContextSnapshot } from "./run-context-snapshot.service";
 
 type ServiceDb = Pick<Db, "select">;
-type UnknownRecord = Record<string, unknown>;
 
 interface AgentComposeContent {
   agent?: { framework?: string };
@@ -74,133 +71,6 @@ type RunContextResult =
   | { readonly kind: "not-found" }
   | { readonly kind: "no-snapshot" }
   | { readonly kind: "ok"; readonly context: RunContextResponse };
-
-function isRecord(value: unknown): value is UnknownRecord {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-function numberValue(value: unknown): number | undefined {
-  return typeof value === "number" ? value : undefined;
-}
-
-function booleanValue(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
-}
-
-function stringArrayValue(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const strings = value.filter((item): item is string => {
-    return typeof item === "string";
-  });
-  return strings.length === value.length ? strings : undefined;
-}
-
-function stringRecordValue(value: unknown): Record<string, string> | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const entries = Object.entries(value).filter(
-    (entry): entry is [string, string] => {
-      return typeof entry[1] === "string";
-    },
-  );
-  if (entries.length === 0) {
-    return undefined;
-  }
-  return Object.fromEntries(entries);
-}
-
-function networkActionValue(
-  value: unknown,
-): NetworkLogEntry["action"] | undefined {
-  const parsed = networkLogActionSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
-}
-
-function networkBodyEncodingValue(
-  value: unknown,
-): NetworkLogEntry["request_body_encoding"] | undefined {
-  if (value !== "base64" && value !== "binary") {
-    if (
-      typeof value !== "string" ||
-      value.length !== 5 ||
-      value.slice(0, 3) !== "utf" ||
-      value[3] !== "-" ||
-      value[4] !== "8"
-    ) {
-      return undefined;
-    }
-  }
-  return value as NetworkLogEntry["request_body_encoding"];
-}
-
-function omitUndefined<T extends UnknownRecord>(record: T): UnknownRecord {
-  return Object.fromEntries(
-    Object.entries(record).filter((entry) => {
-      return entry[1] !== undefined;
-    }),
-  );
-}
-
-function sanitizeNetworkEvent(event: AxiomNetworkEvent): NetworkLogEntry {
-  return omitUndefined({
-    timestamp: event._time,
-    type: stringValue(event.type),
-    action: networkActionValue(event.action),
-    host: stringValue(event.host),
-    port: numberValue(event.port),
-    method: stringValue(event.method),
-    url: stringValue(event.url),
-    status: numberValue(event.status),
-    latency_ms: numberValue(event.latency_ms),
-    request_size: numberValue(event.request_size),
-    response_size: numberValue(event.response_size),
-    browser_user_agent: booleanValue(event.browser_user_agent),
-    dns_event: stringValue(event.dns_event),
-    dns_query_type: stringValue(event.dns_query_type),
-    dns_result: stringValue(event.dns_result),
-    dns_serial: stringValue(event.dns_serial),
-    firewall_base: stringValue(event.firewall_base),
-    firewall_name: stringValue(event.firewall_name),
-    firewall_permission: stringValue(event.firewall_permission),
-    firewall_rule_match: stringValue(event.firewall_rule_match),
-    firewall_params: stringRecordValue(event.firewall_params),
-    firewall_billable: booleanValue(event.firewall_billable),
-    firewall_error: stringValue(event.firewall_error),
-    connector_diagnostic_type: stringValue(event.connector_diagnostic_type),
-    connector_diagnostic_reason: stringValue(event.connector_diagnostic_reason),
-    connector_diagnostic_env_names: stringArrayValue(
-      event.connector_diagnostic_env_names,
-    ),
-    connector_diagnostic_base: stringValue(event.connector_diagnostic_base),
-    auth_resolved_secrets: stringArrayValue(event.auth_resolved_secrets),
-    auth_refreshed_connectors: stringArrayValue(
-      event.auth_refreshed_connectors,
-    ),
-    auth_refreshed_secrets: stringArrayValue(event.auth_refreshed_secrets),
-    auth_cache_hit: booleanValue(event.auth_cache_hit),
-    auth_url_rewrite: booleanValue(event.auth_url_rewrite),
-    error: stringValue(event.error),
-    request_headers: stringRecordValue(event.request_headers),
-    request_body: stringValue(event.request_body),
-    request_body_encoding: networkBodyEncodingValue(
-      event.request_body_encoding,
-    ),
-    request_body_truncated: booleanValue(event.request_body_truncated),
-    response_headers: stringRecordValue(event.response_headers),
-    response_body: stringValue(event.response_body),
-    response_body_encoding: networkBodyEncodingValue(
-      event.response_body_encoding,
-    ),
-    response_body_truncated: booleanValue(event.response_body_truncated),
-  }) as NetworkLogEntry;
-}
 
 export function zeroRunContext(
   runId: string,
@@ -297,12 +167,10 @@ ${sinceFilter}
 | order by _time ${order}
 | limit ${limit + 1}`;
 
-    const events = (await get(queryAxiom(apl))) as AxiomNetworkEvent[];
+    const events = (await get(queryAxiom(apl))).slice();
 
     const hasMore = events.length > limit;
-    const records = hasMore ? events.slice(0, limit) : events;
-
-    const networkLogs = records.map(sanitizeNetworkEvent);
+    const networkLogs = sanitizeAxiomNetworkEvents(events).slice(0, limit);
 
     return { networkLogs, hasMore };
   });

--- a/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-detail.service.ts
@@ -170,7 +170,8 @@ ${sinceFilter}
     const events = (await get(queryAxiom(apl))).slice();
 
     const hasMore = events.length > limit;
-    const networkLogs = sanitizeAxiomNetworkEvents(events).slice(0, limit);
+    const pageEvents = hasMore ? events.slice(0, limit) : events;
+    const networkLogs = sanitizeAxiomNetworkEvents(pageEvents);
 
     return { networkLogs, hasMore };
   });


### PR DESCRIPTION
## Summary
- preserve the Axiom match `_time` when event payloads also contain `_time`
- route agent and zero network log reads through a shared sanitizer that drops malformed rows and invalid optional fields
- add API route coverage for malformed network rows and adapter coverage for Axiom timestamp precedence

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts src/signals/external/__tests__/axiom.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: `pnpm exec prettier --write ...`, `pnpm knip --cache`, `pnpm check-types`

Closes #17860