### PR TITLE
perf: bound guest mock claude stream output

### DIFF
--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -490,10 +490,7 @@ fn capture_shell_stream(mut reader: impl Read) -> CapturedShellStream {
         }
 
         let retained = remaining.min(read);
-        let Some(retained_bytes) = buffer.get(..retained) else {
-            break;
-        };
-        stream.bytes.extend_from_slice(retained_bytes);
+        stream.bytes.extend(buffer.iter().take(retained).copied());
         if retained < read {
             stream.truncated = true;
         }
@@ -528,8 +525,14 @@ fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
     let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
 
     let exit_code = child.wait().map_or(1, |status| status.code().unwrap_or(1));
-    let stdout = stdout_thread.join().unwrap_or_default();
-    let stderr = stderr_thread.join().unwrap_or_default();
+    let stdout = match stdout_thread.join() {
+        Ok(stdout) => stdout,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
+    let stderr = match stderr_thread.join() {
+        Ok(stderr) => stderr,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
 
     CapturedShellOutput {
         stdout,

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -8,13 +8,16 @@ use crate::transcript::{
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::process::{Command, ExitCode, Stdio};
+use std::thread;
 use std::time::Duration;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
+const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
+const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
 
 pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
     if parsed.input_format == "stream-json" {
@@ -444,6 +447,121 @@ fn run_text_mode(prompt: &str) -> ExitCode {
     }
 }
 
+#[derive(Default)]
+struct CapturedShellStream {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+struct CapturedShellOutput {
+    stdout: CapturedShellStream,
+    stderr: CapturedShellStream,
+    exit_code: i32,
+}
+
+impl CapturedShellOutput {
+    fn spawn_failed() -> Self {
+        Self {
+            stdout: CapturedShellStream::default(),
+            stderr: CapturedShellStream::default(),
+            exit_code: 1,
+        }
+    }
+}
+
+fn capture_shell_stream(mut reader: impl Read) -> CapturedShellStream {
+    let mut stream = CapturedShellStream {
+        bytes: Vec::with_capacity(STREAM_JSON_SHELL_READ_BUFFER_BYTES),
+        truncated: false,
+    };
+    let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
+
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => break,
+        };
+
+        let remaining = STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.saturating_sub(stream.bytes.len());
+        if remaining == 0 {
+            stream.truncated = true;
+            continue;
+        }
+
+        let retained = remaining.min(read);
+        let Some(retained_bytes) = buffer.get(..retained) else {
+            break;
+        };
+        stream.bytes.extend_from_slice(retained_bytes);
+        if retained < read {
+            stream.truncated = true;
+        }
+    }
+
+    stream
+}
+
+fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
+    let mut child = match Command::new("bash")
+        .args(["-c", prompt])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => return CapturedShellOutput::spawn_failed(),
+    };
+
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return CapturedShellOutput::spawn_failed();
+    };
+    let Some(stderr) = child.stderr.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return CapturedShellOutput::spawn_failed();
+    };
+    let stdout_thread = thread::spawn(move || capture_shell_stream(stdout));
+    let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
+
+    let exit_code = child.wait().map_or(1, |status| status.code().unwrap_or(1));
+    let stdout = stdout_thread.join().unwrap_or_default();
+    let stderr = stderr_thread.join().unwrap_or_default();
+
+    CapturedShellOutput {
+        stdout,
+        stderr,
+        exit_code,
+    }
+}
+
+fn append_truncation_marker(output: &mut String, stream_name: &str) {
+    output.push_str("\n[");
+    output.push_str(stream_name);
+    output.push_str(" truncated after ");
+    output.push_str(&STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.to_string());
+    output.push_str(" bytes]\n");
+}
+
+fn format_captured_shell_output(captured: &CapturedShellOutput) -> String {
+    let mut output = String::from_utf8_lossy(&captured.stdout.bytes).into_owned();
+    if captured.stdout.truncated {
+        append_truncation_marker(&mut output, "stdout");
+    }
+
+    if captured.exit_code != 0 {
+        output.push_str(&String::from_utf8_lossy(&captured.stderr.bytes));
+        if captured.stderr.truncated {
+            append_truncation_marker(&mut output, "stderr");
+        }
+    }
+
+    output
+}
+
 /// Execute prompt in stream-json mode: output JSONL events, capture output.
 fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
     let session_history_file = create_session_history(session_id);
