### PR TITLE
Forward web marketing pages to so frontend

### DIFF
--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -27,7 +27,19 @@ describe("so frontend rewrites", () => {
 
     expect(rewrites).toContainEqual({
       source: "/",
-      destination: "https://pr-123-so.vm6.ai/",
+      destination: "https://pr-123-so.vm6.ai/en",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/report",
+      destination: "https://pr-123-so.vm6.ai/en/report",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/docs",
+      destination: "https://pr-123-so.vm6.ai/en/docs",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/docs/:path*",
+      destination: "https://pr-123-so.vm6.ai/en/docs/:path*",
     });
     expect(rewrites).toContainEqual({
       source: "/en/models/:path*",

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSoFrontendRewrites,
+  resolveSoFrontendUrl,
+} from "../so-frontend-rewrites";
+
+describe("so frontend rewrites", () => {
+  it("uses PAID_ONBOARDING_URL as the target origin", () => {
+    expect(
+      resolveSoFrontendUrl({
+        PAID_ONBOARDING_URL: "https://staging-so.vm6.ai/",
+      }),
+    ).toBe("https://staging-so.vm6.ai");
+  });
+
+  it("falls back to production so.vm0.ai only for production", () => {
+    expect(resolveSoFrontendUrl({ VERCEL_ENV: "production" })).toBe(
+      "https://so.vm0.ai",
+    );
+    expect(resolveSoFrontendUrl({ VERCEL_ENV: "preview" })).toBeUndefined();
+  });
+
+  it("rewrites marketing content and sign-in/sign-up to so", () => {
+    const rewrites = buildSoFrontendRewrites({
+      PAID_ONBOARDING_URL: "https://pr-123-so.vm6.ai",
+    });
+
+    expect(rewrites).toContainEqual({
+      source: "/",
+      destination: "https://pr-123-so.vm6.ai/",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/en/models/:path*",
+      destination: "https://pr-123-so.vm6.ai/en/models/:path*",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/sign-in/:path*",
+      destination: "https://pr-123-so.vm6.ai/sign-in/:path*",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/sign-up",
+      destination: "https://pr-123-so.vm6.ai/sign-up",
+    });
+  });
+
+  it("does not rewrite app-only functional routes", () => {
+    const rewrites = buildSoFrontendRewrites({
+      PAID_ONBOARDING_URL: "https://so.vm0.ai",
+    });
+    const sources = new Set(
+      rewrites.map((rewrite: { source: string }) => {
+        return rewrite.source;
+      }),
+    );
+
+    expect(sources.has("/api/:path*")).toBe(false);
+    expect(sources.has("/desktop-auth/:path*")).toBe(false);
+    expect(sources.has("/connector/:path*")).toBe(false);
+    expect(sources.has("/export")).toBe(false);
+    expect(sources.has("/sign-in-token")).toBe(false);
+  });
+});

--- a/turbo/apps/web/next.config.js
+++ b/turbo/apps/web/next.config.js
@@ -1,6 +1,7 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import createNextIntlPlugin from "next-intl/plugin";
 import { API_BACKEND_REWRITES } from "./api-backend-rewrites.js";
+import { buildSoFrontendRewrites } from "./so-frontend-rewrites.js";
 
 const withNextIntl = createNextIntlPlugin("./i18n.ts");
 
@@ -74,6 +75,7 @@ const nextConfig = {
   async rewrites() {
     return {
       beforeFiles: [
+        ...buildSoFrontendRewrites(process.env),
         ...API_BACKEND_REWRITES.flatMap(([source, destinationPath]) => {
           const destination = buildApiBackendDestination(destinationPath);
           if (!destination) {

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -1,0 +1,110 @@
+const LOCALES = ["en", "de", "ja", "es"];
+
+const SO_FRONTEND_EXACT_PATHS = [
+  "/",
+  "/pricing",
+  "/security",
+  "/rankings",
+  "/illustration",
+  "/web-design",
+  "/presentation",
+  "/report",
+  "/sprite",
+  "/terms-of-use",
+  "/privacy-policy",
+  "/support",
+  "/use-cases",
+  "/models",
+  "/blog",
+  "/docs",
+];
+
+const SO_FRONTEND_WILDCARD_PATHS = [
+  "/use-cases/:path*",
+  "/models/:path*",
+  "/blog/:path*",
+  "/docs/:path*",
+];
+
+const SO_FRONTEND_AUTH_PATHS = [
+  "/sign-in",
+  "/sign-in/:path*",
+  "/sign-up",
+  "/sign-up/:path*",
+];
+
+const SO_FRONTEND_ASSET_PATHS = [
+  "/assets/:path*",
+  "/images/:path*",
+  "/favicon.ico",
+  "/icon.svg",
+  "/apple-touch-icon.png",
+  "/og-image.png",
+  "/checkmark-primary.svg",
+];
+
+function withoutTrailingSlash(value) {
+  return value.replace(/\/$/u, "");
+}
+
+export function resolveSoFrontendUrl(env) {
+  const explicit =
+    env.PAID_ONBOARDING_URL?.trim() ||
+    env.NEXT_PUBLIC_PAID_ONBOARDING_URL?.trim();
+  if (explicit) {
+    return withoutTrailingSlash(explicit);
+  }
+
+  if (env.VERCEL_ENV === "production") {
+    return "https://so.vm0.ai";
+  }
+
+  return undefined;
+}
+
+function exactRewrite(source, destinationPrefix) {
+  return {
+    source,
+    destination: `${destinationPrefix}${source}`,
+  };
+}
+
+function localizedExactRewrite(locale, source, destinationPrefix) {
+  return {
+    source: `/${locale}${source === "/" ? "" : source}`,
+    destination: `${destinationPrefix}/${locale}${source === "/" ? "" : source}`,
+  };
+}
+
+export function buildSoFrontendRewrites(env) {
+  const soFrontendUrl = resolveSoFrontendUrl(env);
+  if (!soFrontendUrl) {
+    return [];
+  }
+
+  const destinationPrefix = withoutTrailingSlash(soFrontendUrl);
+  const localizedContentPaths = [
+    ...SO_FRONTEND_EXACT_PATHS,
+    ...SO_FRONTEND_WILDCARD_PATHS,
+  ];
+
+  return [
+    ...SO_FRONTEND_EXACT_PATHS.map((source) => {
+      return exactRewrite(source, destinationPrefix);
+    }),
+    ...SO_FRONTEND_WILDCARD_PATHS.map((source) => {
+      return exactRewrite(source, destinationPrefix);
+    }),
+    ...LOCALES.flatMap((locale) => {
+      return localizedContentPaths.map((source) => {
+        return localizedExactRewrite(locale, source, destinationPrefix);
+      });
+    }),
+    ...SO_FRONTEND_AUTH_PATHS.map((source) => {
+      return exactRewrite(source, destinationPrefix);
+    }),
+    ...SO_FRONTEND_ASSET_PATHS.map((source) => {
+      return exactRewrite(source, destinationPrefix);
+    }),
+  ];
+}

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -26,6 +26,13 @@ const SO_FRONTEND_WILDCARD_PATHS = [
   "/docs/:path*",
 ];
 
+const SO_FRONTEND_DESTINATION_OVERRIDES = new Map([
+  ["/", "/en"],
+  ["/report", "/en/report"],
+  ["/docs", "/en/docs"],
+  ["/docs/:path*", "/en/docs/:path*"],
+]);
+
 const SO_FRONTEND_AUTH_PATHS = [
   "/sign-in",
   "/sign-in/:path*",
@@ -63,9 +70,11 @@ export function resolveSoFrontendUrl(env) {
 }
 
 function exactRewrite(source, destinationPrefix) {
+  const destinationPath =
+    SO_FRONTEND_DESTINATION_OVERRIDES.get(source) ?? source;
   return {
     source,
-    destination: `${destinationPrefix}${source}`,
+    destination: `${destinationPrefix}${destinationPath}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add Vercel/Next rewrites from vm0 web marketing content paths to the configured so frontend origin
- Include /sign-in and /sign-up in the forwarded paths
- Keep app-only functional routes local to web: API, desktop auth, connector callbacks, export, sign-in-token
- Forward so public asset paths so proxied pages can load shared public images/icons

## Verification
- pnpm --filter web test -- __tests__/so-frontend-rewrites.test.ts
- pnpm --filter web lint
- node helper smoke check for /sign-in and localized content rewrites

## Notes
- This pairs with vm0-marketing PR #58, which sets the so assetPrefix on Vercel so proxied pages load their own Next build assets from the so service.
- turbo                                    |  WARN  The field "pnpm.peerDependencyRules" was found in /Users/yuma/workspace/vm0/turbo/package.json. This will not take effect. You should configure "pnpm.peerDependencyRules" at the root of the workspace instead.
turbo                                    |  WARN  The field "pnpm.overrides" was found in /Users/yuma/workspace/vm0/turbo/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.

> web@12.435.5 check-types /Users/yuma/workspace/vm0/turbo/apps/web
> next typegen && tsc --noEmit

Generating route types...
✓ Types generated successfully
../../packages/connectors/src/firewalls/index.ts(162,3): error TS2305: Module '"./google-docs.generated"' has no exported member 'googleDocsDefaultAllowed'.
../../packages/connectors/src/firewalls/index.ts(163,3): error TS2305: Module '"./google-docs.generated"' has no exported member 'googleDocsDefaultUnknownPolicy'.
/Users/yuma/workspace/vm0/turbo/apps/web:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  web@12.435.5 check-types: `next typegen && tsc --noEmit`
Exit status 2 currently fails in Next typegen around the existing /monday-app-association.json dotted route.
- turbo                                    |  WARN  The field "pnpm.peerDependencyRules" was found in /Users/yuma/workspace/vm0/turbo/package.json. This will not take effect. You should configure "pnpm.peerDependencyRules" at the root of the workspace instead.
turbo                                    |  WARN  The field "pnpm.overrides" was found in /Users/yuma/workspace/vm0/turbo/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.

> web@12.435.5 build /Users/yuma/workspace/vm0/turbo/apps/web
> next build

▲ Next.js 16.2.6 (Turbopack)
- Environments: .env.local
- Experiments (use with caution):
  · clientTraceMetadata
  · optimizePackageImports

  Creating an optimized production build ...
/Users/yuma/workspace/vm0/turbo/apps/web:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  web@12.435.5 build: `next build`
Exit status 1 currently fails on existing generated Google Docs firewall exports in packages/connectors, before this rewrite code is involved.