### PR TITLE
feat: add server firewall metadata facade

### DIFF
--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -44,6 +44,10 @@
       "import": "./src/firewall-metadata/index.ts",
       "types": "./src/firewall-metadata/index.ts"
     },
+    "./firewall-metadata/server": {
+      "import": "./src/firewall-metadata/server.ts",
+      "types": "./src/firewall-metadata/server.ts"
+    },
     "./firewalls": {
       "import": "./src/firewalls/index.ts",
       "types": "./src/firewalls/index.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -29,6 +29,7 @@ import {
   loadFirewallPermissionIndex,
 } from "../firewall-metadata/server";
 import {
+  getAllBuiltinConnectorHosts,
   getAllConnectorFirewalls,
   getDefaultFirewallPolicies,
   getPermissionCategories,
@@ -325,8 +326,19 @@ describe("firewall metadata", () => {
     }
   });
 
-  it("looks up fixed builtin host owners from server metadata", () => {
+  it("keeps fixed builtin host owners synchronized with runtime hosts", () => {
+    for (const [host, type] of getAllBuiltinConnectorHosts()) {
+      expect(getBuiltinConnectorHostOwner(host)).toStrictEqual({
+        type,
+        label: connectorLabel(type),
+      });
+    }
+
     expect(getBuiltinConnectorHostOwner("api.github.com")).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
+    expect(getBuiltinConnectorHostOwner("API.GITHUB.COM")).toStrictEqual({
       type: "github",
       label: "GitHub",
     });

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -342,11 +342,31 @@ describe("firewall metadata", () => {
       type: "github",
       label: "GitHub",
     });
+    expect(getBuiltinConnectorHostOwner(" api.github.com ")).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
+    expect(getBuiltinConnectorHostOwner("api.github.com:443")).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
+    expect(getBuiltinConnectorHostOwner("api.github.com.")).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
+    expect(
+      getBuiltinConnectorHostOwner("https://api.github.com/repos"),
+    ).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
     expect(getBuiltinConnectorHostOwner("slack.com")).toStrictEqual({
       type: "slack",
       label: "Slack",
     });
     expect(getBuiltinConnectorHostOwner("example.invalid")).toBeNull();
+    expect(getBuiltinConnectorHostOwner("")).toBeNull();
+    expect(getBuiltinConnectorHostOwner("api.github.com:80")).toBeNull();
     expect(getBuiltinConnectorHostOwner("toString")).toBeNull();
     expect(getBuiltinConnectorHostOwner("__proto__")).toBeNull();
   });

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -354,6 +354,10 @@ describe("firewall metadata", () => {
       type: "github",
       label: "GitHub",
     });
+    expect(getBuiltinConnectorHostOwner("api.github.com....")).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
     expect(
       getBuiltinConnectorHostOwner("https://api.github.com/repos"),
     ).toStrictEqual({

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -347,6 +347,8 @@ describe("firewall metadata", () => {
       label: "Slack",
     });
     expect(getBuiltinConnectorHostOwner("example.invalid")).toBeNull();
+    expect(getBuiltinConnectorHostOwner("toString")).toBeNull();
+    expect(getBuiltinConnectorHostOwner("__proto__")).toBeNull();
   });
 
   it("loads memoized server permission indexes from lazy detail metadata", async () => {
@@ -357,9 +359,15 @@ describe("firewall metadata", () => {
 
     const first = await loadFirewallPermissionIndex("slack");
     const second = await loadFirewallPermissionIndex("slack");
+    const [concurrentFirst, concurrentSecond] = await Promise.all([
+      loadFirewallPermissionIndex("github"),
+      loadFirewallPermissionIndex("github"),
+    ]);
 
     expect(first).not.toBeNull();
     expect(first).toBe(second);
+    expect(concurrentFirst).not.toBeNull();
+    expect(concurrentFirst).toBe(concurrentSecond);
     expect(first!.type).toBe("slack");
     expect(first!.label).toBe("Slack");
     expect(first!.hasPermission("channels:read")).toBe(true);
@@ -373,6 +381,17 @@ describe("firewall metadata", () => {
     expect(first!.policyResolver.permission("channels:read")).toBe("allow");
     expect(first!.policyResolver.permission("chat:write")).toBe("deny");
     expect(await loadFirewallPermissionIndex("cloudinary")).toBeNull();
+  });
+
+  it("keeps server permission indexes aligned with generated summaries", async () => {
+    for (const [type, summary] of Object.entries(
+      FIREWALL_PERMISSION_METADATA_SUMMARIES,
+    )) {
+      const index = await loadFirewallPermissionIndex(type);
+      expect(index).not.toBeNull();
+      expect(index!.type).toBe(type);
+      expect(index!.label).toBe(summary.label);
+    }
   });
 
   it("keeps summary metadata synchronized with the runtime registry", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -23,6 +23,12 @@ import {
   type FirewallConfig,
 } from "../firewall-types";
 import {
+  getBuiltinConnectorHostOwner,
+  getFirewallServerMetadataSummary,
+  isFirewallServerMetadataConnectorType,
+  loadFirewallPermissionIndex,
+} from "../firewall-metadata/server";
+import {
   getAllConnectorFirewalls,
   getDefaultFirewallPolicies,
   getPermissionCategories,
@@ -199,6 +205,22 @@ describe("firewall metadata", () => {
     ]);
   });
 
+  it("keeps server metadata behind an explicit package subpath", () => {
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        "utf-8",
+      ),
+    ) as { exports: Record<string, unknown> };
+
+    expect(rootEntrypoint).not.toContain("firewall-metadata/server");
+    expect(packageJson.exports).toHaveProperty("./firewall-metadata/server");
+  });
+
   it("resolves metadata permission defaults and overrides", () => {
     const resolver = createFirewallMetadataPolicyResolver(RESOLVER_METADATA);
 
@@ -301,6 +323,44 @@ describe("firewall metadata", () => {
         expect(spec).not.toMatch(/\/firewalls(?:\/|$)/);
       }
     }
+  });
+
+  it("looks up fixed builtin host owners from server metadata", () => {
+    expect(getBuiltinConnectorHostOwner("api.github.com")).toStrictEqual({
+      type: "github",
+      label: "GitHub",
+    });
+    expect(getBuiltinConnectorHostOwner("slack.com")).toStrictEqual({
+      type: "slack",
+      label: "Slack",
+    });
+    expect(getBuiltinConnectorHostOwner("example.invalid")).toBeNull();
+  });
+
+  it("loads memoized server permission indexes from lazy detail metadata", async () => {
+    expect(isFirewallServerMetadataConnectorType("slack")).toBe(true);
+    expect(getFirewallServerMetadataSummary("slack")?.label).toBe("Slack");
+    expect(isFirewallServerMetadataConnectorType("cloudinary")).toBe(false);
+    expect(getFirewallServerMetadataSummary("cloudinary")).toBeNull();
+
+    const first = await loadFirewallPermissionIndex("slack");
+    const second = await loadFirewallPermissionIndex("slack");
+
+    expect(first).not.toBeNull();
+    expect(first).toBe(second);
+    expect(first!.type).toBe("slack");
+    expect(first!.label).toBe("Slack");
+    expect(first!.hasPermission("channels:read")).toBe(true);
+    expect(first!.permissionNames.has("channels:read")).toBe(true);
+    expect(first!.permissionDescription("channels:read")).toBe(
+      "View basic information about public channels in a workspace",
+    );
+    expect(first!.hasPermission(UNKNOWN_PERMISSION_GRANT)).toBe(false);
+    expect(first!.permissionNames.has(UNKNOWN_PERMISSION_GRANT)).toBe(false);
+    expect(first!.unknownPolicy).toBe("allow");
+    expect(first!.policyResolver.permission("channels:read")).toBe("allow");
+    expect(first!.policyResolver.permission("chat:write")).toBe("deny");
+    expect(await loadFirewallPermissionIndex("cloudinary")).toBeNull();
   });
 
   it("keeps summary metadata synchronized with the runtime registry", () => {

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -39,6 +39,32 @@ const builtinFirewallFixedHostOwnerLookup: Readonly<
   Record<string, FirewallPermissionSummaryMetadata["type"]>
 > = BUILTIN_FIREWALL_FIXED_HOST_OWNERS;
 
+function stripHostnameTrailingDot(host: string): string {
+  const portStart = host.startsWith("[") ? -1 : host.lastIndexOf(":");
+  if (portStart === -1) {
+    return host.replace(/\.+$/, "");
+  }
+
+  const hostname = host.slice(0, portStart).replace(/\.+$/, "");
+  return `${hostname}${host.slice(portStart)}`;
+}
+
+function normalizeBuiltinConnectorHostLookupKey(host: string): string | null {
+  const trimmedHost = host.trim();
+  if (trimmedHost.length === 0) {
+    return null;
+  }
+
+  try {
+    const url = trimmedHost.includes("://")
+      ? new URL(trimmedHost)
+      : new URL(`https://${trimmedHost}`);
+    return stripHostnameTrailingDot(url.host.toLowerCase());
+  } catch {
+    return stripHostnameTrailingDot(trimmedHost.toLowerCase());
+  }
+}
+
 export function isFirewallServerMetadataConnectorType(
   type: string,
 ): type is FirewallServerMetadataConnectorType {
@@ -60,7 +86,11 @@ export function getFirewallServerMetadataSummary(
 export function getBuiltinConnectorHostOwner(
   host: string,
 ): BuiltinConnectorHostOwner | null {
-  const normalizedHost = host.toLowerCase();
+  const normalizedHost = normalizeBuiltinConnectorHostLookupKey(host);
+  if (!normalizedHost) {
+    return null;
+  }
+
   const type = Object.prototype.hasOwnProperty.call(
     builtinFirewallFixedHostOwnerLookup,
     normalizedHost,

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -39,13 +39,21 @@ const builtinFirewallFixedHostOwnerLookup: Readonly<
   Record<string, FirewallPermissionSummaryMetadata["type"]>
 > = BUILTIN_FIREWALL_FIXED_HOST_OWNERS;
 
+function trimTrailingDots(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 46) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function stripHostnameTrailingDot(host: string): string {
   const portStart = host.startsWith("[") ? -1 : host.lastIndexOf(":");
   if (portStart === -1) {
-    return host.replace(/\.+$/, "");
+    return trimTrailingDots(host);
   }
 
-  const hostname = host.slice(0, portStart).replace(/\.+$/, "");
+  const hostname = trimTrailingDots(host.slice(0, portStart));
   return `${hostname}${host.slice(portStart)}`;
 }
 

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -60,7 +60,13 @@ export function getFirewallServerMetadataSummary(
 export function getBuiltinConnectorHostOwner(
   host: string,
 ): BuiltinConnectorHostOwner | null {
-  const type = builtinFirewallFixedHostOwnerLookup[host.toLowerCase()];
+  const normalizedHost = host.toLowerCase();
+  const type = Object.prototype.hasOwnProperty.call(
+    builtinFirewallFixedHostOwnerLookup,
+    normalizedHost,
+  )
+    ? builtinFirewallFixedHostOwnerLookup[normalizedHost]
+    : undefined;
   if (!type || !isFirewallServerMetadataConnectorType(type)) {
     return null;
   }
@@ -78,6 +84,11 @@ async function loadFirewallPermissionDetail(
   const detail = await loadGeneratedFirewallPermissionMetadata(type);
   if (!detail) {
     throw new Error(`Missing firewall permission metadata: ${type}`);
+  }
+  if (detail.type !== type) {
+    throw new Error(
+      `Mismatched firewall permission metadata: requested ${type}, got ${detail.type}`,
+    );
   }
   return detail;
 }

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -1,0 +1,140 @@
+import { UNKNOWN_PERMISSION_GRANT } from "../firewall-types";
+import {
+  createFirewallMetadataPolicyResolver,
+  type FirewallMetadataPolicyResolver,
+} from "./policy-resolver";
+import { BUILTIN_FIREWALL_FIXED_HOST_OWNERS } from "./server.generated";
+import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./summary.generated";
+import type {
+  FirewallPermissionDefaultPolicyMetadata,
+  FirewallPermissionDetailMetadata,
+  FirewallPermissionSummaryMetadata,
+} from "./types";
+
+export type FirewallServerMetadataConnectorType =
+  keyof typeof FIREWALL_PERMISSION_METADATA_SUMMARIES;
+
+export interface BuiltinConnectorHostOwner {
+  readonly type: FirewallServerMetadataConnectorType;
+  readonly label: string;
+}
+
+export interface FirewallPermissionIndex {
+  readonly type: FirewallPermissionDetailMetadata["type"];
+  readonly label: string;
+  readonly permissionNames: ReadonlySet<string>;
+  readonly permissionDescriptions: ReadonlyMap<string, string>;
+  readonly defaultPolicy: FirewallPermissionDefaultPolicyMetadata;
+  readonly unknownPolicy: FirewallPermissionDefaultPolicyMetadata["unknownPolicy"];
+  readonly policyResolver: FirewallMetadataPolicyResolver;
+  hasPermission(name: string): boolean;
+  permissionDescription(name: string): string | null;
+}
+
+const permissionIndexCache = new Map<
+  FirewallServerMetadataConnectorType,
+  Promise<FirewallPermissionIndex>
+>();
+const builtinFirewallFixedHostOwnerLookup: Readonly<
+  Record<string, FirewallPermissionSummaryMetadata["type"]>
+> = BUILTIN_FIREWALL_FIXED_HOST_OWNERS;
+
+export function isFirewallServerMetadataConnectorType(
+  type: string,
+): type is FirewallServerMetadataConnectorType {
+  return Object.prototype.hasOwnProperty.call(
+    FIREWALL_PERMISSION_METADATA_SUMMARIES,
+    type,
+  );
+}
+
+export function getFirewallServerMetadataSummary(
+  type: string,
+): FirewallPermissionSummaryMetadata | null {
+  if (!isFirewallServerMetadataConnectorType(type)) {
+    return null;
+  }
+  return FIREWALL_PERMISSION_METADATA_SUMMARIES[type];
+}
+
+export function getBuiltinConnectorHostOwner(
+  host: string,
+): BuiltinConnectorHostOwner | null {
+  const type = builtinFirewallFixedHostOwnerLookup[host];
+  if (!type || !isFirewallServerMetadataConnectorType(type)) {
+    return null;
+  }
+  return {
+    type,
+    label: FIREWALL_PERMISSION_METADATA_SUMMARIES[type].label,
+  };
+}
+
+async function loadFirewallPermissionDetail(
+  type: FirewallServerMetadataConnectorType,
+): Promise<FirewallPermissionDetailMetadata> {
+  const { loadGeneratedFirewallPermissionMetadata } =
+    await import("./loader.generated");
+  const detail = await loadGeneratedFirewallPermissionMetadata(type);
+  if (!detail) {
+    throw new Error(`Missing firewall permission metadata: ${type}`);
+  }
+  return detail;
+}
+
+function buildFirewallPermissionIndex(
+  detail: FirewallPermissionDetailMetadata,
+): FirewallPermissionIndex {
+  const permissionNames = new Set<string>();
+  const permissionDescriptions = new Map<string, string>();
+
+  for (const permission of detail.permissions) {
+    if (permission.name === UNKNOWN_PERMISSION_GRANT) {
+      continue;
+    }
+    permissionNames.add(permission.name);
+    if (permission.description !== undefined) {
+      permissionDescriptions.set(permission.name, permission.description);
+    }
+  }
+
+  return {
+    type: detail.type,
+    label: detail.label,
+    permissionNames,
+    permissionDescriptions,
+    defaultPolicy: detail.defaultPolicy,
+    unknownPolicy: detail.defaultPolicy.unknownPolicy,
+    policyResolver: createFirewallMetadataPolicyResolver(detail),
+    hasPermission: (name) => {
+      return permissionNames.has(name);
+    },
+    permissionDescription: (name) => {
+      return permissionDescriptions.get(name) ?? null;
+    },
+  };
+}
+
+export async function loadFirewallPermissionIndex(
+  type: string,
+): Promise<FirewallPermissionIndex | null> {
+  if (!isFirewallServerMetadataConnectorType(type)) {
+    return null;
+  }
+
+  const cached = permissionIndexCache.get(type);
+  if (cached) {
+    return await cached;
+  }
+
+  const load = loadFirewallPermissionDetail(type)
+    .then((detail) => {
+      return buildFirewallPermissionIndex(detail);
+    })
+    .catch((error: unknown) => {
+      permissionIndexCache.delete(type);
+      throw error;
+    });
+  permissionIndexCache.set(type, load);
+  return await load;
+}

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -60,7 +60,7 @@ export function getFirewallServerMetadataSummary(
 export function getBuiltinConnectorHostOwner(
   host: string,
 ): BuiltinConnectorHostOwner | null {
-  const type = builtinFirewallFixedHostOwnerLookup[host];
+  const type = builtinFirewallFixedHostOwnerLookup[host.toLowerCase()];
   if (!type || !isFirewallServerMetadataConnectorType(type)) {
     return null;
   }

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -2,8 +2,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { fixedFirewallApiBaseHost } from "../metadata";
-
 function staticValueImportSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
   for (const match of source.matchAll(
@@ -61,16 +59,6 @@ describe("firewall metadata generator", () => {
     expect(source).not.toContain("CONNECTOR_TYPES");
   });
 
-  it("matches runtime fixed-host extraction semantics", () => {
-    expect(fixedFirewallApiBaseHost("https://api.github.com/repos")).toBe(
-      "api.github.com",
-    );
-    expect(
-      fixedFirewallApiBaseHost("https://${{ vars.TENANT }}.example.com"),
-    ).toBeNull();
-    expect(fixedFirewallApiBaseHost("not a url")).toBeNull();
-  });
-
   it("keeps generated server metadata host-owner only", () => {
     const source = fs.readFileSync(
       path.resolve(
@@ -82,7 +70,9 @@ describe("firewall metadata generator", () => {
 
     expect(staticValueModuleSpecifiers(source)).toStrictEqual([]);
     expect(source).toContain('"api.github.com": "github"');
+    expect(source).toContain('"{network}.g.alchemy.com": "alchemy"');
     expect(source).toContain('"slack.com": "slack"');
+    expect(source).not.toContain("${{");
     expect(source).not.toContain('"permissions"');
     expect(source).not.toContain('"description"');
     expect(source).not.toContain('"rules"');

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -2,6 +2,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { fixedFirewallApiBaseHost } from "../metadata";
+
 function staticValueImportSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
   for (const match of source.matchAll(
@@ -57,5 +59,32 @@ describe("firewall metadata generator", () => {
       "../../connectors/src/firewalls",
     );
     expect(source).not.toContain("CONNECTOR_TYPES");
+  });
+
+  it("matches runtime fixed-host extraction semantics", () => {
+    expect(fixedFirewallApiBaseHost("https://api.github.com/repos")).toBe(
+      "api.github.com",
+    );
+    expect(
+      fixedFirewallApiBaseHost("https://${{ vars.TENANT }}.example.com"),
+    ).toBeNull();
+    expect(fixedFirewallApiBaseHost("not a url")).toBeNull();
+  });
+
+  it("keeps generated server metadata host-owner only", () => {
+    const source = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../connectors/src/firewall-metadata/server.generated.ts",
+      ),
+      "utf-8",
+    );
+
+    expect(staticValueModuleSpecifiers(source)).toStrictEqual([]);
+    expect(source).toContain('"api.github.com": "github"');
+    expect(source).toContain('"slack.com": "slack"');
+    expect(source).not.toContain('"permissions"');
+    expect(source).not.toContain('"description"');
+    expect(source).not.toContain('"rules"');
   });
 });

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -491,6 +491,33 @@ function sortedRecord(
   );
 }
 
+export function fixedFirewallApiBaseHost(base: string): string | null {
+  if (base.includes("${{")) {
+    return null;
+  }
+  try {
+    return new URL(base).host;
+  } catch {
+    return null;
+  }
+}
+
+function buildFixedHostOwners(
+  sources: readonly GeneratedFirewallSource[],
+): Record<string, string> {
+  const owners = new Map<string, string>();
+  for (const source of sources) {
+    for (const api of source.firewall.apis) {
+      const host = fixedFirewallApiBaseHost(api.base);
+      if (!host || owners.has(host)) {
+        continue;
+      }
+      owners.set(host, source.type);
+    }
+  }
+  return sortedRecord(owners.entries());
+}
+
 function choosePermissionDefault(policy: FirewallPolicy): FirewallPolicyValue {
   const counts = new Map<FirewallPolicyValue, number>(
     POLICY_VALUES.map((value) => {
@@ -611,6 +638,13 @@ export const FIREWALL_PERMISSION_METADATA_SUMMARIES = ${stableJson(summaries)} a
 `;
 }
 
+function renderServerFile(fixedHostOwners: Record<string, string>): string {
+  return `${generatedHeader()}import type { FirewallPermissionSummaryMetadata } from "./types";
+
+export const BUILTIN_FIREWALL_FIXED_HOST_OWNERS = ${stableJson(fixedHostOwners)} as const satisfies Readonly<Record<string, FirewallPermissionSummaryMetadata["type"]>>;
+`;
+}
+
 function renderLoaderFile(types: readonly FirewallConnectorType[]): string {
   const loaders = types
     .map((type) => {
@@ -660,15 +694,27 @@ export async function generateFirewallMetadata(): Promise<void> {
   );
   const summaryFile = path.join(outputDir, "summary.generated.ts");
   const loaderFile = path.join(outputDir, "loader.generated.ts");
+  const serverFile = path.join(outputDir, "server.generated.ts");
   const detailsDir = path.join(outputDir, "details");
 
+  const registeredTypes = extractRegisteredFirewallTypes(firewallsIndexFile);
   const sources = await Promise.all(
-    extractRegisteredFirewallTypes(firewallsIndexFile)
-      .sort(compareStrings)
-      .map((type) => {
-        return loadGeneratedFirewallSource(firewallsDir, connectorsDir, type);
-      }),
+    [...registeredTypes].sort(compareStrings).map((type) => {
+      return loadGeneratedFirewallSource(firewallsDir, connectorsDir, type);
+    }),
   );
+  const sourceByType = new Map<FirewallConnectorType, GeneratedFirewallSource>(
+    sources.map((source) => {
+      return [source.type, source];
+    }),
+  );
+  const registryOrderedSources = registeredTypes.map((type) => {
+    const source = sourceByType.get(type);
+    if (!source) {
+      throw new Error(`Missing firewall metadata source: ${type}`);
+    }
+    return source;
+  });
   const summaries: Record<string, FirewallPermissionSummaryMetadata> = {};
   const details: {
     readonly type: FirewallConnectorType;
@@ -698,6 +744,10 @@ export async function generateFirewallMetadata(): Promise<void> {
     renderSummaryFile(summaries),
   );
   writeGeneratedFile(
+    path.join(nextOutputDir, "server.generated.ts"),
+    renderServerFile(buildFixedHostOwners(registryOrderedSources)),
+  );
+  writeGeneratedFile(
     path.join(nextOutputDir, "loader.generated.ts"),
     renderLoaderFile(
       sources.map((source) => {
@@ -719,6 +769,12 @@ export async function generateFirewallMetadata(): Promise<void> {
       replaceGeneratedPath(
         loaderFile,
         path.join(nextOutputDir, "loader.generated.ts"),
+      ),
+    );
+    replacements.push(
+      replaceGeneratedPath(
+        serverFile,
+        path.join(nextOutputDir, "server.generated.ts"),
       ),
     );
   } catch (error) {

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -491,7 +491,7 @@ function sortedRecord(
   );
 }
 
-export function fixedFirewallApiBaseHost(base: string): string | null {
+function fixedFirewallApiBaseHost(base: string): string | null {
   if (base.includes("${{")) {
     return null;
   }


### PR DESCRIPTION
## Summary
- add `@vm0/connectors/firewall-metadata/server` as an explicit server-only metadata facade
- generate a small fixed built-in host owner metadata file during firewall metadata generation
- build memoized per-connector permission indexes lazily from existing generated detail metadata
- add import-boundary and behavior coverage for the new server metadata surface

## Tests
- `pnpm format`
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F @vm0/connectors test -- --run src/__tests__/firewall-metadata.test.ts`
- `pnpm -F @vm0/firewalls-generator exec vitest run`
- `pnpm lint`
- `pnpm check-types`
- `pnpm test`
- `pnpm knip`

Closes #18079