### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -619,9 +619,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -664,9 +664,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",


### PR DESCRIPTION
## Summary

- Ran `cargo update --verbose` in the Rust workspace at `crates/`.
- Updated 3 locked dependencies:
  - `bitvec` `1.0.1` -> `1.1.1`
  - `bytes` `1.11.1` -> `1.12.0`
  - `cc` `1.2.64` -> `1.2.65`
- No `Cargo.toml` files were changed.

## Dependencies not updated

- `generic-array` stayed at `0.14.7` while `0.14.9` is available. `cargo update -p generic-array --precise 0.14.9` reports that `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`; this is pulled in through `digest v0.10.7` -> `crc-fast v1.10.0` -> `aws-smithy-checksums v0.64.8` -> `aws-sdk-s3 v1.137.0` -> `runner`.

## Manual version bumps

- None. No safe minor or patch `Cargo.toml` version-specifier bumps were needed for direct workspace dependencies.

## Test status

- `cargo test --workspace` initially failed in this sandbox because `/tmp` filled while compiling test artifacts.
- Retried with `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target` and `-j1`. Compilation completed, but `runner` tests failed under the sandbox default `umask 0002`; the failures were environment permission checks rejecting temp directories as group/other writable without the sticky bit.
- Verified the representative failing test directly from the built `runner` test binary:
  - `umask 0002`: failed with the same group/other-writable tempdir check.
  - `umask 0077`: passed.
- Verified the full built `runner` test binary under `umask 0077`: 2004 passed, 0 failed, 2 ignored.
- A final `cargo test --workspace --exclude runner -j1 --quiet` under `umask 0077` was attempted, but the target mount filled while compiling `nbd-cow` tests. No dependency-related compile or test failure was observed before that resource failure.
