### PR TITLE
fix: update playful launch presentation card preview

### DIFF
--- a/turbo/packages/core/src/presentation-template-items.ts
+++ b/turbo/packages/core/src/presentation-template-items.ts
@@ -2131,7 +2131,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d0f6b313-9899-4143-a6da-26781fd7b946/aplocoto.html",
       previewImage: PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f37e3c21-0864-46a2-b961-4adfebb1cba9/template-card-presentation-playful-launch-presentation-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/bd6ce25a-6e94-4b9a-a77b-7827086c7c6d/template-card-presentation-playful-launch-presentation-480x270.jpg",
       previewImages: PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES,
       colorSystemId: "color-system:carnival",
       designSystemId: "design-system:playful-editorial",

--- a/turbo/packages/core/src/presentation-template-items.ts
+++ b/turbo/packages/core/src/presentation-template-items.ts
@@ -2146,7 +2146,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/449e7efe-c73d-497d-962c-d77c576d0768/botane-organic.html",
       previewImage: BOTANE_ORGANIC_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a9d30ea3-4647-4c2e-ab50-9d2edfeff9cd/template-card-presentation-botane-organic-deck-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/5afda839-ba20-4a63-bf35-0f7d3b6524a9/template-card-presentation-botane-organic-deck-480x270.jpg",
       previewImages: BOTANE_ORGANIC_PREVIEW_IMAGES,
       colorSystemId: "color-system:mauve-dusk",
       designSystemId: "design-system:botane-organic",
@@ -2161,7 +2161,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8a570cf6-d398-40a6-8de5-3857f1fa21a2/business-data.html",
       previewImage: BUSINESS_DATA_CDN_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/35258dc3-bbd1-4a4f-b714-e504ff14cee1/template-card-presentation-business-data-presentation-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/27b0767f-0df0-42e3-ad1e-ed878e69d796/template-card-presentation-business-data-presentation-480x270.jpg",
       previewImages: BUSINESS_DATA_CDN_PREVIEW_IMAGES,
       colorSystemId: "color-system:berry-pop",
       designSystemId: "design-system:business-data",
@@ -2176,7 +2176,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/4aa31138-3cfa-4ed2-997a-aeb37b51e258/crayon.html",
       previewImage: CRAYON_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f71dd44c-8543-4b00-9677-d885e7c7758b/template-card-presentation-crayon-learning-deck-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/ce37d6be-85f3-40eb-b380-09445cb944a6/template-card-presentation-crayon-learning-deck-480x270.jpg",
       previewImages: CRAYON_PREVIEW_IMAGES,
       previewHtmls: CRAYON_PREVIEW_HTMLS,
       colorSystemId: "color-system:prism",
@@ -2192,7 +2192,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/128e103c-8eed-4436-8da8-7d99d1a71021/creative-agency.html",
       previewImage: CREATIVE_AGENCY_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/1540d613-5882-41dd-be2b-219c319af340/template-card-presentation-creative-agency-presentation-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6fd65b4a-8c3d-4219-9461-5558a0d71fcb/template-card-presentation-creative-agency-presentation-480x270.jpg",
       previewImages: CREATIVE_AGENCY_PREVIEW_IMAGES,
       previewHtmls: CREATIVE_AGENCY_PREVIEW_HTMLS,
       colorSystemId: "color-system:coral-studio",
@@ -2208,7 +2208,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8ee4af44-fedf-4472-9754-b237b8d8ab4f/data-report.html",
       previewImage: DATA_REPORT_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/1d384ab7-5e0d-4a71-9658-e249143eef65/template-card-presentation-data-report-presentation-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6b336b2c-c2ce-489a-9b3a-faca4813b4de/template-card-presentation-data-report-presentation-480x270.jpg",
       previewImages: DATA_REPORT_PREVIEW_IMAGES,
       previewHtmls: DATA_REPORT_PREVIEW_HTMLS,
       colorSystemId: "color-system:prism",
