### PR TITLE
refactor(mitm-addon): consolidate failed flush retention handling

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -23,6 +23,7 @@ from .models import (
     _DeliveryCompletion,
     _PendingBatch,
     _PendingFlush,
+    _RetainBatchesResult,
 )
 from .state import _UsageBufferState
 from .summaries import _apply_retained_batch_counts, _build_flush_summaries
@@ -221,48 +222,34 @@ class UsageEventBuffer:
             try:
                 admission_result = self._enqueue_pending_flush(pending_flush, trigger)
             except _BatchEnqueueError as exc:
-                timer_to_start = None
                 with self._lock:
                     retain_result = self._state.complete_admission(
                         pending_flush, exc.admission_result
                     )
-                    if retain_result.retained_batches and trigger != "shutdown":
-                        timer_to_start = self._schedule_timer_if_buffered_locked()
-                    self._sync_buffered_counter_locked()
-                if retain_result.dropped_batches:
-                    _log_dropped_batches(
+                    timer_to_start = self._prepare_failed_flush_retention_locked(
                         trigger,
-                        pending_flush.flush_sequence,
-                        retain_result.dropped_batches,
+                        schedule_retry=bool(retain_result.retained_batches),
                     )
-                _log_shutdown_retained_batches(
+                self._finish_failed_flush_retention(
                     trigger,
-                    pending_flush.flush_sequence,
-                    retain_result.retained_batches,
+                    pending_flush,
+                    retain_result,
+                    timer_to_start,
                 )
-                if timer_to_start is not None:
-                    timer_to_start.start()
                 raise exc.original from exc
             except Exception:
-                timer_to_start = None
                 with self._lock:
                     retain_result = self._state.fail_enqueue(pending_flush, flush_generation)
-                    if trigger != "shutdown":
-                        timer_to_start = self._schedule_timer_if_buffered_locked()
-                    self._sync_buffered_counter_locked()
-                if retain_result.dropped_batches:
-                    _log_dropped_batches(
+                    timer_to_start = self._prepare_failed_flush_retention_locked(
                         trigger,
-                        pending_flush.flush_sequence,
-                        retain_result.dropped_batches,
+                        schedule_retry=True,
                     )
-                _log_shutdown_retained_batches(
+                self._finish_failed_flush_retention(
                     trigger,
-                    pending_flush.flush_sequence,
-                    retain_result.retained_batches,
+                    pending_flush,
+                    retain_result,
+                    timer_to_start,
                 )
-                if timer_to_start is not None:
-                    timer_to_start.start()
                 raise
 
             flushed_batch_count += admission_result.admitted_batch_count
@@ -282,6 +269,39 @@ class UsageEventBuffer:
                 timer_to_start.start()
             if admission_result.retained_batches:
                 return flushed_batch_count
+
+    def _prepare_failed_flush_retention_locked(
+        self,
+        trigger: UsageFlushTrigger,
+        *,
+        schedule_retry: bool,
+    ) -> _TimerHandle | None:
+        timer_to_start = None
+        if schedule_retry and trigger != "shutdown":
+            timer_to_start = self._schedule_timer_if_buffered_locked()
+        self._sync_buffered_counter_locked()
+        return timer_to_start
+
+    @staticmethod
+    def _finish_failed_flush_retention(
+        trigger: UsageFlushTrigger,
+        pending_flush: _PendingFlush,
+        retain_result: _RetainBatchesResult,
+        timer_to_start: _TimerHandle | None,
+    ) -> None:
+        if retain_result.dropped_batches:
+            _log_dropped_batches(
+                trigger,
+                pending_flush.flush_sequence,
+                retain_result.dropped_batches,
+            )
+        _log_shutdown_retained_batches(
+            trigger,
+            pending_flush.flush_sequence,
+            retain_result.retained_batches,
+        )
+        if timer_to_start is not None:
+            timer_to_start.start()
 
     def _enqueue_pending_flush(
         self,

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_timer_shutdown.py
@@ -468,6 +468,73 @@ def test_shutdown_flush_failure_preserves_retry_without_rescheduling_timer(tmp_p
     )
 
 
+def test_shutdown_partial_enqueue_failure_retains_unfinished_without_rescheduling_timer(
+    tmp_path,
+):
+    pending_path = tmp_path / "usage-pending"
+    attempted_runs: list[str] = []
+
+    def fail_second_batch(url, sandbox_token, payload, path, log_type):
+        del url, sandbox_token, path, log_type
+        attempted_runs.append(payload["runId"])
+        if payload["runId"] == "run-2":
+            raise OSError("shutdown second batch failed")
+        return True
+
+    enqueue = RecordingEnqueue(side_effect=fail_second_batch)
+    timers = install_recording_usage_timer(enqueue_webhook=enqueue)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    usage.set_pending_path(str(pending_path))
+    for run_id, source_key in (("run-1", "source-1"), ("run-2", "source-2")):
+        usage.buffer_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            run_id,
+            [event(source_key=source_key)],
+            str(proxy_log_path),
+        )
+    assert len(timers) == 1
+
+    with pytest.raises(OSError, match="shutdown second batch failed"):
+        usage.flush_usage_events(trigger="shutdown")
+
+    assert attempted_runs == ["run-1", "run-2"]
+    assert len(timers) == 1
+    assert timers[0].cancelled is True
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=1,
+        reports=0,
+        flush_request_id="shutdown-partial-retained",
+    )
+    retained_entries = [
+        entry
+        for entry in flush_log_entries(proxy_log_path)
+        if entry.get("reason") == "shutdown_retained_without_retry"
+    ]
+    assert len(retained_entries) == 1
+    assert retained_entries[0]["level"] == "error"
+    assert retained_entries[0]["type"] == "usage_underbilling"
+    assert retained_entries[0]["trigger"] == "shutdown"
+    assert retained_entries[0]["retained_source_event_count"] == 1
+    assert retained_entries[0]["retained_webhook_batch_count"] == 1
+
+    enqueue.side_effect = None
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload["runId"] == "run-2"
+    assert_current_pending(
+        pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="shutdown-partial-drained",
+    )
+
+
 def test_shutdown_saturated_flush_retains_without_rescheduling_timer(tmp_path):
     pending_path = tmp_path / "usage-pending"
     proxy_log_path = tmp_path / "proxy.jsonl"


### PR DESCRIPTION
## Summary

- Consolidate duplicated failed-flush retained/dropped follow-up handling in the usage buffer orchestrator.
- Keep `_BatchEnqueueError` and generic exception state transitions explicit so partial admission and full enqueue failure semantics stay separate.
- Add a shutdown partial enqueue failure regression test that verifies retained work, no retry timer reschedule, shutdown-retained underbilling logging, and later retry drain.

Closes #18415

## Tests

- `PYTHONPATH=src:/tmp/mitm-addon-testdeps-18415 python3 -m pytest tests/test_usage_buffer_flush_failures.py`
- `PYTHONPATH=src:/tmp/mitm-addon-testdeps-18415 python3 -m pytest tests/test_usage_buffer_timer_shutdown.py`
- `PYTHONPATH=src:/tmp/mitm-addon-testdeps-18415 python3 -m pytest tests/test_usage_buffer_logging.py`
- `PYTHONPATH=src:/tmp/mitm-addon-testdeps-18415 python3 -m ruff check src/usage/buffer/orchestrator.py tests/test_usage_buffer_timer_shutdown.py`
- `PYTHONPATH=src:/tmp/mitm-addon-testdeps-18415 python3 -m ruff format --check src/usage/buffer/orchestrator.py tests/test_usage_buffer_timer_shutdown.py`
