### PR TITLE
perf: avoid eager firewall catalogs in run creation

### DIFF
--- a/turbo/.prettierignore
+++ b/turbo/.prettierignore
@@ -8,6 +8,10 @@ packages/connectors/src/firewall-metadata/*.generated.ts
 packages/connectors/src/firewall-metadata/.metadata-*
 packages/connectors/src/firewall-metadata/.*.previous-*
 packages/connectors/src/firewall-metadata/details/*.generated.ts
+packages/connectors/src/firewall-execution-metadata/*.generated.ts
+packages/connectors/src/firewall-execution-metadata/.metadata-*
+packages/connectors/src/firewall-execution-metadata/.*.previous-*
+packages/connectors/src/firewall-execution-metadata/details/*.generated.ts
 pnpm-lock.yaml
 coverage
 .claude

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -922,6 +922,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         return firewallEntryName(firewall);
       }),
     ).toContain("x");
+    expect(findFirewallEntry(claim.firewalls, "x")).toStrictEqual({
+      kind: "builtin",
+      name: "x",
+    });
     expect(claim.billableFirewalls).toContain("x");
     expect(claim.networkPolicies?.x?.unknownPolicy).toBe("allow");
 
@@ -1202,6 +1206,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.environment?.EXTERNAL_TOKEN).toBe("user-shared-secret");
     expect(claim.secretValues).toContain("user-shared-secret");
+    expect(claim.firewalls ?? []).toStrictEqual([]);
+    expect(claim.networkPolicies ?? {}).toStrictEqual({});
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -1319,6 +1325,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         return firewallEntryName(firewall);
       }),
     ).toContain("zendesk");
+    expect(findFirewallEntry(claim.firewalls, "zendesk")).toStrictEqual({
+      kind: "builtin",
+      name: "zendesk",
+      baseUrlVars: { ZENDESK_SUBDOMAIN: "connector-subdomain" },
+    });
     expect(customApis[0]?.base).toBe("https://internal.example.com/api/");
 
     await api.requestCancelRun(actor, run.runId, [200]);

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -15,6 +15,7 @@ const FORBIDDEN_RUNTIME_FIREWALL_IMPORTS = [
   "@vm0/connectors/firewalls",
   "@vm0/core/firewalls",
 ] as const;
+const RUN_CREATION_SERVICE = "agent-run-create.service.ts";
 const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
@@ -30,6 +31,18 @@ function importsSpecifier(source: string, specifier: string): boolean {
       importedSpecifier === specifier ||
       importedSpecifier.startsWith(`${specifier}/`)
     );
+  });
+}
+
+function importsEagerConnectorRuntimeFirewall(source: string): boolean {
+  return importSpecifiers(source).some((specifier) => {
+    if (specifier === "@vm0/connectors/firewalls") {
+      return true;
+    }
+    if (specifier === "@vm0/connectors/firewalls/runtime") {
+      return false;
+    }
+    return specifier.startsWith("@vm0/connectors/firewalls/");
   });
 }
 
@@ -66,4 +79,14 @@ describe("firewall metadata import boundary", () => {
       }
     },
   );
+
+  it("keeps run creation off eager runtime firewall catalogs", () => {
+    const source = readFileSync(
+      resolve(SERVICE_DIR, RUN_CREATION_SERVICE),
+      "utf8",
+    );
+
+    expect(importsEagerConnectorRuntimeFirewall(source)).toBeFalsy();
+    expect(importsSpecifier(source, "@vm0/core/firewalls")).toBeFalsy();
+  });
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -36,12 +36,16 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
-  BILLABLE_CONNECTORS,
-  getConnectorFirewall,
-  getDefaultFirewallPolicies,
-  isFirewallConnectorType,
-  type FirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+  isFirewallExecutionMetadataConnectorType,
+  loadFirewallExecutionMetadata,
+  type FirewallExecutionMetadataDetail,
+  type FirewallExecutionMetadataConnectorType,
+} from "@vm0/connectors/firewall-execution-metadata/server";
+import {
+  loadFirewallPermissionIndex,
+  type FirewallPermissionIndex,
+} from "@vm0/connectors/firewall-metadata/server";
+import { loadConnectorFirewall } from "@vm0/connectors/firewalls/runtime";
 import { getModelProviderRefreshMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
 import {
   expandHostWildcardsInBaseUrl,
@@ -188,6 +192,8 @@ const CUSTOM_CONNECTOR_SECRET_PLACEHOLDER = "{{secret}}";
 const L = logger("AgentRunCreate");
 const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VAR_REF_PREFIX = "$vars.";
+const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
+  "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
 
 type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -327,7 +333,10 @@ interface ResolvedModelProviderEnvironment {
 interface PermissionManifest {
   readonly firewalls: ExecutionFirewalls;
   readonly networkPolicies: NetworkPolicies;
-  readonly environmentFirewalls: readonly ExpandedFirewallConfig[];
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
+  readonly billableFirewalls: readonly string[];
 }
 
 interface StoredExecutionSecrets {
@@ -868,7 +877,9 @@ function expandEnvironment(args: {
   readonly vars: Record<string, string> | undefined;
   readonly secrets: Record<string, string> | undefined;
   readonly additionalEnvironment: Record<string, string> | undefined;
-  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
   readonly storedConnectorEnvironment: Record<string, string> | undefined;
   readonly connectorVars: Record<string, string> | undefined;
 }): Record<string, string> | null {
@@ -880,7 +891,7 @@ function expandEnvironment(args: {
     }),
     vars: args.connectorVars,
     secrets: args.secrets,
-    environmentFirewalls: args.environmentFirewalls,
+    environmentSecretPlaceholders: args.environmentSecretPlaceholders,
   });
   const mergedEnvironment = environmentTemplates({
     content: args.content,
@@ -894,7 +905,7 @@ function expandEnvironment(args: {
     vars: args.vars,
     secrets: {
       ...args.secrets,
-      ...firewallSecretPlaceholders(args.environmentFirewalls),
+      ...args.environmentSecretPlaceholders,
     },
   });
   return mergeRecords(result, storedConnectorEnvironment) ?? null;
@@ -930,7 +941,9 @@ function expandStoredConnectorEnvironment(args: {
   readonly environment: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secrets: Record<string, string> | undefined;
-  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
 }): Record<string, string> | undefined {
   if (!args.environment) {
     return undefined;
@@ -939,7 +952,7 @@ function expandStoredConnectorEnvironment(args: {
   const expanded: Record<string, string> = {};
   const secretSources = mergeRecords(
     args.secrets,
-    firewallSecretPlaceholders(args.environmentFirewalls),
+    args.environmentSecretPlaceholders,
   );
   for (const [key, value] of Object.entries(args.environment)) {
     const expansion = expandVariablesInString(value, {
@@ -966,20 +979,19 @@ function formatMissingReferences(
     .join(", ");
 }
 
-function firewallSecretPlaceholders(
-  environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined,
+function firewallSecretPlaceholdersFromFirewalls(
+  firewalls: readonly ExpandedFirewallConfig[] | undefined,
 ): Record<string, string> | undefined {
-  if (!environmentFirewalls || environmentFirewalls.length === 0) {
+  if (!firewalls || firewalls.length === 0) {
     return undefined;
   }
 
   const placeholders: Record<string, string> = {};
-  for (const firewall of environmentFirewalls) {
+  for (const firewall of firewalls) {
     const secretNames = extractSecretNamesFromApis(firewall.apis);
     for (const name of secretNames) {
       placeholders[name] =
-        firewall.placeholders?.[name] ??
-        "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
+        firewall.placeholders?.[name] ?? DEFAULT_FIREWALL_SECRET_PLACEHOLDER;
     }
     for (const [name, value] of Object.entries(firewall.placeholders ?? {})) {
       placeholders[name] = value;
@@ -993,7 +1005,9 @@ function missingEnvironmentReferences(args: {
   readonly content: AgentComposeContent;
   readonly vars: Record<string, string> | undefined;
   readonly secrets: Record<string, string> | undefined;
-  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
   readonly additionalEnvironment: Record<string, string> | undefined;
   readonly storedConnectorEnvironment: Record<string, string> | undefined;
   readonly connectorVars: Record<string, string> | undefined;
@@ -1006,7 +1020,7 @@ function missingEnvironmentReferences(args: {
     }),
     vars: args.connectorVars,
     secrets: args.secrets,
-    environmentFirewalls: args.environmentFirewalls,
+    environmentSecretPlaceholders: args.environmentSecretPlaceholders,
   });
   const environment = environmentTemplates({
     content: args.content,
@@ -1016,7 +1030,7 @@ function missingEnvironmentReferences(args: {
     environment,
     vars: args.vars,
     secrets: args.secrets,
-    environmentFirewalls: args.environmentFirewalls,
+    environmentSecretPlaceholders: args.environmentSecretPlaceholders,
   });
   return environmentMissing;
 }
@@ -1025,15 +1039,14 @@ function missingReferencesInEnvironment(args: {
   readonly environment: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secrets: Record<string, string> | undefined;
-  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
 }): string[] {
   if (!args.environment) {
     return [];
   }
   const grouped = extractAndGroupVariables(args.environment);
-  const firewallPlaceholders = firewallSecretPlaceholders(
-    args.environmentFirewalls,
-  );
   const missingVars = grouped.vars
     .filter((ref) => {
       return args.vars?.[ref.name] === undefined;
@@ -1045,7 +1058,7 @@ function missingReferencesInEnvironment(args: {
     .filter((ref) => {
       return (
         args.secrets?.[ref.name] === undefined &&
-        firewallPlaceholders?.[ref.name] === undefined
+        args.environmentSecretPlaceholders?.[ref.name] === undefined
       );
     })
     .map((ref) => {
@@ -1058,7 +1071,9 @@ function assertStoredConnectorEnvironmentReferences(args: {
   readonly environment: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secrets: Record<string, string> | undefined;
-  readonly environmentFirewalls: readonly ExpandedFirewallConfig[] | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
 }): void {
   const missing = missingReferencesInEnvironment(args);
   if (missing.length > 0) {
@@ -2193,14 +2208,37 @@ function allAllowPolicyForPermissions(
   };
 }
 
-function defaultBuiltinConnectorPolicyForFirewall(
-  firewall: ExpandedFirewallConfig,
-  permissionNames: readonly string[],
+function defaultPolicyForPermissionIndex(
+  index: FirewallPermissionIndex,
 ): FirewallPolicy {
-  if (isFirewallConnectorType(firewall.name)) {
-    return getDefaultFirewallPolicies(firewall.name);
+  const policies: Record<string, FirewallPolicy["policies"][string]> = {};
+  for (const name of index.permissionNames) {
+    policies[name] = index.policyResolver.permission(name);
   }
-  return allAllowPolicyForPermissions(permissionNames);
+  return {
+    policies,
+    unknownPolicy: index.policyResolver.unknown(),
+  };
+}
+
+async function loadRequiredFirewallPermissionIndex(
+  type: string,
+): Promise<FirewallPermissionIndex> {
+  const index = await loadFirewallPermissionIndex(type);
+  if (!index) {
+    throw new Error(`Missing firewall permission metadata: ${type}`);
+  }
+  return index;
+}
+
+async function loadRequiredFirewallExecutionMetadata(
+  type: FirewallExecutionMetadataConnectorType,
+): Promise<FirewallExecutionMetadataDetail> {
+  const metadata = await loadFirewallExecutionMetadata(type);
+  if (!metadata) {
+    throw new Error(`Missing firewall execution metadata: ${type}`);
+  }
+  return metadata;
 }
 
 function networkPolicyForFirewallPolicy(
@@ -2230,6 +2268,10 @@ function networkPolicyForFirewallPolicy(
 }
 
 const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+const BASE_URL_VALIDATION_SECRET_TEMPLATE = [
+  "$",
+  "{{ secrets.__VM0_FIREWALL_BASE_URL_VALIDATION }}",
+].join("");
 
 function runtimeFirewall(firewall: ExpandedFirewallConfig): Firewall {
   return {
@@ -2272,15 +2314,58 @@ function builtinFirewallEntry(
   return { kind: "builtin", name: firewall.name, baseUrlVars };
 }
 
+function baseUrlValidationAuth(
+  credentialed: boolean,
+): Firewall["apis"][number]["auth"] {
+  return credentialed
+    ? {
+        headers: {
+          Authorization: `Bearer ${BASE_URL_VALIDATION_SECRET_TEMPLATE}`,
+        },
+      }
+    : {};
+}
+
+function builtinFirewallEntryForMetadata(
+  metadata: FirewallExecutionMetadataDetail,
+  vars: Record<string, string> | undefined,
+): ExecutionFirewallEntry {
+  if (metadata.baseUrlVarNames.length === 0) {
+    return { kind: "builtin", name: metadata.type };
+  }
+
+  const baseUrlVars: Record<string, string> = {};
+  for (const name of metadata.baseUrlVarNames) {
+    const value = vars?.[name];
+    if (!value) {
+      throw new Error(
+        `Firewall "${metadata.type}" base URL requires variable "${name}" but it was not provided`,
+      );
+    }
+    baseUrlVars[name] = value;
+  }
+  resolveFirewallBaseUrlVars(
+    [
+      {
+        name: metadata.type,
+        apis: metadata.baseUrlTemplates.map((template) => {
+          return {
+            base: template.base,
+            auth: baseUrlValidationAuth(template.credentialed),
+            permissions: [],
+          };
+        }),
+      },
+    ],
+    vars,
+  );
+  return { kind: "builtin", name: metadata.type, baseUrlVars };
+}
+
 function inlineFirewallEntry(
   firewall: ExpandedFirewallConfig,
 ): ExecutionFirewallEntry {
   return { kind: "inline", firewall: runtimeFirewall(firewall) };
-}
-
-interface RuntimeConnectorFirewall {
-  readonly firewall: ExpandedFirewallConfig;
-  readonly inline: boolean;
 }
 
 const FIGMA_API_TOKEN_TEMPLATE = ["$", "{{ secrets.FIGMA_TOKEN }}"].join("");
@@ -2305,15 +2390,12 @@ function figmaApiTokenFirewall(
   };
 }
 
-function runtimeConnectorFirewall(
-  type: FirewallConnectorType,
-  authMethod: string | undefined,
-): RuntimeConnectorFirewall {
-  const firewall = getConnectorFirewall(type);
-  if (type === "figma" && authMethod === "api-token") {
-    return { firewall: figmaApiTokenFirewall(firewall), inline: true };
+async function loadFigmaApiTokenFirewall(): Promise<ExpandedFirewallConfig> {
+  const firewall = await loadConnectorFirewall("figma");
+  if (!firewall) {
+    throw new Error("Missing figma runtime firewall");
   }
-  return { firewall, inline: false };
+  return figmaApiTokenFirewall(firewall);
 }
 
 function applyConnectorPolicies(
@@ -2326,7 +2408,7 @@ function applyConnectorPolicies(
     firewall: ExpandedFirewallConfig,
     permissionNames: readonly string[],
   ) => FirewallPolicy,
-): Omit<PermissionManifest, "environmentFirewalls"> {
+): Pick<PermissionManifest, "firewalls" | "networkPolicies"> {
   const firewalls: ExecutionFirewalls = [];
   const networkPolicies: NetworkPolicies = {};
 
@@ -2376,7 +2458,10 @@ function modelProviderPermissionManifest(
   const askSet = new Set(firewall.defaultPolicies?.ask ?? []);
   return {
     firewalls: [builtinFirewallEntry(firewall, vars)],
-    environmentFirewalls: [firewall],
+    environmentSecretPlaceholders: firewallSecretPlaceholdersFromFirewalls([
+      firewall,
+    ]),
+    billableFirewalls: [],
     networkPolicies: {
       [firewall.name]: {
         allow: permissionNames.filter((name) => {
@@ -2390,7 +2475,60 @@ function modelProviderPermissionManifest(
   };
 }
 
-function buildPermissionManifest(args: {
+interface BuiltinConnectorManifestSource {
+  readonly metadata: FirewallExecutionMetadataDetail;
+  readonly permissionIndex: FirewallPermissionIndex;
+}
+
+function applyBuiltinConnectorMetadataPolicies(
+  sources: readonly BuiltinConnectorManifestSource[],
+  policies: FirewallPolicies | undefined,
+  vars: Record<string, string> | undefined,
+): PermissionManifest {
+  const firewalls: ExecutionFirewalls = [];
+  const networkPolicies: NetworkPolicies = {};
+  const environmentSecretPlaceholders: Record<string, string> = {};
+  const billableFirewalls: string[] = [];
+
+  for (const source of sources) {
+    const name = source.metadata.type;
+    const permissionNames = [...source.permissionIndex.permissionNames];
+    const defaultPolicy = defaultPolicyForPermissionIndex(
+      source.permissionIndex,
+    );
+    const policy = policies?.[name];
+    firewalls.push(builtinFirewallEntryForMetadata(source.metadata, vars));
+    Object.assign(
+      environmentSecretPlaceholders,
+      source.metadata.placeholderValues,
+    );
+    if (source.metadata.billable) {
+      billableFirewalls.push(name);
+    }
+
+    if (!policy) {
+      networkPolicies[name] = networkPolicyForFirewallPolicy(
+        permissionNames,
+        defaultPolicy,
+      );
+      continue;
+    }
+
+    networkPolicies[name] = networkPolicyForFirewallPolicy(permissionNames, {
+      ...policy,
+      unknownPolicy: policy.unknownPolicy ?? defaultPolicy.unknownPolicy,
+    });
+  }
+
+  return {
+    firewalls,
+    networkPolicies,
+    environmentSecretPlaceholders: compactRecord(environmentSecretPlaceholders),
+    billableFirewalls,
+  };
+}
+
+async function buildPermissionManifest(args: {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly permissionPolicies: FirewallPolicies | undefined;
   readonly vars: Record<string, string> | undefined;
@@ -2398,38 +2536,75 @@ function buildPermissionManifest(args: {
   readonly connectorTypes?: readonly ConnectorType[];
   readonly connectorAuthMethods?: Partial<Record<ConnectorType, string>>;
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
-}): PermissionManifest | undefined {
+}): Promise<PermissionManifest | undefined> {
   const connectorTypes =
     args.connectorTypes ??
-    Object.keys(args.permissionPolicies ?? {}).filter(isFirewallConnectorType);
+    Object.keys(args.permissionPolicies ?? {}).filter(
+      isFirewallExecutionMetadataConnectorType,
+    );
   const connectorBaseUrlVars = mergeRecords(args.vars, args.connectorVars);
-  const runtimeConnectorFirewalls = connectorTypes
-    .filter(isFirewallConnectorType)
-    .map((type) => {
-      return runtimeConnectorFirewall(type, args.connectorAuthMethods?.[type]);
-    });
-  const connectorFirewalls = runtimeConnectorFirewalls.map(({ firewall }) => {
-    return firewall;
-  });
-  const inlineConnectorFirewallNames = new Set(
-    runtimeConnectorFirewalls
-      .filter(({ inline }) => {
-        return inline;
-      })
-      .map(({ firewall }) => {
-        return firewall.name;
-      }),
+  const builtinConnectorTypes = connectorTypes.filter(
+    isFirewallExecutionMetadataConnectorType,
   );
-  const connectorManifest = applyConnectorPolicies(
-    connectorFirewalls,
-    args.permissionPolicies,
-    (firewall) => {
-      if (inlineConnectorFirewallNames.has(firewall.name)) {
-        return inlineFirewallEntry(firewall);
+
+  const builtinSources: BuiltinConnectorManifestSource[] = [];
+  const inlineConnectorFirewalls: ExpandedFirewallConfig[] = [];
+  const inlineConnectorDefaultPolicies = new Map<string, FirewallPolicy>();
+  const inlineConnectorBillableFirewalls: string[] = [];
+
+  const loadedConnectorSources = await Promise.all(
+    builtinConnectorTypes.map(async (type) => {
+      const [metadata, permissionIndex] = await Promise.all([
+        loadRequiredFirewallExecutionMetadata(type),
+        loadRequiredFirewallPermissionIndex(type),
+      ]);
+      if (
+        type === "figma" &&
+        args.connectorAuthMethods?.[type] === "api-token"
+      ) {
+        return {
+          type,
+          metadata,
+          permissionIndex,
+          inlineFirewall: await loadFigmaApiTokenFirewall(),
+        };
       }
-      return builtinFirewallEntry(firewall, connectorBaseUrlVars);
+      return { type, metadata, permissionIndex, inlineFirewall: null };
+    }),
+  );
+  for (const source of loadedConnectorSources) {
+    if (source.inlineFirewall) {
+      inlineConnectorFirewalls.push(source.inlineFirewall);
+      inlineConnectorDefaultPolicies.set(
+        source.type,
+        defaultPolicyForPermissionIndex(source.permissionIndex),
+      );
+      if (source.metadata.billable) {
+        inlineConnectorBillableFirewalls.push(source.type);
+      }
+      continue;
+    }
+    builtinSources.push({
+      metadata: source.metadata,
+      permissionIndex: source.permissionIndex,
+    });
+  }
+
+  const connectorManifest = applyBuiltinConnectorMetadataPolicies(
+    builtinSources,
+    args.permissionPolicies,
+    connectorBaseUrlVars,
+  );
+  const inlineConnectorManifest = applyConnectorPolicies(
+    inlineConnectorFirewalls,
+    args.permissionPolicies,
+    inlineFirewallEntry,
+    (firewall, permissionNames) => {
+      return (
+        inlineConnectorDefaultPolicies.get(firewall.name) ??
+        allAllowPolicyForPermissions(permissionNames)
+      );
     },
-    defaultBuiltinConnectorPolicyForFirewall,
   );
   const resolvedCustomConnectorFirewalls = resolveFirewallBaseUrlVars(
     (args.customConnectorFirewalls ?? []).map(runtimeFirewall),
@@ -2450,6 +2625,7 @@ function buildPermissionManifest(args: {
   const firewalls = [
     ...(providerManifest?.firewalls ?? []),
     ...connectorManifest.firewalls,
+    ...inlineConnectorManifest.firewalls,
     ...customConnectorManifest.firewalls,
   ];
 
@@ -2459,14 +2635,21 @@ function buildPermissionManifest(args: {
 
   return {
     firewalls,
-    environmentFirewalls: [
-      ...(providerManifest?.environmentFirewalls ?? []),
-      ...connectorFirewalls,
-      ...(args.customConnectorFirewalls ?? []),
+    environmentSecretPlaceholders: mergeRecords(
+      providerManifest?.environmentSecretPlaceholders,
+      connectorManifest.environmentSecretPlaceholders,
+      firewallSecretPlaceholdersFromFirewalls(inlineConnectorFirewalls),
+      firewallSecretPlaceholdersFromFirewalls(args.customConnectorFirewalls),
+    ),
+    billableFirewalls: [
+      ...(providerManifest?.billableFirewalls ?? []),
+      ...connectorManifest.billableFirewalls,
+      ...inlineConnectorBillableFirewalls,
     ],
     networkPolicies: {
       ...providerManifest?.networkPolicies,
       ...connectorManifest.networkPolicies,
+      ...inlineConnectorManifest.networkPolicies,
       ...customConnectorManifest.networkPolicies,
     },
   };
@@ -2966,7 +3149,7 @@ function validateCompose(
   secrets: Record<string, string> | undefined,
   options?: {
     readonly validateEnvironmentReferences?: boolean;
-    readonly environmentFirewalls?: readonly ExpandedFirewallConfig[];
+    readonly environmentSecretPlaceholders?: Readonly<Record<string, string>>;
     readonly additionalEnvironment?: Record<string, string>;
     readonly storedConnectorEnvironment?: Record<string, string>;
     readonly connectorVars?: Record<string, string>;
@@ -2984,7 +3167,7 @@ function validateCompose(
       content,
       vars,
       secrets,
-      environmentFirewalls: options?.environmentFirewalls,
+      environmentSecretPlaceholders: options?.environmentSecretPlaceholders,
       additionalEnvironment: options?.additionalEnvironment,
       storedConnectorEnvironment: options?.storedConnectorEnvironment,
       connectorVars: options?.connectorVars,
@@ -3222,6 +3405,7 @@ async function buildStoredExecutionContext(args: {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
+  readonly permissionManifest: PermissionManifest | undefined;
   readonly apiStartTime: number;
   readonly storageManifest: StorageManifest;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
@@ -3229,15 +3413,7 @@ async function buildStoredExecutionContext(args: {
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
 }): Promise<BuiltStoredExecutionContext> {
-  const permissions = buildPermissionManifest({
-    modelProvider: args.modelProvider,
-    permissionPolicies: args.body.permissionPolicies,
-    vars: args.body.vars,
-    connectorVars: args.connectorContext.vars,
-    connectorTypes: args.connectorContext.connectorTypes,
-    connectorAuthMethods: args.connectorContext.connectorAuthMethods,
-    customConnectorFirewalls: args.customConnectorContext.firewalls,
-  });
+  const permissions = args.permissionManifest;
   const executionSecrets = buildStoredExecutionSecrets({
     connectorContext: args.connectorContext,
     modelProvider: args.modelProvider,
@@ -3260,7 +3436,8 @@ async function buildStoredExecutionContext(args: {
           vars: args.body.vars,
           secrets: executionSecrets.secrets,
           additionalEnvironment: args.modelProvider?.environment,
-          environmentFirewalls: permissions?.environmentFirewalls,
+          environmentSecretPlaceholders:
+            permissions?.environmentSecretPlaceholders,
           storedConnectorEnvironment: args.connectorContext.storedEnvironment,
           connectorVars: args.connectorContext.vars,
         }),
@@ -3450,7 +3627,6 @@ function billableFirewallsForPermissions(args: {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly permissions: PermissionManifest | undefined;
 }): string[] {
-  const billableConnectorSet = new Set<string>(BILLABLE_CONNECTORS);
   const firewalls = args.permissions?.firewalls ?? [];
   const firewallNames = firewalls.map((firewall) => {
     return firewall.kind === "builtin" ? firewall.name : firewall.firewall.name;
@@ -3461,9 +3637,7 @@ function billableFirewallsForPermissions(args: {
           return name.startsWith("model-provider:");
         })
       : [];
-  const connectorFirewalls = firewallNames.filter((name) => {
-    return billableConnectorSet.has(name);
-  });
+  const connectorFirewalls = args.permissions?.billableFirewalls ?? [];
 
   return [...modelFirewalls, ...connectorFirewalls];
 }
@@ -3534,6 +3708,7 @@ function buildRunnerJobPayload(
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
     readonly customConnectorContext: CustomConnectorRuntimeContext;
+    readonly permissionManifest: PermissionManifest | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly includeZeroTokenSecret: boolean | undefined;
@@ -3653,6 +3828,7 @@ function dispatchRun(
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
     readonly customConnectorContext: CustomConnectorRuntimeContext;
+    readonly permissionManifest: PermissionManifest | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly includeZeroTokenSecret: boolean | undefined;
@@ -3727,6 +3903,7 @@ function enqueueRunForConcurrency(
     readonly modelProvider: ResolvedModelProviderEnvironment | null;
     readonly connectorContext: ConnectorRuntimeContext;
     readonly customConnectorContext: CustomConnectorRuntimeContext;
+    readonly permissionManifest: PermissionManifest | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly includeZeroTokenSecret: boolean | undefined;
@@ -3832,6 +4009,7 @@ interface PreparedRunContext {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
+  readonly permissionManifest: PermissionManifest | undefined;
   readonly artifacts: readonly ContextArtifact[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly userTimezone: string | undefined;
@@ -4000,17 +4178,9 @@ function validateRunEnvironmentReferences(args: {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
+  readonly permissionManifest: PermissionManifest | undefined;
   readonly validateEnvironmentReferences: boolean | undefined;
 }): CreateRunErrorResult | null {
-  const validationPermissions = buildPermissionManifest({
-    modelProvider: args.modelProvider,
-    permissionPolicies: args.body.permissionPolicies,
-    vars: args.body.vars,
-    connectorVars: args.connectorContext.vars,
-    connectorTypes: args.connectorContext.connectorTypes,
-    connectorAuthMethods: args.connectorContext.connectorAuthMethods,
-    customConnectorFirewalls: args.customConnectorContext.firewalls,
-  });
   const validationSecrets = buildStoredExecutionSecrets({
     connectorContext: args.connectorContext,
     modelProvider: args.modelProvider,
@@ -4023,7 +4193,8 @@ function validateRunEnvironmentReferences(args: {
     validationSecrets.secrets,
     {
       validateEnvironmentReferences: args.validateEnvironmentReferences,
-      environmentFirewalls: validationPermissions?.environmentFirewalls,
+      environmentSecretPlaceholders:
+        args.permissionManifest?.environmentSecretPlaceholders,
       additionalEnvironment: args.modelProvider?.environment,
       storedConnectorEnvironment: args.connectorContext.storedEnvironment,
       connectorVars: args.connectorContext.vars,
@@ -4031,6 +4202,43 @@ function validateRunEnvironmentReferences(args: {
   );
 
   return isRouteError(validation) ? validation : null;
+}
+
+async function buildPreparedPermissionManifest(args: {
+  readonly body: CreateRunBody;
+  readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  readonly connectorContext: ConnectorRuntimeContext;
+  readonly customConnectorContext: CustomConnectorRuntimeContext;
+}): Promise<PermissionManifest | undefined> {
+  return await buildPermissionManifest({
+    modelProvider: args.modelProvider,
+    permissionPolicies: args.body.permissionPolicies,
+    vars: args.body.vars,
+    connectorVars: args.connectorContext.vars,
+    connectorTypes: args.connectorContext.connectorTypes,
+    connectorAuthMethods: args.connectorContext.connectorAuthMethods,
+    customConnectorFirewalls: args.customConnectorContext.firewalls,
+  });
+}
+
+function preparedRunAdditionalVolumes(args: {
+  readonly createArgs: CreateAgentRunArgs;
+  readonly framework: SupportedFramework;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly body: CreateRunBody;
+  readonly resolved: ResolvedCompose;
+}): readonly AdditionalVolume[] | undefined {
+  return mergeAdditionalVolumes({
+    prepend: buildInjectedSkillVolumes(
+      args.createArgs,
+      args.framework,
+      isFeatureEnabled(
+        FeatureSwitchKey.GoalWorkflows,
+        args.featureSwitchContext,
+      ),
+    ),
+    base: args.body.additionalVolumes ?? args.resolved.additionalVolumes,
+  });
 }
 
 function prepareRunContext(
@@ -4122,12 +4330,21 @@ function prepareRunContext(
         await loadRunConnectorContexts(db, args, featureSwitchContext);
       signal.throwIfAborted();
 
+      const permissionManifest = await buildPreparedPermissionManifest({
+        body,
+        modelProvider,
+        connectorContext,
+        customConnectorContext,
+      });
+      signal.throwIfAborted();
+
       const validation = validateRunEnvironmentReferences({
         resolved,
         body,
         modelProvider,
         connectorContext,
         customConnectorContext,
+        permissionManifest,
         validateEnvironmentReferences: args.validateEnvironmentReferences,
       });
       if (validation) {
@@ -4142,16 +4359,12 @@ function prepareRunContext(
         framework,
         bodyArtifacts: body.artifacts,
       });
-      const additionalVolumes = mergeAdditionalVolumes({
-        prepend: buildInjectedSkillVolumes(
-          args,
-          framework,
-          isFeatureEnabled(
-            FeatureSwitchKey.GoalWorkflows,
-            featureSwitchContext,
-          ),
-        ),
-        base: body.additionalVolumes ?? resolved.additionalVolumes,
+      const additionalVolumes = preparedRunAdditionalVolumes({
+        createArgs: args,
+        framework,
+        featureSwitchContext,
+        body,
+        resolved,
       });
 
       return {
@@ -4161,6 +4374,7 @@ function prepareRunContext(
         modelProvider,
         connectorContext,
         customConnectorContext,
+        permissionManifest,
         artifacts: runArtifacts.artifacts,
         additionalVolumes,
         userTimezone,
@@ -4238,6 +4452,7 @@ function completeQueuedRun(input: {
             modelProvider: input.context.modelProvider,
             connectorContext: input.context.connectorContext,
             customConnectorContext: input.context.customConnectorContext,
+            permissionManifest: input.context.permissionManifest,
             apiStartTime: input.args.apiStartTime,
             additionalVolumes: input.context.additionalVolumes,
             includeZeroTokenSecret: input.args.includeZeroTokenSecret,
@@ -4290,6 +4505,7 @@ function completePendingRun(input: {
             modelProvider: input.context.modelProvider,
             connectorContext: input.context.connectorContext,
             customConnectorContext: input.context.customConnectorContext,
+            permissionManifest: input.context.permissionManifest,
             apiStartTime: input.args.apiStartTime,
             additionalVolumes: input.context.additionalVolumes,
             includeZeroTokenSecret: input.args.includeZeroTokenSecret,

--- a/turbo/packages/connectors/.gitignore
+++ b/turbo/packages/connectors/.gitignore
@@ -7,3 +7,9 @@ src/firewall-metadata/*.generated.ts
 src/firewall-metadata/.metadata-*
 src/firewall-metadata/.*.previous-*
 src/firewall-metadata/details/*
+
+# Firewall execution metadata produced by @vm0/firewalls-generator at install time.
+src/firewall-execution-metadata/*.generated.ts
+src/firewall-execution-metadata/.metadata-*
+src/firewall-execution-metadata/.*.previous-*
+src/firewall-execution-metadata/details/*

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -48,6 +48,10 @@
       "import": "./src/firewall-metadata/server.ts",
       "types": "./src/firewall-metadata/server.ts"
     },
+    "./firewall-execution-metadata/server": {
+      "import": "./src/firewall-execution-metadata/server.ts",
+      "types": "./src/firewall-execution-metadata/server.ts"
+    },
     "./firewalls": {
       "import": "./src/firewalls/index.ts",
       "types": "./src/firewalls/index.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -20,8 +20,17 @@ import type {
 } from "../firewall-metadata";
 import {
   UNKNOWN_PERMISSION_GRANT,
+  extractBaseUrlVarNames,
+  extractSecretNamesFromApis,
+  firewallAuthInjectsCredentials,
+  hasBaseUrlVars,
   type FirewallConfig,
 } from "../firewall-types";
+import {
+  getFirewallExecutionMetadataSummary,
+  isFirewallExecutionMetadataConnectorType,
+  loadFirewallExecutionMetadata,
+} from "../firewall-execution-metadata/server";
 import {
   getBuiltinConnectorHostOwner,
   getFirewallServerMetadataSummary,
@@ -30,6 +39,7 @@ import {
   resolveFirewallServerMetadataPolicies,
 } from "../firewall-metadata/server";
 import {
+  BILLABLE_CONNECTORS,
   getAllBuiltinConnectorHosts,
   getAllConnectorFirewalls,
   getDefaultFirewallPolicies,
@@ -45,6 +55,14 @@ const FORBIDDEN_METADATA_KEYS = new Set([
   "placeholders",
   "rules",
 ]);
+const FORBIDDEN_EXECUTION_METADATA_KEYS = new Set([
+  "apis",
+  "auth",
+  "permissions",
+  "rules",
+]);
+const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
+  "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
 
 function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
@@ -82,6 +100,47 @@ function collectRuntimePermissions(
   return [...permissions.values()].sort((a, b) => {
     return compareStrings(a.name, b.name);
   });
+}
+
+function collectRuntimeBaseUrlTemplates(
+  firewall: FirewallConfig,
+): readonly { readonly base: string; readonly credentialed: boolean }[] {
+  const templates = new Map<string, boolean>();
+  for (const api of firewall.apis) {
+    if (!hasBaseUrlVars(api.base)) {
+      continue;
+    }
+    templates.set(
+      api.base,
+      (templates.get(api.base) ?? false) ||
+        firewallAuthInjectsCredentials(api.auth),
+    );
+  }
+  return [...templates.entries()]
+    .sort(([a], [b]) => {
+      return compareStrings(a, b);
+    })
+    .map(([base, credentialed]) => {
+      return { base, credentialed };
+    });
+}
+
+function collectRuntimePlaceholderValues(
+  firewall: FirewallConfig,
+): Record<string, string> {
+  const placeholders: Record<string, string> = {};
+  for (const name of extractSecretNamesFromApis(firewall.apis)) {
+    placeholders[name] =
+      firewall.placeholders?.[name] ?? DEFAULT_FIREWALL_SECRET_PLACEHOLDER;
+  }
+  for (const [name, value] of Object.entries(firewall.placeholders ?? {})) {
+    placeholders[name] = value;
+  }
+  return Object.fromEntries(
+    Object.entries(placeholders).sort(([a], [b]) => {
+      return compareStrings(a, b);
+    }),
+  );
 }
 
 function listTsFiles(dir: string): string[] {
@@ -158,6 +217,30 @@ function assertNoForbiddenMetadataKeys(value: unknown, location: string): void {
   }
 }
 
+function assertNoForbiddenExecutionMetadataKeys(
+  value: unknown,
+  location: string,
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      assertNoForbiddenExecutionMetadataKeys(item, `${location}[${index}]`);
+    });
+    return;
+  }
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (FORBIDDEN_EXECUTION_METADATA_KEYS.has(key)) {
+      throw new Error(
+        `execution metadata contains runtime key "${key}" at ${location}`,
+      );
+    }
+    assertNoForbiddenExecutionMetadataKeys(nested, `${location}.${key}`);
+  }
+}
+
 function runtimeEntries(): [FirewallConnectorType, FirewallConfig][] {
   return Object.entries(getAllConnectorFirewalls()).sort(([a], [b]) => {
     return compareStrings(a, b);
@@ -221,6 +304,24 @@ describe("firewall metadata", () => {
 
     expect(rootEntrypoint).not.toContain("firewall-metadata/server");
     expect(packageJson.exports).toHaveProperty("./firewall-metadata/server");
+  });
+
+  it("keeps execution metadata behind an explicit package subpath", () => {
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        "utf-8",
+      ),
+    ) as { exports: Record<string, unknown> };
+
+    expect(rootEntrypoint).not.toContain("firewall-execution-metadata/server");
+    expect(packageJson.exports).toHaveProperty(
+      "./firewall-execution-metadata/server",
+    );
   });
 
   it("resolves metadata permission defaults and overrides", () => {
@@ -315,6 +416,22 @@ describe("firewall metadata", () => {
     const metadataRoot = path.resolve(
       import.meta.dirname,
       "../firewall-metadata",
+    );
+    for (const file of listTsFiles(metadataRoot)) {
+      const source = fs.readFileSync(file, "utf-8");
+      const specs = importSpecifiers(source);
+      for (const spec of specs) {
+        expect(spec).not.toBe("@vm0/connectors/firewalls");
+        expect(spec).not.toMatch(/^(\.\.\/)+firewalls(?:\/|$)/);
+        expect(spec).not.toMatch(/\/firewalls(?:\/|$)/);
+      }
+    }
+  });
+
+  it("keeps execution metadata modules independent from runtime firewall modules", () => {
+    const metadataRoot = path.resolve(
+      import.meta.dirname,
+      "../firewall-execution-metadata",
     );
     for (const file of listTsFiles(metadataRoot)) {
       const source = fs.readFileSync(file, "utf-8");
@@ -493,6 +610,45 @@ describe("firewall metadata", () => {
     expect(isFirewallMetadataConnectorType("cloudinary")).toBe(false);
     await expect(
       loadFirewallPermissionMetadata("cloudinary"),
+    ).resolves.toBeNull();
+  });
+
+  it("keeps execution metadata synchronized with runtime construction data", async () => {
+    const billableConnectors = new Set<string>(BILLABLE_CONNECTORS);
+
+    for (const [type, firewall] of runtimeEntries()) {
+      expect(isFirewallExecutionMetadataConnectorType(type)).toBe(true);
+      const detail = await loadFirewallExecutionMetadata(type);
+      expect(detail).not.toBeNull();
+      const baseUrlTemplates = collectRuntimeBaseUrlTemplates(firewall);
+      const baseUrlVarNames = [
+        ...new Set(
+          baseUrlTemplates.flatMap((template) => {
+            return extractBaseUrlVarNames(template.base);
+          }),
+        ),
+      ].sort(compareStrings);
+      const placeholderValues = collectRuntimePlaceholderValues(firewall);
+
+      expect(getFirewallExecutionMetadataSummary(type)).toStrictEqual({
+        type,
+        billable: billableConnectors.has(type),
+      });
+      expect(detail!.type).toBe(type);
+      expect(detail!.billable).toBe(billableConnectors.has(type));
+      expect(detail!.baseUrlVarNames).toStrictEqual(baseUrlVarNames);
+      expect(detail!.baseUrlTemplates).toStrictEqual(baseUrlTemplates);
+      expect(detail!.placeholderValues).toStrictEqual(placeholderValues);
+      expect(detail!.secretPlaceholderNames).toStrictEqual(
+        Object.keys(placeholderValues),
+      );
+      assertNoForbiddenExecutionMetadataKeys(detail, type);
+    }
+
+    expect(isFirewallExecutionMetadataConnectorType("cloudinary")).toBe(false);
+    expect(getFirewallExecutionMetadataSummary("cloudinary")).toBeNull();
+    await expect(
+      loadFirewallExecutionMetadata("cloudinary"),
     ).resolves.toBeNull();
   });
 

--- a/turbo/packages/connectors/src/firewall-execution-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-execution-metadata/server.ts
@@ -1,0 +1,75 @@
+import { FIREWALL_EXECUTION_METADATA_SUMMARIES } from "./summary.generated";
+import type {
+  FirewallExecutionMetadataDetail,
+  FirewallExecutionMetadataSummary,
+} from "./types";
+
+export type {
+  FirewallExecutionMetadataDetail,
+  FirewallExecutionMetadataSummary,
+} from "./types";
+
+export type FirewallExecutionMetadataConnectorType =
+  keyof typeof FIREWALL_EXECUTION_METADATA_SUMMARIES;
+
+const executionMetadataCache = new Map<
+  FirewallExecutionMetadataConnectorType,
+  Promise<FirewallExecutionMetadataDetail>
+>();
+
+export function isFirewallExecutionMetadataConnectorType(
+  type: string,
+): type is FirewallExecutionMetadataConnectorType {
+  return Object.prototype.hasOwnProperty.call(
+    FIREWALL_EXECUTION_METADATA_SUMMARIES,
+    type,
+  );
+}
+
+export function getFirewallExecutionMetadataSummary(
+  type: string,
+): FirewallExecutionMetadataSummary | null {
+  if (!isFirewallExecutionMetadataConnectorType(type)) {
+    return null;
+  }
+  return FIREWALL_EXECUTION_METADATA_SUMMARIES[type];
+}
+
+async function loadFirewallExecutionMetadataDetail(
+  type: FirewallExecutionMetadataConnectorType,
+): Promise<FirewallExecutionMetadataDetail> {
+  const { loadGeneratedFirewallExecutionMetadata } =
+    await import("./loader.generated");
+  const detail = await loadGeneratedFirewallExecutionMetadata(type);
+  if (!detail) {
+    throw new Error(`Missing firewall execution metadata: ${type}`);
+  }
+  if (detail.type !== type) {
+    throw new Error(
+      `Mismatched firewall execution metadata: requested ${type}, got ${detail.type}`,
+    );
+  }
+  return detail;
+}
+
+export async function loadFirewallExecutionMetadata(
+  type: string,
+): Promise<FirewallExecutionMetadataDetail | null> {
+  if (!isFirewallExecutionMetadataConnectorType(type)) {
+    return null;
+  }
+
+  const cached = executionMetadataCache.get(type);
+  if (cached) {
+    return await cached;
+  }
+
+  const load = loadFirewallExecutionMetadataDetail(type).catch(
+    (error: unknown) => {
+      executionMetadataCache.delete(type);
+      throw error;
+    },
+  );
+  executionMetadataCache.set(type, load);
+  return await load;
+}

--- a/turbo/packages/connectors/src/firewall-execution-metadata/types.ts
+++ b/turbo/packages/connectors/src/firewall-execution-metadata/types.ts
@@ -1,0 +1,16 @@
+export interface FirewallExecutionBaseUrlTemplateMetadata {
+  readonly base: string;
+  readonly credentialed: boolean;
+}
+
+export interface FirewallExecutionMetadataSummary {
+  readonly type: string;
+  readonly billable: boolean;
+}
+
+export interface FirewallExecutionMetadataDetail extends FirewallExecutionMetadataSummary {
+  readonly baseUrlVarNames: readonly string[];
+  readonly baseUrlTemplates: readonly FirewallExecutionBaseUrlTemplateMetadata[];
+  readonly secretPlaceholderNames: readonly string[];
+  readonly placeholderValues: Readonly<Record<string, string>>;
+}

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -672,6 +672,14 @@ export function hasBaseUrlVars(base: string): boolean {
   return BASE_URL_VARS_PATTERN.test(base);
 }
 
+export function extractBaseUrlVarNames(base: string): string[] {
+  const names = new Set<string>();
+  for (const match of base.matchAll(BASE_URL_VARS_PATTERN_G)) {
+    names.add(match[1]!);
+  }
+  return [...names];
+}
+
 function baseUrlVariableError(
   base: string,
   serviceName: string,
@@ -1202,7 +1210,9 @@ function validateBaseUrlTemplateVariable({
   );
 }
 
-function firewallAuthInjectsCredentials(auth: FirewallApi["auth"]): boolean {
+export function firewallAuthInjectsCredentials(
+  auth: FirewallApi["auth"],
+): boolean {
   return (
     Object.keys(auth.headers ?? {}).length > 0 ||
     Object.keys(auth.query ?? {}).length > 0 ||

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -107,6 +107,9 @@ describe("firewall metadata generator", () => {
     expect(staticValueModuleSpecifiers(source)).not.toContain(
       "../../connectors/src/firewalls",
     );
+    for (const specifier of staticValueModuleSpecifiers(source)) {
+      expect(specifier).not.toMatch(/^\.\.\/\.\.\/connectors\/src\//);
+    }
     expect(dynamicImportSpecifiers(source)).not.toContain(
       "../../connectors/src/firewalls",
     );

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -4,15 +4,10 @@ import { pathToFileURL } from "node:url";
 import ts from "typescript";
 
 import type { ConnectorType } from "../../connectors/src/connectors";
-import { expandFirewallPlaceholders } from "../../connectors/src/firewall-placeholder-expansion";
-import {
-  extractBaseUrlVarNames,
-  extractSecretNamesFromApis,
-  firewallAuthInjectsCredentials,
-  hasBaseUrlVars,
-  type FirewallConfig,
-  type FirewallPolicy,
-  type FirewallPolicyValue,
+import type {
+  FirewallConfig,
+  FirewallPolicy,
+  FirewallPolicyValue,
 } from "../../connectors/src/firewall-types";
 import type {
   FirewallExecutionMetadataDetail,
@@ -30,10 +25,23 @@ const POLICY_VALUES = ["allow", "deny", "ask"] as const;
 const GENERATED_FILE_STEM_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
   "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
+const BASE_URL_VARS_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/;
+const BASE_URL_VARS_PATTERN_G = new RegExp(BASE_URL_VARS_PATTERN.source, "g");
+const AUTH_SECRET_REFERENCE_PATTERN = /\bsecrets\.([a-zA-Z_][a-zA-Z0-9_]*)\b/g;
 
 interface ConnectorCategories {
   readonly categories: Record<string, string>;
   readonly displayOrder: readonly string[];
+}
+
+interface ConnectorEnvBindingEntry {
+  readonly envName: string;
+  readonly valueRef: string;
+}
+
+interface ConnectorMetadata {
+  readonly label: string;
+  readonly envBindingEntries: readonly ConnectorEnvBindingEntry[];
 }
 
 interface GeneratedFirewallSource {
@@ -41,6 +49,7 @@ interface GeneratedFirewallSource {
   readonly firewallExportName: string;
   readonly firewall: FirewallConfig;
   readonly label: string;
+  readonly envBindingEntries: readonly ConnectorEnvBindingEntry[];
   readonly categories: ConnectorCategories | null;
   readonly defaultAllowed: readonly string[] | null;
   readonly defaultUnknownPolicy: FirewallPolicyValue;
@@ -241,10 +250,78 @@ function stringLiteralText(expression: ts.Expression): string | null {
   return null;
 }
 
-function loadConnectorLabel(
+function connectorEnvBindingValueRef(expression: ts.Expression): string | null {
+  const direct = stringLiteralText(expression);
+  if (direct !== null) {
+    return direct;
+  }
+  const object = unwrapObjectLiteral(expression);
+  if (!object) {
+    return null;
+  }
+  const valueRef = findObjectProperty(object, "valueRef");
+  return valueRef ? stringLiteralText(valueRef) : null;
+}
+
+function connectorEnvBindingEntries(
+  expression: ts.Expression,
+): ConnectorEnvBindingEntry[] {
+  const envBindings = unwrapObjectLiteral(expression);
+  if (!envBindings) {
+    return [];
+  }
+
+  const entries: ConnectorEnvBindingEntry[] = [];
+  for (const property of envBindings.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+    const envName = propertyNameText(property.name);
+    const valueRef = connectorEnvBindingValueRef(property.initializer);
+    if (envName && valueRef) {
+      entries.push({ envName, valueRef });
+    }
+  }
+  return entries;
+}
+
+function connectorAuthMethodEnvBindingEntries(
+  connectorObject: ts.ObjectLiteralExpression,
+): ConnectorEnvBindingEntry[] {
+  const authMethods = findObjectProperty(connectorObject, "authMethods");
+  const authMethodsObject = authMethods
+    ? unwrapObjectLiteral(authMethods)
+    : null;
+  if (!authMethodsObject) {
+    return [];
+  }
+
+  const entries: ConnectorEnvBindingEntry[] = [];
+  for (const property of authMethodsObject.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+    const authMethod = unwrapObjectLiteral(property.initializer);
+    if (!authMethod) {
+      continue;
+    }
+    const access = findObjectProperty(authMethod, "access");
+    const accessObject = access ? unwrapObjectLiteral(access) : null;
+    if (!accessObject) {
+      continue;
+    }
+    const envBindings = findObjectProperty(accessObject, "envBindings");
+    if (envBindings) {
+      entries.push(...connectorEnvBindingEntries(envBindings));
+    }
+  }
+  return entries;
+}
+
+function loadConnectorMetadata(
   connectorsDir: string,
   type: FirewallConnectorType,
-): string {
+): ConnectorMetadata {
   const connectorFile = path.join(connectorsDir, `${type}.ts`);
   if (!fs.existsSync(connectorFile)) {
     throw new Error(
@@ -279,13 +356,15 @@ function loadConnectorLabel(
         continue;
       }
       const label = findObjectProperty(connectorObject, "label");
-      if (!label) {
+      const labelText = label ? stringLiteralText(label) : null;
+      if (labelText === null) {
         continue;
       }
-      const labelText = stringLiteralText(label);
-      if (labelText !== null) {
-        return labelText;
-      }
+      return {
+        label: labelText,
+        envBindingEntries:
+          connectorAuthMethodEnvBindingEntries(connectorObject),
+      };
     }
   }
 
@@ -314,6 +393,7 @@ async function loadGeneratedFirewallSource(
   registration: RegisteredFirewallSource,
 ): Promise<GeneratedFirewallSource> {
   const { type, firewallExportName } = registration;
+  const connectorMetadata = loadConnectorMetadata(connectorsDir, type);
   const moduleExports = await importModule(
     path.join(firewallsDir, generatedDetailFileName(type)),
   );
@@ -345,7 +425,8 @@ async function loadGeneratedFirewallSource(
     type,
     firewallExportName,
     firewall,
-    label: loadConnectorLabel(connectorsDir, type),
+    label: connectorMetadata.label,
+    envBindingEntries: connectorMetadata.envBindingEntries,
     categories:
       categories && displayOrder ? { categories, displayOrder } : null,
     defaultAllowed: getOptionalGeneratedExport(
@@ -745,6 +826,111 @@ function buildSummaryMetadata(
   };
 }
 
+function hasBaseUrlVars(base: string): boolean {
+  return BASE_URL_VARS_PATTERN.test(base);
+}
+
+function extractBaseUrlVarNames(base: string): string[] {
+  const names = new Set<string>();
+  for (const match of base.matchAll(BASE_URL_VARS_PATTERN_G)) {
+    names.add(match[1]!);
+  }
+  return [...names];
+}
+
+function firewallAuthInjectsCredentials(
+  auth: FirewallConfig["apis"][number]["auth"],
+): boolean {
+  return (
+    Object.keys(auth.headers ?? {}).length > 0 ||
+    Object.keys(auth.query ?? {}).length > 0 ||
+    Object.keys(auth.awsSigv4 ?? {}).length > 0 ||
+    (typeof auth.base === "string" && auth.base.length > 0)
+  );
+}
+
+function extractSecretNamesFromTemplate(template: string): string[] {
+  const names = new Set<string>();
+  for (const match of template.matchAll(AUTH_SECRET_REFERENCE_PATTERN)) {
+    names.add(match[1]!);
+  }
+  return [...names];
+}
+
+function extractSecretNamesFromApis(apis: FirewallConfig["apis"]): string[] {
+  const names = new Set<string>();
+  for (const entry of apis) {
+    for (const value of Object.values(entry.auth.headers ?? {})) {
+      for (const name of extractSecretNamesFromTemplate(value)) {
+        names.add(name);
+      }
+    }
+    if (entry.auth.base) {
+      for (const name of extractSecretNamesFromTemplate(entry.auth.base)) {
+        names.add(name);
+      }
+    }
+    for (const value of Object.values(entry.auth.query ?? {})) {
+      for (const name of extractSecretNamesFromTemplate(value)) {
+        names.add(name);
+      }
+    }
+    for (const value of Object.values(entry.auth.awsSigv4 ?? {})) {
+      if (!value) {
+        continue;
+      }
+      for (const name of extractSecretNamesFromTemplate(value)) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names];
+}
+
+function expandFirewallPlaceholders(
+  firewall: FirewallConfig,
+  envBindingEntries: readonly ConnectorEnvBindingEntry[],
+): FirewallConfig {
+  if (!firewall.placeholders || envBindingEntries.length === 0) {
+    return firewall;
+  }
+
+  const expanded: Record<string, string> = { ...firewall.placeholders };
+
+  for (const [key, placeholderValue] of Object.entries(firewall.placeholders)) {
+    const valueRefs = envBindingEntries
+      .filter(({ envName }) => {
+        return envName === key;
+      })
+      .map(({ valueRef }) => {
+        return valueRef;
+      });
+    for (const valueRef of valueRefs) {
+      if (!valueRef.startsWith("$secrets.")) {
+        continue;
+      }
+      const rawName = valueRef.slice("$secrets.".length);
+      if (!expanded[rawName]) {
+        expanded[rawName] = placeholderValue;
+      }
+      for (const entry of envBindingEntries) {
+        if (entry.valueRef === valueRef && !expanded[entry.envName]) {
+          expanded[entry.envName] = placeholderValue;
+        }
+      }
+    }
+
+    const rawRef = `$secrets.${key}`;
+    for (const entry of envBindingEntries) {
+      if (entry.valueRef === rawRef && !expanded[entry.envName]) {
+        expanded[entry.envName] = placeholderValue;
+      }
+    }
+  }
+
+  return { ...firewall, placeholders: expanded };
+}
+
 function buildExecutionBaseUrlTemplates(
   firewall: FirewallConfig,
 ): FirewallExecutionMetadataDetail["baseUrlTemplates"] {
@@ -789,7 +975,7 @@ function buildExecutionMetadata(
 ): FirewallExecutionMetadataDetail {
   const firewall = expandFirewallPlaceholders(
     source.firewall,
-    source.type as ConnectorType,
+    source.envBindingEntries,
   );
   const baseUrlTemplates = buildExecutionBaseUrlTemplates(firewall);
   const baseUrlVarNames = sortedStrings(

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -4,11 +4,20 @@ import { pathToFileURL } from "node:url";
 import ts from "typescript";
 
 import type { ConnectorType } from "../../connectors/src/connectors";
-import type {
-  FirewallConfig,
-  FirewallPolicy,
-  FirewallPolicyValue,
+import { expandFirewallPlaceholders } from "../../connectors/src/firewall-placeholder-expansion";
+import {
+  extractBaseUrlVarNames,
+  extractSecretNamesFromApis,
+  firewallAuthInjectsCredentials,
+  hasBaseUrlVars,
+  type FirewallConfig,
+  type FirewallPolicy,
+  type FirewallPolicyValue,
 } from "../../connectors/src/firewall-types";
+import type {
+  FirewallExecutionMetadataDetail,
+  FirewallExecutionMetadataSummary,
+} from "../../connectors/src/firewall-execution-metadata/types";
 import type {
   FirewallPermissionDefaultPolicyMetadata,
   FirewallPermissionDetailMetadata,
@@ -19,6 +28,8 @@ import type { FirewallConnectorType } from "../../connectors/src/firewalls";
 
 const POLICY_VALUES = ["allow", "deny", "ask"] as const;
 const GENERATED_FILE_STEM_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
+  "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
 
 interface ConnectorCategories {
   readonly categories: Record<string, string>;
@@ -180,6 +191,22 @@ function unwrapObjectLiteral(
     ts.isParenthesizedExpression(expression)
   ) {
     return unwrapObjectLiteral(expression.expression);
+  }
+  return null;
+}
+
+function unwrapArrayLiteral(
+  expression: ts.Expression,
+): ts.ArrayLiteralExpression | null {
+  if (ts.isArrayLiteralExpression(expression)) {
+    return expression;
+  }
+  if (
+    ts.isAsExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isParenthesizedExpression(expression)
+  ) {
+    return unwrapArrayLiteral(expression.expression);
   }
   return null;
 }
@@ -362,6 +389,32 @@ function findConnectorFirewallsRegistry(
   return registry;
 }
 
+function findVariableInitializer(
+  sourceFile: ts.SourceFile,
+  variableName: string,
+): ts.Expression | null {
+  let initializer: ts.Expression | null = null;
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === variableName &&
+      node.initializer
+    ) {
+      if (initializer) {
+        throw new Error(`Duplicate variable declaration: ${variableName}`);
+      }
+      initializer = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return initializer;
+}
+
 function extractRegisteredFirewallSources(
   firewallsIndexFile: string,
 ): RegisteredFirewallSource[] {
@@ -397,6 +450,37 @@ function extractRegisteredFirewallSources(
       firewallExportName: property.initializer.text,
     };
   });
+}
+
+function extractBillableConnectorTypes(
+  firewallsIndexFile: string,
+): ReadonlySet<FirewallConnectorType> {
+  const source = fs.readFileSync(firewallsIndexFile, "utf-8");
+  const sourceFile = ts.createSourceFile(
+    firewallsIndexFile,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const initializer = findVariableInitializer(
+    sourceFile,
+    "BILLABLE_CONNECTORS",
+  );
+  const entries = initializer ? unwrapArrayLiteral(initializer) : null;
+  if (!entries) {
+    throw new Error("Unable to find BILLABLE_CONNECTORS registry");
+  }
+
+  const billable = new Set<FirewallConnectorType>();
+  for (const element of entries.elements) {
+    const type = stringLiteralText(element);
+    if (type === null) {
+      throw new Error("BILLABLE_CONNECTORS must only contain string entries");
+    }
+    billable.add(type as FirewallConnectorType);
+  }
+  return billable;
 }
 
 function compareStrings(a: string, b: string): number {
@@ -524,6 +608,10 @@ function sortedRecord(
   return Object.fromEntries(
     [...entries].sort(([a], [b]) => compareStrings(a, b)),
   );
+}
+
+function sortedStrings(values: Iterable<string>): string[] {
+  return [...values].sort(compareStrings);
 }
 
 function fixedFirewallApiBaseHost(base: string): string | null {
@@ -657,10 +745,94 @@ function buildSummaryMetadata(
   };
 }
 
+function buildExecutionBaseUrlTemplates(
+  firewall: FirewallConfig,
+): FirewallExecutionMetadataDetail["baseUrlTemplates"] {
+  const templates = new Map<string, boolean>();
+  for (const api of firewall.apis) {
+    if (!hasBaseUrlVars(api.base)) {
+      continue;
+    }
+    templates.set(
+      api.base,
+      (templates.get(api.base) ?? false) ||
+        firewallAuthInjectsCredentials(api.auth),
+    );
+  }
+  return [...templates.entries()]
+    .sort(([a], [b]) => {
+      return compareStrings(a, b);
+    })
+    .map(([base, credentialed]) => {
+      return { base, credentialed };
+    });
+}
+
+function buildExecutionPlaceholderValues(
+  firewall: FirewallConfig,
+): Record<string, string> {
+  const placeholders: Record<string, string> = {};
+  const secretNames = extractSecretNamesFromApis(firewall.apis);
+  for (const name of secretNames) {
+    placeholders[name] =
+      firewall.placeholders?.[name] ?? DEFAULT_FIREWALL_SECRET_PLACEHOLDER;
+  }
+  for (const [name, value] of Object.entries(firewall.placeholders ?? {})) {
+    placeholders[name] = value;
+  }
+  return sortedRecord(Object.entries(placeholders));
+}
+
+function buildExecutionMetadata(
+  source: GeneratedFirewallSource,
+  billableTypes: ReadonlySet<FirewallConnectorType>,
+): FirewallExecutionMetadataDetail {
+  const firewall = expandFirewallPlaceholders(
+    source.firewall,
+    source.type as ConnectorType,
+  );
+  const baseUrlTemplates = buildExecutionBaseUrlTemplates(firewall);
+  const baseUrlVarNames = sortedStrings(
+    new Set(
+      baseUrlTemplates.flatMap((template) => {
+        return extractBaseUrlVarNames(template.base);
+      }),
+    ),
+  );
+  const placeholderValues = buildExecutionPlaceholderValues(firewall);
+
+  return {
+    type: source.type as FirewallConnectorType & ConnectorType,
+    billable: billableTypes.has(source.type),
+    baseUrlVarNames,
+    baseUrlTemplates,
+    secretPlaceholderNames: Object.keys(placeholderValues),
+    placeholderValues,
+  };
+}
+
+function buildExecutionSummaryMetadata(
+  detail: FirewallExecutionMetadataDetail,
+): FirewallExecutionMetadataSummary {
+  return {
+    type: detail.type,
+    billable: detail.billable,
+  };
+}
+
 function renderDetailFile(metadata: FirewallPermissionDetailMetadata): string {
   return `${generatedHeader()}import type { FirewallPermissionDetailMetadata } from "../types";
 
 export const firewallPermissionMetadata = ${stableJson(metadata)} as const satisfies FirewallPermissionDetailMetadata;
+`;
+}
+
+function renderExecutionDetailFile(
+  metadata: FirewallExecutionMetadataDetail,
+): string {
+  return `${generatedHeader()}import type { FirewallExecutionMetadataDetail } from "../types";
+
+export const firewallExecutionMetadata = ${stableJson(metadata)} as const satisfies FirewallExecutionMetadataDetail;
 `;
 }
 
@@ -673,10 +845,52 @@ export const FIREWALL_PERMISSION_METADATA_SUMMARIES = ${stableJson(summaries)} a
 `;
 }
 
+function renderExecutionSummaryFile(
+  summaries: Record<string, FirewallExecutionMetadataSummary>,
+): string {
+  return `${generatedHeader()}import type { FirewallExecutionMetadataSummary } from "./types";
+
+export const FIREWALL_EXECUTION_METADATA_SUMMARIES = ${stableJson(summaries)} as const satisfies Readonly<Record<string, FirewallExecutionMetadataSummary>>;
+`;
+}
+
 function renderServerFile(fixedHostOwners: Record<string, string>): string {
   return `${generatedHeader()}import type { FirewallPermissionSummaryMetadata } from "./types";
 
 export const BUILTIN_FIREWALL_FIXED_HOST_OWNERS = ${stableJson(fixedHostOwners)} as const satisfies Readonly<Record<string, FirewallPermissionSummaryMetadata["type"]>>;
+`;
+}
+
+function renderExecutionLoaderFile(
+  types: readonly FirewallConnectorType[],
+): string {
+  const loaders = types
+    .map((type) => {
+      const key = JSON.stringify(type);
+      const specifier = JSON.stringify(generatedDetailModuleSpecifier(type));
+      return `  ${key}: async () => {
+    return (await import(${specifier})).firewallExecutionMetadata;
+  },`;
+    })
+    .join("\n");
+
+  return `${generatedHeader()}import type { FirewallExecutionMetadataDetail } from "./types";
+
+const FIREWALL_EXECUTION_METADATA_LOADERS: Readonly<
+  Record<string, () => Promise<FirewallExecutionMetadataDetail>>
+> = {
+${loaders}
+};
+
+export async function loadGeneratedFirewallExecutionMetadata(
+  type: string,
+): Promise<FirewallExecutionMetadataDetail | null> {
+  const load = FIREWALL_EXECUTION_METADATA_LOADERS[type];
+  if (!load) {
+    return null;
+  }
+  return await load();
+}
 `;
 }
 
@@ -779,10 +993,23 @@ export async function generateFirewallMetadata(): Promise<void> {
     import.meta.dirname,
     "../../connectors/src/firewall-metadata",
   );
+  const executionOutputDir = path.resolve(
+    import.meta.dirname,
+    "../../connectors/src/firewall-execution-metadata",
+  );
   const summaryFile = path.join(outputDir, "summary.generated.ts");
   const loaderFile = path.join(outputDir, "loader.generated.ts");
   const serverFile = path.join(outputDir, "server.generated.ts");
   const detailsDir = path.join(outputDir, "details");
+  const executionSummaryFile = path.join(
+    executionOutputDir,
+    "summary.generated.ts",
+  );
+  const executionLoaderFile = path.join(
+    executionOutputDir,
+    "loader.generated.ts",
+  );
+  const executionDetailsDir = path.join(executionOutputDir, "details");
   const runtimeLoaderFile = path.join(
     firewallsDir,
     "runtime-loader.generated.ts",
@@ -790,6 +1017,7 @@ export async function generateFirewallMetadata(): Promise<void> {
 
   const registeredSources =
     extractRegisteredFirewallSources(firewallsIndexFile);
+  const billableTypes = extractBillableConnectorTypes(firewallsIndexFile);
   const sources = await Promise.all(
     [...registeredSources]
       .sort((a, b) => {
@@ -816,26 +1044,50 @@ export async function generateFirewallMetadata(): Promise<void> {
     return source;
   });
   const summaries: Record<string, FirewallPermissionSummaryMetadata> = {};
-  const details: {
+  const executionSummaries: Record<string, FirewallExecutionMetadataSummary> =
+    {};
+  const permissionDetails: {
+    readonly type: FirewallConnectorType;
+    readonly content: string;
+  }[] = [];
+  const executionDetails: {
     readonly type: FirewallConnectorType;
     readonly content: string;
   }[] = [];
 
   for (const source of sources) {
     const detail = buildDetailMetadata(source);
+    const executionDetail = buildExecutionMetadata(source, billableTypes);
     summaries[source.type] = buildSummaryMetadata(detail);
-    details.push({
+    executionSummaries[source.type] =
+      buildExecutionSummaryMetadata(executionDetail);
+    permissionDetails.push({
       type: source.type,
       content: renderDetailFile(detail),
     });
+    executionDetails.push({
+      type: source.type,
+      content: renderExecutionDetailFile(executionDetail),
+    });
   }
 
+  fs.mkdirSync(executionOutputDir, { recursive: true });
   const nextOutputDir = fs.mkdtempSync(path.join(outputDir, ".metadata-"));
   const nextDetailsDir = path.join(nextOutputDir, "details");
+  const nextExecutionOutputDir = fs.mkdtempSync(
+    path.join(executionOutputDir, ".metadata-"),
+  );
+  const nextExecutionDetailsDir = path.join(nextExecutionOutputDir, "details");
 
-  for (const detail of details) {
+  for (const detail of permissionDetails) {
     writeGeneratedFile(
       path.join(nextDetailsDir, generatedDetailFileName(detail.type)),
+      detail.content,
+    );
+  }
+  for (const detail of executionDetails) {
+    writeGeneratedFile(
+      path.join(nextExecutionDetailsDir, generatedDetailFileName(detail.type)),
       detail.content,
     );
   }
@@ -844,12 +1096,24 @@ export async function generateFirewallMetadata(): Promise<void> {
     renderSummaryFile(summaries),
   );
   writeGeneratedFile(
+    path.join(nextExecutionOutputDir, "summary.generated.ts"),
+    renderExecutionSummaryFile(executionSummaries),
+  );
+  writeGeneratedFile(
     path.join(nextOutputDir, "server.generated.ts"),
     renderServerFile(buildFixedHostOwners(registryOrderedSources)),
   );
   writeGeneratedFile(
     path.join(nextOutputDir, "loader.generated.ts"),
     renderLoaderFile(
+      sources.map((source) => {
+        return source.type;
+      }),
+    ),
+  );
+  writeGeneratedFile(
+    path.join(nextExecutionOutputDir, "loader.generated.ts"),
+    renderExecutionLoaderFile(
       sources.map((source) => {
         return source.type;
       }),
@@ -882,6 +1146,21 @@ export async function generateFirewallMetadata(): Promise<void> {
       ),
     );
     replacements.push(
+      replaceGeneratedPath(executionDetailsDir, nextExecutionDetailsDir),
+    );
+    replacements.push(
+      replaceGeneratedPath(
+        executionSummaryFile,
+        path.join(nextExecutionOutputDir, "summary.generated.ts"),
+      ),
+    );
+    replacements.push(
+      replaceGeneratedPath(
+        executionLoaderFile,
+        path.join(nextExecutionOutputDir, "loader.generated.ts"),
+      ),
+    );
+    replacements.push(
       replaceGeneratedPath(
         runtimeLoaderFile,
         path.join(nextOutputDir, "runtime-loader.generated.ts"),
@@ -892,6 +1171,7 @@ export async function generateFirewallMetadata(): Promise<void> {
     throw error;
   } finally {
     fs.rmSync(nextOutputDir, { recursive: true, force: true });
+    fs.rmSync(nextExecutionOutputDir, { recursive: true, force: true });
   }
 
   for (const replacement of replacements) {

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -988,7 +988,7 @@ function buildExecutionMetadata(
   const placeholderValues = buildExecutionPlaceholderValues(firewall);
 
   return {
-    type: source.type as FirewallConnectorType & ConnectorType,
+    type: source.type,
     billable: billableTypes.has(source.type),
     baseUrlVarNames,
     baseUrlTemplates,


### PR DESCRIPTION
Closes #18116.

## Summary
- Add server-only firewall execution metadata generated from the firewall catalog without runtime API rules or permissions.
- Refactor run creation to build stored firewall manifests from execution metadata plus permission metadata instead of eagerly importing the full connector firewall registry.
- Keep full runtime firewall loading only for paths that still need it: custom/model-provider firewalls and the Figma api-token override.
- Add tests for execution metadata parity, import boundaries, and claimed run firewall manifest shape.

## Tests
- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-metadata.test.ts
- pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/metadata.test.ts
- pnpm --filter ./apps/api exec vitest run src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/firewalls-generator check-types
- pnpm --filter ./apps/api check-types
- pnpm -F @vm0/connectors lint
- pnpm --filter ./apps/api lint
- pre-commit: pnpm knip --cache; pnpm check-types