@@ -463,24 +581,10 @@ fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
         json!({"command": prompt}),
     ));
 
-    // 4. Execute bash and capture output
-    let (output, exit_code) = match Command::new("bash")
-        .args(["-c", prompt])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-    {
-        Ok(result) => {
-            let mut combined = String::from_utf8_lossy(&result.stdout).into_owned();
-            if !result.status.success() {
-                combined.push_str(&String::from_utf8_lossy(&result.stderr));
-            }
-            let code = result.status.code().unwrap_or(1);
-            (combined, code)
-        }
-        Err(_) => (String::new(), 1),
-    };
+    // 4. Execute bash and capture bounded output
+    let captured = capture_shell_output(prompt);
+    let output = format_captured_shell_output(&captured);
+    let exit_code = captured.exit_code;
 
     let is_error = exit_code != 0;
 

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -8,7 +8,7 @@ use crate::transcript::{
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::path::Path;
 use std::process::{Command, ExitCode, Stdio};
 use std::thread;
@@ -460,7 +460,7 @@ struct CapturedShellOutput {
 }
 
 impl CapturedShellOutput {
-    fn spawn_failed() -> Self {
+    fn failed() -> Self {
         Self {
             stdout: CapturedShellStream::default(),
             stderr: CapturedShellStream::default(),
@@ -469,7 +469,7 @@ impl CapturedShellOutput {
     }
 }
 
-fn capture_shell_stream(mut reader: impl Read) -> CapturedShellStream {
+fn capture_shell_stream(mut reader: impl Read) -> std::io::Result<CapturedShellStream> {
     let mut stream = CapturedShellStream {
         bytes: Vec::with_capacity(STREAM_JSON_SHELL_READ_BUFFER_BYTES),
         truncated: false,
@@ -480,7 +480,8 @@ fn capture_shell_stream(mut reader: impl Read) -> CapturedShellStream {
         let read = match reader.read(&mut buffer) {
             Ok(0) => break,
             Ok(read) => read,
-            Err(_) => break,
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
         };
 
         let remaining = STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.saturating_sub(stream.bytes.len());
@@ -496,7 +497,16 @@ fn capture_shell_stream(mut reader: impl Read) -> CapturedShellStream {
         }
     }
 
-    stream
+    Ok(stream)
+}
+
+fn join_captured_shell_stream(
+    handle: thread::JoinHandle<std::io::Result<CapturedShellStream>>,
+) -> std::io::Result<CapturedShellStream> {
+    match handle.join() {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
@@ -508,30 +518,27 @@ fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
         .spawn()
     {
         Ok(child) => child,
-        Err(_) => return CapturedShellOutput::spawn_failed(),
+        Err(_) => return CapturedShellOutput::failed(),
     };
 
     let Some(stdout) = child.stdout.take() else {
         let _ = child.kill();
         let _ = child.wait();
-        return CapturedShellOutput::spawn_failed();
+        return CapturedShellOutput::failed();
     };
     let Some(stderr) = child.stderr.take() else {
         let _ = child.kill();
         let _ = child.wait();
-        return CapturedShellOutput::spawn_failed();
+        return CapturedShellOutput::failed();
     };
     let stdout_thread = thread::spawn(move || capture_shell_stream(stdout));
     let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
 
     let exit_code = child.wait().map_or(1, |status| status.code().unwrap_or(1));
-    let stdout = match stdout_thread.join() {
-        Ok(stdout) => stdout,
-        Err(payload) => std::panic::resume_unwind(payload),
-    };
-    let stderr = match stderr_thread.join() {
-        Ok(stderr) => stderr,
-        Err(payload) => std::panic::resume_unwind(payload),
+    let stdout = join_captured_shell_stream(stdout_thread);
+    let stderr = join_captured_shell_stream(stderr_thread);
+    let (Ok(stdout), Ok(stderr)) = (stdout, stderr) else {
+        return CapturedShellOutput::failed();
     };
 
     CapturedShellOutput {

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Output, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -12,6 +12,10 @@ const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
 const CHILD_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const EVENT_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_STREAM_JSON_EVENTS: usize = 32;
+const MOCK_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
+const LARGE_MOCK_OUTPUT_BYTES: usize = MOCK_CAPTURE_LIMIT_BYTES + 1024;
+const STDOUT_TRUNCATION_MARKER: &str = "[stdout truncated after 1048576 bytes]";
+const STDERR_TRUNCATION_MARKER: &str = "[stderr truncated after 1048576 bytes]";
 
 struct StreamJsonChild {
     child: Option<Child>,
@@ -106,6 +110,32 @@ fn event_kind(event: &Value) -> String {
             format!("{event_type}/{content_type}")
         }
         _ => event_type.to_string(),
+    }
+}
+
+fn tool_result_content(events: &[Value]) -> Result<&str, Box<dyn std::error::Error>> {
+    match events.iter().find_map(|event| {
+        if event.get("type").and_then(Value::as_str) != Some("user") {
+            return None;
+        }
+        event
+            .pointer("/message/content/0/content")
+            .and_then(Value::as_str)
+    }) {
+        Some(content) => Ok(content),
+        None => Err("missing tool result content".into()),
+    }
+}
+
+fn result_content(events: &[Value]) -> Result<&str, Box<dyn std::error::Error>> {
+    match events.iter().find_map(|event| {
+        if event.get("type").and_then(Value::as_str) != Some("result") {
+            return None;
+        }
+        event.get("result").and_then(Value::as_str)
+    }) {
+        Some(content) => Ok(content),
+        None => Err("missing result content".into()),
     }
 }
 
@@ -264,6 +294,77 @@ fn wait_child(
         .join()
         .map_err(|_| std::io::Error::other("stderr reader thread panicked"))??;
     Ok((child_result?, stderr))
+}
+
+fn wait_child_output(mut child: Child) -> Result<Output, Box<dyn std::error::Error>> {
+    let pid = child.id();
+    let mut child_stdout = child.stdout.take().ok_or("missing stdout")?;
+    let mut child_stderr = child.stderr.take().ok_or("missing stderr")?;
+    let stdout_thread = std::thread::spawn(move || -> Result<Vec<u8>, std::io::Error> {
+        let mut stdout = Vec::new();
+        child_stdout.read_to_end(&mut stdout)?;
+        Ok(stdout)
+    });
+    let stderr_thread = std::thread::spawn(move || -> Result<Vec<u8>, std::io::Error> {
+        let mut stderr = Vec::new();
+        child_stderr.read_to_end(&mut stderr)?;
+        Ok(stderr)
+    });
+    let (tx, rx) = mpsc::channel();
+    let wait_thread = std::thread::spawn(move || {
+        let result = child.wait();
+        let _ = tx.send(result);
+    });
+
+    let child_result = match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            // SAFETY: this is a test cleanup path for the child process that
+            // this helper just spawned. The wait thread reaps it below.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            rx.recv_timeout(CHILD_EXIT_TIMEOUT).map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("mock child did not exit after SIGKILL: {error}"),
+                )
+            })?
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(std::io::Error::other(
+            "mock child wait thread exited without status",
+        )),
+    };
+
+    wait_thread
+        .join()
+        .map_err(|_| std::io::Error::other("child wait thread panicked"))?;
+    let stdout = stdout_thread
+        .join()
+        .map_err(|_| std::io::Error::other("stdout reader thread panicked"))??;
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| std::io::Error::other("stderr reader thread panicked"))??;
+
+    Ok(Output {
+        status: child_result?,
+        stdout,
+        stderr,
+    })
+}
+
+fn mock_stream_json_shell_output(
+    home: &std::path::Path,
+    prompt: &str,
+) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut command = mock_claude();
+    command
+        .env("HOME", home)
+        .args(["--output-format", "stream-json", "--", prompt])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    wait_child_output(command.spawn()?)
 }
 
 #[test]
@@ -762,6 +863,130 @@ fn stream_json_shell_failure_writes_error_history() -> Result<(), Box<dyn std::e
         events[4].get("is_error").and_then(Value::as_bool),
         Some(true)
     );
+    Ok(())
+}
+
+#[test]
+fn stream_json_shell_large_stdout_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let prompt = format!("yes A | head -c {LARGE_MOCK_OUTPUT_BYTES}");
+
+    let output = mock_stream_json_shell_output(home.path(), &prompt)?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let session_id = init_session_id(&events)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+    let tool_output = tool_result_content(&events)?;
+    let result_output = result_content(&events)?;
+
+    assert_eq!(history, stdout);
+    assert_eq!(tool_output, result_output);
+    assert!(tool_output.contains(STDOUT_TRUNCATION_MARKER));
+    assert!(!tool_output.contains(STDERR_TRUNCATION_MARKER));
+    assert!(tool_output.len() <= MOCK_CAPTURE_LIMIT_BYTES + 128);
+    Ok(())
+}
+
+#[test]
+fn stream_json_shell_large_stderr_failure_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let prompt = format!("printf out; yes E | head -c {LARGE_MOCK_OUTPUT_BYTES} >&2; exit 7");
+
+    let output = mock_stream_json_shell_output(home.path(), &prompt)?;
+
+    assert_eq!(output.status.code(), Some(7));
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let tool_output = tool_result_content(&events)?;
+    let result_output = result_content(&events)?;
+
+    assert_eq!(tool_output, result_output);
+    assert!(tool_output.starts_with("out"));
+    assert!(tool_output.contains(STDERR_TRUNCATION_MARKER));
+    assert!(!tool_output.contains(STDOUT_TRUNCATION_MARKER));
+    assert!(tool_output.len() <= MOCK_CAPTURE_LIMIT_BYTES + 128);
+    Ok(())
+}
+
+#[test]
+fn stream_json_shell_large_stdout_and_stderr_do_not_deadlock()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let prompt = format!(
+        "yes O | head -c {LARGE_MOCK_OUTPUT_BYTES}; \
+         yes E | head -c {LARGE_MOCK_OUTPUT_BYTES} >&2; \
+         exit 8"
+    );
+
+    let output = mock_stream_json_shell_output(home.path(), &prompt)?;
+
+    assert_eq!(output.status.code(), Some(8));
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let tool_output = tool_result_content(&events)?;
+    let result_output = result_content(&events)?;
+
+    assert_eq!(tool_output, result_output);
+    assert!(tool_output.contains(STDOUT_TRUNCATION_MARKER));
+    assert!(tool_output.contains(STDERR_TRUNCATION_MARKER));
+    assert!(tool_output.len() <= (MOCK_CAPTURE_LIMIT_BYTES * 2) + 256);
+    Ok(())
+}
+
+#[test]
+fn stream_json_shell_success_drains_stderr_without_exposing_it()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let prompt = format!("yes hidden-stderr | head -c {LARGE_MOCK_OUTPUT_BYTES} >&2; printf ok");
+
+    let output = mock_stream_json_shell_output(home.path(), &prompt)?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let tool_output = tool_result_content(&events)?;
+    let result_output = result_content(&events)?;
+
+    assert_eq!(tool_output, "ok");
+    assert_eq!(result_output, "ok");
+    Ok(())
+}
+
+#[test]
+fn stream_json_shell_invalid_utf8_output_remains_valid_jsonl()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+
+    let output = mock_stream_json_shell_output(home.path(), "printf '\\377'")?;
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    let tool_output = tool_result_content(&events)?;
+    let result_output = result_content(&events)?;
+
+    assert_eq!(tool_output, "\u{fffd}");
+    assert_eq!(result_output, "\u{fffd}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Replace `guest-mock-claude` stream-json shell `Command::output()` with bounded concurrent stdout/stderr draining.
- Preserve existing mock semantics: success emits stdout only; failure emits stdout followed by stderr; child exit codes are preserved.
- Add binary-level integration coverage for large stdout, large stderr, concurrent stdout/stderr, success stderr draining, and invalid UTF-8 output.

Closes #18410.

## Verification

- `cargo fmt -p guest-mock-claude`
- `cargo clippy -p guest-mock-claude --all-targets -- -D warnings`
- `cargo test -p guest-mock-claude`
- pre-commit hook: cargo doc, cargo clippy, commitlint
