### PR TITLE
fix: validate workspace promotion identity on reuse

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -250,6 +250,7 @@ mod tests {
             budget_lease: lease,
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
+            workspace_image_size_bytes: b"workspace image".len() as u64,
             workspace_promotion: Some(fixture.promotion),
         });
         let candidate = match request.park_for_idle().await {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
@@ -57,6 +58,15 @@ struct AdmittedClaim {
     claimed: ClaimedJob,
     budget_lease: BudgetLease,
     cancel: RunCancellationHandle,
+}
+
+struct ReuseAdmissionRequest<'a> {
+    profile_name: &'a str,
+    device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
+    workspace_disk_mb: u32,
+    context: &'a ExecutionContext,
+    resume_session_valid: bool,
+    job_lease: BudgetLease,
 }
 
 impl LocalAdmission {
@@ -124,11 +134,14 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot) = try_reuse_from_pool(
         run_id,
-        &profile_name,
-        &device_rate_limits,
-        claimed.context(),
-        resume_session_valid,
-        job_lease,
+        ReuseAdmissionRequest {
+            profile_name: &profile_name,
+            device_rate_limits: &device_rate_limits,
+            workspace_disk_mb: job_workspace_disk_mb,
+            context: claimed.context(),
+            resume_session_valid,
+            job_lease,
+        },
         &mut ctx,
     )
     .await;
