### PR TITLE
fix(api): reject out-of-range telemetry since cursors with 400

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1668,6 +1668,24 @@ describe("RUN-04: agent run telemetry families", () => {
     );
     expect(invalidSystemQuery.status).toBe(400);
 
+    // Out-of-range `since` cursors are finite numbers that survive coercion but
+    // overflow `new Date(...).toISOString()`. They must be rejected with a 400
+    // at validation time instead of throwing a 500 inside the service.
+    const outOfRangeSince = await reads.rawApiRequest(
+      actor,
+      `/api/agent/runs/${runId}/telemetry/system-log?since=8640000000000001`,
+    );
+    expect(outOfRangeSince.status).toBe(400);
+
+    // The maximum representable timestamp still pages successfully.
+    const maxSince = await reads.requestRunSystemLog(
+      actor,
+      pendingRun.runId,
+      { limit: 10, order: "desc", since: 8_640_000_000_000_000 },
+      [200],
+    );
+    expect(maxSince.body).toStrictEqual({ systemLog: "", hasMore: false });
+
     // Metric pages.
     const metricsPage = await reads.requestRunMetrics(
       actor,
@@ -1818,6 +1836,15 @@ describe("RUN-04: agent run telemetry families", () => {
       networkLogs: expectedNetworkLogs,
       hasMore: true,
     });
+
+    // The zero network read shares the same bounded `since` cursor: an
+    // out-of-range timestamp is rejected with a 400 before reaching the
+    // service, not surfaced as a 500 from `new Date(...).toISOString()`.
+    const zeroOutOfRangeSince = await reads.rawApiRequest(
+      actor,
+      `/api/zero/runs/${zeroRun.runId}/network?since=8640000000000001`,
+    );
+    expect(zeroOutOfRangeSince.status).toBe(400);
   });
 
   it("maps zero run context, network, events, and runner metadata from axiom snapshots", async () => {

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -12,6 +12,27 @@ import { orgTierSchema } from "./orgs";
 const c = initContract();
 export type DirectRunModelProviderType = Exclude<ModelProviderType, "vm0">;
 
+/**
+ * Largest absolute epoch-millisecond value JavaScript `Date` can represent
+ * (ECMA-262 time-clip: ±8.64e15). A finite `since` cursor outside this range
+ * survives plain number coercion but makes the time-based telemetry services
+ * throw `RangeError: Invalid time value` from `new Date(since).toISOString()`,
+ * turning a bad client query into a 500. Bounding the cursor here rejects such
+ * values at request validation time with a 400 instead.
+ */
+const MAX_EPOCH_MS = 8_640_000_000_000_000;
+
+/**
+ * `since` cursor for time-based telemetry reads: a coerced epoch-millisecond
+ * value constrained to the representable `Date` range so the service layer can
+ * safely build `datetime(...)` filters.
+ */
+export const telemetrySinceCursorSchema = z.coerce
+  .number()
+  .min(-MAX_EPOCH_MS)
+  .max(MAX_EPOCH_MS)
+  .optional();
+
 const directRunModelProviderTypeSchema = modelProviderTypeSchema.refine(
   (type) => {
     return type !== "vm0";
@@ -556,12 +577,13 @@ export const runSystemLogContract = c.router({
       id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
-      since: z.coerce.number().optional(),
+      since: telemetrySinceCursorSchema,
       limit: z.coerce.number().min(1).max(100).default(5),
       order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: systemLogResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -585,12 +607,13 @@ export const runMetricsContract = c.router({
       id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
-      since: z.coerce.number().optional(),
+      since: telemetrySinceCursorSchema,
       limit: z.coerce.number().min(1).max(100).default(5),
       order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: metricsResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
@@ -643,12 +666,13 @@ export const runNetworkLogsContract = c.router({
       id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
-      since: z.coerce.number().optional(),
+      since: telemetrySinceCursorSchema,
       limit: z.coerce.number().min(1).max(100).default(5),
       order: z.enum(["asc", "desc"]).default("desc"),
     }),
     responses: {
       200: networkLogsResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       404: apiErrorSchema,
     },

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -14,6 +14,7 @@ import {
   unifiedRunRequestSchema,
   networkLogsResponseSchema,
   logsSearchResponseSchema,
+  telemetrySinceCursorSchema,
 } from "./runs";
 import { sandboxReuseResultSchema } from "./webhooks";
 
@@ -252,7 +253,7 @@ export const zeroRunNetworkLogsContract = c.router({
       id: z.uuid("Run ID must be a valid UUID"),
     }),
     query: z.object({
-      since: z.coerce.number().optional(),
+      since: telemetrySinceCursorSchema,
       limit: z.coerce.number().min(1).max(500).default(500),
       order: z.enum(["asc", "desc"]).default("asc"),
     }),


### PR DESCRIPTION
Fixes #18344

## Problem

The time-based telemetry read contracts coerce `since` with `z.coerce.number().optional()`. Zod rejects `Infinity` and `NaN`, but it accepts finite numbers outside JavaScript's representable `Date` range (`|t| > 8.64e15`), e.g.:

```
since=8640000000000001
since=-8640000000000001
since=999999999999999999999
```

These pass coercion and reach the service layer, which builds the APL filter via `new Date(since).toISOString()`:

- `agent-run-telemetry.service.ts` → `systemTelemetrySinceFilter()` (system log, metrics, network)
- `zero-run-detail.service.ts` → `zeroRunNetworkLogs()`

For out-of-range values `toISOString()` throws `RangeError: Invalid time value`, turning a bad client query into a **500** instead of a **400**.

## Solution

Add a shared `telemetrySinceCursorSchema` (`runs.ts`) that coerces the cursor and constrains it to the representable `Date` range (`±8_640_000_000_000_000`, the ECMA-262 time-clip limit). Apply it to the four affected query contracts:

- `runSystemLogContract.getSystemLog`
- `runMetricsContract.getMetrics`
- `runNetworkLogsContract.getNetworkLogs`
- `zeroRunNetworkLogsContract.getNetworkLogs`

Query validation already short-circuits to a `400` (`requestValidation$` in `context/request.ts`), so out-of-range cursors are now rejected before reaching the service. Added the `400` response to the three agent telemetry contracts' response maps (the zero network contract already declared it). Sequence-based agent-event routes are untouched — they don't build a `Date` from `since`.

## Why this approach

Bounding at the contract is the smallest fix that turns the 500 into a 400 uniformly across every affected route, with no service-layer try/catch (consistent with the project's "let exceptions propagate / validate at the edge" guidance). Valid boundary timestamps (`±8.64e15`) still pass and still work with `new Date(...).toISOString()`.

## Testing

`pnpm -F api check-types`, `pnpm -F @vm0/api-contracts check-types`, lint, and prettier all clean.

Added integration coverage in `run-reads.bdd.test.ts`:
- agent `system-log`: out-of-range `since` → `400`; maximum representable timestamp still pages (`200`)
- zero `network`: out-of-range `since` → `400`

Verified the bounded schema against `zod` directly: out-of-range values reject, while `±8.64e15`, normal timestamps, and `undefined` accept and round-trip through `new Date(...).toISOString()` without throwing.