### PR TITLE
refactor(runner): model workspace image lease identity

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -203,7 +203,7 @@ mod tests {
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
     use crate::workspace_image_cache::{
-        WorkspaceCacheTerminalStatus, WorkspaceImagePrepareRequest,
+        WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
     };
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{SandboxFactory, SandboxId};
@@ -252,12 +252,14 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let lease = cache
             .prepare(WorkspaceImagePrepareRequest {
-                run_id,
-                sandbox_id,
-                profile_name: "vm0/default",
-                cli_agent_session_id: Some(session_id),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: b"image".len() as u64,
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
                 workspace_drive_required: true,
             })
             .await;

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -600,7 +600,8 @@ mod tests {
     use crate::storage_fingerprints::StorageFingerprint;
     use crate::types::SandboxReuseResult;
     use crate::workspace_image_cache::{
-        SessionWorkspaceCache, WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext,
+        SessionWorkspaceCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+        WorkspaceImagePromotionContext,
     };
 
     fn test_budget_lease() -> (Arc<ResourceBudget>, BudgetLease) {
@@ -701,12 +702,14 @@ mod tests {
     ) -> WorkspaceImageLease {
         let lease = cache
             .prepare(WorkspaceImagePrepareRequest {
-                run_id,
-                sandbox_id,
-                profile_name: "vm0/default",
-                cli_agent_session_id: Some(session_id),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: b"image".len() as u64,
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
                 workspace_drive_required: true,
             })
             .await;
@@ -977,12 +980,14 @@ mod tests {
             drop(promotion);
             let checkout = cache
                 .prepare(WorkspaceImagePrepareRequest {
-                    run_id: RunId::new_v4(),
-                    sandbox_id: SandboxId::new_v4(),
-                    profile_name: "vm0/default",
-                    cli_agent_session_id: Some(session_id),
-                    working_dir: CANONICAL_WORKING_DIR,
-                    image_size_bytes: b"image".len() as u64,
+                    identity: WorkspaceImageLeaseIdentity {
+                        run_id: RunId::new_v4(),
+                        sandbox_id: SandboxId::new_v4(),
+                        profile_name: "vm0/default",
+                        cli_agent_session_id: Some(session_id),
+                        working_dir: CANONICAL_WORKING_DIR,
+                        image_size_bytes: b"image".len() as u64,
+                    },
                     workspace_drive_required: true,
                 })
                 .await;
@@ -1054,12 +1059,14 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
             .prepare(WorkspaceImagePrepareRequest {
-                run_id,
-                sandbox_id,
-                profile_name: "vm0/default",
-                cli_agent_session_id: None,
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: b"image".len() as u64,
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: None,
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
                 workspace_drive_required: true,
             })
             .await;
@@ -1138,12 +1145,14 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
             .prepare(WorkspaceImagePrepareRequest {
-                run_id,
-                sandbox_id,
-                profile_name: "vm0/default",
-                cli_agent_session_id: Some("sess-new"),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: b"image".len() as u64,
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some("sess-new"),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
                 workspace_drive_required: true,
             })
             .await;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -116,6 +116,7 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceImageActiveLeaseRequest, WorkspaceImageLease,
+    WorkspaceImageLeaseIdentity,
 };
 
 fn guest_runtime_dir(run_id: RunId) -> RunnerResult<String> {
@@ -470,17 +471,7 @@ pub async fn execute_job_reuse(
 
     if let Err(error) = validate_resume_session_id(&context) {
         let workspace_image = match config.workspace_cache.as_ref() {
-            Some(_) => workspace_promotion.map(|promotion| {
-                promotion.into_active_lease(WorkspaceImageActiveLeaseRequest {
-                    run_id,
-                    sandbox_id,
-                    profile_name: &params.profile_name,
-                    cli_agent_session_id: Some(idle_cli_agent_session_id.as_str()),
-                    working_dir: CANONICAL_WORKING_DIR,
-                    image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
-                    workspace_drive_available: true,
-                })
-            }),
+            Some(_) => workspace_promotion.map(|promotion| promotion.into_active_lease(true)),
             None => {
                 if let Some(promotion) = workspace_promotion
                     && let Err(error) = promotion
@@ -524,21 +515,24 @@ pub async fn execute_job_reuse(
     }
 
     let workspace_image = match config.workspace_cache.as_ref() {
-        Some(cache) => {
-            let active_request = WorkspaceImageActiveLeaseRequest {
-                run_id,
-                sandbox_id,
-                profile_name: &params.profile_name,
-                cli_agent_session_id: context.cli_agent_session_id(),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
-                workspace_drive_available: true,
-            };
-            Some(match workspace_promotion {
-                Some(promotion) => promotion.into_active_lease(active_request),
-                None => cache.lease_active(active_request).await,
-            })
-        }
+        Some(cache) => Some(match workspace_promotion {
+            Some(promotion) => promotion.into_active_lease(true),
+            None => {
+                cache
+                    .lease_active(WorkspaceImageActiveLeaseRequest {
+                        identity: WorkspaceImageLeaseIdentity {
+                            run_id,
+                            sandbox_id,
+                            profile_name: &params.profile_name,
+                            cli_agent_session_id: context.cli_agent_session_id(),
+                            working_dir: CANONICAL_WORKING_DIR,
+                            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                        },
+                        workspace_drive_available: true,
+                    })
+                    .await
+            }
+        }),
         None => {
             if let Some(promotion) = workspace_promotion
                 && let Err(error) = promotion

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -26,7 +26,9 @@ use crate::paths::diagnostic_session_fingerprint;
 use crate::proxy;
 use crate::telemetry::JobTelemetry;
 use crate::types::ExecutionContext;
-use crate::workspace_image_cache::{WorkspaceImageLease, WorkspaceImagePrepareRequest};
+use crate::workspace_image_cache::{
+    WorkspaceImageLease, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+};
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
@@ -208,12 +210,14 @@ pub(super) async fn prepare_workspace_image(
     let cache = config.workspace_cache.as_ref()?;
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: context.run_id,
-            sandbox_id,
-            profile_name,
-            cli_agent_session_id: context.cli_agent_session_id(),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: context.run_id,
+                sandbox_id,
+                profile_name,
+                cli_agent_session_id: context.cli_agent_session_id(),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -39,7 +39,7 @@ use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
 use crate::types::{ResumeSession, SandboxReuseResult};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImagePrepareRequest,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 use tracing::Level;
 use tracing_subscriber::prelude::*;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -224,12 +224,14 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
 
     let checkout = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: &params.profile_name,
-            cli_agent_session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -264,12 +266,14 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
 
     let checkout = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: &params.profile_name,
-            cli_agent_session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -439,12 +443,14 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
 
     let checkout = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: &params.profile_name,
-            cli_agent_session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -496,12 +502,14 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
 
     let checkout = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: &params.profile_name,
-            cli_agent_session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -535,12 +543,14 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: &params.profile_name,
-            cli_agent_session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: &params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -631,12 +641,14 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: &params.profile_name,
-            cli_agent_session_id: None,
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: &params.profile_name,
+                cli_agent_session_id: None,
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -7,7 +7,7 @@ use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImagePrepareRequest,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
 };
 
 pub(in crate::executor::tests) async fn seed_workspace_image_cache(
@@ -20,12 +20,14 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
     let run_id = RunId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: "vm0/default",
-            cli_agent_session_id: Some(session_id),
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default",
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+            },
             workspace_drive_required: true,
         })
         .await;

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -26,7 +26,8 @@ use super::path_safety::{
 };
 use super::types::{
     CacheBudget, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImageActiveLeaseRequest, WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
+    WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+    WorkspaceImagePromotionRequest,
 };
 use super::{
     CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
@@ -78,9 +79,105 @@ struct WorkspaceImagePromotionInput<'a> {
     storage_fingerprints: &'a StorageFingerprints,
 }
 
+struct WorkspaceImageLeaseCommon<'a> {
+    run_id: RunId,
+    profile_name: &'a str,
+    cli_agent_session_id: Option<&'a str>,
+    raw_working_dir: &'a str,
+    normalized_working_dir: Option<String>,
+    active_image: PathBuf,
+    image_size_bytes: u64,
+}
+
+struct WorkspaceImageLeaseBase {
+    cache: SessionWorkspaceCache,
+    profile_name: String,
+    cli_agent_session_id: Option<String>,
+    working_dir: String,
+    active_image: PathBuf,
+    image_size_bytes: u64,
+}
+
+struct WorkspaceImageLeaseState {
+    cache_key: Option<String>,
+    source_image: Option<PathBuf>,
+    consumed_cache_hit: bool,
+    previous_storage: Option<StorageFingerprints>,
+    entry_lock: Option<Flock<std::fs::File>>,
+    workspace_drive_enabled: bool,
+    result: WorkspaceCacheCheckoutResult,
+}
+
 fn workspace_image_size_mb(image_size_bytes: u64) -> u32 {
     let mib = 1024 * 1024;
     image_size_bytes.div_ceil(mib).min(u64::from(u32::MAX)) as u32
+}
+
+impl<'a> WorkspaceImageLeaseCommon<'a> {
+    fn new(cache: &SessionWorkspaceCache, identity: WorkspaceImageLeaseIdentity<'a>) -> Self {
+        Self {
+            run_id: identity.run_id,
+            profile_name: identity.profile_name,
+            cli_agent_session_id: identity.cli_agent_session_id,
+            raw_working_dir: identity.working_dir,
+            normalized_working_dir: normalize_safe_guest_working_dir(identity.working_dir),
+            active_image: cache.paths().active_workspace_image(&identity.sandbox_id),
+            image_size_bytes: identity.image_size_bytes,
+        }
+    }
+
+    fn safe_working_dir(&self) -> Option<&str> {
+        self.normalized_working_dir.as_deref()
+    }
+
+    fn lease_working_dir(&self) -> &str {
+        self.safe_working_dir().unwrap_or(self.raw_working_dir)
+    }
+
+    fn cache_key(
+        &self,
+        cache: &SessionWorkspaceCache,
+        cli_agent_session_id: &str,
+        working_dir: &str,
+    ) -> String {
+        cache.scoped_cache_key(
+            self.profile_name,
+            cli_agent_session_id,
+            working_dir,
+            self.image_size_bytes,
+        )
+    }
+
+    fn lease_base(&self, cache: &SessionWorkspaceCache) -> WorkspaceImageLeaseBase {
+        WorkspaceImageLeaseBase {
+            cache: cache.clone(),
+            profile_name: self.profile_name.to_owned(),
+            cli_agent_session_id: self.cli_agent_session_id.map(str::to_owned),
+            working_dir: self.lease_working_dir().to_owned(),
+            active_image: self.active_image.clone(),
+            image_size_bytes: self.image_size_bytes,
+        }
+    }
+}
+
+impl WorkspaceImageLease {
+    fn from_parts(base: WorkspaceImageLeaseBase, state: WorkspaceImageLeaseState) -> Self {
+        Self {
+            cache: base.cache,
+            cache_key: state.cache_key,
+            profile_name: base.profile_name,
+            cli_agent_session_id: base.cli_agent_session_id,
+            working_dir: base.working_dir,
+            active_image: base.active_image,
+            source_image: state.source_image,
+            consumed_cache_hit: state.consumed_cache_hit,
+            image_size_bytes: base.image_size_bytes,
+            workspace_drive_enabled: state.workspace_drive_enabled,
+            result: state.result,
+            previous_storage: state.previous_storage,
+            entry_lock: state.entry_lock,
+        }
+    }
 }
 
 impl SessionWorkspaceCache {
@@ -88,45 +185,35 @@ impl SessionWorkspaceCache {
         &self,
         request: WorkspaceImageActiveLeaseRequest<'_>,
     ) -> WorkspaceImageLease {
-        let active_image = self.paths().active_workspace_image(&request.sandbox_id);
-        let normalized_working_dir = normalize_safe_guest_working_dir(request.working_dir);
-        let lease_working_dir = normalized_working_dir
-            .as_deref()
-            .unwrap_or(request.working_dir);
-        let active_lease = |result, lock, cache_key| WorkspaceImageLease {
-            cache: self.clone(),
-            cache_key,
-            profile_name: request.profile_name.to_owned(),
-            cli_agent_session_id: request.cli_agent_session_id.map(str::to_owned),
-            working_dir: lease_working_dir.to_owned(),
-            active_image: active_image.clone(),
-            source_image: None,
-            consumed_cache_hit: false,
-            image_size_bytes: request.image_size_bytes,
-            workspace_drive_enabled: request.workspace_drive_available,
-            result,
-            previous_storage: None,
-            entry_lock: lock,
+        let common = WorkspaceImageLeaseCommon::new(self, request.identity);
+        let active_lease = |result, entry_lock, cache_key| {
+            WorkspaceImageLease::from_parts(
+                common.lease_base(self),
+                WorkspaceImageLeaseState {
+                    cache_key,
+                    source_image: None,
+                    consumed_cache_hit: false,
+                    previous_storage: None,
+                    entry_lock,
+                    workspace_drive_enabled: request.workspace_drive_available,
+                    result,
+                },
+            )
         };
 
-        let Some(working_dir) = normalized_working_dir.as_deref() else {
+        let Some(working_dir) = common.safe_working_dir() else {
             warn!(
-                run_id = %request.run_id,
-                working_dir = %request.working_dir,
+                run_id = %common.run_id,
+                working_dir = %common.raw_working_dir,
                 "workspace image cache active lease disabled for unsafe working directory"
             );
             return active_lease(WorkspaceCacheCheckoutResult::InvalidWorkingDir, None, None);
         };
-        let Some(cli_agent_session_id) = request.cli_agent_session_id else {
+        let Some(cli_agent_session_id) = common.cli_agent_session_id else {
             return active_lease(WorkspaceCacheCheckoutResult::NoSession, None, None);
         };
 
-        let cache_key = self.scoped_cache_key(
-            request.profile_name,
-            cli_agent_session_id,
-            working_dir,
-            request.image_size_bytes,
-        );
+        let cache_key = common.cache_key(self, cli_agent_session_id, working_dir);
         match crate::lock::try_acquire(self.entry_lock_path(&cache_key)).await {
             Ok(lock) => active_lease(
                 WorkspaceCacheCheckoutResult::Miss,
@@ -135,7 +222,7 @@ impl SessionWorkspaceCache {
             ),
             Err(e) => {
                 info!(
-                    run_id = %request.run_id,
+                    run_id = %common.run_id,
                     cache_key,
                     error = %e,
                     "workspace image cache active lease lock busy or unavailable; promotion disabled"
@@ -149,40 +236,33 @@ impl SessionWorkspaceCache {
         &self,
         request: WorkspaceImagePrepareRequest<'_>,
     ) -> WorkspaceImageLease {
-        let active_image = self.paths().active_workspace_image(&request.sandbox_id);
-        let normalized_working_dir = normalize_safe_guest_working_dir(request.working_dir);
-        let lease_working_dir = normalized_working_dir
-            .as_deref()
-            .unwrap_or(request.working_dir);
+        let common = WorkspaceImageLeaseCommon::new(self, request.identity);
         let workspace_drive = |result,
                                source_image: Option<PathBuf>,
-                               previous_storage,
-                               lock,
+                               previous_storage: Option<StorageFingerprints>,
+                               entry_lock,
                                cache_key,
                                workspace_drive_enabled| {
             let consumed_cache_hit =
                 result == WorkspaceCacheCheckoutResult::Hit && source_image.is_some();
-            WorkspaceImageLease {
-                cache: self.clone(),
-                cache_key,
-                profile_name: request.profile_name.to_owned(),
-                cli_agent_session_id: request.cli_agent_session_id.map(str::to_owned),
-                working_dir: lease_working_dir.to_owned(),
-                active_image: active_image.clone(),
-                source_image,
-                consumed_cache_hit,
-                image_size_bytes: request.image_size_bytes,
-                workspace_drive_enabled,
-                result,
-                previous_storage,
-                entry_lock: lock,
-            }
+            WorkspaceImageLease::from_parts(
+                common.lease_base(self),
+                WorkspaceImageLeaseState {
+                    cache_key,
+                    source_image,
+                    consumed_cache_hit,
+                    previous_storage,
+                    entry_lock,
+                    workspace_drive_enabled,
+                    result,
+                },
+            )
         };
 
-        let Some(working_dir) = normalized_working_dir.as_deref() else {
+        let Some(working_dir) = common.safe_working_dir() else {
             warn!(
-                run_id = %request.run_id,
-                working_dir = %request.working_dir,
+                run_id = %common.run_id,
+                working_dir = %common.raw_working_dir,
                 "workspace image cache disabled for unsafe working directory"
             );
             return workspace_drive(
@@ -194,7 +274,7 @@ impl SessionWorkspaceCache {
                 request.workspace_drive_required,
             );
         };
-        let Some(cli_agent_session_id) = request.cli_agent_session_id else {
+        let Some(cli_agent_session_id) = common.cli_agent_session_id else {
             return workspace_drive(
                 WorkspaceCacheCheckoutResult::NoSession,
                 None,
@@ -206,7 +286,7 @@ impl SessionWorkspaceCache {
         };
         let Ok(mut stats) = self.fs_stats().await else {
             warn!(
-                run_id = %request.run_id,
+                run_id = %common.run_id,
                 "workspace image cache disabled because filesystem stats are unavailable"
             );
             return workspace_drive(
@@ -227,14 +307,14 @@ impl SessionWorkspaceCache {
                         budget = CacheBudget::from_fs_stats(stats);
                     }
                     Err(e) => warn!(
-                        run_id = %request.run_id,
+                        run_id = %common.run_id,
                         error = %e,
                         "workspace image cache stats refresh failed after GC"
                     ),
                 },
                 Ok(_) => {}
                 Err(e) => warn!(
-                    run_id = %request.run_id,
+                    run_id = %common.run_id,
                     error = %e,
                     "workspace image cache GC failed before checkout"
                 ),
@@ -242,7 +322,7 @@ impl SessionWorkspaceCache {
         }
         if stats.available_bytes < budget.min_free_bytes {
             info!(
-                run_id = %request.run_id,
+                run_id = %common.run_id,
                 available_bytes = stats.available_bytes,
                 min_free_bytes = budget.min_free_bytes,
                 "workspace image cache skipped due to free-space pressure"
@@ -257,18 +337,13 @@ impl SessionWorkspaceCache {
             );
         }
 
-        let cache_key = self.scoped_cache_key(
-            request.profile_name,
-            cli_agent_session_id,
-            working_dir,
-            request.image_size_bytes,
-        );
+        let cache_key = common.cache_key(self, cli_agent_session_id, working_dir);
         let lock_path = self.entry_lock_path(&cache_key);
         let lock = match crate::lock::try_acquire(lock_path).await {
             Ok(lock) => lock,
             Err(e) => {
                 info!(
-                    run_id = %request.run_id,
+                    run_id = %common.run_id,
                     cache_key,
                     error = %e,
                     "workspace image cache lock busy or unavailable; using fresh workspace image"
@@ -288,7 +363,7 @@ impl SessionWorkspaceCache {
         match remove_non_directory_workspace_cache_entry(&entry_dir).await {
             Ok(true) => {
                 info!(
-                    run_id = %request.run_id,
+                    run_id = %common.run_id,
                     cache_key,
                     path = %entry_dir.display(),
                     "removed non-directory workspace image cache entry before checkout"
@@ -305,7 +380,7 @@ impl SessionWorkspaceCache {
             Ok(false) => {}
             Err(e) => {
                 warn!(
-                    run_id = %request.run_id,
+                    run_id = %common.run_id,
                     cache_key,
                     path = %entry_dir.display(),
                     error = %e,
@@ -327,10 +402,10 @@ impl SessionWorkspaceCache {
         let hit = match self
             .read_valid_metadata(
                 &metadata_path,
-                request.profile_name,
+                common.profile_name,
                 cli_agent_session_id,
                 working_dir,
-                request.image_size_bytes,
+                common.image_size_bytes,
             )
             .await
         {
@@ -339,14 +414,14 @@ impl SessionWorkspaceCache {
                 match fs::remove_file(&metadata_path).await {
                     Ok(()) => {
                         info!(
-                            run_id = %request.run_id,
+                            run_id = %common.run_id,
                             cache_key,
                             "workspace image cache hit checked out with move seed"
                         );
                     }
                     Err(e) => {
                         warn!(
-                            run_id = %request.run_id,
+                            run_id = %common.run_id,
                             cache_key,
                             error = %e,
                             "failed to remove workspace image cache metadata before move checkout; using fresh workspace image"
@@ -366,7 +441,7 @@ impl SessionWorkspaceCache {
             Ok(None) => None,
             Err(e) => {
                 warn!(
-                    run_id = %request.run_id,
+                    run_id = %common.run_id,
                     cache_key,
                     error = %e,
                     "workspace image cache metadata invalid; using fresh workspace image"
@@ -375,7 +450,7 @@ impl SessionWorkspaceCache {
                 match fs::remove_dir_all(&entry_dir).await {
                     Ok(()) => {
                         info!(
-                            run_id = %request.run_id,
+                            run_id = %common.run_id,
                             cache_key,
                             "removed invalid workspace image cache entry before fresh checkout"
                         );
@@ -400,7 +475,7 @@ impl SessionWorkspaceCache {
                     }
                     Err(remove_error) => {
                         warn!(
-                            run_id = %request.run_id,
+                            run_id = %common.run_id,
                             cache_key,
                             error = %remove_error,
                             "failed to remove invalid workspace image cache entry"
@@ -1108,16 +1183,13 @@ impl WorkspaceImagePromotionContext {
             .await
     }
 
-    pub(crate) fn into_active_lease(
-        self,
-        request: WorkspaceImageActiveLeaseRequest<'_>,
-    ) -> WorkspaceImageLease {
+    pub(crate) fn into_active_lease(self, workspace_drive_available: bool) -> WorkspaceImageLease {
         let Self {
             cache,
             cache_key,
             entry_lock,
             run_id: _,
-            sandbox_id,
+            sandbox_id: _,
             profile_name,
             cli_agent_session_id,
             working_dir,
@@ -1128,32 +1200,26 @@ impl WorkspaceImagePromotionContext {
             completed_at: _,
             storage_fingerprints: _,
         } = self;
-        debug_assert_eq!(request.sandbox_id, sandbox_id);
-        debug_assert_eq!(request.profile_name, profile_name.as_str());
-        debug_assert_eq!(
-            request.cli_agent_session_id,
-            Some(cli_agent_session_id.as_str())
-        );
-        debug_assert_eq!(
-            normalize_safe_guest_working_dir(request.working_dir).as_deref(),
-            Some(working_dir.as_str())
-        );
-        debug_assert_eq!(request.image_size_bytes, image_size_bytes);
-        WorkspaceImageLease {
+        let base = WorkspaceImageLeaseBase {
             cache,
-            cache_key: Some(cache_key),
             profile_name,
             cli_agent_session_id: Some(cli_agent_session_id),
             working_dir,
             active_image,
-            source_image: None,
-            consumed_cache_hit,
             image_size_bytes,
-            workspace_drive_enabled: request.workspace_drive_available,
-            result: WorkspaceCacheCheckoutResult::Miss,
-            previous_storage: None,
-            entry_lock,
-        }
+        };
+        WorkspaceImageLease::from_parts(
+            base,
+            WorkspaceImageLeaseState {
+                cache_key: Some(cache_key),
+                source_image: None,
+                consumed_cache_hit,
+                previous_storage: None,
+                entry_lock,
+                workspace_drive_enabled: workspace_drive_available,
+                result: WorkspaceCacheCheckoutResult::Miss,
+            },
+        )
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -47,8 +47,8 @@ pub(crate) use types::{
     CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
     WorkspaceImageActiveLeaseRequest, WorkspaceImageCacheInspection,
     WorkspaceImageCacheInspectionEntry, WorkspaceImageCacheInspectionStatus,
-    WorkspaceImageCacheInspectionSummary, WorkspaceImagePrepareRequest,
-    WorkspaceImagePromotionRequest,
+    WorkspaceImageCacheInspectionSummary, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
 };
 
 const CACHE_FORMAT_VERSION: u32 = 1;

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -102,12 +102,14 @@ async fn promote_current_cache_entry(
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: image.len() as u64,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image.len() as u64,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -150,12 +152,14 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
     let stale_sandbox_id = sandbox::SandboxId::new_v4();
     let stale_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: stale_run_id,
-            sandbox_id: stale_sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: stale_run_id,
+                sandbox_id: stale_sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -215,12 +219,14 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
     let competing_sandbox_id = sandbox::SandboxId::new_v4();
     let competing_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: competing_run_id,
-            sandbox_id: competing_sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: competing_run_id,
+                sandbox_id: competing_sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -286,12 +292,14 @@ async fn promotion_overwrites_older_cache_entry() {
     let newer_sandbox_id = sandbox::SandboxId::new_v4();
     let newer_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: newer_run_id,
-            sandbox_id: newer_sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: newer_run_id,
+                sandbox_id: newer_sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -941,12 +949,14 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -1093,12 +1103,14 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/",
-            image_size_bytes: 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/",
+                image_size_bytes: 1024,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1111,12 +1123,14 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
 
     let no_session_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/",
-            image_size_bytes: 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/",
+                image_size_bytes: 1024,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1129,12 +1143,14 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
 
     let snapshot_restore_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/",
-            image_size_bytes: 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/",
+                image_size_bytes: 1024,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -1170,12 +1186,14 @@ async fn prepare_normalizes_working_dir_for_cache_identity() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace//repo/",
-            image_size_bytes: 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace//repo/",
+                image_size_bytes: 1024,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1207,12 +1225,14 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
 
     let lease = cache_a
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1238,12 +1258,14 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
 
     let checkout = cache_b
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1293,12 +1315,14 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-move-hit"),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-move-hit"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -1334,12 +1358,14 @@ async fn metadata_missing_current_present_is_not_a_cache_hit() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-no-metadata"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-no-metadata"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -1376,12 +1402,14 @@ async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-move-promote"),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-move-promote"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -1444,12 +1472,14 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-move-invalidate"),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-move-invalidate"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: true,
         })
         .await;
@@ -1485,12 +1515,14 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
 
     let lease_a = cache_a
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1498,12 +1530,14 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
 
     let blocked_checkout = cache_b
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1522,12 +1556,14 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
     drop(lease_a);
     let checkout_after_drop = cache_b
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1560,12 +1596,14 @@ async fn shared_cache_is_scoped_by_runner_group() {
 
     let lease = cache_a
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1591,12 +1629,14 @@ async fn shared_cache_is_scoped_by_runner_group() {
 
     let checkout = cache_b
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -1631,12 +1671,14 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
 
     let lease = cache_a
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2065,12 +2107,14 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: image_size,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: image_size,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2489,12 +2533,14 @@ async fn cache_hit_checkout_does_not_require_copy_headroom() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: current_metadata.len(),
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: current_metadata.len(),
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2557,12 +2603,14 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 1024,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2632,12 +2680,14 @@ async fn active_lease_hides_cached_session_until_dropped() {
 
     let lease = cache
         .lease_active(WorkspaceImageActiveLeaseRequest {
-            run_id,
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-1"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-1"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_available: true,
         })
         .await;
@@ -2660,12 +2710,14 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
 
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2685,12 +2737,14 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
 
     let blocked_by_context = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2699,24 +2753,18 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
         WorkspaceCacheCheckoutResult::LockBusy
     );
 
-    let active_lease = promotion.into_active_lease(WorkspaceImageActiveLeaseRequest {
-        run_id: RunId::new_v4(),
-        sandbox_id,
-        profile_name: TEST_PROFILE_NAME,
-        cli_agent_session_id: Some(session_id),
-        working_dir: "/workspace",
-        image_size_bytes,
-        workspace_drive_available: true,
-    });
+    let active_lease = promotion.into_active_lease(true);
 
     let blocked_by_active_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -2728,12 +2776,14 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
     drop(active_lease);
     let after_drop = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id: RunId::new_v4(),
-            sandbox_id: sandbox::SandboxId::new_v4(),
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3413,12 +3463,14 @@ async fn promote_skips_symlink_active_image_without_following_it() {
     let session_id = "sess-active-symlink";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3469,12 +3521,14 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
     let session_id = "sess-promote-entry-symlink";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some(session_id),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3533,12 +3587,14 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3592,12 +3648,14 @@ async fn promote_removes_stale_temporary_directory_before_copy() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3641,12 +3699,14 @@ async fn promote_replaces_stale_current_directory_before_rename() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3690,12 +3750,14 @@ async fn promote_skips_copied_image_with_unexpected_logical_size() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-size-mismatch"),
-            working_dir: "/workspace",
-            image_size_bytes: 16 * 1024 * 1024,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-size-mismatch"),
+                working_dir: "/workspace",
+                image_size_bytes: 16 * 1024 * 1024,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3737,12 +3799,14 @@ async fn promote_skips_when_capacity_lock_is_busy() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: Some("sess-capacity-lock"),
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some("sess-capacity-lock"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3787,12 +3851,14 @@ async fn no_session_checkout_can_promote_with_late_discovered_cli_agent_session_
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3845,12 +3911,14 @@ async fn late_session_promotion_skips_when_entry_lock_is_busy() {
     let session_id = "sess-late-lock-busy";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/workspace",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3900,12 +3968,14 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
     let session_id = "sess-reused-late-context";
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
-            run_id,
-            sandbox_id,
-            profile_name: TEST_PROFILE_NAME,
-            cli_agent_session_id: None,
-            working_dir: "/workspace//repo/",
-            image_size_bytes: 5,
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace//repo/",
+                image_size_bytes: 5,
+            },
             workspace_drive_required: false,
         })
         .await;
@@ -3921,15 +3991,7 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
         })
         .unwrap();
 
-    let active_lease = promotion.into_active_lease(WorkspaceImageActiveLeaseRequest {
-        run_id: RunId::new_v4(),
-        sandbox_id,
-        profile_name: TEST_PROFILE_NAME,
-        cli_agent_session_id: Some(session_id),
-        working_dir: "/workspace//repo/",
-        image_size_bytes: 5,
-        workspace_drive_available: true,
-    });
+    let active_lease = promotion.into_active_lease(true);
 
     assert_eq!(active_lease.working_dir(), "/workspace/repo");
     assert!(active_lease.can_attempt_promotion(Some(session_id)));

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -25,24 +25,24 @@ pub(crate) enum WorkspaceCacheTerminalStatus {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct WorkspaceImagePrepareRequest<'a> {
+pub(crate) struct WorkspaceImageLeaseIdentity<'a> {
     pub(crate) run_id: RunId,
     pub(crate) sandbox_id: sandbox::SandboxId,
     pub(crate) profile_name: &'a str,
     pub(crate) cli_agent_session_id: Option<&'a str>,
     pub(crate) working_dir: &'a str,
     pub(crate) image_size_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorkspaceImagePrepareRequest<'a> {
+    pub(crate) identity: WorkspaceImageLeaseIdentity<'a>,
     pub(crate) workspace_drive_required: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WorkspaceImageActiveLeaseRequest<'a> {
-    pub(crate) run_id: RunId,
-    pub(crate) sandbox_id: sandbox::SandboxId,
-    pub(crate) profile_name: &'a str,
-    pub(crate) cli_agent_session_id: Option<&'a str>,
-    pub(crate) working_dir: &'a str,
-    pub(crate) image_size_bytes: u64,
+    pub(crate) identity: WorkspaceImageLeaseIdentity<'a>,
     pub(crate) workspace_drive_available: bool,
 }
 

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -5,8 +5,8 @@ use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImagePrepareRequest,
-    WorkspaceImagePromotionContext, WorkspaceImagePromotionRequest,
+    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext, WorkspaceImagePromotionRequest,
 };
 
 pub(crate) const TEST_COMPLETED_AT: &str = "2026-06-03T00:00:00.000Z";
@@ -30,12 +30,14 @@ impl WorkspacePromotionFixture {
         let image = b"workspace image";
         let workspace_image = cache
             .prepare(WorkspaceImagePrepareRequest {
-                run_id,
-                sandbox_id,
-                profile_name: "vm0/default",
-                cli_agent_session_id: Some(session_id),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: image.len() as u64,
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: image.len() as u64,
+                },
                 workspace_drive_required: true,
             })
             .await;


### PR DESCRIPTION
## Summary

- Add an explicit workspace image lease identity shared by prepare and active lease requests.
- Centralize common workspace image lease normalization and construction in the cache lifecycle.
- Simplify promotion-to-active lease conversion so it uses identity already stored in the promotion context.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml -p runner --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::sandbox_run_tests::workspace_cache`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc

Closes #18364