@@ -268,11 +281,7 @@ async fn claim_with_local_admission(
 
 async fn try_reuse_from_pool(
     run_id: RunId,
-    profile_name: &str,
-    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
-    context: &ExecutionContext,
-    resume_session_valid: bool,
-    job_lease: BudgetLease,
+    request: ReuseAdmissionRequest<'_>,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> (
     Option<ReusableIdleSandbox>,
@@ -280,6 +289,15 @@ async fn try_reuse_from_pool(
     SandboxReuseResult,
     Option<IdlePoolSnapshot>,
 ) {
+    let ReuseAdmissionRequest {
+        profile_name,
+        device_rate_limits,
+        workspace_disk_mb,
+        context,
+        resume_session_valid,
+        job_lease,
+    } = request;
+
     if !resume_session_valid {
         return (None, job_lease, SandboxReuseResult::NoSessionId, None);
     }
@@ -313,6 +331,27 @@ async fn try_reuse_from_pool(
             if entry.profile_name() == profile_name
                 && entry.device_rate_limits() == device_rate_limits =>
         {
+            if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref()
+                && let Err(mismatch) = entry.validate_workspace_promotion_identity(
+                    cache,
+                    CANONICAL_WORKING_DIR,
+                    u64::from(workspace_disk_mb) * 1024 * 1024,
+                )
+            {
+                warn!(
+                    run_id = %run_id,
+                    session_fingerprint = %session_fingerprint,
+                    profile = %profile_name,
+                    mismatch = mismatch.as_str(),
+                    "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
+                );
+                spawn_idle_destroy_job(
+                    ctx.destroy_tasks,
+                    entry.into_destroy_job_without_workspace_promotion_for_mismatch(),
+                    "reuse_workspace_promotion_mismatch",
+                );
+                return (None, job_lease, SandboxReuseResult::PoolMiss, snapshot);
+            }
             match entry.try_unpark().await {
                 IdleUnparkResult::Reused {
                     sandbox,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -211,6 +211,7 @@ struct FinalizationPhase {
     completion_auth: CompletionAuth,
     active_lease: BudgetLease,
     reuse_result: SandboxReuseResult,
+    workspace_disk_mb: u32,
     profile_name: String,
     cli_agent_session_id: Option<String>,
     storage_fingerprints: StorageFingerprints,
@@ -242,6 +243,7 @@ impl FinalizationPhase {
             completion_auth,
             active_lease,
             reuse_result,
+            workspace_disk_mb,
             profile_name,
             cli_agent_session_id,
             storage_fingerprints,
@@ -299,6 +301,7 @@ impl FinalizationPhase {
                 source_ip,
                 network_log_session,
                 workspace_image,
+                workspace_image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
                 workspace_promotable,
                 storage_fingerprints,
                 device_rate_limits,
@@ -445,6 +448,7 @@ pub(super) fn spawn_job(
     };
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
+    let workspace_disk_mb = job_profile.workspace_disk_mb;
     let active_lease = job_profile.budget_lease;
     let profile_name = job_profile.profile_name;
     let factory = job_profile.factory;
@@ -453,7 +457,7 @@ pub(super) fn spawn_job(
         profile_name: profile_name.clone(),
         vcpu,
         memory_mb,
-        workspace_disk_mb: job_profile.workspace_disk_mb,
+        workspace_disk_mb,
         restore_guest_state: job_profile.restore_guest_state,
         device_rate_limits: job_profile.device_rate_limits.clone(),
     };
@@ -532,6 +536,7 @@ pub(super) fn spawn_job(
         completion_auth,
         active_lease,
         reuse_result,
+        workspace_disk_mb,
         profile_name,
         cli_agent_session_id,
         storage_fingerprints,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -67,6 +67,7 @@ pub(super) struct FinalizeContext {
     pub(super) source_ip: String,
     pub(super) network_log_session: Option<NetworkLogSession>,
     pub(super) workspace_image: Option<WorkspaceImageLease>,
+    pub(super) workspace_image_size_bytes: u64,
     pub(super) workspace_promotable: bool,
     pub(super) storage_fingerprints: StorageFingerprints,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
@@ -104,6 +105,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         source_ip,
         mut network_log_session,
         workspace_image,
+        workspace_image_size_bytes,
         workspace_promotable,
         storage_fingerprints,
         device_rate_limits,
@@ -169,6 +171,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             budget_lease: active_lease.into_idle_park_lease(),
             source_ip,
             storage_fingerprints,
+            workspace_image_size_bytes,
             workspace_promotion,
         });
         let candidate = match park_request.park_for_idle().await {
@@ -581,7 +584,7 @@ mod tests {
 
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
-    use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory};
+    use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::{
@@ -675,6 +678,7 @@ mod tests {
                 source_ip: "10.0.0.1".into(),
                 network_log_session: Some(network_log_session),
                 workspace_image: None,
+                workspace_image_size_bytes: 0,
                 workspace_promotable: false,
                 storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
                 device_rate_limits: None,
@@ -1087,6 +1091,7 @@ mod tests {
         context.cli_agent_session_id = None;
         context.discovered_cli_agent_session_id = Some("sess-guest".into());
         context.workspace_image = Some(workspace_image);
+        context.workspace_image_size_bytes = b"image".len() as u64;
         context.workspace_promotable = true;
 
         let _completion_ready = finalize_sandbox_for_completion(
@@ -1111,6 +1116,78 @@ mod tests {
         assert!(
             cache_states.is_empty(),
             "parked sandboxes keep the live workspace mounted and must not publish a separate cache image"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalizer_rejects_mismatched_workspace_promotion_before_parking() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some("sess-mismatch"),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
+                workspace_drive_required: true,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let (factory, sandbox) = sandbox_with_overrides(sandbox_id, Arc::clone(&overrides)).await;
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "sess-mismatch",
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.factory = factory;
+        context.workspace_image = Some(workspace_image);
+        context.workspace_image_size_bytes = b"image".len() as u64 + 1;
+        context.workspace_promotable = true;
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(sandbox),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        assert_eq!(
+            overrides.park_call_count(),
+            0,
+            "mismatched promotion should be rejected before sandbox park"
+        );
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(fixture.idle_pool.lock().await.len(), 0);
+        assert!(
+            cache.held_session_states().await.is_empty(),
+            "mismatched park-time promotion must not publish workspace cache"
         );
     }
 
@@ -1170,6 +1247,7 @@ mod tests {
             RunCancellationHandle::new(),
         );
         context.workspace_image = Some(workspace_image);
+        context.workspace_image_size_bytes = b"image".len() as u64;
         context.workspace_promotable = true;
 
         let _completion_ready = finalize_sandbox_for_completion(
@@ -1251,6 +1329,7 @@ mod tests {
             device_rate_limits: None,
             budget_lease: existing_lease,
             storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
+            workspace_image_size_bytes: b"image".len() as u64,
             workspace_promotion: Some(old_promotion),
         })
         .park_for_idle()

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -1,16 +1,18 @@
 use super::super::*;
 use super::support::{
-    assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
-    mock_run_config_with_overrides, publish_idle_status, push_job, seed_idle_pool,
-    seed_idle_pool_with_overrides, shutdown, status_idle_sessions, test_profiles, two_profiles,
-    wait_budget_count, wait_cancel_token, wait_discover_entered, wait_idle_pool_len,
-    wait_idle_pool_session_states, wait_idle_pool_sessions, wait_parking_state,
-    wait_sandbox_lifecycle_counts, wait_status_idle_empty_with_active_run,
-    wait_status_idle_sessions_and_active_runs,
+    WorkspacePromotionSeedSpec, assert_run_exits_within, context_with_session, minimal_context,
+    mock_run_config, mock_run_config_with_overrides, publish_idle_status, push_job, seed_idle_pool,
+    seed_idle_pool_with_overrides, seed_idle_pool_with_workspace_promotion, shutdown,
+    status_idle_sessions, test_profiles, two_profiles, wait_budget_count, wait_cancel_token,
+    wait_discover_entered, wait_idle_pool_len, wait_idle_pool_session_states,
+    wait_idle_pool_sessions, wait_parking_state, wait_sandbox_lifecycle_counts,
+    wait_status_idle_empty_with_active_run, wait_status_idle_sessions_and_active_runs,
 };
 
 use crate::idle_pool::ParkingState;
+use crate::paths::RunnerPaths;
 use crate::types::SandboxReuseResult;
+use crate::workspace_image_cache::SessionWorkspaceCache;
 
 // -----------------------------------------------------------------------
 // Test 9: idle pool park/take is gated on session ID availability
@@ -369,6 +371,67 @@ async fn session_affinity_reuses_idle_vm() {
         budget.allocated().2,
         1,
         "budget should remain at 1 (reused, not additive)"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = SessionWorkspaceCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache.clone());
+    let session_id = "sess-workspace-promotion-mismatch";
+    let stale_sandbox_id = seed_idle_pool_with_workspace_promotion(
+        &idle_pool,
+        &budget,
+        &workspace_cache,
+        &runner_paths,
+        WorkspacePromotionSeedSpec {
+            session_id,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            image_size_bytes: 16 * 1024 * 1024,
+        },
+    )
+    .await;
+
+    let run_handle = tokio::spawn(run(config));
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, session_id)),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_ne!(
+        completion.sandbox_id,
+        Some(stale_sandbox_id),
+        "workspace promotion mismatch should force a fresh sandbox"
+    );
+    wait_idle_pool_sessions(&idle_pool, &[session_id], Duration::from_secs(5)).await;
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    assert!(
+        workspace_cache.held_session_states().await.is_empty(),
+        "mismatched stale idle VM must be destroyed without publishing its workspace image"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -2,7 +2,15 @@ use super::super::super::*;
 use super::TEST_SESSION_LAST_COMPLETED_AT;
 
 use crate::idle_pool::{ParkResult, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts};
+use crate::ids::RunId;
+use crate::paths::RunnerPaths;
 use crate::resource_budget::BudgetLease;
+use crate::storage_fingerprints::StorageFingerprints;
+use crate::workspace_image_cache::{
+    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
+};
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::{SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
@@ -98,6 +106,77 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
         })
         .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string()),
     );
+    assert!(matches!(result, ParkResult::Parked));
+    sandbox_id
+}
+
+pub(in super::super) struct WorkspacePromotionSeedSpec<'a> {
+    pub(in super::super) session_id: &'a str,
+    pub(in super::super) profile_name: &'a str,
+    pub(in super::super) vcpu: u32,
+    pub(in super::super) memory_mb: u32,
+    pub(in super::super) image_size_bytes: u64,
+}
+
+pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
+    pool: &SharedIdlePool,
+    budget: &Arc<ResourceBudget>,
+    cache: &SessionWorkspaceCache,
+    paths: &RunnerPaths,
+    spec: WorkspacePromotionSeedSpec<'_>,
+) -> SandboxId {
+    let run_id = RunId::new_v4();
+    let sandbox_id = SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: spec.profile_name,
+                cli_agent_session_id: Some(spec.session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: spec.image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(&active_image).await.unwrap();
+    file.set_len(spec.image_size_bytes).await.unwrap();
+    drop(file);
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override: Some(spec.session_id),
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: TEST_SESSION_LAST_COMPLETED_AT.into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            promotable: true,
+        })
+        .expect("workspace image should be promotable");
+    let budget_lease = ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb)
+        .expect("reserve budget");
+    let candidate = ParkedIdleCandidate::synthetic_for_test_with_workspace_promotion(
+        SyntheticParkedIdleCandidateParts {
+            sandbox: Box::new(MockSandbox::new("idle-workspace-promotion-test")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            cli_agent_session_id: spec.session_id.into(),
+            sandbox_id,
+            profile_name: spec.profile_name.into(),
+            device_rate_limits: None,
+            budget_lease,
+            source_ip: "10.0.0.1".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+        },
+        promotion,
+    )
+    .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string());
+    let mut guard = pool.lock().await;
+    let result = guard.park(candidate);
     assert!(matches!(result, ParkResult::Parked));
     sandbox_id
 }

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -9,8 +9,9 @@ pub(super) use self::env::{
     mock_run_config_with_overrides, mock_run_config_with_runtime, test_profiles, two_profiles,
 };
 pub(super) use self::idle_pool::{
-    TestParkedIdleCandidateSpec, seed_idle_pool, seed_idle_pool_expired,
-    seed_idle_pool_with_overrides, seed_idle_pool_with_timing,
+    TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,
+    seed_idle_pool_expired, seed_idle_pool_with_overrides, seed_idle_pool_with_timing,
+    seed_idle_pool_with_workspace_promotion,
 };
 pub(super) use self::jobs::{
     TEST_SESSION_LAST_COMPLETED_AT, context_with_session, minimal_context, push_job, shutdown,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -118,7 +118,8 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceImageActiveLeaseRequest, WorkspaceImageLease,
-    WorkspaceImageLeaseIdentity,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePromotionContext,
+    WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
 };
 
 fn guest_runtime_dir(run_id: RunId) -> RunnerResult<String> {
@@ -509,7 +510,39 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
 
     if let Err(error) = validate_resume_session_id(&context) {
         let workspace_image = match config.workspace_cache.as_ref() {
-            Some(_) => workspace_promotion.map(|promotion| promotion.into_active_lease(true)),
+            Some(cache) => match workspace_promotion {
+                Some(promotion) => match reused_promotion_into_active_lease(
+                    cache,
+                    promotion,
+                    run_id,
+                    sandbox_id,
+                    params,
+                    &idle_cli_agent_session_id,
+                ) {
+                    Ok(lease) => Some(lease),
+                    Err(mismatch) => {
+                        let failure = workspace_promotion_identity_failure(
+                            run_id,
+                            sandbox_id,
+                            &params.profile_name,
+                            mismatch,
+                        );
+                        return (
+                            ExecuteOutcome {
+                                failure: Some(failure),
+                                sandbox: Some(sandbox),
+                                source_ip,
+                                network_log_session: None,
+                                workspace_image: None,
+                                workspace_promotable: false,
+                                discovered_cli_agent_session_id: None,
+                            },
+                            telemetry,
+                        );
+                    }
+                },
+                None => None,
+            },
             None => {
                 if let Some(promotion) = workspace_promotion
                     && let Err(error) = promotion
@@ -554,7 +587,41 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
 
     let workspace_image = match config.workspace_cache.as_ref() {
         Some(cache) => Some(match workspace_promotion {
-            Some(promotion) => promotion.into_active_lease(true),
+            Some(promotion) => {
+                let expected_session_id = context
+                    .cli_agent_session_id()
+                    .unwrap_or(idle_cli_agent_session_id.as_str());
+                match reused_promotion_into_active_lease(
+                    cache,
+                    promotion,
+                    run_id,
+                    sandbox_id,
+                    params,
+                    expected_session_id,
+                ) {
+                    Ok(lease) => lease,
+                    Err(mismatch) => {
+                        let failure = workspace_promotion_identity_failure(
+                            run_id,
+                            sandbox_id,
+                            &params.profile_name,
+                            mismatch,
+                        );
+                        return (
+                            ExecuteOutcome {
+                                failure: Some(failure),
+                                sandbox: Some(sandbox),
+                                source_ip,
+                                network_log_session: None,
+                                workspace_image: None,
+                                workspace_promotable: false,
+                                discovered_cli_agent_session_id: None,
+                            },
+                            telemetry,
+                        );
+                    }
+                }
+            }
             None => {
                 cache
                     .lease_active(WorkspaceImageActiveLeaseRequest {
@@ -640,6 +707,52 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
     };
 
     (outcome, telemetry)
+}
+
+fn reused_promotion_into_active_lease(
+    cache: &SessionWorkspaceCache,
+    promotion: WorkspaceImagePromotionContext,
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    params: &JobParams,
+    cli_agent_session_id: &str,
+) -> Result<WorkspaceImageLease, WorkspaceImagePromotionIdentityMismatch> {
+    let expected = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: &params.profile_name,
+            cli_agent_session_id,
+            working_dir: CANONICAL_WORKING_DIR,
+            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+        })
+        .inspect_err(|mismatch| {
+            tracing::warn!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                profile_name = %params.profile_name,
+                mismatch = mismatch.as_str(),
+                "workspace promotion expected identity could not be constructed"
+            );
+        })?;
+    promotion.try_into_active_lease(&expected, true)
+}
+
+fn workspace_promotion_identity_failure(
+    run_id: RunId,
+    sandbox_id: SandboxId,
+    profile_name: &str,
+    mismatch: WorkspaceImagePromotionIdentityMismatch,
+) -> ExecutionFailure {
+    tracing::warn!(
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        profile_name,
+        mismatch = mismatch.as_str(),
+        "workspace promotion identity mismatch during reused sandbox execution"
+    );
+    ExecutionFailure::from_error(format!(
+        "workspace promotion identity mismatch during reused sandbox execution: {mismatch}"
+    ))
 }
 
 /// Dispatch inputs for the fresh-create path. Holds the UUID for the new VM

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -239,6 +239,53 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
 }
 
 #[tokio::test]
+async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let promotion_params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let current_params = JobParams {
+        workspace_disk_mb: 32,
+        ..default_params()
+    };
+    let session_id = "sess-cache-reuse-identity-mismatch";
+    let (idle_sandbox, _current_image, overrides) = reusable_idle_sandbox_with_workspace_promotion(
+        &cache,
+        &runner_paths,
+        &promotion_params,
+        session_id,
+    )
+    .await;
+
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        session_history: r#"{"type":"init"}"#.into(),
+    });
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (reuse_outcome, _telemetry) =
+        execute_job_reuse(idle_sandbox, ctx, &config, &current_params, cancel).await;
+
+    assert_eq!(reuse_outcome.exit_code(), 1);
+    assert!(reuse_outcome.sandbox.is_some());
+    assert!(reuse_outcome.workspace_image.is_none());
+    assert!(!reuse_outcome.workspace_promotable);
+    let error = reuse_outcome.error().expect("error should be set");
+    assert!(error.contains("workspace promotion identity mismatch"));
+    assert!(!error.contains(session_id));
+    assert!(
+        overrides.start_process_calls().is_empty(),
+        "agent must not start after workspace promotion identity mismatch"
+    );
+}
+
+#[tokio::test]
 async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache_entry() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
@@ -596,6 +643,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         budget_lease: test_budget_lease(),
         source_ip,
         storage_fingerprints: StorageFingerprints::default(),
+        workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })
     .park_for_idle()
@@ -701,6 +749,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         budget_lease: test_budget_lease(),
         source_ip,
         storage_fingerprints: StorageFingerprints::default(),
+        workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })
     .park_for_idle()

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -6,6 +6,7 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
@@ -13,7 +14,10 @@ use crate::resource_budget::BudgetLease;
 use crate::status::IdleVm;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::HeldSessionState;
-use crate::workspace_image_cache::WorkspaceImagePromotionContext;
+use crate::workspace_image_cache::{
+    SessionWorkspaceCache, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityMismatch,
+    WorkspaceImagePromotionIdentityRequest,
+};
 use crate::workspace_promotion::promote_workspace_image_from_parked_sandbox;
 
 /// Default idle timeout for kept-alive VMs (30 minutes).
@@ -134,6 +138,7 @@ pub(crate) struct IdleParkRequestParts {
     pub(crate) budget_lease: BudgetLease,
     pub(crate) source_ip: String,
     pub(crate) storage_fingerprints: StorageFingerprints,
+    pub(crate) workspace_image_size_bytes: u64,
     pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
 
@@ -291,6 +296,7 @@ impl IdleParkRequest {
             budget_lease,
             source_ip,
             storage_fingerprints,
+            workspace_image_size_bytes,
             workspace_promotion,
         } = self.parts;
 
@@ -302,6 +308,33 @@ impl IdleParkRequest {
             source_ip,
             storage_fingerprints,
         );
+
+        if let Some(promotion) = workspace_promotion.as_ref()
+            && let Err(mismatch) =
+                promotion.validate_stored_cache_identity(WorkspaceImagePromotionIdentityRequest {
+                    sandbox_id: metadata.sandbox_id,
+                    profile_name: &metadata.profile_name,
+                    cli_agent_session_id: metadata.cli_agent_session_id(),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: workspace_image_size_bytes,
+                })
+        {
+            tracing::warn!(
+                sandbox_id = %metadata.sandbox_id,
+                profile_name = %metadata.profile_name,
+                mismatch = mismatch.as_str(),
+                "workspace promotion identity mismatch before idle park; destroying without workspace promotion"
+            );
+            return Err(IdleParkFailure {
+                resources: IdleSandboxResources {
+                    sandbox,
+                    factory,
+                    workspace_promotion: None,
+                },
+                budget_lease,
+                error: format!("workspace promotion identity mismatch: {mismatch}"),
+            });
+        }
 
         match AssertUnwindSafe(sandbox.park()).catch_unwind().await {
             Ok(Ok(())) => Ok(ParkedIdleCandidate {
@@ -371,6 +404,29 @@ impl ParkedIdleCandidate {
                 sandbox: parts.sandbox,
                 factory: parts.factory,
                 workspace_promotion: None,
+            },
+            metadata: IdleSandboxMetadata::new(
+                parts.cli_agent_session_id,
+                parts.sandbox_id,
+                parts.profile_name,
+                parts.device_rate_limits,
+                parts.source_ip,
+                parts.storage_fingerprints,
+            ),
+            budget_lease: parts.budget_lease,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn synthetic_for_test_with_workspace_promotion(
+        parts: SyntheticParkedIdleCandidateParts,
+        workspace_promotion: WorkspaceImagePromotionContext,
+    ) -> Self {
+        Self {
+            resources: IdleSandboxResources {
+                sandbox: parts.sandbox,
+                factory: parts.factory,
+                workspace_promotion: Some(workspace_promotion),
             },
             metadata: IdleSandboxMetadata::new(
                 parts.cli_agent_session_id,
@@ -734,6 +790,31 @@ impl IdleEntry {
 
     pub fn into_destroy_job(self) -> IdleDestroyJob {
         self.into_destroy_job_with_workspace_promotion(WorkspacePromotionPolicy::Keep)
+    }
+
+    pub fn into_destroy_job_without_workspace_promotion_for_mismatch(self) -> IdleDestroyJob {
+        self.into_destroy_job_without_workspace_promotion()
+    }
+
+    pub fn validate_workspace_promotion_identity(
+        &self,
+        cache: &SessionWorkspaceCache,
+        working_dir: &str,
+        image_size_bytes: u64,
+    ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
+        let Some(promotion) = self.resources.workspace_promotion.as_ref() else {
+            return Ok(());
+        };
+        promotion.validate_expected_identity(
+            cache,
+            WorkspaceImagePromotionIdentityRequest {
+                sandbox_id: self.metadata.sandbox_id,
+                profile_name: &self.metadata.profile_name,
+                cli_agent_session_id: self.metadata.cli_agent_session_id(),
+                working_dir,
+                image_size_bytes,
+            },
+        )
     }
 
     fn into_destroy_job_without_workspace_promotion(self) -> IdleDestroyJob {
@@ -1113,6 +1194,7 @@ mod tests {
             budget_lease,
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
+            workspace_image_size_bytes: 0,
             workspace_promotion: None,
         })
     }
@@ -1180,6 +1262,7 @@ mod tests {
             budget_lease,
             source_ip: source_ip.into(),
             storage_fingerprints,
+            workspace_image_size_bytes: 0,
             workspace_promotion: None,
         });
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -27,7 +27,8 @@ use super::path_safety::{
 use super::types::{
     CacheBudget, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
     WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
-    WorkspaceImagePromotionRequest,
+    WorkspaceImagePromotionIdentity, WorkspaceImagePromotionIdentityMismatch,
+    WorkspaceImagePromotionIdentityRequest, WorkspaceImagePromotionRequest,
 };
 use super::{
     CACHE_FORMAT_VERSION, CACHE_KEY_VERSION, SessionWorkspaceCache, WORKSPACE_DRIVE_LAYOUT,
@@ -181,6 +182,31 @@ impl WorkspaceImageLease {
 }
 
 impl SessionWorkspaceCache {
+    pub(crate) fn expected_promotion_identity(
+        &self,
+        request: WorkspaceImagePromotionIdentityRequest<'_>,
+    ) -> Result<WorkspaceImagePromotionIdentity, WorkspaceImagePromotionIdentityMismatch> {
+        let Some(working_dir) = normalize_safe_guest_working_dir(request.working_dir) else {
+            return Err(WorkspaceImagePromotionIdentityMismatch::UnsafeWorkingDir);
+        };
+        let cache_key = self.scoped_cache_key(
+            request.profile_name,
+            request.cli_agent_session_id,
+            &working_dir,
+            request.image_size_bytes,
+        );
+
+        Ok(WorkspaceImagePromotionIdentity {
+            sandbox_id: request.sandbox_id,
+            profile_name: request.profile_name.to_owned(),
+            cli_agent_session_id: request.cli_agent_session_id.to_owned(),
+            working_dir,
+            image_size_bytes: request.image_size_bytes,
+            active_image: self.paths().active_workspace_image(&request.sandbox_id),
+            cache_key,
+        })
+    }
+
     pub(crate) async fn lease_active(
         &self,
         request: WorkspaceImageActiveLeaseRequest<'_>,
@@ -1101,6 +1127,50 @@ impl WorkspaceImagePromotionContext {
         &self.cli_agent_session_id
     }
 
+    pub(crate) fn validate_identity(
+        &self,
+        expected: &WorkspaceImagePromotionIdentity,
+    ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
+        if self.sandbox_id != expected.sandbox_id {
+            return Err(WorkspaceImagePromotionIdentityMismatch::SandboxId);
+        }
+        if self.profile_name != expected.profile_name {
+            return Err(WorkspaceImagePromotionIdentityMismatch::ProfileName);
+        }
+        if self.cli_agent_session_id != expected.cli_agent_session_id {
+            return Err(WorkspaceImagePromotionIdentityMismatch::CliAgentSessionId);
+        }
+        if self.working_dir != expected.working_dir {
+            return Err(WorkspaceImagePromotionIdentityMismatch::WorkingDir);
+        }
+        if self.image_size_bytes != expected.image_size_bytes {
+            return Err(WorkspaceImagePromotionIdentityMismatch::ImageSizeBytes);
+        }
+        if self.active_image != expected.active_image {
+            return Err(WorkspaceImagePromotionIdentityMismatch::ActiveImage);
+        }
+        if self.cache_key != expected.cache_key {
+            return Err(WorkspaceImagePromotionIdentityMismatch::CacheKey);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_expected_identity(
+        &self,
+        cache: &SessionWorkspaceCache,
+        request: WorkspaceImagePromotionIdentityRequest<'_>,
+    ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
+        let expected = cache.expected_promotion_identity(request)?;
+        self.validate_identity(&expected)
+    }
+
+    pub(crate) fn validate_stored_cache_identity(
+        &self,
+        request: WorkspaceImagePromotionIdentityRequest<'_>,
+    ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
+        self.validate_expected_identity(&self.cache, request)
+    }
+
     pub(crate) async fn promote(&self) -> RunnerResult<bool> {
         let tainted_storage_fingerprints;
         let promotion_storage_fingerprints = match self.terminal_status {
@@ -1183,7 +1253,16 @@ impl WorkspaceImagePromotionContext {
             .await
     }
 
-    pub(crate) fn into_active_lease(self, workspace_drive_available: bool) -> WorkspaceImageLease {
+    pub(crate) fn try_into_active_lease(
+        self,
+        expected: &WorkspaceImagePromotionIdentity,
+        workspace_drive_available: bool,
+    ) -> Result<WorkspaceImageLease, WorkspaceImagePromotionIdentityMismatch> {
+        self.validate_identity(expected)?;
+        Ok(self.into_active_lease_unchecked(workspace_drive_available))
+    }
+
+    fn into_active_lease_unchecked(self, workspace_drive_available: bool) -> WorkspaceImageLease {
         let Self {
             cache,
             cache_key,

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -1,9 +1,11 @@
 //! Local session workspace image cache.
 //!
 //! This cache stores reusable workspace drive images for session-backed runs.
-//! Each cache entry is keyed by cache scope, profile, session id, normalized
-//! working directory, and logical workspace image size. A cache entry contains a
-//! `metadata.json` file and a `current.ext4` image file.
+//! Each cache entry is keyed by cache scope, profile, session id, and logical
+//! workspace image size. The normalized working directory is still stored in
+//! metadata and validated at promotion/reuse boundaries; the hash key itself
+//! follows the canonical-workspace semantics in `paths.rs`. A cache entry
+//! contains a `metadata.json` file and a `current.ext4` image file.
 //!
 //! ## Invariants
 //!
@@ -48,7 +50,8 @@ pub(crate) use types::{
     WorkspaceImageActiveLeaseRequest, WorkspaceImageCacheInspection,
     WorkspaceImageCacheInspectionEntry, WorkspaceImageCacheInspectionStatus,
     WorkspaceImageCacheInspectionSummary, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentityMismatch,
+    WorkspaceImagePromotionIdentityRequest, WorkspaceImagePromotionRequest,
 };
 
 const CACHE_FORMAT_VERSION: u32 = 1;

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -2753,7 +2753,16 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
         WorkspaceCacheCheckoutResult::LockBusy
     );
 
-    let active_lease = promotion.into_active_lease(true);
+    let expected = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/workspace",
+            image_size_bytes,
+        })
+        .unwrap();
+    let active_lease = promotion.try_into_active_lease(&expected, true).unwrap();
 
     let blocked_by_active_lease = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -2788,6 +2797,127 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
         })
         .await;
     assert_eq!(after_drop.result(), WorkspaceCacheCheckoutResult::Miss);
+}
+
+#[tokio::test]
+async fn promotion_context_validates_expected_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let session_id = "sess-identity";
+    let image_size_bytes = 16 * 1024 * 1024;
+
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace//repo/",
+                image_size_bytes,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override: Some(session_id),
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: local_timestamp(),
+            storage_fingerprints: StorageFingerprints::default(),
+            promotable: true,
+        })
+        .unwrap();
+
+    let expected = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/workspace/repo",
+            image_size_bytes,
+        })
+        .unwrap();
+    assert_eq!(promotion.validate_identity(&expected), Ok(()));
+
+    let wrong_sandbox = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id: sandbox::SandboxId::new_v4(),
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/workspace/repo",
+            image_size_bytes,
+        })
+        .unwrap();
+    assert_eq!(
+        promotion.validate_identity(&wrong_sandbox),
+        Err(WorkspaceImagePromotionIdentityMismatch::SandboxId),
+    );
+
+    let wrong_session = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: "sess-other",
+            working_dir: "/workspace/repo",
+            image_size_bytes,
+        })
+        .unwrap();
+    assert_eq!(
+        promotion.validate_identity(&wrong_session),
+        Err(WorkspaceImagePromotionIdentityMismatch::CliAgentSessionId),
+    );
+
+    let wrong_size = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/workspace/repo",
+            image_size_bytes: image_size_bytes + 1,
+        })
+        .unwrap();
+    assert_eq!(
+        promotion.validate_identity(&wrong_size),
+        Err(WorkspaceImagePromotionIdentityMismatch::ImageSizeBytes),
+    );
+
+    let scoped_cache = SessionWorkspaceCache::with_cache_dirs(
+        paths.clone(),
+        paths.workspace_image_cache_dir(),
+        paths.base_dir().join("locks"),
+        "other-scope",
+    );
+    let wrong_cache_key = scoped_cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/workspace/repo",
+            image_size_bytes,
+        })
+        .unwrap();
+    assert_eq!(
+        promotion.validate_identity(&wrong_cache_key),
+        Err(WorkspaceImagePromotionIdentityMismatch::CacheKey),
+    );
+
+    assert_eq!(
+        cache.expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/",
+            image_size_bytes,
+        }),
+        Err(WorkspaceImagePromotionIdentityMismatch::UnsafeWorkingDir),
+    );
 }
 
 #[tokio::test]
