### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.183"
+CLAUDE_CODE_VERSION="2.1.185"
 CODEX_CLI_VERSION="0.141.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.28.0"
+AGENT_BROWSER_VERSION="0.29.1"
 PNPM_VERSION="11.8.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updates pinned rootfs tool versions in `crates/runner/scripts/build-template.sh`.

Updated versions:
- Claude Code: `2.1.183` -> `2.1.185`
- agent-browser: `0.28.0` -> `0.29.1`

Checked and left unchanged:
- Go: `1.26.4`
- Codex CLI: `0.141.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- pnpm: `11.8.0`
- Node.js: `24.x` LTS series
- PostgreSQL: `18` series

## Validation

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`

Note: `shellcheck` is not installed in this runtime.