### PR TITLE
fix: apply mobile single-line composer switch to tiptap composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -38,12 +38,23 @@ import {
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 
 // Match the textarea metrics so swapping inputs is visually seamless. The editor
-// element itself scrolls (single layer), so there is no overlay to sync.
+// element itself scrolls (single layer), so there is no overlay to sync. The
+// resting min-height is applied separately (see editorContentClass) so the
+// mobileSingleLineComposer switch can rest the editor at a single line on mobile.
 const EDITOR_CONTENT_CLASS =
-  "w-full min-h-[96px] max-h-[200px] overflow-y-auto whitespace-pre-wrap " +
+  "w-full max-h-[200px] overflow-y-auto whitespace-pre-wrap " +
   "break-words px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground " +
   "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
   "selection:bg-primary/20";
+
+// Resting height: a single line on mobile (below the md breakpoint) when the
+// switch is on, otherwise the three-line desktop height on every viewport. This
+// mirrors the textarea composer in zero-chat-composer.tsx.
+function editorContentClass(singleLineOnMobile: boolean): string {
+  return singleLineOnMobile
+    ? `${EDITOR_CONTENT_CLASS} min-h-[44px] md:min-h-[96px]`
+    : `${EDITOR_CONTENT_CLASS} min-h-[96px]`;
+}
 
 const WORKFLOW_HIGHLIGHT_CLASS = "text-primary";
 
@@ -380,6 +391,7 @@ interface EditorOptionsParams {
   readonly input: string;
   readonly workflowNames: readonly string[];
   readonly autoFocus: boolean | undefined;
+  readonly singleLineOnMobile: boolean;
   readonly onInputChange: (value: string) => void;
   readonly onPaste: (event: ComposerPasteEvent) => void;
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
@@ -402,7 +414,7 @@ function buildEditorOptions(
     autofocus: params.autoFocus && !isIOS() ? "end" : false,
     shouldRerenderOnTransaction: false,
     editorProps: {
-      attributes: { class: EDITOR_CONTENT_CLASS },
+      attributes: { class: editorContentClass(params.singleLineOnMobile) },
       handleKeyDown: (_view, event) => {
         return params.onEditorKeyDown(event);
       },
@@ -488,6 +500,8 @@ export function TiptapWorkflowComposer({
   const setSelectedWorkflowIndex = useSet(setSelectedSlashWorkflowIndex$);
   const currentAgentId = useLastResolved(currentChatAgentRecordId$);
   const features = useLastResolved(featureSwitch$);
+  const singleLineOnMobile =
+    features?.[FeatureSwitchKey.MobileSingleLineComposer] ?? false;
   const orgWorkflowsLoadable = useLastLoadable(orgWorkflows$);
   const orgWorkflowsData =
     orgWorkflowsLoadable.state === "hasData" ? orgWorkflowsLoadable.data : [];
@@ -519,6 +533,7 @@ export function TiptapWorkflowComposer({
       input,
       workflowNames,
       autoFocus,
+      singleLineOnMobile,
       onInputChange,
       onPaste,
       setInputRef,
@@ -583,7 +598,9 @@ export function TiptapWorkflowComposer({
     // is fully controlled by composer state, so Escape/typing close it.
     <Popover open={showSlashWorkflowMenu}>
       <SlashCaretAnchor editor={editor} slashRange={slashRange} />
-      <div className="relative min-h-[96px]">
+      <div
+        className={`relative ${singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]"}`}
+      >
         {input === "" && (
           <div
             className="pointer-events-none absolute left-0 top-0 px-4 pt-4 text-[0.9375rem] leading-6 text-muted-foreground/40"


### PR DESCRIPTION
## Summary

Follow-up to #18380. That PR defaulted the chat composer to a single-line resting height on mobile behind the org-scoped `mobileSingleLineComposer` switch — but it only changed the **textarea** composer (`ComposerTextarea`).

Staff orgs also have `chatSlashWorkflowCommands` enabled (also `STAFF_ORG_ID_HASHES`), so `ComposerInputSlot` renders **`TiptapWorkflowComposer`** instead. That component carried its own hardcoded `min-h-[96px]` (both the ProseMirror editor content class and the wrapper div), so for staff users on mobile the composer stayed three lines tall — i.e. the switch appeared to do nothing.

This was caught from on-device screenshots: the Lab toggle was on, viewport was mobile, but the composer was still three lines because the staff path uses the tiptap editor.

## Changes

`turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx`:
- Split the resting `min-h` out of `EDITOR_CONTENT_CLASS` into `editorContentClass(singleLineOnMobile)`, returning `min-h-[44px] md:min-h-[96px]` when the switch is on, else `min-h-[96px]`.
- Threaded `singleLineOnMobile` through `EditorOptionsParams` → `buildEditorOptions` (rebuilt each render and applied via `setOptions`, so it stays reactive to the switch).
- Made the wrapper `div` min-height responsive the same way.
- Reads the flag via the already-present `featureSwitch$` in the component.

Net effect: both composer implementations now honor `mobileSingleLineComposer` identically — single line below `md`, three lines on desktop. Default-off behavior is unchanged.

## Verification

Pure presentation change gated behind the default-off switch. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)