@@ -2224,7 +2224,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/ecb06a73-8d96-4565-951e-5ee3688af8c9/editorial-magazine.html",
       previewImage: EDITORIAL_MAGAZINE_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b28ca11d-4ca0-4eaa-bee9-295482eef074/template-card-presentation-editorial-magazine-deck-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/7f394ba6-e2a6-4622-8562-421e72055fdd/template-card-presentation-editorial-magazine-deck-480x270.jpg",
       previewImages: EDITORIAL_MAGAZINE_PREVIEW_IMAGES,
       previewHtmls: EDITORIAL_MAGAZINE_PREVIEW_HTMLS,
       colorSystemId: "color-system:warm-sand",
@@ -2240,7 +2240,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/675da276-43e2-4925-9744-ee0ce44fd3d3/landing-consulting.html",
       previewImage: LANDING_CONSULTING_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/f9e50e29-d532-4fe8-9620-fb5bdce2acf1/template-card-presentation-landing-consulting-deck-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8e59681b-5504-4907-b357-0d3f3801174b/template-card-presentation-landing-consulting-deck-480x270.jpg",
       previewImages: LANDING_CONSULTING_PREVIEW_IMAGES,
       previewHtmls: LANDING_CONSULTING_PREVIEW_HTMLS,
       colorSystemId: "color-system:pop-art",
@@ -2256,7 +2256,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/bd8fd3cd-7b48-4903-ad4c-ce8aae44a690/lumina-creative-studio.html",
       previewImage: LUMINA_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/18dd03a3-8354-4696-b705-0fd11e64a69e/template-card-presentation-lumina-creative-studio-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/129bc4b6-df50-4537-88a9-6e42c533c8ad/template-card-presentation-lumina-creative-studio-480x270.jpg",
       previewImages: LUMINA_PREVIEW_IMAGES,
       previewHtmls: LUMINA_PREVIEW_HTMLS,
       colorSystemId: "color-system:prism",
@@ -2272,7 +2272,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/3d6a7348-5ed7-40a0-a482-aced65491923/mosaic-geometric-hidden.html",
       previewImage: MOSAIC_GEOMETRIC_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/19ffef15-d346-4b8b-8e2d-c7c4b2b9a7d7/template-card-presentation-mosaic-geometric-pitch-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/8e5e8b1e-b34c-405a-9c71-0058c16751ff/template-card-presentation-mosaic-geometric-pitch-480x270.jpg",
       previewImages: MOSAIC_GEOMETRIC_PREVIEW_IMAGES,
       previewHtmls: MOSAIC_GEOMETRIC_PREVIEW_HTMLS,
       colorSystemId: "color-system:carnival",
@@ -2288,7 +2288,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/71a868cb-6e9b-4e9e-a99d-66a75c112b01/playful-pop.html",
       previewImage: PLAYFUL_POP_PREVIEW_IMAGES[0],
       cardPreviewImage:
-        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/d477b488-3263-4463-90d5-5c8fae7a01e9/template-card-presentation-playful-pop-deck-480x270.jpg",
+        "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/790e2212-a7e1-40bc-8e9f-57754cfd01e5/template-card-presentation-playful-pop-deck-480x270.jpg",
       previewImages: PLAYFUL_POP_PREVIEW_IMAGES,
       previewHtmls: PLAYFUL_POP_PREVIEW_HTMLS,
       colorSystemId: "color-system:pop-art",


### PR DESCRIPTION
Summary
- Uploaded refreshed 480x270 JPG card previews for all mismatched presentation picker templates.
- Updated cardPreviewImage URLs so every presentation picker card now matches the first slide from its current embedUrl.
- Kept the already-fixed playful launch preview in place and refreshed the other 10 mismatched cards.

Verification
- Captured each current embedUrl first slide at 480x270 with agent-browser.
- Downloaded every current cardPreviewImage from CDN and verified JPEG 480x270.
- Compared each downloaded card image against the corresponding current first-slide screenshot with SSIM; all 11 passed above 0.99 after JPEG encoding, lowest refreshed-card score was 0.9926.
- git diff --check
- Not run: pnpm --dir turbo --filter @vm0/core test -- src/__tests__/presentation-template-items.spec.ts (fresh checkout has no node_modules; vitest is unavailable locally).