### PR TITLE
fix: preserve legacy workflow volumes during backfill

### DIFF
--- a/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/README.md
+++ b/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/README.md
@@ -48,13 +48,17 @@ For each org that owns workflows (or a single `--org`), in order:
    `null`.
 
 3. **Preserve legacy name-keyed volumes by default.** Cleanup is a separate,
-   explicit `--cleanup-legacy` run. This lets rollout keep the old
-   `custom-skill@{name}` volumes available until the new id-keyed volumes have
-   been verified in production.
+   explicit `--cleanup-legacy` run. Cleanup is deletion-only: it verifies each
+   current workflow already has an id-keyed volume, preserves the legacy volume
+   for any workflow that does not, and deletes only the remaining legacy
+   `custom-skill@{name}` volumes. It never syncs legacy content back into an
+   existing id-keyed volume, so it is safe to run after the new code has started
+   writing id-keyed volumes.
 
 The script is **idempotent** and **defaults to dry-run**. It only mutates when
 `--migrate` is passed. Re-running detects already-id-keyed volumes, syncs them
-when the legacy head changed, and skips already-backfilled instructions.
+when the legacy head changed during the preseed/backfill phases, and skips
+already-backfilled instructions.
 
 ## Prerequisites
 
@@ -96,6 +100,7 @@ pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts -
 pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate --org=org_xxx
 
 # 3. After production verification: delete leftover legacy name-keyed volumes.
+#    This is deletion-only and does not sync legacy content into id-keyed volumes.
 pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --cleanup-legacy
 pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate --cleanup-legacy
 ```
@@ -156,7 +161,8 @@ After a `--migrate` run:
 ## Notes
 
 - **Idempotent**: safe to re-run; existing id-keyed volumes are synced forward
-  when the legacy head changed, and already-backfilled instructions are skipped.
+  during preseed/backfill when the legacy head changed, cleanup only deletes
+  legacy volumes, and already-backfilled instructions are skipped.
 - **Pre-seed is partial by design**: it can only create id-keyed volumes for
   workflow rows that exist before `0480`. Run the post-`0480` backfill again so
   duplicated workflow rows receive their own id-keyed copies.

--- a/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/README.md
+++ b/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/README.md
@@ -14,7 +14,8 @@ The SQL migration already transformed the database:
 - `zero_workflow_agents` was dropped.
 
 What SQL could **not** do (it needs object-storage I/O) is the R2 volume work
-and the `instruction` backfill. That is what this script does.
+and the `instruction` backfill. That is what this script does after `0480`, and
+it can also pre-seed the R2 copies before `0480` to reduce the cutover window.
 
 A workflow's files live in an org-scoped storage "volume": a `storages` row
 (`orgId`, `userId = VOLUME_ORG_USER_ID`, `name`, `type='volume'`,
@@ -35,24 +36,25 @@ For each org that owns workflows (or a single `--org`), in order:
    and every `storage_versions` row are recreated and each version's S3 objects
    (`archive.tar.gz`, `manifest.json`) are copied under the new key. Because
    duplicated rows share a `name`, **each id-keyed row gets its own copy** and
-   never shares an `s3Prefix`. Always copies (never renames in place) so the
-   legacy volume stays intact for the other duplicates.
+   never shares an `s3Prefix`. Always copies (never renames in place). When an
+   id-keyed volume already exists, the script compares it with the legacy head
+   and syncs it forward if the legacy volume changed after a pre-seed run.
 
-2. **Backfill `instruction`.** For each workflow whose `instruction` is `null`,
+2. **Backfill `instruction`** (post-`0480` mode only). For each workflow whose
+   `instruction` is `null`,
    reads `SKILL.md` from the id-keyed volume's head version archive, runs
    `extractInstructionFromSkillMd` (from `@vm0/core`), and writes the body back
    to `zero_workflows.instruction`. Empty bodies / missing SKILL.md are left
    `null`.
 
-3. **Delete legacy name-keyed volumes.** After all workflows in an org have
-   been re-keyed, deletes every leftover `custom-skill@*` volume that is not a
-   current id-keyed volume and is not being preserved because its workflow could
-   not be safely re-keyed in this run (storages row + versions via FK cascade +
-   S3 objects).
+3. **Preserve legacy name-keyed volumes by default.** Cleanup is a separate,
+   explicit `--cleanup-legacy` run. This lets rollout keep the old
+   `custom-skill@{name}` volumes available until the new id-keyed volumes have
+   been verified in production.
 
 The script is **idempotent** and **defaults to dry-run**. It only mutates when
-`--migrate` is passed. Re-running detects already-id-keyed volumes and
-already-backfilled instructions and skips them.
+`--migrate` is passed. Re-running detects already-id-keyed volumes, syncs them
+when the legacy head changed, and skips already-backfilled instructions.
 
 ## Prerequisites
 
@@ -77,14 +79,25 @@ These mirror the S3/R2 client construction in
 From `turbo/packages/db`:
 
 ```bash
