### PR TITLE
refactor(mitm-addon): consolidate firewall auth request inputs

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -28,6 +28,7 @@ from firewall_auth_cache import InvalidBillableAuthExpiryError, get_firewall_hea
 from firewall_auth_client import (
     ConnectorNotConfiguredError,
     FirewallAuthApiError,
+    FirewallAuthRequest,
     InsufficientCreditsError,
 )
 from firewall_auth_config import auth_config_injects_credentials
@@ -57,16 +58,7 @@ class _FirewallAuthContext:
     api_id: str
     run_id: str
     proxy_log_path: str
-    sandbox_token: str
-    encrypted_secrets: str
-    auth_headers: dict
-    auth_base: str | None
-    auth_query: dict | None
-    auth_aws_sigv4: dict | None
-    secret_connector_map: dict | None
-    secret_connector_metadata_map: dict | None
-    vars_map: dict | None
-    firewall_billable: bool
+    auth_request: FirewallAuthRequest
 
 
 def is_billable_firewall(firewall_name: str, vm_info: dict) -> bool:
@@ -120,26 +112,28 @@ def _build_firewall_auth_context(
         api_id=flow.metadata[metadata_keys.FIREWALL_API_ID],
         run_id=flow.metadata.get(metadata_keys.VM_RUN_ID, ""),
         proxy_log_path=flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
-        sandbox_token=vm_info.get("sandboxToken", ""),
-        encrypted_secrets=vm_info.get("encryptedSecrets") or "",
-        auth_headers=auth_config.get("headers", {}),
-        auth_base=auth_config.get("base"),
-        auth_query=auth_config.get("query"),
-        auth_aws_sigv4=auth_config.get("awsSigv4"),
-        secret_connector_map=vm_info.get("secretConnectorMap"),
-        secret_connector_metadata_map=vm_info.get("secretConnectorMetadataMap"),
-        vars_map=vm_info.get("vars"),
-        firewall_billable=bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE]),
+        auth_request=FirewallAuthRequest(
+            sandbox_token=vm_info.get("sandboxToken", ""),
+            encrypted_secrets=vm_info.get("encryptedSecrets") or "",
+            auth_headers=auth_config.get("headers", {}),
+            auth_base=auth_config.get("base"),
+            auth_query=auth_config.get("query"),
+            auth_aws_sigv4=auth_config.get("awsSigv4"),
+            secret_connector_map=vm_info.get("secretConnectorMap"),
+            secret_connector_metadata_map=vm_info.get("secretConnectorMetadataMap"),
+            vars_map=vm_info.get("vars"),
+            firewall_billable=bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE]),
+        ),
     )
 
 
 def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) -> bool:
     return auth_config_injects_credentials(
         {
-            "headers": context.auth_headers,
-            "query": context.auth_query,
-            "awsSigv4": context.auth_aws_sigv4,
-            "base": context.auth_base,
+            "headers": context.auth_request.auth_headers,
+            "query": context.auth_request.auth_query,
+            "awsSigv4": context.auth_request.auth_aws_sigv4,
+            "base": context.auth_request.auth_base,
         }
     )
 
@@ -424,7 +418,7 @@ def _preflight_firewall_auth(
     context: _FirewallAuthContext,
 ) -> FirewallAuthHandlingResult | None:
     """Handle local firewall auth failures that must happen before auth resolution."""
