### PR TITLE
feat: show connector reconnect reasons by default

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -238,28 +238,7 @@ describe("connectors page", () => {
     ).toBeTruthy();
   });
 
-  it("keeps reconnect reasons hidden when the feature switch is disabled", async () => {
-    mockConnectors([
-      {
-        type: "github",
-        connectionStatus: "reconnect-required",
-        reconnectReason: "authorization_expired_or_revoked",
-      },
-    ]);
-
-    detachedSetupPage({ context, path: "/connectors" });
-
-    await waitFor(() => {
-      expect(
-        within(connectorCardByLabel("GitHub")).getByText("Connection expired"),
-      ).toBeInTheDocument();
-    });
-    expect(
-      reconnectReasonHelpButton(connectorCardByLabel("GitHub")),
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows reconnect reason tooltip help when the feature switch is enabled", async () => {
+  it("shows reconnect reason tooltip help for known reconnect causes", async () => {
     mockConnectors([
       {
         type: "github",
@@ -271,9 +250,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorReconnectReasons]: true,
-      },
     });
 
     let helpButton: HTMLElement | null = null;
@@ -311,9 +287,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorReconnectReasons]: true,
-      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -20,7 +20,6 @@ import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
@@ -83,7 +82,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 // Callback ref that attaches scroll tracking while enabled. Each call returns
 // a fresh ref callback; React only invokes it when the underlying element
@@ -311,7 +309,6 @@ function GlobalConnectorCard({
   onDisconnect,
   onReviewScopes,
   isDisconnecting,
-  showReconnectReasonTooltip,
 }: {
   connector: ConnectorTypeWithStatus;
   isPolling: boolean;
@@ -319,13 +316,11 @@ function GlobalConnectorCard({
   onDisconnect: () => void;
   onReviewScopes?: () => void;
   isDisconnecting: boolean;
-  showReconnectReasonTooltip: boolean;
 }) {
   const status = (() => {
     const connectionStatus = connectorCurrentConnectionStatus(connector);
-    const reconnectReasonTooltip = showReconnectReasonTooltip
-      ? connectorReconnectReasonTooltipText(connector)
-      : null;
+    const reconnectReasonTooltip =
+      connectorReconnectReasonTooltipText(connector);
     if (isPolling) {
       const standaloneHint = isStandaloneMode()
         ? " Switch back here after completing sign-in."
@@ -638,9 +633,6 @@ export function ZeroConnectorsPage() {
   const activeTab = useGet(connectorsPageTab$);
   const setActiveTab = useSet(setConnectorsPageTab$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
-  const features = useLastResolved(featureSwitch$);
-  const showReconnectReasonTooltip =
-    features?.[FeatureSwitchKey.ConnectorReconnectReasons] ?? false;
   const openCreateCustom = useSet(openCustomConnectorCreateDialog$);
   const activeCategoryId = useGet(activeConnectorCategoryId$);
   const attachScrollTracking = useSet(attachConnectorCategoryScrollTracking$);
@@ -727,7 +719,6 @@ export function ZeroConnectorsPage() {
         connector={optimisticConnector}
         isPolling={isPolling}
         isDisconnecting={disconnecting}
-        showReconnectReasonTooltip={showReconnectReasonTooltip}
         onConnect={() => {
           return connectHandler(c.type);
         }}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,7 +53,6 @@ export enum FeatureSwitchKey {
   MemoryDevRefresh = "memoryDevRefresh",
   PresentationHtmlPptxDownload = "presentationHtmlPptxDownload",
   ChatSlashWorkflowCommands = "chatSlashWorkflowCommands",
-  ConnectorReconnectReasons = "connectorReconnectReasons",
   AutomationWebhookTriggers = "automationWebhookTriggers",
   AutomationMultiTrigger = "automationMultiTrigger",
   GoalWorkflows = "goalWorkflows",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -301,13 +301,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ConnectorReconnectReasons]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Show explanatory tooltip help for connectors that need reconnect.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.AutomationWebhookTriggers]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the ConnectorReconnectReasons feature switch
- show known connector reconnect reason tooltips by default
- keep unknown reconnect causes without tooltip help

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/core lint
- pnpm -F @vm0/connectors lint
- git diff --check
- pre-commit: prettier, knip, turbo run check-types --concurrency=1, commitlint