-# Dry run (default) — prints the plan with counts, makes no changes
-pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
+# 1. Before SQL migration 0480: pre-seed existing workflow volumes only.
+#    This uses the pre-0480 schema, does not touch instruction, and preserves
+#    legacy name-keyed volumes.
+pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --preseed
+pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --preseed --migrate
 
-# Execute for all orgs that own workflows
+# 2. After SQL migration 0480: sync all current rows, including duplicated
+#    multi-agent workflow rows created by SQL, and backfill instruction. Legacy
+#    name-keyed volumes are still preserved by default.
+pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
 pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate
 
-# Execute for a single org
+# Execute for a single org in either phase
+pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --preseed --migrate --org=org_xxx
 pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate --org=org_xxx
+
+# 3. After production verification: delete leftover legacy name-keyed volumes.
+pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --cleanup-legacy
+pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate --cleanup-legacy
 ```
 
 ## Verification
@@ -112,8 +125,10 @@ After a `--migrate` run:
    -- residual nulls = goals or workflows whose SKILL.md body was empty/missing
    ```
 
-3. **No leftover legacy name-keyed volumes.** Confirm remaining `custom-skill@*`
-   volumes are all id-keyed (name matches an existing `zero_workflows.id`):
+3. **Legacy name-keyed volumes preserved until cleanup.** Before cleanup, this
+   query may return rows by design. After a `--cleanup-legacy --migrate` run,
+   confirm remaining `custom-skill@*` volumes are all id-keyed (name matches an
+   existing `zero_workflows.id`):
 
    ```sql
    SELECT s.name
@@ -140,8 +155,11 @@ After a `--migrate` run:
 
 ## Notes
 
-- **Idempotent**: safe to re-run; already-migrated volumes/instructions are
-  skipped.
+- **Idempotent**: safe to re-run; existing id-keyed volumes are synced forward
+  when the legacy head changed, and already-backfilled instructions are skipped.
+- **Pre-seed is partial by design**: it can only create id-keyed volumes for
+  workflow rows that exist before `0480`. Run the post-`0480` backfill again so
+  duplicated workflow rows receive their own id-keyed copies.
 - **Excluded from CI**: like all `scripts/migrations/**`, this directory is
   excluded from the package `tsconfig.json` (`exclude`) and `eslint.config.mjs`
   (`ignores`), so it does not participate in the `@vm0/db` build, type-check, or

--- a/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
@@ -26,8 +26,9 @@
  *      `extractInstructionFromSkillMd`, and persist the body.
  *
  *   3. Preserve legacy name-keyed volumes by default. A later explicit
- *      `--cleanup-legacy` run deletes leftover `custom-skill@{name}` volumes
- *      after the id-keyed copies have been verified.
+ *      `--cleanup-legacy` run is deletion-only: it verifies each current
+ *      workflow has an id-keyed volume, preserves legacy volumes for any
+ *      workflow that does not, and deletes the remaining legacy volumes.
  *
  * The script is idempotent and defaults to dry-run. It only mutates when
  * `--migrate` is passed. Legacy name-keyed volumes are preserved by default;
@@ -92,6 +93,11 @@ const DRY_RUN = !args.migrate;
 const SINGLE_ORG_ID = args.org;
 const PRESEED = args.preseed === true;
 const CLEANUP_LEGACY = args["cleanup-legacy"] === true;
+const PHASE = PRESEED
+  ? "preseed (volume sync only, pre-0480 compatible)"
+  : CLEANUP_LEGACY
+    ? "cleanup (delete legacy volumes only)"
+    : "post-0480 backfill";
 
 if (PRESEED && CLEANUP_LEGACY) {
   throw new Error("--preseed cannot be combined with --cleanup-legacy");
@@ -148,6 +154,7 @@ interface Stats {
   volumesSynced: number;
   volumesAlreadyKeyed: number;
   legacyMissing: number;
+  cleanupIdVolumesMissing: number;
   instructionsBackfilled: number;
   instructionsSkipped: number;
   legacyVolumesDeleted: number;
@@ -731,8 +738,8 @@ async function deleteLegacyVolumes(
     if (currentIdNames.has(volume.name)) {
       continue;
     }
-    // Keep legacy name-keyed volumes only when a workflow failed before it could
-    // be safely re-keyed in this run.
+    // Keep legacy name-keyed volumes when a current workflow does not yet have
+    // its id-keyed volume. Cleanup must not delete the only available copy.
     if (preserveLegacyNames.has(volume.name)) {
       continue;
     }
@@ -811,8 +818,51 @@ async function processOrg(
   stats.workflows += workflows.length;
 
   // Legacy names to keep during an explicit cleanup run because their workflow
-  // could not be safely re-keyed in this run.
+  // does not have an id-keyed volume yet.
   const preserveLegacyNames = new Set<string>();
+
+  if (CLEANUP_LEGACY) {
+    for (const workflow of workflows) {
+      console.log(`    workflow ${workflow.id} ("${workflow.name}")`);
+      const idStorageName = getCustomSkillStorageName(workflow.id);
+      const legacyStorageName = getCustomSkillStorageName(workflow.name);
+      try {
+        const existing = await lookupVolume(db, workflow.orgId, idStorageName);
+        if (existing) {
+          stats.volumesAlreadyKeyed++;
+          console.log(
+            `      id-keyed volume "${idStorageName}" present — legacy eligible for cleanup`,
+          );
+        } else {
+          stats.cleanupIdVolumesMissing++;
+          preserveLegacyNames.add(legacyStorageName);
+          console.log(
+            `      id-keyed volume "${idStorageName}" not found — preserving legacy "${legacyStorageName}"`,
+          );
+        }
+      } catch (err) {
+        stats.errors++;
+        preserveLegacyNames.add(legacyStorageName);
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`      ✗ cleanup check for ${workflow.id}: ${message}`);
+      }
+    }
+
+    try {
+      stats.legacyVolumesDeleted += await deleteLegacyVolumes(
+        db,
+        client,
+        bucket,
+        orgId,
+        preserveLegacyNames,
+      );
+    } catch (err) {
+      stats.errors++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`    ✗ legacy volume cleanup for ${orgId}: ${message}`);
+    }
+    return;
+  }
 
   for (const workflow of workflows) {
     console.log(`    workflow ${workflow.id} ("${workflow.name}")`);
@@ -855,25 +905,7 @@ async function processOrg(
     }
   }
 
-  if (!CLEANUP_LEGACY) {
-    console.log("    legacy cleanup disabled — preserving name-keyed volumes");
-    return;
-  }
-
-  // Step 3: delete legacy name-keyed volumes for this org when explicitly asked.
-  try {
-    stats.legacyVolumesDeleted += await deleteLegacyVolumes(
-      db,
-      client,
-      bucket,
-      orgId,
-      preserveLegacyNames,
-    );
-  } catch (err) {
-    stats.errors++;
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(`    ✗ legacy volume cleanup for ${orgId}: ${message}`);
-  }
+  console.log("    legacy cleanup disabled — preserving name-keyed volumes");
 }
 
 // ---------------------------------------------------------------------------
@@ -888,9 +920,7 @@ async function main(): Promise<void> {
   console.log(
     `Mode: ${DRY_RUN ? "dry-run (pass --migrate to execute)" : "MIGRATE"}`,
   );
-  console.log(
-    `Phase: ${PRESEED ? "preseed (volume sync only, pre-0480 compatible)" : "post-0480 backfill"}`,
-  );
+  console.log(`Phase: ${PHASE}`);
   console.log(
     `Legacy cleanup: ${CLEANUP_LEGACY ? "enabled" : "disabled (preserve legacy volumes)"}`,
   );
@@ -909,6 +939,7 @@ async function main(): Promise<void> {
     volumesSynced: 0,
     volumesAlreadyKeyed: 0,
     legacyMissing: 0,
+    cleanupIdVolumesMissing: 0,
     instructionsBackfilled: 0,
     instructionsSkipped: 0,
     legacyVolumesDeleted: 0,
@@ -941,6 +972,7 @@ async function main(): Promise<void> {
     console.log(`Volumes synced:             ${stats.volumesSynced}`);
     console.log(`Volumes already id-keyed:   ${stats.volumesAlreadyKeyed}`);
     console.log(`Legacy volume missing:      ${stats.legacyMissing}`);
+    console.log(`Cleanup id volumes missing: ${stats.cleanupIdVolumesMissing}`);
     console.log(`Instructions backfilled:    ${stats.instructionsBackfilled}`);
     console.log(`Instructions skipped:       ${stats.instructionsSkipped}`);
     console.log(`Legacy volumes deleted:     ${stats.legacyVolumesDeleted}`);

--- a/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
@@ -25,16 +25,20 @@
  *      read the id-keyed volume's SKILL.md, strip the frontmatter via
  *      `extractInstructionFromSkillMd`, and persist the body.
  *
- *   3. Delete legacy name-keyed volumes. After every workflow has an id-keyed
- *      copy, any leftover `custom-skill@{name}` volume is deleted unless a
- *      workflow failed before it could be safely re-keyed in this run.
+ *   3. Preserve legacy name-keyed volumes by default. A later explicit
+ *      `--cleanup-legacy` run deletes leftover `custom-skill@{name}` volumes
+ *      after the id-keyed copies have been verified.
  *
  * The script is idempotent and defaults to dry-run. It only mutates when
- * `--migrate` is passed.
+ * `--migrate` is passed. Legacy name-keyed volumes are preserved by default;
+ * pass `--cleanup-legacy` in a later cleanup run to delete them.
  *
  * Usage (from turbo/packages/db):
+ *   pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --preseed
+ *   pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --preseed --migrate
  *   pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
  *   pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate
+ *   pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate --cleanup-legacy
  *   pnpm exec tsx scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts --migrate --org=org_xxx
  *
  * Environment:
@@ -78,12 +82,20 @@ const { values: args } = parseArgs({
   options: {
     migrate: { type: "boolean", default: false },
     org: { type: "string" },
+    preseed: { type: "boolean", default: false },
+    "cleanup-legacy": { type: "boolean", default: false },
   },
   strict: true,
 });
 
 const DRY_RUN = !args.migrate;
 const SINGLE_ORG_ID = args.org;
+const PRESEED = args.preseed === true;
+const CLEANUP_LEGACY = args["cleanup-legacy"] === true;
+
+if (PRESEED && CLEANUP_LEGACY) {
+  throw new Error("--preseed cannot be combined with --cleanup-legacy");
+}
 
 const SKILL_FILENAME = "SKILL.md";
 
@@ -133,10 +145,11 @@ interface S3Manifest {
 interface Stats {
   workflows: number;
   volumesCopied: number;
+  volumesSynced: number;
   volumesAlreadyKeyed: number;
   legacyMissing: number;
   instructionsBackfilled: number;
-  instructionsSkilled: number;
+  instructionsSkipped: number;
   legacyVolumesDeleted: number;
   errors: number;
 }
@@ -388,8 +401,113 @@ function lookupVersions(db: Db, storageId: string): Promise<VersionRow[]> {
 // ---------------------------------------------------------------------------
 
 interface RekeyResult {
-  readonly status: "copied" | "already-keyed" | "legacy-missing";
+  readonly status: "copied" | "synced" | "already-keyed" | "legacy-missing";
   readonly idVolumeS3Prefix: string | null;
+}
+
+interface SyncResult {
+  readonly changed: boolean;
+  readonly versionCount: number;
+}
+
+async function storageVersionExists(
+  db: Db,
+  storageId: string,
+  versionId: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: storageVersions.id })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, storageId),
+        eq(storageVersions.id, versionId),
+      ),
+    )
+    .limit(1);
+  return row !== undefined;
+}
+
+async function copyLegacyVersionsToStorage(
+  db: Db,
+  client: S3Client,
+  bucket: string,
+  legacy: VolumeRow,
+  target: VolumeRow,
+): Promise<SyncResult> {
+  const legacyVersions = await lookupVersions(db, legacy.id);
+  let headVersionId: string | null = null;
+  let headSize = 0;
+  let headFileCount = 0;
+  let changed = false;
+
+  for (const version of legacyVersions) {
+    const manifest = await downloadManifestJson(
+      client,
+      bucket,
+      `${version.s3Key}/manifest.json`,
+    );
+    const newVersionId = computeStorageVersionId(target.id, manifest.files);
+    const newS3Key = `${target.s3Prefix}/${newVersionId}`;
+
+    if (version.id === legacy.headVersionId) {
+      headVersionId = newVersionId;
+      headSize = version.size;
+      headFileCount = version.fileCount;
+    }
+
+    if (DRY_RUN) {
+      continue;
+    }
+
+    if (await storageVersionExists(db, target.id, newVersionId)) {
+      continue;
+    }
+
+    const sourceObjects = await listObjectsUnderPrefix(
+      client,
+      bucket,
+      version.s3Key,
+    );
+    for (const sourceKey of sourceObjects) {
+      const suffix = sourceKey.slice(version.s3Key.length);
+      await copyObject(client, bucket, sourceKey, `${newS3Key}${suffix}`);
+    }
+
+    await db
+      .insert(storageVersions)
+      .values({
+        id: newVersionId,
+        storageId: target.id,
+        s3Key: newS3Key,
+        size: version.size,
+        fileCount: version.fileCount,
+        message: version.message,
+        createdBy: version.createdBy,
+      })
+      .onConflictDoNothing();
+    changed = true;
+  }
+
+  if (target.headVersionId !== headVersionId) {
+    changed = true;
+  }
+
+  if (!DRY_RUN && changed) {
+    await db
+      .update(storages)
+      .set({
+        headVersionId,
+        size: headSize,
+        fileCount: headFileCount,
+      })
+      .where(eq(storages.id, target.id));
+  }
+
+  return {
+    changed,
+    versionCount: legacyVersions.length,
+  };
 }
 
 /**
@@ -398,7 +516,8 @@ interface RekeyResult {
  *
  * Always copies into a fresh, id-scoped s3Prefix so duplicated rows that share
  * a name never share storage. Idempotent: re-running detects the existing
- * id-keyed volume and does nothing.
+ * id-keyed volume and syncs it forward when the legacy head changed after a
+ * preseed run.
  */
 async function rekeyWorkflowVolume(
   db: Db,
@@ -408,20 +527,38 @@ async function rekeyWorkflowVolume(
 ): Promise<RekeyResult> {
   const idStorageName = getCustomSkillStorageName(workflow.id);
   const existing = await lookupVolume(db, workflow.orgId, idStorageName);
-  if (existing) {
-    return { status: "already-keyed", idVolumeS3Prefix: existing.s3Prefix };
-  }
-
   const legacyStorageName = getCustomSkillStorageName(workflow.name);
   const legacy = await lookupVolume(db, workflow.orgId, legacyStorageName);
   if (!legacy) {
+    if (existing) {
+      return { status: "already-keyed", idVolumeS3Prefix: existing.s3Prefix };
+    }
     return { status: "legacy-missing", idVolumeS3Prefix: null };
   }
 
-  const legacyVersions = await lookupVersions(db, legacy.id);
+  if (existing) {
+    const sync = await copyLegacyVersionsToStorage(
+      db,
+      client,
+      bucket,
+      legacy,
+      existing,
+    );
+    if (!sync.changed) {
+      return { status: "already-keyed", idVolumeS3Prefix: existing.s3Prefix };
+    }
+    console.log(
+      `      ${DRY_RUN ? "would sync" : "synced"} existing id-keyed volume ` +
+        `"${idStorageName}" from legacy "${legacyStorageName}" ` +
+        `(${sync.versionCount} version(s))`,
+    );
+    return { status: "synced", idVolumeS3Prefix: existing.s3Prefix };
+  }
+
   const newPrefix = `${workflow.orgId}/volume/${idStorageName}`;
 
   if (DRY_RUN) {
+    const legacyVersions = await lookupVersions(db, legacy.id);
     console.log(
       `      would copy legacy volume "${legacyStorageName}" → "${idStorageName}" ` +
         `(${legacyVersions.length} version(s), new prefix ${newPrefix})`,
@@ -446,65 +583,15 @@ async function rekeyWorkflowVolume(
     throw new Error(`Failed to create id-keyed storage for ${workflow.id}`);
   }
 
-  // Copy every version's S3 objects under the new prefix, re-pointing s3Key.
-  // Version ids are scoped by storage id in normal writes; recompute them for
-  // the new storage instead of reusing the legacy row's global primary key.
-  let headVersionId: string | null = null;
-  let headSize = 0;
-  let headFileCount = 0;
-
-  for (const version of legacyVersions) {
-    const manifest = await downloadManifestJson(
-      client,
-      bucket,
-      `${version.s3Key}/manifest.json`,
-    );
-    const newVersionId = computeStorageVersionId(newStorage.id, manifest.files);
-    const newS3Key = `${newPrefix}/${newVersionId}`;
-    const sourceObjects = await listObjectsUnderPrefix(
-      client,
-      bucket,
-      version.s3Key,
-    );
-    for (const sourceKey of sourceObjects) {
-      const suffix = sourceKey.slice(version.s3Key.length);
-      await copyObject(client, bucket, sourceKey, `${newS3Key}${suffix}`);
-    }
-
-    await db
-      .insert(storageVersions)
-      .values({
-        id: newVersionId,
-        storageId: newStorage.id,
-        s3Key: newS3Key,
-        size: version.size,
-        fileCount: version.fileCount,
-        message: version.message,
-        createdBy: version.createdBy,
-      })
-      .onConflictDoNothing();
-
-    if (version.id === legacy.headVersionId) {
-      headVersionId = newVersionId;
-      headSize = version.size;
-      headFileCount = version.fileCount;
-    }
-  }
-
-  if (headVersionId) {
-    await db
-      .update(storages)
-      .set({
-        headVersionId,
-        size: headSize,
-        fileCount: headFileCount,
-      })
-      .where(eq(storages.id, newStorage.id));
-  }
+  const sync = await copyLegacyVersionsToStorage(db, client, bucket, legacy, {
+    id: newStorage.id,
+    s3Prefix: newPrefix,
+    headVersionId: null,
+  });
 
   console.log(
     `      copied legacy volume "${legacyStorageName}" → "${idStorageName}" ` +
-      `(${legacyVersions.length} version(s), prefix ${newPrefix})`,
+      `(${sync.versionCount} version(s), prefix ${newPrefix})`,
   );
   return { status: "copied", idVolumeS3Prefix: newPrefix };
 }
@@ -681,14 +768,24 @@ async function deleteLegacyVolumes(
 // Per-org processing
 // ---------------------------------------------------------------------------
 
-async function processOrg(
-  db: Db,
-  client: S3Client,
-  bucket: string,
-  orgId: string,
-  stats: Stats,
-): Promise<void> {
-  const workflows = await db
+async function loadWorkflows(db: Db, orgId: string): Promise<WorkflowRow[]> {
+  if (PRESEED) {
+    const rows = await db
+      .select({
+        id: zeroWorkflows.id,
+        orgId: zeroWorkflows.orgId,
+        name: zeroWorkflows.name,
+      })
+      .from(zeroWorkflows)
+      .where(eq(zeroWorkflows.orgId, orgId))
+      .orderBy(asc(zeroWorkflows.createdAt));
+
+    return rows.map((row) => {
+      return { ...row, description: null, instruction: null };
+    });
+  }
+
+  return await db
     .select({
       id: zeroWorkflows.id,
       orgId: zeroWorkflows.orgId,
@@ -699,12 +796,22 @@ async function processOrg(
     .from(zeroWorkflows)
     .where(eq(zeroWorkflows.orgId, orgId))
     .orderBy(asc(zeroWorkflows.createdAt));
+}
+
+async function processOrg(
+  db: Db,
+  client: S3Client,
+  bucket: string,
+  orgId: string,
+  stats: Stats,
+): Promise<void> {
+  const workflows = await loadWorkflows(db, orgId);
 
   console.log(`\n  Org ${orgId} — ${workflows.length} workflow(s)`);
   stats.workflows += workflows.length;
 
-  // Legacy names to keep because their workflow could not be safely re-keyed in
-  // this run. Successfully copied sources are deleted below.
+  // Legacy names to keep during an explicit cleanup run because their workflow
+  // could not be safely re-keyed in this run.
   const preserveLegacyNames = new Set<string>();
 
   for (const workflow of workflows) {
@@ -714,6 +821,8 @@ async function processOrg(
       const rekey = await rekeyWorkflowVolume(db, client, bucket, workflow);
       if (rekey.status === "already-keyed") {
         stats.volumesAlreadyKeyed++;
+      } else if (rekey.status === "synced") {
+        stats.volumesSynced++;
       } else if (rekey.status === "copied") {
         stats.volumesCopied++;
       } else {
@@ -726,15 +835,17 @@ async function processOrg(
       }
 
       // Step 2: backfill instruction (needs the id-keyed volume to exist).
-      if (rekey.status !== "legacy-missing") {
+      if (PRESEED) {
+        stats.instructionsSkipped++;
+      } else if (rekey.status !== "legacy-missing") {
         const result = await backfillInstruction(db, client, bucket, workflow);
         if (result === "backfilled") {
           stats.instructionsBackfilled++;
         } else {
-          stats.instructionsSkilled++;
+          stats.instructionsSkipped++;
         }
       } else {
-        stats.instructionsSkilled++;
+        stats.instructionsSkipped++;
       }
     } catch (err) {
       stats.errors++;
@@ -744,7 +855,12 @@ async function processOrg(
     }
   }
 
-  // Step 3: delete legacy name-keyed volumes for this org.
+  if (!CLEANUP_LEGACY) {
+    console.log("    legacy cleanup disabled — preserving name-keyed volumes");
+    return;
+  }
+
+  // Step 3: delete legacy name-keyed volumes for this org when explicitly asked.
   try {
     stats.legacyVolumesDeleted += await deleteLegacyVolumes(
       db,
@@ -772,6 +888,12 @@ async function main(): Promise<void> {
   console.log(
     `Mode: ${DRY_RUN ? "dry-run (pass --migrate to execute)" : "MIGRATE"}`,
   );
+  console.log(
+    `Phase: ${PRESEED ? "preseed (volume sync only, pre-0480 compatible)" : "post-0480 backfill"}`,
+  );
+  console.log(
+    `Legacy cleanup: ${CLEANUP_LEGACY ? "enabled" : "disabled (preserve legacy volumes)"}`,
+  );
   if (SINGLE_ORG_ID) {
     console.log(`Target: ${SINGLE_ORG_ID} (single-org mode)`);
   }
@@ -784,10 +906,11 @@ async function main(): Promise<void> {
   const stats: Stats = {
     workflows: 0,
     volumesCopied: 0,
+    volumesSynced: 0,
     volumesAlreadyKeyed: 0,
     legacyMissing: 0,
     instructionsBackfilled: 0,
-    instructionsSkilled: 0,
+    instructionsSkipped: 0,
     legacyVolumesDeleted: 0,
     errors: 0,
   };
@@ -815,10 +938,11 @@ async function main(): Promise<void> {
     console.log("\n=== Summary ===");
     console.log(`Workflows processed:        ${stats.workflows}`);
     console.log(`Volumes copied (re-keyed):  ${stats.volumesCopied}`);
+    console.log(`Volumes synced:             ${stats.volumesSynced}`);
     console.log(`Volumes already id-keyed:   ${stats.volumesAlreadyKeyed}`);
     console.log(`Legacy volume missing:      ${stats.legacyMissing}`);
     console.log(`Instructions backfilled:    ${stats.instructionsBackfilled}`);
-    console.log(`Instructions skipped:       ${stats.instructionsSkilled}`);
+    console.log(`Instructions skipped:       ${stats.instructionsSkipped}`);
     console.log(`Legacy volumes deleted:     ${stats.legacyVolumesDeleted}`);
     console.log(`Errors:                     ${stats.errors}`);
 


### PR DESCRIPTION
## Summary
- add a pre-0480 `--preseed` mode that only creates/syncs id-keyed workflow volumes
- preserve legacy name-keyed workflow volumes by default during post-0480 backfill
- add explicit `--cleanup-legacy` mode for delayed legacy volume deletion
- sync existing id-keyed volumes forward when the legacy head changed after a preseed run
- update the migration README with preseed, backfill, and cleanup sequencing

## Verification
- `pnpm -C turbo exec prettier --check packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/README.md`
- `pnpm -C turbo --filter @vm0/db check-types`