### PR TITLE
feat: add Codex app-server JSON-RPC client

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -352,8 +352,9 @@ impl CodexAppServerClient {
             }
         }
 
-        self.closed = true;
         self.drain_stderr().await;
+        self.clear_child_process_handles();
+        self.closed = true;
         Ok(())
     }
 
@@ -377,10 +378,7 @@ impl CodexAppServerClient {
     ) -> Result<ExitStatus, CodexAppServerError> {
         self.wait_rx = None;
         match result {
-            Ok(Ok(status)) => {
-                self.clear_child_process_handles();
-                Ok(status)
-            }
+            Ok(Ok(status)) => Ok(status),
             Ok(Err(error)) => {
                 self.kill_and_clear_child_process_handles();
                 Err(CodexAppServerError::Io(error))
@@ -402,7 +400,6 @@ impl CodexAppServerClient {
         match wait_rx.try_recv() {
             Ok(Ok(status)) => {
                 self.wait_rx = None;
-                self.clear_child_process_handles();
                 Ok(Some(status))
             }
             Ok(Err(error)) => {
@@ -578,6 +575,9 @@ impl CodexAppServerClient {
         };
         self.mark_stream_unusable(message);
         self.signal_process_group(libc::SIGKILL);
+        if self.wait_rx.is_none() {
+            self.clear_child_process_handles();
+        }
         error
     }
 
@@ -585,6 +585,9 @@ impl CodexAppServerClient {
         let message = message.into();
         self.mark_stream_unusable(message.clone());
         self.signal_process_group(libc::SIGKILL);
+        if self.wait_rx.is_none() {
+            self.clear_child_process_handles();
+        }
         CodexAppServerError::Protocol(message)
     }
 
@@ -595,18 +598,30 @@ impl CodexAppServerClient {
     }
 
     async fn drain_stderr(&mut self) {
-        let Some(stderr_handle) = self.stderr_handle.take() else {
+        let Some(stderr_handle) = self.stderr_handle.as_ref() else {
             return;
         };
-        let mut stderr_handle = stderr_handle;
+        let stderr_open = !stderr_handle.is_finished();
+        if stderr_open {
+            self.signal_process_group(libc::SIGKILL);
+        }
 
-        match tokio::time::timeout(STDERR_DRAIN_GRACE, &mut stderr_handle).await {
+        let Some(stderr_handle) = self.stderr_handle.as_mut() else {
+            return;
+        };
+
+        match tokio::time::timeout(STDERR_DRAIN_GRACE, stderr_handle).await {
             Ok(Ok(lines)) => {
                 self.stderr_tail = lines;
+                self.stderr_handle = None;
             }
-            Ok(Err(_join_error)) => {}
+            Ok(Err(_join_error)) => {
+                self.stderr_handle = None;
+            }
             Err(_elapsed) => {
-                stderr_handle.abort();
+                if let Some(stderr_handle) = self.stderr_handle.take() {
+                    stderr_handle.abort();
+                }
             }
         }
     }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -654,6 +654,14 @@ impl CodexAppServerClient {
         self.signal_process_group(libc::SIGKILL);
         self.clear_child_process_handles();
     }
+
+    fn drop_needs_process_group_signal(&self) -> bool {
+        self.wait_rx.is_some()
+            || self
+                .stderr_handle
+                .as_ref()
+                .is_some_and(|stderr_handle| !stderr_handle.is_finished())
+    }
 }
 
 impl Drop for CodexAppServerClient {
@@ -661,7 +669,9 @@ impl Drop for CodexAppServerClient {
         if !self.closed {
             self.stdin.take();
             let _ = self.try_finish_child_wait();
-            self.signal_process_group(libc::SIGKILL);
+            if self.drop_needs_process_group_signal() {
+                self.signal_process_group(libc::SIGKILL);
+            }
         }
         if let Some(stderr_handle) = self.stderr_handle.take() {
             stderr_handle.abort();

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -348,13 +348,21 @@ impl CodexAppServerClient {
         result: Result<std::io::Result<ExitStatus>, oneshot::error::RecvError>,
     ) -> Result<ExitStatus, CodexAppServerError> {
         self.wait_rx = None;
-        self.clear_child_process_handles();
         match result {
-            Ok(Ok(status)) => Ok(status),
-            Ok(Err(error)) => Err(CodexAppServerError::Io(error)),
-            Err(_) => Err(CodexAppServerError::Protocol(
-                "app-server wait task ended without status".to_string(),
-            )),
+            Ok(Ok(status)) => {
+                self.clear_child_process_handles();
+                Ok(status)
+            }
+            Ok(Err(error)) => {
+                self.kill_and_clear_child_process_handles();
+                Err(CodexAppServerError::Io(error))
+            }
+            Err(_) => {
+                self.kill_and_clear_child_process_handles();
+                Err(CodexAppServerError::Protocol(
+                    "app-server wait task ended without status".to_string(),
+                ))
+            }
         }
     }
 
@@ -371,13 +379,13 @@ impl CodexAppServerClient {
             }
             Ok(Err(error)) => {
                 self.wait_rx = None;
-                self.clear_child_process_handles();
+                self.kill_and_clear_child_process_handles();
                 Err(CodexAppServerError::Io(error))
             }
             Err(oneshot::error::TryRecvError::Empty) => Ok(None),
             Err(oneshot::error::TryRecvError::Closed) => {
                 self.wait_rx = None;
-                self.clear_child_process_handles();
+                self.kill_and_clear_child_process_handles();
                 Err(CodexAppServerError::Protocol(
                     "app-server wait task ended without status".to_string(),
                 ))
@@ -521,6 +529,11 @@ impl CodexAppServerClient {
     fn clear_child_process_handles(&mut self) {
         self.process_id = None;
         self.process_group_id = None;
+    }
+
+    fn kill_and_clear_child_process_handles(&mut self) {
+        self.signal_process_group(libc::SIGKILL);
+        self.clear_child_process_handles();
     }
 }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -140,6 +140,7 @@ pub struct CodexAppServerClient {
     stderr_handle: Option<JoinHandle<Vec<String>>>,
     stderr_tail: Vec<String>,
     next_request_id: i64,
+    in_flight_request_id: Option<JsonRpcId>,
     notifications: VecDeque<QueuedNotification>,
     notification_queue_bytes: usize,
     closed: bool,
@@ -196,6 +197,7 @@ impl CodexAppServerClient {
             stderr_handle: Some(stderr_handle),
             stderr_tail: Vec::new(),
             next_request_id: 1,
+            in_flight_request_id: None,
             notifications: VecDeque::with_capacity(NOTIFICATION_QUEUE_CAPACITY),
             notification_queue_bytes: 0,
             closed: false,
@@ -259,25 +261,46 @@ impl CodexAppServerClient {
         method: &str,
         params: Value,
     ) -> Result<Value, CodexAppServerError> {
+        if self.in_flight_request_id.take().is_some() {
+            self.signal_process_group(libc::SIGKILL);
+            return Err(CodexAppServerError::Protocol(
+                "previous app-server request did not complete".to_string(),
+            ));
+        }
         let id = JsonRpcId::Number(self.next_request_id);
         self.next_request_id = self.next_request_id.checked_add(1).ok_or_else(|| {
             CodexAppServerError::Protocol("app-server request id counter overflow".to_string())
         })?;
-        self.write_message(&outgoing_request(&id, method, params))
-            .await?;
+        self.in_flight_request_id = Some(id.clone());
+        if let Err(error) = self
+            .write_message(&outgoing_request(&id, method, params))
+            .await
+        {
+            self.in_flight_request_id = None;
+            return Err(error);
+        }
 
         loop {
-            match self.read_next_message(method).await? {
+            let message = match self.read_next_message(method).await {
+                Ok(message) => message,
+                Err(error) => {
+                    self.in_flight_request_id = None;
+                    return Err(error);
+                }
+            };
+            match message {
                 IncomingMessage::Success {
                     id: response_id,
                     result,
                 } if response_id == id => {
+                    self.in_flight_request_id = None;
                     return Ok(result);
                 }
                 IncomingMessage::Error {
                     id: response_id,
                     error,
                 } if response_id == id => {
+                    self.in_flight_request_id = None;
                     return Err(CodexAppServerError::Rpc {
                         method: method.to_string(),
                         id: response_id,
@@ -285,6 +308,7 @@ impl CodexAppServerClient {
                     });
                 }
                 IncomingMessage::Success { .. } | IncomingMessage::Error { .. } => {
+                    self.in_flight_request_id = None;
                     self.signal_process_group(libc::SIGKILL);
                     return Err(CodexAppServerError::Protocol(format!(
                         "received response for unknown id while waiting for {method}"
@@ -295,12 +319,16 @@ impl CodexAppServerClient {
                     line_bytes,
                 } => {
                     if let Err(error) = self.push_notification(notification, line_bytes) {
+                        self.in_flight_request_id = None;
                         self.signal_process_group(libc::SIGKILL);
                         return Err(error);
                     }
                 }
                 IncomingMessage::Request(request) => {
-                    self.reject_server_request(&request).await?;
+                    if let Err(error) = self.reject_server_request(&request).await {
+                        self.in_flight_request_id = None;
+                        return Err(error);
+                    }
                 }
             }
         }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -160,8 +160,6 @@ impl CodexAppServerClient {
         let mut cmd = tokio::process::Command::new(&config.binary);
         child_env::apply_to_tokio_command(&mut cmd);
         cmd.args(["app-server", "--listen", "stdio://"])
-            .env("CODEX_HOME", &config.codex_home)
-            .env_remove("MOCK_CODEX_FIXTURE")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -170,6 +168,8 @@ impl CodexAppServerClient {
         for (key, value) in config.extra_env {
             cmd.env(key, value);
         }
+        cmd.env("CODEX_HOME", &config.codex_home)
+            .env_remove("MOCK_CODEX_FIXTURE");
 
         let mut child = cmd.spawn().map_err(CodexAppServerError::Spawn)?;
         let process_id = child.id();

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -592,7 +592,9 @@ impl CodexAppServerClient {
         };
         self.mark_stream_unusable(message);
         self.close_io_handles();
-        self.signal_process_group(libc::SIGKILL);
+        if self.process_group_signal_needed() {
+            self.signal_process_group(libc::SIGKILL);
+        }
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
         }
@@ -603,7 +605,9 @@ impl CodexAppServerClient {
         let message = message.into();
         self.mark_stream_unusable(message.clone());
         self.close_io_handles();
-        self.signal_process_group(libc::SIGKILL);
+        if self.process_group_signal_needed() {
+            self.signal_process_group(libc::SIGKILL);
+        }
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
         }
@@ -679,7 +683,7 @@ impl CodexAppServerClient {
         self.clear_child_process_handles();
     }
 
-    fn drop_needs_process_group_signal(&self) -> bool {
+    fn process_group_signal_needed(&self) -> bool {
         self.wait_rx.is_some()
             || self
                 .stderr_handle
@@ -693,7 +697,7 @@ impl Drop for CodexAppServerClient {
         if !self.closed {
             self.close_io_handles();
             let _ = self.try_finish_child_wait();
-            if self.drop_needs_process_group_signal() {
+            if self.process_group_signal_needed() {
                 self.signal_process_group(libc::SIGKILL);
             }
         }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -601,8 +601,14 @@ impl CodexAppServerClient {
         let Some(stderr_handle) = self.stderr_handle.as_ref() else {
             return;
         };
-        let stderr_open = !stderr_handle.is_finished();
-        if stderr_open {
+        if !stderr_handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+
+        let Some(stderr_handle) = self.stderr_handle.as_ref() else {
+            return;
+        };
+        if !stderr_handle.is_finished() {
             self.signal_process_group(libc::SIGKILL);
         }
 
@@ -621,6 +627,7 @@ impl CodexAppServerClient {
             Err(_elapsed) => {
                 if let Some(stderr_handle) = self.stderr_handle.take() {
                     stderr_handle.abort();
+                    let _ = stderr_handle.await;
                 }
             }
         }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -133,7 +133,7 @@ impl From<CodexAppServerError> for AgentError {
 
 pub struct CodexAppServerClient {
     stdin: Option<ChildStdin>,
-    stdout_reader: BufReader<ChildStdout>,
+    stdout_reader: Option<BufReader<ChildStdout>>,
     process_id: Option<u32>,
     process_group_id: Option<i32>,
     wait_rx: Option<oneshot::Receiver<std::io::Result<ExitStatus>>>,
@@ -192,7 +192,7 @@ impl CodexAppServerClient {
 
         Ok(Self {
             stdin: Some(stdin),
-            stdout_reader: BufReader::new(stdout),
+            stdout_reader: Some(BufReader::new(stdout)),
             process_id,
             process_group_id,
             wait_rx: Some(wait_rx),
@@ -341,7 +341,7 @@ impl CodexAppServerClient {
             return Ok(());
         }
 
-        self.stdin.take();
+        self.close_io_handles();
         if self.wait_rx.is_some() && !self.wait_for_child(SHUTDOWN_SIGTERM_GRACE).await? {
             self.signal_process_group(libc::SIGTERM);
             if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
@@ -425,7 +425,12 @@ impl CodexAppServerClient {
         loop {
             tokio::select! {
                 biased;
-                line = read_stdout_line(&mut self.stdout_reader) => {
+                line = {
+                    let Some(stdout_reader) = self.stdout_reader.as_mut() else {
+                        return Err(self.poison_stream("app-server stdout is closed"));
+                    };
+                    read_stdout_line(stdout_reader)
+                } => {
                     let line = match line {
                         Ok(Some(line)) => line,
                         Ok(None) => {
@@ -565,6 +570,9 @@ impl CodexAppServerClient {
         if self.stdin.is_none() {
             return Err(self.poison_stream("app-server stdin is closed"));
         }
+        if self.stdout_reader.is_none() {
+            return Err(self.poison_stream("app-server stdout is closed"));
+        }
         if self.in_flight_request_id.is_some() {
             return Err(self.poison_stream("previous app-server request did not complete"));
         }
@@ -577,6 +585,7 @@ impl CodexAppServerClient {
             _ => error.to_string(),
         };
         self.mark_stream_unusable(message);
+        self.close_io_handles();
         self.signal_process_group(libc::SIGKILL);
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
@@ -587,6 +596,7 @@ impl CodexAppServerClient {
     fn poison_stream(&mut self, message: impl Into<String>) -> CodexAppServerError {
         let message = message.into();
         self.mark_stream_unusable(message.clone());
+        self.close_io_handles();
         self.signal_process_group(libc::SIGKILL);
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
@@ -653,6 +663,11 @@ impl CodexAppServerClient {
         self.process_group_id = None;
     }
 
+    fn close_io_handles(&mut self) {
+        self.stdin.take();
+        self.stdout_reader.take();
+    }
+
     fn kill_and_clear_child_process_handles(&mut self) {
         self.signal_process_group(libc::SIGKILL);
         self.clear_child_process_handles();
@@ -670,7 +685,7 @@ impl CodexAppServerClient {
 impl Drop for CodexAppServerClient {
     fn drop(&mut self) {
         if !self.closed {
-            self.stdin.take();
+            self.close_io_handles();
             let _ = self.try_finish_child_wait();
             if self.drop_needs_process_group_signal() {
                 self.signal_process_group(libc::SIGKILL);

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -333,19 +333,16 @@ impl CodexAppServerClient {
     }
 
     async fn wait_for_child(&mut self, timeout: Duration) -> Result<bool, CodexAppServerError> {
-        let Some(mut wait_rx) = self.wait_rx.take() else {
+        let Some(wait_rx) = self.wait_rx.as_mut() else {
             return Ok(true);
         };
 
-        match tokio::time::timeout(timeout, &mut wait_rx).await {
+        match tokio::time::timeout(timeout, wait_rx).await {
             Ok(result) => {
                 self.finish_child_wait(result)?;
                 Ok(true)
             }
-            Err(_) => {
-                self.wait_rx = Some(wait_rx);
-                Ok(false)
-            }
+            Err(_) => Ok(false),
         }
     }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -538,7 +538,7 @@ impl CodexAppServerClient {
 
     async fn write_message(&mut self, message: &Value) -> Result<(), CodexAppServerError> {
         if let Some(message) = self.stream_unusable_reason.clone() {
-            self.signal_process_group(libc::SIGKILL);
+            self.kill_unusable_stream_process_if_needed()?;
             return Err(CodexAppServerError::Protocol(message));
         }
         if self.outbound_write_in_progress {
@@ -567,7 +567,7 @@ impl CodexAppServerClient {
 
     fn ensure_stream_usable(&mut self) -> Result<(), CodexAppServerError> {
         if let Some(message) = self.stream_unusable_reason.clone() {
-            self.signal_process_group(libc::SIGKILL);
+            self.kill_unusable_stream_process_if_needed()?;
             return Err(CodexAppServerError::Protocol(message));
         }
         if self.outbound_write_in_progress {
@@ -689,6 +689,17 @@ impl CodexAppServerClient {
                 .stderr_handle
                 .as_ref()
                 .is_some_and(|stderr_handle| !stderr_handle.is_finished())
+    }
+
+    fn kill_unusable_stream_process_if_needed(&mut self) -> Result<(), CodexAppServerError> {
+        let _ = self.try_finish_child_wait()?;
+        if self.process_group_signal_needed() {
+            self.signal_process_group(libc::SIGKILL);
+        }
+        if self.wait_rx.is_none() {
+            self.clear_child_process_handles();
+        }
+        Ok(())
     }
 }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -94,7 +94,7 @@ pub enum CodexAppServerError {
     Io(#[from] std::io::Error),
     #[error("codex app-server JSON error: {0}")]
     Json(#[from] serde_json::Error),
-    #[error("codex app-server RPC error for {method}: {error:?}")]
+    #[error("codex app-server RPC error for {method}: {error}")]
     Rpc {
         method: String,
         id: JsonRpcId,
@@ -108,6 +108,17 @@ pub enum CodexAppServerError {
     ChildExited { method: String, status: String },
     #[error("codex app-server did not exit after shutdown")]
     ShutdownTimeout,
+}
+
+impl std::fmt::Display for JsonRpcError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "code={} message={}",
+            self.code,
+            bounded_error_message(&self.message)
+        )
+    }
 }
 
 impl From<CodexAppServerError> for AgentError {
@@ -509,7 +520,8 @@ fn outgoing_notification(method: &str, params: Value) -> Value {
 fn parse_incoming_message(line: &str) -> Result<IncomingMessage, CodexAppServerError> {
     let value: Value = serde_json::from_str(line).map_err(|error| {
         CodexAppServerError::Protocol(format!(
-            "malformed app-server stdout JSON: {error}; line={line:?}"
+            "malformed app-server stdout JSON: {error}; line_bytes={}",
+            line.len()
         ))
     })?;
 
@@ -580,6 +592,17 @@ fn parse_id(value: &Value) -> Result<JsonRpcId, CodexAppServerError> {
 fn bounded_method_name(method: &str) -> String {
     const MAX_CHARS: usize = 120;
     let mut chars = method.chars();
+    let bounded = chars.by_ref().take(MAX_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{bounded}...")
+    } else {
+        bounded
+    }
+}
+
+fn bounded_error_message(message: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    let mut chars = message.chars();
     let bounded = chars.by_ref().take(MAX_CHARS).collect::<String>();
     if chars.next().is_some() {
         format!("{bounded}...")

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -348,6 +348,8 @@ impl CodexAppServerClient {
         result: Result<std::io::Result<ExitStatus>, oneshot::error::RecvError>,
     ) -> Result<ExitStatus, CodexAppServerError> {
         self.wait_rx = None;
+        self.process_id = None;
+        self.process_group_id = None;
         match result {
             Ok(Ok(status)) => Ok(status),
             Ok(Err(error)) => Err(CodexAppServerError::Io(error)),

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -348,8 +348,7 @@ impl CodexAppServerClient {
         result: Result<std::io::Result<ExitStatus>, oneshot::error::RecvError>,
     ) -> Result<ExitStatus, CodexAppServerError> {
         self.wait_rx = None;
-        self.process_id = None;
-        self.process_group_id = None;
+        self.clear_child_process_handles();
         match result {
             Ok(Ok(status)) => Ok(status),
             Ok(Err(error)) => Err(CodexAppServerError::Io(error)),
@@ -367,15 +366,18 @@ impl CodexAppServerClient {
         match wait_rx.try_recv() {
             Ok(Ok(status)) => {
                 self.wait_rx = None;
+                self.clear_child_process_handles();
                 Ok(Some(status))
             }
             Ok(Err(error)) => {
                 self.wait_rx = None;
+                self.clear_child_process_handles();
                 Err(CodexAppServerError::Io(error))
             }
             Err(oneshot::error::TryRecvError::Empty) => Ok(None),
             Err(oneshot::error::TryRecvError::Closed) => {
                 self.wait_rx = None;
+                self.clear_child_process_handles();
                 Err(CodexAppServerError::Protocol(
                     "app-server wait task ended without status".to_string(),
                 ))
@@ -515,12 +517,18 @@ impl CodexAppServerClient {
             }
         }
     }
+
+    fn clear_child_process_handles(&mut self) {
+        self.process_id = None;
+        self.process_group_id = None;
+    }
 }
 
 impl Drop for CodexAppServerClient {
     fn drop(&mut self) {
         if !self.closed {
             self.stdin.take();
+            let _ = self.try_finish_child_wait();
             self.signal_process_group(libc::SIGKILL);
         }
         if let Some(stderr_handle) = self.stderr_handle.take() {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -686,11 +686,21 @@ fn parse_incoming_message(line: &str) -> Result<IncomingMessage, CodexAppServerE
 }
 
 fn parse_id(value: &Value) -> Result<JsonRpcId, CodexAppServerError> {
-    serde_json::from_value(value.clone()).map_err(|error| {
-        CodexAppServerError::Protocol(format!(
-            "app-server message id must be an integer or string: {error}"
-        ))
-    })
+    match value {
+        Value::Number(number) => number
+            .as_i64()
+            .map(JsonRpcId::Number)
+            .ok_or_else(invalid_id_error),
+        Value::String(value) => Ok(JsonRpcId::String(value.clone())),
+        Value::Null => Ok(JsonRpcId::Null),
+        _ => Err(invalid_id_error()),
+    }
+}
+
+fn invalid_id_error() -> CodexAppServerError {
+    CodexAppServerError::Protocol(
+        "app-server message id must be an integer, string, or null".to_string(),
+    )
 }
 
 fn parse_error_object(value: &Value) -> Result<JsonRpcError, CodexAppServerError> {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -538,7 +538,7 @@ impl CodexAppServerClient {
 
     async fn write_message(&mut self, message: &Value) -> Result<(), CodexAppServerError> {
         if let Some(message) = self.stream_unusable_reason.clone() {
-            self.kill_unusable_stream_process_if_needed()?;
+            self.kill_unusable_stream_process_if_needed();
             return Err(CodexAppServerError::Protocol(message));
         }
         if self.outbound_write_in_progress {
@@ -567,7 +567,7 @@ impl CodexAppServerClient {
 
     fn ensure_stream_usable(&mut self) -> Result<(), CodexAppServerError> {
         if let Some(message) = self.stream_unusable_reason.clone() {
-            self.kill_unusable_stream_process_if_needed()?;
+            self.kill_unusable_stream_process_if_needed();
             return Err(CodexAppServerError::Protocol(message));
         }
         if self.outbound_write_in_progress {
@@ -691,15 +691,14 @@ impl CodexAppServerClient {
                 .is_some_and(|stderr_handle| !stderr_handle.is_finished())
     }
 
-    fn kill_unusable_stream_process_if_needed(&mut self) -> Result<(), CodexAppServerError> {
-        let _ = self.try_finish_child_wait()?;
+    fn kill_unusable_stream_process_if_needed(&mut self) {
+        let _ = self.try_finish_child_wait();
         if self.process_group_signal_needed() {
             self.signal_process_group(libc::SIGKILL);
         }
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
         }
-        Ok(())
     }
 }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -24,6 +24,7 @@ use super::{child_env, diagnostics};
 
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
+const STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
 const SHUTDOWN_SIGTERM_GRACE: Duration = Duration::from_secs(2);
 const SHUTDOWN_SIGKILL_GRACE: Duration = Duration::from_secs(2);
 const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
@@ -129,7 +130,7 @@ impl From<CodexAppServerError> for AgentError {
 
 pub struct CodexAppServerClient {
     stdin: Option<ChildStdin>,
-    stdout_lines: Lines<BufReader<ChildStdout>>,
+    stdout_reader: BufReader<ChildStdout>,
     process_id: Option<u32>,
     process_group_id: Option<i32>,
     wait_rx: Option<oneshot::Receiver<std::io::Result<ExitStatus>>>,
@@ -179,7 +180,7 @@ impl CodexAppServerClient {
 
         Ok(Self {
             stdin: Some(stdin),
-            stdout_lines: BufReader::new(stdout).lines(),
+            stdout_reader: BufReader::new(stdout),
             process_id,
             process_group_id,
             wait_rx: Some(wait_rx),
@@ -242,7 +243,9 @@ impl CodexAppServerClient {
         params: Value,
     ) -> Result<Value, CodexAppServerError> {
         let id = JsonRpcId::Number(self.next_request_id);
-        self.next_request_id += 1;
+        self.next_request_id = self.next_request_id.checked_add(1).ok_or_else(|| {
+            CodexAppServerError::Protocol("app-server request id counter overflow".to_string())
+        })?;
         self.write_message(&outgoing_request(&id, method, params))
             .await?;
 
@@ -367,10 +370,10 @@ impl CodexAppServerClient {
         loop {
             tokio::select! {
                 biased;
-                line = self.stdout_lines.next_line() => {
-                    let line = match line? {
-                        Some(line) => line,
-                        None => {
+                line = read_stdout_line(&mut self.stdout_reader) => {
+                    let line = match line {
+                        Ok(Some(line)) => line,
+                        Ok(None) => {
                             if let Some(status) = self.try_finish_child_wait()? {
                                 return Err(CodexAppServerError::ChildExited {
                                     method: pending_method.to_string(),
@@ -380,6 +383,10 @@ impl CodexAppServerClient {
                             return Err(CodexAppServerError::Disconnected {
                                 method: pending_method.to_string(),
                             });
+                        }
+                        Err(error) => {
+                            self.signal_process_group(libc::SIGKILL);
+                            return Err(error);
                         }
                     };
                     if line.trim().is_empty() {
@@ -515,6 +522,65 @@ fn outgoing_notification(method: &str, params: Value) -> Value {
             "params": params,
         })
     }
+}
+
+async fn read_stdout_line(
+    stdout_reader: &mut BufReader<ChildStdout>,
+) -> Result<Option<String>, CodexAppServerError> {
+    let mut line = Vec::new();
+
+    loop {
+        let (consumed, reached_line_end) = {
+            let available = stdout_reader.fill_buf().await?;
+            if available.is_empty() {
+                if line.is_empty() {
+                    return Ok(None);
+                }
+                break;
+            }
+
+            if let Some(newline_index) = available.iter().position(|byte| *byte == b'\n') {
+                if line.len() + newline_index > STDOUT_MAX_LINE_BYTES {
+                    return Err(stdout_line_too_large_error());
+                }
+                let line_chunk = available.get(..newline_index).ok_or_else(|| {
+                    CodexAppServerError::Protocol(
+                        "app-server stdout reader returned an invalid newline offset".to_string(),
+                    )
+                })?;
+                line.extend_from_slice(line_chunk);
+                (newline_index + 1, true)
+            } else {
+                if line.len() + available.len() > STDOUT_MAX_LINE_BYTES {
+                    return Err(stdout_line_too_large_error());
+                }
+                line.extend_from_slice(available);
+                (available.len(), false)
+            }
+        };
+
+        stdout_reader.consume(consumed);
+        if reached_line_end {
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            break;
+        }
+    }
+
+    String::from_utf8(line).map(Some).map_err(|error| {
+        CodexAppServerError::Protocol(format!(
+            "app-server stdout line is not UTF-8: {}; line_bytes={}",
+            error.utf8_error(),
+            error.as_bytes().len()
+        ))
+    })
+}
+
+fn stdout_line_too_large_error() -> CodexAppServerError {
+    CodexAppServerError::Protocol(format!(
+        "app-server stdout line exceeded {STDOUT_MAX_LINE_BYTES} bytes"
+    ))
 }
 
 fn parse_incoming_message(line: &str) -> Result<IncomingMessage, CodexAppServerError> {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -142,6 +142,7 @@ pub struct CodexAppServerClient {
     next_request_id: i64,
     in_flight_request_id: Option<JsonRpcId>,
     outbound_write_in_progress: bool,
+    stream_unusable_reason: Option<String>,
     notifications: VecDeque<QueuedNotification>,
     notification_queue_bytes: usize,
     closed: bool,
@@ -200,6 +201,7 @@ impl CodexAppServerClient {
             next_request_id: 1,
             in_flight_request_id: None,
             outbound_write_in_progress: false,
+            stream_unusable_reason: None,
             notifications: VecDeque::with_capacity(NOTIFICATION_QUEUE_CAPACITY),
             notification_queue_bytes: 0,
             closed: false,
@@ -251,8 +253,7 @@ impl CodexAppServerClient {
     {
         let value = self.request_value(method, params).await?;
         serde_json::from_value(value).map_err(|_error| {
-            self.signal_process_group(libc::SIGKILL);
-            CodexAppServerError::Protocol(format!(
+            self.poison_stream(format!(
                 "app-server response for {method} had an unexpected shape"
             ))
         })
@@ -306,8 +307,7 @@ impl CodexAppServerClient {
                 }
                 IncomingMessage::Success { .. } | IncomingMessage::Error { .. } => {
                     self.in_flight_request_id = None;
-                    self.signal_process_group(libc::SIGKILL);
-                    return Err(CodexAppServerError::Protocol(format!(
+                    return Err(self.poison_stream(format!(
                         "received response for unknown id while waiting for {method}"
                     )));
                 }
@@ -317,8 +317,7 @@ impl CodexAppServerClient {
                 } => {
                     if let Err(error) = self.push_notification(notification, line_bytes) {
                         self.in_flight_request_id = None;
-                        self.signal_process_group(libc::SIGKILL);
-                        return Err(error);
+                        return Err(self.poison_error(error));
                     }
                 }
                 IncomingMessage::Request(request) => {
@@ -444,16 +443,13 @@ impl CodexAppServerClient {
                             });
                         }
                         Err(error) => {
-                            self.signal_process_group(libc::SIGKILL);
-                            return Err(error);
+                            return Err(self.poison_error(error));
                         }
                     };
                     if line.trim().is_empty() {
                         continue;
                     }
-                    return parse_incoming_message(&line).inspect_err(|_error| {
-                        self.signal_process_group(libc::SIGKILL);
-                    });
+                    return parse_incoming_message(&line).map_err(|error| self.poison_error(error));
                 }
                 result = async {
                     match self.wait_rx.as_mut() {
@@ -462,9 +458,7 @@ impl CodexAppServerClient {
                     }
                 }, if self.wait_rx.is_some() => {
                     let Some(result) = result else {
-                        return Err(CodexAppServerError::Protocol(
-                            "app-server wait receiver disappeared".to_string(),
-                        ));
+                        return Err(self.poison_stream("app-server wait receiver disappeared"));
                     };
                     let status = self.finish_child_wait(result)?;
                     return Err(CodexAppServerError::ChildExited {
@@ -523,11 +517,12 @@ impl CodexAppServerClient {
     }
 
     async fn write_message(&mut self, message: &Value) -> Result<(), CodexAppServerError> {
-        if self.outbound_write_in_progress {
+        if let Some(message) = self.stream_unusable_reason.clone() {
             self.signal_process_group(libc::SIGKILL);
-            return Err(CodexAppServerError::Protocol(
-                "previous app-server write did not complete".to_string(),
-            ));
+            return Err(CodexAppServerError::Protocol(message));
+        }
+        if self.outbound_write_in_progress {
+            return Err(self.poison_stream("previous app-server write did not complete"));
         }
         let mut bytes = serde_json::to_vec(message)?;
         bytes.push(b'\n');
@@ -546,19 +541,40 @@ impl CodexAppServerClient {
     }
 
     fn ensure_stream_usable(&mut self) -> Result<(), CodexAppServerError> {
-        if self.outbound_write_in_progress {
+        if let Some(message) = self.stream_unusable_reason.clone() {
             self.signal_process_group(libc::SIGKILL);
-            return Err(CodexAppServerError::Protocol(
-                "previous app-server write did not complete".to_string(),
-            ));
+            return Err(CodexAppServerError::Protocol(message));
         }
-        if self.in_flight_request_id.take().is_some() {
-            self.signal_process_group(libc::SIGKILL);
-            return Err(CodexAppServerError::Protocol(
-                "previous app-server request did not complete".to_string(),
-            ));
+        if self.outbound_write_in_progress {
+            return Err(self.poison_stream("previous app-server write did not complete"));
+        }
+        if self.in_flight_request_id.is_some() {
+            return Err(self.poison_stream("previous app-server request did not complete"));
         }
         Ok(())
+    }
+
+    fn poison_error(&mut self, error: CodexAppServerError) -> CodexAppServerError {
+        let message = match &error {
+            CodexAppServerError::Protocol(message) => message.clone(),
+            _ => error.to_string(),
+        };
+        self.mark_stream_unusable(message);
+        self.signal_process_group(libc::SIGKILL);
+        error
+    }
+
+    fn poison_stream(&mut self, message: impl Into<String>) -> CodexAppServerError {
+        let message = message.into();
+        self.mark_stream_unusable(message.clone());
+        self.signal_process_group(libc::SIGKILL);
+        CodexAppServerError::Protocol(message)
+    }
+
+    fn mark_stream_unusable(&mut self, message: String) {
+        if self.stream_unusable_reason.is_none() {
+            self.stream_unusable_reason = Some(message);
+        }
     }
 
     async fn drain_stderr(&mut self) {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -141,6 +141,7 @@ pub struct CodexAppServerClient {
     stderr_tail: Vec<String>,
     next_request_id: i64,
     in_flight_request_id: Option<JsonRpcId>,
+    outbound_write_in_progress: bool,
     notifications: VecDeque<QueuedNotification>,
     notification_queue_bytes: usize,
     closed: bool,
@@ -198,6 +199,7 @@ impl CodexAppServerClient {
             stderr_tail: Vec::new(),
             next_request_id: 1,
             in_flight_request_id: None,
+            outbound_write_in_progress: false,
             notifications: VecDeque::with_capacity(NOTIFICATION_QUEUE_CAPACITY),
             notification_queue_bytes: 0,
             closed: false,
@@ -261,12 +263,7 @@ impl CodexAppServerClient {
         method: &str,
         params: Value,
     ) -> Result<Value, CodexAppServerError> {
-        if self.in_flight_request_id.take().is_some() {
-            self.signal_process_group(libc::SIGKILL);
-            return Err(CodexAppServerError::Protocol(
-                "previous app-server request did not complete".to_string(),
-            ));
-        }
+        self.ensure_stream_usable()?;
         let id = JsonRpcId::Number(self.next_request_id);
         self.next_request_id = self.next_request_id.checked_add(1).ok_or_else(|| {
             CodexAppServerError::Protocol("app-server request id counter overflow".to_string())
@@ -335,6 +332,7 @@ impl CodexAppServerClient {
     }
 
     pub async fn notify(&mut self, method: &str, params: Value) -> Result<(), CodexAppServerError> {
+        self.ensure_stream_usable()?;
         self.write_message(&outgoing_notification(method, params))
             .await
     }
@@ -525,13 +523,41 @@ impl CodexAppServerClient {
     }
 
     async fn write_message(&mut self, message: &Value) -> Result<(), CodexAppServerError> {
-        let stdin = self.stdin.as_mut().ok_or_else(|| {
-            CodexAppServerError::Protocol("app-server stdin is closed".to_string())
-        })?;
+        if self.outbound_write_in_progress {
+            self.signal_process_group(libc::SIGKILL);
+            return Err(CodexAppServerError::Protocol(
+                "previous app-server write did not complete".to_string(),
+            ));
+        }
         let mut bytes = serde_json::to_vec(message)?;
         bytes.push(b'\n');
-        stdin.write_all(&bytes).await?;
-        stdin.flush().await?;
+        self.outbound_write_in_progress = true;
+        let result = async {
+            let stdin = self.stdin.as_mut().ok_or_else(|| {
+                CodexAppServerError::Protocol("app-server stdin is closed".to_string())
+            })?;
+            stdin.write_all(&bytes).await?;
+            stdin.flush().await?;
+            Ok(())
+        }
+        .await;
+        self.outbound_write_in_progress = false;
+        result
+    }
+
+    fn ensure_stream_usable(&mut self) -> Result<(), CodexAppServerError> {
+        if self.outbound_write_in_progress {
+            self.signal_process_group(libc::SIGKILL);
+            return Err(CodexAppServerError::Protocol(
+                "previous app-server write did not complete".to_string(),
+            ));
+        }
+        if self.in_flight_request_id.take().is_some() {
+            self.signal_process_group(libc::SIGKILL);
+            return Err(CodexAppServerError::Protocol(
+                "previous app-server request did not complete".to_string(),
+            ));
+        }
         Ok(())
     }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -240,7 +240,12 @@ impl CodexAppServerClient {
         T: DeserializeOwned,
     {
         let value = self.request_value(method, params).await?;
-        Ok(serde_json::from_value(value)?)
+        serde_json::from_value(value).map_err(|_error| {
+            self.signal_process_group(libc::SIGKILL);
+            CodexAppServerError::Protocol(format!(
+                "app-server response for {method} had an unexpected shape"
+            ))
+        })
     }
 
     pub async fn request_value(
@@ -521,13 +526,6 @@ impl Drop for CodexAppServerClient {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct IncomingErrorObject {
-    code: i64,
-    message: String,
-    data: Option<Value>,
-}
-
 struct QueuedNotification {
     notification: ServerNotification,
     bytes: usize,
@@ -671,17 +669,10 @@ fn parse_incoming_message(line: &str) -> Result<IncomingMessage, CodexAppServerE
             id,
             result: result.clone(),
         }),
-        (None, Some(error)) => {
-            let error: IncomingErrorObject = serde_json::from_value(error.clone())?;
-            Ok(IncomingMessage::Error {
-                id,
-                error: JsonRpcError {
-                    code: error.code,
-                    message: error.message,
-                    data: error.data,
-                },
-            })
-        }
+        (None, Some(error)) => Ok(IncomingMessage::Error {
+            id,
+            error: parse_error_object(error)?,
+        }),
         (Some(_), Some(_)) => Err(CodexAppServerError::Protocol(
             "response contains both result and error".to_string(),
         )),
@@ -696,6 +687,31 @@ fn parse_id(value: &Value) -> Result<JsonRpcId, CodexAppServerError> {
         CodexAppServerError::Protocol(format!(
             "app-server message id must be an integer or string: {error}"
         ))
+    })
+}
+
+fn parse_error_object(value: &Value) -> Result<JsonRpcError, CodexAppServerError> {
+    let Value::Object(fields) = value else {
+        return Err(CodexAppServerError::Protocol(
+            "error response must be an object".to_string(),
+        ));
+    };
+    let code = fields.get("code").and_then(Value::as_i64).ok_or_else(|| {
+        CodexAppServerError::Protocol("error response must contain an integer code".to_string())
+    })?;
+    let message = fields
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CodexAppServerError::Protocol(
+                "error response must contain a string message".to_string(),
+            )
+        })?
+        .to_string();
+    Ok(JsonRpcError {
+        code,
+        message,
+        data: fields.get("data").cloned(),
     })
 }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -341,8 +341,14 @@ impl CodexAppServerClient {
             return Ok(());
         }
 
+        let requested_graceful_shutdown = self.stdin.is_some();
         self.close_io_handles();
-        if self.wait_rx.is_some() && !self.wait_for_child(SHUTDOWN_SIGTERM_GRACE).await? {
+        let child_exited = if requested_graceful_shutdown {
+            self.wait_for_child(SHUTDOWN_SIGTERM_GRACE).await?
+        } else {
+            self.try_finish_child_wait()?.is_some()
+        };
+        if self.wait_rx.is_some() && !child_exited {
             self.signal_process_group(libc::SIGTERM);
             if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
                 self.signal_process_group(libc::SIGKILL);

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -562,6 +562,9 @@ impl CodexAppServerClient {
         if self.outbound_write_in_progress {
             return Err(self.poison_stream("previous app-server write did not complete"));
         }
+        if self.stdin.is_none() {
+            return Err(self.poison_stream("app-server stdin is closed"));
+        }
         if self.in_flight_request_id.is_some() {
             return Err(self.poison_stream("previous app-server request did not complete"));
         }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout};
+use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -146,6 +147,11 @@ pub struct CodexAppServerClient {
 
 impl CodexAppServerClient {
     pub fn spawn(config: CodexAppServerConfig) -> Result<Self, CodexAppServerError> {
+        let runtime = Handle::try_current().map_err(|_error| {
+            CodexAppServerError::Protocol(
+                "codex app-server client requires a Tokio runtime".to_string(),
+            )
+        })?;
         std::fs::create_dir_all(&config.codex_home)?;
 
         let mut cmd = tokio::process::Command::new(&config.binary);
@@ -175,9 +181,9 @@ impl CodexAppServerClient {
             CodexAppServerError::Protocol("app-server stderr was not piped".to_string())
         })?;
         let stderr_handle =
-            tokio::spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
+            runtime.spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
         let (wait_tx, wait_rx) = oneshot::channel();
-        tokio::spawn(async move {
+        runtime.spawn(async move {
             let _ = wait_tx.send(child.wait().await);
         });
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -278,9 +278,10 @@ impl CodexAppServerClient {
                         error: Box::new(error),
                     });
                 }
-                IncomingMessage::Success { id, .. } | IncomingMessage::Error { id, .. } => {
+                IncomingMessage::Success { .. } | IncomingMessage::Error { .. } => {
+                    self.signal_process_group(libc::SIGKILL);
                     return Err(CodexAppServerError::Protocol(format!(
-                        "received response for unknown id {id:?} while waiting for {method}"
+                        "received response for unknown id while waiting for {method}"
                     )));
                 }
                 IncomingMessage::Notification {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -282,7 +282,10 @@ impl CodexAppServerClient {
                     notification,
                     line_bytes,
                 } => {
-                    self.push_notification(notification, line_bytes)?;
+                    if let Err(error) = self.push_notification(notification, line_bytes) {
+                        self.signal_process_group(libc::SIGKILL);
+                        return Err(error);
+                    }
                 }
                 IncomingMessage::Request(request) => {
                     self.reject_server_request(&request).await?;

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -24,7 +24,8 @@ use super::{child_env, diagnostics};
 
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
-const STDOUT_MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
+const NOTIFICATION_QUEUE_MAX_BYTES: usize = 16 * 1024 * 1024;
+const STDOUT_MAX_LINE_BYTES: usize = 64 * 1024 * 1024;
 const SHUTDOWN_SIGTERM_GRACE: Duration = Duration::from_secs(2);
 const SHUTDOWN_SIGKILL_GRACE: Duration = Duration::from_secs(2);
 const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
@@ -56,6 +57,7 @@ impl CodexAppServerConfig {
 pub enum JsonRpcId {
     Number(i64),
     String(String),
+    Null,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -137,7 +139,8 @@ pub struct CodexAppServerClient {
     stderr_handle: Option<JoinHandle<Vec<String>>>,
     stderr_tail: Vec<String>,
     next_request_id: i64,
-    notifications: VecDeque<ServerNotification>,
+    notifications: VecDeque<QueuedNotification>,
+    notification_queue_bytes: usize,
     closed: bool,
 }
 
@@ -188,6 +191,7 @@ impl CodexAppServerClient {
             stderr_tail: Vec::new(),
             next_request_id: 1,
             notifications: VecDeque::with_capacity(NOTIFICATION_QUEUE_CAPACITY),
+            notification_queue_bytes: 0,
             closed: false,
         })
     }
@@ -197,7 +201,9 @@ impl CodexAppServerClient {
     }
 
     pub fn pop_notification(&mut self) -> Option<ServerNotification> {
-        self.notifications.pop_front()
+        let queued = self.notifications.pop_front()?;
+        self.notification_queue_bytes = self.notification_queue_bytes.saturating_sub(queued.bytes);
+        Some(queued.notification)
     }
 
     pub fn stderr_tail(&self) -> &[String] {
@@ -272,8 +278,11 @@ impl CodexAppServerClient {
                         "received response for unknown id {id:?} while waiting for {method}"
                     )));
                 }
-                IncomingMessage::Notification(notification) => {
-                    self.push_notification(notification)?;
+                IncomingMessage::Notification {
+                    notification,
+                    line_bytes,
+                } => {
+                    self.push_notification(notification, line_bytes)?;
                 }
                 IncomingMessage::Request(request) => {
                     self.reject_server_request(&request).await?;
@@ -435,13 +444,31 @@ impl CodexAppServerClient {
     fn push_notification(
         &mut self,
         notification: ServerNotification,
+        line_bytes: usize,
     ) -> Result<(), CodexAppServerError> {
         if self.notifications.len() == NOTIFICATION_QUEUE_CAPACITY {
             return Err(CodexAppServerError::Protocol(format!(
                 "server notification queue exceeded {NOTIFICATION_QUEUE_CAPACITY} entries"
             )));
         }
-        self.notifications.push_back(notification);
+        let next_bytes = self
+            .notification_queue_bytes
+            .checked_add(line_bytes)
+            .ok_or_else(|| {
+                CodexAppServerError::Protocol(
+                    "server notification queue byte count overflowed".to_string(),
+                )
+            })?;
+        if next_bytes > NOTIFICATION_QUEUE_MAX_BYTES {
+            return Err(CodexAppServerError::Protocol(format!(
+                "server notification queue exceeded {NOTIFICATION_QUEUE_MAX_BYTES} bytes"
+            )));
+        }
+        self.notification_queue_bytes = next_bytes;
+        self.notifications.push_back(QueuedNotification {
+            notification,
+            bytes: line_bytes,
+        });
         Ok(())
     }
 
@@ -498,10 +525,24 @@ struct IncomingErrorObject {
     data: Option<Value>,
 }
 
+struct QueuedNotification {
+    notification: ServerNotification,
+    bytes: usize,
+}
+
 enum IncomingMessage {
-    Success { id: JsonRpcId, result: Value },
-    Error { id: JsonRpcId, error: JsonRpcError },
-    Notification(ServerNotification),
+    Success {
+        id: JsonRpcId,
+        result: Value,
+    },
+    Error {
+        id: JsonRpcId,
+        error: JsonRpcError,
+    },
+    Notification {
+        notification: ServerNotification,
+        line_bytes: usize,
+    },
     Request(ServerRequest),
 }
 
@@ -609,10 +650,10 @@ fn parse_incoming_message(line: &str) -> Result<IncomingMessage, CodexAppServerE
                 params,
             }));
         }
-        return Ok(IncomingMessage::Notification(ServerNotification {
-            method,
-            params,
-        }));
+        return Ok(IncomingMessage::Notification {
+            notification: ServerNotification { method, params },
+            line_bytes: line.len(),
+        });
     }
 
     let Some(id_value) = value.get("id") else {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -432,15 +432,23 @@ impl CodexAppServerClient {
                     let line = match line {
                         Ok(Some(line)) => line,
                         Ok(None) => {
-                            if let Some(status) = self.try_finish_child_wait()? {
-                                return Err(CodexAppServerError::ChildExited {
-                                    method: pending_method.to_string(),
-                                    status: status.to_string(),
-                                });
+                            match self.try_finish_child_wait() {
+                                Ok(Some(status)) => {
+                                    let error = CodexAppServerError::ChildExited {
+                                        method: pending_method.to_string(),
+                                        status: status.to_string(),
+                                    };
+                                    return Err(self.poison_error(error));
+                                }
+                                Ok(None) => {
+                                    return Err(self.poison_error(CodexAppServerError::Disconnected {
+                                        method: pending_method.to_string(),
+                                    }));
+                                }
+                                Err(error) => {
+                                    return Err(self.poison_error(error));
+                                }
                             }
-                            return Err(CodexAppServerError::Disconnected {
-                                method: pending_method.to_string(),
-                            });
                         }
                         Err(error) => {
                             return Err(self.poison_error(error));
@@ -460,11 +468,15 @@ impl CodexAppServerClient {
                     let Some(result) = result else {
                         return Err(self.poison_stream("app-server wait receiver disappeared"));
                     };
-                    let status = self.finish_child_wait(result)?;
-                    return Err(CodexAppServerError::ChildExited {
+                    let status = match self.finish_child_wait(result) {
+                        Ok(status) => status,
+                        Err(error) => return Err(self.poison_error(error)),
+                    };
+                    let error = CodexAppServerError::ChildExited {
                         method: pending_method.to_string(),
                         status: status.to_string(),
-                    });
+                    };
+                    return Err(self.poison_error(error));
                 }
             }
         }
@@ -524,6 +536,11 @@ impl CodexAppServerClient {
         if self.outbound_write_in_progress {
             return Err(self.poison_stream("previous app-server write did not complete"));
         }
+        if self.stdin.is_none() {
+            return Err(CodexAppServerError::Protocol(
+                "app-server stdin is closed".to_string(),
+            ));
+        }
         let mut bytes = serde_json::to_vec(message)?;
         bytes.push(b'\n');
         self.outbound_write_in_progress = true;
@@ -537,7 +554,7 @@ impl CodexAppServerClient {
         }
         .await;
         self.outbound_write_in_progress = false;
-        result
+        result.map_err(|error| self.poison_error(error))
     }
 
     fn ensure_stream_usable(&mut self) -> Result<(), CodexAppServerError> {

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -508,9 +508,16 @@ impl CodexAppServerClient {
         let Some(stderr_handle) = self.stderr_handle.take() else {
             return;
         };
+        let mut stderr_handle = stderr_handle;
 
-        if let Ok(Ok(lines)) = tokio::time::timeout(STDERR_DRAIN_GRACE, stderr_handle).await {
-            self.stderr_tail = lines;
+        match tokio::time::timeout(STDERR_DRAIN_GRACE, &mut stderr_handle).await {
+            Ok(Ok(lines)) => {
+                self.stderr_tail = lines;
+            }
+            Ok(Err(_join_error)) => {}
+            Err(_elapsed) => {
+                stderr_handle.abort();
+            }
         }
     }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -1,0 +1,589 @@
+//! Codex app-server stdio JSON-RPC client.
+//!
+//! This module owns the protocol and process boundary for
+//! `codex app-server --listen stdio://`. It intentionally does not interpret
+//! thread or turn semantics; later runtime code can build those policies on
+//! top of this generic request/notification layer.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{ChildStdin, ChildStdout};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::error::AgentError;
+
+use super::{child_env, diagnostics};
+
+const METHOD_NOT_FOUND: i64 = -32601;
+const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
+const SHUTDOWN_SIGTERM_GRACE: Duration = Duration::from_secs(2);
+const SHUTDOWN_SIGKILL_GRACE: Duration = Duration::from_secs(2);
+const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone)]
+pub struct CodexAppServerConfig {
+    binary: PathBuf,
+    codex_home: PathBuf,
+    extra_env: Vec<(String, String)>,
+}
+
+impl CodexAppServerConfig {
+    pub fn new(binary: impl Into<PathBuf>, codex_home: impl Into<PathBuf>) -> Self {
+        Self {
+            binary: binary.into(),
+            codex_home: codex_home.into(),
+            extra_env: Vec::new(),
+        }
+    }
+
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra_env.push((key.into(), value.into()));
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcId {
+    Number(i64),
+    String(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerNotification {
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerRequest {
+    pub id: JsonRpcId,
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeResponse {
+    pub user_agent: String,
+    pub codex_home: String,
+    pub platform_family: String,
+    pub platform_os: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CodexAppServerError {
+    #[error("failed to spawn codex app-server: {0}")]
+    Spawn(#[source] std::io::Error),
+    #[error("codex app-server io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("codex app-server JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("codex app-server RPC error for {method}: {error:?}")]
+    Rpc {
+        method: String,
+        id: JsonRpcId,
+        error: Box<JsonRpcError>,
+    },
+    #[error("codex app-server protocol error: {0}")]
+    Protocol(String),
+    #[error("codex app-server disconnected while waiting for {method}")]
+    Disconnected { method: String },
+    #[error("codex app-server child exited while waiting for {method}: {status}")]
+    ChildExited { method: String, status: String },
+    #[error("codex app-server did not exit after shutdown")]
+    ShutdownTimeout,
+}
+
+impl From<CodexAppServerError> for AgentError {
+    fn from(value: CodexAppServerError) -> Self {
+        AgentError::Execution(value.to_string())
+    }
+}
+
+pub struct CodexAppServerClient {
+    stdin: Option<ChildStdin>,
+    stdout_lines: Lines<BufReader<ChildStdout>>,
+    process_id: Option<u32>,
+    process_group_id: Option<i32>,
+    wait_rx: Option<oneshot::Receiver<std::io::Result<ExitStatus>>>,
+    stderr_handle: Option<JoinHandle<Vec<String>>>,
+    stderr_tail: Vec<String>,
+    next_request_id: i64,
+    notifications: VecDeque<ServerNotification>,
+    closed: bool,
+}
+
+impl CodexAppServerClient {
+    pub fn spawn(config: CodexAppServerConfig) -> Result<Self, CodexAppServerError> {
+        std::fs::create_dir_all(&config.codex_home)?;
+
+        let mut cmd = tokio::process::Command::new(&config.binary);
+        child_env::apply_to_tokio_command(&mut cmd);
+        cmd.args(["app-server", "--listen", "stdio://"])
+            .env("CODEX_HOME", &config.codex_home)
+            .env_remove("MOCK_CODEX_FIXTURE")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0)
+            .kill_on_drop(true);
+        for (key, value) in config.extra_env {
+            cmd.env(key, value);
+        }
+
+        let mut child = cmd.spawn().map_err(CodexAppServerError::Spawn)?;
+        let process_id = child.id();
+        let process_group_id = process_id.map(|pid| pid as i32);
+        let stdin = child.stdin.take().ok_or_else(|| {
+            CodexAppServerError::Protocol("app-server stdin was not piped".to_string())
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            CodexAppServerError::Protocol("app-server stdout was not piped".to_string())
+        })?;
+        let stderr = child.stderr.take().ok_or_else(|| {
+            CodexAppServerError::Protocol("app-server stderr was not piped".to_string())
+        })?;
+        let stderr_handle =
+            tokio::spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
+        let (wait_tx, wait_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = wait_tx.send(child.wait().await);
+        });
+
+        Ok(Self {
+            stdin: Some(stdin),
+            stdout_lines: BufReader::new(stdout).lines(),
+            process_id,
+            process_group_id,
+            wait_rx: Some(wait_rx),
+            stderr_handle: Some(stderr_handle),
+            stderr_tail: Vec::new(),
+            next_request_id: 1,
+            notifications: VecDeque::with_capacity(NOTIFICATION_QUEUE_CAPACITY),
+            closed: false,
+        })
+    }
+
+    pub fn process_id(&self) -> Option<u32> {
+        self.process_id
+    }
+
+    pub fn pop_notification(&mut self) -> Option<ServerNotification> {
+        self.notifications.pop_front()
+    }
+
+    pub fn stderr_tail(&self) -> &[String] {
+        &self.stderr_tail
+    }
+
+    pub async fn initialize(&mut self) -> Result<InitializeResponse, CodexAppServerError> {
+        let response = self
+            .request(
+                "initialize",
+                json!({
+                    "clientInfo": {
+                        "name": "vm0-guest-agent",
+                        "title": null,
+                        "version": env!("CARGO_PKG_VERSION")
+                    },
+                    "capabilities": {
+                        "experimentalApi": true,
+                        "requestAttestation": false
+                    }
+                }),
+            )
+            .await?;
+        self.notify("initialized", Value::Null).await?;
+        Ok(response)
+    }
+
+    pub async fn request<T>(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> Result<T, CodexAppServerError>
+    where
+        T: DeserializeOwned,
+    {
+        let value = self.request_value(method, params).await?;
+        Ok(serde_json::from_value(value)?)
+    }
+
+    pub async fn request_value(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, CodexAppServerError> {
+        let id = JsonRpcId::Number(self.next_request_id);
+        self.next_request_id += 1;
+        self.write_message(&outgoing_request(&id, method, params))
+            .await?;
+
+        loop {
+            match self.read_next_message(method).await? {
+                IncomingMessage::Success {
+                    id: response_id,
+                    result,
+                } if response_id == id => {
+                    return Ok(result);
+                }
+                IncomingMessage::Error {
+                    id: response_id,
+                    error,
+                } if response_id == id => {
+                    return Err(CodexAppServerError::Rpc {
+                        method: method.to_string(),
+                        id: response_id,
+                        error: Box::new(error),
+                    });
+                }
+                IncomingMessage::Success { id, .. } | IncomingMessage::Error { id, .. } => {
+                    return Err(CodexAppServerError::Protocol(format!(
+                        "received response for unknown id {id:?} while waiting for {method}"
+                    )));
+                }
+                IncomingMessage::Notification(notification) => {
+                    self.push_notification(notification)?;
+                }
+                IncomingMessage::Request(request) => {
+                    self.reject_server_request(&request).await?;
+                }
+            }
+        }
+    }
+
+    pub async fn notify(&mut self, method: &str, params: Value) -> Result<(), CodexAppServerError> {
+        self.write_message(&outgoing_notification(method, params))
+            .await
+    }
+
+    pub async fn shutdown(&mut self) -> Result<(), CodexAppServerError> {
+        if self.closed {
+            return Ok(());
+        }
+
+        self.stdin.take();
+        if self.wait_rx.is_some() && !self.wait_for_child(SHUTDOWN_SIGTERM_GRACE).await? {
+            self.signal_process_group(libc::SIGTERM);
+            if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
+                self.signal_process_group(libc::SIGKILL);
+                if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
+                    return Err(CodexAppServerError::ShutdownTimeout);
+                }
+            }
+        }
+
+        self.closed = true;
+        self.drain_stderr().await;
+        Ok(())
+    }
+
+    async fn wait_for_child(&mut self, timeout: Duration) -> Result<bool, CodexAppServerError> {
+        let Some(mut wait_rx) = self.wait_rx.take() else {
+            return Ok(true);
+        };
+
+        match tokio::time::timeout(timeout, &mut wait_rx).await {
+            Ok(result) => {
+                self.finish_child_wait(result)?;
+                Ok(true)
+            }
+            Err(_) => {
+                self.wait_rx = Some(wait_rx);
+                Ok(false)
+            }
+        }
+    }
+
+    fn finish_child_wait(
+        &mut self,
+        result: Result<std::io::Result<ExitStatus>, oneshot::error::RecvError>,
+    ) -> Result<ExitStatus, CodexAppServerError> {
+        self.wait_rx = None;
+        match result {
+            Ok(Ok(status)) => Ok(status),
+            Ok(Err(error)) => Err(CodexAppServerError::Io(error)),
+            Err(_) => Err(CodexAppServerError::Protocol(
+                "app-server wait task ended without status".to_string(),
+            )),
+        }
+    }
+
+    fn try_finish_child_wait(&mut self) -> Result<Option<ExitStatus>, CodexAppServerError> {
+        let Some(wait_rx) = self.wait_rx.as_mut() else {
+            return Ok(None);
+        };
+
+        match wait_rx.try_recv() {
+            Ok(Ok(status)) => {
+                self.wait_rx = None;
+                Ok(Some(status))
+            }
+            Ok(Err(error)) => {
+                self.wait_rx = None;
+                Err(CodexAppServerError::Io(error))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => Ok(None),
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.wait_rx = None;
+                Err(CodexAppServerError::Protocol(
+                    "app-server wait task ended without status".to_string(),
+                ))
+            }
+        }
+    }
+
+    async fn read_next_message(
+        &mut self,
+        pending_method: &str,
+    ) -> Result<IncomingMessage, CodexAppServerError> {
+        loop {
+            tokio::select! {
+                biased;
+                line = self.stdout_lines.next_line() => {
+                    let line = match line? {
+                        Some(line) => line,
+                        None => {
+                            if let Some(status) = self.try_finish_child_wait()? {
+                                return Err(CodexAppServerError::ChildExited {
+                                    method: pending_method.to_string(),
+                                    status: status.to_string(),
+                                });
+                            }
+                            return Err(CodexAppServerError::Disconnected {
+                                method: pending_method.to_string(),
+                            });
+                        }
+                    };
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    return parse_incoming_message(&line).inspect_err(|_error| {
+                        self.signal_process_group(libc::SIGKILL);
+                    });
+                }
+                result = async {
+                    match self.wait_rx.as_mut() {
+                        Some(wait_rx) => Some(wait_rx.await),
+                        None => None,
+                    }
+                }, if self.wait_rx.is_some() => {
+                    let Some(result) = result else {
+                        return Err(CodexAppServerError::Protocol(
+                            "app-server wait receiver disappeared".to_string(),
+                        ));
+                    };
+                    let status = self.finish_child_wait(result)?;
+                    return Err(CodexAppServerError::ChildExited {
+                        method: pending_method.to_string(),
+                        status: status.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    async fn reject_server_request(
+        &mut self,
+        request: &ServerRequest,
+    ) -> Result<(), CodexAppServerError> {
+        let method = bounded_method_name(&request.method);
+        self.write_message(&json!({
+            "id": request.id.clone(),
+            "error": {
+                "code": METHOD_NOT_FOUND,
+                "message": format!("unsupported server request method {method}")
+            }
+        }))
+        .await
+    }
+
+    fn push_notification(
+        &mut self,
+        notification: ServerNotification,
+    ) -> Result<(), CodexAppServerError> {
+        if self.notifications.len() == NOTIFICATION_QUEUE_CAPACITY {
+            return Err(CodexAppServerError::Protocol(format!(
+                "server notification queue exceeded {NOTIFICATION_QUEUE_CAPACITY} entries"
+            )));
+        }
+        self.notifications.push_back(notification);
+        Ok(())
+    }
+
+    async fn write_message(&mut self, message: &Value) -> Result<(), CodexAppServerError> {
+        let stdin = self.stdin.as_mut().ok_or_else(|| {
+            CodexAppServerError::Protocol("app-server stdin is closed".to_string())
+        })?;
+        let mut bytes = serde_json::to_vec(message)?;
+        bytes.push(b'\n');
+        stdin.write_all(&bytes).await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn drain_stderr(&mut self) {
+        let Some(stderr_handle) = self.stderr_handle.take() else {
+            return;
+        };
+
+        if let Ok(Ok(lines)) = tokio::time::timeout(STDERR_DRAIN_GRACE, stderr_handle).await {
+            self.stderr_tail = lines;
+        }
+    }
+
+    fn signal_process_group(&mut self, signal: libc::c_int) {
+        if let Some(pgid) = self.process_group_id {
+            unsafe {
+                libc::kill(-pgid, signal);
+            }
+        } else if let Some(pid) = self.process_id {
+            unsafe {
+                libc::kill(pid as libc::pid_t, signal);
+            }
+        }
+    }
+}
+
+impl Drop for CodexAppServerClient {
+    fn drop(&mut self) {
+        if !self.closed {
+            self.stdin.take();
+            self.signal_process_group(libc::SIGKILL);
+        }
+        if let Some(stderr_handle) = self.stderr_handle.take() {
+            stderr_handle.abort();
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct IncomingErrorObject {
+    code: i64,
+    message: String,
+    data: Option<Value>,
+}
+
+enum IncomingMessage {
+    Success { id: JsonRpcId, result: Value },
+    Error { id: JsonRpcId, error: JsonRpcError },
+    Notification(ServerNotification),
+    Request(ServerRequest),
+}
+
+fn outgoing_request(id: &JsonRpcId, method: &str, params: Value) -> Value {
+    json!({
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+fn outgoing_notification(method: &str, params: Value) -> Value {
+    if params.is_null() {
+        json!({ "method": method })
+    } else {
+        json!({
+            "method": method,
+            "params": params,
+        })
+    }
+}
+
+fn parse_incoming_message(line: &str) -> Result<IncomingMessage, CodexAppServerError> {
+    let value: Value = serde_json::from_str(line).map_err(|error| {
+        CodexAppServerError::Protocol(format!(
+            "malformed app-server stdout JSON: {error}; line={line:?}"
+        ))
+    })?;
+
+    if let Some(method_value) = value.get("method") {
+        if value.get("result").is_some() || value.get("error").is_some() {
+            return Err(CodexAppServerError::Protocol(
+                "request or notification contains response fields".to_string(),
+            ));
+        }
+        let method = method_value
+            .as_str()
+            .ok_or_else(|| CodexAppServerError::Protocol("method must be a string".to_string()))?
+            .to_string();
+        let params = value.get("params").cloned();
+        if let Some(id_value) = value.get("id") {
+            return Ok(IncomingMessage::Request(ServerRequest {
+                id: parse_id(id_value)?,
+                method,
+                params,
+            }));
+        }
+        return Ok(IncomingMessage::Notification(ServerNotification {
+            method,
+            params,
+        }));
+    }
+
+    let Some(id_value) = value.get("id") else {
+        return Err(CodexAppServerError::Protocol(
+            "message has neither id nor method".to_string(),
+        ));
+    };
+    let id = parse_id(id_value)?;
+
+    match (value.get("result"), value.get("error")) {
+        (Some(result), None) => Ok(IncomingMessage::Success {
+            id,
+            result: result.clone(),
+        }),
+        (None, Some(error)) => {
+            let error: IncomingErrorObject = serde_json::from_value(error.clone())?;
+            Ok(IncomingMessage::Error {
+                id,
+                error: JsonRpcError {
+                    code: error.code,
+                    message: error.message,
+                    data: error.data,
+                },
+            })
+        }
+        (Some(_), Some(_)) => Err(CodexAppServerError::Protocol(
+            "response contains both result and error".to_string(),
+        )),
+        (None, None) => Err(CodexAppServerError::Protocol(
+            "response contains neither result nor error".to_string(),
+        )),
+    }
+}
+
+fn parse_id(value: &Value) -> Result<JsonRpcId, CodexAppServerError> {
+    serde_json::from_value(value.clone()).map_err(|error| {
+        CodexAppServerError::Protocol(format!(
+            "app-server message id must be an integer or string: {error}"
+        ))
+    })
+}
+
+fn bounded_method_name(method: &str) -> String {
+    const MAX_CHARS: usize = 120;
+    let mut chars = method.chars();
+    let bounded = chars.by_ref().take(MAX_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{bounded}...")
+    } else {
+        bounded
+    }
+}

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -16,6 +16,7 @@
 //! flow are part of the runtime contract.
 
 mod child_env;
+pub mod codex_app_server;
 mod codex_setup;
 mod command;
 mod diagnostics;

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -432,6 +432,23 @@ async fn codex_app_server_drop_kills_open_child() -> Result<(), String> {
     wait_for_process_exit(pid).await
 }
 
+#[test]
+fn codex_app_server_spawn_without_tokio_runtime_returns_error() -> Result<(), String> {
+    let codex_home = TempDir::new().map_err(|error| format!("create codex home: {error}"))?;
+    let config = CodexAppServerConfig::new("/definitely/missing/codex", codex_home.path());
+
+    match CodexAppServerClient::spawn(config) {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("requires a Tokio runtime"));
+            Ok(())
+        }
+        Err(error) => Err(format!(
+            "expected Tokio runtime protocol error, got {error:?}"
+        )),
+        Ok(_) => Err("expected Tokio runtime protocol error, got client".to_string()),
+    }
+}
+
 fn spawn_client(scenario: Option<&str>) -> Result<ClientFixture, String> {
     let codex_home = TempDir::new().map_err(|error| format!("create codex home: {error}"))?;
     let mut config = CodexAppServerConfig::new(mock_codex_path()?, codex_home.path());

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -194,6 +194,26 @@ async fn codex_app_server_malformed_stdout_fails_without_hanging() -> Result<(),
 }
 
 #[tokio::test]
+async fn codex_app_server_oversized_stdout_line_is_rejected() -> Result<(), String> {
+    let mut client = spawn_client(Some("oversized-stdout"))?;
+
+    let result = wait_result_allow_error(client.initialize(), "initialize").await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("app-server stdout line exceeded"));
+            assert!(!message.contains("xxx"));
+        }
+        other => {
+            return Err(format!(
+                "expected oversized stdout protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_disconnect_after_initialize_fails_next_request() -> Result<(), String> {
     let mut client = spawn_client(Some("disconnect-after-initialize"))?;
 

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -55,6 +55,21 @@ async fn codex_app_server_initializes_and_sends_initialized_notification() -> Re
 }
 
 #[tokio::test]
+async fn codex_app_server_extra_env_cannot_override_codex_home() -> Result<(), String> {
+    let codex_home = TempDir::new().map_err(|error| format!("create codex home: {error}"))?;
+    let override_home =
+        TempDir::new().map_err(|error| format!("create override codex home: {error}"))?;
+    let config = CodexAppServerConfig::new(mock_codex_path()?, codex_home.path())
+        .with_env("CODEX_HOME", override_home.path().to_string_lossy());
+    let mut client = CodexAppServerClient::spawn(config).map_err(|error| format!("{error:?}"))?;
+
+    let initialized = wait_result(client.initialize(), "initialize").await?;
+
+    assert_eq!(initialized.codex_home, codex_home.path().to_string_lossy());
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_correlates_request_response_by_id() -> Result<(), String> {
     let mut client = spawn_client(None)?;
     wait_result(client.initialize(), "initialize").await?;

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -146,6 +146,32 @@ async fn codex_app_server_rejects_notification_queue_overflow() -> Result<(), St
 }
 
 #[tokio::test]
+async fn codex_app_server_rejects_large_buffered_notifications() -> Result<(), String> {
+    let mut client = spawn_client(Some("large-notification-before-response"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let result = wait_result_allow_error(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await;
+
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("server notification queue exceeded"));
+            assert!(!message.contains("xxx"));
+        }
+        other => {
+            return Err(format!(
+                "expected large notification queue error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_rejects_server_requests_and_continues() -> Result<(), String> {
     let mut client = spawn_client(Some("server-request-before-response"))?;
     wait_result(client.initialize(), "initialize").await?;
@@ -169,6 +195,26 @@ async fn codex_app_server_rejects_server_requests_and_continues() -> Result<(), 
             .as_str()
             .is_some_and(|message| message.contains("unsupported server request method"))
     );
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_rejects_null_id_server_requests_and_continues() -> Result<(), String> {
+    let mut client = spawn_client(Some("null-id-server-request-before-response"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await?;
+    assert!(started["thread"]["id"].as_str().is_some());
+
+    let state = wait_result(client.request_value("mock/state", json!({})), "mock/state").await?;
+    assert_eq!(state["hasPendingResponse"], false);
+    assert!(state["serverRequestResponses"][0]["id"].is_null());
+    assert_eq!(state["serverRequestResponses"][0]["error"]["code"], -32601);
 
     wait_result(client.shutdown(), "shutdown").await
 }

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -1,7 +1,8 @@
-use std::future::Future;
+use std::future::{Future, poll_fn};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::sync::OnceLock;
+use std::task::Poll;
 use std::time::Duration;
 
 use guest_agent::cli::codex_app_server::{
@@ -447,12 +448,11 @@ async fn codex_app_server_cancelled_request_fails_next_request() -> Result<(), S
         .ok_or_else(|| "app-server child missing pid".to_string())?;
     wait_result(client.initialize(), "initialize").await?;
 
-    let timed_out = tokio::time::timeout(
-        Duration::from_millis(100),
+    cancel_after_first_pending(
         client.request_value("thread/start", json!({})),
+        "thread/start",
     )
-    .await;
-    assert!(timed_out.is_err());
+    .await?;
 
     let next_result =
         wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
@@ -499,12 +499,11 @@ async fn codex_app_server_poisoning_one_client_does_not_stop_another() -> Result
         .ok_or_else(|| "survivor app-server child missing pid".to_string())?;
     wait_result(survivor.initialize(), "survivor initialize").await?;
 
-    let timed_out = tokio::time::timeout(
-        Duration::from_millis(100),
+    cancel_after_first_pending(
         victim.request_value("thread/start", json!({})),
+        "victim thread/start",
     )
-    .await;
-    assert!(timed_out.is_err());
+    .await?;
 
     let poisoned = wait_result_allow_error(
         victim.request_value("mock/state", json!({})),
@@ -544,15 +543,14 @@ async fn codex_app_server_cancelled_notification_fails_next_request() -> Result<
     .await?;
     assert_eq!(initialized.platform_family, std::env::consts::FAMILY);
 
-    let timed_out = tokio::time::timeout(
-        Duration::from_millis(100),
+    cancel_after_first_pending(
         client.notify(
             "initialized",
             Value::String("x".repeat(BLOCKED_STDIN_PAYLOAD_BYTES)),
         ),
+        "initialized notification",
     )
-    .await;
-    assert!(timed_out.is_err());
+    .await?;
 
     let next_result =
         wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
@@ -593,8 +591,7 @@ async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Resul
         .process_id()
         .ok_or_else(|| "app-server child missing pid".to_string())?;
 
-    let first_shutdown = tokio::time::timeout(Duration::from_millis(100), client.shutdown()).await;
-    assert!(first_shutdown.is_err());
+    cancel_after_first_pending(client.shutdown(), "shutdown").await?;
 
     wait_result(client.shutdown(), "shutdown after cancellation").await?;
     assert!(client.process_id().is_none());
@@ -608,8 +605,7 @@ async fn codex_app_server_request_after_cancelled_shutdown_kills_child() -> Resu
         .process_id()
         .ok_or_else(|| "app-server child missing pid".to_string())?;
 
-    let first_shutdown = tokio::time::timeout(Duration::from_millis(100), client.shutdown()).await;
-    assert!(first_shutdown.is_err());
+    cancel_after_first_pending(client.shutdown(), "shutdown").await?;
 
     let result =
         wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
@@ -755,6 +751,25 @@ async fn wait_result_allow_error<T>(
     tokio::time::timeout(CLIENT_TIMEOUT, future)
         .await
         .unwrap_or_else(|_| Err(CodexAppServerError::Protocol(format!("{label} timed out"))))
+}
+
+async fn cancel_after_first_pending<T>(
+    future: impl Future<Output = Result<T, CodexAppServerError>>,
+    label: &str,
+) -> Result<(), String> {
+    let mut future = Box::pin(future);
+    poll_fn(|cx| match future.as_mut().poll(cx) {
+        Poll::Pending => Poll::Ready(Ok(())),
+        Poll::Ready(Ok(_)) => Poll::Ready(Err(format!(
+            "{label} completed before it could be cancelled"
+        ))),
+        Poll::Ready(Err(error)) => Poll::Ready(Err(format!(
+            "{label} failed before it could be cancelled: {error:?}"
+        ))),
+    })
+    .await?;
+    drop(future);
+    Ok(())
 }
 
 fn initialize_params() -> Value {

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -408,6 +408,39 @@ async fn codex_app_server_child_exit_before_response_fails_pending_request() -> 
 }
 
 #[tokio::test]
+async fn codex_app_server_cancelled_request_fails_next_request() -> Result<(), String> {
+    let mut client = spawn_client(Some("hang-on-thread-start"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let timed_out = tokio::time::timeout(
+        Duration::from_millis(100),
+        client.request_value("thread/start", json!({})),
+    )
+    .await;
+    assert!(timed_out.is_err());
+
+    let next_result =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    match next_result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("previous app-server request did not complete"));
+        }
+        other => {
+            return Err(format!(
+                "expected previous request protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await?;
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_shutdown_reaps_child() -> Result<(), String> {
     let mut client = spawn_client(None)?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -332,6 +332,19 @@ async fn codex_app_server_unknown_response_id_fails_without_raw_payload() -> Res
         }
     }
 
+    let retry =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    match retry {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("received response for unknown id"));
+        }
+        other => {
+            return Err(format!(
+                "expected persistent unknown response id error, got {other:?}"
+            ));
+        }
+    }
+
     wait_result(client.shutdown(), "shutdown").await
 }
 
@@ -432,6 +445,19 @@ async fn codex_app_server_cancelled_request_fails_next_request() -> Result<(), S
         other => {
             return Err(format!(
                 "expected previous request protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    let retry_result =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    match retry_result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("previous app-server request did not complete"));
+        }
+        other => {
+            return Err(format!(
+                "expected persistent previous request protocol error, got {other:?}"
             ));
         }
     }

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -486,6 +486,52 @@ async fn codex_app_server_cancelled_request_fails_next_request() -> Result<(), S
 }
 
 #[tokio::test]
+async fn codex_app_server_poisoning_one_client_does_not_stop_another() -> Result<(), String> {
+    let mut victim = spawn_client(Some("hang-on-thread-start"))?;
+    let victim_pid = victim
+        .process_id()
+        .ok_or_else(|| "victim app-server child missing pid".to_string())?;
+    wait_result(victim.initialize(), "victim initialize").await?;
+
+    let mut survivor = spawn_client(None)?;
+    let survivor_pid = survivor
+        .process_id()
+        .ok_or_else(|| "survivor app-server child missing pid".to_string())?;
+    wait_result(survivor.initialize(), "survivor initialize").await?;
+
+    let timed_out = tokio::time::timeout(
+        Duration::from_millis(100),
+        victim.request_value("thread/start", json!({})),
+    )
+    .await;
+    assert!(timed_out.is_err());
+
+    let poisoned = wait_result_allow_error(
+        victim.request_value("mock/state", json!({})),
+        "victim poison",
+    )
+    .await;
+    match poisoned {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("previous app-server request did not complete"));
+        }
+        other => return Err(format!("expected victim poison error, got {other:?}")),
+    }
+
+    let survivor_state = wait_result(
+        survivor.request_value("mock/state", json!({})),
+        "survivor mock/state",
+    )
+    .await?;
+    assert_eq!(survivor_state["initializedNotificationReceived"], true);
+
+    wait_result(victim.shutdown(), "victim shutdown").await?;
+    assert_process_exited(victim_pid)?;
+    wait_result(survivor.shutdown(), "survivor shutdown").await?;
+    assert_process_exited(survivor_pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_cancelled_notification_fails_next_request() -> Result<(), String> {
     let mut client = spawn_client(Some("hang-after-initialize-response"))?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
+const BLOCKED_STDIN_PAYLOAD_BYTES: usize = 8 * 1024 * 1024;
 
 static MOCK_CODEX_BUILD: OnceLock<Result<PathBuf, String>> = OnceLock::new();
 
@@ -431,6 +432,47 @@ async fn codex_app_server_cancelled_request_fails_next_request() -> Result<(), S
         other => {
             return Err(format!(
                 "expected previous request protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await?;
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
+async fn codex_app_server_cancelled_notification_fails_next_request() -> Result<(), String> {
+    let mut client = spawn_client(Some("hang-after-initialize-response"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+    let initialized: InitializeResponse = wait_result(
+        client.request("initialize", initialize_params()),
+        "manual initialize",
+    )
+    .await?;
+    assert_eq!(initialized.platform_family, std::env::consts::FAMILY);
+
+    let timed_out = tokio::time::timeout(
+        Duration::from_millis(100),
+        client.notify(
+            "initialized",
+            Value::String("x".repeat(BLOCKED_STDIN_PAYLOAD_BYTES)),
+        ),
+    )
+    .await;
+    assert!(timed_out.is_err());
+
+    let next_result =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    match next_result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("previous app-server write did not complete"));
+        }
+        other => {
+            return Err(format!(
+                "expected previous write protocol error, got {other:?}"
             ));
         }
     }

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -391,6 +391,7 @@ async fn codex_app_server_shutdown_reaps_child() -> Result<(), String> {
     wait_result(client.initialize(), "initialize").await?;
 
     wait_result(client.shutdown(), "shutdown").await?;
+    assert!(client.process_id().is_none());
     assert_process_exited(pid)?;
     wait_result(client.shutdown(), "second shutdown").await
 }

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -422,6 +422,21 @@ async fn codex_app_server_shutdown_reaps_child() -> Result<(), String> {
 }
 
 #[tokio::test]
+async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Result<(), String> {
+    let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+
+    let first_shutdown = tokio::time::timeout(Duration::from_millis(100), client.shutdown()).await;
+    assert!(first_shutdown.is_err());
+
+    wait_result(client.shutdown(), "shutdown after cancellation").await?;
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_drop_kills_open_child() -> Result<(), String> {
     let client = spawn_client(None)?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -335,6 +335,31 @@ async fn codex_app_server_unknown_response_id_fails_without_raw_payload() -> Res
 }
 
 #[tokio::test]
+async fn codex_app_server_invalid_response_id_fails_without_raw_payload() -> Result<(), String> {
+    let mut client = spawn_client(Some("invalid-response-id"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let result = wait_result_allow_error(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("app-server message id must be"));
+            assert!(!message.contains("do-not-log-invalid-response-id"));
+        }
+        other => {
+            return Err(format!(
+                "expected invalid response id protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_disconnect_after_initialize_fails_next_request() -> Result<(), String> {
     let mut client = spawn_client(Some("disconnect-after-initialize"))?;
 

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -593,7 +593,11 @@ async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Resul
 
     cancel_after_first_pending(client.shutdown(), "shutdown").await?;
 
-    wait_result(client.shutdown(), "shutdown after cancellation").await?;
+    match tokio::time::timeout(Duration::from_millis(1500), client.shutdown()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(format!("shutdown after cancellation failed: {error:?}")),
+        Err(_) => return Err("shutdown after cancellation waited for grace".to_string()),
+    }
     assert!(client.process_id().is_none());
     assert_process_exited(pid)
 }

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -121,6 +121,31 @@ async fn codex_app_server_buffers_interleaved_notifications() -> Result<(), Stri
 }
 
 #[tokio::test]
+async fn codex_app_server_rejects_notification_queue_overflow() -> Result<(), String> {
+    let mut client = spawn_client(Some("notification-overflow"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let result = wait_result_allow_error(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await;
+
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("server notification queue exceeded"));
+        }
+        other => {
+            return Err(format!(
+                "expected notification overflow error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_rejects_server_requests_and_continues() -> Result<(), String> {
     let mut client = spawn_client(Some("server-request-before-response"))?;
     wait_result(client.initialize(), "initialize").await?;
@@ -156,6 +181,7 @@ async fn codex_app_server_malformed_stdout_fails_without_hanging() -> Result<(),
     match result {
         Err(CodexAppServerError::Protocol(message)) => {
             assert!(message.contains("malformed app-server stdout JSON"));
+            assert!(!message.contains("not-valid-json"));
         }
         other => {
             return Err(format!(

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -260,6 +260,56 @@ async fn codex_app_server_oversized_stdout_line_is_rejected() -> Result<(), Stri
 }
 
 #[tokio::test]
+async fn codex_app_server_malformed_rpc_error_fails_without_raw_payload() -> Result<(), String> {
+    let mut client = spawn_client(Some("malformed-error-response"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let result = wait_result_allow_error(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("error response must be an object"));
+            assert!(!message.contains("do-not-log-malformed-error-payload"));
+        }
+        other => {
+            return Err(format!(
+                "expected malformed error response protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_unexpected_typed_response_fails_without_raw_payload() -> Result<(), String>
+{
+    let mut client = spawn_client(Some("malformed-initialize-result"))?;
+
+    let result: Result<InitializeResponse, CodexAppServerError> = wait_result_allow_error(
+        client.request("initialize", initialize_params()),
+        "initialize",
+    )
+    .await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("unexpected shape"));
+            assert!(!message.contains("do-not-log-malformed-initialize-result"));
+        }
+        other => {
+            return Err(format!(
+                "expected unexpected typed response protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_disconnect_after_initialize_fails_next_request() -> Result<(), String> {
     let mut client = spawn_client(Some("disconnect-after-initialize"))?;
 

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -388,6 +388,24 @@ async fn codex_app_server_disconnect_after_initialize_fails_next_request() -> Re
         wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
     assert_disconnect_like(result)?;
 
+    let retry =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    match retry {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(
+                message.contains("Broken pipe")
+                    || message.contains("child exited")
+                    || message.contains("disconnected"),
+                "unexpected retry error message: {message}"
+            );
+        }
+        other => {
+            return Err(format!(
+                "expected persistent disconnected protocol error, got {other:?}"
+            ));
+        }
+    }
+
     wait_result(client.shutdown(), "shutdown").await
 }
 

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -556,6 +556,38 @@ async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Resul
 }
 
 #[tokio::test]
+async fn codex_app_server_request_after_cancelled_shutdown_kills_child() -> Result<(), String> {
+    let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+
+    let first_shutdown = tokio::time::timeout(Duration::from_millis(100), client.shutdown()).await;
+    assert!(first_shutdown.is_err());
+
+    let result =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("app-server stdin is closed"));
+        }
+        other => {
+            return Err(format!(
+                "expected closed stdin protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    match tokio::time::timeout(Duration::from_millis(1500), client.shutdown()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(format!("shutdown failed: {error:?}")),
+        Err(_) => return Err("shutdown waited for grace after half-closed request".to_string()),
+    }
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_shutdown_kills_stderr_holder_without_drain_timeout() -> Result<(), String>
 {
     let mut client = spawn_client(Some("stderr-holder-on-stdin-eof"))?;

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -556,6 +556,21 @@ async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Resul
 }
 
 #[tokio::test]
+async fn codex_app_server_shutdown_kills_stderr_holder_without_drain_timeout() -> Result<(), String>
+{
+    let mut client = spawn_client(Some("stderr-holder-on-stdin-eof"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    match tokio::time::timeout(Duration::from_millis(1500), client.shutdown()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(format!("shutdown failed: {error:?}")),
+        Err(_) => return Err("shutdown waited for stderr drain timeout".to_string()),
+    }
+    assert!(client.process_id().is_none());
+    Ok(())
+}
+
+#[tokio::test]
 async fn codex_app_server_drop_kills_open_child() -> Result<(), String> {
     let client = spawn_client(None)?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -310,6 +310,31 @@ async fn codex_app_server_unexpected_typed_response_fails_without_raw_payload() 
 }
 
 #[tokio::test]
+async fn codex_app_server_unknown_response_id_fails_without_raw_payload() -> Result<(), String> {
+    let mut client = spawn_client(Some("unknown-response-before-response"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let result = wait_result_allow_error(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("received response for unknown id"));
+            assert!(!message.contains("do-not-log-unknown-response-id"));
+        }
+        other => {
+            return Err(format!(
+                "expected unknown response id protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_disconnect_after_initialize_fails_next_request() -> Result<(), String> {
     let mut client = spawn_client(Some("disconnect-after-initialize"))?;
 

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -1,0 +1,418 @@
+use std::future::Future;
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use guest_agent::cli::codex_app_server::{
+    CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, InitializeResponse,
+};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+static MOCK_CODEX_BUILD: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+
+struct ClientFixture {
+    client: CodexAppServerClient,
+    _codex_home: TempDir,
+}
+
+impl Deref for ClientFixture {
+    type Target = CodexAppServerClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+impl DerefMut for ClientFixture {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.client
+    }
+}
+
+#[tokio::test]
+async fn codex_app_server_initializes_and_sends_initialized_notification() -> Result<(), String> {
+    let mut client = spawn_client(None)?;
+
+    let initialized = wait_result(client.initialize(), "initialize").await?;
+    assert!(
+        initialized
+            .user_agent
+            .starts_with("guest-mock-codex-app-server/")
+    );
+    assert!(!initialized.codex_home.is_empty());
+
+    let state = wait_result(client.request_value("mock/state", json!({})), "mock/state").await?;
+    assert_eq!(state["initializedNotificationReceived"], true);
+    assert_eq!(state["hasPendingResponse"], false);
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_correlates_request_response_by_id() -> Result<(), String> {
+    let mut client = spawn_client(None)?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({ "cwd": "/tmp" })),
+        "thread/start",
+    )
+    .await?;
+
+    assert!(started["thread"]["id"].as_str().is_some());
+    assert_eq!(started["thread"]["source"], "appServer");
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_returns_structured_rpc_errors() -> Result<(), String> {
+    let mut client = spawn_client(None)?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let result = wait_result_allow_error(
+        client.request_value("unknown/method", json!({})),
+        "unknown/method",
+    )
+    .await;
+
+    match result {
+        Err(CodexAppServerError::Rpc { method, error, .. }) => {
+            assert_eq!(method, "unknown/method");
+            assert_eq!(error.code, -32601);
+            assert_eq!(error.message, "unsupported method");
+        }
+        other => return Err(format!("expected RPC error, got {other:?}")),
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_buffers_interleaved_notifications() -> Result<(), String> {
+    let mut client = spawn_client(Some("interleaved-notification"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await?;
+    assert!(started["thread"]["id"].as_str().is_some());
+
+    let notification = client
+        .pop_notification()
+        .ok_or_else(|| "expected buffered notification".to_string())?;
+    assert_eq!(notification.method, "experimental/server-notification");
+    assert_eq!(
+        notification
+            .params
+            .as_ref()
+            .and_then(|value| value.get("message")),
+        Some(&json!("guest-mock-codex notification"))
+    );
+    assert!(client.pop_notification().is_none());
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_rejects_server_requests_and_continues() -> Result<(), String> {
+    let mut client = spawn_client(Some("server-request-before-response"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await?;
+    assert!(started["thread"]["id"].as_str().is_some());
+
+    let state = wait_result(client.request_value("mock/state", json!({})), "mock/state").await?;
+    assert_eq!(state["hasPendingResponse"], false);
+    assert_eq!(
+        state["serverRequestResponses"][0]["id"],
+        "guest-mock-codex-server-request-1"
+    );
+    assert_eq!(state["serverRequestResponses"][0]["error"]["code"], -32601);
+    assert!(
+        state["serverRequestResponses"][0]["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("unsupported server request method"))
+    );
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_malformed_stdout_fails_without_hanging() -> Result<(), String> {
+    let mut client = spawn_client(Some("malformed-stdout"))?;
+
+    let result = wait_result_allow_error(client.initialize(), "initialize").await;
+    match result {
+        Err(CodexAppServerError::Protocol(message)) => {
+            assert!(message.contains("malformed app-server stdout JSON"));
+        }
+        other => {
+            return Err(format!(
+                "expected malformed stdout protocol error, got {other:?}"
+            ));
+        }
+    }
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_disconnect_after_initialize_fails_next_request() -> Result<(), String> {
+    let mut client = spawn_client(Some("disconnect-after-initialize"))?;
+
+    let initialized: InitializeResponse = wait_result(
+        client.request("initialize", initialize_params()),
+        "manual initialize",
+    )
+    .await?;
+    assert_eq!(initialized.platform_family, std::env::consts::FAMILY);
+
+    let result =
+        wait_result_allow_error(client.request_value("mock/state", json!({})), "mock/state").await;
+    assert_disconnect_like(result)?;
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_child_exit_before_response_fails_pending_request() -> Result<(), String> {
+    let mut client = spawn_client(Some("exit-on-turn-start"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await?;
+    let thread_id = started["thread"]["id"]
+        .as_str()
+        .ok_or_else(|| "missing thread id".to_string())?;
+
+    let result = wait_result_allow_error(
+        client.request_value(
+            "turn/start",
+            json!({
+                "threadId": thread_id,
+                "input": [text_input("initial prompt")]
+            }),
+        ),
+        "turn/start",
+    )
+    .await;
+    assert_disconnect_like(result)?;
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_shutdown_reaps_child() -> Result<(), String> {
+    let mut client = spawn_client(None)?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    wait_result(client.shutdown(), "shutdown").await?;
+    assert_process_exited(pid)?;
+    wait_result(client.shutdown(), "second shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_drop_kills_open_child() -> Result<(), String> {
+    let client = spawn_client(None)?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+
+    drop(client);
+    wait_for_process_exit(pid).await
+}
+
+fn spawn_client(scenario: Option<&str>) -> Result<ClientFixture, String> {
+    let codex_home = TempDir::new().map_err(|error| format!("create codex home: {error}"))?;
+    let mut config = CodexAppServerConfig::new(mock_codex_path()?, codex_home.path());
+    if let Some(scenario) = scenario {
+        config = config.with_env("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
+    }
+    let client = CodexAppServerClient::spawn(config).map_err(|error| format!("{error:?}"))?;
+    Ok(ClientFixture {
+        client,
+        _codex_home: codex_home,
+    })
+}
+
+fn mock_codex_path() -> Result<PathBuf, String> {
+    MOCK_CODEX_BUILD
+        .get_or_init(build_and_locate_mock_codex)
+        .clone()
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}
+
+async fn wait_result<T>(
+    future: impl Future<Output = Result<T, CodexAppServerError>>,
+    label: &str,
+) -> Result<T, String> {
+    match tokio::time::timeout(CLIENT_TIMEOUT, future).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(format!("{label} failed: {error:?}")),
+        Err(_) => Err(format!("{label} timed out")),
+    }
+}
+
+async fn wait_result_allow_error<T>(
+    future: impl Future<Output = Result<T, CodexAppServerError>>,
+    label: &str,
+) -> Result<T, CodexAppServerError> {
+    tokio::time::timeout(CLIENT_TIMEOUT, future)
+        .await
+        .unwrap_or_else(|_| Err(CodexAppServerError::Protocol(format!("{label} timed out"))))
+}
+
+fn initialize_params() -> Value {
+    json!({
+        "clientInfo": {
+            "name": "vm0-guest-agent-tests",
+            "title": null,
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "capabilities": {
+            "experimentalApi": true,
+            "requestAttestation": false
+        }
+    })
+}
+
+fn text_input(text: &str) -> Value {
+    json!({
+        "type": "text",
+        "text": text,
+        "text_elements": []
+    })
+}
+
+fn assert_disconnect_like<T: std::fmt::Debug>(
+    result: Result<T, CodexAppServerError>,
+) -> Result<(), String> {
+    match result {
+        Err(CodexAppServerError::Disconnected { .. })
+        | Err(CodexAppServerError::ChildExited { .. })
+        | Err(CodexAppServerError::Io(_)) => Ok(()),
+        other => Err(format!("expected disconnect-like failure, got {other:?}")),
+    }
+}
+
+async fn wait_for_process_exit(pid: u32) -> Result<(), String> {
+    let wait_task = tokio::task::spawn_blocking(move || wait_for_process_exit_blocking(pid));
+    match tokio::time::timeout(CLIENT_TIMEOUT, wait_task).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => Err(format!("waitpid task failed: {error}")),
+        Err(_) => {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            Err(format!("process {pid} did not exit"))
+        }
+    }
+}
+
+fn wait_for_process_exit_blocking(pid: u32) -> Result<(), String> {
+    let mut status = 0;
+    let wait_result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, 0) };
+    if wait_result == pid as libc::pid_t {
+        return Ok(());
+    }
+
+    let wait_error = std::io::Error::last_os_error();
+    if wait_error.raw_os_error() == Some(libc::ECHILD) && process_exited(pid)? {
+        return Ok(());
+    }
+
+    Err(format!("waitpid({pid}) failed: {wait_error}"))
+}
+
+fn assert_process_exited(pid: u32) -> Result<(), String> {
+    if process_exited(pid)? {
+        Ok(())
+    } else {
+        Err(format!("process {pid} is still running"))
+    }
+}
+
+fn process_exited(pid: u32) -> Result<bool, String> {
+    let mut status = 0;
+    let wait_result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+    if wait_result == pid as libc::pid_t {
+        return Ok(true);
+    }
+    if wait_result == 0 {
+        return Ok(false);
+    }
+
+    let wait_error = std::io::Error::last_os_error();
+    if wait_error.raw_os_error() != Some(libc::ECHILD) {
+        return Err(format!("waitpid({pid}) failed: {wait_error}"));
+    }
+
+    let kill_result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if kill_result == 0 {
+        return Ok(false);
+    }
+    let kill_error = std::io::Error::last_os_error();
+    if kill_error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(true)
+    } else {
+        Err(format!("kill -0 {pid} failed: {kill_error}"))
+    }
+}

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -22,6 +22,7 @@ enum Scenario {
     MalformedErrorResponse,
     MalformedInitializeResult,
     LargeNotificationBeforeResponse,
+    HangOnThreadStart,
     MalformedStdout,
     HangOnStdinEof,
     NullIdServerRequestBeforeResponse,
@@ -45,6 +46,7 @@ impl Scenario {
                 "malformed-error-response" => Ok(Self::MalformedErrorResponse),
                 "malformed-initialize-result" => Ok(Self::MalformedInitializeResult),
                 "large-notification-before-response" => Ok(Self::LargeNotificationBeforeResponse),
+                "hang-on-thread-start" => Ok(Self::HangOnThreadStart),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
                 "hang-on-stdin-eof" => Ok(Self::HangOnStdinEof),
                 "null-id-server-request-before-response" => {
@@ -212,6 +214,11 @@ impl AppServerState {
                 if !self.initialized {
                     write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
                     return Ok(ServerAction::Continue);
+                }
+                if self.scenario == Scenario::HangOnThreadStart {
+                    loop {
+                        thread::park();
+                    }
                 }
                 let thread_id = Uuid::now_v7().to_string();
                 self.set_current_thread(thread_id.clone());

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -22,6 +22,7 @@ enum Scenario {
     MalformedErrorResponse,
     MalformedInitializeResult,
     LargeNotificationBeforeResponse,
+    HangAfterInitializeResponse,
     HangOnThreadStart,
     MalformedStdout,
     HangOnStdinEof,
@@ -46,6 +47,7 @@ impl Scenario {
                 "malformed-error-response" => Ok(Self::MalformedErrorResponse),
                 "malformed-initialize-result" => Ok(Self::MalformedInitializeResult),
                 "large-notification-before-response" => Ok(Self::LargeNotificationBeforeResponse),
+                "hang-after-initialize-response" => Ok(Self::HangAfterInitializeResponse),
                 "hang-on-thread-start" => Ok(Self::HangOnThreadStart),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
                 "hang-on-stdin-eof" => Ok(Self::HangOnStdinEof),
@@ -205,6 +207,11 @@ impl AppServerState {
                 }
                 self.initialized = true;
                 write_success(output, id, initialize_response())?;
+                if self.scenario == Scenario::HangAfterInitializeResponse {
+                    loop {
+                        thread::park();
+                    }
+                }
                 if self.scenario == Scenario::DisconnectAfterInitialize {
                     return Ok(ServerAction::Stop);
                 }

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -17,6 +17,8 @@ enum Scenario {
     DisconnectAfterInitialize,
     ExitOnTurnStart,
     InterleavedNotification,
+    MalformedErrorResponse,
+    MalformedInitializeResult,
     LargeNotificationBeforeResponse,
     MalformedStdout,
     NullIdServerRequestBeforeResponse,
@@ -35,6 +37,8 @@ impl Scenario {
                 "disconnect-after-initialize" => Ok(Self::DisconnectAfterInitialize),
                 "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
+                "malformed-error-response" => Ok(Self::MalformedErrorResponse),
+                "malformed-initialize-result" => Ok(Self::MalformedInitializeResult),
                 "large-notification-before-response" => Ok(Self::LargeNotificationBeforeResponse),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
                 "null-id-server-request-before-response" => {
@@ -175,6 +179,16 @@ impl AppServerState {
                     output.flush()?;
                     return Ok(ServerAction::Stop);
                 }
+                if self.scenario == Scenario::MalformedInitializeResult {
+                    write_json_line(
+                        output,
+                        &json!({
+                            "id": id,
+                            "result": "do-not-log-malformed-initialize-result"
+                        }),
+                    )?;
+                    return Ok(ServerAction::Continue);
+                }
                 self.initialized = true;
                 write_success(output, id, initialize_response())?;
                 if self.scenario == Scenario::DisconnectAfterInitialize {
@@ -191,6 +205,15 @@ impl AppServerState {
                 self.set_current_thread(thread_id.clone());
                 let result = thread_response(&thread_id, false);
                 match self.scenario {
+                    Scenario::MalformedErrorResponse => {
+                        write_json_line(
+                            output,
+                            &json!({
+                                "id": id,
+                                "error": "do-not-log-malformed-error-payload"
+                            }),
+                        )?;
+                    }
                     Scenario::InterleavedNotification => {
                         write_json_line(output, &server_notification())?;
                         write_success(output, id, result)?;

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -13,6 +13,9 @@ enum Scenario {
     Success,
     DisconnectAfterInitialize,
     ExitOnTurnStart,
+    InterleavedNotification,
+    MalformedStdout,
+    ServerRequestBeforeResponse,
     StaleTurn,
     NoActiveTurn,
 }
@@ -24,6 +27,9 @@ impl Scenario {
             Ok(value) => match value.as_str() {
                 "disconnect-after-initialize" => Ok(Self::DisconnectAfterInitialize),
                 "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
+                "interleaved-notification" => Ok(Self::InterleavedNotification),
+                "malformed-stdout" => Ok(Self::MalformedStdout),
+                "server-request-before-response" => Ok(Self::ServerRequestBeforeResponse),
                 "stale-turn" => Ok(Self::StaleTurn),
                 "no-active-turn" => Ok(Self::NoActiveTurn),
                 _ => Err(io::Error::new(
@@ -61,7 +67,16 @@ struct AppServerState {
     session_artifact_thread_ids: BTreeMap<String, String>,
     initial_inputs: Vec<String>,
     steered_inputs: Vec<String>,
+    initialized_notification_received: bool,
+    pending_response: Option<PendingResponse>,
+    server_request_responses: Vec<Value>,
     scenario: Scenario,
+}
+
+#[derive(Debug)]
+struct PendingResponse {
+    id: Value,
+    result: Value,
 }
 
 #[derive(Debug)]
@@ -79,6 +94,9 @@ impl AppServerState {
             session_artifact_thread_ids: BTreeMap::new(),
             initial_inputs: Vec::new(),
             steered_inputs: Vec::new(),
+            initialized_notification_received: false,
+            pending_response: None,
+            server_request_responses: Vec::new(),
             scenario,
         }
     }
@@ -104,17 +122,16 @@ impl AppServerState {
         message: Value,
         output: &mut W,
     ) -> io::Result<ServerAction> {
-        let method = message
-            .get("method")
-            .and_then(Value::as_str)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing method"))?;
-        let params = message.get("params").unwrap_or(&Value::Null);
-
-        if let Some(id) = message.get("id").cloned() {
-            self.handle_request(id, method, params, output)
+        if let Some(method) = message.get("method").and_then(Value::as_str) {
+            let params = message.get("params").unwrap_or(&Value::Null);
+            if let Some(id) = message.get("id").cloned() {
+                self.handle_request(id, method, params, output)
+            } else {
+                self.handle_notification(method);
+                Ok(ServerAction::Continue)
+            }
         } else {
-            self.handle_notification(method);
-            Ok(ServerAction::Continue)
+            self.handle_client_response(message, output)
         }
     }
 
@@ -135,6 +152,11 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, message)?;
                     return Ok(ServerAction::Continue);
                 }
+                if self.scenario == Scenario::MalformedStdout {
+                    writeln!(output, "{{not-valid-json")?;
+                    output.flush()?;
+                    return Ok(ServerAction::Stop);
+                }
                 self.initialized = true;
                 write_success(output, id, initialize_response())?;
                 if self.scenario == Scenario::DisconnectAfterInitialize {
@@ -149,7 +171,20 @@ impl AppServerState {
                 }
                 let thread_id = Uuid::now_v7().to_string();
                 self.set_current_thread(thread_id.clone());
-                write_success(output, id, thread_response(&thread_id, false))?;
+                let result = thread_response(&thread_id, false);
+                match self.scenario {
+                    Scenario::InterleavedNotification => {
+                        write_json_line(output, &server_notification())?;
+                        write_success(output, id, result)?;
+                    }
+                    Scenario::ServerRequestBeforeResponse => {
+                        write_json_line(output, &server_request())?;
+                        self.pending_response = Some(PendingResponse { id, result });
+                    }
+                    _ => {
+                        write_success(output, id, result)?;
+                    }
+                }
                 Ok(ServerAction::Continue)
             }
             "thread/resume" => {
@@ -281,6 +316,18 @@ impl AppServerState {
                 )?;
                 Ok(ServerAction::Continue)
             }
+            "mock/state" => {
+                write_success(
+                    output,
+                    id,
+                    json!({
+                        "initializedNotificationReceived": self.initialized_notification_received,
+                        "serverRequestResponses": &self.server_request_responses,
+                        "hasPendingResponse": self.pending_response.is_some(),
+                    }),
+                )?;
+                Ok(ServerAction::Continue)
+            }
             _ => {
                 write_error(output, id, METHOD_NOT_FOUND, "unsupported method")?;
                 Ok(ServerAction::Continue)
@@ -288,10 +335,43 @@ impl AppServerState {
         }
     }
 
-    fn handle_notification(&mut self, _method: &str) {
+    fn handle_client_response<W: Write>(
+        &mut self,
+        message: Value,
+        output: &mut W,
+    ) -> io::Result<ServerAction> {
+        if message.get("id").is_none()
+            || (message.get("result").is_none() && message.get("error").is_none())
+        {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "missing method"));
+        }
+
+        if self.scenario != Scenario::ServerRequestBeforeResponse {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected client response",
+            ));
+        }
+
+        let Some(pending) = self.pending_response.take() else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected client response",
+            ));
+        };
+        self.server_request_responses.push(message);
+        write_success(output, pending.id, pending.result)?;
+
+        Ok(ServerAction::Continue)
+    }
+
+    fn handle_notification(&mut self, method: &str) {
         // The client sends `initialized` after the `initialize` request. It
         // must not substitute for the request itself because later requests
         // need initialize response state to exist.
+        if method == "initialized" {
+            self.initialized_notification_received = true;
+        }
     }
 
     fn set_current_thread(&mut self, thread_id: String) {
@@ -346,6 +426,12 @@ fn validate_initialize_params(params: &Value) -> Result<(), &'static str> {
     if client_info.get("version").and_then(Value::as_str).is_none() {
         return Err("missing clientInfo.version");
     }
+    let Some(capabilities) = params.get("capabilities") else {
+        return Err("missing capabilities");
+    };
+    if capabilities.get("experimentalApi").and_then(Value::as_bool) != Some(true) {
+        return Err("missing capabilities.experimentalApi");
+    }
     Ok(())
 }
 
@@ -371,6 +457,25 @@ fn thread_response(thread_id: &str, resume: bool) -> Value {
         fields.insert("initialTurnsPage".to_string(), Value::Null);
     }
     response
+}
+
+fn server_notification() -> Value {
+    json!({
+        "method": "experimental/server-notification",
+        "params": {
+            "message": "guest-mock-codex notification"
+        }
+    })
+}
+
+fn server_request() -> Value {
+    json!({
+        "id": "guest-mock-codex-server-request-1",
+        "method": "experimental/server-request",
+        "params": {
+            "message": "guest-mock-codex server request"
+        }
+    })
 }
 
 fn thread(thread_id: &str) -> Value {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -602,14 +602,8 @@ fn server_request(id: Value) -> Value {
 }
 
 fn spawn_stderr_holder() -> io::Result<()> {
-    let status = Command::new("sh").args(["-c", "sleep 30 &"]).status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(io::Error::other(format!(
-            "failed to spawn stderr holder: {status}"
-        )))
-    }
+    let _child = Command::new("tail").args(["-f", "/dev/null"]).spawn()?;
+    Ok(())
 }
 
 fn thread(thread_id: &str) -> Value {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -7,8 +7,9 @@ use uuid::Uuid;
 
 const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
+const LARGE_NOTIFICATION_MESSAGE_BYTES: usize = 17 * 1024 * 1024;
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
-const OVERSIZED_STDOUT_BYTES: usize = 17 * 1024 * 1024;
+const OVERSIZED_STDOUT_BYTES: usize = 65 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Scenario {
@@ -16,7 +17,9 @@ enum Scenario {
     DisconnectAfterInitialize,
     ExitOnTurnStart,
     InterleavedNotification,
+    LargeNotificationBeforeResponse,
     MalformedStdout,
+    NullIdServerRequestBeforeResponse,
     NotificationOverflow,
     OversizedStdout,
     ServerRequestBeforeResponse,
@@ -32,7 +35,11 @@ impl Scenario {
                 "disconnect-after-initialize" => Ok(Self::DisconnectAfterInitialize),
                 "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
+                "large-notification-before-response" => Ok(Self::LargeNotificationBeforeResponse),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
+                "null-id-server-request-before-response" => {
+                    Ok(Self::NullIdServerRequestBeforeResponse)
+                }
                 "notification-overflow" => Ok(Self::NotificationOverflow),
                 "oversized-stdout" => Ok(Self::OversizedStdout),
                 "server-request-before-response" => Ok(Self::ServerRequestBeforeResponse),
@@ -188,8 +195,19 @@ impl AppServerState {
                         write_json_line(output, &server_notification())?;
                         write_success(output, id, result)?;
                     }
-                    Scenario::ServerRequestBeforeResponse => {
-                        write_json_line(output, &server_request())?;
+                    Scenario::LargeNotificationBeforeResponse => {
+                        write_json_line(output, &large_server_notification())?;
+                        write_success(output, id, result)?;
+                    }
+                    Scenario::ServerRequestBeforeResponse
+                    | Scenario::NullIdServerRequestBeforeResponse => {
+                        let request_id =
+                            if self.scenario == Scenario::NullIdServerRequestBeforeResponse {
+                                Value::Null
+                            } else {
+                                json!("guest-mock-codex-server-request-1")
+                            };
+                        write_json_line(output, &server_request(request_id))?;
                         self.pending_response = Some(PendingResponse { id, result });
                     }
                     Scenario::NotificationOverflow => {
@@ -363,7 +381,10 @@ impl AppServerState {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "missing method"));
         }
 
-        if self.scenario != Scenario::ServerRequestBeforeResponse {
+        if !matches!(
+            self.scenario,
+            Scenario::ServerRequestBeforeResponse | Scenario::NullIdServerRequestBeforeResponse
+        ) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "unexpected client response",
@@ -490,9 +511,18 @@ fn server_notification_with_index(index: usize) -> Value {
     })
 }
 
-fn server_request() -> Value {
+fn large_server_notification() -> Value {
     json!({
-        "id": "guest-mock-codex-server-request-1",
+        "method": "experimental/server-notification",
+        "params": {
+            "message": "x".repeat(LARGE_NOTIFICATION_MESSAGE_BYTES),
+        }
+    })
+}
+
+fn server_request(id: Value) -> Value {
+    json!({
+        "id": id,
         "method": "experimental/server-request",
         "params": {
             "message": "guest-mock-codex server request"

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
+const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Scenario {
@@ -15,6 +16,7 @@ enum Scenario {
     ExitOnTurnStart,
     InterleavedNotification,
     MalformedStdout,
+    NotificationOverflow,
     ServerRequestBeforeResponse,
     StaleTurn,
     NoActiveTurn,
@@ -29,6 +31,7 @@ impl Scenario {
                 "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
+                "notification-overflow" => Ok(Self::NotificationOverflow),
                 "server-request-before-response" => Ok(Self::ServerRequestBeforeResponse),
                 "stale-turn" => Ok(Self::StaleTurn),
                 "no-active-turn" => Ok(Self::NoActiveTurn),
@@ -180,6 +183,12 @@ impl AppServerState {
                     Scenario::ServerRequestBeforeResponse => {
                         write_json_line(output, &server_request())?;
                         self.pending_response = Some(PendingResponse { id, result });
+                    }
+                    Scenario::NotificationOverflow => {
+                        for index in 0..NOTIFICATION_OVERFLOW_COUNT {
+                            write_json_line(output, &server_notification_with_index(index))?;
+                        }
+                        write_success(output, id, result)?;
                     }
                     _ => {
                         write_success(output, id, result)?;
@@ -460,10 +469,15 @@ fn thread_response(thread_id: &str, resume: bool) -> Value {
 }
 
 fn server_notification() -> Value {
+    server_notification_with_index(0)
+}
+
+fn server_notification_with_index(index: usize) -> Value {
     json!({
         "method": "experimental/server-notification",
         "params": {
-            "message": "guest-mock-codex notification"
+            "message": "guest-mock-codex notification",
+            "index": index
         }
     })
 }

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -25,6 +25,7 @@ enum Scenario {
     NotificationOverflow,
     OversizedStdout,
     ServerRequestBeforeResponse,
+    UnknownResponseBeforeResponse,
     StaleTurn,
     NoActiveTurn,
 }
@@ -47,6 +48,7 @@ impl Scenario {
                 "notification-overflow" => Ok(Self::NotificationOverflow),
                 "oversized-stdout" => Ok(Self::OversizedStdout),
                 "server-request-before-response" => Ok(Self::ServerRequestBeforeResponse),
+                "unknown-response-before-response" => Ok(Self::UnknownResponseBeforeResponse),
                 "stale-turn" => Ok(Self::StaleTurn),
                 "no-active-turn" => Ok(Self::NoActiveTurn),
                 _ => Err(io::Error::new(
@@ -237,6 +239,14 @@ impl AppServerState {
                         for index in 0..NOTIFICATION_OVERFLOW_COUNT {
                             write_json_line(output, &server_notification_with_index(index))?;
                         }
+                        write_success(output, id, result)?;
+                    }
+                    Scenario::UnknownResponseBeforeResponse => {
+                        write_success(
+                            output,
+                            json!("do-not-log-unknown-response-id"),
+                            json!({ "ignored": true }),
+                        )?;
                         write_success(output, id, result)?;
                     }
                     _ => {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -3,6 +3,7 @@ use chrono::Utc;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::io::{self, BufRead, Write};
+use std::thread;
 use uuid::Uuid;
 
 const INVALID_REQUEST: i64 = -32600;
@@ -22,6 +23,7 @@ enum Scenario {
     MalformedInitializeResult,
     LargeNotificationBeforeResponse,
     MalformedStdout,
+    HangOnStdinEof,
     NullIdServerRequestBeforeResponse,
     NotificationOverflow,
     OversizedStdout,
@@ -44,6 +46,7 @@ impl Scenario {
                 "malformed-initialize-result" => Ok(Self::MalformedInitializeResult),
                 "large-notification-before-response" => Ok(Self::LargeNotificationBeforeResponse),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
+                "hang-on-stdin-eof" => Ok(Self::HangOnStdinEof),
                 "null-id-server-request-before-response" => {
                     Ok(Self::NullIdServerRequestBeforeResponse)
                 }
@@ -133,6 +136,11 @@ impl AppServerState {
                 .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
             if self.handle_message(message, &mut output)? == ServerAction::Stop {
                 return Ok(());
+            }
+        }
+        if self.scenario == Scenario::HangOnStdinEof {
+            loop {
+                thread::park();
             }
         }
         Ok(())

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -3,6 +3,7 @@ use chrono::Utc;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::io::{self, BufRead, Write};
+use std::process::Command;
 use std::thread;
 use uuid::Uuid;
 
@@ -30,6 +31,7 @@ enum Scenario {
     NotificationOverflow,
     OversizedStdout,
     ServerRequestBeforeResponse,
+    StderrHolderOnStdinEof,
     UnknownResponseBeforeResponse,
     StaleTurn,
     NoActiveTurn,
@@ -57,6 +59,7 @@ impl Scenario {
                 "notification-overflow" => Ok(Self::NotificationOverflow),
                 "oversized-stdout" => Ok(Self::OversizedStdout),
                 "server-request-before-response" => Ok(Self::ServerRequestBeforeResponse),
+                "stderr-holder-on-stdin-eof" => Ok(Self::StderrHolderOnStdinEof),
                 "unknown-response-before-response" => Ok(Self::UnknownResponseBeforeResponse),
                 "stale-turn" => Ok(Self::StaleTurn),
                 "no-active-turn" => Ok(Self::NoActiveTurn),
@@ -142,10 +145,14 @@ impl AppServerState {
                 return Ok(());
             }
         }
-        if self.scenario == Scenario::HangOnStdinEof {
-            loop {
+        match self.scenario {
+            Scenario::HangOnStdinEof => loop {
                 thread::park();
+            },
+            Scenario::StderrHolderOnStdinEof => {
+                spawn_stderr_holder()?;
             }
+            _ => {}
         }
         Ok(())
     }
@@ -592,6 +599,17 @@ fn server_request(id: Value) -> Value {
             "message": "guest-mock-codex server request"
         }
     })
+}
+
+fn spawn_stderr_holder() -> io::Result<()> {
+    let status = Command::new("sh").args(["-c", "sleep 30 &"]).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "failed to spawn stderr holder: {status}"
+        )))
+    }
 }
 
 fn thread(thread_id: &str) -> Value {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -17,6 +17,7 @@ enum Scenario {
     DisconnectAfterInitialize,
     ExitOnTurnStart,
     InterleavedNotification,
+    InvalidResponseId,
     MalformedErrorResponse,
     MalformedInitializeResult,
     LargeNotificationBeforeResponse,
@@ -38,6 +39,7 @@ impl Scenario {
                 "disconnect-after-initialize" => Ok(Self::DisconnectAfterInitialize),
                 "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
+                "invalid-response-id" => Ok(Self::InvalidResponseId),
                 "malformed-error-response" => Ok(Self::MalformedErrorResponse),
                 "malformed-initialize-result" => Ok(Self::MalformedInitializeResult),
                 "large-notification-before-response" => Ok(Self::LargeNotificationBeforeResponse),
@@ -207,6 +209,13 @@ impl AppServerState {
                 self.set_current_thread(thread_id.clone());
                 let result = thread_response(&thread_id, false);
                 match self.scenario {
+                    Scenario::InvalidResponseId => {
+                        write_success(
+                            output,
+                            json!({ "secret": "do-not-log-invalid-response-id" }),
+                            result,
+                        )?;
+                    }
                     Scenario::MalformedErrorResponse => {
                         write_json_line(
                             output,

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
+const OVERSIZED_STDOUT_BYTES: usize = 17 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Scenario {
@@ -17,6 +18,7 @@ enum Scenario {
     InterleavedNotification,
     MalformedStdout,
     NotificationOverflow,
+    OversizedStdout,
     ServerRequestBeforeResponse,
     StaleTurn,
     NoActiveTurn,
@@ -32,6 +34,7 @@ impl Scenario {
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
                 "notification-overflow" => Ok(Self::NotificationOverflow),
+                "oversized-stdout" => Ok(Self::OversizedStdout),
                 "server-request-before-response" => Ok(Self::ServerRequestBeforeResponse),
                 "stale-turn" => Ok(Self::StaleTurn),
                 "no-active-turn" => Ok(Self::NoActiveTurn),
@@ -157,6 +160,11 @@ impl AppServerState {
                 }
                 if self.scenario == Scenario::MalformedStdout {
                     writeln!(output, "{{not-valid-json")?;
+                    output.flush()?;
+                    return Ok(ServerAction::Stop);
+                }
+                if self.scenario == Scenario::OversizedStdout {
+                    writeln!(output, "{}", "x".repeat(OVERSIZED_STDOUT_BYTES))?;
                     output.flush()?;
                     return Ok(ServerAction::Stop);
                 }

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -308,7 +308,8 @@ fn initialize_params() -> Value {
             "version": "0.1.0"
         },
         "capabilities": {
-            "experimentalApi": true
+            "experimentalApi": true,
+            "requestAttestation": false
         }
     })
 }
@@ -536,6 +537,114 @@ fn app_server_invalid_json_exits_without_hanging() -> std::io::Result<()> {
 
     assert!(server.read_message()?.is_none());
     assert_ne!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_records_initialized_notification() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(dir.path(), &["app-server", "--stdio"], None)?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.notify("initialized", json!({}))?;
+
+    let state = server.request(2, "mock/state", json!({}))?;
+    assert_eq!(state["result"]["initializedNotificationReceived"], true);
+    assert_eq!(state["result"]["hasPendingResponse"], false);
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_interleaved_notification_scenario_emits_before_response() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--stdio"],
+        Some("interleaved-notification"),
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": {}
+    }))?;
+
+    let notification = server.read_required()?;
+    assert_eq!(notification["method"], "experimental/server-notification");
+    assert_eq!(
+        notification["params"]["message"],
+        "guest-mock-codex notification"
+    );
+
+    let response = server.read_required()?;
+    assert_eq!(response["id"], 2);
+    assert!(response["result"]["thread"]["id"].as_str().is_some());
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_server_request_scenario_waits_for_client_response() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--stdio"],
+        Some("server-request-before-response"),
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": {}
+    }))?;
+
+    let server_request = server.read_required()?;
+    assert_eq!(server_request["id"], "guest-mock-codex-server-request-1");
+    assert_eq!(server_request["method"], "experimental/server-request");
+
+    server.send(&json!({
+        "id": "guest-mock-codex-server-request-1",
+        "error": {
+            "code": -32601,
+            "message": "unsupported server request"
+        }
+    }))?;
+
+    let response = server.read_required()?;
+    assert_eq!(response["id"], 2);
+    assert!(response["result"]["thread"]["id"].as_str().is_some());
+
+    let state = server.request(3, "mock/state", json!({}))?;
+    assert_eq!(state["result"]["hasPendingResponse"], false);
+    assert_eq!(
+        state["result"]["serverRequestResponses"][0]["error"]["code"],
+        -32601
+    );
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_malformed_stdout_scenario_exits_after_invalid_line() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--stdio"],
+        Some("malformed-stdout"),
+    )?;
+
+    server.send(&json!({
+        "id": 1,
+        "method": "initialize",
+        "params": initialize_params()
+    }))?;
+
+    let error = server.read_required().unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert_eq!(server.close_and_wait()?, 0);
     Ok(())
 }
 

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -586,6 +586,35 @@ fn app_server_interleaved_notification_scenario_emits_before_response() -> std::
 }
 
 #[test]
+fn app_server_notification_overflow_scenario_emits_many_notifications() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--stdio"],
+        Some("notification-overflow"),
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": {}
+    }))?;
+
+    for index in 0..129 {
+        let notification = server.read_required()?;
+        assert_eq!(notification["method"], "experimental/server-notification");
+        assert_eq!(notification["params"]["index"], index);
+    }
+
+    let response = server.read_required()?;
+    assert_eq!(response["id"], 2);
+    assert!(response["result"]["thread"]["id"].as_str().is_some());
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_server_request_scenario_waits_for_client_response() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(


### PR DESCRIPTION
## Summary
- add a public guest-agent Codex app-server stdio JSON-RPC client for initialize, request/response correlation, notifications, server requests, errors, and child lifecycle cleanup
- extend guest-mock-codex app-server with deterministic interleaved notification, server-request-before-response, malformed stdout, and observable state scenarios
- add guest-agent integration coverage that spawns the real guest-mock-codex app-server binary

## Runtime impact
- ordinary Codex execution still uses `codex exec --json`
- this PR does not enable active input or route production runs through app-server

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex app_server`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent codex_app_server`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- pre-commit crates cargo-doc and cargo-clippy

Closes #18370