### PR TITLE
feat: add lazy runtime firewall loader

### DIFF
--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -52,6 +52,10 @@
       "import": "./src/firewalls/index.ts",
       "types": "./src/firewalls/index.ts"
     },
+    "./firewalls/runtime": {
+      "import": "./src/firewall-runtime.ts",
+      "types": "./src/firewall-runtime.ts"
+    },
     "./firewalls/*": {
       "import": "./src/firewalls/*.ts",
       "types": "./src/firewalls/*.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -65,7 +65,10 @@ describe("firewall runtime loader", () => {
       "utf-8",
     );
 
-    expect(packageJson.exports).toHaveProperty("./firewalls/runtime");
+    expect(packageJson.exports["./firewalls/runtime"]).toStrictEqual({
+      import: "./src/firewall-runtime.ts",
+      types: "./src/firewall-runtime.ts",
+    });
     expect(rootEntrypoint).not.toContain("firewalls/runtime");
   });
 
@@ -93,9 +96,6 @@ describe("firewall runtime loader", () => {
       expect(source).not.toContain("./index");
       expect(source).not.toContain("@vm0/connectors/firewalls");
       for (const specifier of staticValueModuleSpecifiers(source)) {
-        if (specifier === "./runtime-loader.generated") {
-          continue;
-        }
         expect(specifier).not.toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
       }
     }

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -1,0 +1,162 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getAllConnectorFirewalls, getConnectorFirewall } from "../firewalls";
+import {
+  isRuntimeFirewallConnectorType,
+  loadConnectorFirewall,
+  loadConnectorFirewalls,
+  RUNTIME_FIREWALL_CONNECTOR_TYPES,
+} from "../firewall-runtime";
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function staticValueImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*import\s+(?!type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
+  )) {
+    specifiers.push(match[1]!);
+  }
+  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
+    specifiers.push(match[1]!);
+  }
+  return specifiers;
+}
+
+function staticValueExportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*export(?:\s+\*|\s+\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+  )) {
+    specifiers.push(match[1]!);
+  }
+  return specifiers;
+}
+
+function staticValueModuleSpecifiers(source: string): string[] {
+  return [
+    ...staticValueImportSpecifiers(source),
+    ...staticValueExportSpecifiers(source),
+  ];
+}
+
+function dynamicImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(/import\(\s*["']([^"']+)["']\s*\)/g)) {
+    specifiers.push(match[1]!);
+  }
+  return specifiers;
+}
+
+describe("firewall runtime loader", () => {
+  it("keeps the runtime loader behind an explicit package subpath", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        "utf-8",
+      ),
+    ) as { exports: Record<string, unknown> };
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    expect(packageJson.exports).toHaveProperty("./firewalls/runtime");
+    expect(rootEntrypoint).not.toContain("firewalls/runtime");
+  });
+
+  it("does not statically import the eager registry or connector runtime modules", () => {
+    const runtimeSource = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../firewall-runtime.ts"),
+      "utf-8",
+    );
+    const helperSource = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../firewall-placeholder-expansion.ts"),
+      "utf-8",
+    );
+
+    expect(
+      staticValueModuleSpecifiers(runtimeSource).sort(compareStrings),
+    ).toStrictEqual(["./firewalls/runtime-loader.generated"]);
+    expect(dynamicImportSpecifiers(runtimeSource)).toStrictEqual([
+      "./firewall-placeholder-expansion",
+    ]);
+    expect(
+      staticValueModuleSpecifiers(helperSource).sort(compareStrings),
+    ).toStrictEqual(["./connector-utils"]);
+
+    for (const source of [runtimeSource, helperSource]) {
+      expect(source).not.toContain("./index");
+      expect(source).not.toContain("@vm0/connectors/firewalls");
+      for (const specifier of staticValueModuleSpecifiers(source)) {
+        if (specifier === "./runtime-loader.generated") {
+          continue;
+        }
+        expect(specifier).not.toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
+      }
+    }
+  });
+
+  it("uses literal dynamic imports in the generated runtime loader", () => {
+    const loaderSource = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../firewalls/runtime-loader.generated.ts",
+      ),
+      "utf-8",
+    );
+    const dynamicSpecifiers = dynamicImportSpecifiers(loaderSource);
+
+    expect(staticValueModuleSpecifiers(loaderSource)).toStrictEqual([]);
+    expect(dynamicSpecifiers).toContain("./slack.generated");
+    expect(dynamicSpecifiers).toContain("./github.generated");
+    expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
+    for (const specifier of dynamicSpecifiers) {
+      expect(specifier).toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
+    }
+  });
+
+  it("keeps the runtime manifest synchronized with the sync firewall registry", () => {
+    expect(
+      [...RUNTIME_FIREWALL_CONNECTOR_TYPES].sort(compareStrings),
+    ).toStrictEqual(
+      Object.keys(getAllConnectorFirewalls()).sort(compareStrings),
+    );
+  });
+
+  it("loads and caches expanded connector firewalls", async () => {
+    expect(isRuntimeFirewallConnectorType("slack")).toBe(true);
+    expect(isRuntimeFirewallConnectorType("cloudinary")).toBe(false);
+    await expect(loadConnectorFirewall("cloudinary")).resolves.toBeNull();
+
+    const [firstSlack, secondSlack] = await Promise.all([
+      loadConnectorFirewall("slack"),
+      loadConnectorFirewall("slack"),
+    ]);
+    expect(firstSlack).toBe(secondSlack);
+    expect(firstSlack).toStrictEqual(getConnectorFirewall("slack"));
+
+    const repeatedSlack = await loadConnectorFirewall("slack");
+    expect(repeatedSlack).toBe(firstSlack);
+  });
+
+  it("deduplicates batch loads and preserves connector keys", async () => {
+    const firewalls = await loadConnectorFirewalls([
+      "github",
+      "slack",
+      "github",
+      "cloudinary",
+    ]);
+
+    expect(Object.keys(firewalls).sort(compareStrings)).toStrictEqual([
+      "github",
+      "slack",
+    ]);
+    expect(firewalls.github).toStrictEqual(getConnectorFirewall("github"));
+    expect(firewalls.slack).toBe(await loadConnectorFirewall("slack"));
+  });
+});

