### PR TITLE
feat: gate goal-triggered PWA pushes to terminal goal states

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
@@ -18,8 +18,13 @@ import { slackOrgThreadSessions } from "@vm0/db/schema/slack-org-thread-session"
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramThreadSessions } from "@vm0/db/schema/telegram-thread-session";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
+import { pushSubscriptions } from "@vm0/db/schema/push-subscription";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  zeroWorkflows,
+  zeroWorkflowTriggers,
+} from "@vm0/db/schema/zero-workflow";
 
 import { testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
@@ -1642,6 +1647,240 @@ describe("dispatchRunCallbacks$ chat internal dispatch", () => {
       status: "pending",
       attempts: 0,
       lastError: null,
+    });
+  });
+});
+
+async function enablePushDelivery(userId: string): Promise<void> {
+  mockOptionalEnv("VAPID_PUBLIC_KEY", "test-vapid-public-key");
+  mockOptionalEnv("VAPID_PRIVATE_KEY", "test-vapid-private-key");
+  await store
+    .set(writeDb$)
+    .insert(pushSubscriptions)
+    .values({
+      userId,
+      endpoint: `https://push.example.test/send/${randomUUID()}`,
+      p256dh: "test-p256dh",
+      auth: "test-auth",
+    });
+}
+
+async function seedGoalForThread(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly threadId: string;
+  readonly agentId: string;
+  readonly objective: string;
+  readonly workflowActive: boolean;
+  readonly triggerEnabled: boolean;
+  readonly consecutiveFailures?: number;
+}): Promise<void> {
+  const db = store.set(writeDb$);
+  const [workflow] = await db
+    .insert(zeroWorkflows)
+    .values({
+      orgId: args.orgId,
+      name: `goal-${randomUUID().slice(0, 8)}`,
+      type: "goal",
+      active: args.workflowActive,
+      preference: { version: 1, objective: args.objective },
+      ownerUserId: args.userId,
+      createdBy: args.userId,
+    })
+    .returning({ id: zeroWorkflows.id });
+  await db.insert(zeroWorkflowTriggers).values({
+    orgId: args.orgId,
+    workflowId: workflow!.id,
+    agentId: args.agentId,
+    ownerUserId: args.userId,
+    kind: "event",
+    eventType: "thread-idle",
+    enabled: args.triggerEnabled,
+    chatThreadId: args.threadId,
+    consecutiveFailures: args.consecutiveFailures ?? 0,
+  });
+}
+
+function pushPayload(call: readonly unknown[] | undefined): unknown {
+  const raw = call?.[1];
+  return JSON.parse(typeof raw === "string" ? raw : "{}");
+}
+
+describe("dispatchRunCallbacks$ goal push notification gating", () => {
+  it("suppresses the push while an active goal keeps looping", async () => {
+    const fixture = await seedChatCallbackRun({ status: "completed" });
+    await enablePushDelivery(fixture.userId);
+    await seedGoalForThread({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      threadId: fixture.threadId,
+      agentId: fixture.agentId,
+      objective: "Keep the changelog up to date",
+      workflowActive: true,
+      triggerEnabled: true,
+    });
+    mockChatOutput("Made progress this turn.");
+    mockChatOpenRouterCompletions();
+    await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "chat",
+        payload: {
+          threadId: fixture.threadId,
+          agentId: fixture.agentId,
+          isGoalRun: true,
+        },
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+
+    await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "completed" },
+      context.signal,
+    );
+    await flushWaitUntilForTest();
+
+    expect(context.mocks.webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("sends the push once the goal reaches a terminal state", async () => {
+    const fixture = await seedChatCallbackRun({ status: "completed" });
+    await enablePushDelivery(fixture.userId);
+    // completeCurrentGoal runs during the run and deactivates the workflow, so
+    // by the callback the goal is already terminal.
+    await seedGoalForThread({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      threadId: fixture.threadId,
+      agentId: fixture.agentId,
+      objective: "Ship the onboarding revamp",
+      workflowActive: false,
+      triggerEnabled: false,
+    });
+    mockChatOutput("Goal objective achieved.");
+    mockChatOpenRouterCompletions();
+    await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "chat",
+        payload: {
+          threadId: fixture.threadId,
+          agentId: fixture.agentId,
+          isGoalRun: true,
+        },
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+
+    await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "completed" },
+      context.signal,
+    );
+    await flushWaitUntilForTest();
+
+    await expect
+      .poll(() => context.mocks.webpush.sendNotification.mock.calls.length)
+      .toBe(1);
+    expect(
+      pushPayload(context.mocks.webpush.sendNotification.mock.calls[0]),
+    ).toMatchObject({ url: `/chats/${fixture.threadId}` });
+  });
+
+  it("stays silent on a transient goal failure that will retry", async () => {
+    const fixture = await seedChatCallbackRun({
+      status: "failed",
+      error: "Run failed",
+    });
+    await enablePushDelivery(fixture.userId);
+    await seedGoalForThread({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      threadId: fixture.threadId,
+      agentId: fixture.agentId,
+      objective: "Triage the inbox",
+      workflowActive: true,
+      triggerEnabled: true,
+      consecutiveFailures: 0,
+    });
+    await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "chat",
+        payload: {
+          threadId: fixture.threadId,
+          agentId: fixture.agentId,
+          isGoalRun: true,
+        },
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+
+    await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "failed" },
+      context.signal,
+    );
+    await flushWaitUntilForTest();
+
+    expect(context.mocks.webpush.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("sends an auto-stop push when repeated failures stop the goal", async () => {
+    const fixture = await seedChatCallbackRun({
+      status: "failed",
+      error: "Run failed",
+    });
+    await enablePushDelivery(fixture.userId);
+    // Two prior failures: this terminal failure crosses the auto-stop threshold.
+    await seedGoalForThread({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      threadId: fixture.threadId,
+      agentId: fixture.agentId,
+      objective: "Reconcile the ledger",
+      workflowActive: true,
+      triggerEnabled: true,
+      consecutiveFailures: 2,
+    });
+    await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "chat",
+        payload: {
+          threadId: fixture.threadId,
+          agentId: fixture.agentId,
+          isGoalRun: true,
+        },
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+
+    await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "failed" },
+      context.signal,
+    );
+    await flushWaitUntilForTest();
+
+    await expect
+      .poll(() => context.mocks.webpush.sendNotification.mock.calls.length)
+      .toBe(1);
+    expect(
+      pushPayload(context.mocks.webpush.sendNotification.mock.calls[0]),
+    ).toMatchObject({
+      title: "Reconcile the ledger",
+      body: "Goal stopped automatically after repeated failures",
+      url: `/chats/${fixture.threadId}`,
     });
   });
 });

--- a/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
@@ -19,12 +19,14 @@ import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramThreadSessions } from "@vm0/db/schema/telegram-thread-session";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
 import { pushSubscriptions } from "@vm0/db/schema/push-subscription";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   zeroWorkflows,
   zeroWorkflowTriggers,
 } from "@vm0/db/schema/zero-workflow";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 import { testContext } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
@@ -1699,6 +1701,12 @@ async function seedGoalForThread(args: {
     chatThreadId: args.threadId,
     consecutiveFailures: args.consecutiveFailures ?? 0,
   });
+  // Goal continuation only runs when the GoalWorkflows feature is enabled.
+  await db.insert(userFeatureSwitches).values({
+    orgId: args.orgId,
+    userId: args.userId,
+    switches: { [FeatureSwitchKey.GoalWorkflows]: true },
+  });
 }
 
 function pushPayload(call: readonly unknown[] | undefined): unknown {
@@ -1785,7 +1793,9 @@ describe("dispatchRunCallbacks$ goal push notification gating", () => {
     await flushWaitUntilForTest();
 
     await expect
-      .poll(() => context.mocks.webpush.sendNotification.mock.calls.length)
+      .poll(() => {
+        return context.mocks.webpush.sendNotification.mock.calls.length;
+      })
       .toBe(1);
     expect(
       pushPayload(context.mocks.webpush.sendNotification.mock.calls[0]),
@@ -1873,7 +1883,9 @@ describe("dispatchRunCallbacks$ goal push notification gating", () => {
     await flushWaitUntilForTest();
 
     await expect
-      .poll(() => context.mocks.webpush.sendNotification.mock.calls.length)
+      .poll(() => {
+        return context.mocks.webpush.sendNotification.mock.calls.length;
+      })
       .toBe(1);
     expect(
       pushPayload(context.mocks.webpush.sendNotification.mock.calls[0]),

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -57,6 +57,7 @@ import {
   generateChatNotificationSummary,
 } from "./zero-chat-title.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
+import { loadActiveGoalForThread } from "./zero-goal.service";
 import { settle, tapError } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 
@@ -70,6 +71,10 @@ const chatCallbackPayloadSchema = z
   .object({
     threadId: z.string(),
     agentId: z.string(),
+    // Set for goal-triggered runs so terminal push notifications can be gated:
+    // an active goal loops on every idle, so interim per-iteration pushes are
+    // suppressed and only terminal states (complete/blocked/auto-stopped) notify.
+    isGoalRun: z.boolean().optional(),
   })
   .passthrough();
 
@@ -459,6 +464,7 @@ async function insertAssistantErrorMessage(args: {
   readonly userId: string;
   readonly publishRunFinished: boolean;
   readonly lifecycleEvent: "failed" | "cancelled";
+  readonly isGoalRun: boolean;
   readonly getFormattedError: () => Promise<string>;
 }): Promise<boolean> {
   const displayErrorMessage = await args.getFormattedError();
@@ -499,15 +505,21 @@ async function insertAssistantErrorMessage(args: {
       threadId: args.threadId,
     });
   }
-  await sendUserPushNotifications({
-    db: args.db,
-    userId: args.userId,
-    notification: {
-      title: args.prompt.slice(0, 60),
-      body: `Task failed: ${displayErrorMessage.slice(0, 80)}`,
-      url: `/chats/${args.threadId}`,
-    },
-  });
+  // Goal-triggered failures are gated by goal continuation: a transient failure
+  // that will retry stays silent, and only a terminal auto-stop notifies. The
+  // auto-stop decision happens in continueGoalIfIdle$ after this callback, so
+  // the failure push is owned there rather than here.
+  if (!args.isGoalRun) {
+    await sendUserPushNotifications({
+      db: args.db,
+      userId: args.userId,
+      notification: {
+        title: args.prompt.slice(0, 60),
+        body: `Task failed: ${displayErrorMessage.slice(0, 80)}`,
+        url: `/chats/${args.threadId}`,
+      },
+    });
+  }
   return true;
 }
 
@@ -595,6 +607,7 @@ async function handleCompletedChatCallback(args: {
   readonly runId: string;
   readonly run: ChatRunInfo;
   readonly chatThread: ChatThreadForRunRow;
+  readonly isGoalRun: boolean;
   readonly signal: AbortSignal;
   readonly insertAssistantItems: (
     items: readonly AssistantEventItem[],
@@ -677,6 +690,21 @@ async function handleCompletedChatCallback(args: {
   })();
 
   const pushStep = (async () => {
+    // A goal-triggered run that completes while the goal is still active and
+    // enabled is just one iteration of a self-continuing loop, so suppress its
+    // push. completeCurrentGoal / blockCurrentGoal run during the run (before
+    // this callback), so a goal that reached a terminal state already has its
+    // trigger disabled here and will fall through to notify.
+    if (args.isGoalRun) {
+      const goal = await loadActiveGoalForThread(args.db, {
+        orgId: args.chatThread.orgId,
+        threadId: args.chatThread.chatThreadId,
+      });
+      if (goal !== null && goal.triggerEnabled) {
+        return;
+      }
+    }
+
     let summary: string | null = null;
     if (lastResultText) {
       const generated = await settle(
@@ -717,6 +745,7 @@ async function handleFailedChatCallback(args: {
   readonly run: ChatRunInfo;
   readonly chatThread: ChatThreadForRunRow;
   readonly errorMessage: string;
+  readonly isGoalRun: boolean;
   readonly getFormattedError: () => Promise<string>;
 }): Promise<void> {
   const lifecycleEvent =
@@ -731,6 +760,7 @@ async function handleFailedChatCallback(args: {
     userId: args.chatThread.userId,
     publishRunFinished: args.chatThread.triggerSource === "web",
     lifecycleEvent,
+    isGoalRun: args.isGoalRun,
     getFormattedError: args.getFormattedError,
   });
 }
@@ -1594,6 +1624,7 @@ async function processTerminalChatCallback(args: {
     return;
   }
   const { run, chatThread } = loaded;
+  const isGoalRun = args.payload.isGoalRun ?? false;
 
   if (callbackStatus === "completed") {
     await handleCompletedChatCallback({
@@ -1601,6 +1632,7 @@ async function processTerminalChatCallback(args: {
       runId,
       run,
       chatThread,
+      isGoalRun,
       signal: args.signal,
       insertAssistantItems: async (items) => {
         await args.dependencies.insertAssistantItems(
@@ -1630,6 +1662,7 @@ async function processTerminalChatCallback(args: {
       run,
       chatThread,
       errorMessage,
+      isGoalRun,
       getFormattedError: () => {
         return args.dependencies.formatRunError(
           {

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -18,6 +18,7 @@ import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+import { sendUserPushNotifications } from "./zero-push-notifications.service";
 import {
   buildChatOnlyWorkflowTriggerCallbacks,
   runWorkflowTriggerNow$,
@@ -285,6 +286,32 @@ async function latestSessionIdForThread(
   return undefined;
 }
 
+/**
+ * Notify the user that a goal stopped on its own after repeated failures.
+ *
+ * Goal-triggered runs suppress their per-iteration push in the chat callback;
+ * the only failure worth surfacing is the terminal auto-stop, which is decided
+ * here (after the chat callback), so this is where that push is sent.
+ */
+async function notifyGoalAutoStopped(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly chatThreadId: string;
+    readonly objective: string;
+  },
+): Promise<void> {
+  await sendUserPushNotifications({
+    db,
+    userId: args.userId,
+    notification: {
+      title: args.objective.slice(0, 60),
+      body: "Goal stopped automatically after repeated failures",
+      url: `/chats/${args.chatThreadId}`,
+    },
+  });
+}
+
 async function disableGoalTrigger(db: Db, triggerId: string): Promise<void> {
   const currentTime = nowDate();
   await db
@@ -387,6 +414,12 @@ export const continueGoalIfIdle$ = command(
           runId: run.runId,
           consecutiveFailures: failureUpdate.consecutiveFailures,
         });
+        await notifyGoalAutoStopped(db, {
+          userId: run.userId,
+          chatThreadId: run.chatThreadId,
+          objective: goal.preference.objective,
+        });
+        signal.throwIfAborted();
         return {
           kind: "auto-stopped",
           triggerId: trigger.id,
@@ -414,7 +447,9 @@ export const continueGoalIfIdle$ = command(
         prompt: buildGoalContinuationPrompt(goal.preference),
         triggerSource: "workflow-event",
         appendSystemPrompt: buildGoalContinuationSystemPrompt(),
-        callbacks: buildChatOnlyWorkflowTriggerCallbacks(trigger),
+        callbacks: buildChatOnlyWorkflowTriggerCallbacks(trigger, {
+          isGoalRun: true,
+        }),
         recordLastRunAt: true,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },
@@ -439,6 +474,12 @@ export const continueGoalIfIdle$ = command(
         consecutiveFailures: failureUpdate.consecutiveFailures,
         error,
       });
+      await notifyGoalAutoStopped(db, {
+        userId: run.userId,
+        chatThreadId: run.chatThreadId,
+        objective: goal.preference.objective,
+      });
+      signal.throwIfAborted();
       return {
         kind: "auto-stopped",
         triggerId: trigger.id,
@@ -502,7 +543,9 @@ export const bootstrapGoalRun$ = command(
         prompt: buildGoalContinuationPrompt(preference),
         triggerSource: "workflow-event",
         appendSystemPrompt: buildGoalContinuationSystemPrompt(),
-        callbacks: buildChatOnlyWorkflowTriggerCallbacks(args.trigger),
+        callbacks: buildChatOnlyWorkflowTriggerCallbacks(args.trigger, {
+          isGoalRun: true,
+        }),
         recordLastRunAt: true,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -124,7 +124,7 @@ async function currentGoalContext(
   return { threadId: row.threadId, agentId: row.agentId };
 }
 
-async function loadActiveGoalForThread(
+export async function loadActiveGoalForThread(
   db: ReadonlyDb,
   args: { readonly orgId: string; readonly threadId: string },
 ): Promise<ActiveGoalRow | null> {

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -114,6 +114,7 @@ function buildAppendSystemPrompt(workflowName: string): string {
 
 export function buildChatOnlyWorkflowTriggerCallbacks(
   trigger: TriggerRow,
+  options?: { readonly isGoalRun?: boolean },
 ): InternalRunCallbackInput[] {
   if (!trigger.chatThreadId || !trigger.agentId) {
     return [];
@@ -122,7 +123,13 @@ export function buildChatOnlyWorkflowTriggerCallbacks(
     {
       internalKind: "chat",
       secret: generateCallbackSecret(),
-      payload: { threadId: trigger.chatThreadId, agentId: trigger.agentId },
+      payload: {
+        threadId: trigger.chatThreadId,
+        agentId: trigger.agentId,
+        // Goal runs self-continue on idle; the flag lets the chat callback
+        // gate terminal push notifications to terminal goal states only.
+        ...(options?.isGoalRun ? { isGoalRun: true } : {}),
+      },
     },
   ];
 }


### PR DESCRIPTION
## Problem

PWA push notifications fire on **every** chat run completion. Goal-triggered runs self-continue on each thread-idle, so an active goal pushes a notification on every loop iteration — noisy and not actionable.

## Desired behavior

A goal-triggered run should notify **only when the goal reaches a terminal state**; interim "still looping" iterations stay silent.

| Goal run outcome | continuation result | Push? |
|---|---|---|
| Success, goal still active | `continued` | 🔇 silent |
| Success, goal completed/blocked during the run | (trigger already disabled) | ✅ push (+ last-turn summary) |
| Success, thread not idle / another run active | `skipped` | 🔇 silent |
| Failure, transient (will retry) | `continued` | 🔇 silent |
| Failure, crosses auto-stop threshold | `auto-stopped` | ✅ push (alert copy) |
| Cancelled | `paused` | 🔇 silent |

Non-goal chat runs, ordinary workflow runs, and manual messages typed into a goal thread are **unchanged**.

## Why the decision is split across two points

Push notifications fire **before** `continueGoalIfIdle$` runs (callbacks dispatch first, continuation after). So:

- **Success terminal** (`complete`/`blocked`) is already settled at callback time, because `completeCurrentGoal` / `blockCurrentGoal` run *during* the run. The completed chat callback can reliably check "is there still an active + enabled goal trigger for this thread?" and gate the push — no race.
- **Failure terminal** (`auto-stopped`) is decided *later*, inside `continueGoalIfIdle$` (consecutive-failure threshold). Checking goal status at the failure callback would race that decision. So the failure callback simply skips the push for goal runs, and `continueGoalIfIdle$` owns the terminal auto-stop notification.

This was settled after a design review (frontend / service-worker gating was rejected: the SW must `showNotification` on every push or risk losing push permission, has no goal context in the payload, and the app is closed when push matters most — so the decision must be server-side).

## Changes

- **`zero-workflow-trigger-run.service.ts`** — `buildChatOnlyWorkflowTriggerCallbacks` takes an `isGoalRun` option that tags the chat callback payload.
- **`zero-goal-continuation.service.ts`** — goal continuation/bootstrap pass `isGoalRun: true`; on `auto-stopped`, send the terminal "stopped after repeated failures" push.
- **`internal-chat-run-callback.service.ts`** — completed goal runs only push when the goal is no longer active+enabled (reusing the existing summary); failed goal runs skip the callback push (continuation owns it).
- **`zero-goal.service.ts`** — export `loadActiveGoalForThread` for the gate.

## Tests

`agent-run-callback.service.test.ts` — 4 integration tests through `dispatchRunCallbacks$`: active goal → silent, terminal goal → push, transient failure → silent, repeated-failure auto-stop → push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
