### PR TITLE
refactor: expose structured remote exec termination

### DIFF
--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -165,17 +165,20 @@ fn remote_exec_exit_code(termination: SandboxExecTermination) -> ExitCode {
 }
 
 fn write_remote_exec_terminal_diagnostic(stderr: &mut impl Write, result: &RemoteExecResult) {
-    let message = if matches!(result.termination, SandboxExecTermination::Exited { .. }) {
-        None
-    } else if !result.diagnostic.is_empty() {
-        Some(result.diagnostic.as_str())
-    } else {
-        match result.termination {
-            SandboxExecTermination::TimedOut => Some("Timeout"),
-            SandboxExecTermination::Cancelled => Some("Cancelled"),
-            SandboxExecTermination::Exited { .. }
-            | SandboxExecTermination::StartFailed
-            | SandboxExecTermination::WaitFailed => None,
+    let message = match result.termination {
+        SandboxExecTermination::Exited { .. } => None,
+        SandboxExecTermination::TimedOut if !result.diagnostic.is_empty() => {
+            Some(result.diagnostic.as_str())
+        }
+        SandboxExecTermination::TimedOut if result.stderr.is_empty() => Some("Timeout"),
+        SandboxExecTermination::TimedOut => None,
+        SandboxExecTermination::Cancelled if !result.diagnostic.is_empty() => {
+            Some(result.diagnostic.as_str())
+        }
+        SandboxExecTermination::Cancelled if result.stderr.is_empty() => Some("Cancelled"),
+        SandboxExecTermination::Cancelled => None,
+        SandboxExecTermination::StartFailed | SandboxExecTermination::WaitFailed => {
+            (!result.diagnostic.is_empty()).then_some(result.diagnostic.as_str())
         }
     };
 
@@ -347,6 +350,40 @@ mod tests {
         write_remote_exec_terminal_diagnostic(&mut stderr, &result);
 
         assert_eq!(stderr, b"stderr clue\nwait failed\n");
+    }
+
+    #[test]
+    fn terminal_fallback_is_not_added_when_stderr_has_content() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::TimedOut,
+            stdout: Vec::new(),
+            stderr: b"stderr clue".to_vec(),
+            diagnostic: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let mut stderr = result.stderr.clone();
+
+        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+
+        assert_eq!(stderr, b"stderr clue");
+    }
+
+    #[test]
+    fn terminal_fallback_is_added_when_stderr_is_empty() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::Cancelled,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            diagnostic: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let mut stderr = result.stderr.clone();
+
+        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+
+        assert_eq!(stderr, b"Cancelled\n");
     }
 
     // ---- argument quoting -------------------------------------------------

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -123,11 +123,10 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
         .await
     {
         Ok(result) => {
-            let out = std::io::stdout();
+            let _ = std::io::stdout().lock().write_all(&result.stdout);
+
             let err = std::io::stderr();
-            let mut out = out.lock();
             let mut err = err.lock();
-            let _ = out.write_all(&result.stdout);
             let _ = err.write_all(&result.stderr);
             write_remote_exec_terminal_diagnostic(&mut err, &result);
             if result.stdout_truncated {

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -127,22 +127,7 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
 
             let err = std::io::stderr();
             let mut err = err.lock();
-            let _ = err.write_all(&result.stderr);
-            let mut stderr_line_open = write_remote_exec_terminal_diagnostic(&mut err, &result);
-            if result.stdout_truncated {
-                write_remote_exec_warning(
-                    &mut err,
-                    &mut stderr_line_open,
-                    "warning: remote stdout was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest",
-                );
-            }
-            if result.stderr_truncated {
-                write_remote_exec_warning(
-                    &mut err,
-                    &mut stderr_line_open,
-                    "warning: remote stderr was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest",
-                );
-            }
+            write_remote_exec_stderr(&mut err, &result);
 
             Ok(remote_exec_exit_code(result.termination))
         }
@@ -155,6 +140,8 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
 }
 
 const REMOTE_EXEC_TIMEOUT_EXIT_CODE: u8 = 124;
+const REMOTE_EXEC_STDOUT_TRUNCATED_WARNING: &str = "warning: remote stdout was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest";
+const REMOTE_EXEC_STDERR_TRUNCATED_WARNING: &str = "warning: remote stderr was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest";
 
 fn remote_exec_exit_code(termination: SandboxExecTermination) -> ExitCode {
     match termination {
@@ -166,38 +153,45 @@ fn remote_exec_exit_code(termination: SandboxExecTermination) -> ExitCode {
     }
 }
 
+fn write_remote_exec_stderr(stderr: &mut impl Write, result: &RemoteExecResult) {
+    let _ = stderr.write_all(&result.stderr);
+    let mut line_open = !result.stderr.is_empty() && !result.stderr.ends_with(b"\n");
+
+    write_remote_exec_terminal_diagnostic(stderr, result, &mut line_open);
+    if result.stdout_truncated {
+        write_remote_exec_warning(stderr, &mut line_open, REMOTE_EXEC_STDOUT_TRUNCATED_WARNING);
+    }
+    if result.stderr_truncated {
+        write_remote_exec_warning(stderr, &mut line_open, REMOTE_EXEC_STDERR_TRUNCATED_WARNING);
+    }
+}
+
 fn write_remote_exec_terminal_diagnostic(
     stderr: &mut impl Write,
     result: &RemoteExecResult,
-) -> bool {
-    let fallback = match result.termination {
-        SandboxExecTermination::Exited { .. }
-        | SandboxExecTermination::StartFailed
-        | SandboxExecTermination::WaitFailed => None,
-        SandboxExecTermination::TimedOut => Some("Timeout"),
-        SandboxExecTermination::Cancelled => Some("Cancelled"),
+    line_open: &mut bool,
+) {
+    let (fallback, include_diagnostic) = match result.termination {
+        SandboxExecTermination::Exited { .. } => (None, false),
+        SandboxExecTermination::TimedOut => (Some("Timeout"), false),
+        SandboxExecTermination::Cancelled => (Some("Cancelled"), true),
+        SandboxExecTermination::StartFailed | SandboxExecTermination::WaitFailed => (None, true),
     };
-
-    let mut line_open = !result.stderr.is_empty() && !result.stderr.ends_with(b"\n");
 
     if result.stderr.is_empty() {
         if let Some(message) = fallback {
             let _ = writeln!(stderr, "{message}");
-            line_open = false;
+            *line_open = false;
         }
-    } else if !result.diagnostic.is_empty() && line_open {
+    } else if include_diagnostic && !result.diagnostic.is_empty() && *line_open {
         let _ = writeln!(stderr);
-        line_open = false;
+        *line_open = false;
     }
 
-    if !matches!(result.termination, SandboxExecTermination::Exited { .. })
-        && !result.diagnostic.is_empty()
-    {
+    if include_diagnostic && !result.diagnostic.is_empty() {
         let _ = writeln!(stderr, "{}", result.diagnostic);
-        line_open = false;
+        *line_open = false;
     }
-
-    line_open
 }
 
 fn write_remote_exec_warning(stderr: &mut impl Write, line_open: &mut bool, message: &str) {
@@ -352,9 +346,9 @@ mod tests {
             stdout_truncated: false,
             stderr_truncated: false,
         };
-        let mut stderr = result.stderr.clone();
+        let mut stderr = Vec::new();
 
-        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result);
 
         assert_eq!(stderr, b"stderr clue\nwait failed\n");
     }
@@ -369,9 +363,9 @@ mod tests {
             stdout_truncated: false,
             stderr_truncated: false,
         };
-        let mut stderr = result.stderr.clone();
+        let mut stderr = Vec::new();
 
-        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result);
 
         assert_eq!(stderr, b"stderr clue");
     }
@@ -386,9 +380,9 @@ mod tests {
             stdout_truncated: false,
             stderr_truncated: false,
         };
-        let mut stderr = result.stderr.clone();
+        let mut stderr = Vec::new();
 
-        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result);
 
         assert_eq!(stderr, b"Cancelled\n");
     }