@@ -3991,7 +4121,16 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
         })
         .unwrap();
 
-    let active_lease = promotion.into_active_lease(true);
+    let expected = cache
+        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+            sandbox_id,
+            profile_name: TEST_PROFILE_NAME,
+            cli_agent_session_id: session_id,
+            working_dir: "/workspace//repo/",
+            image_size_bytes: 5,
+        })
+        .unwrap();
+    let active_lease = promotion.try_into_active_lease(&expected, true).unwrap();
 
     assert_eq!(active_lease.working_dir(), "/workspace/repo");
     assert!(active_lease.can_attempt_promotion(Some(session_id)));

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 use crate::ids::RunId;
@@ -44,6 +46,59 @@ pub(crate) struct WorkspaceImagePrepareRequest<'a> {
 pub(crate) struct WorkspaceImageActiveLeaseRequest<'a> {
     pub(crate) identity: WorkspaceImageLeaseIdentity<'a>,
     pub(crate) workspace_drive_available: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorkspaceImagePromotionIdentityRequest<'a> {
+    pub(crate) sandbox_id: sandbox::SandboxId,
+    pub(crate) profile_name: &'a str,
+    pub(crate) cli_agent_session_id: &'a str,
+    pub(crate) working_dir: &'a str,
+    pub(crate) image_size_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorkspaceImagePromotionIdentity {
+    pub(crate) sandbox_id: sandbox::SandboxId,
+    pub(crate) profile_name: String,
+    pub(crate) cli_agent_session_id: String,
+    pub(crate) working_dir: String,
+    pub(crate) image_size_bytes: u64,
+    pub(crate) active_image: PathBuf,
+    pub(crate) cache_key: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WorkspaceImagePromotionIdentityMismatch {
+    UnsafeWorkingDir,
+    SandboxId,
+    ProfileName,
+    CliAgentSessionId,
+    WorkingDir,
+    ImageSizeBytes,
+    ActiveImage,
+    CacheKey,
+}
+
+impl WorkspaceImagePromotionIdentityMismatch {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::UnsafeWorkingDir => "unsafe working directory",
+            Self::SandboxId => "sandbox id mismatch",
+            Self::ProfileName => "profile mismatch",
+            Self::CliAgentSessionId => "cli agent session id mismatch",
+            Self::WorkingDir => "working directory mismatch",
+            Self::ImageSizeBytes => "image size mismatch",
+            Self::ActiveImage => "active image path mismatch",
+            Self::CacheKey => "cache key mismatch",
+        }
+    }
+}
+
+impl std::fmt::Display for WorkspaceImagePromotionIdentityMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 pub(crate) struct WorkspaceImagePromotionRequest<'a> {


### PR DESCRIPTION
## Summary
- add explicit workspace promotion identity validation for cache key, sandbox, profile, session, working directory, active image path, and image size
- reject mismatched promotion contexts before idle park and before idle reuse, destroying known-bad idle VMs without workspace promotion
- replace unchecked reused promotion conversion with an executor backstop and add regression coverage

Fixes #18448

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::sandbox_finalization
- cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::sandbox_run_tests::workspace_cache
- cargo test --manifest-path crates/Cargo.toml -p runner destroy_idle_jobs_and_wait_reports_workspace_cache_promotion
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo check --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings