### PR TITLE
feat: enable ChatInlineFeedback for all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -96,6 +96,7 @@ describe("getAllFeatureStates", () => {
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     expect(states[FeatureSwitchKey.StripeConnector]).toBe(true);
+    expect(states[FeatureSwitchKey.ChatInlineFeedback]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {
@@ -126,7 +127,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatTemplatePicker]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -136,7 +136,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatTemplatePicker]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {
@@ -148,16 +147,16 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.DropboxConnector]).toBe(false);
   });
 
-  it("should let individuals opt in to chat PR tracking and inline feedback", () => {
+  it("should let individuals opt in to chat PR tracking and opt out of inline feedback", () => {
     const states = getAllFeatureStates({
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       overrides: {
         [FeatureSwitchKey.ChatGithubPrTracking]: true,
-        [FeatureSwitchKey.ChatInlineFeedback]: true,
+        [FeatureSwitchKey.ChatInlineFeedback]: false,
       },
     });
     expect(states[FeatureSwitchKey.ChatGithubPrTracking]).toBe(true);
-    expect(states[FeatureSwitchKey.ChatInlineFeedback]).toBe(true);
+    expect(states[FeatureSwitchKey.ChatInlineFeedback]).toBe(false);
   });
 
   it("should apply overrides to disable enabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -302,9 +302,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ChatInlineFeedback]: {
     maintainer: "ming@vm0.ai",
     description:
-      "Show the inline feedback toolbar (Copy / Provide feedback) when selecting text inside an agent message in the Zero chat thread. Individuals opt in via feature-switch overrides.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+      "Show the inline feedback toolbar (Copy / Provide feedback) when selecting text inside an agent message in the Zero chat thread.",
+    enabled: true,
   },
   [FeatureSwitchKey.ChatSlashWorkflowCommands]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary

Flip the `ChatInlineFeedback` feature switch from staff-org gated (`enabled: false` + `STAFF_ORG_ID_HASHES`) to fully enabled (`enabled: true`), so the inline feedback toolbar (Copy / Provide feedback) is visible to all users when selecting text inside an agent message in the Zero chat thread.

## Changes

- `turbo/packages/core/src/feature-switch.ts`: set `ChatInlineFeedback.enabled = true` and removed the now-unnecessary `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` line.

## Notes

- This is a registry-level default change; existing individual/org overrides in the DB still take precedence.
- Feature switches control UI visibility only and are not an authorization boundary.

Relies on PR CI for lint/typecheck/test validation.