### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"


### PR DESCRIPTION
## Summary

- Updated the Rust workspace lockfile under `crates/` with `cargo update --verbose`.
- `log` moved from `0.4.32` to `0.4.33`.

## Dependencies not updated

- `generic-array` stayed at `0.14.7` even though `0.14.9` is available. Cargo reports this is blocked by transitive `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"` via the `digest` dependency chain. This is not a direct `Cargo.toml` constraint in this workspace.

## Manual version bumps

- None. No safe direct minor/patch `Cargo.toml` version bumps were needed.

## Test status

- Pass: `cargo test --workspace --jobs 1` from `crates/`.
- Note: the local automation shell had `umask 0002`, which made Rust temp directories group-writable and caused runner permission-guard tests to fail. Re-running with `umask 077` produced a clean pass.
