### PR TITLE
feat: default chat composer to single line on mobile behind org switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5021,9 +5021,7 @@ function ComposerTextarea({
         // The resting height is floored by min-height; rows is kept at 1 so the
         // floor governs. Mobile rests at a single line and grows back to the
         // three-line desktop height from the md breakpoint up.
-        singleLineOnMobile
-          ? "min-h-[44px] md:min-h-[96px]"
-          : "min-h-[96px]",
+        singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]",
       )}
       rows={singleLineOnMobile ? 1 : 3}
       placeholder={

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4995,6 +4995,7 @@ function ComposerTextarea({
   onPaste,
   onAfterInputChange,
   onPointerSelectionChange,
+  singleLineOnMobile,
 }: {
   readonly input: string;
   readonly onInputChange: (value: string) => void;
@@ -5005,6 +5006,7 @@ function ComposerTextarea({
   readonly onPaste: (e: ComposerPasteEvent) => void;
   readonly onAfterInputChange?: (textarea: HTMLTextAreaElement) => void;
   readonly onPointerSelectionChange?: (textarea: HTMLTextAreaElement) => void;
+  readonly singleLineOnMobile: boolean;
 }) {
   return (
     <textarea
@@ -5015,9 +5017,15 @@ function ComposerTextarea({
         setInputRef?.(el);
       }}
       className={cn(
-        "relative z-10 w-full resize-none bg-transparent px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground caret-foreground placeholder:text-muted-foreground/40 border-0 focus:outline-none focus:ring-0 min-h-[96px] selection:bg-primary/20",
+        "relative z-10 w-full resize-none bg-transparent px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground caret-foreground placeholder:text-muted-foreground/40 border-0 focus:outline-none focus:ring-0 selection:bg-primary/20",
+        // The resting height is floored by min-height; rows is kept at 1 so the
+        // floor governs. Mobile rests at a single line and grows back to the
+        // three-line desktop height from the md breakpoint up.
+        singleLineOnMobile
+          ? "min-h-[44px] md:min-h-[96px]"
+          : "min-h-[96px]",
       )}
-      rows={3}
+      rows={singleLineOnMobile ? 1 : 3}
       placeholder={
         sending
           ? "Type your next message\u2026"
@@ -5066,6 +5074,8 @@ function ComposerInputSlot({
   const features = useLastResolved(featureSwitch$);
   const slashWorkflowCommandsEnabled =
     features?.[FeatureSwitchKey.ChatSlashWorkflowCommands] ?? false;
+  const singleLineOnMobile =
+    features?.[FeatureSwitchKey.MobileSingleLineComposer] ?? false;
 
   if (slashWorkflowCommandsEnabled) {
     return (
@@ -5083,7 +5093,12 @@ function ComposerInputSlot({
   }
 
   return (
-    <div className="relative min-h-[96px]">
+    <div
+      className={cn(
+        "relative",
+        singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]",
+      )}
+    >
       <ComposerTextarea
         input={input}
         onInputChange={onInputChange}
@@ -5092,6 +5107,7 @@ function ComposerInputSlot({
         setInputRef={setInputRef}
         onKeyDown={onKeyDown}
         onPaste={onPaste}
+        singleLineOnMobile={singleLineOnMobile}
       />
     </div>
   );

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -57,4 +57,5 @@ export enum FeatureSwitchKey {
   AutomationWebhookTriggers = "automationWebhookTriggers",
   AutomationMultiTrigger = "automationMultiTrigger",
   GoalWorkflows = "goalWorkflows",
+  MobileSingleLineComposer = "mobileSingleLineComposer",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -328,6 +328,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable persistent thread goals, the zero goal CLI, and run-terminal goal continuation. Individuals opt in via feature-switch overrides.",
     enabled: false,
   },
+  [FeatureSwitchKey.MobileSingleLineComposer]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Default the chat composer to a single-line resting height on mobile (below the md breakpoint) instead of the three-line desktop height.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

On desktop the chat composer rests at a three-line height, which is fine. On mobile that resting height is too tall and eats into the viewport. This PR defaults the composer to a **single-line** resting height on mobile (below the `md` breakpoint), while keeping the three-line desktop height.

The change is fully gated behind a new **org-scoped feature switch** (`mobileSingleLineComposer`), so it does not ship to everyone yet — only orgs in `STAFF_ORG_ID_HASHES` get it. When the switch is off, behavior is identical to today.

## Changes

- **New feature switch key** `MobileSingleLineComposer` (`turbo/packages/connectors/src/feature-switch-key.ts`).
- **Registered** the switch in `turbo/packages/core/src/feature-switch.ts` with `enabled: false` + `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` (org-only, mirroring `Lab` / `Banking`).
- **Composer** (`zero-chat-composer.tsx`): `ComposerInputSlot` reads the switch and threads a `singleLineOnMobile` flag into the textarea + its wrapper. When on, the resting height is `min-h-[44px] md:min-h-[96px]` and `rows={1}`; when off, it stays `min-h-[96px]` / `rows={3}`.

## Why this approach

The textarea's resting height is floored by `min-height`, so a responsive Tailwind class (`min-h-[44px] md:min-h-[96px]`) gives one line on mobile and three on desktop without any JS media-query/`useIsMobile` hook (the codebase has none and uses `md:` breakpoints for mobile). `rows` is dropped to `1` when the switch is on so the responsive floor governs the height on both form factors.

## Scope notes

- This targets the default textarea composer. The experimental Tiptap composer (behind the separate `chatSlashWorkflowCommands` switch) is left unchanged.
- "Org-only" is implemented as `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` (our org), the same gating pattern as existing staged-rollout switches. Easy to widen later by adding org hashes.

## Verification

Behavior is unchanged when the switch is off (default), so existing composer tests are unaffected. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)