--- a/turbo/packages/connectors/src/firewall-placeholder-expansion.ts
+++ b/turbo/packages/connectors/src/firewall-placeholder-expansion.ts
@@ -1,0 +1,54 @@
+import type { ConnectorType } from "./connectors";
+import { getConnectorEnvBindingEntries } from "./connector-utils";
+import type { FirewallConfig } from "./firewall-types";
+
+/**
+ * Expand firewall placeholders to cover all secret names related to the
+ * connector. For each existing placeholder key, find related names via
+ * configured env binding entries (raw storage names and sibling aliases)
+ * and assign the same placeholder value.
+ */
+export function expandFirewallPlaceholders(
+  firewall: FirewallConfig,
+  connectorType: ConnectorType,
+): FirewallConfig {
+  if (!firewall.placeholders) return firewall;
+
+  const envBindingEntries = getConnectorEnvBindingEntries(connectorType);
+  if (envBindingEntries.length === 0) return firewall;
+
+  const expanded: Record<string, string> = { ...firewall.placeholders };
+
+  for (const [key, placeholderValue] of Object.entries(firewall.placeholders)) {
+    const valueRefs = envBindingEntries
+      .filter(({ envName }) => {
+        return envName === key;
+      })
+      .map(({ valueRef }) => {
+        return valueRef;
+      });
+    for (const valueRef of valueRefs) {
+      if (!valueRef.startsWith("$secrets.")) {
+        continue;
+      }
+      const rawName = valueRef.slice("$secrets.".length);
+      if (!expanded[rawName]) {
+        expanded[rawName] = placeholderValue;
+      }
+      for (const entry of envBindingEntries) {
+        if (entry.valueRef === valueRef && !expanded[entry.envName]) {
+          expanded[entry.envName] = placeholderValue;
+        }
+      }
+    }
+
+    const rawRef = `$secrets.${key}`;
+    for (const entry of envBindingEntries) {
+      if (entry.valueRef === rawRef && !expanded[entry.envName]) {
+        expanded[entry.envName] = placeholderValue;
+      }
+    }
+  }
+
+  return { ...firewall, placeholders: expanded };
+}

