### PR TITLE
refactor: remove delivered connector feature switches

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts
@@ -214,13 +214,6 @@ describe("zeroConnectorList", () => {
       type: "meta-ads",
       authMethod: "oauth",
     });
-    await writeDb.insert(userFeatureSwitches).values({
-      orgId,
-      userId,
-      switches: {
-        [FeatureSwitchKey.MetaAdsConnector]: true,
-      },
-    });
     await writeDb.insert(secrets).values([
       {
         orgId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -445,7 +445,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.MetaAdsConnector]: true },
     });
 
     await fill(await screen.findByPlaceholderText("Find connectors"), "meta");

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -2180,15 +2180,10 @@ describe("getAvailableConnectorAuthMethodIds", () => {
     ).toStrictEqual(["oauth"]);
   });
 
-  it("exposes Meta Ads OAuth only when its switch is enabled", () => {
-    expect(getAvailableConnectorAuthMethodIds("meta-ads", {})).toStrictEqual(
-      [],
-    );
-    expect(
-      getAvailableConnectorAuthMethodIds("meta-ads", {
-        [FeatureSwitchKey.MetaAdsConnector]: true,
-      }),
-    ).toStrictEqual(["oauth"]);
+  it("exposes Meta Ads OAuth", () => {
+    expect(getAvailableConnectorAuthMethodIds("meta-ads", {})).toStrictEqual([
+      "oauth",
+    ]);
   });
 
   it("exposes Microsoft 365 OAuth only when its switch is enabled", () => {

--- a/turbo/packages/connectors/src/connectors/meta-ads.ts
+++ b/turbo/packages/connectors/src/connectors/meta-ads.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connectors";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const metaAds = {
   "meta-ads": {
@@ -9,7 +8,6 @@ export const metaAds = {
       "Connect your Meta Ads Manager account to manage ad campaigns, audiences, and insights",
     authMethods: {
       oauth: {
-        featureFlag: FeatureSwitchKey.MetaAdsConnector,
         showExperimentalLabel: false,
         label: "OAuth (Recommended)",
         helpText: "Sign in with Facebook to grant access to Ads Manager.",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -24,7 +24,6 @@ export enum FeatureSwitchKey {
   CloseConnector = "closeConnector",
   OutlookMailConnector = "outlookMailConnector",
   OutlookCalendarConnector = "outlookCalendarConnector",
-  MetaAdsConnector = "metaAdsConnector",
   TikTokAdsConnector = "tiktokAdsConnector",
   AwsConnector = "awsConnector",
   PosthogConnector = "posthogConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -134,11 +134,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Outlook Calendar connector",
     enabled: false,
   },
-  [FeatureSwitchKey.MetaAdsConnector]: {
-    maintainer: "ethan@vm0.ai",
-    description: "Enable the Meta Ads Manager connector",
-    enabled: true,
-  },
   [FeatureSwitchKey.TikTokAdsConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the TikTok Ads Manager connector",


### PR DESCRIPTION
## Summary
- confirmed `MetaAdsConnector` was already globally enabled and removed its remaining feature switch gate
- confirmed `StripeConnector` and `ConnectorReconnectReasons` no longer have source references outside historical changelogs
- updated connector/API/platform tests so Meta Ads behaves as a generally available OAuth connector

## Verification
- `pnpm exec prettier --write --ignore-unknown apps/api/src/signals/services/__tests__/zero-connector-data.service.test.ts apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx packages/connectors/src/__tests__/connectors.test.ts packages/connectors/src/connectors/meta-ads.ts packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts`
- `pnpm turbo run lint --log-order grouped` (initial full run hit `SIGKILL` in app type-aware lint; reran affected lints below)
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/services/__tests__/zero-connector-data.service.test.ts`