@@ -403,11 +397,28 @@ mod tests {
             stdout_truncated: false,
             stderr_truncated: false,
         };
-        let mut stderr = result.stderr.clone();
+        let mut stderr = Vec::new();
 
-        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+        write_remote_exec_stderr(&mut stderr, &result);
 
         assert_eq!(stderr, b"Cancelled\ncancel diagnostic\n");
+    }
+
+    #[test]
+    fn terminal_timeout_diagnostic_preserves_legacy_timeout_display() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::TimedOut,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            diagnostic: "timeout diagnostic".into(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let mut stderr = Vec::new();
+
+        write_remote_exec_stderr(&mut stderr, &result);
+
+        assert_eq!(stderr, b"Timeout\n");
     }
 
     #[test]
@@ -420,12 +431,14 @@ mod tests {
             stdout_truncated: true,
             stderr_truncated: false,
         };
-        let mut stderr = result.stderr.clone();
-        let mut line_open = write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+        let mut stderr = Vec::new();
 
-        write_remote_exec_warning(&mut stderr, &mut line_open, "warning: truncated");
+        write_remote_exec_stderr(&mut stderr, &result);
 
-        assert_eq!(stderr, b"stderr clue\nwarning: truncated\n");
+        assert_eq!(
+            stderr,
+            format!("stderr clue\n{REMOTE_EXEC_STDOUT_TRUNCATED_WARNING}\n").into_bytes()
+        );
     }
 
     #[test]
@@ -438,12 +451,15 @@ mod tests {
             stdout_truncated: true,
             stderr_truncated: false,
         };
-        let mut stderr = result.stderr.clone();
-        let mut line_open = write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+        let mut stderr = Vec::new();
 
-        write_remote_exec_warning(&mut stderr, &mut line_open, "warning: truncated");
+        write_remote_exec_stderr(&mut stderr, &result);
 
