### PR TITLE
perf: remove metadata-only runtime firewall imports

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -1550,6 +1550,23 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expect(builtinCollision.body.error.message).toContain("api.github.com");
     expect(builtinCollision.body.error.message).toContain("GitHub");
 
+    const builtinTrailingDotCollision =
+      await connectorsApi.requestCreateCustomConnector(
+        admin,
+        {
+          displayName: "Fake GitHub Trailing Dot",
+          prefixes: ["https://api.github.com./v3/"],
+          headerName: "Authorization",
+          headerTemplate: "Bearer {{secret}}",
+        },
+        [400],
+      );
+    expectApiError(builtinTrailingDotCollision.body);
+    expect(builtinTrailingDotCollision.body.error.message).toContain(
+      "api.github.com.",
+    );
+    expect(builtinTrailingDotCollision.body.error.message).toContain("GitHub");
+
     const listed = await connectorsApi.listCustomConnectors(admin);
     expect(
       listed

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-user-permission-grants.test.ts
@@ -5,8 +5,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewalls";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -15,23 +15,26 @@ const FORBIDDEN_RUNTIME_FIREWALL_IMPORTS = [
   "@vm0/connectors/firewalls",
   "@vm0/core/firewalls",
 ] as const;
+const IMPORT_SPECIFIER_PATTERN =
+  /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+function importSpecifiers(source: string): readonly string[] {
+  return [...source.matchAll(IMPORT_SPECIFIER_PATTERN)].map((match) => {
+    return match[1] ?? match[2] ?? match[3] ?? match[4] ?? "";
+  });
 }
 
