### PR TITLE
fix: group chat messages by run turn

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1008,6 +1008,42 @@ function shouldMergeIntoGroup(
   return groupRunId === msg.runId;
 }
 
+function orderMessagesByRunTurn(
+  messages: readonly EnrichedChatMessage[],
+): EnrichedChatMessage[] {
+  const items: {
+    order: number;
+    messages: EnrichedChatMessage[];
+  }[] = [];
+  const itemByRunId = new Map<string, (typeof items)[number]>();
+
+  for (const message of messages) {
+    const runId = message.runId;
+    if (runId === undefined) {
+      items.push({ order: items.length, messages: [message] });
+      continue;
+    }
+
+    const existing = itemByRunId.get(runId);
+    if (existing) {
+      existing.messages.push(message);
+      continue;
+    }
+
+    const item = { order: items.length, messages: [message] };
+    itemByRunId.set(runId, item);
+    items.push(item);
+  }
+
+  return items
+    .sort((a, b) => {
+      return a.order - b.order;
+    })
+    .flatMap((item) => {
+      return item.messages;
+    });
+}
+
 function groupMessagesForDisplay(
   messages: EnrichedChatMessage[],
 ): GroupedChatMessageGroup[] {
@@ -1032,7 +1068,7 @@ function groupMessagesForDisplay(
   }
 
   const groups = [
-    ...mergeIntoGroups([], activeMessages),
+    ...mergeIntoGroups([], orderMessagesByRunTurn(activeMessages)),
     ...mergeIntoGroups([], queuedMessages),
   ];
   return groups.map((group) => {
@@ -2376,7 +2412,9 @@ function createRecallMessage(deps: RecallMessageDeps) {
 }
 
 interface MessageCommandsDeps
-  extends SendMessageDeps, QueueMessageDeps, RecallMessageDeps {}
+  extends SendMessageDeps,
+    QueueMessageDeps,
+    RecallMessageDeps {}
 
 function createMessageCommands(deps: MessageCommandsDeps) {
   return {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2412,9 +2412,7 @@ function createRecallMessage(deps: RecallMessageDeps) {
 }
 
 interface MessageCommandsDeps
-  extends SendMessageDeps,
-    QueueMessageDeps,
-    RecallMessageDeps {}
+  extends SendMessageDeps, QueueMessageDeps, RecallMessageDeps {}
 
 function createMessageCommands(deps: MessageCommandsDeps) {
   return {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1517,6 +1517,82 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("keeps interleaved run messages grouped by run turn", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-interleaved-run-turns",
+      chatMessages: [
+        {
+          id: "msg-run-a-user",
+          role: "user",
+          content: "Start run A",
+          runId: "run-a",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-run-a-first-assistant",
+          role: "assistant",
+          content: "A first update",
+          runId: "run-a",
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+        {
+          id: "msg-run-b-user",
+          role: "user",
+          content: "Start run B",
+          runId: "run-b",
+          createdAt: "2026-06-09T10:00:03Z",
+        },
+        {
+          id: "msg-run-a-final-assistant",
+          role: "assistant",
+          content: "A final update",
+          runId: "run-a",
+          createdAt: "2026-06-09T10:00:04Z",
+        },
+        {
+          id: "msg-run-a-completed-marker",
+          role: "assistant",
+          content: null,
+          runId: "run-a",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:05Z",
+        },
+        {
+          id: "msg-run-b-assistant",
+          role: "assistant",
+          content: "B answer",
+          runId: "run-b",
+          createdAt: "2026-06-09T10:00:06Z",
+        },
+        {
+          id: "msg-run-b-completed-marker",
+          role: "assistant",
+          content: null,
+          runId: "run-b",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:07Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-interleaved-run-turns",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("A final update")).toBeInTheDocument();
+      expect(screen.getByText("Start run B")).toBeInTheDocument();
+      expect(screen.getByText("B answer")).toBeInTheDocument();
+    });
+
+    expectTextBefore(document.body, "A final update", "Start run B");
+    expectTextBefore(document.body, "Start run B", "B answer");
+    expect(document.querySelectorAll('[data-role="assistant"]')).toHaveLength(
+      2,
+    );
+  });
+
   it("shows thinking when the latest message is a user message", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-message-list-latest-user",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5714,6 +5714,13 @@ function PagedAssistantGroup({
     onToggle: () => void;
   };
 }) {
+  const hasRenderableMessage = group.messages.some((message) => {
+    return isRenderableAssistantMessage(message);
+  });
+  if (!hasRenderableMessage && !completedWorkFold) {
+    return null;
+  }
+
   const groupElementId = `chat-message-group-${group.beginMessageId}`;
   const fullContent = group.messages
     .map((m) => {


### PR DESCRIPTION
## Summary

- Group chat messages by logical `runId` turn before rendering, so late-arriving messages for run A do not get split by run B's prompt.
- Keep assistant lifecycle/control-only groups from rendering empty avatar rows.
- Add a chat lifecycle test for the interleaved sequence: A user, A assistant, B user, A assistant, A finish, B assistant, B finish.

## Testing

- `npx prettier@3.6.2 --write apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `git diff --check`
- Attempted targeted vitest: `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "keeps interleaved run messages grouped by run turn"` but this fresh checkout has no installed workspace dependencies, so `vitest` was not found. PR CI should run the test.
