### PR TITLE
fix(sandbox-fc): harden runtime socket namespace

### DIFF
--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -41,7 +41,10 @@ pub struct SnapshotConfig {
     pub drive_bind_path: PathBuf,
     /// Workspace drive path recorded in the snapshot's Firecracker config.
     pub workspace_drive_bind_path: PathBuf,
-    /// Vsock directory recorded in the snapshot's Firecracker config (bind mount target).
+    /// Vsock directory recorded in the snapshot's Firecracker config.
+    ///
+    /// Restore expects this to be the private runtime bind target
+    /// `/run/vm0/sock/<snapshot-id>/vsock`.
     pub vsock_bind_dir: PathBuf,
 }
 

--- a/crates/sandbox-fc/src/control/server.rs
+++ b/crates/sandbox-fc/src/control/server.rs
@@ -24,6 +24,7 @@ use crate::exec_result_compat::{
 };
 use crate::guest_operations::{GuestOperationStartError, GuestOperationStartGate};
 use crate::park_coordinator::ParkCoordinator;
+use crate::runtime_dirs::set_private_runtime_socket_mode;
 
 const RUNNER_EXEC_CAPTURE_LIMIT_BYTES: u32 = 7 * 1024 * 1024;
 const CONTROL_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -257,6 +258,10 @@ pub(crate) fn bind_server(
 
 fn bind_unix_listener(sock_path: &Path) -> io::Result<UnixListener> {
     let listener = std::os::unix::net::UnixListener::bind(sock_path)?;
+    if let Err(e) = set_private_runtime_socket_mode(sock_path) {
+        remove_socket_path(sock_path);
+        return Err(e);
+    }
     if let Err(e) = listener.set_nonblocking(true) {
         remove_socket_path(sock_path);
         return Err(e);

--- a/crates/sandbox-fc/src/control/server/tests.rs
+++ b/crates/sandbox-fc/src/control/server/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use std::future::Future;
+use std::os::unix::fs::PermissionsExt;
 
 use base64::Engine;
 use sandbox::SandboxExecTermination;
@@ -19,6 +20,7 @@ use crate::control::{
 use crate::park_coordinator::{
     CoordinatorState, DirtyReason, ParkCoordinator, PrepareParkEvidence,
 };
+use crate::runtime_dirs::PRIVATE_RUNTIME_SOCKET_MODE;
 
 type GuestState = Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>;
 
@@ -195,6 +197,20 @@ fn bind_test_server(
     guest_operations: GuestOperationStartGate,
 ) -> io::Result<BoundControlServer> {
     bind_server(sock_path, guest_operations, test_termination_handle())
+}
+
+#[tokio::test]
+async fn bind_server_sets_private_socket_mode() {
+    let fixture = ControlServerFixture::new();
+    let _server = fixture.bind_default().unwrap();
+
+    let mode = std::fs::symlink_metadata(&fixture.sock_path)
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+
+    assert_eq!(mode, PRIVATE_RUNTIME_SOCKET_MODE);
 }
 
 #[test]

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -28,6 +28,7 @@ use crate::factory::leak_cleaner::LeakCleaner;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
+use crate::runtime_dirs::prepare_private_socket_dir;
 use crate::sandbox::{FirecrackerSandbox, FirecrackerSandboxInit};
 use crate::workspace_drive_image::prepare_workspace_drive_image;
 
@@ -310,12 +311,12 @@ impl SandboxFactory for FirecrackerFactory {
                 let sock_result = match clean_stale_sock_dir(&id, sock_paths.dir()) {
                     Ok(()) => {
                         tx.track_sock_dir(sock_paths.dir().to_owned());
-                        tokio::fs::create_dir_all(sock_paths.vsock_dir())
-                            .await
-                            .map_err(|e| SandboxError::Initialization {
+                        prepare_private_socket_dir(&sock_paths).map_err(|e| {
+                            SandboxError::Initialization {
                                 phase: SandboxInitializationPhase::SandboxAllocation,
-                                message: format!("mkdir vsock dir: {e}"),
-                            })
+                                message: format!("prepare sock dir: {e}"),
+                            }
+                        })
                     }
                     Err(e) => Err(e),
                 };

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -28,7 +28,7 @@ use crate::factory::leak_cleaner::LeakCleaner;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
-use crate::runtime_dirs::prepare_private_socket_dir;
+use crate::runtime_dirs::prepare_runtime_socket_dir;
 use crate::sandbox::{FirecrackerSandbox, FirecrackerSandboxInit};
 use crate::workspace_drive_image::prepare_workspace_drive_image;
 
@@ -311,7 +311,7 @@ impl SandboxFactory for FirecrackerFactory {
                 let sock_result = match clean_stale_sock_dir(&id, sock_paths.dir()) {
                     Ok(()) => {
                         tx.track_sock_dir(sock_paths.dir().to_owned());
-                        prepare_private_socket_dir(&sock_paths).map_err(|e| {
+                        prepare_runtime_socket_dir(&sock_paths).map_err(|e| {
                             SandboxError::Initialization {
                                 phase: SandboxInitializationPhase::SandboxAllocation,
                                 message: format!("prepare sock dir: {e}"),

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -40,6 +40,7 @@ mod paths;
 mod prerequisites;
 mod process;
 mod runtime;
+mod runtime_dirs;
 mod sandbox;
 mod snapshot;
 mod workspace_drive_image;

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use crate::SnapshotConfig;
 
 /// Base directory for runtime sockets under `/run`.
-/// Created with mode 1777 (world-writable + sticky bit) by `prerequisites.rs`.
+/// Created and validated as a private runtime namespace by `prerequisites.rs`.
 pub const RUNTIME_DIR: &str = "/run/vm0";
 
 /// Runtime paths under `/run/vm0/`.

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use crate::SnapshotConfig;
 
 /// Base directory for runtime sockets under `/run`.
-/// Created and validated as a private runtime namespace by `prerequisites.rs`.
+/// Created and validated as an owner-writable runtime namespace by `prerequisites.rs`.
 pub const RUNTIME_DIR: &str = "/run/vm0";
 
 /// Runtime paths under `/run/vm0/`.

--- a/crates/sandbox-fc/src/paths.rs
+++ b/crates/sandbox-fc/src/paths.rs
@@ -35,6 +35,11 @@ impl RuntimePaths {
         }
     }
 
+    #[cfg(test)]
+    pub fn with_dir_for_test(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
     /// Socket base directory: `/run/vm0/sock/`.
     pub fn sock_base(&self) -> PathBuf {
         self.base_dir.join("sock")

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -549,7 +549,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_namespace_creates_private_runtime_and_sock_dirs() {
+    fn runtime_namespace_creates_traversable_runtime_and_sock_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let runtime_dir = tmp.path().join("vm0");
         let sock_base = runtime_dir.join("sock");

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -8,7 +8,7 @@ use sandbox::SandboxError;
 
 use crate::config::SnapshotConfig;
 use crate::paths::{RUNTIME_DIR, RuntimePaths};
-use crate::runtime_dirs::ensure_private_runtime_dir;
+use crate::runtime_dirs::ensure_traversable_runtime_dir;
 
 /// Common inputs needed for prerequisite checks.
 ///
@@ -288,21 +288,21 @@ fn required_commands_for_groups<'a>(command_groups: &[&'a [&'a str]]) -> Vec<&'a
     commands
 }
 
-/// Create and validate the private runtime socket namespace.
+/// Create and validate the owner-writable runtime socket namespace.
 fn ensure_runtime_namespace(errors: &mut Vec<String>) {
     let runtime = RuntimePaths::new();
     ensure_runtime_namespace_at(Path::new(RUNTIME_DIR), &runtime.sock_base(), errors);
 }
 
 fn ensure_runtime_namespace_at(runtime_dir: &Path, sock_base: &Path, errors: &mut Vec<String>) {
-    if let Err(e) = ensure_private_runtime_dir(runtime_dir) {
+    if let Err(e) = ensure_traversable_runtime_dir(runtime_dir) {
         errors.push(format!(
             "failed to prepare runtime dir {}: {e}",
             runtime_dir.display()
         ));
         return;
     }
-    if let Err(e) = ensure_private_runtime_dir(sock_base) {
+    if let Err(e) = ensure_traversable_runtime_dir(sock_base) {
         errors.push(format!(
             "failed to prepare runtime sock dir {}: {e}",
             sock_base.display()
@@ -558,8 +558,8 @@ mod tests {
         ensure_runtime_namespace_at(&runtime_dir, &sock_base, &mut errors);
 
         assert_no_errors(&errors);
-        assert_eq!(mode(&runtime_dir), 0o700);
-        assert_eq!(mode(&sock_base), 0o700);
+        assert_eq!(mode(&runtime_dir), 0o711);
+        assert_eq!(mode(&sock_base), 0o711);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -7,7 +7,8 @@ use nix::unistd::{AccessFlags, eaccess};
 use sandbox::SandboxError;
 
 use crate::config::SnapshotConfig;
-use crate::paths::RUNTIME_DIR;
+use crate::paths::{RUNTIME_DIR, RuntimePaths};
+use crate::runtime_dirs::ensure_private_runtime_dir;
 
 /// Common inputs needed for prerequisite checks.
 ///
@@ -79,7 +80,7 @@ pub(crate) async fn check_prerequisites(
     check_kvm(&mut errors);
     let commands = required_commands(config.mode);
     check_required_commands(&commands, &mut errors);
-    ensure_runtime_dir(&mut errors);
+    ensure_runtime_namespace(&mut errors);
 
     prerequisite_result(errors)
 }
@@ -287,14 +288,25 @@ fn required_commands_for_groups<'a>(command_groups: &[&'a [&'a str]]) -> Vec<&'a
     commands
 }
 
-/// Create `/run/vm0` with mode 1777 (world-writable + sticky bit) if needed.
-fn ensure_runtime_dir(errors: &mut Vec<String>) {
-    if let Err(e) = std::fs::create_dir_all(RUNTIME_DIR) {
-        errors.push(format!("failed to create {RUNTIME_DIR}: {e}"));
+/// Create and validate the private runtime socket namespace.
+fn ensure_runtime_namespace(errors: &mut Vec<String>) {
+    let runtime = RuntimePaths::new();
+    ensure_runtime_namespace_at(Path::new(RUNTIME_DIR), &runtime.sock_base(), errors);
+}
+
+fn ensure_runtime_namespace_at(runtime_dir: &Path, sock_base: &Path, errors: &mut Vec<String>) {
+    if let Err(e) = ensure_private_runtime_dir(runtime_dir) {
+        errors.push(format!(
+            "failed to prepare runtime dir {}: {e}",
+            runtime_dir.display()
+        ));
         return;
     }
-    if let Err(e) = std::fs::set_permissions(RUNTIME_DIR, std::fs::Permissions::from_mode(0o1777)) {
-        errors.push(format!("failed to chmod {RUNTIME_DIR}: {e}"));
+    if let Err(e) = ensure_private_runtime_dir(sock_base) {
+        errors.push(format!(
+            "failed to prepare runtime sock dir {}: {e}",
+            sock_base.display()
+        ));
     }
 }
 
@@ -422,6 +434,14 @@ mod tests {
         );
     }
 
+    fn mode(path: &Path) -> u32 {
+        std::fs::symlink_metadata(path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777
+    }
+
     fn snapshot_config() -> SnapshotConfig {
         SnapshotConfig {
             snapshot_path: PathBuf::from("/tmp/snapshot.bin"),
@@ -526,6 +546,37 @@ mod tests {
             required_commands_for_groups(&[NETWORK_COMMANDS]),
             vec!["ip", "iptables", "iptables-save", "sysctl"]
         );
+    }
+
+    #[test]
+    fn runtime_namespace_creates_private_runtime_and_sock_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("vm0");
+        let sock_base = runtime_dir.join("sock");
+        let mut errors = Vec::new();
+
+        ensure_runtime_namespace_at(&runtime_dir, &sock_base, &mut errors);
+
+        assert_no_errors(&errors);
+        assert_eq!(mode(&runtime_dir), 0o700);
+        assert_eq!(mode(&sock_base), 0o700);
+    }
+
+    #[test]
+    fn runtime_namespace_reports_unsafe_sock_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("vm0");
+        let sock_base = runtime_dir.join("sock");
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&runtime_dir).unwrap();
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &sock_base).unwrap();
+        let mut errors = Vec::new();
+
+        ensure_runtime_namespace_at(&runtime_dir, &sock_base, &mut errors);
+
+        assert_error_contains(&errors, "failed to prepare runtime sock dir");
+        assert_error_contains(&errors, "is a symlink");
     }
 
     #[test]

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -12,6 +12,7 @@ use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::factory::FirecrackerFactory;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
+use crate::runtime_dirs::checked_runtime_sock_dir;
 
 /// Firecracker-backed sandbox runtime.
 ///
@@ -64,7 +65,10 @@ impl FirecrackerRuntime {
     }
 
     fn to_firecracker_config(&self, config: FactoryConfig) -> sandbox::Result<FirecrackerConfig> {
-        let snapshot = config.snapshot.map(|s| Self::resolve_snapshot(&s));
+        let snapshot = match config.snapshot.as_ref() {
+            Some(snapshot_ref) => Some(Self::resolve_snapshot(snapshot_ref)?),
+            None => None,
+        };
         Ok(FirecrackerConfig {
             binary_path: config.binary_path,
             kernel_path: config.kernel_path,
@@ -77,19 +81,24 @@ impl FirecrackerRuntime {
         })
     }
 
-    fn resolve_snapshot(snapshot_ref: &SnapshotRef) -> SnapshotConfig {
+    fn resolve_snapshot(snapshot_ref: &SnapshotRef) -> sandbox::Result<SnapshotConfig> {
         let output = SnapshotOutputPaths::new(snapshot_ref.output_dir.clone());
         let work = SandboxPaths::new(output.work_dir());
         let runtime = RuntimePaths::new();
-        let sock = SockPaths::new(runtime.sock_dir(&snapshot_ref.hash));
-        SnapshotConfig {
+        let sock_dir = checked_runtime_sock_dir(&runtime, &snapshot_ref.hash).map_err(|e| {
+            SandboxError::Configuration {
+                message: format!("snapshot socket id: {e}"),
+            }
+        })?;
+        let sock = SockPaths::new(sock_dir);
+        Ok(SnapshotConfig {
             snapshot_path: output.snapshot(),
             memory_path: output.memory(),
             cow_path: output.cow(),
             drive_bind_path: work.cow_device_bind(),
             workspace_drive_bind_path: work.workspace_device_bind(),
             vsock_bind_dir: sock.vsock_dir(),
-        }
+        })
     }
 }
 
@@ -140,5 +149,49 @@ impl RuntimeProvider for FirecrackerRuntimeProvider {
         config: sandbox::RuntimeConfig,
     ) -> sandbox::Result<Box<dyn SandboxRuntime>> {
         Ok(Box::new(FirecrackerRuntime::new(config).await?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_snapshot_rejects_invalid_socket_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snapshot_ref = SnapshotRef {
+            output_dir: tmp.path().join("snapshot"),
+            hash: "../snapshot".into(),
+        };
+
+        let err = FirecrackerRuntime::resolve_snapshot(&snapshot_ref).unwrap_err();
+
+        match err {
+            SandboxError::Configuration { message } => {
+                assert!(message.contains("snapshot socket id"), "got: {message}");
+                assert!(
+                    message.contains("runtime socket id must be"),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected configuration error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_snapshot_uses_checked_runtime_socket_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hash = "a".repeat(64);
+        let snapshot_ref = SnapshotRef {
+            output_dir: tmp.path().join("snapshot"),
+            hash: hash.clone(),
+        };
+
+        let snapshot = FirecrackerRuntime::resolve_snapshot(&snapshot_ref).unwrap();
+
+        assert_eq!(
+            snapshot.vsock_bind_dir,
+            RuntimePaths::new().sock_dir(&hash).join("vsock")
+        );
     }
 }

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -1,5 +1,6 @@
 use std::fs::DirBuilder;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
 use std::path::{Component, Path};
 
@@ -8,6 +9,28 @@ use nix::unistd::{AccessFlags, eaccess, geteuid};
 use crate::paths::{RuntimePaths, SockPaths};
 
 pub(crate) const PRIVATE_RUNTIME_DIR_MODE: u32 = 0o700;
+const MAX_UNIX_SOCKET_PATH_BYTES: usize = 107;
+
+pub(crate) fn checked_runtime_sock_dir(
+    runtime_paths: &RuntimePaths,
+    sock_id: &str,
+) -> io::Result<std::path::PathBuf> {
+    validate_runtime_sock_id(sock_id)?;
+    let sock_dir = runtime_paths.sock_dir(sock_id);
+    let sock_paths = SockPaths::new(sock_dir.clone());
+    let vsock_path = sock_paths.vsock();
+    let vsock_path_len = vsock_path.as_os_str().as_bytes().len();
+    if vsock_path_len > MAX_UNIX_SOCKET_PATH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "runtime socket id {sock_id:?} makes vsock path too long: {} bytes (max {})",
+                vsock_path_len, MAX_UNIX_SOCKET_PATH_BYTES
+            ),
+        ));
+    }
+    Ok(sock_dir)
+}
 
 pub(crate) fn ensure_private_runtime_dir(path: &Path) -> io::Result<()> {
     create_private_dir_if_missing(path)?;
@@ -147,6 +170,36 @@ fn runtime_dir_owner_is_trusted(owner_uid: u32, effective_uid: u32) -> bool {
     owner_uid == 0 || owner_uid == effective_uid
 }
 
+fn validate_runtime_sock_id(sock_id: &str) -> io::Result<()> {
+    if sock_id.is_empty() {
+        return Err(invalid_runtime_sock_id(sock_id));
+    }
+    if !sock_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'))
+    {
+        return Err(invalid_runtime_sock_id(sock_id));
+    }
+
+    let mut components = Path::new(sock_id).components();
+    let Some(Component::Normal(_)) = components.next() else {
+        return Err(invalid_runtime_sock_id(sock_id));
+    };
+    if components.next().is_some() {
+        return Err(invalid_runtime_sock_id(sock_id));
+    }
+    Ok(())
+}
+
+fn invalid_runtime_sock_id(sock_id: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+            "runtime socket id must be a single non-empty ASCII path segment using only letters, digits, '.', '-', and '_': {sock_id:?}"
+        ),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::{PermissionsExt, symlink};
@@ -219,6 +272,57 @@ mod tests {
 
         assert_eq!(mode(sock_paths.dir()), PRIVATE_RUNTIME_DIR_MODE);
         assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn checked_runtime_sock_dir_accepts_safe_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_paths = RuntimePaths::with_dir_for_test(tmp.path().to_path_buf());
+
+        let sock_dir = checked_runtime_sock_dir(&runtime_paths, "snapshot-test_1.2").unwrap();
+
+        assert_eq!(sock_dir, tmp.path().join("sock").join("snapshot-test_1.2"));
+    }
+
+    #[test]
+    fn checked_runtime_sock_dir_rejects_parent_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_paths = RuntimePaths::with_dir_for_test(tmp.path().to_path_buf());
+
+        let err = checked_runtime_sock_dir(&runtime_paths, "../snapshot").unwrap_err();
+
+        assert!(err.to_string().contains("runtime socket id must be"));
+    }
+
+    #[test]
+    fn checked_runtime_sock_dir_rejects_nested_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_paths = RuntimePaths::with_dir_for_test(tmp.path().to_path_buf());
+
+        let err = checked_runtime_sock_dir(&runtime_paths, "root/snapshot").unwrap_err();
+
+        assert!(err.to_string().contains("runtime socket id must be"));
+    }
+
+    #[test]
+    fn checked_runtime_sock_dir_rejects_unsafe_character() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_paths = RuntimePaths::with_dir_for_test(tmp.path().to_path_buf());
+
+        let err = checked_runtime_sock_dir(&runtime_paths, "snapshot test").unwrap_err();
+
+        assert!(err.to_string().contains("runtime socket id must be"));
+    }
+
+    #[test]
+    fn checked_runtime_sock_dir_rejects_overlong_vsock_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_paths = RuntimePaths::with_dir_for_test(tmp.path().to_path_buf());
+        let sock_id = "a".repeat(200);
+
+        let err = checked_runtime_sock_dir(&runtime_paths, &sock_id).unwrap_err();
+
+        assert!(err.to_string().contains("vsock path too long"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -18,17 +18,7 @@ pub(crate) fn checked_runtime_sock_dir(
     validate_runtime_sock_id(sock_id)?;
     let sock_dir = runtime_paths.sock_dir(sock_id);
     let sock_paths = SockPaths::new(sock_dir.clone());
-    let vsock_path = sock_paths.vsock();
-    let vsock_path_len = vsock_path.as_os_str().as_bytes().len();
-    if vsock_path_len > MAX_UNIX_SOCKET_PATH_BYTES {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!(
-                "runtime socket id {sock_id:?} makes vsock path too long: {} bytes (max {})",
-                vsock_path_len, MAX_UNIX_SOCKET_PATH_BYTES
-            ),
-        ));
-    }
+    validate_runtime_vsock_path_len(sock_id, &sock_paths.vsock())?;
     Ok(sock_dir)
 }
 
@@ -59,7 +49,7 @@ fn prepare_private_vsock_dir_under(sock_base: &Path, vsock_bind_dir: &Path) -> i
     })?;
 
     let mut components = relative.components();
-    let Some(Component::Normal(_sock_id)) = components.next() else {
+    let Some(Component::Normal(sock_id)) = components.next() else {
         return Err(invalid_vsock_dir_shape(sock_base, vsock_bind_dir));
     };
     let Some(Component::Normal(vsock_dir)) = components.next() else {
@@ -68,6 +58,11 @@ fn prepare_private_vsock_dir_under(sock_base: &Path, vsock_bind_dir: &Path) -> i
     if vsock_dir != "vsock" || components.next().is_some() {
         return Err(invalid_vsock_dir_shape(sock_base, vsock_bind_dir));
     }
+    let sock_id = sock_id
+        .to_str()
+        .ok_or_else(|| invalid_runtime_sock_id(&sock_id.to_string_lossy()))?;
+    validate_runtime_sock_id(sock_id)?;
+    validate_runtime_vsock_path_len(sock_id, &vsock_bind_dir.join("vsock.sock"))?;
 
     ensure_private_runtime_dir(sock_base)?;
     let sock_dir = vsock_bind_dir.parent().ok_or_else(|| {
@@ -187,6 +182,20 @@ fn validate_runtime_sock_id(sock_id: &str) -> io::Result<()> {
     };
     if components.next().is_some() {
         return Err(invalid_runtime_sock_id(sock_id));
+    }
+    Ok(())
+}
+
+fn validate_runtime_vsock_path_len(sock_id: &str, vsock_path: &Path) -> io::Result<()> {
+    let vsock_path_len = vsock_path.as_os_str().as_bytes().len();
+    if vsock_path_len > MAX_UNIX_SOCKET_PATH_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "runtime socket id {sock_id:?} makes vsock path too long: {} bytes (max {})",
+                vsock_path_len, MAX_UNIX_SOCKET_PATH_BYTES
+            ),
+        ));
     }
     Ok(())
 }
@@ -383,6 +392,28 @@ mod tests {
         let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
 
         assert!(err.to_string().contains("is outside socket base"));
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_rejects_unsafe_socket_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let vsock_dir = sock_base.join("snapshot test").join("vsock");
+
+        let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
+
+        assert!(err.to_string().contains("runtime socket id must be"));
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_rejects_overlong_vsock_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let vsock_dir = sock_base.join("a".repeat(200)).join("vsock");
+
+        let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
+
+        assert!(err.to_string().contains("vsock path too long"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -8,7 +8,12 @@ use nix::unistd::{AccessFlags, eaccess, geteuid};
 
 use crate::paths::{RuntimePaths, SockPaths};
 
+/// Owner-only runtime directory, used for guest vsock bind targets.
 pub(crate) const PRIVATE_RUNTIME_DIR_MODE: u32 = 0o700;
+/// Owner-writable directory that lets host tools stat known socket paths.
+pub(crate) const TRAVERSABLE_RUNTIME_DIR_MODE: u32 = 0o711;
+/// Owner-only runtime socket mode, used under traversable runtime dirs.
+pub(crate) const PRIVATE_RUNTIME_SOCKET_MODE: u32 = 0o600;
 const MAX_UNIX_SOCKET_PATH_BYTES: usize = 107;
 
 pub(crate) fn checked_runtime_sock_dir(
@@ -23,17 +28,37 @@ pub(crate) fn checked_runtime_sock_dir(
 }
 
 pub(crate) fn ensure_private_runtime_dir(path: &Path) -> io::Result<()> {
-    create_private_dir_if_missing(path)?;
-    validate_private_runtime_dir(path)
+    ensure_runtime_dir_with_mode(path, PRIVATE_RUNTIME_DIR_MODE)
+}
+
+pub(crate) fn ensure_traversable_runtime_dir(path: &Path) -> io::Result<()> {
+    ensure_runtime_dir_with_mode(path, TRAVERSABLE_RUNTIME_DIR_MODE)
 }
 
 pub(crate) fn prepare_private_socket_dir(sock_paths: &SockPaths) -> io::Result<()> {
-    ensure_private_runtime_dir(sock_paths.dir())?;
+    ensure_traversable_runtime_dir(sock_paths.dir())?;
     ensure_private_runtime_dir(&sock_paths.vsock_dir())
 }
 
 pub(crate) fn prepare_private_runtime_vsock_dir(vsock_bind_dir: &Path) -> io::Result<()> {
     prepare_private_vsock_dir_under(&RuntimePaths::new().sock_base(), vsock_bind_dir)
+}
+
+pub(crate) fn set_private_runtime_socket_mode(path: &Path) -> io::Result<()> {
+    std::fs::set_permissions(
+        path,
+        std::fs::Permissions::from_mode(PRIVATE_RUNTIME_SOCKET_MODE),
+    )
+    .map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!(
+                "chmod runtime socket {} to {:04o}: {e}",
+                path.display(),
+                PRIVATE_RUNTIME_SOCKET_MODE
+            ),
+        )
+    })
 }
 
 fn prepare_private_vsock_dir_under(sock_base: &Path, vsock_bind_dir: &Path) -> io::Result<()> {
@@ -64,7 +89,7 @@ fn prepare_private_vsock_dir_under(sock_base: &Path, vsock_bind_dir: &Path) -> i
     validate_runtime_sock_id(sock_id)?;
     validate_runtime_vsock_path_len(sock_id, &vsock_bind_dir.join("vsock.sock"))?;
 
-    ensure_private_runtime_dir(sock_base)?;
+    ensure_traversable_runtime_dir(sock_base)?;
     let sock_dir = vsock_bind_dir.parent().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -74,7 +99,7 @@ fn prepare_private_vsock_dir_under(sock_base: &Path, vsock_bind_dir: &Path) -> i
             ),
         )
     })?;
-    ensure_private_runtime_dir(sock_dir)?;
+    ensure_traversable_runtime_dir(sock_dir)?;
     ensure_private_runtime_dir(vsock_bind_dir)
 }
 
@@ -89,36 +114,41 @@ fn invalid_vsock_dir_shape(sock_base: &Path, vsock_bind_dir: &Path) -> io::Error
     )
 }
 
-fn create_private_dir_if_missing(path: &Path) -> io::Result<()> {
+fn ensure_runtime_dir_with_mode(path: &Path, mode: u32) -> io::Result<()> {
+    create_runtime_dir_if_missing(path, mode)?;
+    validate_runtime_dir(path, mode)
+}
+
+fn create_runtime_dir_if_missing(path: &Path, mode: u32) -> io::Result<()> {
     let mut builder = DirBuilder::new();
-    builder.mode(PRIVATE_RUNTIME_DIR_MODE);
+    builder.mode(mode);
     match builder.create(path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
         Err(e) => Err(io::Error::new(
             e.kind(),
-            format!("create private runtime dir {}: {e}", path.display()),
+            format!("create runtime dir {}: {e}", path.display()),
         )),
     }
 }
 
-fn validate_private_runtime_dir(path: &Path) -> io::Result<()> {
+fn validate_runtime_dir(path: &Path, expected_mode: u32) -> io::Result<()> {
     let metadata = std::fs::symlink_metadata(path).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("stat private runtime dir {}: {e}", path.display()),
+            format!("stat runtime dir {}: {e}", path.display()),
         )
     })?;
     let file_type = metadata.file_type();
     if file_type.is_symlink() {
         return Err(io::Error::other(format!(
-            "private runtime dir is a symlink: {}",
+            "runtime dir is a symlink: {}",
             path.display()
         )));
     }
     if !file_type.is_dir() {
         return Err(io::Error::other(format!(
-            "private runtime dir is not a directory: {}",
+            "runtime dir is not a directory: {}",
             path.display()
         )));
     }
@@ -126,35 +156,33 @@ fn validate_private_runtime_dir(path: &Path) -> io::Result<()> {
     let euid = geteuid().as_raw();
     if !runtime_dir_owner_is_trusted(metadata.uid(), euid) {
         return Err(io::Error::other(format!(
-            "private runtime dir has untrusted owner uid {}: {}",
+            "runtime dir has untrusted owner uid {}: {}",
             metadata.uid(),
             path.display()
         )));
     }
 
     let mode = metadata.permissions().mode() & 0o7777;
-    if mode != PRIVATE_RUNTIME_DIR_MODE {
-        std::fs::set_permissions(
-            path,
-            std::fs::Permissions::from_mode(PRIVATE_RUNTIME_DIR_MODE),
-        )
-        .map_err(|e| {
-            io::Error::new(
-                e.kind(),
-                format!(
-                    "chmod private runtime dir {} to {:04o}: {e}",
-                    path.display(),
-                    PRIVATE_RUNTIME_DIR_MODE
-                ),
-            )
-        })?;
+    if mode != expected_mode {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(expected_mode)).map_err(
+            |e| {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "chmod runtime dir {} to {:04o}: {e}",
+                        path.display(),
+                        expected_mode
+                    ),
+                )
+            },
+        )?;
     }
 
     eaccess(path, AccessFlags::W_OK | AccessFlags::X_OK).map_err(|e| {
         io::Error::new(
             io::ErrorKind::PermissionDenied,
             format!(
-                "private runtime dir is not writable/traversable: {}: {e}",
+                "runtime dir is not writable/traversable: {}: {e}",
                 path.display()
             ),
         )
@@ -236,6 +264,17 @@ mod tests {
     }
 
     #[test]
+    fn ensure_traversable_runtime_dir_creates_missing_dir_with_traversable_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("runtime");
+
+        ensure_traversable_runtime_dir(&path).unwrap();
+
+        assert!(path.is_dir());
+        assert_eq!(mode(&path), TRAVERSABLE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
     fn ensure_private_runtime_dir_normalizes_existing_trusted_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("runtime");
@@ -273,13 +312,25 @@ mod tests {
     }
 
     #[test]
+    fn set_private_runtime_socket_mode_sets_owner_only_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_path = tmp.path().join("runtime.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        set_private_runtime_socket_mode(&socket_path).unwrap();
+
+        assert_eq!(mode(&socket_path), PRIVATE_RUNTIME_SOCKET_MODE);
+    }
+
+    #[test]
     fn prepare_private_socket_dir_creates_sock_and_vsock_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let sock_paths = SockPaths::new(tmp.path().join("sandbox"));
 
         prepare_private_socket_dir(&sock_paths).unwrap();
 
-        assert_eq!(mode(sock_paths.dir()), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(sock_paths.dir()), TRAVERSABLE_RUNTIME_DIR_MODE);
         assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
     }
 
@@ -349,7 +400,7 @@ mod tests {
 
         prepare_private_socket_dir(&sock_paths).unwrap();
 
-        assert_eq!(mode(sock_paths.dir()), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(sock_paths.dir()), TRAVERSABLE_RUNTIME_DIR_MODE);
         assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
     }
 
@@ -361,8 +412,11 @@ mod tests {
 
         prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap();
 
-        assert_eq!(mode(&sock_base), PRIVATE_RUNTIME_DIR_MODE);
-        assert_eq!(mode(&sock_base.join("snapshot")), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(&sock_base), TRAVERSABLE_RUNTIME_DIR_MODE);
+        assert_eq!(
+            mode(&sock_base.join("snapshot")),
+            TRAVERSABLE_RUNTIME_DIR_MODE
+        );
         assert_eq!(mode(&vsock_dir), PRIVATE_RUNTIME_DIR_MODE);
     }
 

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -1,11 +1,11 @@
 use std::fs::DirBuilder;
 use std::io;
 use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
-use std::path::Path;
+use std::path::{Component, Path};
 
 use nix::unistd::{AccessFlags, eaccess, geteuid};
 
-use crate::paths::SockPaths;
+use crate::paths::{RuntimePaths, SockPaths};
 
 pub(crate) const PRIVATE_RUNTIME_DIR_MODE: u32 = 0o700;
 
@@ -17,6 +17,58 @@ pub(crate) fn ensure_private_runtime_dir(path: &Path) -> io::Result<()> {
 pub(crate) fn prepare_private_socket_dir(sock_paths: &SockPaths) -> io::Result<()> {
     ensure_private_runtime_dir(sock_paths.dir())?;
     ensure_private_runtime_dir(&sock_paths.vsock_dir())
+}
+
+pub(crate) fn prepare_private_runtime_vsock_dir(vsock_bind_dir: &Path) -> io::Result<()> {
+    prepare_private_vsock_dir_under(&RuntimePaths::new().sock_base(), vsock_bind_dir)
+}
+
+fn prepare_private_vsock_dir_under(sock_base: &Path, vsock_bind_dir: &Path) -> io::Result<()> {
+    let relative = vsock_bind_dir.strip_prefix(sock_base).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "runtime vsock dir {} is outside socket base {}",
+                vsock_bind_dir.display(),
+                sock_base.display()
+            ),
+        )
+    })?;
+
+    let mut components = relative.components();
+    let Some(Component::Normal(_sock_id)) = components.next() else {
+        return Err(invalid_vsock_dir_shape(sock_base, vsock_bind_dir));
+    };
+    let Some(Component::Normal(vsock_dir)) = components.next() else {
+        return Err(invalid_vsock_dir_shape(sock_base, vsock_bind_dir));
+    };
+    if vsock_dir != "vsock" || components.next().is_some() {
+        return Err(invalid_vsock_dir_shape(sock_base, vsock_bind_dir));
+    }
+
+    ensure_private_runtime_dir(sock_base)?;
+    let sock_dir = vsock_bind_dir.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "runtime vsock dir has no parent: {}",
+                vsock_bind_dir.display()
+            ),
+        )
+    })?;
+    ensure_private_runtime_dir(sock_dir)?;
+    ensure_private_runtime_dir(vsock_bind_dir)
+}
+
+fn invalid_vsock_dir_shape(sock_base: &Path, vsock_bind_dir: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+            "runtime vsock dir must be {}/<id>/vsock: {}",
+            sock_base.display(),
+            vsock_bind_dir.display()
+        ),
+    )
 }
 
 fn create_private_dir_if_missing(path: &Path) -> io::Result<()> {
@@ -186,6 +238,69 @@ mod tests {
 
         assert_eq!(mode(sock_paths.dir()), PRIVATE_RUNTIME_DIR_MODE);
         assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_creates_private_runtime_vsock_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let vsock_dir = sock_base.join("snapshot").join("vsock");
+
+        prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap();
+
+        assert_eq!(mode(&sock_base), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(&sock_base.join("snapshot")), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(&vsock_dir), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_rejects_symlinked_runtime_sock_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let target = tmp.path().join("target");
+        let snapshot_dir = sock_base.join("snapshot");
+        let vsock_dir = snapshot_dir.join("vsock");
+        std::fs::create_dir(&sock_base).unwrap();
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &snapshot_dir).unwrap();
+
+        let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
+
+        assert!(err.to_string().contains("is a symlink"));
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_rejects_path_outside_sock_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let vsock_dir = tmp.path().join("other").join("snapshot").join("vsock");
+
+        let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
+
+        assert!(err.to_string().contains("is outside socket base"));
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_rejects_parent_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let vsock_dir = sock_base.join("snapshot").join("..").join("vsock");
+
+        let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
+
+        assert!(err.to_string().contains("must be"));
+    }
+
+    #[test]
+    fn prepare_private_vsock_dir_under_rejects_wrong_leaf() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_base = tmp.path().join("sock");
+        let vsock_dir = sock_base.join("snapshot").join("api");
+
+        let err = prepare_private_vsock_dir_under(&sock_base, &vsock_dir).unwrap_err();
+
+        assert!(err.to_string().contains("must be"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -35,7 +35,7 @@ pub(crate) fn ensure_traversable_runtime_dir(path: &Path) -> io::Result<()> {
     ensure_runtime_dir_with_mode(path, TRAVERSABLE_RUNTIME_DIR_MODE)
 }
 
-pub(crate) fn prepare_private_socket_dir(sock_paths: &SockPaths) -> io::Result<()> {
+pub(crate) fn prepare_runtime_socket_dir(sock_paths: &SockPaths) -> io::Result<()> {
     ensure_traversable_runtime_dir(sock_paths.dir())?;
     ensure_private_runtime_dir(&sock_paths.vsock_dir())
 }
@@ -324,11 +324,11 @@ mod tests {
     }
 
     #[test]
-    fn prepare_private_socket_dir_creates_sock_and_vsock_dirs() {
+    fn prepare_runtime_socket_dir_creates_traversable_sock_and_private_vsock_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let sock_paths = SockPaths::new(tmp.path().join("sandbox"));
 
-        prepare_private_socket_dir(&sock_paths).unwrap();
+        prepare_runtime_socket_dir(&sock_paths).unwrap();
 
         assert_eq!(mode(sock_paths.dir()), TRAVERSABLE_RUNTIME_DIR_MODE);
         assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_private_socket_dir_normalizes_existing_dirs() {
+    fn prepare_runtime_socket_dir_normalizes_existing_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let sock_paths = SockPaths::new(tmp.path().join("sandbox"));
         std::fs::create_dir(sock_paths.dir()).unwrap();
@@ -398,7 +398,7 @@ mod tests {
         )
         .unwrap();
 
-        prepare_private_socket_dir(&sock_paths).unwrap();
+        prepare_runtime_socket_dir(&sock_paths).unwrap();
 
         assert_eq!(mode(sock_paths.dir()), TRAVERSABLE_RUNTIME_DIR_MODE);
         assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);

--- a/crates/sandbox-fc/src/runtime_dirs.rs
+++ b/crates/sandbox-fc/src/runtime_dirs.rs
@@ -1,0 +1,201 @@
+use std::fs::DirBuilder;
+use std::io;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+use std::path::Path;
+
+use nix::unistd::{AccessFlags, eaccess, geteuid};
+
+use crate::paths::SockPaths;
+
+pub(crate) const PRIVATE_RUNTIME_DIR_MODE: u32 = 0o700;
+
+pub(crate) fn ensure_private_runtime_dir(path: &Path) -> io::Result<()> {
+    create_private_dir_if_missing(path)?;
+    validate_private_runtime_dir(path)
+}
+
+pub(crate) fn prepare_private_socket_dir(sock_paths: &SockPaths) -> io::Result<()> {
+    ensure_private_runtime_dir(sock_paths.dir())?;
+    ensure_private_runtime_dir(&sock_paths.vsock_dir())
+}
+
+fn create_private_dir_if_missing(path: &Path) -> io::Result<()> {
+    let mut builder = DirBuilder::new();
+    builder.mode(PRIVATE_RUNTIME_DIR_MODE);
+    match builder.create(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(io::Error::new(
+            e.kind(),
+            format!("create private runtime dir {}: {e}", path.display()),
+        )),
+    }
+}
+
+fn validate_private_runtime_dir(path: &Path) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!("stat private runtime dir {}: {e}", path.display()),
+        )
+    })?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(io::Error::other(format!(
+            "private runtime dir is a symlink: {}",
+            path.display()
+        )));
+    }
+    if !file_type.is_dir() {
+        return Err(io::Error::other(format!(
+            "private runtime dir is not a directory: {}",
+            path.display()
+        )));
+    }
+
+    let euid = geteuid().as_raw();
+    if !runtime_dir_owner_is_trusted(metadata.uid(), euid) {
+        return Err(io::Error::other(format!(
+            "private runtime dir has untrusted owner uid {}: {}",
+            metadata.uid(),
+            path.display()
+        )));
+    }
+
+    let mode = metadata.permissions().mode() & 0o7777;
+    if mode != PRIVATE_RUNTIME_DIR_MODE {
+        std::fs::set_permissions(
+            path,
+            std::fs::Permissions::from_mode(PRIVATE_RUNTIME_DIR_MODE),
+        )
+        .map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "chmod private runtime dir {} to {:04o}: {e}",
+                    path.display(),
+                    PRIVATE_RUNTIME_DIR_MODE
+                ),
+            )
+        })?;
+    }
+
+    eaccess(path, AccessFlags::W_OK | AccessFlags::X_OK).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "private runtime dir is not writable/traversable: {}: {e}",
+                path.display()
+            ),
+        )
+    })
+}
+
+fn runtime_dir_owner_is_trusted(owner_uid: u32, effective_uid: u32) -> bool {
+    owner_uid == 0 || owner_uid == effective_uid
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::Path;
+
+    use super::*;
+
+    fn mode(path: &Path) -> u32 {
+        std::fs::symlink_metadata(path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777
+    }
+
+    #[test]
+    fn ensure_private_runtime_dir_creates_missing_dir_with_private_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("runtime");
+
+        ensure_private_runtime_dir(&path).unwrap();
+
+        assert!(path.is_dir());
+        assert_eq!(mode(&path), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_private_runtime_dir_normalizes_existing_trusted_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("runtime");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        ensure_private_runtime_dir(&path).unwrap();
+
+        assert_eq!(mode(&path), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn ensure_private_runtime_dir_rejects_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("runtime");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        let err = ensure_private_runtime_dir(&link).unwrap_err();
+
+        assert!(err.to_string().contains("is a symlink"));
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    fn ensure_private_runtime_dir_rejects_non_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("runtime");
+        std::fs::write(&path, b"not a dir").unwrap();
+
+        let err = ensure_private_runtime_dir(&path).unwrap_err();
+
+        assert!(err.to_string().contains("is not a directory"));
+    }
+
+    #[test]
+    fn prepare_private_socket_dir_creates_sock_and_vsock_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_paths = SockPaths::new(tmp.path().join("sandbox"));
+
+        prepare_private_socket_dir(&sock_paths).unwrap();
+
+        assert_eq!(mode(sock_paths.dir()), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn prepare_private_socket_dir_normalizes_existing_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_paths = SockPaths::new(tmp.path().join("sandbox"));
+        std::fs::create_dir(sock_paths.dir()).unwrap();
+        std::fs::create_dir(sock_paths.vsock_dir()).unwrap();
+        std::fs::set_permissions(sock_paths.dir(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(
+            sock_paths.vsock_dir(),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+
+        prepare_private_socket_dir(&sock_paths).unwrap();
+
+        assert_eq!(mode(sock_paths.dir()), PRIVATE_RUNTIME_DIR_MODE);
+        assert_eq!(mode(&sock_paths.vsock_dir()), PRIVATE_RUNTIME_DIR_MODE);
+    }
+
+    #[test]
+    fn owner_trust_accepts_root_and_effective_uid() {
+        assert!(runtime_dir_owner_is_trusted(0, 1000));
+        assert!(runtime_dir_owner_is_trusted(1000, 1000));
+    }
+
+    #[test]
+    fn owner_trust_rejects_unrelated_uid() {
+        assert!(!runtime_dir_owner_is_trusted(1001, 1000));
+    }
+}

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -49,6 +49,7 @@ use crate::park_coordinator::{
 };
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{ChildExitNotifier, kill_process_group};
+use crate::runtime_dirs::prepare_private_runtime_vsock_dir;
 
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -1191,11 +1192,11 @@ impl FirecrackerSandbox {
         }
 
         // Ensure bind mount target directories exist.
-        tokio::fs::create_dir_all(&snapshot.vsock_bind_dir)
-            .await
-            .map_err(|e| SandboxError::Start {
-                message: format!("mkdir snapshot vsock: {e}"),
-            })?;
+        prepare_private_runtime_vsock_dir(&snapshot.vsock_bind_dir).map_err(|e| {
+            SandboxError::Start {
+                message: format!("prepare snapshot vsock dir: {e}"),
+            }
+        })?;
 
         ensure_snapshot_drive_bind_target(&snapshot.drive_bind_path).await?;
         ensure_snapshot_drive_bind_target(&snapshot.workspace_drive_bind_path).await?;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -49,7 +49,7 @@ use crate::park_coordinator::{
 };
 use crate::paths::{SandboxPaths, SockPaths};
 use crate::process::{ChildExitNotifier, kill_process_group};
-use crate::runtime_dirs::prepare_private_runtime_vsock_dir;
+use crate::runtime_dirs::{prepare_private_runtime_vsock_dir, set_private_runtime_socket_mode};
 
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -1158,6 +1158,9 @@ impl FirecrackerSandbox {
                         ),
                     }
                 })?;
+                set_private_runtime_socket_mode(&api_sock).map_err(|e| SandboxError::Start {
+                    message: format!("restrict API socket permissions: {e}"),
+                })?;
             }
             state = wait_for_process_exit(self.state_tx.subscribe()) => {
                 return Err(SandboxError::Start {
@@ -1286,6 +1289,9 @@ impl FirecrackerSandbox {
                             api_sock.display()
                         ),
                     }
+                })?;
+                set_private_runtime_socket_mode(&api_sock).map_err(|e| SandboxError::Start {
+                    message: format!("restrict API socket permissions: {e}"),
                 })?;
             }
             state = wait_for_process_exit(self.state_tx.subscribe()) => {

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -18,7 +18,7 @@ use crate::config::SnapshotConfig;
 use crate::network::NetnsPool;
 use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process::kill_process_group;
-use crate::runtime_dirs::prepare_private_socket_dir;
+use crate::runtime_dirs::prepare_runtime_socket_dir;
 use crate::workspace_drive_image::prepare_workspace_drive_image;
 
 use super::SnapshotError;
@@ -217,7 +217,7 @@ impl SnapshotAttempt {
         // The empty bind target file is consumed by `mount --bind` inside
         // `unshare --mount` at spawn time; file content is irrelevant
         // because the bind overlay is what FC reads.
-        if let Err(e) = prepare_private_socket_dir(self.sock_paths()?) {
+        if let Err(e) = prepare_runtime_socket_dir(self.sock_paths()?) {
             self.cleanup_resources
                 .destroy_cow_after_setup_error("prepare sock dir")
                 .await;

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -18,6 +18,7 @@ use crate::config::SnapshotConfig;
 use crate::network::NetnsPool;
 use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process::kill_process_group;
+use crate::runtime_dirs::prepare_private_socket_dir;
 use crate::workspace_drive_image::prepare_workspace_drive_image;
 
 use super::SnapshotError;
@@ -216,11 +217,11 @@ impl SnapshotAttempt {
         // The empty bind target file is consumed by `mount --bind` inside
         // `unshare --mount` at spawn time; file content is irrelevant
         // because the bind overlay is what FC reads.
-        if let Err(e) = tokio::fs::create_dir_all(self.sock_paths()?.dir()).await {
+        if let Err(e) = prepare_private_socket_dir(self.sock_paths()?) {
             self.cleanup_resources
-                .destroy_cow_after_setup_error("mkdir sock dir")
+                .destroy_cow_after_setup_error("prepare sock dir")
                 .await;
-            return Err(SnapshotError::Setup(format!("mkdir sock dir: {e}")));
+            return Err(SnapshotError::Setup(format!("prepare sock dir: {e}")));
         }
 
         let drive_bind = self.paths.cow_device_bind();

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -213,10 +213,6 @@ impl SnapshotAttempt {
         // (mkdir, write) doesn't leak an acquired netns. A checked-out netns
         // lease requires explicit release, and `netns_pool.cleanup()` only
         // drains queued (not acquired) entries.
-        //
-        // The empty bind target file is consumed by `mount --bind` inside
-        // `unshare --mount` at spawn time; file content is irrelevant
-        // because the bind overlay is what FC reads.
         if let Err(e) = prepare_runtime_socket_dir(self.sock_paths()?) {
             self.cleanup_resources
                 .destroy_cow_after_setup_error("prepare sock dir")
@@ -224,6 +220,9 @@ impl SnapshotAttempt {
             return Err(SnapshotError::Setup(format!("prepare sock dir: {e}")));
         }
 
+        // The empty bind target file is consumed by `mount --bind` inside
+        // `unshare --mount` at spawn time; file content is irrelevant
+        // because the bind overlay is what FC reads.
         let drive_bind = self.paths.cow_device_bind();
         if let Err(e) = tokio::fs::write(&drive_bind, b"").await {
             self.cleanup_resources

--- a/crates/sandbox-fc/src/snapshot/attempt/tests.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/tests.rs
@@ -1,3 +1,4 @@
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::time::Duration;
 
@@ -345,6 +346,35 @@ async fn cleanup_existing_snapshot_sock_dir_removes_existing_dir() {
     );
 
     cleanup_existing_snapshot_sock_dir(&sock_dir).await;
+}
+
+#[tokio::test]
+async fn snapshot_attempt_prepare_firecracker_files_rejects_socket_symlink() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (mut attempt, sock_dir) = snapshot_attempt_for_test(&dir);
+    let target = dir.path().join("target");
+    std::fs::create_dir(&target).expect("create symlink target");
+    symlink(&target, &sock_dir).expect("create sock symlink");
+    let config = SnapshotCreateConfig {
+        id: "snapshot-attempt-test".into(),
+        binary_path: dir.path().join("firecracker"),
+        kernel_path: dir.path().join("vmlinux"),
+        rootfs_path: dir.path().join("rootfs.ext4"),
+        output_dir: dir.path().join("output"),
+        vcpu_count: 2,
+        memory_mb: 512,
+        workspace_disk_mb: 1024,
+    };
+
+    let err = attempt
+        .prepare_firecracker_files(&config)
+        .await
+        .expect_err("prepare firecracker files should reject sock symlink");
+
+    let message = err.to_string();
+    assert!(message.contains("prepare sock dir"), "got: {message}");
+    assert!(message.contains("is a symlink"), "got: {message}");
+    assert!(target.is_dir());
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -17,6 +17,7 @@ use crate::config::SnapshotConfig;
 use crate::network::{NetnsPool, NetnsPoolConfig};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::prerequisites;
+use crate::runtime_dirs::checked_runtime_sock_dir;
 
 use self::attempt::{
     SnapshotAttempt, cleanup_after_netns_pool_failure, cleanup_existing_snapshot_sock_dir,
@@ -85,7 +86,8 @@ async fn create_uncommitted_snapshot(
 
     // Socket directory under /run, keyed by config id so concurrent builds don't collide.
     let runtime_paths = RuntimePaths::new();
-    let sock_dir = runtime_paths.sock_dir(&config.id);
+    let sock_dir = checked_runtime_sock_dir(&runtime_paths, &config.id)
+        .map_err(|e| SnapshotError::Setup(format!("snapshot socket id: {e}")))?;
     cleanup_existing_snapshot_sock_dir(&sock_dir).await;
 
     let paths = SandboxPaths::new(work);

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -69,6 +69,10 @@ pub async fn create_snapshot(
 async fn create_uncommitted_snapshot(
     config: SnapshotCreateConfig,
 ) -> Result<FirecrackerPendingSnapshotPublish, SnapshotError> {
+    let runtime_paths = RuntimePaths::new();
+    let sock_dir = checked_runtime_sock_dir(&runtime_paths, &config.id)
+        .map_err(|e| SnapshotError::Setup(format!("snapshot socket id: {e}")))?;
+
     // Check prerequisites (binary, kernel, rootfs, kvm, runtime dir, etc.).
     prerequisites::check_prerequisites(&prerequisites::PrerequisiteConfig {
         binary_path: &config.binary_path,
@@ -85,9 +89,6 @@ async fn create_uncommitted_snapshot(
     let work = prepare_snapshot_output(&output).await?;
 
     // Socket directory under /run, keyed by config id so concurrent builds don't collide.
-    let runtime_paths = RuntimePaths::new();
-    let sock_dir = checked_runtime_sock_dir(&runtime_paths, &config.id)
-        .map_err(|e| SnapshotError::Setup(format!("snapshot socket id: {e}")))?;
     cleanup_existing_snapshot_sock_dir(&sock_dir).await;
 
     let paths = SandboxPaths::new(work);
@@ -173,4 +174,43 @@ async fn create_uncommitted_snapshot(
     attempt.cleanup_sock_dir().await;
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_uncommitted_snapshot_rejects_invalid_socket_id_before_output_cleanup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let output_dir = tmp.path().join("output");
+        tokio::fs::create_dir_all(&output_dir).await.unwrap();
+        let sentinel = output_dir.join("keep.txt");
+        tokio::fs::write(&sentinel, b"keep").await.unwrap();
+
+        let result = create_uncommitted_snapshot(SnapshotCreateConfig {
+            id: "../snapshot".into(),
+            binary_path: tmp.path().join("firecracker"),
+            kernel_path: tmp.path().join("vmlinux"),
+            rootfs_path: tmp.path().join("rootfs.ext4"),
+            output_dir,
+            vcpu_count: 2,
+            memory_mb: 512,
+            workspace_disk_mb: 1024,
+        })
+        .await;
+
+        match result {
+            Ok(_) => panic!("expected invalid socket id to fail"),
+            Err(SnapshotError::Setup(message)) => {
+                assert!(message.contains("snapshot socket id"), "got: {message}");
+                assert!(
+                    message.contains("runtime socket id must be"),
+                    "got: {message}"
+                );
+            }
+            Err(other) => panic!("expected setup error, got {other:?}"),
+        }
+        assert!(sentinel.exists());
+    }
 }

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -17,7 +17,7 @@ use crate::exec_result_compat::{captured_exec_output_bytes, reject_stream_overfl
 use crate::factory::InvariantConfig;
 use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process::kill_process_group;
-use crate::runtime_dirs::prepare_private_socket_dir;
+use crate::runtime_dirs::{prepare_private_socket_dir, set_private_runtime_socket_mode};
 use sandbox::SnapshotCreateConfig;
 
 use super::SnapshotError;
@@ -289,6 +289,7 @@ async fn run_with_firecracker(
     let api_sock = sock_paths.api_sock();
     let client = ApiClient::new(&api_sock);
     client.wait_for_ready(API_READY_TIMEOUT).await?;
+    set_private_runtime_socket_mode(&api_sock)?;
 
     info!("firecracker API ready");
 

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -17,6 +17,7 @@ use crate::exec_result_compat::{captured_exec_output_bytes, reject_stream_overfl
 use crate::factory::InvariantConfig;
 use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process::kill_process_group;
+use crate::runtime_dirs::prepare_private_socket_dir;
 use sandbox::SnapshotCreateConfig;
 
 use super::SnapshotError;
@@ -443,7 +444,7 @@ async fn configure_snapshot_vm(
     // 6. Configure VM via API. Keep drive requests ordered so snapshot creation
     // matches the fresh-boot config path: rootfs first, workspace second.
     let kernel_path = config.kernel_path.display().to_string();
-    tokio::fs::create_dir_all(&sock_paths.vsock_dir()).await?;
+    prepare_private_socket_dir(sock_paths)?;
     let vsock_uds_str = sock_paths.vsock().display().to_string();
 
     client

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -17,7 +17,7 @@ use crate::exec_result_compat::{captured_exec_output_bytes, reject_stream_overfl
 use crate::factory::InvariantConfig;
 use crate::paths::{SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::process::kill_process_group;
-use crate::runtime_dirs::{prepare_private_socket_dir, set_private_runtime_socket_mode};
+use crate::runtime_dirs::{prepare_runtime_socket_dir, set_private_runtime_socket_mode};
 use sandbox::SnapshotCreateConfig;
 
 use super::SnapshotError;
@@ -445,7 +445,7 @@ async fn configure_snapshot_vm(
     // 6. Configure VM via API. Keep drive requests ordered so snapshot creation
     // matches the fresh-boot config path: rootfs first, workspace second.
     let kernel_path = config.kernel_path.display().to_string();
-    prepare_private_socket_dir(sock_paths)?;
+    prepare_runtime_socket_dir(sock_paths)?;
     let vsock_uds_str = sock_paths.vsock().display().to_string();
 
     client


### PR DESCRIPTION
## Summary

- create and validate `/run/vm0` and `/run/vm0/sock` as trusted private runtime directories
- create per-sandbox socket and vsock directories with explicit private permissions
- reject symlink, non-directory, untrusted-owner, and inaccessible runtime path components before factory or snapshot socket use
- add focused filesystem tests for creation, normalization, symlink rejection, and owner trust

Closes #18413

## Verification

- `cargo fmt --manifest-path crates/Cargo.toml -p sandbox-fc --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- pre-commit `cargo-fmt`, `cargo-doc`, `cargo-clippy`, and commitlint hooks

## Note

A local workflow compatibility adjustment for direct `/run/vm0/sock/...` probes may be needed if those probes run outside sudo after `/run/vm0` becomes private. This environment cannot push `.github/workflows/*` changes because the available token lacks `workflow` scope, so this PR keeps the code change scoped to `sandbox-fc`.