### PR TITLE
fix: stop stamping http.route onto pg client spans

### DIFF
--- a/turbo/apps/api/src/app-factory.ts
+++ b/turbo/apps/api/src/app-factory.ts
@@ -1,11 +1,8 @@
 import { httpInstrumentationMiddleware } from "@hono/otel";
-import { context as otelContext, propagation } from "@opentelemetry/api";
 import * as Sentry from "@sentry/node";
 // oxlint-disable-next-line no-restricted-imports -- app-factory owns the Hono instance, confirmed by ethan@vm0.ai
-import { Hono, type Context, type MiddlewareHandler } from "hono";
+import { Hono, type Context } from "hono";
 import { HTTPException } from "hono/http-exception";
-// oxlint-disable-next-line no-restricted-imports -- app-factory needs the matched route resolver before next(); other signals files use the wrappers from signals/context/hono.
-import { routePath } from "hono/route";
 
 import { corsMiddleware } from "./lib/cors";
 import { env } from "./lib/env";
@@ -18,33 +15,6 @@ import { isAbortError } from "./signals/utils";
 const L = logger("App");
 
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
-
-// Stamp the matched route template into OTel baggage so child spans (db
-// queries, outbound fetches) can carry `http.route` without reaching back
-// into the parent SERVER span. Any code further down the call tree —
-// including the pg pool wrapper in `lib/db.ts` — reads it from
-// `propagation.getActiveBaggage()`.
-//
-// `c.req.routePath` reflects the *current* middleware's pattern (here `"*"`)
-// until next() returns, but we need the matched route *before* next() so the
-// db queries that run inside the handler can pick it up. `routePath(c, -1)`
-// from `hono/route` resolves to the last-matched handler's path even when
-// called from a middleware position — exactly what @hono/otel uses to name
-// its SERVER span.
-const httpRouteBaggage: MiddlewareHandler = async (c, next) => {
-  const route = routePath(c, -1);
-  if (!route || route === "*") {
-    return next();
-  }
-  const current = propagation.getActiveBaggage() ?? propagation.createBaggage();
-  const baggage = current.setEntry("http.route", { value: route });
-  await otelContext.with(
-    propagation.setBaggage(otelContext.active(), baggage),
-    () => {
-      return next();
-    },
-  );
-};
 
 function shouldCaptureError(error: Error): boolean {
   return !(error instanceof HTTPException) || error.status >= 500;
@@ -90,11 +60,11 @@ export function createApp({ routes = ROUTES, signal }: CreateAppOptions): Hono {
   app.onError(handleError);
 
   // OpenTelemetry: each request gets a SERVER span named after its matched
-  // route template (e.g. `GET /api/v1/chat-threads/:threadId`). The baggage
-  // middleware then propagates that template down so child spans inherit
-  // `http.route` for direct slicing without trace_id joins.
+  // route template (e.g. `GET /api/v1/chat-threads/:threadId`). Child spans
+  // (db queries, outbound fetches) parent to it via standard context
+  // propagation; correlate them to a route by their `trace_id`, not by
+  // copying `http.route` onto each child span.
   app.use("*", httpInstrumentationMiddleware({ serviceName: "vm0-api" }));
-  app.use("*", httpRouteBaggage);
   // Browser cross-origin requests (e.g. https://app.vm0.ai → api.vm0.ai). Must
   // run before the route handlers so OPTIONS preflight short-circuits without
   // matching a registered method, and so registered route responses receive

--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -1,9 +1,4 @@
-import {
-  propagation,
-  SpanKind,
-  SpanStatusCode,
-  trace,
-} from "@opentelemetry/api";
+import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import { schema } from "@vm0/db";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool, type PoolClient, type QueryConfig } from "pg";
@@ -15,7 +10,6 @@ import { logger } from "./log";
 import { singleton } from "./singleton";
 import { deriveSqlSpanName } from "./sql-span-name";
 
-const HTTP_ROUTE_BAGGAGE_KEY = "http.route";
 const log = logger("api:db");
 
 const pool = singleton((): Pool => {
@@ -71,12 +65,12 @@ const pool = singleton((): Pool => {
           },
         },
         (span) => {
-          const route = propagation
-            .getActiveBaggage()
-            ?.getEntry(HTTP_ROUTE_BAGGAGE_KEY)?.value;
-          if (route) {
-            span.setAttribute("http.route", route);
-          }
+          // The span parents to whatever request span is active when the
+          // query runs (standard OTel context propagation). Slice DB spans by
+          // route via a `trace_id` join to the `@hono/otel` SERVER span — never
+          // by stamping a request-scoped `http.route` onto these pooled CLIENT
+          // spans, which mis-attributes across concurrent requests.
+          //
           // Promise chain instead of try/catch so this file doesn't have to
           // opt out of `no-restricted-syntax` (the api package centralises
           // guarded operations). `.then(onOk, onErr)` covers both branches in


### PR DESCRIPTION
## Problem

DB telemetry in `vm0-traces-prod` mis-attributes SQL across requests. Concrete proof from the last 24h on `POST /api/zero/chat/messages`:

- Telemetry attributed **2,192 `INSERT agent_runs` spans** to that one route.
- The masked production DB shows the **entire platform created only 1,406 `agent_runs`** in the same window (all sources combined).
- One route's span count exceeding the whole platform's real inserts is impossible — the route attribution on pg spans is wrong.

This made route-grouped and trace-grouped pg-span analysis untrustworthy (it briefly produced a bogus "one chat send creates ~80 runs / hundreds of sequential SQL" conclusion). The reliable `@hono/otel` SERVER-span RED was never in question; only the pg CLIENT-span attribution.

## Root cause

`app-factory.ts` stamped the matched route template into OTel **baggage**, and the pg pool wrapper in `lib/db.ts` read it back via `propagation.getActiveBaggage()` at **query-execution time**, copying `http.route` onto every DB CLIENT span.

The `pg.Pool` is a process-global singleton. Queries flow through its shared connection queue, and a meaningful share of DB work runs in fire-and-forget background / signal side-effects scheduled via `waitUntil`. The OTel context active when a pooled query actually executes is therefore **not reliably the originating request's** — so the `http.route` copied onto the span bleeds across concurrent requests on the same warm instance.

Stamping a request-scoped attribute onto child spans of a shared pool is a denormalization anti-pattern. The original comment even acknowledged it was an optimization "for direct slicing without trace_id joins."

## Fix

Delete the denormalization and use standard OTel context propagation:

- Remove the `httpRouteBaggage` middleware (`app-factory.ts`).
- Remove the baggage read + `span.setAttribute("http.route", …)` in the pg wrapper (`lib/db.ts`).

DB spans still parent to the active `@hono/otel` SERVER span (which carries the correct `http.route`). To slice DB spans by route, **join on `trace_id`** to the server span — the standard model — instead of trusting a per-span route copy. Pure removal: no fallback, no added config.

## Tradeoff / follow-ups

- Any dashboard or query that grouped pg spans by `http.route` must switch to a `trace_id` → SERVER-span join. (The internal `axiom-red` skill's pg-by-route queries need this update.)
- **Verification after deploy:** re-run the count check — group `INSERT agent_runs` pg spans by `trace_id`, join to the SERVER span, and confirm per-request counts normalize (≈1 run/chat-send) and total pg `INSERT agent_runs` ≈ real `agent_runs` rows. If a residual cross-request *trace_id* leak remains (not just the route attribute), the canonical next step is migrating to the official `@opentelemetry/instrumentation-pg`. That is **not** included here because this app bundles to a single **ESM** file via `@hono/vite-build/vercel`, where `require/import-in-the-middle` hooks don't fire without externalizing `pg` **and** registering an ESM loader hook (`--import @opentelemetry/instrumentation/hook.mjs`) — a deploy-config change that must be validated on a preview deploy, not shipped blind.

## Testing

No behavior change to request handling; this only removes a span attribute. Relies on CI (lint/type-check/test) and the preview deploy + the post-deploy Axiom re-measurement above.
