### PR TITLE
feat: show goal workflows in the workflow list

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -195,7 +195,7 @@ describe("zero goals", () => {
     });
   });
 
-  it("creates, reads, blocks, resumes, completes, and hides goal workflows from the registry", async () => {
+  it("creates, reads, blocks, resumes, completes, and lists goal workflows in the registry", async () => {
     const fixture = await seedGoalApiFixture({ featureEnabled: true });
 
     const created = await accept(
@@ -258,7 +258,7 @@ describe("zero goals", () => {
     const workflowNames = workflows.body.map((workflow) => {
       return workflow.name;
     });
-    expect(workflowNames).not.toContain(goalRows?.workflowName);
+    expect(workflowNames).toContain(goalRows?.workflowName);
 
     const blocked = await accept(
       goalsClient().block({ headers: headers(fixture) }),

--- a/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
@@ -184,7 +184,10 @@ export function zeroWorkflowList(args: {
       .where(
         and(
           eq(zeroWorkflows.orgId, args.orgId),
-          eq(zeroWorkflows.type, "workflow"),
+          // Goal workflows (type = "goal") are intentionally included here so
+          // they show up in the workflow list. They remain excluded from the
+          // view/edit/delete/attach routes (which still filter type =
+          // "workflow"), since goals are managed via the `zero goal` CLI.
           visibleWorkflowCondition(args.member.userId),
         ),
       )


### PR DESCRIPTION
## What

Goal workflows (`zero_workflows.type = "goal"`) were filtered out of the workflow listing, so they never showed up in `zero workflow list` or the web workflow list. This removes that exclusion so goals are visible.

## Why

Goals are real `zero_workflows` rows (a `type = "goal"` row + a `thread-idle` event trigger). They were deliberately hidden from listings to avoid clutter, but we want them visible in the web workflow list.

## Change

- Drop the `eq(zeroWorkflows.type, "workflow")` filter from `zeroWorkflowList` only.

Intentionally **left untouched** so goals stay managed through the `zero goal` CLI rather than the workflow management surface:
- `loadVisibleWorkflow` / `loadWorkflowByName` (view / edit / delete / attach routes) still filter `type = "workflow"`.
- the manage-permission check and the schedule poller (`zero-workflow-trigger-poller`) still filter `type = "workflow"`.

So goals now appear in the list, but are not editable/deletable/attachable as workflows.

## Tests

Updated the goal route test: it now asserts the created goal workflow **is** present in the workflow registry listing (was asserting it was hidden).

`tsc --noEmit` (api) and eslint pass locally.

## Follow-ups (not in this PR)
- The list summary does not yet expose `type`, so the web UI cannot badge goals as "Goal" or change click-through behavior. Worth adding if we want the UI to distinguish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
