### PR TITLE
fix: prevent template tab autofocus on mobile

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1444,6 +1444,42 @@ describe("chat composer models", () => {
 });
 
 describe("chat composer templates", () => {
+  it("opens the template picker without focusing the tabs on small screens", async () => {
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatTemplatePicker]: true,
+        [FeatureSwitchKey.VideoTemplatePicker]: true,
+      },
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    expect(tabByText("Presentation")).toBeInTheDocument();
+    expect(tabByText("Illustration")).toBeInTheDocument();
+    expect(tabByText("Video")).toBeInTheDocument();
+    expect(document.activeElement).not.toBe(tabByText("Presentation"));
+
+    const tabScroller = document.querySelector(
+      "[data-template-picker-tabs-scroll]",
+    );
+    expect(tabScroller).toBeInstanceOf(HTMLElement);
+    expect(tabScroller).toHaveClass("overflow-x-auto");
+    expect(tabScroller).toHaveClass("sm:overflow-visible");
+    expect(tabScroller).toHaveClass("[scrollbar-width:thin]");
+  });
+
   it("selects a presentation template from the picker", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -3528,76 +3528,85 @@ function TemplatePickerTabs({
   onChange: (value: string) => void;
 }) {
   return (
-    <Tabs value={selectedCategory} onValueChange={onChange} className="-mb-px">
-      <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
-        {hasPptTab && (
-          <TabsTrigger
-            value="slides"
-            className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-              selectedCategory === "slides"
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <IconPresentation
+    <div
+      data-template-picker-tabs-scroll=""
+      className="-mx-5 w-[calc(100%+2.5rem)] overflow-x-auto px-5 pb-1 [scrollbar-color:hsl(var(--muted-foreground)/0.24)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/25 [&::-webkit-scrollbar-track]:bg-transparent sm:mx-0 sm:w-auto sm:overflow-visible sm:px-0 sm:pb-0 sm:[scrollbar-color:auto] sm:[scrollbar-width:auto] sm:[&::-webkit-scrollbar]:hidden"
+    >
+      <Tabs
+        value={selectedCategory}
+        onValueChange={onChange}
+        className="-mb-px min-w-max"
+      >
+        <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
+          {hasPptTab && (
+            <TabsTrigger
+              value="slides"
               className={cn(
-                "h-5 w-5",
+                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
                 selectedCategory === "slides"
-                  ? "text-blue-500"
-                  : "text-muted-foreground",
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
               )}
-              stroke={1.8}
-            />
-            Presentation
-          </TabsTrigger>
-        )}
-        {hasIllustrationTab && (
-          <TabsTrigger
-            value="illustration"
-            className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-              selectedCategory === "illustration"
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <IconPhoto
+            >
+              <IconPresentation
+                className={cn(
+                  "h-5 w-5",
+                  selectedCategory === "slides"
+                    ? "text-blue-500"
+                    : "text-muted-foreground",
+                )}
+                stroke={1.8}
+              />
+              Presentation
+            </TabsTrigger>
+          )}
+          {hasIllustrationTab && (
+            <TabsTrigger
+              value="illustration"
               className={cn(
-                "h-5 w-5",
+                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
                 selectedCategory === "illustration"
-                  ? "text-emerald-500"
-                  : "text-muted-foreground",
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
               )}
-              stroke={1.8}
-            />
-            Illustration
-          </TabsTrigger>
-        )}
-        {hasVideoTab && (
-          <TabsTrigger
-            value="video"
-            className={cn(
-              "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
-              selectedCategory === "video"
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <IconVideo
+            >
+              <IconPhoto
+                className={cn(
+                  "h-5 w-5",
+                  selectedCategory === "illustration"
+                    ? "text-emerald-500"
+                    : "text-muted-foreground",
+                )}
+                stroke={1.8}
+              />
+              Illustration
+            </TabsTrigger>
+          )}
+          {hasVideoTab && (
+            <TabsTrigger
+              value="video"
               className={cn(
-                "h-5 w-5",
+                "h-12 gap-2 rounded-none border-b-2 bg-transparent px-1 pb-3 pt-2 text-base font-semibold shadow-none focus-visible:ring-inset focus-visible:ring-offset-0",
                 selectedCategory === "video"
-                  ? "text-purple-500"
-                  : "text-muted-foreground",
+                  ? "border-foreground text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
               )}
-              stroke={1.8}
-            />
-            Video
-          </TabsTrigger>
-        )}
-      </TabsList>
-    </Tabs>
+            >
+              <IconVideo
+                className={cn(
+                  "h-5 w-5",
+                  selectedCategory === "video"
+                    ? "text-purple-500"
+                    : "text-muted-foreground",
+                )}
+                stroke={1.8}
+              />
+              Video
+            </TabsTrigger>
+          )}
+        </TabsList>
+      </Tabs>
+    </div>
   );
 }
 
@@ -3825,7 +3834,8 @@ function TemplatePickerDialog({
       <DialogContent
         className={dialogContentClassName}
         aria-describedby={undefined}
-        onOpenAutoFocus={() => {
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
           if (!isPreviewing) {
             prewarmTemplatePreviewsForCategory(selectedCategory);
           }


### PR DESCRIPTION
## Summary
- Prevent the template picker dialog from auto-focusing the first tab on open while preserving preview prewarm.
- Wrap the template tabs in a mobile-only horizontal scroller with a visible thin scrollbar; desktop remains overflow-visible.
- Add regression coverage for the no-autofocus behavior and mobile tab scroller.

## Deep dive
- Completed code research against `zero-chat-composer.tsx`, shared Dialog/Tabs primitives, and the provided mobile screenshot.
- Google Drive upload for `deep-dive/chat-template-mobile-tabs/research.md` is blocked by the `google-drive` connector `files.write` permission; a 1h permission request was generated.

## Tests
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --max-warnings 0`