### PR TITLE
test: add codex app-server mock harness

### DIFF
--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -221,6 +221,15 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, "missing expectedTurnId")?;
                     return Ok(ServerAction::Continue);
                 };
+                if expected_turn_id.is_empty() {
+                    write_error(
+                        output,
+                        id,
+                        INVALID_REQUEST,
+                        "expectedTurnId must not be empty",
+                    )?;
+                    return Ok(ServerAction::Continue);
+                }
                 let Some(thread_id) = non_empty_string_param(params, "threadId") else {
                     write_error(output, id, INVALID_REQUEST, "missing threadId")?;
                     return Ok(ServerAction::Continue);

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -1,6 +1,7 @@
 use crate::session;
 use chrono::Utc;
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 use std::io::{self, BufRead, Write};
 use uuid::Uuid;
 
@@ -58,6 +59,7 @@ struct AppServerState {
     initialized: bool,
     thread_id: Option<String>,
     session_artifact_thread_id: Option<String>,
+    session_artifact_thread_ids: BTreeMap<String, String>,
     active_turn_id: Option<String>,
     initial_inputs: Vec<String>,
     steered_inputs: Vec<String>,
@@ -70,6 +72,7 @@ impl AppServerState {
             initialized: false,
             thread_id: None,
             session_artifact_thread_id: None,
+            session_artifact_thread_ids: BTreeMap::new(),
             active_turn_id: None,
             initial_inputs: Vec::new(),
             steered_inputs: Vec::new(),
@@ -256,7 +259,12 @@ impl AppServerState {
     }
 
     fn set_current_thread(&mut self, thread_id: String) {
-        self.session_artifact_thread_id = Some(session_artifact_thread_id(&thread_id));
+        let artifact_thread_id = self
+            .session_artifact_thread_ids
+            .entry(thread_id.clone())
+            .or_insert_with(|| session_artifact_thread_id(&thread_id))
+            .clone();
+        self.session_artifact_thread_id = Some(artifact_thread_id);
         self.thread_id = Some(thread_id);
         self.active_turn_id = None;
     }

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -166,6 +166,10 @@ impl AppServerState {
                 Ok(ServerAction::Continue)
             }
             "turn/start" => {
+                if !self.initialized {
+                    write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
+                    return Ok(ServerAction::Continue);
+                }
                 if self.scenario == Scenario::ExitOnTurnStart {
                     return Ok(ServerAction::Stop);
                 }
@@ -205,6 +209,10 @@ impl AppServerState {
                 Ok(ServerAction::Continue)
             }
             "turn/steer" => {
+                if !self.initialized {
+                    write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
+                    return Ok(ServerAction::Continue);
+                }
                 let Some(expected_turn_id) = string_param(params, "expectedTurnId") else {
                     write_error(output, id, INVALID_REQUEST, "missing expectedTurnId")?;
                     return Ok(ServerAction::Continue);

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -424,13 +424,21 @@ fn session_artifact_thread_id(thread_id: &str) -> String {
 }
 
 fn write_success<W: Write>(output: &mut W, id: Value, result: Value) -> io::Result<()> {
-    write_json_line(output, &json!({ "id": id, "result": result }))
+    write_json_line(
+        output,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result
+        }),
+    )
 }
 
 fn write_error<W: Write>(output: &mut W, id: Value, code: i64, message: &str) -> io::Result<()> {
     write_json_line(
         output,
         &json!({
+            "jsonrpc": "2.0",
             "id": id,
             "error": {
                 "code": code,

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -174,7 +174,11 @@ impl AppServerState {
                     return Ok(ServerAction::Stop);
                 }
 
-                let current_thread = match self.current_thread(string_param(params, "threadId")) {
+                let Some(thread_id) = non_empty_string_param(params, "threadId") else {
+                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                let current_thread = match self.current_thread(thread_id) {
                     Ok(current_thread) => current_thread,
                     Err(message) => {
                         write_error(output, id, INVALID_REQUEST, message)?;
@@ -217,7 +221,11 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, "missing expectedTurnId")?;
                     return Ok(ServerAction::Continue);
                 };
-                let current_thread = match self.current_thread(string_param(params, "threadId")) {
+                let Some(thread_id) = non_empty_string_param(params, "threadId") else {
+                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                let current_thread = match self.current_thread(thread_id) {
                     Ok(current_thread) => current_thread,
                     Err(message) => {
                         write_error(output, id, INVALID_REQUEST, message)?;
@@ -290,13 +298,11 @@ impl AppServerState {
         });
     }
 
-    fn current_thread(&self, requested_thread_id: Option<&str>) -> Result<&AppServerThread, &str> {
+    fn current_thread(&self, requested_thread_id: &str) -> Result<&AppServerThread, &str> {
         let Some(current_thread) = &self.current_thread else {
             return Err("no active thread");
         };
-        if let Some(requested_thread_id) = requested_thread_id
-            && requested_thread_id != current_thread.protocol_thread_id
-        {
+        if requested_thread_id != current_thread.protocol_thread_id {
             return Err("unknown threadId");
         }
         Ok(current_thread)

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -255,15 +255,16 @@ impl AppServerState {
         }
     }
 
-    fn handle_notification(&mut self, method: &str) {
-        if method == "initialized" {
-            self.initialized = true;
-        }
+    fn handle_notification(&mut self, _method: &str) {
+        // The client sends `initialized` after the `initialize` request. It
+        // must not substitute for the request itself because later requests
+        // need initialize response state to exist.
     }
 
     fn set_current_thread(&mut self, thread_id: String) {
         self.session_artifact_thread_id = Some(session_artifact_thread_id(&thread_id));
         self.thread_id = Some(thread_id);
+        self.active_turn_id = None;
     }
 
     fn current_thread(&self, requested_thread_id: Option<&str>) -> Result<(&str, &str), &str> {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -7,12 +7,6 @@ use uuid::Uuid;
 const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
 
-#[derive(Debug)]
-pub struct AppServerOptions {
-    pub listen: String,
-    pub stdio: bool,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Scenario {
     Success,
@@ -41,13 +35,13 @@ impl Scenario {
     }
 }
 
-pub fn run_app_server(options: AppServerOptions) -> io::Result<()> {
-    if options.listen != "stdio://" {
+pub fn run_app_server(listen: &str) -> io::Result<()> {
+    if listen != "stdio://" {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
                 "guest-mock-codex app-server only supports stdio transport, got {:?}",
-                options.listen
+                listen
             ),
         ));
     }

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -127,6 +127,14 @@ impl AppServerState {
     ) -> io::Result<ServerAction> {
         match method {
             "initialize" => {
+                if self.initialized {
+                    write_error(output, id, INVALID_REQUEST, "Already initialized")?;
+                    return Ok(ServerAction::Continue);
+                }
+                if let Err(message) = validate_initialize_params(params) {
+                    write_error(output, id, INVALID_REQUEST, message)?;
+                    return Ok(ServerAction::Continue);
+                }
                 self.initialized = true;
                 write_success(output, id, initialize_response())?;
                 if self.scenario == Scenario::DisconnectAfterInitialize {
@@ -300,6 +308,22 @@ fn initialize_response() -> Value {
         "platformFamily": std::env::consts::FAMILY,
         "platformOs": std::env::consts::OS,
     })
+}
+
+fn validate_initialize_params(params: &Value) -> Result<(), &'static str> {
+    let Some(client_info) = params.get("clientInfo") else {
+        return Err("missing clientInfo");
+    };
+    let Some(name) = client_info.get("name").and_then(Value::as_str) else {
+        return Err("missing clientInfo.name");
+    };
+    if name.contains(['\r', '\n']) {
+        return Err("invalid clientInfo.name");
+    }
+    if client_info.get("version").and_then(Value::as_str).is_none() {
+        return Err("missing clientInfo.version");
+    }
+    Ok(())
 }
 
 fn thread_response(thread_id: &str, resume: bool) -> Value {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -1,0 +1,400 @@
+use crate::session;
+use chrono::Utc;
+use serde_json::{Value, json};
+use std::io::{self, BufRead, Write};
+use uuid::Uuid;
+
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+
+#[derive(Debug)]
+pub struct AppServerOptions {
+    pub listen: String,
+    pub stdio: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Scenario {
+    Success,
+    DisconnectAfterInitialize,
+    ExitOnTurnStart,
+    StaleTurn,
+    NoActiveTurn,
+}
+
+impl Scenario {
+    fn from_env() -> io::Result<Self> {
+        match std::env::var("MOCK_CODEX_APP_SERVER_SCENARIO") {
+            Ok(value) if value.is_empty() => Ok(Self::Success),
+            Ok(value) => match value.as_str() {
+                "disconnect-after-initialize" => Ok(Self::DisconnectAfterInitialize),
+                "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
+                "stale-turn" => Ok(Self::StaleTurn),
+                "no-active-turn" => Ok(Self::NoActiveTurn),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unsupported MOCK_CODEX_APP_SERVER_SCENARIO={value:?}"),
+                )),
+            },
+            Err(_) => Ok(Self::Success),
+        }
+    }
+}
+
+pub fn run_app_server(options: AppServerOptions) -> io::Result<()> {
+    if !options.stdio && options.listen != "stdio://" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "guest-mock-codex app-server only supports stdio transport, got {:?}",
+                options.listen
+            ),
+        ));
+    }
+
+    let scenario = Scenario::from_env()?;
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut state = AppServerState::new(scenario);
+    state.run(stdin.lock(), stdout.lock())
+}
+
+#[derive(Debug)]
+struct AppServerState {
+    initialized: bool,
+    thread_id: Option<String>,
+    active_turn_id: Option<String>,
+    initial_inputs: Vec<String>,
+    steered_inputs: Vec<String>,
+    scenario: Scenario,
+}
+
+impl AppServerState {
+    fn new(scenario: Scenario) -> Self {
+        Self {
+            initialized: false,
+            thread_id: None,
+            active_turn_id: None,
+            initial_inputs: Vec::new(),
+            steered_inputs: Vec::new(),
+            scenario,
+        }
+    }
+
+    fn run<R: BufRead, W: Write>(&mut self, input: R, mut output: W) -> io::Result<()> {
+        for line_result in input.lines() {
+            let line = line_result?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let message: Value = serde_json::from_str(&line)
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+            if self.handle_message(message, &mut output)? == ServerAction::Stop {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_message<W: Write>(
+        &mut self,
+        message: Value,
+        output: &mut W,
+    ) -> io::Result<ServerAction> {
+        let method = message
+            .get("method")
+            .and_then(Value::as_str)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing method"))?;
+        let params = message.get("params").unwrap_or(&Value::Null);
+
+        if let Some(id) = message.get("id").cloned() {
+            self.handle_request(id, method, params, output)
+        } else {
+            self.handle_notification(method);
+            Ok(ServerAction::Continue)
+        }
+    }
+
+    fn handle_request<W: Write>(
+        &mut self,
+        id: Value,
+        method: &str,
+        params: &Value,
+        output: &mut W,
+    ) -> io::Result<ServerAction> {
+        match method {
+            "initialize" => {
+                self.initialized = true;
+                write_success(output, id, initialize_response())?;
+                if self.scenario == Scenario::DisconnectAfterInitialize {
+                    return Ok(ServerAction::Stop);
+                }
+                Ok(ServerAction::Continue)
+            }
+            "thread/start" => {
+                if !self.initialized {
+                    write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
+                    return Ok(ServerAction::Continue);
+                }
+                let thread_id = Uuid::now_v7().to_string();
+                self.thread_id = Some(thread_id.clone());
+                write_success(output, id, thread_response(&thread_id, false))?;
+                Ok(ServerAction::Continue)
+            }
+            "thread/resume" => {
+                if !self.initialized {
+                    write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
+                    return Ok(ServerAction::Continue);
+                }
+                let Some(thread_id) = string_param(params, "threadId") else {
+                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                self.thread_id = Some(thread_id.to_string());
+                write_success(output, id, thread_response(thread_id, true))?;
+                Ok(ServerAction::Continue)
+            }
+            "turn/start" => {
+                if self.scenario == Scenario::ExitOnTurnStart {
+                    return Ok(ServerAction::Stop);
+                }
+
+                let Some(thread_id) = string_param(params, "threadId")
+                    .or(self.thread_id.as_deref())
+                    .map(str::to_string)
+                else {
+                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                let inputs = match text_inputs(params) {
+                    Ok(inputs) => inputs,
+                    Err(message) => {
+                        write_error(output, id, INVALID_REQUEST, &message)?;
+                        return Ok(ServerAction::Continue);
+                    }
+                };
+
+                let turn_id = Uuid::now_v7().to_string();
+                if self.scenario != Scenario::NoActiveTurn {
+                    self.active_turn_id = Some(turn_id.clone());
+                }
+                self.initial_inputs.extend(inputs.iter().cloned());
+                persist_input_events(&thread_id, &turn_id, "initial", &inputs)?;
+                write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
+                Ok(ServerAction::Continue)
+            }
+            "turn/steer" => {
+                let Some(active_turn_id) = self.active_turn_id.clone() else {
+                    write_error(output, id, INVALID_REQUEST, "no active turn")?;
+                    return Ok(ServerAction::Continue);
+                };
+                let Some(expected_turn_id) = string_param(params, "expectedTurnId") else {
+                    write_error(output, id, INVALID_REQUEST, "missing expectedTurnId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                if self.scenario == Scenario::StaleTurn || expected_turn_id != active_turn_id {
+                    write_error(output, id, INVALID_REQUEST, "stale expectedTurnId")?;
+                    return Ok(ServerAction::Continue);
+                }
+
+                let Some(thread_id) = string_param(params, "threadId")
+                    .or(self.thread_id.as_deref())
+                    .map(str::to_string)
+                else {
+                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                let inputs = match text_inputs(params) {
+                    Ok(inputs) => inputs,
+                    Err(message) => {
+                        write_error(output, id, INVALID_REQUEST, &message)?;
+                        return Ok(ServerAction::Continue);
+                    }
+                };
+                self.steered_inputs.extend(inputs.iter().cloned());
+                persist_input_events(&thread_id, &active_turn_id, "steered", &inputs)?;
+                write_success(output, id, json!({ "turnId": active_turn_id }))?;
+                Ok(ServerAction::Continue)
+            }
+            "mock/inputs" => {
+                write_success(
+                    output,
+                    id,
+                    json!({
+                        "initial": &self.initial_inputs,
+                        "steered": &self.steered_inputs,
+                    }),
+                )?;
+                Ok(ServerAction::Continue)
+            }
+            _ => {
+                write_error(output, id, METHOD_NOT_FOUND, "unsupported method")?;
+                Ok(ServerAction::Continue)
+            }
+        }
+    }
+
+    fn handle_notification(&mut self, method: &str) {
+        if method == "initialized" {
+            self.initialized = true;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ServerAction {
+    Continue,
+    Stop,
+}
+
+fn initialize_response() -> Value {
+    json!({
+        "userAgent": "guest-mock-codex-app-server/0.2.5",
+        "codexHome": session::codex_home(),
+        "platformFamily": "unix",
+        "platformOs": std::env::consts::OS,
+    })
+}
+
+fn thread_response(thread_id: &str, resume: bool) -> Value {
+    let mut response = json!({
+        "thread": thread(thread_id),
+        "model": "gpt-5",
+        "modelProvider": "openai",
+        "serviceTier": null,
+        "cwd": "/tmp",
+        "runtimeWorkspaceRoots": [],
+        "instructionSources": [],
+        "approvalPolicy": "on-failure",
+        "approvalsReviewer": "user",
+        "sandbox": {
+            "type": "dangerFullAccess"
+        },
+        "activePermissionProfile": null,
+        "reasoningEffort": null,
+        "multiAgentMode": null
+    });
+    if resume && let Value::Object(fields) = &mut response {
+        fields.insert("initialTurnsPage".to_string(), Value::Null);
+    }
+    response
+}
+
+fn thread(thread_id: &str) -> Value {
+    json!({
+        "id": thread_id,
+        "sessionId": thread_id,
+        "forkedFromId": null,
+        "parentThreadId": null,
+        "preview": "guest-mock-codex app-server thread",
+        "ephemeral": false,
+        "modelProvider": "openai",
+        "createdAt": 1,
+        "updatedAt": 1,
+        "recencyAt": 1,
+        "status": {
+            "type": "idle"
+        },
+        "path": null,
+        "cwd": "/tmp",
+        "cliVersion": "guest-mock-codex",
+        "source": "appServer",
+        "threadSource": null,
+        "agentNickname": null,
+        "agentRole": null,
+        "gitInfo": null,
+        "name": null,
+        "turns": []
+    })
+}
+
+fn turn(turn_id: &str) -> Value {
+    json!({
+        "id": turn_id,
+        "items": [],
+        "itemsView": "full",
+        "status": "inProgress",
+        "error": null,
+        "startedAt": 1,
+        "completedAt": null,
+        "durationMs": null
+    })
+}
+
+fn string_param<'a>(params: &'a Value, name: &str) -> Option<&'a str> {
+    params.get(name).and_then(Value::as_str)
+}
+
+fn text_inputs(params: &Value) -> Result<Vec<String>, String> {
+    let Some(values) = params.get("input").and_then(Value::as_array) else {
+        return Err("missing input".to_string());
+    };
+    if values.is_empty() {
+        return Err("input must not be empty".to_string());
+    }
+
+    let mut inputs = Vec::with_capacity(values.len());
+    for value in values {
+        let input_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        if input_type != "text" {
+            return Err(format!("unsupported input type {input_type:?}"));
+        }
+        let Some(text) = value.get("text").and_then(Value::as_str) else {
+            return Err("text input is missing text".to_string());
+        };
+        if text.is_empty() {
+            return Err("text input must not be empty".to_string());
+        }
+        inputs.push(text.to_string());
+    }
+    Ok(inputs)
+}
+
+fn persist_input_events(
+    thread_id: &str,
+    turn_id: &str,
+    kind: &str,
+    inputs: &[String],
+) -> io::Result<()> {
+    let events = inputs
+        .iter()
+        .map(|text| {
+            json!({
+                "type": "mock.app_server.input",
+                "kind": kind,
+                "thread_id": thread_id,
+                "turn_id": turn_id,
+                "text": text
+            })
+        })
+        .collect::<Vec<_>>();
+    let home = session::codex_home();
+    session::persist_resume_session(&home, Utc::now().date_naive(), thread_id, &events)
+}
+
+fn write_success<W: Write>(output: &mut W, id: Value, result: Value) -> io::Result<()> {
+    write_json_line(output, &json!({ "id": id, "result": result }))
+}
+
+fn write_error<W: Write>(output: &mut W, id: Value, code: i64, message: &str) -> io::Result<()> {
+    write_json_line(
+        output,
+        &json!({
+            "id": id,
+            "error": {
+                "code": code,
+                "message": message
+            }
+        }),
+    )
+}
+
+fn write_json_line<W: Write>(output: &mut W, value: &Value) -> io::Result<()> {
+    serde_json::to_writer(&mut *output, value).map_err(io::Error::other)?;
+    writeln!(output)?;
+    output.flush()
+}

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -396,10 +396,10 @@ fn turn(turn_id: &str) -> Value {
     json!({
         "id": turn_id,
         "items": [],
-        "itemsView": "full",
+        "itemsView": "notLoaded",
         "status": "inProgress",
         "error": null,
-        "startedAt": 1,
+        "startedAt": null,
         "completedAt": null,
         "durationMs": null
     })

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -63,6 +63,7 @@ pub fn run_app_server(options: AppServerOptions) -> io::Result<()> {
 struct AppServerState {
     initialized: bool,
     thread_id: Option<String>,
+    session_artifact_thread_id: Option<String>,
     active_turn_id: Option<String>,
     initial_inputs: Vec<String>,
     steered_inputs: Vec<String>,
@@ -74,6 +75,7 @@ impl AppServerState {
         Self {
             initialized: false,
             thread_id: None,
+            session_artifact_thread_id: None,
             active_turn_id: None,
             initial_inputs: Vec::new(),
             steered_inputs: Vec::new(),
@@ -138,7 +140,7 @@ impl AppServerState {
                     return Ok(ServerAction::Continue);
                 }
                 let thread_id = Uuid::now_v7().to_string();
-                self.thread_id = Some(thread_id.clone());
+                self.set_current_thread(thread_id.clone());
                 write_success(output, id, thread_response(&thread_id, false))?;
                 Ok(ServerAction::Continue)
             }
@@ -151,7 +153,7 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, "missing threadId")?;
                     return Ok(ServerAction::Continue);
                 };
-                self.thread_id = Some(thread_id.to_string());
+                self.set_current_thread(thread_id.to_string());
                 write_success(output, id, thread_response(thread_id, true))?;
                 Ok(ServerAction::Continue)
             }
@@ -160,13 +162,16 @@ impl AppServerState {
                     return Ok(ServerAction::Stop);
                 }
 
-                let Some(thread_id) = string_param(params, "threadId")
-                    .or(self.thread_id.as_deref())
-                    .map(str::to_string)
-                else {
-                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
-                    return Ok(ServerAction::Continue);
-                };
+                let (thread_id, artifact_thread_id) =
+                    match self.current_thread(string_param(params, "threadId")) {
+                        Ok((thread_id, artifact_thread_id)) => {
+                            (thread_id.to_string(), artifact_thread_id.to_string())
+                        }
+                        Err(message) => {
+                            write_error(output, id, INVALID_REQUEST, message)?;
+                            return Ok(ServerAction::Continue);
+                        }
+                    };
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -180,7 +185,13 @@ impl AppServerState {
                     self.active_turn_id = Some(turn_id.clone());
                 }
                 self.initial_inputs.extend(inputs.iter().cloned());
-                persist_input_events(&thread_id, &turn_id, "initial", &inputs)?;
+                persist_input_events(
+                    &artifact_thread_id,
+                    &thread_id,
+                    &turn_id,
+                    "initial",
+                    &inputs,
+                )?;
                 write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
                 Ok(ServerAction::Continue)
             }
@@ -198,13 +209,16 @@ impl AppServerState {
                     return Ok(ServerAction::Continue);
                 }
 
-                let Some(thread_id) = string_param(params, "threadId")
-                    .or(self.thread_id.as_deref())
-                    .map(str::to_string)
-                else {
-                    write_error(output, id, INVALID_REQUEST, "missing threadId")?;
-                    return Ok(ServerAction::Continue);
-                };
+                let (thread_id, artifact_thread_id) =
+                    match self.current_thread(string_param(params, "threadId")) {
+                        Ok((thread_id, artifact_thread_id)) => {
+                            (thread_id.to_string(), artifact_thread_id.to_string())
+                        }
+                        Err(message) => {
+                            write_error(output, id, INVALID_REQUEST, message)?;
+                            return Ok(ServerAction::Continue);
+                        }
+                    };
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -213,7 +227,13 @@ impl AppServerState {
                     }
                 };
                 self.steered_inputs.extend(inputs.iter().cloned());
-                persist_input_events(&thread_id, &active_turn_id, "steered", &inputs)?;
+                persist_input_events(
+                    &artifact_thread_id,
+                    &thread_id,
+                    &active_turn_id,
+                    "steered",
+                    &inputs,
+                )?;
                 write_success(output, id, json!({ "turnId": active_turn_id }))?;
                 Ok(ServerAction::Continue)
             }
@@ -240,6 +260,26 @@ impl AppServerState {
             self.initialized = true;
         }
     }
+
+    fn set_current_thread(&mut self, thread_id: String) {
+        self.session_artifact_thread_id = Some(session_artifact_thread_id(&thread_id));
+        self.thread_id = Some(thread_id);
+    }
+
+    fn current_thread(&self, requested_thread_id: Option<&str>) -> Result<(&str, &str), &str> {
+        let Some(thread_id) = self.thread_id.as_deref() else {
+            return Err("no active thread");
+        };
+        if let Some(requested_thread_id) = requested_thread_id
+            && requested_thread_id != thread_id
+        {
+            return Err("unknown threadId");
+        }
+        let Some(artifact_thread_id) = self.session_artifact_thread_id.as_deref() else {
+            return Err("missing session artifact thread id");
+        };
+        Ok((thread_id, artifact_thread_id))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -250,9 +290,9 @@ enum ServerAction {
 
 fn initialize_response() -> Value {
     json!({
-        "userAgent": "guest-mock-codex-app-server/0.2.5",
+        "userAgent": format!("guest-mock-codex-app-server/{}", env!("CARGO_PKG_VERSION")),
         "codexHome": session::codex_home(),
-        "platformFamily": "unix",
+        "platformFamily": std::env::consts::FAMILY,
         "platformOs": std::env::consts::OS,
     })
 }
@@ -355,6 +395,7 @@ fn text_inputs(params: &Value) -> Result<Vec<String>, String> {
 }
 
 fn persist_input_events(
+    artifact_thread_id: &str,
     thread_id: &str,
     turn_id: &str,
     kind: &str,
@@ -373,7 +414,14 @@ fn persist_input_events(
         })
         .collect::<Vec<_>>();
     let home = session::codex_home();
-    session::persist_resume_session(&home, Utc::now().date_naive(), thread_id, &events)
+    session::persist_resume_session(&home, Utc::now().date_naive(), artifact_thread_id, &events)
+}
+
+fn session_artifact_thread_id(thread_id: &str) -> String {
+    match Uuid::parse_str(thread_id) {
+        Ok(uuid) if uuid.to_string() == thread_id => thread_id.to_string(),
+        _ => Uuid::now_v7().to_string(),
+    }
 }
 
 fn write_success<W: Write>(output: &mut W, id: Value, result: Value) -> io::Result<()> {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -432,21 +432,13 @@ fn session_artifact_thread_id(thread_id: &str) -> String {
 }
 
 fn write_success<W: Write>(output: &mut W, id: Value, result: Value) -> io::Result<()> {
-    write_json_line(
-        output,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": id,
-            "result": result
-        }),
-    )
+    write_json_line(output, &json!({ "id": id, "result": result }))
 }
 
 fn write_error<W: Write>(output: &mut W, id: Value, code: i64, message: &str) -> io::Result<()> {
     write_json_line(
         output,
         &json!({
-            "jsonrpc": "2.0",
             "id": id,
             "error": {
                 "code": code,

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -42,7 +42,7 @@ impl Scenario {
 }
 
 pub fn run_app_server(options: AppServerOptions) -> io::Result<()> {
-    if !options.stdio && options.listen != "stdio://" {
+    if options.listen != "stdio://" {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
@@ -149,7 +149,7 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
                     return Ok(ServerAction::Continue);
                 }
-                let Some(thread_id) = string_param(params, "threadId") else {
+                let Some(thread_id) = non_empty_string_param(params, "threadId") else {
                     write_error(output, id, INVALID_REQUEST, "missing threadId")?;
                     return Ok(ServerAction::Continue);
                 };
@@ -365,6 +365,10 @@ fn turn(turn_id: &str) -> Value {
 
 fn string_param<'a>(params: &'a Value, name: &str) -> Option<&'a str> {
     params.get(name).and_then(Value::as_str)
+}
+
+fn non_empty_string_param<'a>(params: &'a Value, name: &str) -> Option<&'a str> {
+    string_param(params, name).filter(|value| !value.is_empty())
 }
 
 fn text_inputs(params: &Value) -> Result<Vec<String>, String> {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -57,23 +57,26 @@ pub fn run_app_server(listen: &str) -> io::Result<()> {
 #[derive(Debug)]
 struct AppServerState {
     initialized: bool,
-    thread_id: Option<String>,
-    session_artifact_thread_id: Option<String>,
+    current_thread: Option<AppServerThread>,
     session_artifact_thread_ids: BTreeMap<String, String>,
-    active_turn_id: Option<String>,
     initial_inputs: Vec<String>,
     steered_inputs: Vec<String>,
     scenario: Scenario,
+}
+
+#[derive(Debug)]
+struct AppServerThread {
+    protocol_thread_id: String,
+    artifact_thread_id: String,
+    active_turn_id: Option<String>,
 }
 
 impl AppServerState {
     fn new(scenario: Scenario) -> Self {
         Self {
             initialized: false,
-            thread_id: None,
-            session_artifact_thread_id: None,
+            current_thread: None,
             session_artifact_thread_ids: BTreeMap::new(),
-            active_turn_id: None,
             initial_inputs: Vec::new(),
             steered_inputs: Vec::new(),
             scenario,
@@ -159,16 +162,15 @@ impl AppServerState {
                     return Ok(ServerAction::Stop);
                 }
 
-                let (thread_id, artifact_thread_id) =
-                    match self.current_thread(string_param(params, "threadId")) {
-                        Ok((thread_id, artifact_thread_id)) => {
-                            (thread_id.to_string(), artifact_thread_id.to_string())
-                        }
-                        Err(message) => {
-                            write_error(output, id, INVALID_REQUEST, message)?;
-                            return Ok(ServerAction::Continue);
-                        }
-                    };
+                let current_thread = match self.current_thread(string_param(params, "threadId")) {
+                    Ok(current_thread) => current_thread,
+                    Err(message) => {
+                        write_error(output, id, INVALID_REQUEST, message)?;
+                        return Ok(ServerAction::Continue);
+                    }
+                };
+                let thread_id = current_thread.protocol_thread_id.clone();
+                let artifact_thread_id = current_thread.artifact_thread_id.clone();
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -178,8 +180,10 @@ impl AppServerState {
                 };
 
                 let turn_id = Uuid::now_v7().to_string();
-                if self.scenario != Scenario::NoActiveTurn {
-                    self.active_turn_id = Some(turn_id.clone());
+                if self.scenario != Scenario::NoActiveTurn
+                    && let Some(current_thread) = &mut self.current_thread
+                {
+                    current_thread.active_turn_id = Some(turn_id.clone());
                 }
                 self.initial_inputs.extend(inputs.iter().cloned());
                 persist_input_events(
@@ -193,12 +197,19 @@ impl AppServerState {
                 Ok(ServerAction::Continue)
             }
             "turn/steer" => {
-                let Some(active_turn_id) = self.active_turn_id.clone() else {
-                    write_error(output, id, INVALID_REQUEST, "no active turn")?;
-                    return Ok(ServerAction::Continue);
-                };
                 let Some(expected_turn_id) = string_param(params, "expectedTurnId") else {
                     write_error(output, id, INVALID_REQUEST, "missing expectedTurnId")?;
+                    return Ok(ServerAction::Continue);
+                };
+                let current_thread = match self.current_thread(string_param(params, "threadId")) {
+                    Ok(current_thread) => current_thread,
+                    Err(message) => {
+                        write_error(output, id, INVALID_REQUEST, message)?;
+                        return Ok(ServerAction::Continue);
+                    }
+                };
+                let Some(active_turn_id) = current_thread.active_turn_id.clone() else {
+                    write_error(output, id, INVALID_REQUEST, "no active turn")?;
                     return Ok(ServerAction::Continue);
                 };
                 if self.scenario == Scenario::StaleTurn || expected_turn_id != active_turn_id {
@@ -206,16 +217,8 @@ impl AppServerState {
                     return Ok(ServerAction::Continue);
                 }
 
-                let (thread_id, artifact_thread_id) =
-                    match self.current_thread(string_param(params, "threadId")) {
-                        Ok((thread_id, artifact_thread_id)) => {
-                            (thread_id.to_string(), artifact_thread_id.to_string())
-                        }
-                        Err(message) => {
-                            write_error(output, id, INVALID_REQUEST, message)?;
-                            return Ok(ServerAction::Continue);
-                        }
-                    };
+                let thread_id = current_thread.protocol_thread_id.clone();
+                let artifact_thread_id = current_thread.artifact_thread_id.clone();
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -264,24 +267,23 @@ impl AppServerState {
             .entry(thread_id.clone())
             .or_insert_with(|| session_artifact_thread_id(&thread_id))
             .clone();
-        self.session_artifact_thread_id = Some(artifact_thread_id);
-        self.thread_id = Some(thread_id);
-        self.active_turn_id = None;
+        self.current_thread = Some(AppServerThread {
+            protocol_thread_id: thread_id,
+            artifact_thread_id,
+            active_turn_id: None,
+        });
     }
 
-    fn current_thread(&self, requested_thread_id: Option<&str>) -> Result<(&str, &str), &str> {
-        let Some(thread_id) = self.thread_id.as_deref() else {
+    fn current_thread(&self, requested_thread_id: Option<&str>) -> Result<&AppServerThread, &str> {
+        let Some(current_thread) = &self.current_thread else {
             return Err("no active thread");
         };
         if let Some(requested_thread_id) = requested_thread_id
-            && requested_thread_id != thread_id
+            && requested_thread_id != current_thread.protocol_thread_id
         {
             return Err("unknown threadId");
         }
-        let Some(artifact_thread_id) = self.session_artifact_thread_id.as_deref() else {
-            return Err("missing session artifact thread id");
-        };
-        Ok((thread_id, artifact_thread_id))
+        Ok(current_thread)
     }
 }
 

--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -11,11 +11,13 @@ use chrono::Utc;
 use std::io;
 use uuid::Uuid;
 
+mod app_server;
 mod events;
 mod fixtures;
 mod prompt;
 mod session;
 
+pub use app_server::{AppServerOptions, run_app_server};
 pub use events::build_events;
 pub use fixtures::{lookup_fixture, run_fixture};
 pub use prompt::{join_prompt, join_prompt_cow};

--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -21,7 +21,7 @@ mod fixtures;
 mod prompt;
 mod session;
 
-pub use app_server::{AppServerOptions, run_app_server};
+pub use app_server::run_app_server;
 pub use events::build_events;
 pub use fixtures::{lookup_fixture, run_fixture};
 pub use prompt::{join_prompt, join_prompt_cow};

--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -1,8 +1,12 @@
 //! Reusable mock Codex contract used by the `guest-mock-codex` binary and tests.
 //!
-//! The mock emits Codex `exec --json` protocol events on stdout and persists a
-//! JSONL session file under Codex's date-partitioned session tree:
-//! `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`.
+//! The mock supports two test-only Codex surfaces:
+//!
+//! - `exec --json`: emits Codex JSONL protocol events on stdout and persists a
+//!   JSONL session file under Codex's date-partitioned session tree:
+//!   `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`.
+//! - `app-server`: speaks newline-delimited JSON-RPC over stdio for focused
+//!   app-server client tests.
 //!
 //! Resume can also append to runner-restored rollout filenames, matching the
 //! real Codex CLI's filesystem resume candidates.

--- a/crates/guest-mock-codex/src/lib.rs
+++ b/crates/guest-mock-codex/src/lib.rs
@@ -5,8 +5,8 @@
 //! - `exec --json`: emits Codex JSONL protocol events on stdout and persists a
 //!   JSONL session file under Codex's date-partitioned session tree:
 //!   `$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`.
-//! - `app-server`: speaks newline-delimited JSON-RPC over stdio for focused
-//!   app-server client tests.
+//! - `app-server`: speaks the Codex app-server newline-delimited JSON
+//!   request/response protocol over stdio for focused app-server client tests.
 //!
 //! Resume can also append to runner-restored rollout filenames, matching the
 //! real Codex CLI's filesystem resume candidates.

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -29,7 +29,10 @@
 //! codex-event-parser branches that the synthetic sequence cannot reach.
 
 use clap::{Parser, Subcommand};
-use guest_mock_codex::{join_prompt_cow, lookup_fixture, run_fixture, run_new, run_resume};
+use guest_mock_codex::{
+    AppServerOptions, join_prompt_cow, lookup_fixture, run_app_server, run_fixture, run_new,
+    run_resume,
+};
 use std::io;
 use std::path::PathBuf;
 
@@ -44,6 +47,8 @@ struct Cli {
 enum Cmd {
     /// Mirrors `codex exec`.
     Exec(ExecArgs),
+    /// Mirrors `codex app-server`.
+    AppServer(AppServerArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -102,36 +107,62 @@ enum ExecSub {
     },
 }
 
+#[derive(clap::Args, Debug)]
+struct AppServerArgs {
+    /// Listen URL (mock supports stdio://).
+    #[arg(long, default_value = "stdio://")]
+    listen: String,
+
+    /// Use stdio transport.
+    #[arg(long)]
+    stdio: bool,
+
+    /// Codex config override (accepted, ignored).
+    #[arg(short = 'c', long = "config")]
+    config: Vec<String>,
+}
+
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
 
-    // Fixture mode short-circuits the synthetic event sequence. Used by
-    // `t-codex-event-mapping.bats` to exercise codex-event-parser
-    // branches (command_execution, file_edit, file_read, file_change,
-    // reasoning, turn.failed, error) that the 3-event synthetic
-    // sequence cannot reach.
+    match cli.command {
+        Cmd::AppServer(AppServerArgs {
+            listen,
+            stdio,
+            config: _,
+        }) => run_app_server(AppServerOptions { listen, stdio }),
+        Cmd::Exec(ExecArgs {
+            sub: Some(ExecSub::Resume { thread_id, prompt }),
+            ..
+        }) => {
+            if maybe_run_fixture()? {
+                return Ok(());
+            }
+            let joined_prompt = join_prompt_cow(&prompt);
+            run_resume(&thread_id, joined_prompt.as_ref())
+        }
+        Cmd::Exec(ExecArgs { prompt, .. }) => {
+            if maybe_run_fixture()? {
+                return Ok(());
+            }
+            let joined_prompt = join_prompt_cow(&prompt);
+            run_new(joined_prompt.as_ref())
+        }
+    }
+}
+
+fn maybe_run_fixture() -> io::Result<bool> {
+    // Fixture mode is specific to the one-shot `exec --json` event stream.
     if let Ok(fixture_name) = std::env::var("MOCK_CODEX_FIXTURE")
         && !fixture_name.is_empty()
     {
         if let Some(content) = lookup_fixture(&fixture_name) {
-            return run_fixture(content);
+            run_fixture(content)?;
+            return Ok(true);
         }
         eprintln!(
             "warning: MOCK_CODEX_FIXTURE={fixture_name:?} not found, falling through to synthetic events"
         );
     }
-
-    match cli.command {
-        Cmd::Exec(ExecArgs {
-            sub: Some(ExecSub::Resume { thread_id, prompt }),
-            ..
-        }) => {
-            let joined_prompt = join_prompt_cow(&prompt);
-            run_resume(&thread_id, joined_prompt.as_ref())
-        }
-        Cmd::Exec(ExecArgs { prompt, .. }) => {
-            let joined_prompt = join_prompt_cow(&prompt);
-            run_new(joined_prompt.as_ref())
-        }
-    }
+    Ok(false)
 }

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -35,8 +35,7 @@
 
 use clap::{Parser, Subcommand};
 use guest_mock_codex::{
-    AppServerOptions, join_prompt_cow, lookup_fixture, run_app_server, run_fixture, run_new,
-    run_resume,
+    join_prompt_cow, lookup_fixture, run_app_server, run_fixture, run_new, run_resume,
 };
 use std::io;
 use std::path::PathBuf;
@@ -133,9 +132,9 @@ fn main() -> io::Result<()> {
     match cli.command {
         Cmd::AppServer(AppServerArgs {
             listen,
-            stdio,
+            stdio: _,
             config: _,
-        }) => run_app_server(AppServerOptions { listen, stdio }),
+        }) => run_app_server(&listen),
         Cmd::Exec(ExecArgs {
             sub: Some(ExecSub::Resume { thread_id, prompt }),
             ..

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -18,6 +18,8 @@
 //!                          [--append-system-prompt <s>] [--last]
 //!                          [-- <prompt>]
 //!   guest-mock-codex exec resume <canonical-uuid-thread-id> [-- <prompt>]
+//!   guest-mock-codex app-server --listen stdio:// [-c <config>]
+//!   guest-mock-codex app-server --stdio [-c <config>]
 //! ```
 //!
 //! Fixture mode: when `MOCK_CODEX_FIXTURE=<name>` is set in the env, the
@@ -27,6 +29,9 @@
 //! persisted to the session file. Used by
 //! `e2e/tests/03-runner/t-codex-event-mapping.bats` to exercise the
 //! codex-event-parser branches that the synthetic sequence cannot reach.
+//!
+//! App-server mode speaks newline-delimited JSON-RPC on stdio. Failure
+//! scenarios are selected with `MOCK_CODEX_APP_SERVER_SCENARIO`.
 
 use clap::{Parser, Subcommand};
 use guest_mock_codex::{

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -1,8 +1,10 @@
 //! Mock Codex CLI for testing.
 //!
-//! Emits Codex `exec --json` protocol events on stdout and persists a JSONL
-//! session file under Codex's date-partitioned session tree
-//! (`$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`).
+//! Supports test-only Codex `exec --json` and `app-server` surfaces. Exec mode
+//! emits JSONL protocol events on stdout and persists a JSONL session file under
+//! Codex's date-partitioned session tree
+//! (`$CODEX_HOME/sessions/YYYY/MM/DD/<thread_id>.jsonl`). App-server mode speaks
+//! newline-delimited JSON-RPC over stdio.
 //!
 //! Resume can also append to runner-restored rollout filenames, matching the
 //! real Codex CLI's filesystem resume candidates.

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -30,8 +30,9 @@
 //! `e2e/tests/03-runner/t-codex-event-mapping.bats` to exercise the
 //! codex-event-parser branches that the synthetic sequence cannot reach.
 //!
-//! App-server mode speaks newline-delimited JSON-RPC on stdio. Failure
-//! scenarios are selected with `MOCK_CODEX_APP_SERVER_SCENARIO`.
+//! App-server mode speaks the Codex app-server newline-delimited JSON
+//! request/response protocol on stdio. Failure scenarios are selected with
+//! `MOCK_CODEX_APP_SERVER_SCENARIO`.
 
 use clap::{Parser, Subcommand};
 use guest_mock_codex::{

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -1,8 +1,9 @@
 //! Integration tests that spawn the real binary via Cargo's
 //! `CARGO_BIN_EXE_guest-mock-codex` env var.
 //!
-//! Cover the contract guest-agent will rely on: stdout JSONL shape, the
-//! on-disk session file path / format, and resume semantics.
+//! Cover the contract guest-agent will rely on: exec stdout JSONL shape,
+//! app-server stdio JSON-RPC shape, on-disk session file path / format, and
+//! resume semantics.
 
 use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader, Write};
@@ -634,14 +635,39 @@ fn app_server_initialized_notification_does_not_replace_initialize_request() -> 
     let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
 
     server.notify("initialized", json!({}))?;
-    let error = server.request(1, "thread/start", json!({}))?;
+    let thread_start_error = server.request(1, "thread/start", json!({}))?;
+    let turn_start_error = server.request(
+        2,
+        "turn/start",
+        json!({
+            "threadId": "thread-1",
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_steer_error = server.request(
+        3,
+        "turn/steer",
+        json!({
+            "threadId": "thread-1",
+            "expectedTurnId": "turn-1",
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
 
-    assert_eq!(error["error"]["code"], -32600);
+    assert_eq!(thread_start_error["error"]["code"], -32600);
     assert!(
-        error["error"]["message"]
+        thread_start_error["error"]["message"]
             .as_str()
             .unwrap()
             .contains("not initialized")
+    );
+    assert_eq!(
+        turn_start_error["error"]["message"],
+        "app server is not initialized"
+    );
+    assert_eq!(
+        turn_steer_error["error"]["message"],
+        "app server is not initialized"
     );
     assert_eq!(server.close_and_wait()?, 0);
     Ok(())

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -307,6 +307,35 @@ fn app_server_turn_steer_returns_active_turn_and_records_inputs() -> std::io::Re
 }
 
 #[test]
+fn app_server_rejects_invalid_or_duplicate_initialize() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--listen", "stdio://"], None)?;
+
+    let invalid = server.request(1, "initialize", json!({}))?;
+    assert_eq!(invalid["id"], 1);
+    assert_eq!(invalid["error"]["code"], -32600);
+    assert!(
+        invalid["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("clientInfo")
+    );
+
+    let initialized = server.request(2, "initialize", initialize_params())?;
+    assert_eq!(
+        initialized["result"]["platformFamily"],
+        std::env::consts::FAMILY
+    );
+
+    let duplicate = server.request(3, "initialize", initialize_params())?;
+    assert_eq!(duplicate["error"]["code"], -32600);
+    assert_eq!(duplicate["error"]["message"], "Already initialized");
+
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_accepts_stdio_and_resumes_supplied_thread() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let supplied_thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -238,6 +238,7 @@ fn app_server_turn_steer_returns_active_turn_and_records_inputs() -> std::io::Re
 
     let initialized = server.request(1, "initialize", json!({}))?;
     assert_eq!(initialized["id"], 1);
+    assert!(initialized.get("jsonrpc").is_none());
     assert!(initialized.get("type").is_none());
     assert!(initialized["result"]["codexHome"].as_str().is_some());
     server.notify("initialized", json!({}))?;
@@ -565,7 +566,7 @@ fn app_server_new_thread_clears_previous_active_turn() -> std::io::Result<()> {
 }
 
 #[test]
-fn app_server_stale_turn_scenario_returns_json_rpc_error() -> std::io::Result<()> {
+fn app_server_stale_turn_scenario_returns_protocol_error() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(
         dir.path(),
@@ -602,6 +603,7 @@ fn app_server_stale_turn_scenario_returns_json_rpc_error() -> std::io::Result<()
         }),
     )?;
     assert_eq!(error["id"], 4);
+    assert!(error.get("jsonrpc").is_none());
     assert_eq!(error["error"]["code"], -32600);
     assert!(
         error["error"]["message"]
@@ -614,7 +616,7 @@ fn app_server_stale_turn_scenario_returns_json_rpc_error() -> std::io::Result<()
 }
 
 #[test]
-fn app_server_no_active_turn_scenario_returns_json_rpc_error() -> std::io::Result<()> {
+fn app_server_no_active_turn_scenario_returns_protocol_error() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(
         dir.path(),

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -185,7 +185,20 @@ fn text_input(text: &str) -> Value {
     json!({
         "type": "text",
         "text": text,
-        "text_elements": []
+        "textElements": []
+    })
+}
+
+fn initialize_params() -> Value {
+    json!({
+        "clientInfo": {
+            "name": "guest-mock-codex-tests",
+            "title": null,
+            "version": "0.1.0"
+        },
+        "capabilities": {
+            "experimentalApi": true
+        }
     })
 }
 
@@ -236,7 +249,7 @@ fn app_server_turn_steer_returns_active_turn_and_records_inputs() -> std::io::Re
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(dir.path(), &["app-server", "--listen", "stdio://"], None)?;
 
-    let initialized = server.request(1, "initialize", json!({}))?;
+    let initialized = server.request(1, "initialize", initialize_params())?;
     assert_eq!(initialized["id"], 1);
     assert!(initialized.get("jsonrpc").is_none());
     assert!(initialized.get("type").is_none());
@@ -310,7 +323,7 @@ fn app_server_accepts_stdio_and_resumes_supplied_thread() -> std::io::Result<()>
         None,
     )?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     server.notify("initialized", json!({}))?;
     let resumed = server.request(
         2,
@@ -355,7 +368,7 @@ fn app_server_resumed_non_uuid_thread_records_inputs() -> std::io::Result<()> {
     let supplied_thread_id = "thread-1";
     let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let resumed = server.request(
         2,
         "thread/resume",
@@ -412,7 +425,7 @@ fn app_server_reuses_artifact_for_repeated_non_uuid_resume() -> std::io::Result<
     let supplied_thread_id = "thread-1";
     let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     server.request(
         2,
         "thread/resume",
@@ -475,7 +488,7 @@ fn app_server_rejects_empty_resume_thread_id() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let error = server.request(
         2,
         "thread/resume",
@@ -520,7 +533,7 @@ fn app_server_new_thread_clears_previous_active_turn() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let first_thread = server.request(2, "thread/start", json!({}))?;
     let first_thread_id = first_thread["result"]["thread"]["id"]
         .as_str()
@@ -574,7 +587,7 @@ fn app_server_stale_turn_scenario_returns_protocol_error() -> std::io::Result<()
         Some("stale-turn"),
     )?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let started = server.request(2, "thread/start", json!({}))?;
     let thread_id = started["result"]["thread"]["id"]
         .as_str()
@@ -624,7 +637,7 @@ fn app_server_no_active_turn_scenario_returns_protocol_error() -> std::io::Resul
         Some("no-active-turn"),
     )?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let started = server.request(2, "thread/start", json!({}))?;
     let thread_id = started["result"]["thread"]["id"]
         .as_str()
@@ -672,7 +685,7 @@ fn app_server_disconnect_after_initialize_closes_stdout() -> std::io::Result<()>
         Some("disconnect-after-initialize"),
     )?;
 
-    let initialized = server.request(1, "initialize", json!({}))?;
+    let initialized = server.request(1, "initialize", initialize_params())?;
     assert_eq!(
         initialized["result"]["platformFamily"],
         std::env::consts::FAMILY
@@ -691,7 +704,7 @@ fn app_server_exit_on_turn_start_closes_stdout_without_response() -> std::io::Re
         Some("exit-on-turn-start"),
     )?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let started = server.request(2, "thread/start", json!({}))?;
     let thread_id = started["result"]["thread"]["id"]
         .as_str()
@@ -716,7 +729,7 @@ fn app_server_returns_errors_for_unsupported_method_and_input() -> std::io::Resu
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(dir.path(), &["app-server", "--listen", "stdio://"], None)?;
 
-    server.request(1, "initialize", json!({}))?;
+    server.request(1, "initialize", initialize_params())?;
     let unsupported = server.request(2, "unknown/method", json!({}))?;
     assert_eq!(unsupported["error"]["code"], -32601);
 

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -5,15 +5,16 @@
 //! on-disk session file path / format, and resume semantics.
 
 use std::collections::BTreeSet;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
 use chrono::{Datelike, Utc};
 use guest_mock_codex::{
     build_events, build_session_path, find_session_file, read_session_file, session_artifacts,
     session_files, write_session_file,
 };
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-mock-codex");
@@ -71,6 +72,123 @@ fn spawn(codex_home: &Path, args: &[&str]) -> std::io::Result<Child> {
     cmd.spawn()
 }
 
+struct AppServerProcess {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl AppServerProcess {
+    fn request(&mut self, id: i64, method: &str, params: Value) -> std::io::Result<Value> {
+        self.send(&json!({
+            "id": id,
+            "method": method,
+            "params": params,
+        }))?;
+        self.read_required()
+    }
+
+    fn notify(&mut self, method: &str, params: Value) -> std::io::Result<()> {
+        self.send(&json!({
+            "method": method,
+            "params": params,
+        }))
+    }
+
+    fn send(&mut self, message: &Value) -> std::io::Result<()> {
+        let stdin = self.stdin.as_mut().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "app-server stdin is closed")
+        })?;
+        serde_json::to_writer(&mut *stdin, message).map_err(std::io::Error::other)?;
+        writeln!(stdin)?;
+        stdin.flush()
+    }
+
+    fn read_required(&mut self) -> std::io::Result<Value> {
+        self.read_message()?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "app-server closed stdout before responding",
+            )
+        })
+    }
+
+    fn read_message(&mut self) -> std::io::Result<Option<Value>> {
+        let mut line = String::new();
+        if self.stdout.read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        let value = serde_json::from_str(&line)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+        Ok(Some(value))
+    }
+
+    fn close_and_wait(&mut self) -> std::io::Result<i32> {
+        self.stdin.take();
+        let status = self.child.wait()?;
+        Ok(status.code().unwrap_or(-1))
+    }
+}
+
+impl Drop for AppServerProcess {
+    fn drop(&mut self) {
+        self.stdin.take();
+        match self.child.try_wait() {
+            Ok(Some(_)) => {
+                let _ = self.child.wait();
+            }
+            Ok(None) => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+fn spawn_app_server(
+    codex_home: &Path,
+    args: &[&str],
+    scenario: Option<&str>,
+) -> std::io::Result<AppServerProcess> {
+    let mut cmd = Command::new(BIN);
+    cmd.env("CODEX_HOME", codex_home).args(args);
+    cmd.env_remove("MOCK_CODEX_FIXTURE");
+    cmd.env_remove("MOCK_CODEX_APP_SERVER_SCENARIO");
+    if let Some(value) = scenario {
+        cmd.env("MOCK_CODEX_APP_SERVER_SCENARIO", value);
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let stdin = child.stdin.take().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "failed to open app-server stdin",
+        )
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "failed to open app-server stdout",
+        )
+    })?;
+    Ok(AppServerProcess {
+        child,
+        stdin: Some(stdin),
+        stdout: BufReader::new(stdout),
+    })
+}
+
+fn text_input(text: &str) -> Value {
+    json!({
+        "type": "text",
+        "text": text,
+        "text_elements": []
+    })
+}
+
 fn assert_invalid_resume_rejected(codex_home: &Path, out: &RunOutput) -> std::io::Result<()> {
     assert_ne!(out.status, 0, "invalid resume id should fail");
     assert!(
@@ -111,6 +229,276 @@ fn require_session_file(codex_home: &Path) -> std::io::Result<PathBuf> {
 fn session_year_candidates() -> [String; 2] {
     let year = Utc::now().date_naive().year();
     [format!("{year:04}"), format!("{:04}", year + 1)]
+}
+
+#[test]
+fn app_server_turn_steer_returns_active_turn_and_records_inputs() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--listen", "stdio://"], None)?;
+
+    let initialized = server.request(1, "initialize", json!({}))?;
+    assert_eq!(initialized["id"], 1);
+    assert!(initialized.get("type").is_none());
+    assert!(initialized["result"]["codexHome"].as_str().is_some());
+    server.notify("initialized", json!({}))?;
+
+    let started = server.request(2, "thread/start", json!({ "cwd": "/tmp" }))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(started["result"]["thread"]["source"], "appServer");
+    assert_eq!(started["result"]["thread"]["status"]["type"], "idle");
+    assert_eq!(started["result"]["sandbox"]["type"], "dangerFullAccess");
+
+    let turn_started = server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_id = turn_started["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(turn_started["result"]["turn"]["status"], "inProgress");
+
+    let steered = server.request(
+        4,
+        "turn/steer",
+        json!({
+            "threadId": thread_id,
+            "expectedTurnId": turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    assert_eq!(steered["result"]["turnId"], turn_id);
+
+    let recorded = server.request(5, "mock/inputs", json!({}))?;
+    assert_eq!(recorded["result"]["initial"], json!(["initial prompt"]));
+    assert_eq!(recorded["result"]["steered"], json!(["follow-up prompt"]));
+
+    let session_path = require_session_file(dir.path())?;
+    let events = read_session_file(&session_path)?;
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["type"], "mock.app_server.input");
+    assert_eq!(events[0]["kind"], "initial");
+    assert_eq!(events[0]["text"], "initial prompt");
+    assert_eq!(events[1]["kind"], "steered");
+    assert_eq!(events[1]["text"], "follow-up prompt");
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_accepts_stdio_and_resumes_supplied_thread() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let supplied_thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+    let mut server = spawn_app_server(
+        dir.path(),
+        &[
+            "app-server",
+            "--stdio",
+            "-c",
+            "model=gpt-5",
+            "--config",
+            "sandbox=danger-full-access",
+        ],
+        None,
+    )?;
+
+    server.request(1, "initialize", json!({}))?;
+    server.notify("initialized", json!({}))?;
+    let resumed = server.request(
+        2,
+        "thread/resume",
+        json!({
+            "threadId": supplied_thread_id
+        }),
+    )?;
+
+    assert_eq!(resumed["result"]["thread"]["id"], supplied_thread_id);
+    assert_eq!(resumed["result"]["thread"]["sessionId"], supplied_thread_id);
+    assert!(resumed["result"]["initialTurnsPage"].is_null());
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_stale_turn_scenario_returns_json_rpc_error() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("stale-turn"),
+    )?;
+
+    server.request(1, "initialize", json!({}))?;
+    let started = server.request(2, "thread/start", json!({}))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let turn_started = server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_id = turn_started["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let error = server.request(
+        4,
+        "turn/steer",
+        json!({
+            "threadId": thread_id,
+            "expectedTurnId": turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    assert_eq!(error["id"], 4);
+    assert_eq!(error["error"]["code"], -32600);
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("stale")
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_no_active_turn_scenario_returns_json_rpc_error() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("no-active-turn"),
+    )?;
+
+    server.request(1, "initialize", json!({}))?;
+    let started = server.request(2, "thread/start", json!({}))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let turn_started = server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_id = turn_started["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let error = server.request(
+        4,
+        "turn/steer",
+        json!({
+            "threadId": thread_id,
+            "expectedTurnId": turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    assert_eq!(error["error"]["code"], -32600);
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("no active turn")
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_disconnect_after_initialize_closes_stdout() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("disconnect-after-initialize"),
+    )?;
+
+    let initialized = server.request(1, "initialize", json!({}))?;
+    assert_eq!(initialized["result"]["platformFamily"], "unix");
+    assert!(server.read_message()?.is_none());
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_exit_on_turn_start_closes_stdout_without_response() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("exit-on-turn-start"),
+    )?;
+
+    server.request(1, "initialize", json!({}))?;
+    let started = server.request(2, "thread/start", json!({}))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.send(&json!({
+        "id": 3,
+        "method": "turn/start",
+        "params": {
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }
+    }))?;
+
+    assert!(server.read_message()?.is_none());
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_returns_errors_for_unsupported_method_and_input() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--listen", "stdio://"], None)?;
+
+    server.request(1, "initialize", json!({}))?;
+    let unsupported = server.request(2, "unknown/method", json!({}))?;
+    assert_eq!(unsupported["error"]["code"], -32601);
+
+    let started = server.request(3, "thread/start", json!({}))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let invalid_input = server.request(
+        4,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": []
+        }),
+    )?;
+    assert_eq!(invalid_input["error"]["code"], -32600);
+    assert!(
+        invalid_input["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("input")
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
 }
 
 #[test]

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -369,6 +369,8 @@ fn app_server_turn_steer_returns_active_turn_and_records_inputs() -> std::io::Re
         .unwrap()
         .to_string();
     assert_eq!(turn_started["result"]["turn"]["status"], "inProgress");
+    assert_eq!(turn_started["result"]["turn"]["itemsView"], "notLoaded");
+    assert!(turn_started["result"]["turn"]["startedAt"].is_null());
 
     let steered = server.request(
         4,

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -7,7 +7,10 @@
 use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 use chrono::{Datelike, Utc};
 use guest_mock_codex::{
@@ -18,6 +21,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-mock-codex");
+const APP_SERVER_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const APP_SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 struct RunOutput {
@@ -73,9 +78,10 @@ fn spawn(codex_home: &Path, args: &[&str]) -> std::io::Result<Child> {
 }
 
 struct AppServerProcess {
-    child: Child,
+    child: Option<Child>,
     stdin: Option<ChildStdin>,
-    stdout: BufReader<ChildStdout>,
+    stdout_rx: Receiver<Result<Option<Value>, String>>,
+    stdout_thread: Option<JoinHandle<()>>,
 }
 
 impl AppServerProcess {
@@ -114,36 +120,91 @@ impl AppServerProcess {
     }
 
     fn read_message(&mut self) -> std::io::Result<Option<Value>> {
-        let mut line = String::new();
-        if self.stdout.read_line(&mut line)? == 0 {
-            return Ok(None);
+        match self.stdout_rx.recv_timeout(APP_SERVER_READ_TIMEOUT) {
+            Ok(result) => result
+                .map_err(|message| std::io::Error::new(std::io::ErrorKind::InvalidData, message)),
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "timed out waiting for app-server stdout message",
+            )),
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "app-server stdout reader exited without EOF",
+            )),
         }
-        let value = serde_json::from_str(&line)
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-        Ok(Some(value))
     }
 
     fn close_and_wait(&mut self) -> std::io::Result<i32> {
         self.stdin.take();
-        let status = self.child.wait()?;
+        let child = self
+            .child
+            .take()
+            .ok_or_else(|| std::io::Error::other("app-server child already waited"))?;
+        let status = wait_child(child)?;
+        self.join_stdout_thread()?;
         Ok(status.code().unwrap_or(-1))
+    }
+
+    fn join_stdout_thread(&mut self) -> std::io::Result<()> {
+        if let Some(stdout_thread) = self.stdout_thread.take() {
+            stdout_thread
+                .join()
+                .map_err(|_| std::io::Error::other("app-server stdout reader panicked"))?;
+        }
+        Ok(())
     }
 }
 
 impl Drop for AppServerProcess {
     fn drop(&mut self) {
         self.stdin.take();
-        match self.child.try_wait() {
-            Ok(Some(_)) => {
-                let _ = self.child.wait();
+        if let Some(mut child) = self.child.take() {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    let _ = child.wait();
+                }
+                Ok(None) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                }
+                Err(_) => {}
             }
-            Ok(None) => {
-                let _ = self.child.kill();
-                let _ = self.child.wait();
-            }
-            Err(_) => {}
         }
+        let _ = self.join_stdout_thread();
     }
+}
+
+fn wait_child(mut child: Child) -> std::io::Result<ExitStatus> {
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+    let wait_thread = std::thread::spawn(move || {
+        let result = child.wait();
+        let _ = tx.send(result);
+    });
+
+    let status = match rx.recv_timeout(APP_SERVER_EXIT_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            // SAFETY: this is test cleanup for the child process spawned by this helper.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            rx.recv_timeout(APP_SERVER_EXIT_TIMEOUT).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("app-server child did not exit after SIGKILL: {error}"),
+                )
+            })?
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
+            "app-server child wait thread exited without status",
+        )),
+    };
+
+    wait_thread
+        .join()
+        .map_err(|_| std::io::Error::other("app-server child wait thread panicked"))?;
+    status
 }
 
 fn spawn_app_server(
@@ -174,10 +235,34 @@ fn spawn_app_server(
             "failed to open app-server stdout",
         )
     })?;
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    let stdout_thread = std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    let _ = stdout_tx.send(Err(format!("read app-server stdout line: {error}")));
+                    return;
+                }
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value = serde_json::from_str::<Value>(&line)
+                .map(Some)
+                .map_err(|error| format!("parse app-server stdout JSON: {error}; line={line:?}"));
+            if stdout_tx.send(value).is_err() {
+                return;
+            }
+        }
+        let _ = stdout_tx.send(Ok(None));
+    });
     Ok(AppServerProcess {
-        child,
+        child: Some(child),
         stdin: Some(stdin),
-        stdout: BufReader::new(stdout),
+        stdout_rx,
+        stdout_thread: Some(stdout_thread),
     })
 }
 

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -410,6 +410,70 @@ fn app_server_resumed_non_uuid_thread_records_inputs() -> std::io::Result<()> {
 }
 
 #[test]
+fn app_server_reuses_artifact_for_repeated_non_uuid_resume() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let supplied_thread_id = "thread-1";
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", json!({}))?;
+    server.request(
+        2,
+        "thread/resume",
+        json!({
+            "threadId": supplied_thread_id
+        }),
+    )?;
+    server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": supplied_thread_id,
+            "input": [text_input("first prompt")]
+        }),
+    )?;
+
+    server.request(
+        4,
+        "thread/resume",
+        json!({
+            "threadId": supplied_thread_id
+        }),
+    )?;
+    server.request(
+        5,
+        "turn/start",
+        json!({
+            "threadId": supplied_thread_id,
+            "input": [text_input("second prompt")]
+        }),
+    )?;
+
+    let artifacts = session_artifacts(dir.path())?
+        .into_iter()
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "repeated resume for the same non-UUID app-server thread should append to one artifact: {artifacts:?}"
+    );
+    let session_path = artifacts.into_iter().next().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "app-server session artifact not found",
+        )
+    })?;
+    let events = read_session_file(&session_path)?;
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["thread_id"], supplied_thread_id);
+    assert_eq!(events[0]["text"], "first prompt");
+    assert_eq!(events[1]["thread_id"], supplied_thread_id);
+    assert_eq!(events[1]["text"], "second prompt");
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_rejects_empty_resume_thread_id() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -111,6 +111,14 @@ impl AppServerProcess {
         stdin.flush()
     }
 
+    fn send_raw_line(&mut self, line: &str) -> std::io::Result<()> {
+        let stdin = self.stdin.as_mut().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "app-server stdin is closed")
+        })?;
+        writeln!(stdin, "{line}")?;
+        stdin.flush()
+    }
+
     fn read_required(&mut self) -> std::io::Result<Value> {
         self.read_message()?.ok_or_else(|| {
             std::io::Error::new(
@@ -218,12 +226,24 @@ fn spawn_app_server(
     args: &[&str],
     scenario: Option<&str>,
 ) -> std::io::Result<AppServerProcess> {
+    spawn_app_server_with_env(codex_home, args, scenario, &[])
+}
+
+fn spawn_app_server_with_env(
+    codex_home: &Path,
+    args: &[&str],
+    scenario: Option<&str>,
+    env: &[(&str, &str)],
+) -> std::io::Result<AppServerProcess> {
     let mut cmd = Command::new(BIN);
     cmd.env("CODEX_HOME", codex_home).args(args);
     cmd.env_remove("MOCK_CODEX_FIXTURE");
     cmd.env_remove("MOCK_CODEX_APP_SERVER_SCENARIO");
     if let Some(value) = scenario {
         cmd.env("MOCK_CODEX_APP_SERVER_SCENARIO", value);
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
     }
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -481,6 +501,41 @@ fn app_server_rejects_non_stdio_listen_url() -> std::io::Result<()> {
         "unsupported app-server listen URL should fail clearly: {:?}",
         out.stderr
     );
+    Ok(())
+}
+
+#[test]
+fn app_server_ignores_exec_fixture_mode() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server_with_env(
+        dir.path(),
+        &["app-server", "--stdio"],
+        None,
+        &[("MOCK_CODEX_FIXTURE", "event-mapping-rich")],
+    )?;
+
+    let initialized = server.request(1, "initialize", initialize_params())?;
+
+    assert_eq!(initialized["id"], 1);
+    assert!(initialized.get("type").is_none());
+    assert!(
+        initialized["result"]["userAgent"]
+            .as_str()
+            .is_some_and(|user_agent| user_agent.starts_with("guest-mock-codex-app-server/"))
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_invalid_json_exits_without_hanging() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.send_raw_line("{not-json")?;
+
+    assert!(server.read_message()?.is_none());
+    assert_ne!(server.close_and_wait()?, 0);
     Ok(())
 }
 

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -163,11 +163,10 @@ impl Drop for AppServerProcess {
                 Ok(Some(_)) => {
                     let _ = child.wait();
                 }
-                Ok(None) => {
+                Ok(None) | Err(_) => {
                     let _ = child.kill();
                     let _ = child.wait();
                 }
-                Err(_) => {}
             }
         }
         let _ = self.join_stdout_thread();

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -188,12 +188,18 @@ fn wait_child(mut child: Child) -> std::io::Result<ExitStatus> {
             unsafe {
                 libc::kill(pid as libc::pid_t, libc::SIGKILL);
             }
-            rx.recv_timeout(APP_SERVER_EXIT_TIMEOUT).map_err(|error| {
-                std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!("app-server child did not exit after SIGKILL: {error}"),
-                )
-            })?
+            match rx.recv_timeout(APP_SERVER_EXIT_TIMEOUT) {
+                Ok(result) => result,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "app-server child did not exit after SIGKILL",
+                    ));
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
+                    "app-server child wait thread exited without status",
+                )),
+            }
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
             "app-server child wait thread exited without status",

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -81,6 +81,7 @@ struct AppServerProcess {
 impl AppServerProcess {
     fn request(&mut self, id: i64, method: &str, params: Value) -> std::io::Result<Value> {
         self.send(&json!({
+            "jsonrpc": "2.0",
             "id": id,
             "method": method,
             "params": params,
@@ -90,6 +91,7 @@ impl AppServerProcess {
 
     fn notify(&mut self, method: &str, params: Value) -> std::io::Result<()> {
         self.send(&json!({
+            "jsonrpc": "2.0",
             "method": method,
             "params": params,
         }))
@@ -105,12 +107,14 @@ impl AppServerProcess {
     }
 
     fn read_required(&mut self) -> std::io::Result<Value> {
-        self.read_message()?.ok_or_else(|| {
+        let value = self.read_message()?.ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "app-server closed stdout before responding",
             )
-        })
+        })?;
+        assert_eq!(value.get("jsonrpc").and_then(Value::as_str), Some("2.0"));
+        Ok(value)
     }
 
     fn read_message(&mut self) -> std::io::Result<Option<Value>> {
@@ -632,6 +636,7 @@ fn app_server_exit_on_turn_start_closes_stdout_without_response() -> std::io::Re
         .unwrap()
         .to_string();
     server.send(&json!({
+        "jsonrpc": "2.0",
         "id": 3,
         "method": "turn/start",
         "params": {

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -81,7 +81,6 @@ struct AppServerProcess {
 impl AppServerProcess {
     fn request(&mut self, id: i64, method: &str, params: Value) -> std::io::Result<Value> {
         self.send(&json!({
-            "jsonrpc": "2.0",
             "id": id,
             "method": method,
             "params": params,
@@ -91,7 +90,6 @@ impl AppServerProcess {
 
     fn notify(&mut self, method: &str, params: Value) -> std::io::Result<()> {
         self.send(&json!({
-            "jsonrpc": "2.0",
             "method": method,
             "params": params,
         }))
@@ -107,14 +105,12 @@ impl AppServerProcess {
     }
 
     fn read_required(&mut self) -> std::io::Result<Value> {
-        let value = self.read_message()?.ok_or_else(|| {
+        self.read_message()?.ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "app-server closed stdout before responding",
             )
-        })?;
-        assert_eq!(value.get("jsonrpc").and_then(Value::as_str), Some("2.0"));
-        Ok(value)
+        })
     }
 
     fn read_message(&mut self) -> std::io::Result<Option<Value>> {
@@ -700,7 +696,6 @@ fn app_server_exit_on_turn_start_closes_stdout_without_response() -> std::io::Re
         .unwrap()
         .to_string();
     server.send(&json!({
-        "jsonrpc": "2.0",
         "id": 3,
         "method": "turn/start",
         "params": {

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -702,6 +702,58 @@ fn app_server_rejects_missing_or_empty_turn_thread_id() -> std::io::Result<()> {
 }
 
 #[test]
+fn app_server_rejects_missing_or_empty_expected_turn_id() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", initialize_params())?;
+    let started = server.request(2, "thread/start", json!({}))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+
+    let missing_expected_turn = server.request(
+        4,
+        "turn/steer",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    let empty_expected_turn = server.request(
+        5,
+        "turn/steer",
+        json!({
+            "threadId": thread_id,
+            "expectedTurnId": "",
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+
+    assert_eq!(missing_expected_turn["error"]["code"], -32600);
+    assert_eq!(
+        missing_expected_turn["error"]["message"],
+        "missing expectedTurnId"
+    );
+    assert_eq!(empty_expected_turn["error"]["code"], -32600);
+    assert_eq!(
+        empty_expected_turn["error"]["message"],
+        "expectedTurnId must not be empty"
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_initialized_notification_does_not_replace_initialize_request() -> std::io::Result<()>
 {
     let dir = TempDir::new().unwrap();

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -629,6 +629,77 @@ fn app_server_rejects_empty_resume_thread_id() -> std::io::Result<()> {
 }
 
 #[test]
+fn app_server_rejects_missing_or_empty_turn_thread_id() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", initialize_params())?;
+    let started = server.request(2, "thread/start", json!({}))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let missing_start = server.request(
+        3,
+        "turn/start",
+        json!({
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let empty_start = server.request(
+        4,
+        "turn/start",
+        json!({
+            "threadId": "",
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+
+    let turn_started = server.request(
+        5,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_id = turn_started["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let missing_steer = server.request(
+        6,
+        "turn/steer",
+        json!({
+            "expectedTurnId": turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    let empty_steer = server.request(
+        7,
+        "turn/steer",
+        json!({
+            "threadId": "",
+            "expectedTurnId": turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+
+    for error in [missing_start, empty_start, missing_steer, empty_steer] {
+        assert_eq!(error["error"]["code"], -32600);
+        assert!(
+            error["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("threadId")
+        );
+    }
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_initialized_notification_does_not_replace_initialize_request() -> std::io::Result<()>
 {
     let dir = TempDir::new().unwrap();

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -661,10 +661,12 @@ fn app_server_initialized_notification_does_not_replace_initialize_request() -> 
             .unwrap()
             .contains("not initialized")
     );
+    assert_eq!(turn_start_error["error"]["code"], -32600);
     assert_eq!(
         turn_start_error["error"]["message"],
         "app server is not initialized"
     );
+    assert_eq!(turn_steer_error["error"]["code"], -32600);
     assert_eq!(
         turn_steer_error["error"]["message"],
         "app server is not initialized"

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -384,6 +384,76 @@ fn app_server_resumed_non_uuid_thread_records_inputs() -> std::io::Result<()> {
 }
 
 #[test]
+fn app_server_initialized_notification_does_not_replace_initialize_request() -> std::io::Result<()>
+{
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.notify("initialized", json!({}))?;
+    let error = server.request(1, "thread/start", json!({}))?;
+
+    assert_eq!(error["error"]["code"], -32600);
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("not initialized")
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_new_thread_clears_previous_active_turn() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", json!({}))?;
+    let first_thread = server.request(2, "thread/start", json!({}))?;
+    let first_thread_id = first_thread["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let first_turn = server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": first_thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let first_turn_id = first_turn["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let second_thread = server.request(4, "thread/start", json!({}))?;
+    let second_thread_id = second_thread["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let error = server.request(
+        5,
+        "turn/steer",
+        json!({
+            "threadId": second_thread_id,
+            "expectedTurnId": first_turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+
+    assert_eq!(error["error"]["code"], -32600);
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("no active turn")
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_stale_turn_scenario_returns_json_rpc_error() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -327,6 +327,28 @@ fn app_server_accepts_stdio_and_resumes_supplied_thread() -> std::io::Result<()>
 }
 
 #[test]
+fn app_server_rejects_non_stdio_listen_url() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let out = run(
+        dir.path(),
+        &["app-server", "--stdio", "--listen", "tcp://127.0.0.1:0"],
+    )?;
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "unsupported app-server listen URL should not emit stdout JSON: {:?}",
+        out.events
+    );
+    assert!(
+        out.stderr.contains("only supports stdio transport"),
+        "unsupported app-server listen URL should fail clearly: {:?}",
+        out.stderr
+    );
+    Ok(())
+}
+
+#[test]
 fn app_server_resumed_non_uuid_thread_records_inputs() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let supplied_thread_id = "thread-1";
@@ -379,6 +401,31 @@ fn app_server_resumed_non_uuid_thread_records_inputs() -> std::io::Result<()> {
     assert_eq!(events[0]["text"], "initial prompt");
     assert_eq!(events[1]["thread_id"], supplied_thread_id);
     assert_eq!(events[1]["text"], "follow-up prompt");
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_rejects_empty_resume_thread_id() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", json!({}))?;
+    let error = server.request(
+        2,
+        "thread/resume",
+        json!({
+            "threadId": ""
+        }),
+    )?;
+
+    assert_eq!(error["error"]["code"], -32600);
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("threadId")
+    );
     assert_eq!(server.close_and_wait()?, 0);
     Ok(())
 }
@@ -560,7 +607,10 @@ fn app_server_disconnect_after_initialize_closes_stdout() -> std::io::Result<()>
     )?;
 
     let initialized = server.request(1, "initialize", json!({}))?;
-    assert_eq!(initialized["result"]["platformFamily"], "unix");
+    assert_eq!(
+        initialized["result"]["platformFamily"],
+        std::env::consts::FAMILY
+    );
     assert!(server.read_message()?.is_none());
     assert_eq!(server.close_and_wait()?, 0);
     Ok(())

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -327,6 +327,63 @@ fn app_server_accepts_stdio_and_resumes_supplied_thread() -> std::io::Result<()>
 }
 
 #[test]
+fn app_server_resumed_non_uuid_thread_records_inputs() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let supplied_thread_id = "thread-1";
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", json!({}))?;
+    let resumed = server.request(
+        2,
+        "thread/resume",
+        json!({
+            "threadId": supplied_thread_id
+        }),
+    )?;
+    assert_eq!(resumed["result"]["thread"]["id"], supplied_thread_id);
+
+    let turn_started = server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": supplied_thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_id = turn_started["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let steered = server.request(
+        4,
+        "turn/steer",
+        json!({
+            "threadId": supplied_thread_id,
+            "expectedTurnId": turn_id,
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    assert_eq!(steered["result"]["turnId"], turn_id);
+
+    let session_path = require_session_file(dir.path())?;
+    let file_name = session_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    assert!(
+        !file_name.starts_with(supplied_thread_id),
+        "non-UUID app-server thread ids should not be used directly as session filenames: {file_name}"
+    );
+    let events = read_session_file(&session_path)?;
+    assert_eq!(events[0]["thread_id"], supplied_thread_id);
+    assert_eq!(events[0]["text"], "initial prompt");
+    assert_eq!(events[1]["thread_id"], supplied_thread_id);
+    assert_eq!(events[1]["text"], "follow-up prompt");
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_stale_turn_scenario_returns_json_rpc_error() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(


### PR DESCRIPTION
## Summary
- Add a `guest-mock-codex app-server` stdio JSON-RPC mock path for Codex app-server tests.
- Support initialize/thread/turn start and steer flows, deterministic failure scenarios, and input recording.
- Add binary-level integration coverage for success, stale turn, no active turn, disconnect, child exit, unsupported methods, and invalid input.

## Tests
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_jsonl_failure_logging`

Closes #18369