### PR TITLE
feat: surface a thread's active goal above the composer via folded goal-state messages

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -120,6 +120,28 @@ export async function publishChatThreadRunFinished(args: {
 }
 
 /**
+ * Notify a chat thread's UI that a new message row was appended. The thread's
+ * message data source subscribes to this topic and refetches, so derived state
+ * (e.g. the composer's folded goal state) updates live.
+ *
+ * Best-effort: a failed publish must not fail the mutation that triggered it.
+ */
+export async function publishChatThreadMessageCreatedSafely(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`),
+    (error) => {
+      L.warn("Failed to publish chat thread message created signal", {
+        threadId,
+        error,
+      });
+    },
+  );
+}
+
+/**
  * Notify a chat thread's UI that its linked automation set changed (created,
  * deleted, enabled, or disabled). The chat-thread header automation menu
  * subscribes to this topic and refetches its thread-scoped list.

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -1,7 +1,9 @@
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import { zeroWorkflowsCollectionContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import {
@@ -173,6 +175,37 @@ async function loadGoalRows(fixture: GoalApiFixture) {
     )
     .limit(1);
   return row;
+}
+
+async function loadGoalMarkers(fixture: GoalApiFixture) {
+  const db = store.set(writeDb$);
+  const rows = await db
+    .select({
+      role: chatMessages.role,
+      content: chatMessages.content,
+      runId: chatMessages.runId,
+      runEventId: chatMessages.runEventId,
+    })
+    .from(chatMessages)
+    .where(eq(chatMessages.chatThreadId, fixture.threadId));
+  return rows.filter((row) => {
+    return row.runEventId?.startsWith("goal-") ?? false;
+  });
+}
+
+/**
+ * Order-independent multiset of `${runEventId}|${content}` keys. Markers written
+ * in the same transaction (e.g. create's workflow+trigger pair) share a
+ * timestamp, so the test compares the set rather than a brittle row order.
+ */
+function markerKeys(
+  rows: readonly { runEventId: string | null; content: string | null }[],
+): string[] {
+  return rows
+    .map((row) => {
+      return `${row.runEventId ?? ""}|${row.content ?? ""}`;
+    })
+    .sort();
 }
 
 describe("zero goals", () => {
@@ -445,5 +478,73 @@ describe("zero goals", () => {
       agentComposeId: fixture.agentId,
       title: "merge the release PR into main",
     });
+  });
+
+  it("publishes goal-state markers into the thread on each transition", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+
+    await accept(
+      goalsClient().create({
+        headers: headers(fixture),
+        body: { objective: "ship goal workflows" },
+      }),
+      [201],
+    );
+
+    const afterCreate = await loadGoalMarkers(fixture);
+    // Every marker is an assistant control row that belongs to no run.
+    for (const marker of afterCreate) {
+      expect(marker.role).toBe("assistant");
+      expect(marker.runId).toBeNull();
+    }
+    // Creating a goal publishes both dimensions active; the workflow marker
+    // carries the objective so the client fold can render it.
+    expect(markerKeys(afterCreate)).toStrictEqual([
+      "goal-trigger:active|",
+      "goal-workflow:active|ship goal workflows",
+    ]);
+
+    await accept(goalsClient().block({ headers: headers(fixture) }), [200]);
+    await accept(goalsClient().resume({ headers: headers(fixture) }), [200]);
+    await accept(goalsClient().complete({ headers: headers(fixture) }), [200]);
+
+    // block → trigger inactive, resume → trigger active, complete → workflow +
+    // trigger inactive. The full history lets the client fold the final state.
+    expect(markerKeys(await loadGoalMarkers(fixture))).toStrictEqual([
+      "goal-trigger:active|",
+      "goal-trigger:active|",
+      "goal-trigger:inactive|",
+      "goal-trigger:inactive|",
+      "goal-workflow:active|ship goal workflows",
+      "goal-workflow:inactive|",
+    ]);
+  });
+
+  it("excludes goal-state markers from a thread's unread state", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    await accept(
+      goalsClient().create({
+        headers: headers(fixture),
+        body: { objective: "ship goal workflows" },
+      }),
+      [201],
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const unreads = await accept(
+      setupApp({ context })(chatThreadsContract).unreads({
+        headers: { authorization: "Bearer clerk-session" },
+        query: { agentId: fixture.agentId },
+      }),
+      [200],
+    );
+
+    // The thread's only messages are goal markers (control rows). Even though
+    // they are the newest rows, the thread must not be surfaced as unread.
+    expect(
+      unreads.body.unreads.map((unread) => {
+        return unread.threadId;
+      }),
+    ).not.toContain(fixture.threadId);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -194,18 +194,32 @@ async function loadGoalMarkers(fixture: GoalApiFixture) {
 }
 
 /**
- * Order-independent multiset of `${runEventId}|${content}` keys. Markers written
- * in the same transaction (e.g. create's workflow+trigger pair) share a
- * timestamp, so the test compares the set rather than a brittle row order.
+ * Order-independent multiset of marker event ids. Markers written in the same
+ * transaction (e.g. create's workflow+trigger pair) share a timestamp, so the
+ * test compares the set rather than a brittle row order.
  */
-function markerKeys(
-  rows: readonly { runEventId: string | null; content: string | null }[],
-): string[] {
+function eventIds(
+  rows: readonly { runEventId: string | null }[],
+): (string | null)[] {
   return rows
     .map((row) => {
-      return `${row.runEventId ?? ""}|${row.content ?? ""}`;
+      return row.runEventId;
     })
     .sort();
+}
+
+/** The `content` payloads of every marker carrying the given event id. */
+function markerContent(
+  rows: readonly { runEventId: string | null; content: string | null }[],
+  eventId: string,
+): (string | null)[] {
+  return rows
+    .filter((row) => {
+      return row.runEventId === eventId;
+    })
+    .map((row) => {
+      return row.content;
+    });
 }
 
 describe("zero goals", () => {
@@ -491,6 +505,7 @@ describe("zero goals", () => {
       [201],
     );
 
+    const goalRows = await loadGoalRows(fixture);
     const afterCreate = await loadGoalMarkers(fixture);
     // Every marker is an assistant control row that belongs to no run.
     for (const marker of afterCreate) {
@@ -498,10 +513,17 @@ describe("zero goals", () => {
       expect(marker.runId).toBeNull();
     }
     // Creating a goal publishes both dimensions active; the workflow marker
-    // carries the objective so the client fold can render it.
-    expect(markerKeys(afterCreate)).toStrictEqual([
-      "goal-trigger:active|",
-      "goal-workflow:active|ship goal workflows",
+    // carries the objective and the trigger marker carries the trigger id (for
+    // the client fold + cancel control).
+    expect(eventIds(afterCreate)).toStrictEqual([
+      "goal-trigger:active",
+      "goal-workflow:active",
+    ]);
+    expect(markerContent(afterCreate, "goal-workflow:active")).toStrictEqual([
+      "ship goal workflows",
+    ]);
+    expect(markerContent(afterCreate, "goal-trigger:active")).toStrictEqual([
+      goalRows!.triggerId,
     ]);
 
     await accept(goalsClient().block({ headers: headers(fixture) }), [200]);
@@ -510,13 +532,13 @@ describe("zero goals", () => {
 
     // block → trigger inactive, resume → trigger active, complete → workflow +
     // trigger inactive. The full history lets the client fold the final state.
-    expect(markerKeys(await loadGoalMarkers(fixture))).toStrictEqual([
-      "goal-trigger:active|",
-      "goal-trigger:active|",
-      "goal-trigger:inactive|",
-      "goal-trigger:inactive|",
-      "goal-workflow:active|ship goal workflows",
-      "goal-workflow:inactive|",
+    expect(eventIds(await loadGoalMarkers(fixture))).toStrictEqual([
+      "goal-trigger:active",
+      "goal-trigger:active",
+      "goal-trigger:inactive",
+      "goal-trigger:inactive",
+      "goal-workflow:active",
+      "goal-workflow:inactive",
     ]);
   });
 

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -17,7 +17,7 @@ import type { Db } from "../external/db";
  * search hit. The workflow markers carry the objective in `content` so the fold
  * can render it; the trigger markers carry no content.
  */
-export const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
+const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
 export const GOAL_WORKFLOW_INACTIVE_EVENT_ID = "goal-workflow:inactive";
 export const GOAL_TRIGGER_ACTIVE_EVENT_ID = "goal-trigger:active";
 export const GOAL_TRIGGER_INACTIVE_EVENT_ID = "goal-trigger:inactive";

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -55,14 +55,40 @@ export async function appendGoalStateMarker(
 }
 
 /**
+ * Publish a newly created goal's initial state: the workflow is active (the
+ * marker carries the objective so the client fold can render it) and its
+ * trigger is enabled.
+ */
+export async function appendGoalCreatedMarkers(
+  tx: Pick<Db, "insert">,
+  chatThreadId: string,
+  objective: string,
+): Promise<void> {
+  await appendGoalStateMarker(tx, {
+    chatThreadId,
+    eventId: GOAL_WORKFLOW_ACTIVE_EVENT_ID,
+    objective,
+  });
+  await appendGoalStateMarker(tx, {
+    chatThreadId,
+    eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
+    objective: null,
+  });
+}
+
+/**
  * Exclude goal marker rows from a query. Goal markers are assistant control
  * rows that must never count toward a thread's unread state or appear in chat
  * search. The message-list endpoint does NOT apply this — the client needs the
  * markers to fold the goal state.
  */
 export function excludeGoalMarkerCondition() {
+  // `run_event_id` is NULL for almost every row, and `NULL IN (...)` is NULL —
+  // `NOT NULL` would then drop those rows. The explicit IS NOT NULL guard keeps
+  // every non-goal-marker row.
   return sql<boolean>`NOT (
       ${chatMessages.role} = 'assistant'
+      AND ${chatMessages.runEventId} IS NOT NULL
       AND ${chatMessages.runEventId} IN (
         ${GOAL_WORKFLOW_ACTIVE_EVENT_ID},
         ${GOAL_WORKFLOW_INACTIVE_EVENT_ID},

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -14,8 +14,9 @@ import type { Db } from "../external/db";
  * These are control rows, not conversation: the client filters them out of the
  * rendered transcript, and they are excluded from unread and search via
  * `excludeGoalMarkerCondition` so they never light up a thread or surface as a
- * search hit. The workflow markers carry the objective in `content` so the fold
- * can render it; the trigger markers carry no content.
+ * search hit. The marker `content` carries the fold's payload: the objective on
+ * workflow-active markers (so the row can render it), and the trigger id on
+ * trigger-active markers (so the composer's cancel control can disable it).
  */
 const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
 export const GOAL_WORKFLOW_INACTIVE_EVENT_ID = "goal-workflow:inactive";
@@ -42,13 +43,13 @@ export async function appendGoalStateMarker(
   args: {
     readonly chatThreadId: string;
     readonly eventId: GoalMarkerEventId;
-    readonly objective: string | null;
+    readonly content: string | null;
   },
 ): Promise<void> {
   await tx.insert(chatMessages).values({
     chatThreadId: args.chatThreadId,
     role: "assistant",
-    content: args.objective,
+    content: args.content,
     runId: null,
     runEventId: args.eventId,
   });
@@ -57,22 +58,24 @@ export async function appendGoalStateMarker(
 /**
  * Publish a newly created goal's initial state: the workflow is active (the
  * marker carries the objective so the client fold can render it) and its
- * trigger is enabled.
+ * trigger is enabled (the marker carries the trigger id so the composer's
+ * cancel control can disable it).
  */
 export async function appendGoalCreatedMarkers(
   tx: Pick<Db, "insert">,
   chatThreadId: string,
   objective: string,
+  triggerId: string,
 ): Promise<void> {
   await appendGoalStateMarker(tx, {
     chatThreadId,
     eventId: GOAL_WORKFLOW_ACTIVE_EVENT_ID,
-    objective,
+    content: objective,
   });
   await appendGoalStateMarker(tx, {
     chatThreadId,
     eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
-    objective: null,
+    content: triggerId,
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -1,0 +1,73 @@
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+/**
+ * Goal state is published into the chat thread as assistant marker messages, so
+ * the web client can fold the thread's message stream into the current goal
+ * state without polling `/api/automations`. Two independent dimensions are
+ * emitted at each goal transition — the goal workflow's active state and the
+ * goal trigger's enabled state — which the client combines with the same rule
+ * the backend `goalResponse` uses (active / blocked / complete).
+ *
+ * These are control rows, not conversation: the client filters them out of the
+ * rendered transcript, and they are excluded from unread and search via
+ * `excludeGoalMarkerCondition` so they never light up a thread or surface as a
+ * search hit. The workflow markers carry the objective in `content` so the fold
+ * can render it; the trigger markers carry no content.
+ */
+export const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
+export const GOAL_WORKFLOW_INACTIVE_EVENT_ID = "goal-workflow:inactive";
+export const GOAL_TRIGGER_ACTIVE_EVENT_ID = "goal-trigger:active";
+export const GOAL_TRIGGER_INACTIVE_EVENT_ID = "goal-trigger:inactive";
+
+const GOAL_MARKER_EVENT_IDS = [
+  GOAL_WORKFLOW_ACTIVE_EVENT_ID,
+  GOAL_WORKFLOW_INACTIVE_EVENT_ID,
+  GOAL_TRIGGER_ACTIVE_EVENT_ID,
+  GOAL_TRIGGER_INACTIVE_EVENT_ID,
+] as const;
+
+type GoalMarkerEventId = (typeof GOAL_MARKER_EVENT_IDS)[number];
+
+/**
+ * Append a single goal-state marker row to a thread. Runs inside the same
+ * transaction as the state change it records so the marker and the state can
+ * never diverge; the caller publishes the realtime message-created signal after
+ * the transaction commits.
+ */
+export async function appendGoalStateMarker(
+  tx: Pick<Db, "insert">,
+  args: {
+    readonly chatThreadId: string;
+    readonly eventId: GoalMarkerEventId;
+    readonly objective: string | null;
+  },
+): Promise<void> {
+  await tx.insert(chatMessages).values({
+    chatThreadId: args.chatThreadId,
+    role: "assistant",
+    content: args.objective,
+    runId: null,
+    runEventId: args.eventId,
+  });
+}
+
+/**
+ * Exclude goal marker rows from a query. Goal markers are assistant control
+ * rows that must never count toward a thread's unread state or appear in chat
+ * search. The message-list endpoint does NOT apply this — the client needs the
+ * markers to fold the goal state.
+ */
+export function excludeGoalMarkerCondition() {
+  return sql<boolean>`NOT (
+      ${chatMessages.role} = 'assistant'
+      AND ${chatMessages.runEventId} IN (
+        ${GOAL_WORKFLOW_ACTIVE_EVENT_ID},
+        ${GOAL_WORKFLOW_INACTIVE_EVENT_ID},
+        ${GOAL_TRIGGER_ACTIVE_EVENT_ID},
+        ${GOAL_TRIGGER_INACTIVE_EVENT_ID}
+      )
+    )`;
+}

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -56,6 +56,7 @@ import {
   resolveAttachFileUrls,
   visibleChatMessageCondition,
 } from "./zero-chat-message-shared.service";
+import { excludeGoalMarkerCondition } from "./zero-chat-goal-marker.service";
 import { cancelRun$, type CancelRunResult } from "./zero-run-cancel.service";
 
 export { insertAssistantEventMessages$ };
@@ -573,6 +574,7 @@ function lastVisibleMessageSubquery(db: Pick<Db, "select">) {
       and(
         eq(chatMessages.chatThreadId, chatThreads.id),
         visibleChatMessageCondition(),
+        excludeGoalMarkerCondition(),
       ),
     )
     .orderBy(desc(chatMessages.createdAt), desc(chatMessages.id))
@@ -930,6 +932,7 @@ export function zeroChatSearch(args: {
       eq(agentComposes.orgId, args.orgId),
       isNotNull(chatMessages.content),
       visibleChatMessageCondition(),
+      excludeGoalMarkerCondition(),
       ilike(chatMessages.content, pattern),
     ];
     if (sinceDate) {
@@ -971,6 +974,7 @@ export function zeroChatSearch(args: {
                     lt(chatMessages.createdAt, match.createdAt),
                     isNotNull(chatMessages.content),
                     visibleChatMessageCondition(),
+                    excludeGoalMarkerCondition(),
                   ),
                 )
                 .orderBy(desc(chatMessages.createdAt))
@@ -986,6 +990,7 @@ export function zeroChatSearch(args: {
                     gt(chatMessages.createdAt, match.createdAt),
                     isNotNull(chatMessages.content),
                     visibleChatMessageCondition(),
+                    excludeGoalMarkerCondition(),
                   ),
                 )
                 .orderBy(asc(chatMessages.createdAt))

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -16,7 +16,17 @@ import { and, eq, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db, ReadonlyDb } from "../external/db";
-import { publishChatThreadAutomationsChangedSafely } from "../external/realtime";
+import {
+  publishChatThreadAutomationsChangedSafely,
+  publishChatThreadMessageCreatedSafely,
+} from "../external/realtime";
+import {
+  GOAL_TRIGGER_ACTIVE_EVENT_ID,
+  GOAL_TRIGGER_INACTIVE_EVENT_ID,
+  GOAL_WORKFLOW_ACTIVE_EVENT_ID,
+  GOAL_WORKFLOW_INACTIVE_EVENT_ID,
+  appendGoalStateMarker,
+} from "./zero-chat-goal-marker.service";
 import type { TriggerRow } from "./zero-workflow-trigger-run.service";
 
 export type GoalResult =
@@ -253,6 +263,20 @@ export async function createGoalForCurrentThread(
       throw new Error("Failed to create goal trigger");
     }
 
+    // Publish the new goal's state into the thread so the composer can fold it
+    // from the message stream: the workflow is active (carries the objective)
+    // and its trigger is enabled.
+    await appendGoalStateMarker(tx, {
+      chatThreadId: threadId,
+      eventId: GOAL_WORKFLOW_ACTIVE_EVENT_ID,
+      objective: args.objective,
+    });
+    await appendGoalStateMarker(tx, {
+      chatThreadId: threadId,
+      eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
+      objective: null,
+    });
+
     return {
       row: {
         workflowId: workflow.id,
@@ -279,6 +303,7 @@ export async function createGoalForCurrentThread(
     args.userId,
     created.threadId,
   );
+  await publishChatThreadMessageCreatedSafely(args.userId, created.threadId);
 
   return {
     kind: "ok",
@@ -337,8 +362,21 @@ export async function completeCurrentGoal(
         updatedAt: completedAt,
       })
       .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
+    // The goal is done: workflow inactive (+ trigger disabled) folds to
+    // "complete", so the composer drops the goal row.
+    await appendGoalStateMarker(tx, {
+      chatThreadId: goal.threadId,
+      eventId: GOAL_WORKFLOW_INACTIVE_EVENT_ID,
+      objective: null,
+    });
+    await appendGoalStateMarker(tx, {
+      chatThreadId: goal.threadId,
+      eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
+      objective: null,
+    });
   });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
+  await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
 
   return {
     kind: "ok",
@@ -360,7 +398,14 @@ export async function blockCurrentGoal(
     .update(zeroWorkflowTriggers)
     .set({ enabled: false, updatedAt: blockedAt })
     .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
+  // Trigger disabled while the workflow stays active folds to "blocked".
+  await appendGoalStateMarker(db, {
+    chatThreadId: goal.threadId,
+    eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
+    objective: null,
+  });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
+  await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
 
   return {
     kind: "ok",
@@ -382,7 +427,14 @@ export async function resumeCurrentGoal(
     .update(zeroWorkflowTriggers)
     .set({ enabled: true, consecutiveFailures: 0, updatedAt: resumedAt })
     .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
+  // Trigger re-enabled while the workflow is active folds back to "active".
+  await appendGoalStateMarker(db, {
+    chatThreadId: goal.threadId,
+    eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
+    objective: null,
+  });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
+  await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
 
   return {
     kind: "ok",

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -265,7 +265,7 @@ export async function createGoalForCurrentThread(
 
     // Publish the new goal's state so the composer can fold it from the message
     // stream (active workflow carrying the objective + enabled trigger).
-    await appendGoalCreatedMarkers(tx, threadId, args.objective);
+    await appendGoalCreatedMarkers(tx, threadId, args.objective, trigger.id);
 
     return {
       row: {
@@ -357,12 +357,12 @@ export async function completeCurrentGoal(
     await appendGoalStateMarker(tx, {
       chatThreadId: goal.threadId,
       eventId: GOAL_WORKFLOW_INACTIVE_EVENT_ID,
-      objective: null,
+      content: null,
     });
     await appendGoalStateMarker(tx, {
       chatThreadId: goal.threadId,
       eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
-      objective: null,
+      content: null,
     });
   });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
@@ -392,7 +392,7 @@ export async function blockCurrentGoal(
   await appendGoalStateMarker(db, {
     chatThreadId: goal.threadId,
     eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
-    objective: null,
+    content: null,
   });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
   await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
@@ -421,7 +421,7 @@ export async function resumeCurrentGoal(
   await appendGoalStateMarker(db, {
     chatThreadId: goal.threadId,
     eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
-    objective: null,
+    content: goal.row.triggerId,
   });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
   await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -23,8 +23,8 @@ import {
 import {
   GOAL_TRIGGER_ACTIVE_EVENT_ID,
   GOAL_TRIGGER_INACTIVE_EVENT_ID,
-  GOAL_WORKFLOW_ACTIVE_EVENT_ID,
   GOAL_WORKFLOW_INACTIVE_EVENT_ID,
+  appendGoalCreatedMarkers,
   appendGoalStateMarker,
 } from "./zero-chat-goal-marker.service";
 import type { TriggerRow } from "./zero-workflow-trigger-run.service";
@@ -263,19 +263,9 @@ export async function createGoalForCurrentThread(
       throw new Error("Failed to create goal trigger");
     }
 
-    // Publish the new goal's state into the thread so the composer can fold it
-    // from the message stream: the workflow is active (carries the objective)
-    // and its trigger is enabled.
-    await appendGoalStateMarker(tx, {
-      chatThreadId: threadId,
-      eventId: GOAL_WORKFLOW_ACTIVE_EVENT_ID,
-      objective: args.objective,
-    });
-    await appendGoalStateMarker(tx, {
-      chatThreadId: threadId,
-      eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
-      objective: null,
-    });
+    // Publish the new goal's state so the composer can fold it from the message
+    // stream (active workflow carrying the objective + enabled trigger).
+    await appendGoalCreatedMarkers(tx, threadId, args.objective);
 
     return {
       row: {

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-poller.service.ts
@@ -196,7 +196,7 @@ async function recordPreRunFailure(
         await appendGoalStateMarker(db, {
           chatThreadId: trigger.chatThreadId,
           eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
-          objective: null,
+          content: null,
         });
         await publishChatThreadMessageCreatedSafely(
           trigger.ownerUserId,

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-poller.service.ts
@@ -9,10 +9,15 @@ import { and, eq, isNotNull, lte } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import { writeDb$, type Db } from "../external/db";
+import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import { now, nowDate } from "../external/time";
 import { settle } from "../utils";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { calculateNextRun } from "./automations/time-trigger";
+import {
+  GOAL_TRIGGER_INACTIVE_EVENT_ID,
+  appendGoalStateMarker,
+} from "./zero-chat-goal-marker.service";
 import {
   buildChatOnlyWorkflowTriggerCallbacks,
   runWorkflowTriggerNow$,
@@ -178,6 +183,27 @@ async function recordPreRunFailure(
       ...context,
       consecutiveFailures: newFailureCount,
     });
+    // Auto-disabling a goal's thread-idle trigger is a trigger→inactive
+    // transition; publish it into the thread so the composer's folded goal
+    // state reflects the pause.
+    if (trigger.chatThreadId && trigger.eventType === "thread-idle") {
+      const [workflow] = await db
+        .select({ type: zeroWorkflows.type })
+        .from(zeroWorkflows)
+        .where(eq(zeroWorkflows.id, trigger.workflowId))
+        .limit(1);
+      if (workflow?.type === "goal") {
+        await appendGoalStateMarker(db, {
+          chatThreadId: trigger.chatThreadId,
+          eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
+          objective: null,
+        });
+        await publishChatThreadMessageCreatedSafely(
+          trigger.ownerUserId,
+          trigger.chatThreadId,
+        );
+      }
+    }
   }
 }
 

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -430,7 +430,7 @@ export async function setChatThreadWorkflowTriggerEnabled(
         eventId: args.enabled
           ? GOAL_TRIGGER_ACTIVE_EVENT_ID
           : GOAL_TRIGGER_INACTIVE_EVENT_ID,
-        objective: null,
+        content: args.enabled ? args.triggerId : null,
       });
       await publishChatThreadMessageCreatedSafely(
         args.userId,

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -15,10 +15,18 @@ import {
 import { and, asc, eq, isNotNull, or } from "drizzle-orm";
 
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { publishChatThreadAutomationsChangedSafely } from "../external/realtime";
+import {
+  publishChatThreadAutomationsChangedSafely,
+  publishChatThreadMessageCreatedSafely,
+} from "../external/realtime";
 import { nowDate } from "../../lib/time";
 import { isValidTimeZone, safeSync } from "../utils";
 import { calculateNextRun } from "./automations/time-trigger";
+import {
+  GOAL_TRIGGER_ACTIVE_EVENT_ID,
+  GOAL_TRIGGER_INACTIVE_EVENT_ID,
+  appendGoalStateMarker,
+} from "./zero-chat-goal-marker.service";
 import { fireWorkflowTriggerTestRun$ } from "./zero-workflow-trigger-poller.service";
 import {
   loadVisibleWorkflow,
@@ -408,6 +416,27 @@ export async function setChatThreadWorkflowTriggerEnabled(
     .where(eq(zeroWorkflowTriggers.id, args.triggerId));
 
   if (trigger.chatThreadId) {
+    // For a goal trigger, the sidebar toggle is the same active/inactive
+    // transition the goal API makes — publish it into the thread so the
+    // composer's folded goal state stays in sync.
+    const [workflow] = await db
+      .select({ type: zeroWorkflows.type })
+      .from(zeroWorkflows)
+      .where(eq(zeroWorkflows.id, trigger.workflowId))
+      .limit(1);
+    if (workflow?.type === "goal") {
+      await appendGoalStateMarker(db, {
+        chatThreadId: trigger.chatThreadId,
+        eventId: args.enabled
+          ? GOAL_TRIGGER_ACTIVE_EVENT_ID
+          : GOAL_TRIGGER_INACTIVE_EVENT_ID,
+        objective: null,
+      });
+      await publishChatThreadMessageCreatedSafely(
+        args.userId,
+        trigger.chatThreadId,
+      );
+    }
     await publishChatThreadAutomationsChangedSafely(
       args.userId,
       trigger.chatThreadId,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -108,6 +108,72 @@ function isQueueMarkerMessage(msg: PagedChatMessage): boolean {
   );
 }
 
+// Goal-state marker event ids (mirrors the backend goal-marker service). These
+// assistant rows publish a goal's workflow/trigger transitions into the thread
+// so the composer can fold the current goal state from the message stream
+// instead of polling. They are control rows: filtered out of the transcript.
+const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
+const GOAL_WORKFLOW_INACTIVE_EVENT_ID = "goal-workflow:inactive";
+const GOAL_TRIGGER_ACTIVE_EVENT_ID = "goal-trigger:active";
+const GOAL_TRIGGER_INACTIVE_EVENT_ID = "goal-trigger:inactive";
+
+const GOAL_MARKER_EVENT_IDS = new Set<string>([
+  GOAL_WORKFLOW_ACTIVE_EVENT_ID,
+  GOAL_WORKFLOW_INACTIVE_EVENT_ID,
+  GOAL_TRIGGER_ACTIVE_EVENT_ID,
+  GOAL_TRIGGER_INACTIVE_EVENT_ID,
+]);
+
+function isGoalMarkerMessage(msg: PagedChatMessage): boolean {
+  return (
+    msg.role === "assistant" &&
+    msg.runEventId !== undefined &&
+    GOAL_MARKER_EVENT_IDS.has(msg.runEventId)
+  );
+}
+
+/** The thread's current active goal, folded from its message stream. */
+export interface ActiveGoalState {
+  readonly objective: string;
+}
+
+/**
+ * Fold the thread's message stream into its current goal, surfaced above the
+ * composer. Combines the two independent dimensions published by the backend —
+ * the goal workflow's active state and its trigger's enabled state — with the
+ * same rule as the backend `goalResponse`: the goal is shown only when it is
+ * active (workflow active AND trigger enabled), mirroring the prior behavior of
+ * hiding paused goals. The objective comes from the latest workflow-active
+ * marker. Messages are chronological, so each dimension is last-write-wins.
+ */
+function foldActiveGoal(
+  messages: readonly PagedChatMessage[],
+): ActiveGoalState | null {
+  let workflowActive = false;
+  let triggerEnabled = false;
+  let objective: string | null = null;
+  for (const message of messages) {
+    if (message.role !== "assistant" || message.runEventId === undefined) {
+      continue;
+    }
+    if (message.runEventId === GOAL_WORKFLOW_ACTIVE_EVENT_ID) {
+      workflowActive = true;
+      objective = message.content;
+    } else if (message.runEventId === GOAL_WORKFLOW_INACTIVE_EVENT_ID) {
+      workflowActive = false;
+    } else if (message.runEventId === GOAL_TRIGGER_ACTIVE_EVENT_ID) {
+      triggerEnabled = true;
+    } else if (message.runEventId === GOAL_TRIGGER_INACTIVE_EVENT_ID) {
+      triggerEnabled = false;
+    }
+  }
+  const trimmed = objective?.trim();
+  if (workflowActive && triggerEnabled && trimmed) {
+    return { objective: trimmed };
+  }
+  return null;
+}
+
 function isUsageMessage(msg: PagedChatMessage): msg is Extract<
   PagedChatMessage,
   { role: "assistant" }
@@ -299,6 +365,11 @@ function deriveRunIndicatorState(
       continue;
     }
     if (isUsageMessage(message)) {
+      continue;
+    }
+    // Goal markers are control rows, not run output — they must not perturb the
+    // queued/running computation.
+    if (isGoalMarkerMessage(message)) {
       continue;
     }
     if (message.role === "assistant") {
@@ -533,6 +604,9 @@ export interface ChatThreadSignals {
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
   hasOlderHistory$: Computed<Promise<boolean>>;
   latestRunStatus$: Computed<Promise<string | null>>;
+  // The thread's active goal, folded from goal-state marker messages. Null when
+  // there is no active goal. Drives the goal row above the composer.
+  activeGoal$: Computed<Promise<ActiveGoalState | null>>;
   allFinished$: Computed<Promise<boolean>>;
   fetchNextPage$: Command<Promise<boolean>, [AbortSignal]>;
   loadHistory$: Command<Promise<LoadHistoryResult>, [AbortSignal]>;
@@ -1324,6 +1398,7 @@ function createAllMessagesComputed(
         return (
           !isRecallControlMessage(entry.message) &&
           !isQueueMarkerMessage(entry.message) &&
+          !isGoalMarkerMessage(entry.message) &&
           !isInterruptedAssistantCancellation(
             entry.message,
             interruptedRunIds,
@@ -1498,6 +1573,20 @@ function createPagedMessages(
   });
   const allMessages$ = createAllMessagesComputed(rawMessages$);
   const latestRunStatus$ = createLatestRunStatus(allMessages$, rawMessages$);
+
+  // The thread's active goal, folded from the (goal-marker) message stream so
+  // the composer reads it without polling /api/automations. Reads rawMessages$
+  // because the markers are filtered out of allMessages$.
+  const activeGoal$ = computed(
+    async (get): Promise<ActiveGoalState | null> => {
+      const raw = await get(rawMessages$);
+      return foldActiveGoal(
+        raw.map((entry) => {
+          return entry.message;
+        }),
+      );
+    },
+  );
 
   const { groupedChatMessages$, refreshGroupedChatMessagesCache$ } =
     createGroupedChatMessagesCache(allMessages$);
@@ -2714,6 +2803,7 @@ export function createChatThreadSignals(
     groupedChatMessages$,
     hasOlderHistory$,
     latestRunStatus$,
+    activeGoal$,
     allFinished$: runTracking.allFinished$,
     fetchNextPage$,
     loadHistory$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -130,6 +130,8 @@ function isGoalMarkerMessage(msg: PagedChatMessage): boolean {
 /** The thread's current active goal, folded from its message stream. */
 export interface ActiveGoalState {
   readonly objective: string;
+  /** The goal trigger's id — the cancel control disables this trigger. */
+  readonly triggerId: string;
 }
 
 /**
@@ -147,6 +149,7 @@ function foldActiveGoal(
   let workflowActive = false;
   let triggerEnabled = false;
   let objective: string | null = null;
+  let triggerId: string | null = null;
   for (const message of messages) {
     if (message.role !== "assistant" || message.runEventId === undefined) {
       continue;
@@ -158,13 +161,14 @@ function foldActiveGoal(
       workflowActive = false;
     } else if (message.runEventId === GOAL_TRIGGER_ACTIVE_EVENT_ID) {
       triggerEnabled = true;
+      triggerId = message.content;
     } else if (message.runEventId === GOAL_TRIGGER_INACTIVE_EVENT_ID) {
       triggerEnabled = false;
     }
   }
   const trimmed = objective?.trim();
-  if (workflowActive && triggerEnabled && trimmed) {
-    return { objective: trimmed };
+  if (workflowActive && triggerEnabled && trimmed && triggerId) {
+    return { objective: trimmed, triggerId };
   }
   return null;
 }

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -362,11 +362,6 @@ function deriveRunIndicatorState(
     if (isUsageMessage(message)) {
       continue;
     }
-    // Goal markers are control rows, not run output — they must not perturb the
-    // queued/running computation.
-    if (isGoalMarkerMessage(message)) {
-      continue;
-    }
     if (message.role === "assistant") {
       if (isQueueMarkerMessage(message)) {
         hasQueued = true;
@@ -1572,16 +1567,14 @@ function createPagedMessages(
   // The thread's active goal, folded from the (goal-marker) message stream so
   // the composer reads it without polling /api/automations. Reads rawMessages$
   // because the markers are filtered out of allMessages$.
-  const activeGoal$ = computed(
-    async (get): Promise<ActiveGoalState | null> => {
-      const raw = await get(rawMessages$);
-      return foldActiveGoal(
-        raw.map((entry) => {
-          return entry.message;
-        }),
-      );
-    },
-  );
+  const activeGoal$ = computed(async (get): Promise<ActiveGoalState | null> => {
+    const raw = await get(rawMessages$);
+    return foldActiveGoal(
+      raw.map((entry) => {
+        return entry.message;
+      }),
+    );
+  });
 
   const { groupedChatMessages$, refreshGroupedChatMessagesCache$ } =
     createGroupedChatMessagesCache(allMessages$);

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -117,18 +117,13 @@ const GOAL_WORKFLOW_INACTIVE_EVENT_ID = "goal-workflow:inactive";
 const GOAL_TRIGGER_ACTIVE_EVENT_ID = "goal-trigger:active";
 const GOAL_TRIGGER_INACTIVE_EVENT_ID = "goal-trigger:inactive";
 
-const GOAL_MARKER_EVENT_IDS = new Set<string>([
-  GOAL_WORKFLOW_ACTIVE_EVENT_ID,
-  GOAL_WORKFLOW_INACTIVE_EVENT_ID,
-  GOAL_TRIGGER_ACTIVE_EVENT_ID,
-  GOAL_TRIGGER_INACTIVE_EVENT_ID,
-]);
-
 function isGoalMarkerMessage(msg: PagedChatMessage): boolean {
   return (
     msg.role === "assistant" &&
-    msg.runEventId !== undefined &&
-    GOAL_MARKER_EVENT_IDS.has(msg.runEventId)
+    (msg.runEventId === GOAL_WORKFLOW_ACTIVE_EVENT_ID ||
+      msg.runEventId === GOAL_WORKFLOW_INACTIVE_EVENT_ID ||
+      msg.runEventId === GOAL_TRIGGER_ACTIVE_EVENT_ID ||
+      msg.runEventId === GOAL_TRIGGER_INACTIVE_EVENT_ID)
   );
 }
 
@@ -1685,6 +1680,7 @@ function createPagedMessages(
     rawMessages$,
     hasOlderHistory$,
     latestRunStatus$,
+    activeGoal$,
     fetchNextPage$,
     refreshLatestMessages$,
     loadHistory$,
@@ -2723,6 +2719,7 @@ export function createChatThreadSignals(
     rawMessages$,
     hasOlderHistory$,
     latestRunStatus$,
+    activeGoal$,
     fetchNextPage$,
     refreshLatestMessages$,
     loadHistory$: loadPagedHistory$,

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -142,12 +142,16 @@ export const toggleWorkflowTriggerEnabled$ = command(
   },
 );
 
-/** Workflow/goal triggers bound to a specific chat thread, for the sidebar. */
+/**
+ * Workflow triggers bound to a specific chat thread, for the sidebar. Goals are
+ * excluded — they are surfaced in the composer (folded from the thread's
+ * goal-state message stream), not the automation sidebar.
+ */
 export function workflowTriggersForThread(
   triggers: readonly HeaderWorkflowTriggerEntry[],
   threadId: string,
 ): readonly HeaderWorkflowTriggerEntry[] {
   return triggers.filter((trigger) => {
-    return trigger.chatThreadId === threadId;
+    return trigger.chatThreadId === threadId && trigger.workflowType !== "goal";
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3341,9 +3341,7 @@ describe("chat lifecycle", () => {
       );
     });
     // The marker is a control row — it must not also render as a chat bubble.
-    expect(
-      screen.getAllByText("Drive the release to merge"),
-    ).toHaveLength(1);
+    expect(screen.getAllByText("Drive the release to merge")).toHaveLength(1);
 
     // The goal is the lowest-priority row: it sits after every queued message.
     await sendQueuedMessage(user, "First queued follow-up");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -33,6 +33,7 @@ import {
   zeroRunsByIdContract,
 } from "@vm0/api-contracts/contracts/zero-runs";
 import { zeroQueuePositionContract } from "@vm0/api-contracts/contracts/zero-queue-position";
+import { automationsMainContract } from "@vm0/api-contracts/contracts/automations";
 import {
   createMockAutomationView,
   createMockWorkflowTrigger,
@@ -3320,13 +3321,23 @@ describe("chat lifecycle", () => {
           id: "msg-goal-trigger-active",
           runId: undefined,
           role: "assistant",
-          content: null,
+          // The trigger-active marker carries the trigger id for the cancel
+          // control to disable.
+          content: "trigger-goal-fold-1",
           runEventId: "goal-trigger:active",
           createdAt: "2026-06-09T10:00:03Z",
         },
       ],
       activeRunIds: ["run-active"],
     });
+    let canceledTrigger: { id: string; enabled: boolean } | null = null;
+    context.mocks.api(
+      automationsMainContract.toggleWorkflowTrigger,
+      ({ params, body, respond }) => {
+        canceledTrigger = { id: params.id, enabled: body.enabled };
+        return respond(204);
+      },
+    );
 
     detachedSetupPage({ context, path: `/chats/${threadId}` });
 
@@ -3356,6 +3367,15 @@ describe("chat lifecycle", () => {
     });
     expect(queuedIndex).toBeGreaterThanOrEqual(0);
     expect(goalIndex).toBeGreaterThan(queuedIndex);
+
+    // Cancelling the goal row disables its trigger (by the folded trigger id).
+    await user.click(within(goalRow).getByLabelText("Cancel goal"));
+    await waitFor(() => {
+      expect(canceledTrigger).toStrictEqual({
+        id: "trigger-goal-fold-1",
+        enabled: false,
+      });
+    });
   });
 
   it("hides the goal row once a completion marker folds in", async () => {
@@ -3375,7 +3395,7 @@ describe("chat lifecycle", () => {
           id: "msg-goalc-trigger-active",
           runId: undefined,
           role: "assistant",
-          content: null,
+          content: "trigger-goal-complete-1",
           runEventId: "goal-trigger:active",
           createdAt: "2026-06-09T10:00:01Z",
         },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3230,9 +3230,26 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("lists thread workflow triggers with their workflow in the sidebar", async () => {
+  it("lists workflow triggers in the sidebar but excludes goals", async () => {
     mockAutomationThread();
     setMockWorkflowTriggers([
+      // A scheduled workflow trigger — shown in the sidebar.
+      createMockWorkflowTrigger({
+        id: "e0000001-0000-4000-a000-000000000002",
+        chatThreadId: AUTOMATION_THREAD_ID,
+        kind: "schedule",
+        scheduleSummary: "Every 60s",
+        eventType: null,
+        workflow: {
+          id: "a0000001-0000-4000-a000-000000000002",
+          name: "nightly-sync",
+          displayName: "Nightly sync",
+          description: "Sync the changelog every night",
+          objective: null,
+          type: "workflow",
+        },
+      }),
+      // A goal trigger — goals now live in the composer, so it must not appear.
       createMockWorkflowTrigger({ chatThreadId: AUTOMATION_THREAD_ID }),
     ]);
     context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
@@ -3255,15 +3272,18 @@ describe("chat lifecycle", () => {
     });
 
     const sidebar = screen.getByTestId("automation-sidebar");
-    // The goal card shows its title and the objective (goals have no
-    // description), plus the Active state with an enable/disable toggle.
-    expect(within(sidebar).getByText("Goal")).toBeInTheDocument();
+    // The workflow trigger card shows its name and description.
+    expect(within(sidebar).getByText("Nightly sync")).toBeInTheDocument();
     expect(
-      within(sidebar).getByText("Drive the release to merge"),
+      within(sidebar).getByText("Sync the changelog every night"),
     ).toBeInTheDocument();
-    // The enabled toggle (its aria-label) uniquely marks the active goal card;
-    // "Active" text also appears on the automation card, so assert the toggle.
-    expect(within(sidebar).getByLabelText("Disable Goal")).toBeInTheDocument();
+    // The goal is excluded from the automation sidebar.
+    expect(
+      within(sidebar).queryByText("Drive the release to merge"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(sidebar).queryByLabelText("Disable Goal"),
+    ).not.toBeInTheDocument();
   });
 
   it("folds goal-state markers into the goal row beneath the queued messages", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3266,6 +3266,121 @@ describe("chat lifecycle", () => {
     expect(within(sidebar).getByLabelText("Disable Goal")).toBeInTheDocument();
   });
 
+  it("folds goal-state markers into the goal row beneath the queued messages", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "thread-goal-fold";
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [
+        {
+          id: "msg-goal-user",
+          role: "user",
+          content: "Start the active run",
+          runId: "run-active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-goal-assistant",
+          role: "assistant",
+          content: null,
+          runId: "run-active",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        // Goal-state markers: the workflow is active (carrying the objective)
+        // and its trigger is enabled — the fold should surface the goal.
+        {
+          id: "msg-goal-workflow-active",
+          runId: undefined,
+          role: "assistant",
+          content: "Drive the release to merge",
+          runEventId: "goal-workflow:active",
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+        {
+          id: "msg-goal-trigger-active",
+          runId: undefined,
+          role: "assistant",
+          content: null,
+          runEventId: "goal-trigger:active",
+          createdAt: "2026-06-09T10:00:03Z",
+        },
+      ],
+      activeRunIds: ["run-active"],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+
+    // The folded goal surfaces above the composer.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Active goal")).toHaveTextContent(
+        "Drive the release to merge",
+      );
+    });
+    // The marker is a control row — it must not also render as a chat bubble.
+    expect(
+      screen.getAllByText("Drive the release to merge"),
+    ).toHaveLength(1);
+
+    // The goal is the lowest-priority row: it sits after every queued message.
+    await sendQueuedMessage(user, "First queued follow-up");
+    await expectQueuedMessages(["First queued follow-up"]);
+    const goalRow = screen.getByLabelText("Active goal");
+    const strip = goalRow.closest('[role="list"]');
+    expect(strip).not.toBeNull();
+    const rows = within(strip as HTMLElement).getAllByRole("listitem");
+    const goalIndex = rows.indexOf(goalRow);
+    const queuedIndex = rows.findIndex((row) => {
+      return row.getAttribute("aria-label") === "Queued message";
+    });
+    expect(queuedIndex).toBeGreaterThanOrEqual(0);
+    expect(goalIndex).toBeGreaterThan(queuedIndex);
+  });
+
+  it("hides the goal row once a completion marker folds in", async () => {
+    const threadId = "thread-goal-complete";
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [
+        {
+          id: "msg-goalc-workflow-active",
+          runId: undefined,
+          role: "assistant",
+          content: "Drive the release to merge",
+          runEventId: "goal-workflow:active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-goalc-trigger-active",
+          runId: undefined,
+          role: "assistant",
+          content: null,
+          runEventId: "goal-trigger:active",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-goalc-workflow-inactive",
+          runId: undefined,
+          role: "assistant",
+          content: null,
+          runEventId: "goal-workflow:inactive",
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    });
+    // Latest workflow marker is inactive → folds to "complete" → no goal row.
+    expect(screen.queryByLabelText("Active goal")).not.toBeInTheDocument();
+  });
+
   it("shows automation run messages as automation links in chat history", async () => {
     const threadId = "thread-automation-message";
     const automationId = "f0000001-0000-4000-a000-000000000721";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -319,6 +319,8 @@ interface ZeroChatComposerProps {
    * Absent when the thread has no in-progress goal.
    */
   activeGoal?: ActiveGoalComposerItem;
+  /** Cancels the active goal (disables its trigger via the caller). */
+  onCancelActiveGoal?: () => void;
   /**
    * Inline feedback drafted from selected assistant text. When at least one
    * quoted fragment is present the composer swaps its textarea for the stacked
@@ -493,10 +495,12 @@ function QueuedMessagesStrip({
   items,
   onRemove,
   activeGoal,
+  onCancelGoal,
 }: {
   items: QueuedComposerItem[] | undefined;
   onRemove?: (id: string) => void;
   activeGoal?: ActiveGoalComposerItem;
+  onCancelGoal?: () => void;
 }) {
   const queued = items ?? [];
   if (queued.length === 0 && !activeGoal) {
@@ -550,13 +554,13 @@ function QueuedMessagesStrip({
         })}
         {/* The active goal sits last — below every queued message — because a
             goal only runs once the queue drains, so it reads as lower priority
-            than the queue. It is informational here (managed from the automation
-            sidebar), so unlike a queued message it carries no remove control. */}
+            than the queue. Like a queued message it can be cancelled; cancelling
+            disables the goal's trigger so it no longer runs behind the queue. */}
         {activeGoal ? (
           <div
             role="listitem"
             aria-label="Active goal"
-            className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground"
+            className="group flex items-center gap-2 rounded-md pl-3 pr-1 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-sidebar-accent"
           >
             <IconTarget
               size={16}
@@ -570,6 +574,16 @@ function QueuedMessagesStrip({
             <span className="shrink-0 rounded-full bg-emerald-800/10 px-2 py-0.5 text-xs font-medium text-emerald-800">
               Goal
             </span>
+            <button
+              type="button"
+              className="shrink-0 rounded-lg p-1.5 text-muted-foreground/45 transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground focus-visible:bg-[hsl(var(--gray-200))] focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => {
+                onCancelGoal?.();
+              }}
+              aria-label="Cancel goal"
+            >
+              <IconX size={16} stroke={1.5} />
+            </button>
           </div>
         ) : null}
       </div>
@@ -5276,6 +5290,7 @@ export function ZeroChatComposer({
   queuedItems,
   onRemoveQueuedItem,
   activeGoal,
+  onCancelActiveGoal,
   feedback,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
@@ -5648,6 +5663,7 @@ export function ZeroChatComposer({
           items={queuedItems}
           onRemove={onRemoveQueuedItem}
           activeGoal={activeGoal}
+          onCancelGoal={onCancelActiveGoal}
         />
         <Card
           className={cn(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -31,6 +31,7 @@ import {
   IconPlus,
   IconQuote,
   IconSearch,
+  IconTarget,
   IconTemplate,
   IconVideo,
   IconX,
@@ -312,6 +313,13 @@ interface ZeroChatComposerProps {
   /** Cancels a queued message (routed to the recall flow by the caller). */
   onRemoveQueuedItem?: (id: string) => void;
   /**
+   * The thread's active goal. Rendered as a row beneath the queued messages in
+   * the strip above the composer — a goal runs only once the queue drains, so it
+   * sits closest to the composer to read as lower priority than the queue.
+   * Absent when the thread has no in-progress goal.
+   */
+  activeGoal?: ActiveGoalComposerItem;
+  /**
    * Inline feedback drafted from selected assistant text. When at least one
    * quoted fragment is present the composer swaps its textarea for the stacked
    * quote + note rows and its Send button dispatches the feedback turn — so the
@@ -333,6 +341,11 @@ export interface ComposerFeedback {
 export interface QueuedComposerItem {
   id: string;
   text: string;
+}
+
+interface ActiveGoalComposerItem {
+  /** The goal's objective — the human-readable text shown in the row. */
+  objective: string;
 }
 
 interface ComposerComputerUseHost {
@@ -479,27 +492,41 @@ function resolveComposerCanSend({
 function QueuedMessagesStrip({
   items,
   onRemove,
+  activeGoal,
 }: {
   items: QueuedComposerItem[] | undefined;
   onRemove?: (id: string) => void;
+  activeGoal?: ActiveGoalComposerItem;
 }) {
-  if (!items || items.length === 0) {
+  const queued = items ?? [];
+  if (queued.length === 0 && !activeGoal) {
     return null;
   }
-  const count = items.length;
+  const count = queued.length;
   const label = `${count} ${count === 1 ? "message" : "messages"} waiting to send`;
   return (
     <div className="relative z-0 mx-5 -mb-6 overflow-hidden rounded-xl bg-gray-50 dark:bg-gray-100">
-      <div className="flex items-center gap-2 px-5 pt-3 pb-2">
-        <span className="inline-flex items-center gap-[2px]" aria-hidden="true">
-          <span className="h-2 w-[3px] rounded-sm bg-emerald-800" />
-          <span className="h-2 w-[3px] rounded-sm bg-emerald-800/60" />
-          <span className="h-2 w-[3px] rounded-sm bg-emerald-800/30" />
-        </span>
-        <span className="text-sm text-muted-foreground">{label}</span>
-      </div>
-      <div className="max-h-[200px] overflow-y-auto px-2 pt-1 pb-7" role="list">
-        {items.map((item) => {
+      {count > 0 ? (
+        <div className="flex items-center gap-2 px-5 pt-3 pb-2">
+          <span
+            className="inline-flex items-center gap-[2px]"
+            aria-hidden="true"
+          >
+            <span className="h-2 w-[3px] rounded-sm bg-emerald-800" />
+            <span className="h-2 w-[3px] rounded-sm bg-emerald-800/60" />
+            <span className="h-2 w-[3px] rounded-sm bg-emerald-800/30" />
+          </span>
+          <span className="text-sm text-muted-foreground">{label}</span>
+        </div>
+      ) : null}
+      <div
+        className={cn(
+          "max-h-[200px] overflow-y-auto px-2 pb-7",
+          count > 0 ? "pt-1" : "pt-3",
+        )}
+        role="list"
+      >
+        {queued.map((item) => {
           return (
             <div
               key={item.id}
@@ -521,6 +548,30 @@ function QueuedMessagesStrip({
             </div>
           );
         })}
+        {/* The active goal sits last — below every queued message — because a
+            goal only runs once the queue drains, so it reads as lower priority
+            than the queue. It is informational here (managed from the automation
+            sidebar), so unlike a queued message it carries no remove control. */}
+        {activeGoal ? (
+          <div
+            role="listitem"
+            aria-label="Active goal"
+            className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm text-muted-foreground"
+          >
+            <IconTarget
+              size={16}
+              stroke={1.5}
+              className="shrink-0 text-emerald-800"
+              aria-hidden="true"
+            />
+            <span className="min-w-0 flex-1 truncate">
+              {activeGoal.objective}
+            </span>
+            <span className="shrink-0 rounded-full bg-emerald-800/10 px-2 py-0.5 text-xs font-medium text-emerald-800">
+              Goal
+            </span>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -5224,6 +5275,7 @@ export function ZeroChatComposer({
   submitBlocker,
   queuedItems,
   onRemoveQueuedItem,
+  activeGoal,
   feedback,
 }: ZeroChatComposerProps) {
   const showAddDialog = useGet(showAddDialog$);
@@ -5595,6 +5647,7 @@ export function ZeroChatComposer({
         <QueuedMessagesStrip
           items={queuedItems}
           onRemove={onRemoveQueuedItem}
+          activeGoal={activeGoal}
         />
         <Card
           className={cn(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3532,6 +3532,29 @@ function useChatComposerQueue(
   return { queuedItems, onRemoveQueuedItem };
 }
 
+// The thread's active goal (folded from goal-state markers, no /api/automations
+// poll) plus its cancel handler. Cancelling disables the goal's trigger; the
+// backend then emits a goal-trigger:inactive marker, so the row folds away.
+function useChatComposerActiveGoal(
+  thread: ChatThreadSignals,
+  pageSignal: AbortSignal,
+) {
+  const activeGoal = useLastResolved(thread.activeGoal$) ?? undefined;
+  const toggleWorkflowTrigger = useSet(toggleWorkflowTriggerEnabled$);
+  const onCancelActiveGoal = activeGoal
+    ? () => {
+        detach(
+          toggleWorkflowTrigger(
+            { triggerId: activeGoal.triggerId, enabled: false },
+            pageSignal,
+          ),
+          Reason.DomCallback,
+        );
+      }
+    : undefined;
+  return { activeGoal, onCancelActiveGoal };
+}
+
 function useChatComposerModel(
   thread: ChatThreadSignals,
   pageSignal: AbortSignal,
@@ -3836,10 +3859,12 @@ function ChatThreadComposer({
     thread,
     groups,
   );
-  // The active goal is folded from the thread's message stream (goal-state
-  // markers) — no /api/automations poll. Shown as a low-priority row beneath
-  // the queued messages above the composer.
-  const activeGoal = useLastResolved(thread.activeGoal$) ?? undefined;
+  // The active goal row above the composer, with its cancel (disable-trigger)
+  // handler — folded from the thread's message stream, no /api/automations poll.
+  const { activeGoal, onCancelActiveGoal } = useChatComposerActiveGoal(
+    thread,
+    pageSignal,
+  );
   const {
     modelPicker,
     modelPickerLoading,
@@ -3923,6 +3948,7 @@ function ChatThreadComposer({
             queuedItems={queuedItems}
             onRemoveQueuedItem={onRemoveQueuedItem}
             activeGoal={activeGoal}
+            onCancelActiveGoal={onCancelActiveGoal}
             feedback={feedback}
           />
           <PersonalClaudeCodeDeviceAuthDialog />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1001,8 +1001,9 @@ export function AutomationMenuButton({
   const workflowTriggers = workflowTriggersForThread(allTriggers, threadId);
   const open = openThreadId === threadId;
 
-  // Show the opener when the thread has either an automation or a workflow/goal
-  // trigger — a thread with only a goal must still reach the sidebar.
+  // Show the opener when the thread has an automation or a (non-goal) workflow
+  // trigger. Goals live in the composer, so a goal-only thread has nothing to
+  // show in the automation sidebar.
   if (automations.length === 0 && workflowTriggers.length === 0) {
     return null;
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3835,6 +3835,10 @@ function ChatThreadComposer({
     thread,
     groups,
   );
+  // The active goal is folded from the thread's message stream (goal-state
+  // markers) — no /api/automations poll. Shown as a low-priority row beneath
+  // the queued messages above the composer.
+  const activeGoal = useLastResolved(thread.activeGoal$) ?? undefined;
   const {
     modelPicker,
     modelPickerLoading,
@@ -3917,6 +3921,7 @@ function ChatThreadComposer({
             submitBlocker={submitBlockerProps}
             queuedItems={queuedItems}
             onRemoveQueuedItem={onRemoveQueuedItem}
+            activeGoal={activeGoal}
             feedback={feedback}
           />
           <PersonalClaudeCodeDeviceAuthDialog />


### PR DESCRIPTION
## What

When a chat thread has an **active goal**, it now appears in the strip above the composer — like a queued message, but positioned **beneath every queued message** (a goal only runs once the queue drains, so it reads as lower priority than the queue).

Instead of polling `/api/automations`, the goal row is **driven entirely by the thread's message stream**: the backend publishes each goal transition into the thread as assistant **marker messages**, and the web client folds them into the current goal state. Follows on from #18346.

## Backend

- **`zero-chat-goal-marker.service.ts`** — appends `goal-workflow:active|inactive` and `goal-trigger:active|inactive` assistant marker rows (workflow markers carry the objective in `content`; `runId` is null). Exposes `excludeGoalMarkerCondition` so these control rows never count toward unread or surface in chat search.
- Markers are emitted at every goal transition: create / complete / block / resume (`zero-goal.service`), the sidebar enable/disable toggle for **goal** triggers (`zero-workflow-trigger.service`), and the poller's auto-disable after consecutive failures (`zero-workflow-trigger-poller.service`). Each also publishes `chatThreadMessageCreated:${threadId}` so open clients re-fold live.
- Goal markers are excluded from the unread last-visible-message subquery and the chat-search queries. The paged message-list endpoint still returns them (the client needs them to fold).

## Frontend

- Fold the two dimensions (workflow active + trigger enabled) with the **same rule** as the backend `goalResponse` (active / blocked / complete); exposed as `thread.activeGoal$`. Markers are filtered out of the transcript and ignored by the run-status fold.
- The composer reads `thread.activeGoal$` (no poll) and renders the goal as a low-priority row beneath the queued messages.
- **Automation sidebar no longer shows goals** — `workflowTriggersForThread` excludes goal triggers (goals live in the composer now).

## Tests

- API integration tests (`zero-goals.test.ts`): goal-state markers are persisted on each transition, and are excluded from a thread's unread state (via the `chat-thread-unreads` route).
- Frontend tests (`chat-lifecycle.test.tsx`): markers fold into the goal row beneath the queued messages and don't render as bubbles; a completion marker hides the row; the sidebar lists workflow triggers but excludes goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)