### PR TITLE
feat: gate goal seed skill on GoalWorkflows and disable built-in goal

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -67,15 +67,17 @@ import {
 } from "@vm0/core/frameworks";
 import {
   getAllFeatureStates,
+  isFeatureEnabled,
   type FeatureSwitchContext,
 } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@vm0/core/github-url";
 import {
   getCustomSkillStorageName,
   getSkillStorageName,
   MEMORY_ARTIFACT_NAME,
 } from "@vm0/core/storage-names";
-import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { SEED_SKILLS, GOAL_SKILL_NAME } from "@vm0/core/zero-seed-skills";
 import {
   expandVariables,
   expandVariablesInString,
@@ -500,11 +502,36 @@ function skillMountPath(
 // declared in the compose — a run can execute on a provider whose framework
 // differs from the compose, and skills mounted at the wrong path are invisible
 // to the agent.
+// The harness ships a built-in `/goal` (Claude Code & Codex). When the vm0
+// `goal` seed skill is injected it must take over, so these built-in goal tool
+// identifiers are added to the run's disallowed-tools list to suppress the
+// native command. Disallowing a name the active harness does not expose is a
+// harmless no-op, so both harnesses' identifiers are listed.
+const BUILTIN_GOAL_DISALLOWED_TOOLS = ["goal", "update_goal"] as const;
+
+function withBuiltinGoalDisabled(
+  disallowedTools: readonly string[] | undefined,
+  goalSeedEnabled: boolean,
+): readonly string[] | undefined {
+  if (!goalSeedEnabled) {
+    return disallowedTools;
+  }
+  return [
+    ...new Set([...(disallowedTools ?? []), ...BUILTIN_GOAL_DISALLOWED_TOOLS]),
+  ];
+}
+
 function buildSystemSkillVolumes(
   connectorTypes: readonly ConnectorType[],
   framework: SupportedFramework,
+  goalSeedEnabled: boolean,
 ): readonly AdditionalVolume[] {
-  const allSkillNames = [...new Set([...SEED_SKILLS, ...connectorTypes])];
+  // The `goal` skill is mounted only when the GoalWorkflows switch is on, so it
+  // is appended here rather than living in the always-on SEED_SKILLS list.
+  const seedNames = goalSeedEnabled
+    ? [...SEED_SKILLS, GOAL_SKILL_NAME]
+    : SEED_SKILLS;
+  const allSkillNames = [...new Set([...seedNames, ...connectorTypes])];
   return allSkillNames.flatMap((skillName) => {
     const url = resolveSkillRef(skillName);
     const parsed = parseGitHubTreeUrl(url);
@@ -540,12 +567,17 @@ function buildWorkflowSkillVolumes(
 function buildInjectedSkillVolumes(
   args: CreateAgentRunArgs,
   framework: SupportedFramework,
+  goalSeedEnabled: boolean,
 ): readonly AdditionalVolume[] | undefined {
   if (!args.injectSkillVolumes) {
     return undefined;
   }
   return [
-    ...buildSystemSkillVolumes(args.allowedConnectorTypes ?? [], framework),
+    ...buildSystemSkillVolumes(
+      args.allowedConnectorTypes ?? [],
+      framework,
+      goalSeedEnabled,
+    ),
     ...buildWorkflowSkillVolumes(
       args.injectSkillVolumes.workflowNames,
       framework,
@@ -1402,7 +1434,8 @@ interface ModelProviderEnvironmentRow {
   readonly encryptedValue: string | null;
 }
 
-interface ResolvableModelProviderEnvironmentRow extends ModelProviderEnvironmentRow {
+interface ResolvableModelProviderEnvironmentRow
+  extends ModelProviderEnvironmentRow {
   readonly type: ModelProviderType;
 }
 
@@ -3249,7 +3282,13 @@ async function buildStoredExecutionContext(args: {
       userTimezone: args.userTimezone,
       firewalls: permissions?.firewalls,
       networkPolicies: permissions?.networkPolicies,
-      disallowedTools: args.body.disallowedTools,
+      disallowedTools: withBuiltinGoalDisabled(
+        args.body.disallowedTools,
+        isFeatureEnabled(
+          FeatureSwitchKey.GoalWorkflows,
+          args.featureSwitchContext,
+        ),
+      ),
       tools: args.body.tools,
       settings: args.body.settings,
       experimentalProfile: runnerProfile(args.resolved.content),
@@ -4100,7 +4139,14 @@ function prepareRunContext(
         bodyArtifacts: body.artifacts,
       });
       const additionalVolumes = mergeAdditionalVolumes({
-        prepend: buildInjectedSkillVolumes(args, framework),
+        prepend: buildInjectedSkillVolumes(
+          args,
+          framework,
+          isFeatureEnabled(
+            FeatureSwitchKey.GoalWorkflows,
+            featureSwitchContext,
+          ),
+        ),
         base: body.additionalVolumes ?? resolved.additionalVolumes,
       });
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -510,9 +510,9 @@ function skillMountPath(
 const BUILTIN_GOAL_DISALLOWED_TOOLS = ["goal", "update_goal"] as const;
 
 function withBuiltinGoalDisabled(
-  disallowedTools: readonly string[] | undefined,
+  disallowedTools: string[] | undefined,
   goalSeedEnabled: boolean,
-): readonly string[] | undefined {
+): string[] | undefined {
   if (!goalSeedEnabled) {
     return disallowedTools;
   }
@@ -1434,8 +1434,7 @@ interface ModelProviderEnvironmentRow {
   readonly encryptedValue: string | null;
 }
 
-interface ResolvableModelProviderEnvironmentRow
-  extends ModelProviderEnvironmentRow {
+interface ResolvableModelProviderEnvironmentRow extends ModelProviderEnvironmentRow {
   readonly type: ModelProviderType;
 }
 

--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -47,6 +47,14 @@ export const SEED_SKILLS: readonly string[] = [
   "status-updates",
 ] as const;
 
+/**
+ * The `goal` skill is NOT an unconditional seed. It is injected only when the
+ * `GoalWorkflows` feature switch is enabled (see agent-run-create.service.ts).
+ * Its body is still synced to storage by cron-sync-skills like every other
+ * skill in the repo, so a conditional mount resolves without listing it here.
+ */
+export const GOAL_SKILL_NAME = "goal";
+
 export function getSeedSkillNames(): string[] {
   const connectorSkillNames = CONNECTOR_TYPE_KEYS.filter((type) => {
     return Object.values(CONNECTOR_TYPES[type].authMethods).some((method) => {


### PR DESCRIPTION
## Summary

Wires up the new **`goal`** seed skill (added in vm0-ai/vm0-skills#275, already merged) so it is injected into a Zero run **only when the `GoalWorkflows` (`goal`) feature switch is enabled**, and when it is, suppresses the harness's **built-in `/goal`** (Claude Code & Codex) so the vm0 goal skill takes over.

This is the second half of the change. The skill body already lives in vm0-skills and is synced to storage by `cron-sync-skills` like every other skill in the repo, so no entry is added to the always-on `SEED_SKILLS` list — `goal` is mounted conditionally instead.

## Changes

- **`turbo/packages/core/src/zero-seed-skills.ts`**: add `GOAL_SKILL_NAME = "goal"`, documented as a conditionally-injected skill (not an always-on seed).
- **`turbo/apps/api/src/signals/services/agent-run-create.service.ts`**:
  - Thread a `goalSeedEnabled` flag through `buildInjectedSkillVolumes` → `buildSystemSkillVolumes`; when true, append `goal` to the mounted system skill volumes. The flag is `isFeatureEnabled(FeatureSwitchKey.GoalWorkflows, featureSwitchContext)`, evaluated where the run's skill volumes are assembled (`featureSwitchContext` is already in scope there).
  - Add `withBuiltinGoalDisabled()` which, when the switch is on, appends the built-in goal tool identifiers to the run's `disallowedTools` (the existing pass-through to `--disallowed-tools` / `VM0_DISALLOWED_TOOLS`). Disallowing a name the active harness does not expose is a harmless no-op.

## Disabling the built-in `/goal` — note for review

The built-in goal command lives in the upstream harness binaries (Codex's `codex-rs/ext/goal` exposes an `update_goal` tool + the `/goal` command; Claude Code ships its own). vm0 has no goal-specific runner code, so the lever used here is the existing `disallowedTools` pass-through, seeded with `["goal", "update_goal"]` and centralized in `BUILTIN_GOAL_DISALLOWED_TOOLS`. If a harness uses a different identifier, it is a one-line addition to that constant — please confirm the exact built-in identifier(s) for each harness.

## Ordering / dependency

- vm0-skills#275 (the `goal/SKILL.md` body) is **merged**. `cron-sync-skills` syncs the whole repo, so `goal` storage exists by the time this deploys.
- `GoalWorkflows` defaults off, so behavior is unchanged for everyone except users/orgs that have opted into the `goal` switch.

## Verification

Server-side composition change gated behind a default-off switch. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)