-function importPattern(specifier: string): RegExp {
-  const escapedSpecifier = escapeRegExp(specifier);
-  const importSpecifier = `${escapedSpecifier}(?:/[^"']*)?`;
-  return new RegExp(
-    `(?:from\\s+["']${importSpecifier}["']|import\\s*\\(\\s*["']${importSpecifier}["']\\s*\\)|import\\s+["']${importSpecifier}["']|require\\s*\\(\\s*["']${importSpecifier}["']\\s*\\))`,
-  );
+function importsSpecifier(source: string, specifier: string): boolean {
+  return importSpecifiers(source).some((importedSpecifier) => {
+    return (
+      importedSpecifier === specifier ||
+      importedSpecifier.startsWith(`${specifier}/`)
+    );
+  });
 }
 
 describe("firewall metadata import boundary", () => {
   it("matches forbidden runtime firewall import forms", () => {
-    const pattern = importPattern("@vm0/connectors/firewalls");
-
     for (const source of [
       `import { getConnectorFirewall } from "@vm0/connectors/firewalls";`,
       `import type { FirewallConnectorType } from "@vm0/connectors/firewalls";`,
@@ -40,12 +43,17 @@ describe("firewall metadata import boundary", () => {
       `import "@vm0/connectors/firewalls";`,
       `require("@vm0/connectors/firewalls/github.generated");`,
     ]) {
-      expect(source).toMatch(pattern);
+      expect(
+        importsSpecifier(source, "@vm0/connectors/firewalls"),
+      ).toBeTruthy();
     }
 
     expect(
-      `import { loadFirewallPermissionIndex } from "@vm0/connectors/firewall-metadata/server";`,
-    ).not.toMatch(pattern);
+      importsSpecifier(
+        `import { loadFirewallPermissionIndex } from "@vm0/connectors/firewall-metadata/server";`,
+        "@vm0/connectors/firewalls",
+      ),
+    ).toBeFalsy();
   });
 
   it.each(METADATA_ONLY_SERVICES)(
@@ -54,7 +62,7 @@ describe("firewall metadata import boundary", () => {
       const source = readFileSync(resolve(SERVICE_DIR, service), "utf8");
 
       for (const specifier of FORBIDDEN_RUNTIME_FIREWALL_IMPORTS) {
-        expect(source).not.toMatch(importPattern(specifier));
+        expect(importsSpecifier(source, specifier)).toBeFalsy();
       }
     },
   );

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -23,7 +23,7 @@ function escapeRegExp(value: string): string {
 function importPattern(specifier: string): RegExp {
   const escapedSpecifier = escapeRegExp(specifier);
   return new RegExp(
-    `(?:from\\s+["']${escapedSpecifier}["']|import\\s*\\(\\s*["']${escapedSpecifier}["']\\s*\\))`,
+    `(?:from\\s+["']${escapedSpecifier}(?:/[^"']*)?["']|import\\s*\\(\\s*["']${escapedSpecifier}(?:/[^"']*)?["']\\s*\\))`,
   );
 }
 

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SERVICE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const METADATA_ONLY_SERVICES = [
+  "cron-aggregate-insights.service.ts",
+  "zero-custom-connector.service.ts",
+  "zero-user-permission-grants.service.ts",
+  "zero-runs-create.service.ts",
+] as const;
+const FORBIDDEN_RUNTIME_FIREWALL_IMPORTS = [
+  "@vm0/connectors/firewalls",
+  "@vm0/core/firewalls",
+] as const;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+function importPattern(specifier: string): RegExp {
+  const escapedSpecifier = escapeRegExp(specifier);
+  return new RegExp(
+    `(?:from\\s+["']${escapedSpecifier}["']|import\\s*\\(\\s*["']${escapedSpecifier}["']\\s*\\))`,
+  );
+}
+
+describe("firewall metadata import boundary", () => {
+  it.each(METADATA_ONLY_SERVICES)(
+    "%s does not import runtime firewall catalogs",
+    (service) => {
+      const source = readFileSync(resolve(SERVICE_DIR, service), "utf8");
+
+      for (const specifier of FORBIDDEN_RUNTIME_FIREWALL_IMPORTS) {
+        expect(source).not.toMatch(importPattern(specifier));
+      }
+    },
+  );
+});

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -22,8 +22,9 @@ function escapeRegExp(value: string): string {
 
 function importPattern(specifier: string): RegExp {
   const escapedSpecifier = escapeRegExp(specifier);
+  const importSpecifier = `${escapedSpecifier}(?:/[^"']*)?`;
   return new RegExp(
-    `(?:from\\s+["']${escapedSpecifier}(?:/[^"']*)?["']|import\\s*\\(\\s*["']${escapedSpecifier}(?:/[^"']*)?["']\\s*\\))`,
+    `(?:from\\s+["']${importSpecifier}["']|import\\s*\\(\\s*["']${importSpecifier}["']\\s*\\)|import\\s+["']${importSpecifier}["'])`,
   );
 }
 

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -24,7 +24,7 @@ function importPattern(specifier: string): RegExp {
   const escapedSpecifier = escapeRegExp(specifier);
   const importSpecifier = `${escapedSpecifier}(?:/[^"']*)?`;
   return new RegExp(
-    `(?:from\\s+["']${importSpecifier}["']|import\\s*\\(\\s*["']${importSpecifier}["']\\s*\\)|import\\s+["']${importSpecifier}["'])`,
+    `(?:from\\s+["']${importSpecifier}["']|import\\s*\\(\\s*["']${importSpecifier}["']\\s*\\)|import\\s+["']${importSpecifier}["']|require\\s*\\(\\s*["']${importSpecifier}["']\\s*\\))`,
   );
 }
 

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -29,6 +29,25 @@ function importPattern(specifier: string): RegExp {
 }
 
 describe("firewall metadata import boundary", () => {
+  it("matches forbidden runtime firewall import forms", () => {
+    const pattern = importPattern("@vm0/connectors/firewalls");
+
+    for (const source of [
+      `import { getConnectorFirewall } from "@vm0/connectors/firewalls";`,
+      `import type { FirewallConnectorType } from "@vm0/connectors/firewalls";`,
+      `export { getConnectorFirewall } from "@vm0/connectors/firewalls";`,
+      `await import("@vm0/connectors/firewalls/github.generated");`,
+      `import "@vm0/connectors/firewalls";`,
+      `require("@vm0/connectors/firewalls/github.generated");`,
+    ]) {
+      expect(source).toMatch(pattern);
+    }
+
+    expect(
+      `import { loadFirewallPermissionIndex } from "@vm0/connectors/firewall-metadata/server";`,
+    ).not.toMatch(pattern);
+  });
+
   it.each(METADATA_ONLY_SERVICES)(
     "%s does not import runtime firewall catalogs",
     (service) => {

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -1,8 +1,8 @@
 import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
-  type FirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+  isFirewallServerMetadataConnectorType,
+  loadFirewallPermissionIndex,
+  type FirewallServerMetadataConnectorType,
+} from "@vm0/connectors/firewall-metadata/server";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
@@ -41,7 +41,7 @@ type NetworkInsightAction = "ALLOW" | "DENY" | "BLOCK";
 
 interface NetworkInsightRow {
   readonly runId: string;
-  readonly firewallName: FirewallConnectorType;
+  readonly firewallName: FirewallServerMetadataConnectorType;
   readonly firewallPermission: string;
   readonly action: NetworkInsightAction;
 }
@@ -246,27 +246,30 @@ function normalizeDbDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-function getPermissionLabel(
-  firewallName: string,
+type PermissionLabelResolver = (
+  firewallName: FirewallServerMetadataConnectorType,
   permissionName: string,
-): string {
-  const key = `${firewallName}:${permissionName}`;
+) => Promise<string>;
 
-  if (isFirewallConnectorType(firewallName)) {
-    const config = getConnectorFirewall(firewallName);
-    for (const api of config.apis) {
-      if (!api.permissions) {
-        continue;
-      }
-      for (const perm of api.permissions) {
-        if (perm.name === permissionName) {
-          return perm.description ?? key;
-        }
-      }
-    }
-  }
+function createPermissionLabelResolver(): PermissionLabelResolver {
+  const indexes = new Map<
+    FirewallServerMetadataConnectorType,
+    ReturnType<typeof loadFirewallPermissionIndex>
+  >();
 
-  return key;
+  return async (firewallName, permissionName) => {
+    const key = `${firewallName}:${permissionName}`;
+    const cached = indexes.get(firewallName);
+    const load =
+      cached ??
+      (() => {
+        const index = loadFirewallPermissionIndex(firewallName);
+        indexes.set(firewallName, index);
+        return index;
+      })();
+    const index = await load;
+    return index?.permissionDescription(permissionName) ?? key;
+  };
 }
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
@@ -311,7 +314,7 @@ function normalizeNetworkInsightRows(
     const firewallNameValue = value.firewall_name;
     if (
       typeof firewallNameValue !== "string" ||
-      !isFirewallConnectorType(firewallNameValue)
+      !isFirewallServerMetadataConnectorType(firewallNameValue)
     ) {
       invalidFirewallNames++;
       continue;
@@ -427,7 +430,7 @@ async function resolveUserNames(
   return nameMap;
 }
 
-function aggregateNetworkDataPerUser(
+async function aggregateNetworkDataPerUser(
   networkRows: NetworkInsightRow[],
   runIdToInfo: Map<
     string,
@@ -437,7 +440,8 @@ function aggregateNetworkDataPerUser(
       readonly agentName: string;
     }
   >,
-): Map<string, UserNetworkData> {
+  resolvePermissionLabel: PermissionLabelResolver,
+): Promise<Map<string, UserNetworkData>> {
   const userNetworkMap = new Map<string, UserNetworkData>();
 
   for (const row of networkRows) {
@@ -482,23 +486,26 @@ function aggregateNetworkDataPerUser(
     const permKey = hasPermission
       ? `${row.firewallName}:${row.firewallPermission}`
       : row.firewallName;
-    const label = hasPermission
-      ? getPermissionLabel(row.firewallName, row.firewallPermission)
-      : row.firewallName;
-    const permission = userData.permMap.get(permKey) ?? {
-      label,
-      connectorType: row.firewallName,
-      allowed: 0,
-      denied: 0,
-      agentNames: new Set<string>(),
-    };
+    let permission = userData.permMap.get(permKey);
+    if (!permission) {
+      const label = hasPermission
+        ? await resolvePermissionLabel(row.firewallName, row.firewallPermission)
+        : row.firewallName;
+      permission = {
+        label,
+        connectorType: row.firewallName,
+        allowed: 0,
+        denied: 0,
+        agentNames: new Set<string>(),
+      };
+      userData.permMap.set(permKey, permission);
+    }
     if (row.action === "ALLOW") {
       permission.allowed++;
     } else {
       permission.denied++;
     }
     permission.agentNames.add(info.agentName);
-    userData.permMap.set(permKey, permission);
   }
 
   return userNetworkMap;
@@ -1175,9 +1182,10 @@ function queryWindowNetworkData(
     }
 
     return {
-      userNetworkMap: aggregateNetworkDataPerUser(
+      userNetworkMap: await aggregateNetworkDataPerUser(
         normalizedNetworkRows.rows,
         runIdToInfo,
+        createPermissionLabelResolver(),
       ),
       networkRows: rawNetworkRows.length,
       axiomDegraded,

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -1181,12 +1181,15 @@ function queryWindowNetworkData(
       });
     }
 
+    const userNetworkMap = await aggregateNetworkDataPerUser(
+      normalizedNetworkRows.rows,
+      runIdToInfo,
+      createPermissionLabelResolver(),
+    );
+    signal.throwIfAborted();
+
     return {
-      userNetworkMap: await aggregateNetworkDataPerUser(
-        normalizedNetworkRows.rows,
-        runIdToInfo,
-        createPermissionLabelResolver(),
-      ),
+      userNetworkMap,
       networkRows: rawNetworkRows.length,
       axiomDegraded,
     };

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1,10 +1,7 @@
 import { command, computed, type Computed } from "ccstate";
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
-import {
-  getAllBuiltinConnectorHosts,
-  getBuiltinConnectorDisplayName,
-} from "@vm0/connectors/firewalls";
+import { getBuiltinConnectorHostOwner } from "@vm0/connectors/firewall-metadata/server";
 import {
   expandHostWildcardsInBaseUrl,
   validateBaseUrl,
@@ -146,13 +143,12 @@ function validateAndNormalisePrefixes(
   // Reject prefixes whose host collides with a built-in connector. Mitm-level
   // matching is still the final line of defense; this early rejection gives
   // admins a clear message at create time instead of a silent shadow.
-  const builtinHosts = getAllBuiltinConnectorHosts();
   for (const p of normalised) {
     const host = safeUrlParse(p)?.host ?? "";
-    const builtinType = builtinHosts.get(host);
-    if (builtinType) {
+    const builtinOwner = getBuiltinConnectorHostOwner(host);
+    if (builtinOwner) {
       return badRequestMessage(
-        `Host "${host}" is already managed by the ${getBuiltinConnectorDisplayName(builtinType)} connector`,
+        `Host "${host}" is already managed by the ${builtinOwner.label} connector`,
       );
     }
   }

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -451,10 +451,13 @@ async function resolveZeroRunPermissionPolicies(
   );
   signal.throwIfAborted();
 
-  return await resolveFirewallServerMetadataPolicies(
+  const resolved = await resolveFirewallServerMetadataPolicies(
     permissionGrantsToFirewallPolicies(grants),
     [...args.allowedConnectorTypes],
   );
+  signal.throwIfAborted();
+
+  return resolved;
 }
 
 async function loadUserInfo(

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -7,10 +7,9 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
-import {
-  permissionGrantsToFirewallPolicies,
-  resolveFirewallPolicies,
-} from "@vm0/connectors/firewalls";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
+import { resolveFirewallServerMetadataPolicies } from "@vm0/connectors/firewall-metadata/server";
+import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
@@ -440,7 +439,7 @@ async function resolveZeroRunPermissionPolicies(
     readonly checkedAt: Date;
   },
   signal: AbortSignal,
-): Promise<ReturnType<typeof resolveFirewallPolicies>> {
+): Promise<FirewallPolicies | null> {
   const grants = await loadActiveUserPermissionGrants(
     db,
     {
@@ -452,9 +451,10 @@ async function resolveZeroRunPermissionPolicies(
   );
   signal.throwIfAborted();
 
-  return resolveFirewallPolicies(permissionGrantsToFirewallPolicies(grants), [
-    ...args.allowedConnectorTypes,
-  ]);
+  return await resolveFirewallServerMetadataPolicies(
+    permissionGrantsToFirewallPolicies(grants),
+    [...args.allowedConnectorTypes],
+  );
 }
 
 async function loadUserInfo(
@@ -513,9 +513,7 @@ function createRunBody(args: {
   readonly body: ZeroRunCreateBody;
   readonly agent: ZeroAgentRunRecord;
   readonly userInfo: UserInfo;
-  readonly permissionPolicies:
-    | ReturnType<typeof resolveFirewallPolicies>
-    | undefined;
+  readonly permissionPolicies: FirewallPolicies | null | undefined;
   readonly triggerAgentId: string | undefined;
   readonly triggerSource: TriggerSource | undefined;
   readonly appendSystemPrompt: string | undefined;
@@ -558,9 +556,7 @@ function createIntegrationRunBody(args: {
   readonly sessionId: string | undefined;
   readonly agent: ZeroAgentRunRecord;
   readonly userInfo: UserInfo;
-  readonly permissionPolicies:
-    | ReturnType<typeof resolveFirewallPolicies>
-    | undefined;
+  readonly permissionPolicies: FirewallPolicies | null | undefined;
   readonly triggerSource: TriggerSource;
   readonly appendSystemPrompt: string | undefined;
 }) {

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -1,8 +1,5 @@
 import { command } from "ccstate";
-import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+import { loadFirewallPermissionIndex } from "@vm0/connectors/firewall-metadata/server";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -111,27 +108,12 @@ async function findVisibleAgent(
   return agent ?? null;
 }
 
-function validPermissionNames(connectorRef: string): Set<string> | null {
-  if (!isFirewallConnectorType(connectorRef)) {
-    return null;
-  }
-
-  const config = getConnectorFirewall(connectorRef);
-  const names = new Set<string>();
-  for (const api of config.apis) {
-    for (const permission of api.permissions ?? []) {
-      names.add(permission.name);
-    }
-  }
-  return names;
-}
-
-function validateGrantTarget(
+async function validateGrantTarget(
   connectorRef: string,
   permission: string,
-): ValidationErrorResponse | null {
-  const names = validPermissionNames(connectorRef);
-  if (!names) {
+): Promise<ValidationErrorResponse | null> {
+  const index = await loadFirewallPermissionIndex(connectorRef);
+  if (!index) {
     return validationError(`Unknown connector ref: ${connectorRef}`);
   }
 
@@ -139,7 +121,7 @@ function validateGrantTarget(
     return null;
   }
 
-  if (!names.has(permission)) {
+  if (!index.hasPermission(permission)) {
     return validationError(
       `Unknown permission "${permission}" for connector "${connectorRef}"`,
     );
@@ -374,11 +356,11 @@ async function upsertVisibleGrantRow(
   });
 }
 
-function validateApplyUserPermissionGrants(
+async function validateApplyUserPermissionGrants(
   apply: ApplyUserPermissionGrantsRequest,
-): ValidationErrorResponse | null {
-  const names = validPermissionNames(apply.connectorRef);
-  if (!names) {
+): Promise<ValidationErrorResponse | null> {
+  const index = await loadFirewallPermissionIndex(apply.connectorRef);
+  if (!index) {
     return validationError(`Unknown connector ref: ${apply.connectorRef}`);
   }
 
@@ -391,7 +373,7 @@ function validateApplyUserPermissionGrants(
 
     if (
       grant.permission !== UNKNOWN_PERMISSION_GRANT &&
-      !names.has(grant.permission)
+      !index.hasPermission(grant.permission)
     ) {
       return validationError(
         `Unknown permission "${grant.permission}" for connector "${apply.connectorRef}"`,
@@ -527,10 +509,11 @@ export const upsertUserPermissionGrant$ = command(
     args: UpsertUserPermissionGrantArgs,
     signal: AbortSignal,
   ): Promise<UpsertUserPermissionGrantResult> => {
-    const validation = validateGrantTarget(
+    const validation = await validateGrantTarget(
       args.grant.connectorRef,
       args.grant.permission,
     );
+    signal.throwIfAborted();
     if (validation) {
       return validation;
     }
@@ -560,7 +543,8 @@ export const applyUserPermissionGrants$ = command(
     args: ApplyUserPermissionGrantsArgs,
     signal: AbortSignal,
   ): Promise<ApplyUserPermissionGrantsResult> => {
-    const validation = validateApplyUserPermissionGrants(args.apply);
+    const validation = await validateApplyUserPermissionGrants(args.apply);
+    signal.throwIfAborted();
     if (validation) {
       return validation;
     }

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -27,6 +27,7 @@ import {
   getFirewallServerMetadataSummary,
   isFirewallServerMetadataConnectorType,
   loadFirewallPermissionIndex,
+  resolveFirewallServerMetadataPolicies,
 } from "../firewall-metadata/server";
 import {
   getAllBuiltinConnectorHosts,
@@ -416,6 +417,39 @@ describe("firewall metadata", () => {
       expect(index!.type).toBe(type);
       expect(index!.label).toBe(summary.label);
     }
+  });
+
+  it("resolves server metadata policies like runtime helpers", async () => {
+    for (const [type] of runtimeEntries()) {
+      const stored = {
+        [type]: {
+          policies: { __metadata_test__: "deny" as const },
+          unknownPolicy: "deny" as const,
+        },
+      };
+      await expect(
+        resolveFirewallServerMetadataPolicies(null, [type]),
+      ).resolves.toStrictEqual(resolveFirewallPolicies(null, [type]));
+      await expect(
+        resolveFirewallServerMetadataPolicies(stored, [type]),
+      ).resolves.toStrictEqual(resolveFirewallPolicies(stored, [type]));
+    }
+
+    await expect(
+      resolveFirewallServerMetadataPolicies(null, ["cloudinary"]),
+    ).resolves.toBeNull();
+
+    const storedUnknownConnector = {
+      cloudinary: {
+        policies: { read: "deny" as const },
+        unknownPolicy: "allow" as const,
+      },
+    };
+    await expect(
+      resolveFirewallServerMetadataPolicies(storedUnknownConnector, [
+        "cloudinary",
+      ]),
+    ).resolves.toStrictEqual(storedUnknownConnector);
   });
 
   it("keeps summary metadata synchronized with the runtime registry", () => {

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -211,9 +211,13 @@ export async function resolveFirewallServerMetadataPolicies(
   connectors: readonly string[],
 ): Promise<FirewallPolicies | null> {
   let resolved: FirewallPolicies | null = stored;
+  const indexes = await Promise.all(
+    connectors.map((connector) => {
+      return loadFirewallPermissionIndex(connector);
+    }),
+  );
 
-  for (const connector of connectors) {
-    const index = await loadFirewallPermissionIndex(connector);
+  for (const index of indexes) {
     if (!index) {
       continue;
     }

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -1,4 +1,8 @@
-import { UNKNOWN_PERMISSION_GRANT } from "../firewall-types";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
+} from "../firewall-types";
 import {
   createFirewallMetadataPolicyResolver,
   type FirewallMetadataPolicyResolver,
@@ -186,4 +190,46 @@ export async function loadFirewallPermissionIndex(
     });
   permissionIndexCache.set(type, load);
   return await load;
+}
+
+function expandDefaultPolicy(index: FirewallPermissionIndex): {
+  readonly policies: Record<string, FirewallPolicyValue>;
+  readonly unknownPolicy: FirewallPolicyValue;
+} {
+  const policies: Record<string, FirewallPolicyValue> = {};
+  for (const name of index.permissionNames) {
+    policies[name] = index.policyResolver.permission(name);
+  }
+  return {
+    policies,
+    unknownPolicy: index.policyResolver.unknown(),
+  };
+}
+
+export async function resolveFirewallServerMetadataPolicies(
+  stored: FirewallPolicies | null,
+  connectors: readonly string[],
+): Promise<FirewallPolicies | null> {
+  let resolved: FirewallPolicies | null = stored;
+
+  for (const connector of connectors) {
+    const index = await loadFirewallPermissionIndex(connector);
+    if (!index) {
+      continue;
+    }
+
+    const defaults = expandDefaultPolicy(index);
+    const existing = resolved?.[index.type];
+    resolved = {
+      ...(resolved ?? {}),
+      [index.type]: {
+        policies: { ...defaults.policies, ...existing?.policies },
+        ...(existing?.unknownPolicy !== undefined
+          ? { unknownPolicy: existing.unknownPolicy }
+          : { unknownPolicy: defaults.unknownPolicy }),
+      },
+    };
+  }
+
+  return resolved;
 }


### PR DESCRIPTION
## Summary
- add a server metadata policy resolver that expands existing FirewallPolicies without importing runtime firewall catalogs
- migrate metadata-only API services for grant validation, custom connector host collisions, insights labels, and run permission policy resolution to @vm0/connectors/firewall-metadata/server
- add an API import-boundary guard so metadata-only services cannot regress to runtime firewall imports

## Out of scope
- runtime execution manifest construction in agent-run-create.service.ts remains on the runtime firewall catalog for #18116
- compact runtime network policy payloads remain tracked by #18070

Closes #18114

## Tests
- pnpm format
- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-metadata.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-user-permission-grants.test.ts src/signals/routes/__tests__/cron-aggregate-insights.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm -F api check-types
- pnpm -F api lint
- pre-commit hook: pnpm knip; pnpm check-types