-        assert_eq!(stderr, b"stderr clue\nwait failed\nwarning: truncated\n");
+        assert_eq!(
+            stderr,
+            format!("stderr clue\nwait failed\n{REMOTE_EXEC_STDOUT_TRUNCATED_WARNING}\n")
+                .into_bytes()
+        );
     }
 
     // ---- argument quoting -------------------------------------------------

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -87,9 +87,10 @@ fn shell_quote(arg: &str) -> String {
 /// targets are resolved through trusted live runner status before
 /// dispatching to [`SandboxControl::exec_remote`].
 ///
-/// Guest stdout and stderr are forwarded to local stdout and stderr. The guest
-/// process exit code is converted to [`ExitCode`] by truncating to `u8`,
-/// matching shell behavior for values outside the 0-255 range.
+/// Guest stdout and stderr are forwarded to local stdout and stderr. The
+/// structured guest terminal state is converted to a local [`ExitCode`] at this
+/// CLI boundary; ordinary process exit codes are truncated to `u8`, matching
+/// shell behavior for values outside the 0-255 range.
 ///
 /// [`SandboxControlError::Remote`] values are printed to stderr and returned
 /// as [`ExitCode::FAILURE`]. Other sandbox-control errors are propagated as
@@ -165,28 +166,26 @@ fn remote_exec_exit_code(termination: SandboxExecTermination) -> ExitCode {
 }
 
 fn write_remote_exec_terminal_diagnostic(stderr: &mut impl Write, result: &RemoteExecResult) {
-    let message = match result.termination {
-        SandboxExecTermination::Exited { .. } => None,
-        SandboxExecTermination::TimedOut if !result.diagnostic.is_empty() => {
-            Some(result.diagnostic.as_str())
-        }
-        SandboxExecTermination::TimedOut if result.stderr.is_empty() => Some("Timeout"),
-        SandboxExecTermination::TimedOut => None,
-        SandboxExecTermination::Cancelled if !result.diagnostic.is_empty() => {
-            Some(result.diagnostic.as_str())
-        }
-        SandboxExecTermination::Cancelled if result.stderr.is_empty() => Some("Cancelled"),
-        SandboxExecTermination::Cancelled => None,
-        SandboxExecTermination::StartFailed | SandboxExecTermination::WaitFailed => {
-            (!result.diagnostic.is_empty()).then_some(result.diagnostic.as_str())
-        }
+    let fallback = match result.termination {
+        SandboxExecTermination::Exited { .. }
+        | SandboxExecTermination::StartFailed
+        | SandboxExecTermination::WaitFailed => None,
+        SandboxExecTermination::TimedOut => Some("Timeout"),
+        SandboxExecTermination::Cancelled => Some("Cancelled"),
     };
 
-    if let Some(message) = message {
-        if !result.stderr.is_empty() && !result.stderr.ends_with(b"\n") {
-            let _ = writeln!(stderr);
+    if result.stderr.is_empty() {
+        if let Some(message) = fallback {
+            let _ = writeln!(stderr, "{message}");
         }
-        let _ = writeln!(stderr, "{message}");
+    } else if !result.diagnostic.is_empty() && !result.stderr.ends_with(b"\n") {
+        let _ = writeln!(stderr);
+    }
+
+    if !matches!(result.termination, SandboxExecTermination::Exited { .. })
+        && !result.diagnostic.is_empty()
+    {
+        let _ = writeln!(stderr, "{}", result.diagnostic);
     }
 }
 
@@ -222,7 +221,7 @@ mod tests {
         let control = MockSandboxControl::new("/tmp");
         control.push_exec_remote_result(Ok(RemoteExecResult {
             termination: SandboxExecTermination::Exited { exit_code: 42 },
-            stdout: b"hello\n".to_vec(),
+            stdout: Vec::new(),
             stderr: Vec::new(),
             diagnostic: String::new(),
             stdout_truncated: false,
@@ -303,36 +302,24 @@ mod tests {
         assert_eq!(r2, ExitCode::from(255));
     }
 
-    #[tokio::test]
-    async fn non_exited_terminations_map_to_cli_exit_codes() {
-        let control = MockSandboxControl::new("/tmp");
-        for termination in [
-            SandboxExecTermination::TimedOut,
-            SandboxExecTermination::Cancelled,
-            SandboxExecTermination::StartFailed,
-            SandboxExecTermination::WaitFailed,
-        ] {
-            control.push_exec_remote_result(Ok(RemoteExecResult {
-                termination,
-                stdout: Vec::new(),
-                stderr: Vec::new(),
-                diagnostic: String::new(),
-                stdout_truncated: false,
-                stderr_truncated: false,
-            }));
-        }
-
-        let timed_out = run_exec(make_args("id", "test"), &control).await.unwrap();
-        assert_eq!(timed_out, ExitCode::from(REMOTE_EXEC_TIMEOUT_EXIT_CODE));
-
-        for _ in [
-            SandboxExecTermination::Cancelled,
-            SandboxExecTermination::StartFailed,
-            SandboxExecTermination::WaitFailed,
-        ] {
-            let result = run_exec(make_args("id", "test"), &control).await.unwrap();
-            assert_eq!(result, ExitCode::FAILURE);
-        }
+    #[test]
+    fn non_exited_terminations_map_to_cli_exit_codes() {
+        assert_eq!(
+            remote_exec_exit_code(SandboxExecTermination::TimedOut),
+            ExitCode::from(REMOTE_EXEC_TIMEOUT_EXIT_CODE)
+        );
+        assert_eq!(
+            remote_exec_exit_code(SandboxExecTermination::Cancelled),
+            ExitCode::FAILURE
+        );
+        assert_eq!(
+            remote_exec_exit_code(SandboxExecTermination::StartFailed),
+            ExitCode::FAILURE
+        );
+        assert_eq!(
+            remote_exec_exit_code(SandboxExecTermination::WaitFailed),
+            ExitCode::FAILURE
+        );
     }
 
     #[test]
@@ -384,6 +371,23 @@ mod tests {
         write_remote_exec_terminal_diagnostic(&mut stderr, &result);
 
         assert_eq!(stderr, b"Cancelled\n");
+    }
+
+    #[test]
+    fn terminal_diagnostic_keeps_fallback_when_stderr_is_empty() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::Cancelled,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            diagnostic: "cancel diagnostic".into(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let mut stderr = result.stderr.clone();
+
+        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+
+        assert_eq!(stderr, b"Cancelled\ncancel diagnostic\n");
     }
 
     // ---- argument quoting -------------------------------------------------

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -5,7 +5,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Args;
-use sandbox::{SandboxControl, SandboxControlError};
+use sandbox::{RemoteExecResult, SandboxControl, SandboxControlError, SandboxExecTermination};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
@@ -124,22 +124,25 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
         Ok(result) => {
             let out = std::io::stdout();
             let err = std::io::stderr();
-            let _ = out.lock().write_all(&result.stdout);
-            let _ = err.lock().write_all(&result.stderr);
+            let mut out = out.lock();
+            let mut err = err.lock();
+            let _ = out.write_all(&result.stdout);
+            let _ = err.write_all(&result.stderr);
+            write_remote_exec_terminal_diagnostic(&mut err, &result);
             if result.stdout_truncated {
-                eprintln!(
+                let _ = writeln!(
+                    err,
                     "warning: remote stdout was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest"
                 );
             }
             if result.stderr_truncated {
-                eprintln!(
+                let _ = writeln!(
+                    err,
                     "warning: remote stderr was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest"
                 );
             }
 
-            // Propagate the actual exit code for debugging utility.
-            // Truncate to u8 like shells do (e.g. 256 → 0, -1 → 255).
-            Ok(ExitCode::from(result.exit_code as u8))
+            Ok(remote_exec_exit_code(result.termination))
         }
         Err(SandboxControlError::Remote(msg)) => {
             eprintln!("error: {msg}");
@@ -149,9 +152,44 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
     }
 }
 
+const REMOTE_EXEC_TIMEOUT_EXIT_CODE: u8 = 124;
+
+fn remote_exec_exit_code(termination: SandboxExecTermination) -> ExitCode {
+    match termination {
+        SandboxExecTermination::Exited { exit_code } => ExitCode::from(exit_code as u8),
+        SandboxExecTermination::TimedOut => ExitCode::from(REMOTE_EXEC_TIMEOUT_EXIT_CODE),
+        SandboxExecTermination::Cancelled
+        | SandboxExecTermination::StartFailed
+        | SandboxExecTermination::WaitFailed => ExitCode::FAILURE,
+    }
+}
+
+fn write_remote_exec_terminal_diagnostic(stderr: &mut impl Write, result: &RemoteExecResult) {
+    let message = if matches!(result.termination, SandboxExecTermination::Exited { .. }) {
+        None
+    } else if !result.diagnostic.is_empty() {
+        Some(result.diagnostic.as_str())
+    } else {
+        match result.termination {
+            SandboxExecTermination::TimedOut => Some("Timeout"),
+            SandboxExecTermination::Cancelled => Some("Cancelled"),
+            SandboxExecTermination::Exited { .. }
+            | SandboxExecTermination::StartFailed
+            | SandboxExecTermination::WaitFailed => None,
+        }
+    };
+
+    if let Some(message) = message {
+        if !result.stderr.is_empty() && !result.stderr.ends_with(b"\n") {
+            let _ = writeln!(stderr);
+        }
+        let _ = writeln!(stderr, "{message}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use sandbox::{RemoteExecResult, SandboxControlError};
+    use sandbox::SandboxControlError;
     use sandbox_mock::MockSandboxControl;
 
     use super::*;
@@ -180,9 +218,10 @@ mod tests {
     async fn success_propagates_exit_code() {
         let control = MockSandboxControl::new("/tmp");
         control.push_exec_remote_result(Ok(RemoteExecResult {
-            exit_code: 42,
+            termination: SandboxExecTermination::Exited { exit_code: 42 },
             stdout: b"hello\n".to_vec(),
             stderr: Vec::new(),
+            diagnostic: String::new(),
             stdout_truncated: false,
             stderr_truncated: false,
         }));
@@ -237,17 +276,19 @@ mod tests {
         let control = MockSandboxControl::new("/tmp");
         // 256 truncates to 0 via `as u8`
         control.push_exec_remote_result(Ok(RemoteExecResult {
-            exit_code: 256,
+            termination: SandboxExecTermination::Exited { exit_code: 256 },
             stdout: Vec::new(),
             stderr: Vec::new(),
+            diagnostic: String::new(),
             stdout_truncated: false,
             stderr_truncated: false,
         }));
         // -1 (0xFFFFFFFF) truncates to 255 via `as u8`
         control.push_exec_remote_result(Ok(RemoteExecResult {
-            exit_code: -1,
+            termination: SandboxExecTermination::Exited { exit_code: -1 },
             stdout: Vec::new(),
             stderr: Vec::new(),
+            diagnostic: String::new(),
             stdout_truncated: false,
             stderr_truncated: false,
         }));
@@ -257,6 +298,55 @@ mod tests {
 
         let r2 = run_exec(make_args("id", "test"), &control).await.unwrap();
         assert_eq!(r2, ExitCode::from(255));
+    }
+
+    #[tokio::test]
+    async fn non_exited_terminations_map_to_cli_exit_codes() {
+        let control = MockSandboxControl::new("/tmp");
+        for termination in [
+            SandboxExecTermination::TimedOut,
+            SandboxExecTermination::Cancelled,
+            SandboxExecTermination::StartFailed,
+            SandboxExecTermination::WaitFailed,
+        ] {
+            control.push_exec_remote_result(Ok(RemoteExecResult {
+                termination,
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+                diagnostic: String::new(),
+                stdout_truncated: false,
+                stderr_truncated: false,
+            }));
+        }
+
+        let timed_out = run_exec(make_args("id", "test"), &control).await.unwrap();
+        assert_eq!(timed_out, ExitCode::from(REMOTE_EXEC_TIMEOUT_EXIT_CODE));
+
+        for _ in [
+            SandboxExecTermination::Cancelled,
+            SandboxExecTermination::StartFailed,
+            SandboxExecTermination::WaitFailed,
+        ] {
+            let result = run_exec(make_args("id", "test"), &control).await.unwrap();
+            assert_eq!(result, ExitCode::FAILURE);
+        }
+    }
+
+    #[test]
+    fn terminal_diagnostic_starts_on_new_line_after_stderr() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::WaitFailed,
+            stdout: Vec::new(),
+            stderr: b"stderr clue".to_vec(),
+            diagnostic: "wait failed".into(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let mut stderr = result.stderr.clone();
+
+        write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+
+        assert_eq!(stderr, b"stderr clue\nwait failed\n");
     }
 
     // ---- argument quoting -------------------------------------------------

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -128,17 +128,19 @@ pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerRes
             let err = std::io::stderr();
             let mut err = err.lock();
             let _ = err.write_all(&result.stderr);
-            write_remote_exec_terminal_diagnostic(&mut err, &result);
+            let mut stderr_line_open = write_remote_exec_terminal_diagnostic(&mut err, &result);
             if result.stdout_truncated {
-                let _ = writeln!(
-                    err,
-                    "warning: remote stdout was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest"
+                write_remote_exec_warning(
+                    &mut err,
+                    &mut stderr_line_open,
+                    "warning: remote stdout was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest",
                 );
             }
             if result.stderr_truncated {
-                let _ = writeln!(
-                    err,
-                    "warning: remote stderr was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest"
+                write_remote_exec_warning(
+                    &mut err,
+                    &mut stderr_line_open,
+                    "warning: remote stderr was truncated by the sandbox capture limit; use a narrower command or redirect output inside the guest",
                 );
             }
 
@@ -164,7 +166,10 @@ fn remote_exec_exit_code(termination: SandboxExecTermination) -> ExitCode {
     }
 }
 
-fn write_remote_exec_terminal_diagnostic(stderr: &mut impl Write, result: &RemoteExecResult) {
+fn write_remote_exec_terminal_diagnostic(
+    stderr: &mut impl Write,
+    result: &RemoteExecResult,
+) -> bool {
     let fallback = match result.termination {
         SandboxExecTermination::Exited { .. }
         | SandboxExecTermination::StartFailed
@@ -173,19 +178,35 @@ fn write_remote_exec_terminal_diagnostic(stderr: &mut impl Write, result: &Remot
         SandboxExecTermination::Cancelled => Some("Cancelled"),
     };
 
+    let mut line_open = !result.stderr.is_empty() && !result.stderr.ends_with(b"\n");
+
     if result.stderr.is_empty() {
         if let Some(message) = fallback {
             let _ = writeln!(stderr, "{message}");
+            line_open = false;
         }
-    } else if !result.diagnostic.is_empty() && !result.stderr.ends_with(b"\n") {
+    } else if !result.diagnostic.is_empty() && line_open {
         let _ = writeln!(stderr);
+        line_open = false;
     }
 
     if !matches!(result.termination, SandboxExecTermination::Exited { .. })
         && !result.diagnostic.is_empty()
     {
         let _ = writeln!(stderr, "{}", result.diagnostic);
+        line_open = false;
     }
+
+    line_open
+}
+
+fn write_remote_exec_warning(stderr: &mut impl Write, line_open: &mut bool, message: &str) {
+    if *line_open {
+        let _ = writeln!(stderr);
+        *line_open = false;
+    }
+
+    let _ = writeln!(stderr, "{message}");
 }
 
 #[cfg(test)]
@@ -387,6 +408,42 @@ mod tests {
         write_remote_exec_terminal_diagnostic(&mut stderr, &result);
 
         assert_eq!(stderr, b"Cancelled\ncancel diagnostic\n");
+    }
+
+    #[test]
+    fn terminal_warning_starts_on_new_line_after_stderr() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::Exited { exit_code: 0 },
+            stdout: Vec::new(),
+            stderr: b"stderr clue".to_vec(),
+            diagnostic: String::new(),
+            stdout_truncated: true,
+            stderr_truncated: false,
+        };
+        let mut stderr = result.stderr.clone();
+        let mut line_open = write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+
+        write_remote_exec_warning(&mut stderr, &mut line_open, "warning: truncated");
+
+        assert_eq!(stderr, b"stderr clue\nwarning: truncated\n");
+    }
+
+    #[test]
+    fn terminal_warning_follows_diagnostic_without_extra_blank_line() {
+        let result = RemoteExecResult {
+            termination: SandboxExecTermination::WaitFailed,
+            stdout: Vec::new(),
+            stderr: b"stderr clue".to_vec(),
+            diagnostic: "wait failed".into(),
+            stdout_truncated: true,
+            stderr_truncated: false,
+        };
+        let mut stderr = result.stderr.clone();
+        let mut line_open = write_remote_exec_terminal_diagnostic(&mut stderr, &result);
+
+        write_remote_exec_warning(&mut stderr, &mut line_open, "warning: truncated");
+
+        assert_eq!(stderr, b"stderr clue\nwait failed\nwarning: truncated\n");
     }
 
     // ---- argument quoting -------------------------------------------------

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -375,6 +375,70 @@ mod tests {
     }
 
     #[test]
+    fn exec_response_rejects_non_exited_termination_with_exit_code() {
+        for exit_code in [serde_json::json!(124), serde_json::Value::Null] {
+            let malformed = serde_json::json!({
+                "termination": {
+                    "kind": "timed_out",
+                    "exit_code": exit_code,
+                },
+                "stdout": BASE64.encode(b""),
+                "stderr": BASE64.encode(b""),
+                "stdout_truncated": false,
+                "stderr_truncated": false,
+                "diagnostic": "",
+            });
+
+            let result = serde_json::from_value::<ExecResponse>(malformed);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn exec_response_rejects_exited_termination_without_exit_code() {
+        for termination in [
+            serde_json::json!({
+                "kind": "exited",
+            }),
+            serde_json::json!({
+                "kind": "exited",
+                "exit_code": null,
+            }),
+        ] {
+            let malformed = serde_json::json!({
+                "termination": termination,
+                "stdout": BASE64.encode(b""),
+                "stderr": BASE64.encode(b""),
+                "stdout_truncated": false,
+                "stderr_truncated": false,
+                "diagnostic": "",
+            });
+
+            let result = serde_json::from_value::<ExecResponse>(malformed);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn exec_response_rejects_termination_unknown_field() {
+        let malformed = serde_json::json!({
+            "termination": {
+                "kind": "exited",
+                "exit_code": 0,
+                "signal": 9,
+            },
+            "stdout": BASE64.encode(b""),
+            "stderr": BASE64.encode(b""),
+            "stdout_truncated": false,
+            "stderr_truncated": false,
+            "diagnostic": "",
+        });
+
+        let result = serde_json::from_value::<ExecResponse>(malformed);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn exec_response_error_serialization() {
         let resp = ExecResponse::Error {
             error: "sandbox not running".into(),

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -349,8 +349,8 @@ mod tests {
             "stderr_truncated": false
         });
 
-        let err = serde_json::from_value::<ExecResponse>(legacy).unwrap_err();
-        assert!(err.to_string().contains("data did not match any variant"));
+        let result = serde_json::from_value::<ExecResponse>(legacy);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -360,6 +360,7 @@ mod tests {
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["error"], "sandbox not running");
+        assert!(json.get("termination").is_none());
         assert!(json.get("exit_code").is_none());
     }
 

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -35,7 +35,7 @@ fn default_timeout() -> u32 {
 /// by shape: a command result response contains command result fields, while an
 /// error response contains only an `error` string.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ExecResponse {
     /// Command execution produced a captured result.
     Success {
@@ -115,7 +115,7 @@ pub enum TerminateStatus {
 /// by shape: a status response contains a `status` field, while an error
 /// response contains only an `error` string.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum TerminateResponse {
     /// Termination request completed with a status result.
     ///
@@ -354,6 +354,25 @@ mod tests {
     }
 
     #[test]
+    fn exec_response_rejects_mixed_success_error_shape() {
+        let mixed = serde_json::json!({
+            "termination": {
+                "kind": "exited",
+                "exit_code": 0,
+            },
+            "stdout": BASE64.encode(b""),
+            "stderr": BASE64.encode(b""),
+            "stdout_truncated": false,
+            "stderr_truncated": false,
+            "diagnostic": "",
+            "error": "sandbox not running",
+        });
+
+        let result = serde_json::from_value::<ExecResponse>(mixed);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn exec_response_error_serialization() {
         let resp = ExecResponse::Error {
             error: "sandbox not running".into(),
@@ -416,6 +435,17 @@ mod tests {
                 error: "sandbox not running".into()
             }
         );
+    }
+
+    #[test]
+    fn terminate_response_rejects_mixed_status_error_shape() {
+        let mixed = serde_json::json!({
+            "status": "accepted",
+            "error": "sandbox not running",
+        });
+
+        let result = serde_json::from_value::<TerminateResponse>(mixed);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use sandbox::SandboxExecTermination;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -37,12 +38,9 @@ fn default_timeout() -> u32 {
 #[serde(untagged)]
 pub enum ExecResponse {
     /// Command execution produced a captured result.
-    ///
-    /// This variant does not imply a zero exit code; inspect `exit_code` for the
-    /// command's status.
     Success {
-        /// Process exit code returned by the guest command runner.
-        exit_code: i32,
+        /// Structured terminal state returned by the guest command runner.
+        termination: SandboxExecTermination,
         /// Base64-encoded captured stdout bytes.
         ///
         /// This is not plain UTF-8 text. `FirecrackerControl::exec_remote`
@@ -61,6 +59,8 @@ pub enum ExecResponse {
         ///
         /// Truncation is independent of the command exit code.
         stderr_truncated: bool,
+        /// Guest-provided terminal diagnostic text.
+        diagnostic: String,
     },
     /// Request failed before a command result could be returned.
     Error {
@@ -227,27 +227,30 @@ mod tests {
 
         // Verify success response round-trips.
         let response = ExecResponse::Success {
-            exit_code: 0,
+            termination: SandboxExecTermination::Exited { exit_code: 0 },
             stdout: BASE64.encode(b"hello\n"),
             stderr: BASE64.encode(b""),
             stdout_truncated: false,
             stderr_truncated: false,
+            diagnostic: "terminal diagnostic".into(),
         };
         let response_json = serde_json::to_vec(&response).unwrap();
         let decoded: ExecResponse = serde_json::from_slice(&response_json).unwrap();
         match decoded {
             ExecResponse::Success {
-                exit_code,
+                termination,
                 stdout,
                 stderr,
                 stdout_truncated,
                 stderr_truncated,
+                diagnostic,
             } => {
-                assert_eq!(exit_code, 0);
+                assert_eq!(termination, SandboxExecTermination::Exited { exit_code: 0 });
                 assert_eq!(BASE64.decode(stdout).unwrap(), b"hello\n");
                 assert_eq!(BASE64.decode(stderr).unwrap(), b"");
                 assert!(!stdout_truncated);
                 assert!(!stderr_truncated);
+                assert_eq!(diagnostic, "terminal diagnostic");
             }
             ExecResponse::Error { .. } => panic!("expected success"),
         }
@@ -288,18 +291,66 @@ mod tests {
     #[test]
     fn exec_response_success_serialization() {
         let resp = ExecResponse::Success {
-            exit_code: 0,
+            termination: SandboxExecTermination::Exited { exit_code: 0 },
             stdout: BASE64.encode(b"output\n"),
             stderr: BASE64.encode(b""),
             stdout_truncated: false,
             stderr_truncated: false,
+            diagnostic: "diagnostic".into(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         // Untagged enum: no "type" field, just the fields directly
-        assert_eq!(json["exit_code"], 0);
+        assert_eq!(json["termination"]["kind"], "exited");
+        assert_eq!(json["termination"]["exit_code"], 0);
+        assert!(json.get("exit_code").is_none());
         assert!(json.get("stdout").is_some());
         assert!(json.get("stderr").is_some());
+        assert_eq!(json["diagnostic"], "diagnostic");
         assert!(json.get("error").is_none());
+    }
+
+    #[test]
+    fn exec_response_success_serializes_non_exited_termination() {
+        for (termination, expected_kind) in [
+            (SandboxExecTermination::TimedOut, "timed_out"),
+            (SandboxExecTermination::Cancelled, "cancelled"),
+            (SandboxExecTermination::StartFailed, "start_failed"),
+            (SandboxExecTermination::WaitFailed, "wait_failed"),
+        ] {
+            let resp = ExecResponse::Success {
+                termination,
+                stdout: BASE64.encode(b""),
+                stderr: BASE64.encode(b""),
+                stdout_truncated: false,
+                stderr_truncated: false,
+                diagnostic: String::new(),
+            };
+            let json = serde_json::to_value(&resp).unwrap();
+            assert_eq!(json["termination"]["kind"], expected_kind);
+            assert!(json["termination"].get("exit_code").is_none());
+            let decoded: ExecResponse = serde_json::from_value(json).unwrap();
+            match decoded {
+                ExecResponse::Success {
+                    termination: decoded,
+                    ..
+                } => assert_eq!(decoded, termination),
+                ExecResponse::Error { .. } => panic!("expected success"),
+            }
+        }
+    }
+
+    #[test]
+    fn exec_response_rejects_legacy_exit_code_success_shape() {
+        let legacy = serde_json::json!({
+            "exit_code": 0,
+            "stdout": BASE64.encode(b""),
+            "stderr": BASE64.encode(b""),
+            "stdout_truncated": false,
+            "stderr_truncated": false
+        });
+
+        let err = serde_json::from_value::<ExecResponse>(legacy).unwrap_err();
+        assert!(err.to_string().contains("data did not match any variant"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -439,6 +439,32 @@ mod tests {
     }
 
     #[test]
+    fn exec_response_rejects_invalid_termination_kind_shapes() {
+        for termination in [
+            r#"{"exit_code":0}"#,
+            r#"{"kind":"unknown","exit_code":0}"#,
+            r#"{"kind":"exited","kind":"timed_out","exit_code":0}"#,
+            r#"{"kind":"exited","exit_code":0,"exit_code":1}"#,
+        ] {
+            let malformed = format!(
+                r#"{{
+                    "termination": {termination},
+                    "stdout": "{}",
+                    "stderr": "{}",
+                    "stdout_truncated": false,
+                    "stderr_truncated": false,
+                    "diagnostic": ""
+                }}"#,
+                BASE64.encode(b""),
+                BASE64.encode(b"")
+            );
+
+            let result = serde_json::from_str::<ExecResponse>(&malformed);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
     fn exec_response_error_serialization() {
         let resp = ExecResponse::Error {
             error: "sandbox not running".into(),

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -34,6 +34,7 @@ fn default_timeout() -> u32 {
 /// This enum is serialized without a tag. Clients should distinguish variants
 /// by shape: a command result response contains command result fields, while an
 /// error response contains only an `error` string.
+/// Unknown fields are rejected so mixed success/error shapes fail closed.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum ExecResponse {
@@ -114,6 +115,7 @@ pub enum TerminateStatus {
 /// This enum is serialized without a tag. Clients should distinguish variants
 /// by shape: a status response contains a `status` field, while an error
 /// response contains only an `error` string.
+/// Unknown fields are rejected so mixed status/error shapes fail closed.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum TerminateResponse {

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -188,6 +188,23 @@ mod tests {
     }
 
     #[test]
+    fn remote_exec_response_invalid_stderr_base64_is_connection_error() {
+        let result = remote_exec_result_from_response(ExecResponse::Success {
+            termination: SandboxExecTermination::Exited { exit_code: 0 },
+            stdout: BASE64.encode(b""),
+            stderr: "not base64".into(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+            diagnostic: String::new(),
+        });
+
+        let Err(SandboxControlError::Connection(message)) = result else {
+            panic!("expected connection error");
+        };
+        assert!(message.contains("decode stderr"));
+    }
+
+    #[test]
     fn remote_exec_response_error_maps_to_remote_error() {
         let result = remote_exec_result_from_response(ExecResponse::Error {
             error: "sandbox not running".into(),

--- a/crates/sandbox-fc/src/control/provider.rs
+++ b/crates/sandbox-fc/src/control/provider.rs
@@ -56,30 +56,7 @@ impl SandboxControl for FirecrackerControl {
                 }
             })?;
 
-        match response {
-            ExecResponse::Success {
-                exit_code,
-                stdout,
-                stderr,
-                stdout_truncated,
-                stderr_truncated,
-            } => {
-                let stdout_bytes = BASE64
-                    .decode(&stdout)
-                    .map_err(|e| SandboxControlError::Connection(format!("decode stdout: {e}")))?;
-                let stderr_bytes = BASE64
-                    .decode(&stderr)
-                    .map_err(|e| SandboxControlError::Connection(format!("decode stderr: {e}")))?;
-                Ok(RemoteExecResult {
-                    exit_code,
-                    stdout: stdout_bytes,
-                    stderr: stderr_bytes,
-                    stdout_truncated,
-                    stderr_truncated,
-                })
-            }
-            ExecResponse::Error { error } => Err(SandboxControlError::Remote(error)),
-        }
+        remote_exec_result_from_response(response)
     }
 
     async fn kill_remote(&self, sandbox_id: &str) -> Result<RemoteKillResult, SandboxControlError> {
@@ -123,6 +100,37 @@ impl SandboxControl for FirecrackerControl {
     }
 }
 
+fn remote_exec_result_from_response(
+    response: ExecResponse,
+) -> Result<RemoteExecResult, SandboxControlError> {
+    match response {
+        ExecResponse::Success {
+            termination,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+            diagnostic,
+        } => {
+            let stdout_bytes = BASE64
+                .decode(&stdout)
+                .map_err(|e| SandboxControlError::Connection(format!("decode stdout: {e}")))?;
+            let stderr_bytes = BASE64
+                .decode(&stderr)
+                .map_err(|e| SandboxControlError::Connection(format!("decode stderr: {e}")))?;
+            Ok(RemoteExecResult {
+                termination,
+                stdout: stdout_bytes,
+                stderr: stderr_bytes,
+                diagnostic,
+                stdout_truncated,
+                stderr_truncated,
+            })
+        }
+        ExecResponse::Error { error } => Err(SandboxControlError::Remote(error)),
+    }
+}
+
 fn request_timeout_secs(timeout: Duration) -> u32 {
     u32::try_from(timeout.as_secs()).unwrap_or(u32::MAX)
 }
@@ -135,7 +143,61 @@ fn control_timeout(timeout_secs: u32) -> Duration {
 
 #[cfg(test)]
 mod tests {
+    use sandbox::SandboxExecTermination;
+
     use super::*;
+
+    #[test]
+    fn remote_exec_response_success_decodes_structured_result() {
+        let result = remote_exec_result_from_response(ExecResponse::Success {
+            termination: SandboxExecTermination::Exited { exit_code: 7 },
+            stdout: BASE64.encode(b"out"),
+            stderr: BASE64.encode(b"err"),
+            stdout_truncated: true,
+            stderr_truncated: false,
+            diagnostic: "diagnostic".into(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            result.termination,
+            SandboxExecTermination::Exited { exit_code: 7 }
+        );
+        assert_eq!(result.stdout, b"out");
+        assert_eq!(result.stderr, b"err");
+        assert!(result.stdout_truncated);
+        assert!(!result.stderr_truncated);
+        assert_eq!(result.diagnostic, "diagnostic");
+    }
+
+    #[test]
+    fn remote_exec_response_invalid_base64_is_connection_error() {
+        let result = remote_exec_result_from_response(ExecResponse::Success {
+            termination: SandboxExecTermination::Exited { exit_code: 0 },
+            stdout: "not base64".into(),
+            stderr: BASE64.encode(b""),
+            stdout_truncated: false,
+            stderr_truncated: false,
+            diagnostic: String::new(),
+        });
+
+        let Err(SandboxControlError::Connection(message)) = result else {
+            panic!("expected connection error");
+        };
+        assert!(message.contains("decode stdout"));
+    }
+
+    #[test]
+    fn remote_exec_response_error_maps_to_remote_error() {
+        let result = remote_exec_result_from_response(ExecResponse::Error {
+            error: "sandbox not running".into(),
+        });
+
+        let Err(SandboxControlError::Remote(message)) = result else {
+            panic!("expected remote error");
+        };
+        assert_eq!(message, "sandbox not running");
+    }
 
     #[tokio::test]
     async fn exec_remote_empty_id() {

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use sandbox::SandboxExecTermination;
 use serde::Serialize;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{mpsc, oneshot};
@@ -19,8 +20,7 @@ use super::protocol::{
     TerminateStatus, read_frame, write_frame,
 };
 use crate::exec_result_compat::{
-    captured_exec_output_bytes, legacy_exit_code_for_exec_termination, reject_stream_overflow,
-    validate_legacy_exec_capture_timeout,
+    captured_exec_output_bytes, reject_stream_overflow, validate_legacy_exec_capture_timeout,
 };
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::park_coordinator::ParkCoordinator;
@@ -479,16 +479,28 @@ fn exec_response_from_operation_result(
     } = result;
 
     let (stdout, stdout_truncated) = captured_exec_output_bytes("stdout", stdout)?;
-    let (mut stderr, stderr_truncated) = captured_exec_output_bytes("stderr", stderr)?;
-    let exit_code = legacy_exit_code_for_exec_termination(termination, &mut stderr, &diagnostic);
+    let (stderr, stderr_truncated) = captured_exec_output_bytes("stderr", stderr)?;
 
     Ok(ExecResponse::Success {
-        exit_code,
+        termination: sandbox_exec_termination(termination),
         stdout: BASE64.encode(stdout),
         stderr: BASE64.encode(stderr),
         stdout_truncated,
         stderr_truncated,
+        diagnostic,
     })
+}
+
+fn sandbox_exec_termination(termination: vsock_proto::ExecTermination) -> SandboxExecTermination {
+    match termination {
+        vsock_proto::ExecTermination::Exited { exit_code } => {
+            SandboxExecTermination::Exited { exit_code }
+        }
+        vsock_proto::ExecTermination::TimedOut => SandboxExecTermination::TimedOut,
+        vsock_proto::ExecTermination::Cancelled => SandboxExecTermination::Cancelled,
+        vsock_proto::ExecTermination::StartFailed => SandboxExecTermination::StartFailed,
+        vsock_proto::ExecTermination::WaitFailed => SandboxExecTermination::WaitFailed,
+    }
 }
 
 fn control_start_error(error: GuestOperationStartError) -> String {

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use std::future::Future;
 
 use base64::Engine;
+use sandbox::SandboxExecTermination;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::{mpsc, oneshot};
@@ -15,7 +16,6 @@ use crate::control::{
     ExecRequest, ExecResponse, TerminateAction, TerminateRequest, TerminateResponse,
     TerminateStatus, send_exec, send_terminate,
 };
-use crate::exec_result_compat::EXEC_TIMEOUT_EXIT_CODE;
 use crate::park_coordinator::{
     CoordinatorState, DirtyReason, ParkCoordinator, PrepareParkEvidence,
 };
@@ -139,20 +139,24 @@ fn control_exec_result(
     }
 }
 
-fn expect_exec_success(response: ExecResponse) -> (i32, Vec<u8>, Vec<u8>, bool, bool) {
+fn expect_exec_success(
+    response: ExecResponse,
+) -> (SandboxExecTermination, Vec<u8>, Vec<u8>, bool, bool, String) {
     match response {
         ExecResponse::Success {
-            exit_code,
+            termination,
             stdout,
             stderr,
             stdout_truncated,
             stderr_truncated,
+            diagnostic,
         } => (
-            exit_code,
+            termination,
             BASE64.decode(stdout).expect("stdout should decode"),
             BASE64.decode(stderr).expect("stderr should decode"),
             stdout_truncated,
             stderr_truncated,
+            diagnostic,
         ),
         ExecResponse::Error { error } => panic!("expected success response, got error: {error}"),
     }
@@ -194,7 +198,7 @@ fn bind_test_server(
 }
 
 #[test]
-fn control_exec_result_preserves_ordinary_exit_compatibility() {
+fn control_exec_result_preserves_ordinary_exit_state() {
     let response = exec_response_from_operation_result(control_exec_result(
         ExecTermination::Exited { exit_code: 7 },
         b"out".to_vec(),
@@ -203,59 +207,56 @@ fn control_exec_result_preserves_ordinary_exit_compatibility() {
     ))
     .expect("ordinary exit should convert");
 
-    let (exit_code, stdout, stderr, stdout_truncated, stderr_truncated) =
+    let (termination, stdout, stderr, stdout_truncated, stderr_truncated, diagnostic) =
         expect_exec_success(response);
-    assert_eq!(exit_code, 7);
+    assert_eq!(termination, SandboxExecTermination::Exited { exit_code: 7 });
     assert_eq!(stdout, b"out");
     assert_eq!(stderr, b"err");
     assert!(stdout_truncated);
     assert!(!stderr_truncated);
+    assert_eq!(diagnostic, "ignored");
 }
 
 #[test]
-fn control_exec_result_preserves_terminal_state_compatibility_mapping() {
-    for (termination, diagnostic, expected_code, expected_stderr) in [
+fn control_exec_result_preserves_structured_terminal_state() {
+    for (termination, diagnostic, expected_termination, expected_stderr) in [
         (
             ExecTermination::TimedOut,
             "",
-            EXEC_TIMEOUT_EXIT_CODE,
-            "Timeout",
+            SandboxExecTermination::TimedOut,
+            Vec::new(),
         ),
         (
             ExecTermination::Cancelled,
             "cancel diagnostic",
-            1,
-            "Cancelled\ncancel diagnostic",
+            SandboxExecTermination::Cancelled,
+            Vec::new(),
         ),
         (
             ExecTermination::StartFailed,
             "spawn failed",
-            1,
-            "spawn failed",
+            SandboxExecTermination::StartFailed,
+            Vec::new(),
         ),
         (
             ExecTermination::WaitFailed,
             "wait failed",
-            1,
-            "stderr clue\nwait failed",
+            SandboxExecTermination::WaitFailed,
+            b"stderr clue".to_vec(),
         ),
     ] {
-        let stderr = if matches!(termination, ExecTermination::WaitFailed) {
-            b"stderr clue".to_vec()
-        } else {
-            Vec::new()
-        };
         let response = exec_response_from_operation_result(control_exec_result(
             termination,
             Vec::new(),
-            stderr,
+            expected_stderr.clone(),
             diagnostic,
         ))
-        .expect("terminal state should convert to compatibility response");
+        .expect("terminal state should convert to structured response");
 
-        let (exit_code, _, stderr, _, _) = expect_exec_success(response);
-        assert_eq!(exit_code, expected_code);
-        assert_eq!(String::from_utf8(stderr).unwrap(), expected_stderr);
+        let (termination, _, stderr, _, _, actual_diagnostic) = expect_exec_success(response);
+        assert_eq!(termination, expected_termination);
+        assert_eq!(stderr, expected_stderr);
+        assert_eq!(actual_diagnostic, diagnostic);
     }
 }
 

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1832,7 +1832,7 @@ impl SnapshotProvider for MockSnapshotProvider {
 ///
 /// Queue custom results with [`push_exec_remote_result`](Self::push_exec_remote_result)
 /// or [`push_kill_remote_result`](Self::push_kill_remote_result).
-/// When queues are empty, exec returns exit code 0 and kill returns accepted.
+/// When queues are empty, exec returns ordinary exit code 0 and kill returns accepted.
 pub struct MockSandboxControl {
     base_dir: PathBuf,
     exec_results: Mutex<VecDeque<std::result::Result<RemoteExecResult, SandboxControlError>>>,
@@ -1845,8 +1845,8 @@ impl MockSandboxControl {
     /// Create a control mock that records remote exec commands and kill ids.
     ///
     /// The `base_dir` is used as the remote exec working directory. Result
-    /// queues start empty, so remote exec succeeds with exit code 0 and remote
-    /// kill returns accepted by default.
+    /// queues start empty, so remote exec succeeds with ordinary exit code 0
+    /// and remote kill returns accepted by default.
     pub fn new(base_dir: impl Into<PathBuf>) -> Self {
         Self {
             base_dir: base_dir.into(),

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -1,6 +1,6 @@
 //! Mock implementations of all sandbox traits for testing.
 //!
-//! All mocks succeed by default with exit code 0 and empty output.
+//! All mocks succeed by default with ordinary exit code 0 and empty output.
 //! Use [`MockSandbox::push_exec_result`], [`MockSandbox::push_write_file_result`],
 //! [`MockSandboxControl::push_exec_remote_result`], or
 //! [`MockSandboxControl::push_kill_remote_result`] to queue custom responses
@@ -1901,9 +1901,10 @@ impl SandboxControl for MockSandboxControl {
             .pop_front()
             .unwrap_or_else(|| {
                 Ok(RemoteExecResult {
-                    exit_code: 0,
+                    termination: SandboxExecTermination::Exited { exit_code: 0 },
                     stdout: Vec::new(),
                     stderr: Vec::new(),
+                    diagnostic: String::new(),
                     stdout_truncated: false,
                     stderr_truncated: false,
                 })
@@ -3795,7 +3796,10 @@ mod tests {
             .exec_remote("sandbox-1", "echo hi", Duration::from_secs(5), false)
             .await
             .unwrap();
-        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            result.termination,
+            SandboxExecTermination::Exited { exit_code: 0 }
+        );
         assert_eq!(
             control.kill_remote("sandbox-1").await.unwrap(),
             RemoteKillResult::Accepted
@@ -3907,7 +3911,10 @@ mod tests {
             .exec_remote("sandbox-1", "test", Duration::from_secs(5), false)
             .await
             .unwrap();
-        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            result.termination,
+            SandboxExecTermination::Exited { exit_code: 0 }
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -2,16 +2,38 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Terminal state for a sandbox exec command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SandboxExecTermination {
+    /// The process exited with an ordinary exit code.
+    Exited {
+        /// Signed process exit code reported by the sandbox provider.
+        exit_code: i32,
+    },
+    /// The provider timed the process out.
+    TimedOut,
+    /// The provider cancelled the process.
+    Cancelled,
+    /// The provider failed to start the process.
+    StartFailed,
+    /// The provider failed while waiting for the process.
+    WaitFailed,
+}
 
 /// Result of executing a command inside a running sandbox.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RemoteExecResult {
-    /// Process exit code.
-    pub exit_code: i32,
+    /// Structured terminal state reported by the provider.
+    pub termination: SandboxExecTermination,
     /// Raw stdout bytes.
     pub stdout: Vec<u8>,
     /// Raw stderr bytes.
     pub stderr: Vec<u8>,
+    /// Provider diagnostic text for non-stream output terminal states.
+    pub diagnostic: String,
     /// True when stdout exceeded the remote capture budget.
     pub stdout_truncated: bool,
     /// True when stderr exceeded the remote capture budget.

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
 /// Terminal state for a sandbox exec command.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SandboxExecTermination {
     /// The process exited with an ordinary exit code.
@@ -21,6 +22,136 @@ pub enum SandboxExecTermination {
     StartFailed,
     /// The provider failed while waiting for the process.
     WaitFailed,
+}
+
+impl<'de> Deserialize<'de> for SandboxExecTermination {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Internally tagged unit variants ignore unknown fields by default, so
+        // parse the map manually to keep terminal states mutually exclusive.
+        const FIELDS: &[&str] = &["kind", "exit_code"];
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        enum TerminationKind {
+            Exited,
+            TimedOut,
+            Cancelled,
+            StartFailed,
+            WaitFailed,
+        }
+
+        enum Field {
+            Kind,
+            ExitCode,
+        }
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl Visitor<'_> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut std::fmt::Formatter<'_>,
+                    ) -> std::fmt::Result {
+                        formatter.write_str("a sandbox exec termination field")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "kind" => Ok(Field::Kind),
+                            "exit_code" => Ok(Field::ExitCode),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct TerminationVisitor;
+
+        impl<'de> Visitor<'de> for TerminationVisitor {
+            type Value = SandboxExecTermination;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a sandbox exec termination object")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut kind = None;
+                let mut exit_code = None;
+
+                while let Some(field) = map.next_key()? {
+                    match field {
+                        Field::Kind => {
+                            if kind.is_some() {
+                                return Err(de::Error::duplicate_field("kind"));
+                            }
+                            kind = Some(map.next_value()?);
+                        }
+                        Field::ExitCode => {
+                            if exit_code.is_some() {
+                                return Err(de::Error::duplicate_field("exit_code"));
+                            }
+                            exit_code = Some(map.next_value::<Option<i32>>()?);
+                        }
+                    }
+                }
+
+                let kind = kind.ok_or_else(|| de::Error::missing_field("kind"))?;
+                match kind {
+                    TerminationKind::Exited => match exit_code {
+                        Some(Some(exit_code)) => Ok(SandboxExecTermination::Exited { exit_code }),
+                        Some(None) | None => Err(de::Error::missing_field("exit_code")),
+                    },
+                    TerminationKind::TimedOut => {
+                        non_exited_termination(exit_code, SandboxExecTermination::TimedOut)
+                    }
+                    TerminationKind::Cancelled => {
+                        non_exited_termination(exit_code, SandboxExecTermination::Cancelled)
+                    }
+                    TerminationKind::StartFailed => {
+                        non_exited_termination(exit_code, SandboxExecTermination::StartFailed)
+                    }
+                    TerminationKind::WaitFailed => {
+                        non_exited_termination(exit_code, SandboxExecTermination::WaitFailed)
+                    }
+                }
+            }
+        }
+
+        deserializer.deserialize_map(TerminationVisitor)
+    }
+}
+
+fn non_exited_termination<E>(
+    exit_code: Option<Option<i32>>,
+    termination: SandboxExecTermination,
+) -> std::result::Result<SandboxExecTermination, E>
+where
+    E: de::Error,
+{
+    if exit_code.is_some() {
+        return Err(E::custom("exit_code is only valid for exited termination"));
+    }
+
+    Ok(termination)
 }
 
 /// Result of executing a command inside a running sandbox.

--- a/crates/sandbox/src/control.rs
+++ b/crates/sandbox/src/control.rs
@@ -24,7 +24,7 @@ pub enum SandboxExecTermination {
 }
 
 /// Result of executing a command inside a running sandbox.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct RemoteExecResult {
     /// Structured terminal state reported by the provider.
     pub termination: SandboxExecTermination,
@@ -32,7 +32,7 @@ pub struct RemoteExecResult {
     pub stdout: Vec<u8>,
     /// Raw stderr bytes.
     pub stderr: Vec<u8>,
-    /// Provider diagnostic text for non-stream output terminal states.
+    /// Provider diagnostic text associated with the terminal state.
     pub diagnostic: String,
     /// True when stdout exceeded the remote capture budget.
     pub stdout_truncated: bool,

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -31,7 +31,9 @@ pub use config::{
     RuntimeConfig, SandboxConfig, SandboxId, SnapshotRef, WorkspaceDriveConfig,
     WorkspaceDriveSeedImage,
 };
-pub use control::{RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError};
+pub use control::{
+    RemoteExecResult, RemoteKillResult, SandboxControl, SandboxControlError, SandboxExecTermination,
+};
 pub use error::{
     Result, SandboxError, SandboxIdleTransition, SandboxInitializationPhase,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,


### PR DESCRIPTION
## Summary
- add `SandboxExecTermination` and carry structured remote exec terminal state through the Firecracker control protocol
- remove remote exec `exit_code` compatibility mapping from the control server/provider response path
- keep CLI exit-code derivation in runner presentation code, including timeout and diagnostic display handling

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::protocol`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::server`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::provider`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::exec`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo check --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`

Closes #18330