--- a/turbo/packages/connectors/src/firewall-runtime.ts
+++ b/turbo/packages/connectors/src/firewall-runtime.ts
@@ -1,0 +1,78 @@
+import type { ConnectorType } from "./connectors";
+import type { FirewallConfig } from "./firewall-types";
+import {
+  hasGeneratedRuntimeFirewall,
+  loadGeneratedRuntimeFirewall,
+  RUNTIME_FIREWALL_CONNECTOR_TYPES,
+  type GeneratedRuntimeFirewallConnectorType,
+} from "./firewalls/runtime-loader.generated";
+
+export { RUNTIME_FIREWALL_CONNECTOR_TYPES };
+export type RuntimeFirewallConnectorType =
+  GeneratedRuntimeFirewallConnectorType;
+
+export type RuntimeConnectorFirewallMap = Partial<
+  Record<RuntimeFirewallConnectorType, FirewallConfig>
+>;
+
+const runtimeFirewallCache = new Map<
+  RuntimeFirewallConnectorType,
+  Promise<FirewallConfig>
+>();
+
+export function isRuntimeFirewallConnectorType(
+  type: string,
+): type is RuntimeFirewallConnectorType {
+  return hasGeneratedRuntimeFirewall(type);
+}
+
+async function loadExpandedConnectorFirewall(
+  type: RuntimeFirewallConnectorType,
+): Promise<FirewallConfig> {
+  const [firewall, { expandFirewallPlaceholders }] = await Promise.all([
+    loadGeneratedRuntimeFirewall(type),
+    import("./firewall-placeholder-expansion"),
+  ]);
+  return expandFirewallPlaceholders(firewall, type as ConnectorType);
+}
+
+export async function loadConnectorFirewall(
+  type: RuntimeFirewallConnectorType,
+): Promise<FirewallConfig>;
+export async function loadConnectorFirewall(
+  type: string,
+): Promise<FirewallConfig | null>;
+export async function loadConnectorFirewall(
+  type: string,
+): Promise<FirewallConfig | null> {
+  if (!isRuntimeFirewallConnectorType(type)) {
+    return null;
+  }
+
+  const cached = runtimeFirewallCache.get(type);
+  if (cached) {
+    return await cached;
+  }
+
+  const load = loadExpandedConnectorFirewall(type).catch((error: unknown) => {
+    runtimeFirewallCache.delete(type);
+    throw error;
+  });
+  runtimeFirewallCache.set(type, load);
+  return await load;
+}
+
+export async function loadConnectorFirewalls(
+  types: readonly string[],
+): Promise<RuntimeConnectorFirewallMap> {
+  const uniqueTypes = [...new Set(types)].filter(
+    isRuntimeFirewallConnectorType,
+  );
+  const firewalls: RuntimeConnectorFirewallMap = {};
+  await Promise.all(
+    uniqueTypes.map(async (type) => {
+      firewalls[type] = await loadConnectorFirewall(type);
+    }),
+  );
+  return firewalls;
+}

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -12,6 +12,7 @@ import {
 } from "../firewall-types";
 import type { ConnectorType } from "../connectors";
 import { CONNECTOR_TYPES } from "../connectors";
