### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,12 +111,12 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.181"
+CLAUDE_CODE_VERSION="2.1.183"
 CODEX_CLI_VERSION="0.141.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.28.0"
-PNPM_VERSION="11.7.0"
+PNPM_VERSION="11.8.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Updates pinned rootfs tool versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.181` -> `2.1.183`
- pnpm: `11.7.0` -> `11.8.0`

Checked and left unchanged because they are already current or on the intended LTS/current major track:

- Go: `1.26.4`
- OpenAI Codex CLI: `0.141.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- agent-browser: `0.28.0`
- Node.js: `24.x` LTS track
- PostgreSQL: `18`

## Validation

- `bash -n crates/runner/scripts/build-template.sh`