-    if context.auth_base and _request_body_exceeds_auth_base_limit(flow):
+    if context.auth_request.auth_base and _request_body_exceeds_auth_base_limit(flow):
         _set_auth_base_request_too_large(
             flow,
             allow=context.allow,
@@ -453,7 +447,7 @@ def _preflight_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    if not context.encrypted_secrets:
+    if not context.auth_request.encrypted_secrets:
         log_proxy_entry(
             context.proxy_log_path,
             "error",
@@ -797,16 +791,7 @@ async def handle_firewall_request(
         token_meta = await get_firewall_headers(
             context.run_id,
             context.api_id,
-            context.encrypted_secrets,
-            context.auth_headers,
-            context.sandbox_token,
-            secret_connector_map=context.secret_connector_map,
-            secret_connector_metadata_map=context.secret_connector_metadata_map,
-            vars_map=context.vars_map,
-            auth_base=context.auth_base,
-            auth_query=context.auth_query,
-            auth_aws_sigv4=context.auth_aws_sigv4,
-            firewall_billable=context.firewall_billable,
+            context.auth_request,
         )
     except Exception as exc:
         return _set_firewall_auth_resolution_failure(flow, context, exc)

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from firewall_auth_client import (
     FirewallAuthPayload,
+    FirewallAuthRequest,
     fetch_firewall_headers,
 )
 
@@ -152,17 +153,7 @@ def _build_cache_hit(
 async def get_firewall_headers(
     run_id: str,
     api_id: str,
-    encrypted_secrets: str,
-    auth_headers: dict,
-    sandbox_token: str,
-    *,
-    secret_connector_map: dict | None = None,
-    secret_connector_metadata_map: dict | None = None,
-    vars_map: dict | None = None,
-    auth_base: str | None = None,
-    auth_query: dict | None = None,
-    auth_aws_sigv4: dict | None = None,
-    firewall_billable: bool = False,
+    request: FirewallAuthRequest,
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
@@ -179,7 +170,7 @@ async def get_firewall_headers(
 
     # Fast path: cache hit (no lock needed — single-threaded event loop)
     if state.cache:
-        hit = _build_cache_hit(state.cache, firewall_billable=firewall_billable)
+        hit = _build_cache_hit(state.cache, firewall_billable=request.firewall_billable)
         if hit:
             return hit
 
@@ -187,7 +178,7 @@ async def get_firewall_headers(
     async with state.lock:
         # Double-check: another coroutine may have populated cache while we waited
         if state.cache:
-            hit = _build_cache_hit(state.cache, firewall_billable=firewall_billable)
+            hit = _build_cache_hit(state.cache, firewall_billable=request.firewall_billable)
             if hit:
                 return hit
 
@@ -203,19 +194,10 @@ async def get_firewall_headers(
             state.last_force_refresh_at = time.time()
 
         result = await fetch_firewall_headers(
-            encrypted_secrets,
-            auth_headers,
-            sandbox_token,
-            secret_connector_map=secret_connector_map,
-            secret_connector_metadata_map=secret_connector_metadata_map,
-            vars_map=vars_map,
-            auth_base=auth_base,
-            auth_query=auth_query,
-            auth_aws_sigv4=auth_aws_sigv4,
-            firewall_billable=firewall_billable,
+            request,
             force_refresh=force_refresh,
         )
-        if firewall_billable and not _has_valid_expiry(result.expires_at):
+        if request.firewall_billable and not _has_valid_expiry(result.expires_at):
             raise InvalidBillableAuthExpiryError(
                 "Billable firewall auth response did not include a valid cache expiry"
             )

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -58,6 +58,46 @@ class _ResponseBodyReader(Protocol):
 
 
 @dataclass(frozen=True)
+class FirewallAuthRequest:
+    """Inputs sent to the runner firewall auth webhook."""
+
+    encrypted_secrets: str = field(repr=False)
+    auth_headers: dict
+    sandbox_token: str = field(repr=False)
+    auth_base: str | None = None
+    auth_query: dict | None = None
+    auth_aws_sigv4: dict | None = None
+    secret_connector_map: dict | None = None
+    secret_connector_metadata_map: dict | None = None
+    vars_map: dict | None = None
+    firewall_billable: bool = False
+
+    def to_body(self, *, force_refresh: bool = False) -> dict:
+        """Build the webhook JSON body while preserving omission semantics."""
+        body: dict = {
+            "encryptedSecrets": self.encrypted_secrets,
+            "authHeaders": self.auth_headers,
+        }
+        if self.auth_base:
+            body["authBase"] = self.auth_base
+        if self.auth_query:
+            body["authQuery"] = self.auth_query
+        if self.auth_aws_sigv4:
+            body["authAwsSigv4"] = self.auth_aws_sigv4
+        if self.secret_connector_map:
+            body["secretConnectorMap"] = self.secret_connector_map
+        if self.secret_connector_metadata_map:
+            body["secretConnectorMetadataMap"] = self.secret_connector_metadata_map
+        if self.vars_map:
+            body["vars"] = self.vars_map
+        if self.firewall_billable:
+            body["firewallBillable"] = True
+        if force_refresh:
+            body["forceRefresh"] = True
+        return body
+
+
+@dataclass(frozen=True)
 class FirewallAuthPayload:
     """Cacheable /firewall/auth data applied to outbound requests."""
 
@@ -222,18 +262,9 @@ def _parse_firewall_auth_success(decoded: object) -> FirewallAuthSuccess:
 
 
 def _fetch_firewall_headers_sync(
-    encrypted_secrets: str,
-    auth_headers: dict,
-    sandbox_token: str,
+    request: FirewallAuthRequest,
     api_url: str,
     *,
-    secret_connector_map: dict | None = None,
-    secret_connector_metadata_map: dict | None = None,
-    vars_map: dict | None = None,
-    auth_base: str | None = None,
-    auth_query: dict | None = None,
-    auth_aws_sigv4: dict | None = None,
-    firewall_billable: bool = False,
     force_refresh: bool = False,
 ) -> FirewallAuthSuccess:
     """Synchronous helper — runs in a thread to avoid blocking the event loop.
@@ -242,25 +273,8 @@ def _fetch_firewall_headers_sync(
     still on the event loop, so this function never touches ctx.options.
     """
     url = f"{api_url}/api/webhooks/agent/firewall/auth"
-    body: dict = {"encryptedSecrets": encrypted_secrets, "authHeaders": auth_headers}
-    if auth_base:
-        body["authBase"] = auth_base
-    if auth_query:
-        body["authQuery"] = auth_query
-    if auth_aws_sigv4:
-        body["authAwsSigv4"] = auth_aws_sigv4
-    if secret_connector_map:
-        body["secretConnectorMap"] = secret_connector_map
-    if secret_connector_metadata_map:
-        body["secretConnectorMetadataMap"] = secret_connector_metadata_map
-    if vars_map:
-        body["vars"] = vars_map
-    if firewall_billable:
-        body["firewallBillable"] = True
-    if force_refresh:
-        body["forceRefresh"] = True
-    data = json.dumps(body).encode()
-    req = platform_api.make_api_request(url, data, sandbox_token)
+    data = json.dumps(request.to_body(force_refresh=force_refresh)).encode()
+    req = platform_api.make_api_request(url, data, request.sandbox_token)
     try:
         # nosemgrep: dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
@@ -295,32 +309,23 @@ def _fetch_firewall_headers_sync(
 
 
 async def fetch_firewall_headers(
-    encrypted_secrets: str,
-    auth_headers: dict,
-    sandbox_token: str,
+    request: FirewallAuthRequest,
     *,
-    secret_connector_map: dict | None = None,
-    secret_connector_metadata_map: dict | None = None,
-    vars_map: dict | None = None,
-    auth_base: str | None = None,
-    auth_query: dict | None = None,
-    auth_aws_sigv4: dict | None = None,
-    firewall_billable: bool = False,
     force_refresh: bool = False,
 ) -> FirewallAuthSuccess:
     """Resolve auth headers via server-side decryption.
 
-    encrypted_secrets is the encrypted runtime secret namespace. After API-side
+    request.encrypted_secrets is the encrypted runtime secret namespace. After API-side
     decryption, keys are the `NAME` in `${{ secrets.NAME }}` and values are the
     real secret values.
 
-    secret_connector_map maps firewall auth secret env aliases (the `NAME` in
-    `${{ secrets.NAME }}`) to the connector or provider owner that can
-    refresh/resolve access. secret_connector_metadata_map uses the same keys to
-    add source details when the owner alone is not enough to locate access
-    storage.
+    request.secret_connector_map maps firewall auth secret env aliases (the
+    `NAME` in `${{ secrets.NAME }}`) to the connector or provider owner that
+    can refresh/resolve access. request.secret_connector_metadata_map uses the
+    same keys to add source details when the owner alone is not enough to
+    locate access storage.
 
-    When secret_connector_map is provided, the auth endpoint can refresh
+    When request.secret_connector_map is provided, the auth endpoint can refresh
     expired access tokens and returns an expiresAt timestamp for TTL caching.
     For billable firewall auth, expiresAt is also bounded by the server-side
     credit authorization lease.
@@ -333,16 +338,7 @@ async def fetch_firewall_headers(
     api_url = platform_api.get_api_url()
     return await asyncio.to_thread(
         _fetch_firewall_headers_sync,
-        encrypted_secrets,
-        auth_headers,
-        sandbox_token,
+        request,
         api_url,
-        secret_connector_map=secret_connector_map,
-        secret_connector_metadata_map=secret_connector_metadata_map,
-        vars_map=vars_map,
-        auth_base=auth_base,
-        auth_query=auth_query,
-        auth_aws_sigv4=auth_aws_sigv4,
-        firewall_billable=firewall_billable,
         force_refresh=force_refresh,
     )

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -9,6 +9,7 @@ import urllib.error
 import pytest
 
 import firewall_auth_cache as auth_cache
+import firewall_auth_client as auth_client
 import registry as registry_cache
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
@@ -17,6 +18,20 @@ from tests.auth_state_helpers import (
     require_cached_headers,
     set_cached_headers,
 )
+
+
+def _firewall_auth_request(
+    encrypted_secrets: str = "enc",
+    auth_headers: dict[str, str] | None = None,
+    sandbox_auth: str = "tok",
+    **kwargs,
+) -> auth_client.FirewallAuthRequest:
+    return auth_client.FirewallAuthRequest(
+        encrypted_secrets=encrypted_secrets,
+        auth_headers=auth_headers or {},
+        sandbox_token=sandbox_auth,
+        **kwargs,
+    )
 
 
 class TestFirewallHeaderCache:
@@ -39,7 +54,9 @@ class TestFirewallHeaderCache:
 
             async def fetch_headers(started_event: asyncio.Event) -> dict:
                 started_event.set()
-                return await auth_cache.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+                return await auth_cache.get_firewall_headers(
+                    "run-1", "api-1", _firewall_auth_request()
+                )
 
             tasks = [asyncio.create_task(fetch_headers(started_event)) for started_event in started]
             try:
@@ -86,8 +103,8 @@ class TestFirewallHeaderCache:
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             first, second = await asyncio.gather(
-                auth_cache.get_firewall_headers("run-1", "api-1", "enc", {}, "tok"),
-                auth_cache.get_firewall_headers("run-1", "api-2", "enc", {}, "tok"),
+                auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request()),
+                auth_cache.get_firewall_headers("run-1", "api-2", _firewall_auth_request()),
             )
 
         assert endpoint.request_count == 2
@@ -112,12 +129,14 @@ class TestFirewallHeaderCache:
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             with pytest.raises(urllib.error.HTTPError):
-                await auth_cache.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+                await auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
 
             assert endpoint.request_count == 1
             assert cached_headers(("run-1", "api-1")) is None
 
-            retry = await auth_cache.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+            retry = await auth_cache.get_firewall_headers(
+                "run-1", "api-1", _firewall_auth_request()
+            )
             assert retry["headers"] == {"Authorization": "Bearer retry"}
             assert retry["cache_hit"] is False
             assert endpoint.request_count == 2
@@ -125,7 +144,9 @@ class TestFirewallHeaderCache:
                 "Authorization": "Bearer retry"
             }
 
-            cached = await auth_cache.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+            cached = await auth_cache.get_firewall_headers(
+                "run-1", "api-1", _firewall_auth_request()
+            )
             assert cached["headers"] == {"Authorization": "Bearer retry"}
             assert cached["cache_hit"] is True
             assert endpoint.request_count == 2

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -69,6 +69,20 @@ def _auth_success(
     )
 
 
+def _firewall_auth_request(
+    encrypted_secrets: str = "iv:tag:data",
+    auth_headers: dict[str, str] | None = None,
+    sandbox_auth: str = "tok-xyz",
+    **kwargs,
+) -> auth_client.FirewallAuthRequest:
+    return auth_client.FirewallAuthRequest(
+        encrypted_secrets=encrypted_secrets,
+        auth_headers=auth_headers or {},
+        sandbox_token=sandbox_auth,
+        **kwargs,
+    )
+
+
 def _json_response(body: object) -> MagicMock:
     mock_resp = MagicMock()
     mock_resp.__enter__.return_value = mock_resp
@@ -195,7 +209,12 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock(return_value=mock_result)
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1", "https://api.github.com", encrypted, auth_templates, "tok-xyz"
+                "run-1",
+                "https://api.github.com",
+                _firewall_auth_request(
+                    encrypted_secrets=encrypted,
+                    auth_headers=auth_templates,
+                ),
             )
 
         assert headers["headers"] == mock_headers
@@ -203,17 +222,13 @@ class TestGetFirewallHeaders:
         assert headers["refreshed_connectors"] == []
         assert headers["refreshed_secrets"] == []
         mock_fetch.assert_called_once()
-        assert mock_fetch.call_args.args == (encrypted, auth_templates, "tok-xyz")
-        assert mock_fetch.call_args.kwargs == {
-            "secret_connector_map": None,
-            "secret_connector_metadata_map": None,
-            "vars_map": None,
-            "auth_base": None,
-            "auth_query": None,
-            "auth_aws_sigv4": None,
-            "firewall_billable": False,
-            "force_refresh": False,
-        }
+        assert mock_fetch.call_args.args == (
+            _firewall_auth_request(
+                encrypted_secrets=encrypted,
+                auth_headers=auth_templates,
+            ),
+        )
+        assert mock_fetch.call_args.kwargs == {"force_refresh": False}
 
         # Verify the cache was populated
         cache_key = ("run-1", "https://api.github.com")
@@ -228,7 +243,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1", "https://api.github.com", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "https://api.github.com", _firewall_auth_request()
             )
 
         assert headers["headers"] == cached_headers
@@ -248,7 +263,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert headers["headers"] == cached_headers
@@ -270,7 +285,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock(return_value=mock_result)
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert headers["headers"] == fresh_headers
@@ -289,7 +304,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert headers["headers"] == cached_headers
@@ -306,10 +321,7 @@ class TestGetFirewallHeaders:
             headers = await auth_cache.get_firewall_headers(
                 "run-1",
                 "api-1",
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                firewall_billable=True,
+                _firewall_auth_request(firewall_billable=True),
             )
 
         assert headers["headers"] == cached_headers
@@ -344,7 +356,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert headers["headers"] == fresh_headers
@@ -368,16 +380,13 @@ class TestGetFirewallHeaders:
             headers = await auth_cache.get_firewall_headers(
                 "run-1",
                 "api-1",
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                firewall_billable=True,
+                _firewall_auth_request(firewall_billable=True),
             )
 
         assert headers["headers"] == fresh_headers
         assert headers["cache_hit"] is False
         mock_fetch.assert_called_once()
-        assert mock_fetch.call_args.kwargs["firewall_billable"] is True
+        assert mock_fetch.call_args.args[0].firewall_billable is True
         assert require_cached_headers(cache_key).expires_at == expires_at
 
     async def test_billable_cache_with_expired_expiry_refetches(self, headers):
@@ -396,10 +405,7 @@ class TestGetFirewallHeaders:
             headers = await auth_cache.get_firewall_headers(
                 "run-1",
                 "api-1",
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                firewall_billable=True,
+                _firewall_auth_request(firewall_billable=True),
             )
 
         assert headers["headers"] == fresh_headers
@@ -433,10 +439,7 @@ class TestGetFirewallHeaders:
             await auth_cache.get_firewall_headers(
                 "run-1",
                 "api-1",
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                firewall_billable=True,
+                _firewall_auth_request(firewall_billable=True),
             )
         assert cached_headers(cache_key) is None
 
@@ -454,7 +457,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert result["base"] == "https://discord.com/api/webhooks/123/abc"
@@ -475,10 +478,10 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             first = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
             second = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert first["query"] == cached_query
@@ -503,10 +506,10 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             first = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
             second = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert first["base"] == cached_base
@@ -533,7 +536,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert "base" not in result
@@ -549,7 +552,7 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock(return_value=_auth_success(headers={"Authorization": "Bearer new"}))
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            await auth_cache.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            await auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
 
         # force_refresh kwarg must be True
         assert mock_fetch.call_args.kwargs["force_refresh"] is True
@@ -569,7 +572,7 @@ class TestGetFirewallHeaders:
             patch.object(auth_cache, "fetch_firewall_headers", mock_fetch),
             pytest.raises(ConnectionError),
         ):
-            await auth_cache.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+            await auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is True
         assert not force_refresh_pending(cache_key)
@@ -595,7 +598,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", side_effect=delayed_fetch):
             task = asyncio.create_task(
-                auth_cache.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+                auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
             )
             try:
                 await asyncio.wait_for(fetch_entered.wait(), timeout=5)
@@ -620,7 +623,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", forced_fetch):
             forced_result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert forced_fetch.call_args.kwargs["force_refresh"] is True
@@ -656,13 +659,13 @@ class TestGetFirewallHeaders:
             auth_cache, "fetch_firewall_headers", side_effect=fetch_with_blocked_leader
         ):
             leader = asyncio.create_task(
-                auth_cache.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+                auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
             )
             waiter = None
             try:
                 await asyncio.wait_for(first_fetch_entered.wait(), timeout=5)
                 waiter = asyncio.create_task(
-                    auth_cache.get_firewall_headers("run-1", "api-1", "iv:tag:data", {}, "tok-xyz")
+                    auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
                 )
                 auth_cache.request_force_refresh(cache_key)
                 allow_first_fetch_return.set()
@@ -684,7 +687,7 @@ class TestGetFirewallHeaders:
         """Without a marker, fetch is called with force_refresh=False (#9860)."""
         mock_fetch = AsyncMock(return_value=_auth_success(headers={}))
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            await auth_cache.get_firewall_headers("run-1", "api-2", "iv:tag:data", {}, "tok-xyz")
+            await auth_cache.get_firewall_headers("run-1", "api-2", _firewall_auth_request())
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is False
         # No consume timestamp written when force-refresh didn't happen
@@ -704,7 +707,7 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", "iv:tag:data", {}, "tok-xyz"
+                "run-1", "api-1", _firewall_auth_request()
             )
 
         assert result["cache_hit"] is True
@@ -1512,9 +1515,9 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             result = await auth_client.fetch_firewall_headers(
-                "iv:tag:data",
-                {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
-                "tok-xyz",
+                _firewall_auth_request(
+                    auth_headers={"Authorization": "Bearer ${{ secrets.TOKEN }}"}
+                ),
             )
 
         assert result.payload.headers == {"Authorization": "Bearer tok"}
@@ -1563,7 +1566,7 @@ class TestFetchFirewallHeaders:
             mitm_ctx(api_url=endpoint.api_url),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
-            result = await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            result = await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         assert result.payload.headers == {
             "Authorization": "Bearer tok",
@@ -1592,20 +1595,19 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             await auth_client.fetch_firewall_headers(
-                "iv:tag:data",
-                {},
-                "tok-xyz",
-                secret_connector_map={"TOKEN": "notion"},
-                secret_connector_metadata_map={"TOKEN": {"kind": "oauth"}},
-                vars_map={"TEAM": "vm0"},
-                auth_base="${{ secrets.WEBHOOK_URL }}",
-                auth_query={"api_key": "${{ secrets.API_KEY }}"},
-                auth_aws_sigv4={
-                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                },
-                firewall_billable=True,
+                _firewall_auth_request(
+                    secret_connector_map={"TOKEN": "notion"},
+                    secret_connector_metadata_map={"TOKEN": {"kind": "oauth"}},
+                    vars_map={"TEAM": "vm0"},
+                    auth_base="${{ secrets.WEBHOOK_URL }}",
+                    auth_query={"api_key": "${{ secrets.API_KEY }}"},
+                    auth_aws_sigv4={
+                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                    },
+                    firewall_billable=True,
+                ),
                 force_refresh=True,
             )
 
@@ -1627,6 +1629,44 @@ class TestFetchFirewallHeaders:
         assert "firewallName" not in body
         assert "modelUsageProvider" not in body
 
+    async def test_omits_falsey_optional_request_body_fields(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": {}})
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+        ):
+            await auth_client.fetch_firewall_headers(
+                _firewall_auth_request(
+                    auth_base="",
+                    auth_query={},
+                    auth_aws_sigv4={},
+                    secret_connector_map={},
+                    secret_connector_metadata_map={},
+                    vars_map={},
+                    firewall_billable=False,
+                ),
+                force_refresh=False,
+            )
+
+        assert endpoint.requests[0].json_body() == {
+            "encryptedSecrets": "iv:tag:data",
+            "authHeaders": {},
+        }
+
+    def test_request_repr_omits_sensitive_values(self):
+        request = _firewall_auth_request(
+            encrypted_secrets="secret-encrypted-payload",
+            sandbox_auth="secret-sandbox-token",
+        )
+
+        rendered = repr(request)
+
+        assert "secret-encrypted-payload" not in rendered
+        assert "secret-sandbox-token" not in rendered
+
     async def test_includes_vercel_bypass_header(self, mitm_ctx):
         endpoint = FakeAuthEndpoint()
         endpoint.queue_json_response({"headers": {}})
@@ -1635,7 +1675,7 @@ class TestFetchFirewallHeaders:
             mitm_ctx(api_url=endpoint.api_url),
             patch.object(platform_api, "VERCEL_BYPASS", "secret-bypass-value"),
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         assert endpoint.requests[0].headers["x-vercel-protection-bypass"] == "secret-bypass-value"
 
@@ -1645,7 +1685,7 @@ class TestFetchFirewallHeaders:
             patch("firewall_auth_client.urllib.request.urlopen") as mock_urlopen,
             pytest.raises(ValueError, match="absolute http"),
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         mock_urlopen.assert_not_called()
 
@@ -1668,7 +1708,7 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             with pytest.raises(auth_client.ConnectorNotConfiguredError) as exc_info:
-                await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+                await auth_client.fetch_firewall_headers(_firewall_auth_request())
             assert "Connector not configured" in str(exc_info.value)
 
     async def test_402_insufficient_credits_raises_custom_error(self, mitm_ctx):
@@ -1689,7 +1729,7 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             with pytest.raises(auth_client.InsufficientCreditsError) as exc_info:
-                await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+                await auth_client.fetch_firewall_headers(_firewall_auth_request())
             assert "Insufficient credits" in str(exc_info.value)
 
     @pytest.mark.parametrize(
@@ -1770,7 +1810,7 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(auth_client.FirewallAuthApiError) as exc_info,
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         assert exc_info.value.status == status
         assert exc_info.value.code == code
@@ -1801,7 +1841,7 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(auth_client.FirewallAuthApiError) as exc_info,
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         assert exc_info.value.code == "TOKEN_REFRESH_FAILED"
 
@@ -1831,7 +1871,7 @@ class TestFetchFirewallHeaders:
                 match="Firewall auth response body too large",
             ),
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
     @pytest.mark.parametrize(
         "error_body",
@@ -1860,7 +1900,7 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         assert exc_info.value.code == 400
 
@@ -1906,7 +1946,7 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(exception_type) as exc_info,
         ):
-            await auth_client.fetch_firewall_headers("iv:tag:data", {}, "tok-xyz")
+            await auth_client.fetch_firewall_headers(_firewall_auth_request())
 
         assert str(exc_info.value) == default_message
 
@@ -1919,7 +1959,9 @@ class TestFetchFirewallHeaders:
             mitm_ctx(api_url=endpoint.api_url),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
-            result = await auth_client.fetch_firewall_headers("enc", {}, "sandbox-tok")
+            result = await auth_client.fetch_firewall_headers(
+                _firewall_auth_request(encrypted_secrets="enc", sandbox_auth="sandbox-tok")
+            )
 
         assert result.payload.headers == {"Auth": "tok"}
         assert endpoint.requests[0].path == "/api/webhooks/agent/firewall/auth"
@@ -1995,9 +2037,7 @@ class TestFetchFirewallHeadersResourceBoundary:
             patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
-            auth_client._fetch_firewall_headers_sync(
-                "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-            )
+            auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
 
         mock_resp.__exit__.assert_called_once()  # urllib external boundary (#9991)
 
@@ -2017,9 +2057,7 @@ class TestFetchFirewallHeadersResourceBoundary:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(urllib.error.HTTPError) as exc_info,
         ):
-            auth_client._fetch_firewall_headers_sync(
-                "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-            )
+            auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
 
         assert exc_info.value is http_error
         http_error.close.assert_called_once()
@@ -2055,9 +2093,7 @@ class TestFetchFirewallHeadersResourceBoundary:
                 match="Firewall auth response body too large",
             ),
         ):
-            auth_client._fetch_firewall_headers_sync(
-                "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-            )
+            auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
 
         http_error.close.assert_called_once()
 
@@ -2096,8 +2132,6 @@ class TestFetchFirewallHeadersResourceBoundary:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             pytest.raises(expected_exception),
         ):
-            auth_client._fetch_firewall_headers_sync(
-                "iv:tag:data", {}, "tok-xyz", "https://api.vm0.ai"
-            )
+            auth_client._fetch_firewall_headers_sync(_firewall_auth_request(), "https://api.vm0.ai")
 
         http_error.close.assert_called_once()  # urllib external boundary (#9991)


### PR DESCRIPTION
## Summary

- Add `FirewallAuthRequest` as the runner-side request object for `/api/webhooks/agent/firewall/auth`.
- Pass that request object through auth/cache/client layers while keeping cache keys, TTL checks, and force-refresh marker state in `firewall_auth_cache.py`.
- Preserve current webhook body omission semantics for falsey optional fields and avoid leaking sensitive request fields in dataclass repr.

Closes #18366

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_firewall_auth.py tests/test_auth_cache.py tests/test_firewall_aws_sigv4_auth.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src tests/test_firewall_auth.py tests/test_auth_cache.py tests/test_firewall_aws_sigv4_auth.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m compileall -q src tests`