+import { expandFirewallPlaceholders } from "../firewall-placeholder-expansion";
 import {
   clerkDefaultAllowed,
   clerkCategories,
@@ -35,7 +36,6 @@ import {
   vercelCategoryOrder,
   vercelFirewall,
 } from "./vercel.generated";
-import { getConnectorEnvBindingEntries } from "../connector-utils";
 import { agentmailFirewall } from "./agentmail.generated";
 import { amplitudeFirewall } from "./amplitude.generated";
 import { amadeusFirewall } from "./amadeus.generated";
@@ -613,64 +613,10 @@ const CONNECTOR_FIREWALLS = defineConnectorFirewalls({
   reducto: reductoFirewall,
 } satisfies Partial<Record<ConnectorType, FirewallConfig>>);
 
-/**
- * Expand firewall placeholders to cover all secret names related to the
- * connector. For each existing placeholder key, find related names via
- * configured env binding entries (raw storage names and sibling aliases)
- * and assign the same placeholder value.
- */
-function expandPlaceholders(
-  firewall: FirewallConfig,
-  connectorType: ConnectorType,
-): FirewallConfig {
-  if (!firewall.placeholders) return firewall;
-
-  const envBindingEntries = getConnectorEnvBindingEntries(connectorType);
-  if (envBindingEntries.length === 0) return firewall;
-
-  const expanded: Record<string, string> = { ...firewall.placeholders };
-
-  for (const [key, placeholderValue] of Object.entries(firewall.placeholders)) {
-    // key is a mapped environment name (e.g. GITHUB_TOKEN)
-    // → add the raw secret name and any sibling aliases
-    const valueRefs = envBindingEntries
-      .filter(({ envName }) => {
-        return envName === key;
-      })
-      .map(({ valueRef }) => {
-        return valueRef;
-      });
-    for (const valueRef of valueRefs) {
-      if (!valueRef.startsWith("$secrets.")) {
-        continue;
-      }
-      const rawName = valueRef.slice("$secrets.".length);
-      if (!expanded[rawName]) {
-        expanded[rawName] = placeholderValue;
-      }
-      for (const entry of envBindingEntries) {
-        if (entry.valueRef === valueRef && !expanded[entry.envName]) {
-          expanded[entry.envName] = placeholderValue;
-        }
-      }
-    }
-
-    // key is a raw secret name -> add all environment names that reference it
-    const rawRef = `$secrets.${key}`;
-    for (const entry of envBindingEntries) {
-      if (entry.valueRef === rawRef && !expanded[entry.envName]) {
-        expanded[entry.envName] = placeholderValue;
-      }
-    }
-  }
-
-  return { ...firewall, placeholders: expanded };
-}
-
 // Pre-compute expanded placeholders at module load time.
 const EXPANDED_CONNECTOR_FIREWALLS = Object.fromEntries(
   Object.entries(CONNECTOR_FIREWALLS).map(([type, firewall]) => {
-    return [type, expandPlaceholders(firewall, type as ConnectorType)];
+    return [type, expandFirewallPlaceholders(firewall, type as ConnectorType)];
   }),
 ) as typeof CONNECTOR_FIREWALLS;
 

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -40,6 +40,42 @@ function dynamicImportSpecifiers(source: string): string[] {
   return specifiers;
 }
 
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function firewallRegistryConnectorTypes(source: string): string[] {
+  const registryMatch = source.match(
+    /const CONNECTOR_FIREWALLS = defineConnectorFirewalls\(\{\n([\s\S]*?)\n\} satisfies/s,
+  );
+  if (!registryMatch) {
+    throw new Error("Unable to find CONNECTOR_FIREWALLS registry");
+  }
+
+  return [
+    ...registryMatch[1]!.matchAll(/^\s*(?:"([^"]+)"|([a-zA-Z_$][\w$]*)):/gm),
+  ]
+    .map((match) => {
+      return match[1] ?? match[2]!;
+    })
+    .sort(compareStrings);
+}
+
+function runtimeLoaderConnectorTypes(source: string): string[] {
+  const manifestMatch = source.match(
+    /export const RUNTIME_FIREWALL_CONNECTOR_TYPES = \[\n([\s\S]*?)\n\] as const;/s,
+  );
+  if (!manifestMatch) {
+    throw new Error("Unable to find runtime firewall connector manifest");
+  }
+
+  return [...manifestMatch[1]!.matchAll(/^\s*"([^"]+)",$/gm)]
+    .map((match) => {
+      return match[1]!;
+    })
+    .sort(compareStrings);
+}
+
 describe("firewall metadata generator", () => {
   it("does not import runtime connector registries", () => {
     const source = fs.readFileSync(
@@ -56,7 +92,7 @@ describe("firewall metadata generator", () => {
     expect(dynamicImportSpecifiers(source)).not.toContain(
       "../../connectors/src/firewalls",
     );
-    expect(source).not.toContain("CONNECTOR_TYPES");
+    expect(source).not.toMatch(/\bCONNECTOR_TYPES\b/);
   });
 
   it("keeps generated server metadata host-owner only", () => {
@@ -76,5 +112,39 @@ describe("firewall metadata generator", () => {
     expect(source).not.toContain('"permissions"');
     expect(source).not.toContain('"description"');
     expect(source).not.toContain('"rules"');
+  });
+
+  it("keeps the generated runtime loader literal and registry-shaped", () => {
+    const registrySource = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../connectors/src/firewalls/index.ts",
+      ),
+      "utf-8",
+    );
+    const loaderSource = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../connectors/src/firewalls/runtime-loader.generated.ts",
+      ),
+      "utf-8",
+    );
+    const dynamicSpecifiers = dynamicImportSpecifiers(loaderSource);
+
+    expect(staticValueModuleSpecifiers(loaderSource)).toStrictEqual([]);
+    expect(runtimeLoaderConnectorTypes(loaderSource)).toStrictEqual(
+      firewallRegistryConnectorTypes(registrySource),
+    );
+    expect(dynamicSpecifiers).toContain("./slack.generated");
+    expect(dynamicSpecifiers).toContain("./github.generated");
+    expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
+    expect(dynamicSpecifiers.length).toBe(
+      runtimeLoaderConnectorTypes(loaderSource).length,
+    );
+    for (const specifier of dynamicSpecifiers) {
+      expect(specifier).toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
+    }
+    expect(loaderSource).toContain('"slack": async () =>');
+    expect(loaderSource).toContain(")).slackFirewall");
   });
 });

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -45,6 +45,10 @@ function compareStrings(a: string, b: string): number {
 }
 
 function firewallRegistryConnectorTypes(source: string): string[] {
+  return [...firewallRegistryExportNames(source).keys()].sort(compareStrings);
+}
+
+function firewallRegistryExportNames(source: string): Map<string, string> {
   const registryMatch = source.match(
     /const CONNECTOR_FIREWALLS = defineConnectorFirewalls\(\{\n([\s\S]*?)\n\} satisfies/s,
   );
@@ -52,13 +56,15 @@ function firewallRegistryConnectorTypes(source: string): string[] {
     throw new Error("Unable to find CONNECTOR_FIREWALLS registry");
   }
 
-  return [
-    ...registryMatch[1]!.matchAll(/^\s*(?:"([^"]+)"|([a-zA-Z_$][\w$]*)):/gm),
-  ]
-    .map((match) => {
-      return match[1] ?? match[2]!;
-    })
-    .sort(compareStrings);
+  return new Map(
+    [
+      ...registryMatch[1]!.matchAll(
+        /^\s*(?:"([^"]+)"|([a-zA-Z_$][\w$]*)):\s*([a-zA-Z_$][\w$]*),$/gm,
+      ),
+    ].map((match) => {
+      return [match[1] ?? match[2]!, match[3]!] as const;
+    }),
+  );
 }
 
 function runtimeLoaderConnectorTypes(source: string): string[] {
@@ -74,6 +80,18 @@ function runtimeLoaderConnectorTypes(source: string): string[] {
       return match[1]!;
     })
     .sort(compareStrings);
+}
+
+function runtimeLoaderExportNames(source: string): Map<string, string> {
+  return new Map(
+    [
+      ...source.matchAll(
+        /^\s*"([^"]+)": async \(\) => \{\n\s+return \(await import\("[^"]+"\)\)\.([a-zA-Z_$][\w$]*);\n\s+\},$/gm,
+      ),
+    ].map((match) => {
+      return [match[1]!, match[2]!] as const;
+    }),
+  );
 }
 
 describe("firewall metadata generator", () => {
@@ -134,6 +152,9 @@ describe("firewall metadata generator", () => {
     expect(staticValueModuleSpecifiers(loaderSource)).toStrictEqual([]);
     expect(runtimeLoaderConnectorTypes(loaderSource)).toStrictEqual(
       firewallRegistryConnectorTypes(registrySource),
+    );
+    expect(runtimeLoaderExportNames(loaderSource)).toStrictEqual(
+      firewallRegistryExportNames(registrySource),
     );
     expect(dynamicSpecifiers).toContain("./slack.generated");
     expect(dynamicSpecifiers).toContain("./github.generated");

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -35,6 +35,11 @@ interface GeneratedFirewallSource {
   readonly defaultUnknownPolicy: FirewallPolicyValue;
 }
 
+interface RegisteredFirewallSource {
+  readonly type: FirewallConnectorType;
+  readonly firewallExportName: string;
+}
+
 interface GeneratedPathReplacement {
   commit: () => void;
   rollback: () => void;
@@ -85,21 +90,6 @@ function getRequiredGeneratedExport<T>(
   suffix: string,
   isExpected: (value: unknown) => value is T,
 ): T {
-  const [, value] = getRequiredGeneratedExportEntry(
-    moduleExports,
-    type,
-    suffix,
-    isExpected,
-  );
-  return value;
-}
-
-function getRequiredGeneratedExportEntry<T>(
-  moduleExports: Readonly<Record<string, unknown>>,
-  type: FirewallConnectorType,
-  suffix: string,
-  isExpected: (value: unknown) => value is T,
-): readonly [string, T] {
   const matches = generatedExportCandidates(moduleExports, suffix);
   if (matches.length !== 1) {
     throw new Error(
@@ -118,7 +108,22 @@ function getRequiredGeneratedExportEntry<T>(
       `Unexpected ${name} export shape for firewall metadata: ${type}`,
     );
   }
-  return [name, value];
+  return value;
+}
+
+function getRequiredGeneratedExportByName<T>(
+  moduleExports: Readonly<Record<string, unknown>>,
+  type: FirewallConnectorType,
+  name: string,
+  isExpected: (value: unknown) => value is T,
+): T {
+  const value = moduleExports[name];
+  if (!isExpected(value)) {
+    throw new Error(
+      `Unexpected ${name} export shape for firewall metadata: ${type}`,
+    );
+  }
+  return value;
 }
 
 function getOptionalGeneratedExport<T>(
@@ -279,15 +284,16 @@ function buildDefaultPolicy(
 async function loadGeneratedFirewallSource(
   firewallsDir: string,
   connectorsDir: string,
-  type: FirewallConnectorType,
+  registration: RegisteredFirewallSource,
 ): Promise<GeneratedFirewallSource> {
+  const { type, firewallExportName } = registration;
   const moduleExports = await importModule(
     path.join(firewallsDir, generatedDetailFileName(type)),
   );
-  const [firewallExportName, firewall] = getRequiredGeneratedExportEntry(
+  const firewall = getRequiredGeneratedExportByName(
     moduleExports,
     type,
-    "Firewall",
+    firewallExportName,
     isFirewallConfig,
   );
   const categories = getOptionalGeneratedExport(
@@ -356,9 +362,9 @@ function findConnectorFirewallsRegistry(
   return registry;
 }
 
-function extractRegisteredFirewallTypes(
+function extractRegisteredFirewallSources(
   firewallsIndexFile: string,
-): FirewallConnectorType[] {
+): RegisteredFirewallSource[] {
   const source = fs.readFileSync(firewallsIndexFile, "utf-8");
   const sourceFile = ts.createSourceFile(
     firewallsIndexFile,
@@ -381,7 +387,15 @@ function extractRegisteredFirewallTypes(
     if (!name) {
       throw new Error("CONNECTOR_FIREWALLS contains an unsupported key");
     }
-    return name as FirewallConnectorType;
+    if (!ts.isIdentifier(property.initializer)) {
+      throw new Error(
+        `CONNECTOR_FIREWALLS contains an unsupported value for: ${name}`,
+      );
+    }
+    return {
+      type: name as FirewallConnectorType,
+      firewallExportName: property.initializer.text,
+    };
   });
 }
 
@@ -774,18 +788,27 @@ export async function generateFirewallMetadata(): Promise<void> {
     "runtime-loader.generated.ts",
   );
 
-  const registeredTypes = extractRegisteredFirewallTypes(firewallsIndexFile);
+  const registeredSources =
+    extractRegisteredFirewallSources(firewallsIndexFile);
   const sources = await Promise.all(
-    [...registeredTypes].sort(compareStrings).map((type) => {
-      return loadGeneratedFirewallSource(firewallsDir, connectorsDir, type);
-    }),
+    [...registeredSources]
+      .sort((a, b) => {
+        return compareStrings(a.type, b.type);
+      })
+      .map((registration) => {
+        return loadGeneratedFirewallSource(
+          firewallsDir,
+          connectorsDir,
+          registration,
+        );
+      }),
   );
   const sourceByType = new Map<FirewallConnectorType, GeneratedFirewallSource>(
     sources.map((source) => {
       return [source.type, source];
     }),
   );
-  const registryOrderedSources = registeredTypes.map((type) => {
+  const registryOrderedSources = registeredSources.map(({ type }) => {
     const source = sourceByType.get(type);
     if (!source) {
       throw new Error(`Missing firewall metadata source: ${type}`);

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -27,6 +27,7 @@ interface ConnectorCategories {
 
 interface GeneratedFirewallSource {
   readonly type: FirewallConnectorType;
+  readonly firewallExportName: string;
   readonly firewall: FirewallConfig;
   readonly label: string;
   readonly categories: ConnectorCategories | null;
@@ -84,6 +85,21 @@ function getRequiredGeneratedExport<T>(
   suffix: string,
   isExpected: (value: unknown) => value is T,
 ): T {
+  const [, value] = getRequiredGeneratedExportEntry(
+    moduleExports,
+    type,
+    suffix,
+    isExpected,
+  );
+  return value;
+}
+
+function getRequiredGeneratedExportEntry<T>(
+  moduleExports: Readonly<Record<string, unknown>>,
+  type: FirewallConnectorType,
+  suffix: string,
+  isExpected: (value: unknown) => value is T,
+): readonly [string, T] {
   const matches = generatedExportCandidates(moduleExports, suffix);
   if (matches.length !== 1) {
     throw new Error(
@@ -102,7 +118,7 @@ function getRequiredGeneratedExport<T>(
       `Unexpected ${name} export shape for firewall metadata: ${type}`,
     );
   }
-  return value;
+  return [name, value];
 }
 
 function getOptionalGeneratedExport<T>(
@@ -268,7 +284,7 @@ async function loadGeneratedFirewallSource(
   const moduleExports = await importModule(
     path.join(firewallsDir, generatedDetailFileName(type)),
   );
-  const firewall = getRequiredGeneratedExport(
+  const [firewallExportName, firewall] = getRequiredGeneratedExportEntry(
     moduleExports,
     type,
     "Firewall",
@@ -294,6 +310,7 @@ async function loadGeneratedFirewallSource(
 
   return {
     type,
+    firewallExportName,
     firewall,
     label: loadConnectorLabel(connectorsDir, type),
     categories:
@@ -406,6 +423,10 @@ function generatedDetailFileName(type: FirewallConnectorType): string {
 
 function generatedDetailModuleSpecifier(type: FirewallConnectorType): string {
   return `./details/${generatedDetailFileName(type).replace(/\.ts$/, "")}`;
+}
+
+function generatedRuntimeModuleSpecifier(type: FirewallConnectorType): string {
+  return `./${generatedDetailFileName(type).replace(/\.ts$/, "")}`;
 }
 
 function replaceGeneratedPath(
@@ -676,6 +697,58 @@ export async function loadGeneratedFirewallPermissionMetadata(
 `;
 }
 
+function renderRuntimeLoaderFile(
+  sources: readonly GeneratedFirewallSource[],
+): string {
+  const connectorTypes = sources
+    .map((source) => {
+      return `  ${JSON.stringify(source.type)},`;
+    })
+    .join("\n");
+  const loaders = sources
+    .map((source) => {
+      const key = JSON.stringify(source.type);
+      const specifier = JSON.stringify(
+        generatedRuntimeModuleSpecifier(source.type),
+      );
+      return `  ${key}: async () => {
+    return (await import(${specifier})).${source.firewallExportName};
+  },`;
+    })
+    .join("\n");
+
+  return `${generatedHeader()}import type { FirewallConfig } from "../firewall-types";
+
+export const RUNTIME_FIREWALL_CONNECTOR_TYPES = [
+${connectorTypes}
+] as const;
+
+export type GeneratedRuntimeFirewallConnectorType =
+  (typeof RUNTIME_FIREWALL_CONNECTOR_TYPES)[number];
+
+const GENERATED_RUNTIME_FIREWALL_LOADERS: Readonly<
+  Record<GeneratedRuntimeFirewallConnectorType, () => Promise<FirewallConfig>>
+> = {
+${loaders}
+};
+
+export function hasGeneratedRuntimeFirewall(
+  type: string,
+): type is GeneratedRuntimeFirewallConnectorType {
+  return Object.prototype.hasOwnProperty.call(
+    GENERATED_RUNTIME_FIREWALL_LOADERS,
+    type,
+  );
+}
+
+export async function loadGeneratedRuntimeFirewall(
+  type: GeneratedRuntimeFirewallConnectorType,
+): Promise<FirewallConfig> {
+  return await GENERATED_RUNTIME_FIREWALL_LOADERS[type]();
+}
+`;
+}
+
 export async function generateFirewallMetadata(): Promise<void> {
   console.error("\n=== firewall metadata ===");
 
@@ -696,6 +769,10 @@ export async function generateFirewallMetadata(): Promise<void> {
   const loaderFile = path.join(outputDir, "loader.generated.ts");
   const serverFile = path.join(outputDir, "server.generated.ts");
   const detailsDir = path.join(outputDir, "details");
+  const runtimeLoaderFile = path.join(
+    firewallsDir,
+    "runtime-loader.generated.ts",
+  );
 
   const registeredTypes = extractRegisteredFirewallTypes(firewallsIndexFile);
   const sources = await Promise.all(
@@ -755,6 +832,10 @@ export async function generateFirewallMetadata(): Promise<void> {
       }),
     ),
   );
+  writeGeneratedFile(
+    path.join(nextOutputDir, "runtime-loader.generated.ts"),
+    renderRuntimeLoaderFile(sources),
+  );
 
   const replacements: GeneratedPathReplacement[] = [];
   try {
@@ -775,6 +856,12 @@ export async function generateFirewallMetadata(): Promise<void> {
       replaceGeneratedPath(
         serverFile,
         path.join(nextOutputDir, "server.generated.ts"),
+      ),
+    );
+    replacements.push(
+      replaceGeneratedPath(
+        runtimeLoaderFile,
+        path.join(nextOutputDir, "runtime-loader.generated.ts"),
       ),
     );
   } catch (error) {


### PR DESCRIPTION
## Summary

- Add an explicit `@vm0/connectors/firewalls/runtime` async loader subpath backed by a generated literal dynamic import manifest.
- Share placeholder expansion between the existing sync registry and the new lazy runtime loader without importing the eager registry from the lazy path.
- Add connector and generator tests that verify import boundaries, manifest synchronization, caching, and behavior compatibility with `getConnectorFirewall()`.

Closes #18115

## Verification

- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors test`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm exec vitest run packages/firewalls-generator/src/__tests__/metadata.test.ts`
- pre-commit: `pnpm knip`, full `pnpm check-types`