### PR TITLE
feat: add goal objective editing, stop reasons, and creation guard

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -154,6 +154,39 @@ describe("auth tokens", () => {
     );
     expect(verifyZeroToken(enabledToken)?.capabilities).toContain("goal:read");
     expect(verifyZeroToken(enabledToken)?.capabilities).toContain("goal:write");
+    expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
+      "goal:update",
+    );
+  });
+
+  it("excludes goal:update for workflow-event runs but keeps goal read/write", () => {
+    const userDrivenToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      "org_zero",
+      { [FeatureSwitchKey.GoalWorkflows]: true },
+      { triggerSource: "web" },
+    );
+    const continuationToken = generateZeroToken(
+      "user_zero",
+      "run_zero",
+      "org_zero",
+      { [FeatureSwitchKey.GoalWorkflows]: true },
+      { triggerSource: "workflow-event" },
+    );
+
+    expect(verifyZeroToken(userDrivenToken)?.capabilities).toContain(
+      "goal:update",
+    );
+    expect(verifyZeroToken(continuationToken)?.capabilities).not.toContain(
+      "goal:update",
+    );
+    expect(verifyZeroToken(continuationToken)?.capabilities).toContain(
+      "goal:read",
+    );
+    expect(verifyZeroToken(continuationToken)?.capabilities).toContain(
+      "goal:write",
+    );
   });
 
   it("gates computer-use capability on an explicit host grant", () => {

--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -155,11 +155,11 @@ describe("auth tokens", () => {
     expect(verifyZeroToken(enabledToken)?.capabilities).toContain("goal:read");
     expect(verifyZeroToken(enabledToken)?.capabilities).toContain("goal:write");
     expect(verifyZeroToken(enabledToken)?.capabilities).toContain(
-      "goal:update",
+      "goal-objective:write",
     );
   });
 
-  it("excludes goal:update for workflow-event runs but keeps goal read/write", () => {
+  it("excludes goal-objective:write for workflow-event runs but keeps goal read/write", () => {
     const userDrivenToken = generateZeroToken(
       "user_zero",
       "run_zero",
@@ -176,10 +176,10 @@ describe("auth tokens", () => {
     );
 
     expect(verifyZeroToken(userDrivenToken)?.capabilities).toContain(
-      "goal:update",
+      "goal-objective:write",
     );
     expect(verifyZeroToken(continuationToken)?.capabilities).not.toContain(
-      "goal:update",
+      "goal-objective:write",
     );
     expect(verifyZeroToken(continuationToken)?.capabilities).toContain(
       "goal:read",

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -4,6 +4,7 @@ import {
   ZERO_CAPABILITIES,
   ZeroCapability,
 } from "@vm0/api-contracts/contracts/composes";
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { z } from "zod";
@@ -27,6 +28,7 @@ const CONDITIONAL_CAPABILITIES = [
   ["banking:read", FeatureSwitchKey.Banking],
   ["goal:read", FeatureSwitchKey.GoalWorkflows],
   ["goal:write", FeatureSwitchKey.GoalWorkflows],
+  ["goal:update", FeatureSwitchKey.GoalWorkflows],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
 const AGENT_EXCLUDED_CAPABILITIES = [
@@ -253,12 +255,23 @@ export function generateZeroToken(
   runId: string,
   orgId: string,
   overrides?: Partial<Record<FeatureSwitchKey, boolean>>,
-  options?: { readonly computerUseHostId?: string },
+  options?: {
+    readonly computerUseHostId?: string;
+    readonly triggerSource?: TriggerSource;
+  },
 ): string {
   const nowSeconds = Math.floor(now() / 1000);
   const capabilities: ZeroCapability[] = [];
   for (const capability of ZERO_CAPABILITIES) {
     if (capability === "computer-use:write" && !options?.computerUseHostId) {
+      continue;
+    }
+    // Goal continuation runs are autonomous and must not edit their own
+    // objective; goal:update is user-driven only.
+    if (
+      capability === "goal:update" &&
+      options?.triggerSource === "workflow-event"
+    ) {
       continue;
     }
     if (

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -28,7 +28,7 @@ const CONDITIONAL_CAPABILITIES = [
   ["banking:read", FeatureSwitchKey.Banking],
   ["goal:read", FeatureSwitchKey.GoalWorkflows],
   ["goal:write", FeatureSwitchKey.GoalWorkflows],
-  ["goal:update", FeatureSwitchKey.GoalWorkflows],
+  ["goal-objective:write", FeatureSwitchKey.GoalWorkflows],
 ] as const satisfies readonly (readonly [ZeroCapability, FeatureSwitchKey])[];
 
 const AGENT_EXCLUDED_CAPABILITIES = [
@@ -267,9 +267,9 @@ export function generateZeroToken(
       continue;
     }
     // Goal continuation runs are autonomous and must not edit their own
-    // objective; goal:update is user-driven only.
+    // objective; goal-objective:write is user-driven only.
     if (
-      capability === "goal:update" &&
+      capability === "goal-objective:write" &&
       options?.triggerSource === "workflow-event"
     ) {
       continue;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -542,6 +542,142 @@ describe("zero goals", () => {
     ]);
   });
 
+  it("edits a goal's objective and token budget", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    await accept(
+      goalsClient().create({
+        headers: headers(fixture),
+        body: { objective: "ship goal workflows" },
+      }),
+      [201],
+    );
+
+    const edited = await accept(
+      goalsClient().edit({
+        headers: headers(fixture, ["goal:update"]),
+        body: { objective: "ship goal workflows v2", tokenBudget: 5_000 },
+      }),
+      [200],
+    );
+    expect(edited.body).toStrictEqual({
+      active: true,
+      objective: "ship goal workflows v2",
+      status: "active",
+      tokenBudget: 5_000,
+    });
+
+    const read = await accept(
+      goalsClient().get({ headers: headers(fixture, ["goal:read"]) }),
+      [200],
+    );
+    expect(read.body).toStrictEqual({
+      active: true,
+      objective: "ship goal workflows v2",
+      status: "active",
+      tokenBudget: 5_000,
+    });
+  });
+
+  it("auto-resumes a blocked goal when edited and clears stopReason", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    await accept(
+      goalsClient().create({
+        headers: headers(fixture),
+        body: { objective: "ship goal workflows" },
+      }),
+      [201],
+    );
+
+    const blocked = await accept(
+      goalsClient().block({ headers: headers(fixture) }),
+      [200],
+    );
+    expect(blocked.body).toMatchObject({
+      status: "blocked",
+      stopReason: "blocked",
+    });
+
+    const edited = await accept(
+      goalsClient().edit({
+        headers: headers(fixture, ["goal:update"]),
+        body: { objective: "resume and keep going" },
+      }),
+      [200],
+    );
+    expect(edited.body).toMatchObject({
+      active: true,
+      objective: "resume and keep going",
+      status: "active",
+    });
+    expect(edited.body.stopReason).toBeUndefined();
+
+    const rows = await loadGoalRows(fixture);
+    expect(rows).toMatchObject({
+      enabled: true,
+      preference: { version: 1, objective: "resume and keep going" },
+    });
+  });
+
+  it("rejects goal edits when the token lacks goal:update", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    await accept(
+      goalsClient().create({
+        headers: headers(fixture),
+        body: { objective: "ship goal workflows" },
+      }),
+      [201],
+    );
+
+    const response = await accept(
+      goalsClient().edit({
+        headers: headers(fixture, ["goal:read", "goal:write"]),
+        body: { objective: "should be forbidden" },
+      }),
+      [403],
+    );
+    expect(response.body.error.message).toContain("goal:update");
+  });
+
+  it("returns 404 when editing with no active goal", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+
+    const response = await accept(
+      goalsClient().edit({
+        headers: headers(fixture, ["goal:update"]),
+        body: { objective: "no goal here" },
+      }),
+      [404],
+    );
+    expect(response.body.error.message).toContain("Goal not found");
+  });
+
+  it("sets stopReason 'blocked' on block and clears it on resume", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    await accept(
+      goalsClient().create({
+        headers: headers(fixture),
+        body: { objective: "ship goal workflows" },
+      }),
+      [201],
+    );
+
+    const blocked = await accept(
+      goalsClient().block({ headers: headers(fixture) }),
+      [200],
+    );
+    expect(blocked.body.stopReason).toBe("blocked");
+    const blockedRows = await loadGoalRows(fixture);
+    expect(blockedRows?.preference).toMatchObject({ stopReason: "blocked" });
+
+    const resumed = await accept(
+      goalsClient().resume({ headers: headers(fixture) }),
+      [200],
+    );
+    expect(resumed.body.stopReason).toBeUndefined();
+    const resumedRows = await loadGoalRows(fixture);
+    expect(resumedRows?.preference).not.toHaveProperty("stopReason");
+  });
+
   it("excludes goal-state markers from a thread's unread state", async () => {
     const fixture = await seedGoalApiFixture({ featureEnabled: true });
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -555,7 +555,7 @@ describe("zero goals", () => {
     const edited = await accept(
       goalsClient().edit({
         headers: headers(fixture, ["goal-objective:write"]),
-        body: { objective: "ship goal workflows v2", tokenBudget: 5_000 },
+        body: { objective: "ship goal workflows v2", tokenBudget: 5000 },
       }),
       [200],
     );
@@ -563,7 +563,7 @@ describe("zero goals", () => {
       active: true,
       objective: "ship goal workflows v2",
       status: "active",
-      tokenBudget: 5_000,
+      tokenBudget: 5000,
     });
 
     const read = await accept(
@@ -574,7 +574,7 @@ describe("zero goals", () => {
       active: true,
       objective: "ship goal workflows v2",
       status: "active",
-      tokenBudget: 5_000,
+      tokenBudget: 5000,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -554,7 +554,7 @@ describe("zero goals", () => {
 
     const edited = await accept(
       goalsClient().edit({
-        headers: headers(fixture, ["goal:update"]),
+        headers: headers(fixture, ["goal-objective:write"]),
         body: { objective: "ship goal workflows v2", tokenBudget: 5_000 },
       }),
       [200],
@@ -599,7 +599,7 @@ describe("zero goals", () => {
 
     const edited = await accept(
       goalsClient().edit({
-        headers: headers(fixture, ["goal:update"]),
+        headers: headers(fixture, ["goal-objective:write"]),
         body: { objective: "resume and keep going" },
       }),
       [200],
@@ -618,7 +618,7 @@ describe("zero goals", () => {
     });
   });
 
-  it("rejects goal edits when the token lacks goal:update", async () => {
+  it("rejects goal edits when the token lacks goal-objective:write", async () => {
     const fixture = await seedGoalApiFixture({ featureEnabled: true });
     await accept(
       goalsClient().create({
@@ -635,7 +635,7 @@ describe("zero goals", () => {
       }),
       [403],
     );
-    expect(response.body.error.message).toContain("goal:update");
+    expect(response.body.error.message).toContain("goal-objective:write");
   });
 
   it("returns 404 when editing with no active goal", async () => {
@@ -643,7 +643,7 @@ describe("zero goals", () => {
 
     const response = await accept(
       goalsClient().edit({
-        headers: headers(fixture, ["goal:update"]),
+        headers: headers(fixture, ["goal-objective:write"]),
         body: { objective: "no goal here" },
       }),
       [404],

--- a/turbo/apps/api/src/signals/routes/zero-goals.ts
+++ b/turbo/apps/api/src/signals/routes/zero-goals.ts
@@ -17,6 +17,7 @@ import {
   blockCurrentGoal,
   completeCurrentGoal,
   createGoalForCurrentThread,
+  editCurrentGoal,
   getCurrentGoal,
   resumeCurrentGoal,
   type GoalResult,
@@ -37,6 +38,13 @@ const goalWriteAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "goal:write",
+  accept: ["zero"],
+} as const;
+
+const goalEditAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "goal:update",
   accept: ["zero"],
 } as const;
 
@@ -150,6 +158,38 @@ const createGoalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return goalErrorResponse(result);
 });
 
+const editGoalBody$ = bodyResultOf(zeroGoalsContract.edit);
+
+const editGoalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = goalAuth(get(organizationAuthContext$));
+  const bodyResult = await get(editGoalBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const db = set(writeDb$);
+  if (!(await goalFeatureEnabled(db, auth))) {
+    return forbidden("Goal workflows are not enabled");
+  }
+  signal.throwIfAborted();
+
+  const result = await editCurrentGoal(db, {
+    ...auth,
+    ...(bodyResult.data.objective !== undefined
+      ? { objective: bodyResult.data.objective }
+      : {}),
+    ...(bodyResult.data.tokenBudget !== undefined
+      ? { tokenBudget: bodyResult.data.tokenBudget }
+      : {}),
+  });
+  signal.throwIfAborted();
+  if (result.kind === "ok") {
+    return { status: 200 as const, body: result.goal };
+  }
+  return goalErrorResponse(result);
+});
+
 const getGoalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = goalAuth(get(organizationAuthContext$));
   const db = set(writeDb$);
@@ -220,6 +260,10 @@ export const zeroGoalsRoutes: readonly RouteEntry[] = [
   {
     route: zeroGoalsContract.create,
     handler: authRoute(goalWriteAuth, createGoalInner$),
+  },
+  {
+    route: zeroGoalsContract.edit,
+    handler: authRoute(goalEditAuth, editGoalInner$),
   },
   {
     route: zeroGoalsContract.get,

--- a/turbo/apps/api/src/signals/routes/zero-goals.ts
+++ b/turbo/apps/api/src/signals/routes/zero-goals.ts
@@ -44,7 +44,7 @@ const goalWriteAuth = {
 const goalEditAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
-  requiredCapability: "goal:update",
+  requiredCapability: "goal-objective:write",
   accept: ["zero"],
 } as const;
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3568,9 +3568,14 @@ function buildRunnerJobPayload(
               args.run.id,
               args.orgId,
               featureSwitchOverrides,
-              args.zeroTokenComputerUseHostId
-                ? { computerUseHostId: args.zeroTokenComputerUseHostId }
-                : undefined,
+              {
+                ...(args.zeroTokenComputerUseHostId
+                  ? { computerUseHostId: args.zeroTokenComputerUseHostId }
+                  : {}),
+                ...(args.body.triggerSource
+                  ? { triggerSource: args.body.triggerSource }
+                  : {}),
+              },
             ),
           )
         : args.body;

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -313,12 +313,18 @@ async function notifyGoalAutoStopped(
   });
 }
 
-async function disableGoalTrigger(db: Db, triggerId: string): Promise<void> {
+// Disables a goal trigger after a user cancel, recording the "paused" stop
+// reason so the goal surfaces as paused rather than agent-blocked.
+async function disableGoalTrigger(
+  db: Db,
+  trigger: { readonly id: string; readonly workflowId: string },
+): Promise<void> {
   const currentTime = nowDate();
   await db
     .update(zeroWorkflowTriggers)
     .set({ enabled: false, nextRunAt: null, updatedAt: currentTime })
-    .where(eq(zeroWorkflowTriggers.id, triggerId));
+    .where(eq(zeroWorkflowTriggers.id, trigger.id));
+  await setGoalStopReason(db, trigger.workflowId, "paused");
 }
 
 /**
@@ -354,9 +360,11 @@ async function resetGoalTriggerFailures(
     .where(eq(zeroWorkflowTriggers.id, triggerId));
 }
 
+// Increments the failure counter and, once the threshold disables the trigger,
+// records the "failed" stop reason so the goal surfaces the auto-stop cause.
 async function incrementGoalTriggerFailures(
   db: Db,
-  triggerId: string,
+  trigger: { readonly id: string; readonly workflowId: string },
 ): Promise<FailureUpdateResult> {
   const currentTime = nowDate();
   const [updated] = await db
@@ -369,7 +377,7 @@ async function incrementGoalTriggerFailures(
     })
     .where(
       and(
-        eq(zeroWorkflowTriggers.id, triggerId),
+        eq(zeroWorkflowTriggers.id, trigger.id),
         eq(zeroWorkflowTriggers.enabled, true),
       ),
     )
@@ -378,14 +386,16 @@ async function incrementGoalTriggerFailures(
       enabled: zeroWorkflowTriggers.enabled,
     });
 
-  if (!updated) {
-    return { disabled: true, consecutiveFailures: MAX_CONSECUTIVE_FAILURES };
+  const result: FailureUpdateResult = updated
+    ? {
+        disabled: !updated.enabled,
+        consecutiveFailures: updated.consecutiveFailures,
+      }
+    : { disabled: true, consecutiveFailures: MAX_CONSECUTIVE_FAILURES };
+  if (result.disabled) {
+    await setGoalStopReason(db, trigger.workflowId, "failed");
   }
-
-  return {
-    disabled: !updated.enabled,
-    consecutiveFailures: updated.consecutiveFailures,
-  };
+  return result;
 }
 
 export const continueGoalIfIdle$ = command(
@@ -424,15 +434,13 @@ export const continueGoalIfIdle$ = command(
     const trigger = goal.trigger;
 
     if (run.status === "cancelled") {
-      await disableGoalTrigger(db, trigger.id);
-      signal.throwIfAborted();
-      await setGoalStopReason(db, trigger.workflowId, "paused");
+      await disableGoalTrigger(db, trigger);
       signal.throwIfAborted();
       return { kind: "paused", triggerId: trigger.id };
     }
 
     if (run.status === "failed" || run.status === "timeout") {
-      const failureUpdate = await incrementGoalTriggerFailures(db, trigger.id);
+      const failureUpdate = await incrementGoalTriggerFailures(db, trigger);
       signal.throwIfAborted();
       if (failureUpdate.disabled) {
         log.warn("Goal continuation auto-stopped after run failures", {
@@ -440,8 +448,6 @@ export const continueGoalIfIdle$ = command(
           runId: run.runId,
           consecutiveFailures: failureUpdate.consecutiveFailures,
         });
-        await setGoalStopReason(db, trigger.workflowId, "failed");
-        signal.throwIfAborted();
         await notifyGoalAutoStopped(db, {
           userId: run.userId,
           chatThreadId: run.chatThreadId,
@@ -492,7 +498,7 @@ export const continueGoalIfIdle$ = command(
       return { kind: "skipped", reason: "previous-run-active" };
     }
 
-    const failureUpdate = await incrementGoalTriggerFailures(db, trigger.id);
+    const failureUpdate = await incrementGoalTriggerFailures(db, trigger);
     signal.throwIfAborted();
     const error = failureMessage(runResult);
     if (failureUpdate.disabled) {
@@ -502,8 +508,6 @@ export const continueGoalIfIdle$ = command(
         consecutiveFailures: failureUpdate.consecutiveFailures,
         error,
       });
-      await setGoalStopReason(db, trigger.workflowId, "failed");
-      signal.throwIfAborted();
       await notifyGoalAutoStopped(db, {
         userId: run.userId,
         chatThreadId: run.chatThreadId,

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -1,6 +1,7 @@
 import {
   zeroGoalPreferenceSchema,
   type ZeroGoalPreference,
+  type ZeroGoalStopReason,
 } from "@vm0/api-contracts/contracts/zero-goals";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
@@ -320,6 +321,29 @@ async function disableGoalTrigger(db: Db, triggerId: string): Promise<void> {
     .where(eq(zeroWorkflowTriggers.id, triggerId));
 }
 
+/**
+ * Record why a goal stopped in the workflow's preference jsonb. The status enum
+ * stays "blocked"; stopReason is an additional field that distinguishes a manual
+ * cancel ("paused") from a repeated-failure auto-stop ("failed").
+ */
+async function setGoalStopReason(
+  db: Db,
+  workflowId: string,
+  stopReason: ZeroGoalStopReason,
+): Promise<void> {
+  const preference = await loadGoalPreference(db, workflowId);
+  if (!preference) {
+    return;
+  }
+  await db
+    .update(zeroWorkflows)
+    .set({
+      preference: { ...preference, stopReason },
+      updatedAt: nowDate(),
+    })
+    .where(eq(zeroWorkflows.id, workflowId));
+}
+
 async function resetGoalTriggerFailures(
   db: Db,
   triggerId: string,
@@ -402,6 +426,8 @@ export const continueGoalIfIdle$ = command(
     if (run.status === "cancelled") {
       await disableGoalTrigger(db, trigger.id);
       signal.throwIfAborted();
+      await setGoalStopReason(db, trigger.workflowId, "paused");
+      signal.throwIfAborted();
       return { kind: "paused", triggerId: trigger.id };
     }
 
@@ -414,6 +440,8 @@ export const continueGoalIfIdle$ = command(
           runId: run.runId,
           consecutiveFailures: failureUpdate.consecutiveFailures,
         });
+        await setGoalStopReason(db, trigger.workflowId, "failed");
+        signal.throwIfAborted();
         await notifyGoalAutoStopped(db, {
           userId: run.userId,
           chatThreadId: run.chatThreadId,
@@ -474,6 +502,8 @@ export const continueGoalIfIdle$ = command(
         consecutiveFailures: failureUpdate.consecutiveFailures,
         error,
       });
+      await setGoalStopReason(db, trigger.workflowId, "failed");
+      signal.throwIfAborted();
       await notifyGoalAutoStopped(db, {
         userId: run.userId,
         chatThreadId: run.chatThreadId,

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -2,7 +2,9 @@ import { randomBytes } from "node:crypto";
 
 import {
   zeroGoalPreferenceSchema,
+  type ZeroGoalPreference,
   type ZeroGoalResponse,
+  type ZeroGoalStopReason,
 } from "@vm0/api-contracts/contracts/zero-goals";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -78,16 +80,66 @@ function generatedGoalName(): string {
 
 function goalResponse(row: ActiveGoalRow): ZeroGoalResponse {
   const preference = zeroGoalPreferenceSchema.parse(row.preference);
+  const status = row.workflowActive
+    ? row.triggerEnabled
+      ? "active"
+      : "blocked"
+    : "complete";
   return {
     active: row.workflowActive,
     objective: preference.objective,
-    status: row.workflowActive
-      ? row.triggerEnabled
-        ? "active"
-        : "blocked"
-      : "complete",
+    status,
     ...(preference.tokenBudget ? { tokenBudget: preference.tokenBudget } : {}),
+    // stopReason is only meaningful while the goal is stopped (trigger
+    // disabled with the workflow still active); otherwise it is omitted.
+    ...(status === "blocked" && preference.stopReason
+      ? { stopReason: preference.stopReason }
+      : {}),
   };
+}
+
+/**
+ * Serialize all state writes for a goal on a chat thread. Every goal mutation
+ * (create, complete, block, resume, edit) acquires this transaction-scoped
+ * advisory lock first so concurrent writers cannot interleave.
+ */
+async function lockGoalThread(
+  tx: Pick<Db, "execute">,
+  threadId: string,
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('goal:' || ${threadId}))`,
+  );
+}
+
+/**
+ * Merge a partial update into the goal workflow's preference jsonb, preserving
+ * the existing objective/tokenBudget unless overridden. `stopReason: null`
+ * clears the field. Keeps `version: 1`.
+ */
+function mergeGoalPreference(
+  current: unknown,
+  update: {
+    readonly objective?: string;
+    readonly tokenBudget?: number;
+    readonly stopReason?: ZeroGoalStopReason | null;
+  },
+): ZeroGoalPreference {
+  const preference = zeroGoalPreferenceSchema.parse(current);
+  const merged: ZeroGoalPreference = {
+    version: 1,
+    objective: update.objective ?? preference.objective,
+  };
+  const tokenBudget = update.tokenBudget ?? preference.tokenBudget;
+  if (tokenBudget !== undefined) {
+    merged.tokenBudget = tokenBudget;
+  }
+  const stopReason =
+    update.stopReason === undefined ? preference.stopReason : update.stopReason;
+  if (stopReason !== null && stopReason !== undefined) {
+    merged.stopReason = stopReason;
+  }
+  return merged;
 }
 
 async function currentGoalContext(
@@ -201,9 +253,7 @@ export async function createGoalForCurrentThread(
       threadId = thread.id;
     }
 
-    await tx.execute(
-      sql`SELECT pg_advisory_xact_lock(hashtext('goal:' || ${threadId}))`,
-    );
+    await lockGoalThread(tx, threadId);
 
     const existing = await loadActiveGoalForThread(tx, {
       orgId: args.orgId,
@@ -339,9 +389,16 @@ export async function completeCurrentGoal(
 
   const completedAt = nowDate();
   await db.transaction(async (tx) => {
+    await lockGoalThread(tx, goal.threadId);
     await tx
       .update(zeroWorkflows)
-      .set({ active: false, updatedAt: completedAt })
+      .set({
+        active: false,
+        preference: mergeGoalPreference(goal.row.preference, {
+          stopReason: null,
+        }),
+        updatedAt: completedAt,
+      })
       .where(eq(zeroWorkflows.id, goal.row.workflowId));
     await tx
       .update(zeroWorkflowTriggers)
@@ -384,22 +441,39 @@ export async function blockCurrentGoal(
   }
 
   const blockedAt = nowDate();
-  await db
-    .update(zeroWorkflowTriggers)
-    .set({ enabled: false, updatedAt: blockedAt })
-    .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
-  // Trigger disabled while the workflow stays active folds to "blocked".
-  await appendGoalStateMarker(db, {
-    chatThreadId: goal.threadId,
-    eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
-    content: null,
+  await db.transaction(async (tx) => {
+    await lockGoalThread(tx, goal.threadId);
+    await tx
+      .update(zeroWorkflows)
+      .set({
+        preference: mergeGoalPreference(goal.row.preference, {
+          stopReason: "blocked",
+        }),
+        updatedAt: blockedAt,
+      })
+      .where(eq(zeroWorkflows.id, goal.row.workflowId));
+    await tx
+      .update(zeroWorkflowTriggers)
+      .set({ enabled: false, updatedAt: blockedAt })
+      .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
+    // Trigger disabled while the workflow stays active folds to "blocked".
+    await appendGoalStateMarker(tx, {
+      chatThreadId: goal.threadId,
+      eventId: GOAL_TRIGGER_INACTIVE_EVENT_ID,
+      content: null,
+    });
   });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
   await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
 
   return {
     kind: "ok",
-    goal: { ...goalResponse(goal.row), active: true, status: "blocked" },
+    goal: {
+      ...goalResponse(goal.row),
+      active: true,
+      status: "blocked",
+      stopReason: "blocked",
+    },
   };
 }
 
@@ -413,15 +487,27 @@ export async function resumeCurrentGoal(
   }
 
   const resumedAt = nowDate();
-  await db
-    .update(zeroWorkflowTriggers)
-    .set({ enabled: true, consecutiveFailures: 0, updatedAt: resumedAt })
-    .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
-  // Trigger re-enabled while the workflow is active folds back to "active".
-  await appendGoalStateMarker(db, {
-    chatThreadId: goal.threadId,
-    eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
-    content: goal.row.triggerId,
+  await db.transaction(async (tx) => {
+    await lockGoalThread(tx, goal.threadId);
+    await tx
+      .update(zeroWorkflows)
+      .set({
+        preference: mergeGoalPreference(goal.row.preference, {
+          stopReason: null,
+        }),
+        updatedAt: resumedAt,
+      })
+      .where(eq(zeroWorkflows.id, goal.row.workflowId));
+    await tx
+      .update(zeroWorkflowTriggers)
+      .set({ enabled: true, consecutiveFailures: 0, updatedAt: resumedAt })
+      .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
+    // Trigger re-enabled while the workflow is active folds back to "active".
+    await appendGoalStateMarker(tx, {
+      chatThreadId: goal.threadId,
+      eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
+      content: goal.row.triggerId,
+    });
   });
   await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
   await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
@@ -429,6 +515,62 @@ export async function resumeCurrentGoal(
   return {
     kind: "ok",
     goal: { ...goalResponse(goal.row), active: true, status: "active" },
+  };
+}
+
+export async function editCurrentGoal(
+  db: Db,
+  args: GoalAuth & {
+    readonly objective?: string;
+    readonly tokenBudget?: number;
+  },
+): Promise<GoalResult> {
+  const goal = await loadGoalForAuth(db, args);
+  if (goal.kind !== "ok") {
+    return goal;
+  }
+
+  // Editing a blocked goal (trigger disabled, workflow active) auto-resumes it:
+  // re-enable the trigger, reset the failure counter, and clear stopReason.
+  const autoResume = !goal.row.triggerEnabled;
+  const editedAt = nowDate();
+  const nextPreference = mergeGoalPreference(goal.row.preference, {
+    ...(args.objective !== undefined ? { objective: args.objective } : {}),
+    ...(args.tokenBudget !== undefined
+      ? { tokenBudget: args.tokenBudget }
+      : {}),
+    ...(autoResume ? { stopReason: null } : {}),
+  });
+
+  await db.transaction(async (tx) => {
+    await lockGoalThread(tx, goal.threadId);
+    await tx
+      .update(zeroWorkflows)
+      .set({ preference: nextPreference, updatedAt: editedAt })
+      .where(eq(zeroWorkflows.id, goal.row.workflowId));
+    if (autoResume) {
+      await tx
+        .update(zeroWorkflowTriggers)
+        .set({ enabled: true, consecutiveFailures: 0, updatedAt: editedAt })
+        .where(eq(zeroWorkflowTriggers.id, goal.row.triggerId));
+      // Trigger re-enabled while the workflow is active folds back to "active".
+      await appendGoalStateMarker(tx, {
+        chatThreadId: goal.threadId,
+        eventId: GOAL_TRIGGER_ACTIVE_EVENT_ID,
+        content: goal.row.triggerId,
+      });
+    }
+  });
+  await publishChatThreadAutomationsChangedSafely(args.userId, goal.threadId);
+  await publishChatThreadMessageCreatedSafely(args.userId, goal.threadId);
+
+  return {
+    kind: "ok",
+    goal: goalResponse({
+      ...goal.row,
+      preference: nextPreference,
+      triggerEnabled: goal.row.triggerEnabled || autoResume,
+    }),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -427,7 +427,13 @@ export async function completeCurrentGoal(
 
   return {
     kind: "ok",
-    goal: { ...goalResponse(goal.row), active: false, status: "complete" },
+    goal: goalResponse({
+      ...goal.row,
+      workflowActive: false,
+      preference: mergeGoalPreference(goal.row.preference, {
+        stopReason: null,
+      }),
+    }),
   };
 }
 
@@ -468,12 +474,13 @@ export async function blockCurrentGoal(
 
   return {
     kind: "ok",
-    goal: {
-      ...goalResponse(goal.row),
-      active: true,
-      status: "blocked",
-      stopReason: "blocked",
-    },
+    goal: goalResponse({
+      ...goal.row,
+      triggerEnabled: false,
+      preference: mergeGoalPreference(goal.row.preference, {
+        stopReason: "blocked",
+      }),
+    }),
   };
 }
 
@@ -514,7 +521,13 @@ export async function resumeCurrentGoal(
 
   return {
     kind: "ok",
-    goal: { ...goalResponse(goal.row), active: true, status: "active" },
+    goal: goalResponse({
+      ...goal.row,
+      triggerEnabled: true,
+      preference: mergeGoalPreference(goal.row.preference, {
+        stopReason: null,
+      }),
+    }),
   };
 }
 

--- a/turbo/apps/cli/src/commands/zero/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/goal/__tests__/index.test.ts
@@ -60,6 +60,38 @@ describe("zero goal command", () => {
     );
   });
 
+  it("edits a goal and prints the JSON response", async () => {
+    const edited = {
+      active: true,
+      objective: "ship goal workflows v2",
+      status: "active",
+      tokenBudget: 5000,
+    };
+    server.use(
+      http.patch("http://localhost:3000/api/zero/goal", async ({ request }) => {
+        await expect(request.json()).resolves.toStrictEqual({
+          objective: "ship goal workflows v2",
+          tokenBudget: 5000,
+        });
+        return HttpResponse.json(edited);
+      }),
+    );
+
+    await zeroGoalCommand.parseAsync([
+      "node",
+      "cli",
+      "edit",
+      "--objective",
+      "ship goal workflows v2",
+      "--token-budget",
+      "5000",
+    ]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      edited,
+    );
+  });
+
   it("gets the current goal", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/goal", () => {

--- a/turbo/apps/cli/src/commands/zero/goal/index.ts
+++ b/turbo/apps/cli/src/commands/zero/goal/index.ts
@@ -4,6 +4,7 @@ import {
   blockGoal,
   completeGoal,
   createGoal,
+  editGoal,
   getGoal,
   resumeGoal,
 } from "../../../lib/api";
@@ -14,29 +15,59 @@ interface CreateOptions {
   readonly tokenBudget?: number;
 }
 
+interface EditOptions {
+  readonly objective?: string;
+  readonly tokenBudget?: number;
+}
+
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value));
 }
 
+function parseTokenBudget(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError("--token-budget must be a positive integer");
+  }
+  return parsed;
+}
+
 const createCommand = new Command()
   .name("create")
-  .description("Create a persistent goal for the current thread")
-  .requiredOption("--objective <text>", "Goal objective")
-  .option("--token-budget <tokens>", "Optional token budget", (value) => {
-    const parsed = Number(value);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      throw new InvalidArgumentError(
-        "--token-budget must be a positive integer",
-      );
-    }
-    return parsed;
-  })
+  .description(
+    "Create a persistent goal for the current thread. Create a goal ONLY when the user explicitly asks for a persistent, autonomous, cross-turn task; do not infer a goal from an ordinary one-off request.",
+  )
+  .requiredOption(
+    "--objective <text>",
+    "Goal objective. Set a goal ONLY on an explicit user request for autonomous cross-turn work; never infer one from a one-off request.",
+  )
+  .option("--token-budget <tokens>", "Optional token budget", parseTokenBudget)
   .action(
     withErrorHandler(async (options: CreateOptions) => {
       printJson(
         await createGoal({
           objective: options.objective,
           ...(options.tokenBudget ? { tokenBudget: options.tokenBudget } : {}),
+        }),
+      );
+    }),
+  );
+
+const editCommand = new Command()
+  .name("edit")
+  .description("Edit the current thread goal's objective or token budget")
+  .option("--objective <text>", "New goal objective")
+  .option("--token-budget <tokens>", "New token budget", parseTokenBudget)
+  .action(
+    withErrorHandler(async (options: EditOptions) => {
+      printJson(
+        await editGoal({
+          ...(options.objective !== undefined
+            ? { objective: options.objective }
+            : {}),
+          ...(options.tokenBudget !== undefined
+            ? { tokenBudget: options.tokenBudget }
+            : {}),
         }),
       );
     }),
@@ -82,6 +113,7 @@ export const zeroGoalCommand = new Command()
   .name("goal")
   .description("Manage the current thread goal")
   .addCommand(createCommand)
+  .addCommand(editCommand)
   .addCommand(getCommand)
   .addCommand(completeCommand)
   .addCommand(blockCommand)

--- a/turbo/apps/cli/src/lib/api/domains/zero-goals.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-goals.ts
@@ -2,6 +2,7 @@ import { initClient } from "@ts-rest/core";
 import {
   zeroGoalsContract,
   type ZeroGoalCreateRequest,
+  type ZeroGoalEditRequest,
   type ZeroGoalResponse,
 } from "@vm0/api-contracts/contracts/zero-goals";
 import { getClientConfig, handleError } from "../core/client-factory";
@@ -14,6 +15,16 @@ export async function createGoal(
   const result = await client.create({ body });
   if (result.status === 201) return result.body;
   handleError(result, "Failed to create goal");
+}
+
+export async function editGoal(
+  body: ZeroGoalEditRequest,
+): Promise<ZeroGoalResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroGoalsContract, config);
+  const result = await client.edit({ body });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to edit goal");
 }
 
 export async function getGoal(): Promise<ZeroGoalResponse> {

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -129,6 +129,7 @@ export {
 // Domain modules - Zero Goals
 export {
   createGoal,
+  editGoal,
   getGoal,
   completeGoal,
   blockGoal,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
@@ -40,8 +40,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 28 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(28);
+  it("should have exactly 29 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(29);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {
@@ -101,6 +101,7 @@ describe("ZERO_CAPABILITIES", () => {
   it("should include goal read and write capabilities", () => {
     expect(ZERO_CAPABILITIES).toContain("goal:read");
     expect(ZERO_CAPABILITIES).toContain("goal:write");
+    expect(ZERO_CAPABILITIES).toContain("goal-objective:write");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -47,6 +47,7 @@ export const ZERO_CAPABILITIES = [
   "automation:delete",
   "goal:read",
   "goal:write",
+  "goal:update",
   "github:read",
   "github:write",
   "slack:write",
@@ -99,6 +100,7 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     },
     "goal:read": { group: "Goals", label: "Read thread goals" },
     "goal:write": { group: "Goals", label: "Create and update thread goals" },
+    "goal:update": { group: "Goals", label: "Edit a thread goal's objective" },
     "github:read": {
       group: "Integrations",
       label: "Download GitHub files",

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -47,7 +47,7 @@ export const ZERO_CAPABILITIES = [
   "automation:delete",
   "goal:read",
   "goal:write",
-  "goal:update",
+  "goal-objective:write",
   "github:read",
   "github:write",
   "slack:write",
@@ -100,7 +100,10 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     },
     "goal:read": { group: "Goals", label: "Read thread goals" },
     "goal:write": { group: "Goals", label: "Create and update thread goals" },
-    "goal:update": { group: "Goals", label: "Edit a thread goal's objective" },
+    "goal-objective:write": {
+      group: "Goals",
+      label: "Edit a thread goal's objective",
+    },
     "github:read": {
       group: "Integrations",
       label: "Download GitHub files",

--- a/turbo/packages/api-contracts/src/contracts/zero-goals.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-goals.ts
@@ -7,10 +7,14 @@ const c = initContract();
 export const zeroGoalStatusSchema = z.enum(["active", "blocked", "complete"]);
 export type ZeroGoalStatus = z.infer<typeof zeroGoalStatusSchema>;
 
+export const zeroGoalStopReasonSchema = z.enum(["paused", "blocked", "failed"]);
+export type ZeroGoalStopReason = z.infer<typeof zeroGoalStopReasonSchema>;
+
 export const zeroGoalPreferenceSchema = z.object({
   version: z.literal(1),
   objective: z.string().min(1),
   tokenBudget: z.number().int().positive().optional(),
+  stopReason: zeroGoalStopReasonSchema.optional(),
 });
 export type ZeroGoalPreference = z.infer<typeof zeroGoalPreferenceSchema>;
 
@@ -20,11 +24,18 @@ export const zeroGoalCreateRequestSchema = z.object({
 });
 export type ZeroGoalCreateRequest = z.infer<typeof zeroGoalCreateRequestSchema>;
 
+export const zeroGoalEditRequestSchema = z.object({
+  objective: z.string().min(1).max(20_000).optional(),
+  tokenBudget: z.number().int().positive().optional(),
+});
+export type ZeroGoalEditRequest = z.infer<typeof zeroGoalEditRequestSchema>;
+
 export const zeroGoalResponseSchema = z.object({
   active: z.boolean(),
   objective: z.string(),
   status: zeroGoalStatusSchema,
   tokenBudget: z.number().int().positive().optional(),
+  stopReason: zeroGoalStopReasonSchema.optional(),
 });
 export type ZeroGoalResponse = z.infer<typeof zeroGoalResponseSchema>;
 
@@ -42,6 +53,20 @@ export const zeroGoalsContract = c.router({
       409: apiErrorSchema,
     },
     summary: "Create a persistent goal for the current thread",
+  },
+  edit: {
+    method: "PATCH",
+    path: "/api/zero/goal",
+    headers: authHeadersSchema,
+    body: zeroGoalEditRequestSchema,
+    responses: {
+      200: zeroGoalResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Edit the current thread goal's objective or token budget",
   },
   get: {
     method: "GET",

--- a/turbo/packages/db/src/schema/zero-workflow.ts
+++ b/turbo/packages/db/src/schema/zero-workflow.ts
@@ -29,6 +29,7 @@ export interface ZeroGoalPreference {
   readonly version: 1;
   readonly objective: string;
   readonly tokenBudget?: number;
+  readonly stopReason?: "paused" | "blocked" | "failed";
 }
 
 export type ZeroWorkflowPreference = ZeroGoalPreference;


### PR DESCRIPTION
## What

Implements the agreed goal-feature evolution (design: deep research + grill-me, compared against Codex `codex-rs/ext/goal/`). Four items:

**1. Objective editing while running (user-side only)**
- New `goal-objective:write` capability, split from `goal:write` (which keeps create/complete/block/resume).
- `PATCH /api/zero/goal` + `zero goal edit --objective "..." [--token-budget N]`.
- Gated by trigger source: `triggerSource` is threaded into `generateZeroToken`; `goal-objective:write` is **withheld only from goal-continuation runs** (`triggerSource: "workflow-event"`) so a goal cannot rewrite its own objective. All other sources get it — no frontend change needed (user tells the agent "change the goal to X" in a normal run).
- Editing a `blocked` goal **auto-resumes** it (re-enables the trigger, resets `consecutive_failures`).

**2. Richer status lifecycle (no new column)**
- A `stopReason` (`paused` | `blocked` | `failed`) is stored in the `preference` jsonb and surfaced in the response, distinguishing a user cancel (`paused`), an agent `zero goal block` (`blocked`), and a 3-consecutive-failure auto-stop (`failed`). The `status` enum stays `active`/`blocked`/`complete`.

**3. Continuation safety**
- The `pg_advisory_xact_lock('goal:'+threadId)` now wraps **every** state write (create/complete/block/resume/edit), not just create — the vm0 analog of Codex's per-thread goal-mutation semaphore.

**4. Anti-inference guard**
- `zero goal create` help now states a goal must only be created on an explicit user request, never inferred from a one-off task. (The matching `goal/SKILL.md` guard is in the companion PR below.)

## Tests

Integration tests at the route and CLI entry points: edit success (objective + tokenBudget); edit auto-resumes a blocked goal and clears `stopReason`; 403 without `goal-objective:write`; 404 with no goal; `block` sets `stopReason: "blocked"` and `resume` clears it; token mint grants `goal-objective:write` for `web` but excludes it for `workflow-event`; `zero goal edit` CLI.

## Related

Companion: vm0-ai/vm0-skills#276 (goal SKILL.md anti-inference guard) — should land first so cron-sync materializes the updated skill body before this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
