### PR TITLE
feat: add computer use automation preflight

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -60,6 +60,18 @@ const COMPUTER_USE_COMMANDS = [
   ...COMPUTER_USE_READ_COMMANDS,
   ...COMPUTER_USE_WRITE_COMMANDS,
 ] as const satisfies readonly ComputerUseCommandKind[];
+const DEFAULT_COMPUTER_USE_AUTOMATION_PERMISSIONS = {
+  chrome: {
+    status: "unknown",
+    updatedAt: null,
+    reason: null,
+  },
+  safari: {
+    status: "unknown",
+    updatedAt: null,
+    reason: null,
+  },
+} as const;
 
 type ComputerUseTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type ComputerUseHostRow = typeof computerUseHosts.$inferSelect;
@@ -194,10 +206,33 @@ function samePermissions(
   left: ComputerUseHostRow["permissions"],
   right: ComputerUseHostRow["permissions"],
 ): boolean {
+  const normalizedLeft = normalizeHostPermissions(left);
+  const normalizedRight = normalizeHostPermissions(right);
   return (
-    left.accessibility === right.accessibility &&
-    left.screenRecording === right.screenRecording
+    normalizedLeft.accessibility === normalizedRight.accessibility &&
+    normalizedLeft.screenRecording === normalizedRight.screenRecording &&
+    JSON.stringify(normalizedLeft.automation) ===
+      JSON.stringify(normalizedRight.automation)
   );
+}
+
+function normalizeHostPermissions(
+  permissions: ComputerUseHostRow["permissions"],
+): ComputerUseHostRow["permissions"] {
+  return {
+    accessibility: permissions.accessibility,
+    screenRecording: permissions.screenRecording,
+    automation: {
+      chrome: {
+        ...DEFAULT_COMPUTER_USE_AUTOMATION_PERMISSIONS.chrome,
+        ...permissions.automation?.chrome,
+      },
+      safari: {
+        ...DEFAULT_COMPUTER_USE_AUTOMATION_PERMISSIONS.safari,
+        ...permissions.automation?.safari,
+      },
+    },
+  };
 }
 
 function hostIsOnline(host: ComputerUseHostRow, now: Date): boolean {
@@ -544,7 +579,7 @@ function serializeHost(row: ComputerUseHostRow, now: Date) {
     appVersion: row.appVersion,
     osVersion: row.osVersion,
     supportedCapabilities: row.supportedCapabilities,
-    permissions: row.permissions,
+    permissions: normalizeHostPermissions(row.permissions),
     status: hostIsOnline(row, now) ? ("online" as const) : ("offline" as const),
     lastSeenAt: row.lastSeenAt.toISOString(),
     createdAt: row.createdAt.toISOString(),
@@ -734,10 +769,7 @@ export const startComputerUseHost$ = command(
       readonly appVersion: string;
       readonly osVersion: string;
       readonly supportedCapabilities: readonly string[];
-      readonly permissions: {
-        readonly accessibility: boolean;
-        readonly screenRecording: boolean;
-      };
+      readonly permissions: ComputerUseHostRow["permissions"];
     },
     signal: AbortSignal,
   ): Promise<StartComputerUseHostResult> => {
@@ -819,10 +851,7 @@ export const heartbeatComputerUseHost$ = command(
       readonly appVersion: string;
       readonly osVersion: string;
       readonly supportedCapabilities: readonly string[];
-      readonly permissions: {
-        readonly accessibility: boolean;
-        readonly screenRecording: boolean;
-      };
+      readonly permissions: ComputerUseHostRow["permissions"];
     },
     signal: AbortSignal,
   ): Promise<HeartbeatComputerUseHostResult> => {

--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -3057,10 +3057,68 @@ func appleScriptFailureMessage(result: AppleScriptRunResult) -> String {
     return "Apple Events browser navigation failed with status \(result.status)."
 }
 
+func automationPermissionTarget(named target: String) -> BrowserAddressNavigationTarget? {
+    switch target.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "chrome":
+        return .chrome
+    case "safari":
+        return .safari
+    default:
+        return nil
+    }
+}
+
+func automationPermissionDeniedMessage(_ message: String) -> Bool {
+    let lowercased = message.lowercased()
+    return message.contains("-1743") || lowercased.contains("not authorized")
+}
+
+func handlePermissionsProbeAutomation(_ request: [String: Any]) throws -> [String: Any] {
+    let targetKey = try requiredString(request, "target")
+    guard let target = automationPermissionTarget(named: targetKey) else {
+        throw HelperFailure(
+            code: "unsupported_command",
+            message: "Unsupported Automation permission target: \(targetKey)"
+        )
+    }
+
+    let bundleId = target.rawValue
+    guard applicationURL(forBundleId: bundleId) != nil else {
+        return [
+            "status": "not_installed",
+            "reason": "Target browser is not installed.",
+        ]
+    }
+    guard findRunningApp(named: bundleId) != nil else {
+        return [
+            "status": "not_running",
+            "reason": "Open the target browser before testing Automation permission.",
+        ]
+    }
+
+    let script = "tell application id \(appleScriptStringLiteral(bundleId)) to get name"
+    let result = try runAppleScript(script, timeout: 3)
+    if !result.timedOut, result.status == 0 {
+        return ["status": "granted"]
+    }
+
+    let message = appleScriptFailureMessage(result: result)
+    if automationPermissionDeniedMessage(message) {
+        return [
+            "status": "denied",
+            "reason": message,
+        ]
+    }
+
+    return [
+        "status": "unknown",
+        "reason": message,
+    ]
+}
+
 func throwBrowserNavigationFailure(result: AppleScriptRunResult) throws -> Never {
     let message = appleScriptFailureMessage(result: result)
-    let lowercased = message.lowercased()
-    if message.contains("-1743") || lowercased.contains("not authorized") {
+    if automationPermissionDeniedMessage(message) {
         throw HelperFailure(
             code: "automation_permission_denied",
             message:
@@ -4807,6 +4865,8 @@ func handle(_ request: [String: Any], session: ComputerUseRuntimeSession?) throw
         return handlePermissionsRequestAccessibility()
     case "permissions.request_screen_recording":
         return handlePermissionsRequestScreenRecording()
+    case "permissions.probe_automation":
+        return try handlePermissionsProbeAutomation(request)
     case "apps.list":
         return handleAppsList()
     case "app.state":

--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -2,7 +2,12 @@ import type { IpcMainInvokeEvent } from "electron";
 import { BrowserWindow, ipcMain, shell } from "electron";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { isDesktopComputerUsePageUrl } from "./computer-use-page-url";
-import type { DesktopComputerUseState } from "./computer-use-types";
+import { MAC_AUTOMATION_SETTINGS_URL } from "./desktop-automation-permission";
+import {
+  COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS,
+  type ComputerUseAutomationPermissionTarget,
+  type DesktopComputerUseState,
+} from "./computer-use-types";
 
 interface ComputerUseIpcOptions {
   readonly rendererUrl: string;
@@ -17,6 +22,9 @@ interface ComputerUseNativeApi {
   readonly stop: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
+  readonly probeAutomationPermission: (
+    target: ComputerUseAutomationPermissionTarget,
+  ) => Promise<DesktopComputerUseState>;
   readonly setKeepAwakeEnabled: (enabled: boolean) => DesktopComputerUseState;
 }
 
@@ -25,6 +33,17 @@ function isComputerUseStartOptions(
 ): value is { readonly userInitiated?: unknown } {
   return (
     typeof value === "object" && value !== null && "userInitiated" in value
+  );
+}
+
+function isAutomationPermissionTarget(
+  value: unknown,
+): value is ComputerUseAutomationPermissionTarget {
+  return (
+    typeof value === "string" &&
+    COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS.some((target) => {
+      return target === value;
+    })
   );
 }
 
@@ -90,6 +109,16 @@ export function installComputerUseIpc(
     },
   );
   ipcMain.handle(
+    COMPUTER_USE_CHANNELS.probeAutomationPermission,
+    (event, target: unknown) => {
+      assertComputerUsePage(event);
+      if (!isAutomationPermissionTarget(target)) {
+        throw new Error("Unknown Computer Use Automation permission target");
+      }
+      return api.probeAutomationPermission(target);
+    },
+  );
+  ipcMain.handle(
     COMPUTER_USE_CHANNELS.setKeepAwakeEnabled,
     (event, enabled: unknown) => {
       assertComputerUsePage(event);
@@ -115,6 +144,13 @@ export function installComputerUseIpc(
       await shell.openExternal(
         "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
       );
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.openAutomationSettings,
+    async (event) => {
+      assertComputerUsePage(event);
+      await shell.openExternal(MAC_AUTOMATION_SETTINGS_URL);
     },
   );
 }

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -5,8 +5,10 @@ export const COMPUTER_USE_CHANNELS = {
   stop: "computer-use:stop",
   requestAccessibilityPermission: "computer-use:request-accessibility",
   requestScreenRecordingPermission: "computer-use:request-screen-recording",
+  probeAutomationPermission: "computer-use:probe-automation",
   setKeepAwakeEnabled: "computer-use:set-keep-awake-enabled",
   openAccessibilitySettings: "computer-use:open-accessibility-settings",
   openScreenRecordingSettings: "computer-use:open-screen-recording-settings",
+  openAutomationSettings: "computer-use:open-automation-settings",
   changed: "computer-use:changed",
 } as const;

--- a/turbo/apps/desktop/src/computer-use-native.test.ts
+++ b/turbo/apps/desktop/src/computer-use-native.test.ts
@@ -95,17 +95,27 @@ const requestLogPath = ${JSON.stringify(requestLogPath)};
 let buffer = "";
 
 function responseFor(request) {
-  if (
-    request.kind === "permissions.state" ||
-    request.kind === "permissions.request_accessibility" ||
-    request.kind === "permissions.request_screen_recording"
-  ) {
+	  if (
+	    request.kind === "permissions.state" ||
+	    request.kind === "permissions.request_accessibility" ||
+	    request.kind === "permissions.request_screen_recording"
+	  ) {
     return {
       id: request.id,
       status: "succeeded",
-      result: { accessibility: true, screenRecording: true }
-    };
-  }
+	      result: { accessibility: true, screenRecording: true }
+	    };
+	  }
+	  if (request.kind === "permissions.probe_automation") {
+	    return {
+	      id: request.id,
+	      status: "succeeded",
+	      result: {
+	        status: "denied",
+	        reason: "Not authorized to send Apple events. (-1743)"
+	      }
+	    };
+	  }
   if (request.kind === "apps.list") {
     return {
       id: request.id,
@@ -400,6 +410,38 @@ describe("computer use native backend", () => {
       expect(requests).toHaveLength(1);
       expect(requests[0]).toMatchObject({
         kind: "permissions.request_screen_recording",
+      });
+    } finally {
+      backend.dispose();
+      await rm(helper.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("probes browser automation permission through the native helper", async () => {
+    const helper = await createSessionHelper();
+    const backend = createComputerUseNativeBackend({
+      helperPath: helper.helperPath,
+    });
+
+    try {
+      await expect(
+        backend.probeAutomationPermission("chrome"),
+      ).resolves.toEqual({
+        status: "denied",
+        updatedAt: null,
+        reason: "Not authorized to send Apple events. (-1743)",
+      });
+
+      const requests = (await readFile(helper.requestLogPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          return JSON.parse(line) as Record<string, unknown>;
+        });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        kind: "permissions.probe_automation",
+        payload: { target: "chrome" },
       });
     } finally {
       backend.dispose();

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -8,7 +8,12 @@ import type {
   ComputerUseCoordinateBounds,
   ComputerUseMouseButton,
 } from "./computer-use-accessibility";
-import type { ComputerUsePermissionState } from "./computer-use-types";
+import type {
+  ComputerUseAutomationPermissionStatus,
+  ComputerUseAutomationPermissionTarget,
+  ComputerUseAutomationPermissionTargetState,
+  ComputerUsePermissionState,
+} from "./computer-use-types";
 
 type ComputerUseNativeErrorCode = ComputerUseCommandFailure["error"]["code"];
 
@@ -63,6 +68,9 @@ export interface ComputerUseNativeBackend {
   readonly getPermissions: () => Promise<ComputerUsePermissionState>;
   readonly requestAccessibilityPermission: () => Promise<ComputerUsePermissionState>;
   readonly requestScreenRecordingPermission: () => Promise<ComputerUsePermissionState>;
+  readonly probeAutomationPermission: (
+    target: ComputerUseAutomationPermissionTarget,
+  ) => Promise<ComputerUseAutomationPermissionTargetState>;
   readonly listApps: () => Promise<readonly ComputerUseNativeAppRecord[]>;
   readonly getAppState: (
     app: string,
@@ -350,6 +358,31 @@ function resultPermissions(
     "accessibility_unavailable",
     "Native Computer Use helper returned invalid permissions",
   );
+}
+
+function resultAutomationPermissionStatus(
+  value: unknown,
+): ComputerUseAutomationPermissionStatus {
+  if (
+    value === "unknown" ||
+    value === "granted" ||
+    value === "denied" ||
+    value === "not_installed" ||
+    value === "not_running"
+  ) {
+    return value;
+  }
+  return "unknown";
+}
+
+function resultAutomationPermissionTargetState(
+  result: Record<string, unknown>,
+): ComputerUseAutomationPermissionTargetState {
+  return {
+    status: resultAutomationPermissionStatus(result.status),
+    updatedAt: resultOptionalString(result, "updatedAt") ?? null,
+    reason: resultOptionalString(result, "reason") ?? null,
+  };
 }
 
 function helperPathCandidates(
@@ -796,6 +829,13 @@ export function createComputerUseNativeBackend(
         kind: "permissions.request_screen_recording",
       });
       return resultPermissions(result);
+    },
+    probeAutomationPermission: async (target) => {
+      const result = await run({
+        kind: "permissions.probe_automation",
+        target,
+      });
+      return resultAutomationPermissionTargetState(result);
     },
     listApps: async () => {
       const result = await run({ kind: "apps.list" });

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -2,12 +2,18 @@ import {
   createComputerUseNativeBackend,
   type ComputerUseNativeBackend,
 } from "./computer-use-native";
-import type { ComputerUsePermissionState } from "./computer-use-types";
+import {
+  defaultComputerUseAutomationPermissionState,
+  normalizeComputerUsePermissionState,
+  type ComputerUseAutomationPermissionTarget,
+  type ComputerUsePermissionState,
+} from "./computer-use-types";
 
 const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
   Object.freeze({
     accessibility: false,
     screenRecording: false,
+    automation: defaultComputerUseAutomationPermissionState(),
   });
 
 let nativeBackend: ComputerUseNativeBackend | null = null;
@@ -29,18 +35,67 @@ export function getComputerUsePermissionState(): ComputerUsePermissionState {
 }
 
 export async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
-  currentPermissionState = await getNativeBackend().getPermissions();
+  const permissions = await getNativeBackend().getPermissions();
+  currentPermissionState = normalizeComputerUsePermissionState({
+    ...permissions,
+    automation: currentPermissionState.automation,
+  });
   return currentPermissionState;
 }
 
 export async function requestComputerUseAccessibilityPermission(): Promise<ComputerUsePermissionState> {
-  currentPermissionState =
-    await getNativeBackend().requestAccessibilityPermission();
+  const permissions = await getNativeBackend().requestAccessibilityPermission();
+  currentPermissionState = normalizeComputerUsePermissionState({
+    ...permissions,
+    automation: currentPermissionState.automation,
+  });
   return currentPermissionState;
 }
 
 export async function requestComputerUseScreenRecordingPermission(): Promise<ComputerUsePermissionState> {
-  currentPermissionState =
+  const automation = currentPermissionState.automation;
+  const permissions =
     await getNativeBackend().requestScreenRecordingPermission();
+  currentPermissionState = normalizeComputerUsePermissionState({
+    ...permissions,
+    automation,
+  });
+  return currentPermissionState;
+}
+
+export async function probeComputerUseAutomationPermission(
+  target: ComputerUseAutomationPermissionTarget,
+): Promise<ComputerUsePermissionState> {
+  const result = await getNativeBackend().probeAutomationPermission(target);
+  currentPermissionState = normalizeComputerUsePermissionState({
+    ...currentPermissionState,
+    automation: {
+      ...defaultComputerUseAutomationPermissionState(),
+      ...currentPermissionState.automation,
+      [target]: {
+        ...result,
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  });
+  return currentPermissionState;
+}
+
+export function recordComputerUseAutomationPermissionDenied(
+  target: ComputerUseAutomationPermissionTarget,
+  reason: string,
+): ComputerUsePermissionState {
+  currentPermissionState = normalizeComputerUsePermissionState({
+    ...currentPermissionState,
+    automation: {
+      ...defaultComputerUseAutomationPermissionState(),
+      ...currentPermissionState.automation,
+      [target]: {
+        status: "denied",
+        updatedAt: new Date().toISOString(),
+        reason,
+      },
+    },
+  });
   return currentPermissionState;
 }

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -1,8 +1,49 @@
 export const COMPUTER_USE_FEATURE_SWITCH_KEY = "computerUse";
 
+export const COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS = [
+  "chrome",
+  "safari",
+] as const;
+
+export type ComputerUseAutomationPermissionTarget =
+  (typeof COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS)[number];
+
+export type ComputerUseAutomationPermissionStatus =
+  | "unknown"
+  | "granted"
+  | "denied"
+  | "not_installed"
+  | "not_running";
+
+export interface ComputerUseAutomationPermissionTargetState {
+  readonly status: ComputerUseAutomationPermissionStatus;
+  readonly updatedAt: string | null;
+  readonly reason: string | null;
+}
+
+export type ComputerUseAutomationPermissionState = Record<
+  ComputerUseAutomationPermissionTarget,
+  ComputerUseAutomationPermissionTargetState
+>;
+
+export const COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS = {
+  chrome: {
+    bundleId: "com.google.Chrome",
+    label: "Google Chrome",
+  },
+  safari: {
+    bundleId: "com.apple.Safari",
+    label: "Safari",
+  },
+} as const satisfies Record<
+  ComputerUseAutomationPermissionTarget,
+  { readonly bundleId: string; readonly label: string }
+>;
+
 export interface ComputerUsePermissionState {
   readonly accessibility: boolean;
   readonly screenRecording: boolean;
+  readonly automation?: ComputerUseAutomationPermissionState;
 }
 
 export type ComputerUseHostRuntimeStatus =
@@ -95,6 +136,40 @@ export function hasRequiredComputerUsePermissions(
   permissions: ComputerUsePermissionState,
 ): boolean {
   return permissions.accessibility && permissions.screenRecording;
+}
+
+function unknownAutomationPermissionTargetState(): ComputerUseAutomationPermissionTargetState {
+  return {
+    status: "unknown",
+    updatedAt: null,
+    reason: null,
+  };
+}
+
+export function defaultComputerUseAutomationPermissionState(): ComputerUseAutomationPermissionState {
+  return {
+    chrome: unknownAutomationPermissionTargetState(),
+    safari: unknownAutomationPermissionTargetState(),
+  };
+}
+
+export function computerUseAutomationPermissionState(
+  permissions: ComputerUsePermissionState,
+): ComputerUseAutomationPermissionState {
+  return {
+    ...defaultComputerUseAutomationPermissionState(),
+    ...permissions.automation,
+  };
+}
+
+export function normalizeComputerUsePermissionState(
+  permissions: ComputerUsePermissionState,
+): ComputerUsePermissionState {
+  return {
+    accessibility: permissions.accessibility,
+    screenRecording: permissions.screenRecording,
+    automation: computerUseAutomationPermissionState(permissions),
+  };
 }
 
 export const OFFLINE_COMPUTER_USE_HOST_STATE: ComputerUseHostRuntimeState =

--- a/turbo/apps/desktop/src/desktop-automation-permission.test.ts
+++ b/turbo/apps/desktop/src/desktop-automation-permission.test.ts
@@ -57,10 +57,12 @@ describe("desktop automation permission prompt", () => {
       async () => 0,
     );
     const openAutomationSettings = vi.fn<() => void>();
+    const onPermissionDenied = vi.fn();
     const prompt = createAutomationPermissionDeniedPrompt({
       sourceLabel: "Zero Computer Use",
       showDialog,
       openAutomationSettings,
+      onPermissionDenied,
     });
 
     prompt({
@@ -74,6 +76,10 @@ describe("desktop automation permission prompt", () => {
     expect(showDialog).toHaveBeenCalledOnce();
     expect(showDialog.mock.calls[0]?.[0].message).toBe(
       "Allow Zero Computer Use to control Google Chrome",
+    );
+    expect(onPermissionDenied).toHaveBeenCalledWith(
+      "chrome",
+      automationFailure.error.message,
     );
   });
 

--- a/turbo/apps/desktop/src/desktop-automation-permission.ts
+++ b/turbo/apps/desktop/src/desktop-automation-permission.ts
@@ -3,6 +3,7 @@ import type {
   ComputerUseCommand,
   ComputerUseCommandFailure,
 } from "./computer-use-accessibility";
+import type { ComputerUseAutomationPermissionTarget } from "./computer-use-types";
 
 export const MAC_AUTOMATION_SETTINGS_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation";
@@ -10,12 +11,17 @@ export const MAC_AUTOMATION_SETTINGS_URL =
 interface AutomationPermissionTarget {
   readonly key: string;
   readonly label: string;
+  readonly permissionTarget: ComputerUseAutomationPermissionTarget | null;
 }
 
 interface AutomationPermissionPromptOptions {
   readonly sourceLabel: string;
   readonly showDialog: (options: MessageBoxOptions) => Promise<number>;
   readonly openAutomationSettings: () => void;
+  readonly onPermissionDenied?: (
+    target: ComputerUseAutomationPermissionTarget,
+    reason: string,
+  ) => void;
   readonly onError?: (error: unknown) => void;
 }
 
@@ -27,6 +33,12 @@ interface AutomationPermissionDeniedNotification {
 const AUTOMATION_TARGET_LABELS = Object.freeze<Record<string, string>>({
   "com.apple.safari": "Safari",
   "com.google.chrome": "Google Chrome",
+});
+const AUTOMATION_PERMISSION_TARGETS = Object.freeze<
+  Record<string, ComputerUseAutomationPermissionTarget>
+>({
+  "com.apple.safari": "safari",
+  "com.google.chrome": "chrome",
 });
 
 function commandApp(command: ComputerUseCommand): string | null {
@@ -41,13 +53,18 @@ function automationPermissionTarget(
 ): AutomationPermissionTarget {
   const app = commandApp(command);
   if (!app) {
-    return { key: "target-app", label: "the target app" };
+    return {
+      key: "target-app",
+      label: "the target app",
+      permissionTarget: null,
+    };
   }
 
   const key = app.toLowerCase();
   return {
     key,
     label: AUTOMATION_TARGET_LABELS[key] ?? app,
+    permissionTarget: AUTOMATION_PERMISSION_TARGETS[key] ?? null,
   };
 }
 
@@ -79,6 +96,12 @@ export function createAutomationPermissionDeniedPrompt(
     }
 
     const target = automationPermissionTarget(command);
+    if (target.permissionTarget) {
+      options.onPermissionDenied?.(
+        target.permissionTarget,
+        failure.error.message,
+      );
+    }
     if (promptedTargets.has(target.key)) {
       return;
     }

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -1,4 +1,7 @@
-import type { DesktopComputerUseState } from "./computer-use-types";
+import type {
+  ComputerUseAutomationPermissionTarget,
+  DesktopComputerUseState,
+} from "./computer-use-types";
 
 export interface DesktopAuthUser {
   readonly userId: string;
@@ -48,11 +51,15 @@ export interface DesktopComputerUseApi {
   readonly stop: () => Promise<DesktopComputerUseState>;
   readonly requestAccessibilityPermission: () => Promise<DesktopComputerUseState>;
   readonly requestScreenRecordingPermission: () => Promise<DesktopComputerUseState>;
+  readonly probeAutomationPermission: (
+    target: ComputerUseAutomationPermissionTarget,
+  ) => Promise<DesktopComputerUseState>;
   readonly setKeepAwakeEnabled: (
     enabled: boolean,
   ) => Promise<DesktopComputerUseState>;
   readonly openAccessibilitySettings: () => Promise<void>;
   readonly openScreenRecordingSettings: () => Promise<void>;
+  readonly openAutomationSettings: () => Promise<void>;
   readonly subscribe: (callback: () => void) => () => void;
 }
 

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
-import type { DesktopComputerUseState } from "./computer-use-types";
+import type {
+  ComputerUseAutomationPermissionTarget,
+  DesktopComputerUseState,
+} from "./computer-use-types";
 import { COMPUTER_USE_FEATURE_SWITCH_KEY } from "./computer-use-types";
 import type { DesktopAuthState } from "./desktop-bridge";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
@@ -83,6 +86,13 @@ describe("Desktop IPC boundary", () => {
     await expect(
       invokeIpc(COMPUTER_USE_CHANNELS.setKeepAwakeEnabled, rendererUrl, "true"),
     ).rejects.toThrow("Desktop keep-awake enabled state must be a boolean");
+    await expect(
+      invokeIpc(
+        COMPUTER_USE_CHANNELS.probeAutomationPermission,
+        rendererUrl,
+        "firefox",
+      ),
+    ).rejects.toThrow("Unknown Computer Use Automation permission target");
 
     await invokeIpc(COMPUTER_USE_CHANNELS.start, rendererUrl, {
       userInitiated: true,
@@ -92,9 +102,15 @@ describe("Desktop IPC boundary", () => {
       rendererUrl,
       true,
     );
+    await invokeIpc(
+      COMPUTER_USE_CHANNELS.probeAutomationPermission,
+      rendererUrl,
+      "chrome",
+    );
 
     expect(api.start).toHaveBeenCalledWith({ userInitiated: true });
     expect(api.setKeepAwakeEnabled).toHaveBeenCalledWith(true);
+    expect(api.probeAutomationPermission).toHaveBeenCalledWith("chrome");
   });
 
   it("protects auth handlers by renderer URL, allowed app origins, and token payloads", async () => {
@@ -225,6 +241,13 @@ function createComputerUseApi(): {
   readonly requestScreenRecordingPermission: ReturnType<
     typeof vi.fn<() => Promise<DesktopComputerUseState>>
   >;
+  readonly probeAutomationPermission: ReturnType<
+    typeof vi.fn<
+      (
+        target: ComputerUseAutomationPermissionTarget,
+      ) => Promise<DesktopComputerUseState>
+    >
+  >;
   readonly setKeepAwakeEnabled: ReturnType<
     typeof vi.fn<(enabled: boolean) => DesktopComputerUseState>
   >;
@@ -237,6 +260,7 @@ function createComputerUseApi(): {
     stop: vi.fn(async () => state),
     requestAccessibilityPermission: vi.fn(async () => state),
     requestScreenRecordingPermission: vi.fn(async () => state),
+    probeAutomationPermission: vi.fn(async () => state),
     setKeepAwakeEnabled: vi.fn(() => state),
   };
 }

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -35,6 +35,7 @@ import {
   COMPUTER_USE_FEATURE_SWITCH_KEY,
   OFFLINE_COMPUTER_USE_HOST_STATE,
   hasRequiredComputerUsePermissions,
+  type ComputerUseAutomationPermissionTarget,
   type ComputerUseHostRuntimeState,
   type DesktopComputerUseState,
 } from "./computer-use-types";
@@ -45,7 +46,9 @@ import {
 } from "./computer-use-startup-gate";
 import {
   getComputerUsePermissionState,
+  probeComputerUseAutomationPermission,
   refreshComputerUsePermissionState,
+  recordComputerUseAutomationPermissionDenied,
   requestComputerUseAccessibilityPermission,
   requestComputerUseScreenRecordingPermission,
   setComputerUsePermissionNativeBackend,
@@ -161,6 +164,10 @@ const automationPermissionPrompt = createAutomationPermissionDeniedPrompt({
   },
   openAutomationSettings: () => {
     openExternal(MAC_AUTOMATION_SETTINGS_URL);
+  },
+  onPermissionDenied: (target, reason) => {
+    recordComputerUseAutomationPermissionDenied(target, reason);
+    notifyComputerUseChanged();
   },
   onError: (error) => {
     console.error("Automation permission prompt failed", error);
@@ -552,6 +559,14 @@ async function refreshComputerUsePermissions(): Promise<DesktopComputerUseState>
   return getComputerUseBridgeState();
 }
 
+async function probeComputerUseAutomation(
+  target: ComputerUseAutomationPermissionTarget,
+): Promise<DesktopComputerUseState> {
+  await probeComputerUseAutomationPermission(target);
+  notifyComputerUseChanged();
+  return getComputerUseBridgeState();
+}
+
 function installComputerUse(): void {
   installComputerUseIpc(
     {
@@ -561,6 +576,7 @@ function installComputerUse(): void {
       stop: stopComputerUseRuntime,
       requestAccessibilityPermission: requestComputerUsePermission,
       requestScreenRecordingPermission: requestComputerUseScreenRecording,
+      probeAutomationPermission: probeComputerUseAutomation,
       setKeepAwakeEnabled,
     },
     { rendererUrl: localRendererUrl },

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -121,9 +121,11 @@ describe("Desktop preload bridge", () => {
     await computerUse.stop();
     await computerUse.requestAccessibilityPermission();
     await computerUse.requestScreenRecordingPermission();
+    await computerUse.probeAutomationPermission("chrome");
     await computerUse.setKeepAwakeEnabled(true);
     await computerUse.openAccessibilitySettings();
     await computerUse.openScreenRecordingSettings();
+    await computerUse.openAutomationSettings();
 
     expect(electronMock.ipcRenderer.invoke.mock.calls).toStrictEqual([
       [COMPUTER_USE_CHANNELS.getState],
@@ -132,9 +134,11 @@ describe("Desktop preload bridge", () => {
       [COMPUTER_USE_CHANNELS.stop],
       [COMPUTER_USE_CHANNELS.requestAccessibilityPermission],
       [COMPUTER_USE_CHANNELS.requestScreenRecordingPermission],
+      [COMPUTER_USE_CHANNELS.probeAutomationPermission, "chrome"],
       [COMPUTER_USE_CHANNELS.setKeepAwakeEnabled, true],
       [COMPUTER_USE_CHANNELS.openAccessibilitySettings],
       [COMPUTER_USE_CHANNELS.openScreenRecordingSettings],
+      [COMPUTER_USE_CHANNELS.openAutomationSettings],
     ]);
   });
 

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -59,6 +59,12 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
       COMPUTER_USE_CHANNELS.requestScreenRecordingPermission,
     );
   },
+  probeAutomationPermission(target): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.probeAutomationPermission,
+      target,
+    );
+  },
   setKeepAwakeEnabled(enabled: boolean): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(
       COMPUTER_USE_CHANNELS.setKeepAwakeEnabled,
@@ -72,6 +78,9 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
     return ipcRenderer.invoke(
       COMPUTER_USE_CHANNELS.openScreenRecordingSettings,
     );
+  },
+  openAutomationSettings(): Promise<void> {
+    return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.openAutomationSettings);
   },
   subscribe(callback: () => void): () => void {
     const listener = (): void => {

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -88,6 +88,9 @@ function createComputerUseBridge(initialState: DesktopComputerUseState): {
     typeof vi.fn<DesktopComputerUseApi["getState"]>
   >;
   readonly start: ReturnType<typeof vi.fn<DesktopComputerUseApi["start"]>>;
+  readonly probeAutomationPermission: ReturnType<
+    typeof vi.fn<DesktopComputerUseApi["probeAutomationPermission"]>
+  >;
   readonly subscribe: ReturnType<
     typeof vi.fn<DesktopComputerUseApi["subscribe"]>
   >;
@@ -143,6 +146,35 @@ function createComputerUseBridge(initialState: DesktopComputerUseState): {
     });
     return currentState;
   });
+  const probeAutomationPermission = vi.fn<
+    DesktopComputerUseApi["probeAutomationPermission"]
+  >(async (target) => {
+    currentState = createComputerUseState({
+      keepAwake: currentState.keepAwake,
+      permissions: {
+        ...currentState.permissions,
+        automation: {
+          chrome: {
+            status: "unknown",
+            updatedAt: null,
+            reason: null,
+          },
+          safari: {
+            status: "unknown",
+            updatedAt: null,
+            reason: null,
+          },
+          [target]: {
+            status: "granted",
+            updatedAt: "2026-06-22T00:00:00.000Z",
+            reason: null,
+          },
+        },
+      },
+      status: currentState.host.status,
+    });
+    return currentState;
+  });
   const setKeepAwakeEnabled = vi.fn<
     DesktopComputerUseApi["setKeepAwakeEnabled"]
   >(async (enabled) => {
@@ -169,12 +201,16 @@ function createComputerUseBridge(initialState: DesktopComputerUseState): {
     stop,
     requestAccessibilityPermission,
     requestScreenRecordingPermission,
+    probeAutomationPermission,
     setKeepAwakeEnabled,
     openAccessibilitySettings: vi.fn<
       DesktopComputerUseApi["openAccessibilitySettings"]
     >(async () => {}),
     openScreenRecordingSettings: vi.fn<
       DesktopComputerUseApi["openScreenRecordingSettings"]
+    >(async () => {}),
+    openAutomationSettings: vi.fn<
+      DesktopComputerUseApi["openAutomationSettings"]
     >(async () => {}),
     subscribe,
   };
@@ -188,6 +224,7 @@ function createComputerUseBridge(initialState: DesktopComputerUseState): {
       }
     },
     getState,
+    probeAutomationPermission,
     start,
     subscribe,
   };
@@ -368,6 +405,28 @@ describe("Desktop renderer bridge integration", () => {
     expect(await screen.findByText("lisa")).toBeTruthy();
     expect(auth.getState).toHaveBeenCalled();
     expect(computerUse.getState).toHaveBeenCalled();
+  });
+
+  it("probes browser automation from an explicit user action", async () => {
+    const { computerUse } = installDesktopBridges();
+    renderDesktopApp();
+
+    expect(await screen.findByText("Browser Automation")).toBeTruthy();
+    expect(await screen.findByText("Google Chrome")).toBeTruthy();
+    expect(screen.getAllByText("Not tested")).toHaveLength(2);
+    expect(computerUse.probeAutomationPermission).not.toHaveBeenCalled();
+
+    const chromeTestButton = screen.getAllByText("Test")[0]?.closest("button");
+    if (!(chromeTestButton instanceof HTMLButtonElement)) {
+      throw new Error("Could not find Chrome Automation test button");
+    }
+    fireEvent.click(chromeTestButton);
+
+    await waitFor(() => {
+      expect(computerUse.probeAutomationPermission).toHaveBeenCalledWith(
+        "chrome",
+      );
+    });
   });
 
   it("keeps offline account actions in the overflow menu until it is opened", async () => {

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -25,7 +25,12 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import type { DesktopAuthState } from "../desktop-bridge";
 import { hasReadyDesktopAuth } from "../computer-use-startup-gate";
 import {
+  COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS,
+  COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS,
+  computerUseAutomationPermissionState,
   hasRequiredComputerUsePermissions,
+  type ComputerUseAutomationPermissionStatus,
+  type ComputerUseAutomationPermissionTarget,
   type DesktopComputerUseState,
 } from "../computer-use-types";
 import {
@@ -36,9 +41,11 @@ import {
   hasDesktopComputerUseBridge,
   hasDesktopDeveloperToolsBridge,
   openAccessibilitySettings$,
+  openAutomationSettings$,
   openDesktopOrgSelection$,
   openDesktopSignIn$,
   openScreenRecordingSettings$,
+  probeAutomationPermission$,
   refreshComputerUse$,
   requestAccessibilityPermission$,
   requestScreenRecordingPermission$,
@@ -76,6 +83,14 @@ const COMMAND_STATUS_LABELS = {
   succeeded: "Succeeded",
   failed: "Failed",
 } as const satisfies Record<CommandLogEntry["status"], string>;
+
+const AUTOMATION_PERMISSION_STATUS_LABELS = {
+  unknown: "Not tested",
+  granted: "Ready",
+  denied: "Needs approval",
+  not_installed: "Not installed",
+  not_running: "Open browser",
+} as const satisfies Record<ComputerUseAutomationPermissionStatus, string>;
 
 const RUNTIME_ERROR_SOURCE_LABELS = {
   start: "Start",
@@ -555,6 +570,128 @@ function PermissionSetupRow({
         </IconButton>
       </div>
     </div>
+  );
+}
+
+function automationPermissionMeta(
+  target: ComputerUseAutomationPermissionTarget,
+  status: ComputerUseAutomationPermissionStatus,
+): string {
+  const label = COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS[target].label;
+  switch (status) {
+    case "granted":
+      return "Automation allowed";
+    case "denied":
+      return `Allow Zero to control ${label} in System Settings`;
+    case "not_installed":
+      return `Install ${label} to test browser automation`;
+    case "not_running":
+      return `Open ${label}, then test again`;
+    case "unknown":
+      return `Test when ${label} is open`;
+  }
+}
+
+function AutomationPermissionRow({
+  disabled,
+  onOpenSettings,
+  onProbe,
+  status,
+  target,
+}: {
+  readonly disabled: boolean;
+  readonly onOpenSettings: () => void;
+  readonly onProbe: () => void;
+  readonly status: ComputerUseAutomationPermissionStatus;
+  readonly target: ComputerUseAutomationPermissionTarget;
+}) {
+  const label = COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS[target].label;
+  return (
+    <div className="permission-row">
+      <div>
+        <div className="row-title">{label}</div>
+        <div className="row-meta">
+          {automationPermissionMeta(target, status)}
+        </div>
+      </div>
+      <div className="row-actions">
+        <span className={`automation-pill automation-pill-${status}`}>
+          {status === "granted" ? (
+            <IconCheck size={14} />
+          ) : (
+            <IconAlertCircle size={14} />
+          )}
+          {AUTOMATION_PERMISSION_STATUS_LABELS[status]}
+        </span>
+        {status !== "granted" && (
+          <IconButton
+            icon={<IconShieldCheck size={15} />}
+            onClick={onProbe}
+            disabled={disabled}
+          >
+            Test
+          </IconButton>
+        )}
+        {status === "denied" && (
+          <IconButton
+            icon={<IconExternalLink size={15} />}
+            onClick={onOpenSettings}
+          >
+            Settings
+          </IconButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BrowserAutomationPanel({
+  state,
+}: {
+  readonly state: DesktopComputerUseState;
+}) {
+  const automation = computerUseAutomationPermissionState(state.permissions);
+  const [probeLoadable, probeAutomation] = useLoadableSet(
+    probeAutomationPermission$,
+  );
+  const [, openAutomationSettings] = useLoadableSet(openAutomationSettings$);
+  const disabled = probeLoadable.state === "loading";
+
+  if (!hasRequiredComputerUsePermissions(state.permissions)) {
+    return null;
+  }
+
+  return (
+    <section className="step-card step-card-expanded browser-automation-card">
+      <div className="step-card-main">
+        <div className="step-kicker">
+          <StepIndex step={3} />
+          <span>Browser Automation</span>
+        </div>
+        <div className="step-heading">
+          <h2>Check browser automation</h2>
+          <p>Chrome and Safari use separate macOS Automation approval.</p>
+        </div>
+        <div className="permission-list">
+          {COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS.map((target) => {
+            return (
+              <AutomationPermissionRow
+                key={target}
+                disabled={disabled}
+                onOpenSettings={() => {
+                  void openAutomationSettings();
+                }}
+                onProbe={() => {
+                  void probeAutomation(target);
+                }}
+                status={automation[target].status}
+                target={target}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -1055,6 +1192,7 @@ function ReadyExperience({
         <OfflineHero authState={authState} state={state} />
       )}
       {!running && <PermissionAutoRefresh />}
+      <BrowserAutomationPanel state={state} />
       {developerToolsEnabled && (
         <>
           <RuntimePanel state={state} />

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -6,7 +6,10 @@ import type {
   DesktopDeveloperToolsApi,
   DesktopDeveloperToolsState,
 } from "../desktop-bridge";
-import type { DesktopComputerUseState } from "../computer-use-types";
+import type {
+  ComputerUseAutomationPermissionTarget,
+  DesktopComputerUseState,
+} from "../computer-use-types";
 
 const DEFAULT_DEVELOPER_TOOLS_STATE: DesktopDeveloperToolsState = {
   available: false,
@@ -143,6 +146,13 @@ export const requestScreenRecordingPermission$ = command(async ({ set }) => {
   set(reloadComputerUse$);
 });
 
+export const probeAutomationPermission$ = command(
+  async ({ set }, target: ComputerUseAutomationPermissionTarget) => {
+    await desktopComputerUseApi().probeAutomationPermission(target);
+    set(reloadComputerUse$);
+  },
+);
+
 export const setKeepAwakeEnabled$ = command(
   async ({ set }, enabled: boolean) => {
     await desktopComputerUseApi().setKeepAwakeEnabled(enabled);
@@ -156,6 +166,10 @@ export const openAccessibilitySettings$ = command(async () => {
 
 export const openScreenRecordingSettings$ = command(async () => {
   await desktopComputerUseApi().openScreenRecordingSettings();
+});
+
+export const openAutomationSettings$ = command(async () => {
+  await desktopComputerUseApi().openAutomationSettings();
 });
 
 export const openDesktopSignIn$ = command(async () => {

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -393,6 +393,10 @@ button {
   background: rgba(249, 250, 251, 0.76);
 }
 
+.browser-automation-card {
+  margin-top: 10px;
+}
+
 .checkbox-row {
   min-height: 58px;
   border: 1px solid rgba(30, 38, 52, 0.08);
@@ -679,6 +683,7 @@ button {
 }
 
 .check-pill,
+.automation-pill,
 .outcome,
 .status-badge,
 .command-status {
@@ -695,11 +700,24 @@ button {
 }
 
 .check-pill,
+.automation-pill-granted,
 .status-online,
 .outcome-approved,
 .command-status-succeeded {
   color: #067647;
   background: #ecfdf3;
+}
+
+.automation-pill-unknown,
+.automation-pill-not_running,
+.automation-pill-not_installed {
+  color: #344054;
+  background: #f2f4f7;
+}
+
+.automation-pill-denied {
+  color: #b42318;
+  background: #fef3f2;
 }
 
 .status-offline {

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -55,6 +55,13 @@ function createNativeBackend(
     requestScreenRecordingPermission: async () => {
       return { accessibility: true, screenRecording: true };
     },
+    probeAutomationPermission: async () => {
+      return {
+        status: "unknown",
+        updatedAt: null,
+        reason: null,
+      };
+    },
     listApps: async () => [],
     getAppState: async (app, snapshotId) => {
       return { app, snapshotId, elements: [] };

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-computer-use.test.ts
@@ -31,6 +31,7 @@ describe("computer-use contract", () => {
   it.each([
     "app_not_found",
     "app_open_failed",
+    "automation_permission_denied",
     "element_not_editable",
     "window_unavailable",
   ])("accepts %s command failures", (code) => {

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -38,6 +38,7 @@ export const computerUseCommandErrorCodeSchema = z.enum([
   "no_host",
   "permission_denied",
   "accessibility_unavailable",
+  "automation_permission_denied",
   "window_unavailable",
   "screen_recording_unavailable",
   "app_not_found",
@@ -69,6 +70,39 @@ const elementIndexSchema = z.number().int().min(0);
 const computerUsePermissionsSchema = z.object({
   accessibility: z.boolean(),
   screenRecording: z.boolean(),
+  automation: z
+    .object({
+      chrome: z
+        .object({
+          status: z.enum([
+            "unknown",
+            "granted",
+            "denied",
+            "not_installed",
+            "not_running",
+          ]),
+          updatedAt: z.string().nullable().default(null),
+          reason: z.string().nullable().default(null),
+        })
+        .default({ status: "unknown", updatedAt: null, reason: null }),
+      safari: z
+        .object({
+          status: z.enum([
+            "unknown",
+            "granted",
+            "denied",
+            "not_installed",
+            "not_running",
+          ]),
+          updatedAt: z.string().nullable().default(null),
+          reason: z.string().nullable().default(null),
+        })
+        .default({ status: "unknown", updatedAt: null, reason: null }),
+    })
+    .default({
+      chrome: { status: "unknown", updatedAt: null, reason: null },
+      safari: { status: "unknown", updatedAt: null, reason: null },
+    }),
 });
 
 const computerUseRuntimeBodySchema = z.object({

--- a/turbo/packages/db/src/schema/computer-use-host.ts
+++ b/turbo/packages/db/src/schema/computer-use-host.ts
@@ -15,6 +15,28 @@ type JsonObject = Record<string, unknown>;
 export interface ComputerUsePermissions {
   readonly accessibility: boolean;
   readonly screenRecording: boolean;
+  readonly automation?: {
+    readonly chrome: {
+      readonly status:
+        | "unknown"
+        | "granted"
+        | "denied"
+        | "not_installed"
+        | "not_running";
+      readonly updatedAt: string | null;
+      readonly reason: string | null;
+    };
+    readonly safari: {
+      readonly status:
+        | "unknown"
+        | "granted"
+        | "denied"
+        | "not_installed"
+        | "not_running";
+      readonly updatedAt: string | null;
+      readonly reason: string | null;
+    };
+  };
 }
 
 export const computerUseHosts = pgTable(


### PR DESCRIPTION
## Summary
- add per-browser Computer Use Automation permission state for Chrome and Safari
- add an explicit native Automation probe that only runs when the user clicks Test
- surface Browser Automation readiness in the desktop setup UI while preserving the runtime failure fallback
- normalize Automation permission data through the API contract and host serialization

Closes #18441

## Test Plan
- `pnpm format`
- `pnpm -F @vm0/desktop exec vitest run src/computer-use-native.test.ts src/desktop-automation-permission.test.ts src/desktop-ipc-boundary.test.ts src/preload.test.ts src/renderer/App.test.tsx src/window-policy.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/zero-computer-use.test.ts`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db check-types`
- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/db lint`
- pre-commit hook: `pnpm knip`, `pnpm check-types`

## Local Notes
- `pnpm -F api exec vitest run src/signals/routes/__tests__/computer-use.bdd.test.ts` is blocked in this checkout by a stale local dev database migration state (`zero_skills` missing during migrate, then `computer_use_hosts.installation_id` missing in the test DB), before exercising this change.