### PR TITLE
fix(runner): abandon unpublished workspace promotions

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -192,7 +192,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 );
                 let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
                     sandbox.as_ref(),
-                    workspace_promotion.as_ref(),
+                    workspace_promotion,
                     "park_failed",
                 )
                 .await;
@@ -386,7 +386,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         // No parkable session — stop + destroy.
         let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
             sandbox.as_ref(),
-            workspace_promotion.as_ref(),
+            workspace_promotion,
             active_cleanup_reason(
                 exit_code,
                 cancelled,
@@ -927,10 +927,9 @@ mod tests {
         );
 
         let promoted =
-            promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
+            promote_workspace_image_from_active_sandbox(&sandbox, Some(promotion), "test").await;
 
         assert!(promoted);
-        drop(promotion);
         let states = cache.held_session_states().await;
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].session_id, "sess-promote");
@@ -977,11 +976,10 @@ mod tests {
             );
 
             let promoted =
-                promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test")
+                promote_workspace_image_from_active_sandbox(&sandbox, Some(promotion), "test")
                     .await;
 
             assert!(promoted);
-            drop(promotion);
             let checkout = cache
                 .prepare(WorkspaceImagePrepareRequest {
                     identity: WorkspaceImageLeaseIdentity {
@@ -1040,7 +1038,7 @@ mod tests {
         );
 
         let promoted =
-            promote_workspace_image_from_active_sandbox(&sandbox, Some(&promotion), "test").await;
+            promote_workspace_image_from_active_sandbox(&sandbox, Some(promotion), "test").await;
 
         assert!(!promoted);
         assert!(

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -119,7 +119,8 @@ use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceImageActiveLeaseRequest, WorkspaceImageLease,
     WorkspaceImageLeaseIdentity, WorkspaceImagePromotionContext,
-    WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
+    WorkspaceImagePromotionIdentityFailure, WorkspaceImagePromotionIdentityMismatch,
+    WorkspaceImagePromotionIdentityRequest,
 };
 use crate::workspace_promotion::abandon_unpublished_workspace_promotion;
 
@@ -522,7 +523,7 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                 ) {
                     Ok(lease) => Some(lease),
                     Err(identity_failure) => {
-                        let ReusedWorkspacePromotionIdentityMismatch {
+                        let WorkspaceImagePromotionIdentityFailure {
                             promotion,
                             mismatch,
                         } = *identity_failure;
@@ -611,7 +612,7 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                 ) {
                     Ok(lease) => lease,
                     Err(identity_failure) => {
-                        let ReusedWorkspacePromotionIdentityMismatch {
+                        let WorkspaceImagePromotionIdentityFailure {
                             promotion,
                             mismatch,
                         } = *identity_failure;
@@ -735,7 +736,7 @@ fn reused_promotion_into_active_lease(
     sandbox_id: SandboxId,
     params: &JobParams,
     cli_agent_session_id: &str,
-) -> Result<WorkspaceImageLease, Box<ReusedWorkspacePromotionIdentityMismatch>> {
+) -> Result<WorkspaceImageLease, Box<WorkspaceImagePromotionIdentityFailure>> {
     let expected = match cache
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
@@ -755,24 +756,13 @@ fn reused_promotion_into_active_lease(
         }) {
         Ok(expected) => expected,
         Err(mismatch) => {
-            return Err(Box::new(ReusedWorkspacePromotionIdentityMismatch {
+            return Err(Box::new(WorkspaceImagePromotionIdentityFailure {
                 promotion,
                 mismatch,
             }));
         }
     };
-    if let Err(mismatch) = promotion.validate_identity(&expected) {
-        return Err(Box::new(ReusedWorkspacePromotionIdentityMismatch {
-            promotion,
-            mismatch,
-        }));
-    }
-    Ok(promotion.into_active_lease_after_identity_validation(true))
-}
-
-struct ReusedWorkspacePromotionIdentityMismatch {
-    promotion: WorkspaceImagePromotionContext,
-    mismatch: WorkspaceImagePromotionIdentityMismatch,
+    promotion.try_into_active_lease_preserving_context(&expected, true)
 }
 
 fn workspace_promotion_identity_failure(

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -121,6 +121,7 @@ use crate::workspace_image_cache::{
     WorkspaceImageLeaseIdentity, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
 };
+use crate::workspace_promotion::abandon_unpublished_workspace_promotion;
 
 fn guest_runtime_dir(run_id: RunId) -> RunnerResult<String> {
     let run_id = run_id.to_string();
@@ -520,13 +521,22 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                     &idle_cli_agent_session_id,
                 ) {
                     Ok(lease) => Some(lease),
-                    Err(mismatch) => {
+                    Err(identity_failure) => {
+                        let ReusedWorkspacePromotionIdentityMismatch {
+                            promotion,
+                            mismatch,
+                        } = *identity_failure;
                         let failure = workspace_promotion_identity_failure(
                             run_id,
                             sandbox_id,
                             &params.profile_name,
                             mismatch,
                         );
+                        abandon_unpublished_workspace_promotion(
+                            Some(promotion),
+                            "reuse_workspace_promotion_mismatch",
+                        )
+                        .await;
                         return (
                             ExecuteOutcome {
                                 failure: Some(failure),
@@ -600,13 +610,22 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                     expected_session_id,
                 ) {
                     Ok(lease) => lease,
-                    Err(mismatch) => {
+                    Err(identity_failure) => {
+                        let ReusedWorkspacePromotionIdentityMismatch {
+                            promotion,
+                            mismatch,
+                        } = *identity_failure;
                         let failure = workspace_promotion_identity_failure(
                             run_id,
                             sandbox_id,
                             &params.profile_name,
                             mismatch,
                         );
+                        abandon_unpublished_workspace_promotion(
+                            Some(promotion),
+                            "reuse_workspace_promotion_mismatch",
+                        )
+                        .await;
                         return (
                             ExecuteOutcome {
                                 failure: Some(failure),
@@ -716,8 +735,8 @@ fn reused_promotion_into_active_lease(
     sandbox_id: SandboxId,
     params: &JobParams,
     cli_agent_session_id: &str,
-) -> Result<WorkspaceImageLease, WorkspaceImagePromotionIdentityMismatch> {
-    let expected = cache
+) -> Result<WorkspaceImageLease, Box<ReusedWorkspacePromotionIdentityMismatch>> {
+    let expected = match cache
         .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: &params.profile_name,
@@ -733,8 +752,27 @@ fn reused_promotion_into_active_lease(
                 mismatch = mismatch.as_str(),
                 "workspace promotion expected identity could not be constructed"
             );
-        })?;
-    promotion.try_into_active_lease(&expected, true)
+        }) {
+        Ok(expected) => expected,
+        Err(mismatch) => {
+            return Err(Box::new(ReusedWorkspacePromotionIdentityMismatch {
+                promotion,
+                mismatch,
+            }));
+        }
+    };
+    if let Err(mismatch) = promotion.validate_identity(&expected) {
+        return Err(Box::new(ReusedWorkspacePromotionIdentityMismatch {
+            promotion,
+            mismatch,
+        }));
+    }
+    Ok(promotion.into_active_lease_after_identity_validation(true))
+}
+
+struct ReusedWorkspacePromotionIdentityMismatch {
+    promotion: WorkspaceImagePromotionContext,
+    mismatch: WorkspaceImagePromotionIdentityMismatch,
 }
 
 fn workspace_promotion_identity_failure(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -254,7 +254,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
         ..default_params()
     };
     let session_id = "sess-cache-reuse-identity-mismatch";
-    let (idle_sandbox, _current_image, overrides) = reusable_idle_sandbox_with_workspace_promotion(
+    let (idle_sandbox, current_image, overrides) = reusable_idle_sandbox_with_workspace_promotion(
         &cache,
         &runner_paths,
         &promotion_params,
@@ -283,6 +283,24 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
         overrides.start_process_calls().is_empty(),
         "agent must not start after workspace promotion identity mismatch"
     );
+    assert!(
+        !current_image.exists(),
+        "identity mismatch must explicitly abandon the consumed cache hit"
+    );
+    let checkout = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: SandboxId::new_v4(),
+                profile_name: &promotion_params.profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(promotion_params.workspace_disk_mb) * 1024 * 1024,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(checkout.result(), WorkspaceCacheCheckoutResult::Miss);
 }
 
 #[tokio::test]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -18,7 +18,9 @@ use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityMismatch,
     WorkspaceImagePromotionIdentityRequest,
 };
-use crate::workspace_promotion::promote_workspace_image_from_parked_sandbox;
+use crate::workspace_promotion::{
+    abandon_unpublished_workspace_promotion, promote_workspace_image_from_parked_sandbox,
+};
 
 /// Default idle timeout for kept-alive VMs (30 minutes).
 ///
@@ -201,21 +203,9 @@ struct IdleSandboxResources {
 
 impl IdleSandboxResources {
     fn into_destroy_payload(self, policy: WorkspacePromotionPolicy) -> IdleDestroyPayload {
-        let Self {
-            sandbox,
-            factory,
-            workspace_promotion,
-        } = self;
-        let workspace_promotion = match policy {
-            WorkspacePromotionPolicy::Keep => workspace_promotion,
-            WorkspacePromotionPolicy::Drop => None,
-        };
         IdleDestroyPayload {
-            resources: Self {
-                sandbox,
-                factory,
-                workspace_promotion,
-            },
+            resources: self,
+            workspace_promotion_policy: policy,
         }
     }
 
@@ -230,8 +220,8 @@ impl IdleSandboxResources {
 }
 
 enum WorkspacePromotionPolicy {
-    Keep,
-    Drop,
+    Promote,
+    AbandonUnpublished(&'static str),
 }
 
 /// Active-owned sandbox after `Sandbox::park()` succeeds, before idle-pool
@@ -325,6 +315,11 @@ impl IdleParkRequest {
                 mismatch = mismatch.as_str(),
                 "workspace promotion identity mismatch before idle park; destroying without workspace promotion"
             );
+            abandon_unpublished_workspace_promotion(
+                workspace_promotion,
+                "promotion_identity_mismatch",
+            )
+            .await;
             return Err(IdleParkFailure {
                 resources: IdleSandboxResources {
                     sandbox,
@@ -355,17 +350,20 @@ impl IdleParkRequest {
                 budget_lease,
                 error: e.to_string(),
             }),
-            Err(_) => Err(IdleParkFailure {
-                resources: IdleSandboxResources {
-                    sandbox,
-                    factory,
-                    // A panic leaves the park transition state uncertain; destroy
-                    // the sandbox, but do not publish a workspace cache image.
-                    workspace_promotion: None,
-                },
-                budget_lease,
-                error: "sandbox park panicked".into(),
-            }),
+            Err(_) => {
+                // A panic leaves the park transition state uncertain; destroy
+                // the sandbox, but do not publish a workspace cache image.
+                abandon_unpublished_workspace_promotion(workspace_promotion, "park_panicked").await;
+                Err(IdleParkFailure {
+                    resources: IdleSandboxResources {
+                        sandbox,
+                        factory,
+                        workspace_promotion: None,
+                    },
+                    budget_lease,
+                    error: "sandbox park panicked".into(),
+                })
+            }
         }
     }
 }
@@ -477,7 +475,7 @@ impl ParkedIdleCandidate {
             ..
         } = self;
         (
-            resources.into_destroy_payload(WorkspacePromotionPolicy::Keep),
+            resources.into_destroy_payload(WorkspacePromotionPolicy::Promote),
             budget_lease,
         )
     }
@@ -490,7 +488,7 @@ impl ParkedIdleCandidate {
         } = self;
 
         RejectedParkedIdleCandidate {
-            payload: resources.into_destroy_payload(WorkspacePromotionPolicy::Keep),
+            payload: resources.into_destroy_payload(WorkspacePromotionPolicy::Promote),
             budget_lease,
         }
     }
@@ -582,6 +580,7 @@ impl ReusableIdleSandbox {
 /// Physical resources needed to destroy an idle VM, without its budget lease.
 pub(crate) struct IdleDestroyPayload {
     resources: IdleSandboxResources,
+    workspace_promotion_policy: WorkspacePromotionPolicy,
 }
 
 pub(crate) struct IdleDestroyResult {
@@ -607,12 +606,20 @@ impl IdleDestroyPayload {
             factory,
             workspace_promotion,
         } = self.resources;
-        let workspace_cache_promoted = promote_workspace_image_from_parked_sandbox(
-            sandbox.as_mut(),
-            workspace_promotion.as_ref(),
-            context,
-        )
-        .await;
+        let workspace_cache_promoted = match self.workspace_promotion_policy {
+            WorkspacePromotionPolicy::Promote => {
+                promote_workspace_image_from_parked_sandbox(
+                    sandbox.as_mut(),
+                    workspace_promotion,
+                    context,
+                )
+                .await
+            }
+            WorkspacePromotionPolicy::AbandonUnpublished(reason) => {
+                abandon_unpublished_workspace_promotion(workspace_promotion, reason).await;
+                false
+            }
+        };
         let mut uncertain = false;
         match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
             Ok(Ok(())) => {}
@@ -759,11 +766,15 @@ impl IdleEntry {
                 }
             }
             Ok(Err(e)) => IdleUnparkResult::Failed {
-                destroy_job: Box::new(self.into_destroy_job_without_workspace_promotion()),
+                destroy_job: Box::new(
+                    self.into_destroy_job_abandoning_workspace_promotion("unpark_failed"),
+                ),
                 error: e.to_string(),
             },
             Err(_) => IdleUnparkResult::Failed {
-                destroy_job: Box::new(self.into_destroy_job_without_workspace_promotion()),
+                destroy_job: Box::new(
+                    self.into_destroy_job_abandoning_workspace_promotion("unpark_panicked"),
+                ),
                 error: "sandbox unpark panicked".into(),
             },
         }
@@ -789,11 +800,11 @@ impl IdleEntry {
     }
 
     pub fn into_destroy_job(self) -> IdleDestroyJob {
-        self.into_destroy_job_with_workspace_promotion(WorkspacePromotionPolicy::Keep)
+        self.into_destroy_job_with_workspace_promotion(WorkspacePromotionPolicy::Promote)
     }
 
     pub fn into_destroy_job_without_workspace_promotion_for_mismatch(self) -> IdleDestroyJob {
-        self.into_destroy_job_without_workspace_promotion()
+        self.into_destroy_job_abandoning_workspace_promotion("promotion_identity_mismatch")
     }
 
     pub fn validate_workspace_promotion_identity(
@@ -817,8 +828,13 @@ impl IdleEntry {
         )
     }
 
-    fn into_destroy_job_without_workspace_promotion(self) -> IdleDestroyJob {
-        self.into_destroy_job_with_workspace_promotion(WorkspacePromotionPolicy::Drop)
+    fn into_destroy_job_abandoning_workspace_promotion(
+        self,
+        reason: &'static str,
+    ) -> IdleDestroyJob {
+        self.into_destroy_job_with_workspace_promotion(
+            WorkspacePromotionPolicy::AbandonUnpublished(reason),
+        )
     }
 
     fn into_destroy_job_with_workspace_promotion(

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -45,6 +45,7 @@ async fn make_idle_destroy_payload_for(
             factory,
             workspace_promotion,
         },
+        workspace_promotion_policy: WorkspacePromotionPolicy::Promote,
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -9,6 +9,7 @@ use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
+use crate::paths::diagnostic_session_fingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES};
 
@@ -65,6 +66,13 @@ pub(crate) struct WorkspaceImagePromotionContext {
     terminal_status: WorkspaceCacheTerminalStatus,
     completed_at: String,
     storage_fingerprints: StorageFingerprints,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WorkspaceImagePromotionOutcome {
+    Promoted,
+    PreservedExisting,
+    SkippedUnpublished,
 }
 
 struct WorkspaceImagePromotionInput<'a> {
@@ -630,7 +638,10 @@ impl SessionWorkspaceCache {
         }
     }
 
-    async fn promote_locked(&self, input: WorkspaceImagePromotionInput<'_>) -> RunnerResult<bool> {
+    async fn promote_locked(
+        &self,
+        input: WorkspaceImagePromotionInput<'_>,
+    ) -> RunnerResult<WorkspaceImagePromotionOutcome> {
         let cache_dir = self.session_workspace_cache_entry_dir(input.cache_key);
         if remove_non_directory_workspace_cache_entry(&cache_dir).await? {
             info!(
@@ -659,7 +670,7 @@ impl SessionWorkspaceCache {
                     promotion_completed_at = %input.completed_at,
                     "workspace image cache promotion skipped because existing cache is newer"
                 );
-                return Ok(false);
+                return Ok(WorkspaceImagePromotionOutcome::PreservedExisting);
             }
             Ok(_) => {}
             Err(e) => warn!(
@@ -679,7 +690,7 @@ impl SessionWorkspaceCache {
                     cache_key = input.cache_key,
                     "workspace image cache promotion skipped: capacity lock busy"
                 );
-                return Ok(false);
+                return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
             }
             Err(e) => {
                 warn!(
@@ -688,7 +699,7 @@ impl SessionWorkspaceCache {
                     error = %e,
                     "workspace image cache promotion skipped: capacity lock unavailable"
                 );
-                return Ok(false);
+                return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
             }
         };
 
@@ -717,7 +728,7 @@ impl SessionWorkspaceCache {
                 min_free_bytes = budget.min_free_bytes,
                 "workspace image cache promotion skipped due to free-space pressure"
             );
-            return Ok(false);
+            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
         let image_metadata = fs::symlink_metadata(input.active_image).await?;
         if !image_metadata.is_file() {
@@ -727,7 +738,7 @@ impl SessionWorkspaceCache {
                 active_image = %input.active_image.display(),
                 "workspace image cache promotion skipped because active image is not a file"
             );
-            return Ok(false);
+            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
         let active_allocated = allocated_bytes(&image_metadata);
         if active_allocated > budget.max_entry_bytes {
@@ -738,7 +749,7 @@ impl SessionWorkspaceCache {
                 max_entry_bytes = budget.max_entry_bytes,
                 "workspace image cache promotion skipped because image is too large"
             );
-            return Ok(false);
+            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
         if !has_copy_headroom(stats, budget, active_allocated) {
             match self.gc_locked(false).await {
@@ -764,7 +775,7 @@ impl SessionWorkspaceCache {
                 min_free_bytes = budget.min_free_bytes,
                 "workspace image cache promotion skipped due to copy free-space pressure"
             );
-            return Ok(false);
+            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
 
         ensure_workspace_cache_entry_dir(&cache_dir).await?;
@@ -798,7 +809,7 @@ impl SessionWorkspaceCache {
                 expected_image_size_bytes = input.image_size_bytes,
                 "workspace image cache promotion skipped because copied image size does not match cache key"
             );
-            return Ok(false);
+            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
         let tmp_allocated = allocated_bytes(&tmp_metadata);
         if tmp_allocated > budget.max_entry_bytes {
@@ -810,7 +821,7 @@ impl SessionWorkspaceCache {
                 max_entry_bytes = budget.max_entry_bytes,
                 "workspace image cache promotion skipped because copied image is too large"
             );
-            return Ok(false);
+            return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
         }
         let current = self.session_workspace_cache_current_image(input.cache_key);
         match fs::symlink_metadata(&current).await {
@@ -882,7 +893,7 @@ impl SessionWorkspaceCache {
                 "workspace image cache GC failed after promotion"
             );
         }
-        Ok(true)
+        Ok(WorkspaceImagePromotionOutcome::Promoted)
     }
 }
 impl WorkspaceImageLease {
@@ -1035,7 +1046,8 @@ impl WorkspaceImageLease {
             return Ok(false);
         };
 
-        self.cache
+        let outcome = self
+            .cache
             .promote_locked(WorkspaceImagePromotionInput {
                 run_id,
                 cache_key,
@@ -1048,7 +1060,8 @@ impl WorkspaceImageLease {
                 completed_at: &completed_at,
                 storage_fingerprints,
             })
-            .await
+            .await?;
+        Ok(matches!(outcome, WorkspaceImagePromotionOutcome::Promoted))
     }
 
     pub(crate) fn into_promotion_context(
@@ -1171,7 +1184,7 @@ impl WorkspaceImagePromotionContext {
         self.validate_expected_identity(&self.cache, request)
     }
 
-    pub(crate) async fn promote(&self) -> RunnerResult<bool> {
+    pub(crate) async fn promote(&self) -> RunnerResult<WorkspaceImagePromotionOutcome> {
         let tainted_storage_fingerprints;
         let promotion_storage_fingerprints = match self.terminal_status {
             WorkspaceCacheTerminalStatus::Success => &self.storage_fingerprints,
@@ -1193,7 +1206,7 @@ impl WorkspaceImagePromotionContext {
                             error = %e,
                             "workspace image cache promotion skipped: late entry lock unavailable"
                         );
-                        return Ok(false);
+                        return Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished);
                     }
                 }
             }
@@ -1212,6 +1225,42 @@ impl WorkspaceImagePromotionContext {
                 completed_at: &self.completed_at,
                 storage_fingerprints: promotion_storage_fingerprints,
             })
+            .await
+    }
+
+    pub(crate) async fn abandon_unpublished(self, reason: &str) -> RunnerResult<bool> {
+        let Self {
+            cache,
+            cache_key,
+            entry_lock,
+            run_id,
+            sandbox_id,
+            profile_name,
+            cli_agent_session_id,
+            consumed_cache_hit,
+            ..
+        } = self;
+        let Some(_entry_lock) = entry_lock else {
+            let session_fingerprint = diagnostic_session_fingerprint(&cli_agent_session_id);
+            info!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                profile_name,
+                session_fingerprint = %session_fingerprint,
+                cache_key,
+                reason,
+                "workspace image cache promotion context abandoned without entry lock"
+            );
+            return Ok(false);
+        };
+        if consumed_cache_hit {
+            return cache
+                .invalidate_cache_entry(run_id, &cache_key, reason)
+                .await;
+        }
+        let current = cache.session_workspace_cache_current_image(&cache_key);
+        cache
+            .invalidate_current_image(run_id, &cache_key, &current, reason)
             .await
     }
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -68,6 +68,11 @@ pub(crate) struct WorkspaceImagePromotionContext {
     storage_fingerprints: StorageFingerprints,
 }
 
+pub(crate) struct WorkspaceImagePromotionIdentityFailure {
+    pub(crate) promotion: WorkspaceImagePromotionContext,
+    pub(crate) mismatch: WorkspaceImagePromotionIdentityMismatch,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum WorkspaceImagePromotionOutcome {
     Promoted,
@@ -1312,11 +1317,18 @@ impl WorkspaceImagePromotionContext {
         Ok(self.into_active_lease_unchecked(workspace_drive_available))
     }
 
-    pub(crate) fn into_active_lease_after_identity_validation(
+    pub(crate) fn try_into_active_lease_preserving_context(
         self,
+        expected: &WorkspaceImagePromotionIdentity,
         workspace_drive_available: bool,
-    ) -> WorkspaceImageLease {
-        self.into_active_lease_unchecked(workspace_drive_available)
+    ) -> Result<WorkspaceImageLease, Box<WorkspaceImagePromotionIdentityFailure>> {
+        if let Err(mismatch) = self.validate_identity(expected) {
+            return Err(Box::new(WorkspaceImagePromotionIdentityFailure {
+                promotion: self,
+                mismatch,
+            }));
+        }
+        Ok(self.into_active_lease_unchecked(workspace_drive_available))
     }
 
     fn into_active_lease_unchecked(self, workspace_drive_available: bool) -> WorkspaceImageLease {

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1302,6 +1302,7 @@ impl WorkspaceImagePromotionContext {
             .await
     }
 
+    #[cfg(test)]
     pub(crate) fn try_into_active_lease(
         self,
         expected: &WorkspaceImagePromotionIdentity,
@@ -1309,6 +1310,13 @@ impl WorkspaceImagePromotionContext {
     ) -> Result<WorkspaceImageLease, WorkspaceImagePromotionIdentityMismatch> {
         self.validate_identity(expected)?;
         Ok(self.into_active_lease_unchecked(workspace_drive_available))
+    }
+
+    pub(crate) fn into_active_lease_after_identity_validation(
+        self,
+        workspace_drive_available: bool,
+    ) -> WorkspaceImageLease {
+        self.into_active_lease_unchecked(workspace_drive_available)
     }
 
     fn into_active_lease_unchecked(self, workspace_drive_available: bool) -> WorkspaceImageLease {

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -44,7 +44,9 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use lifecycle::{WorkspaceImageLease, WorkspaceImagePromotionContext};
+pub(crate) use lifecycle::{
+    WorkspaceImageLease, WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
+};
 pub(crate) use types::{
     CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
     WorkspaceImageActiveLeaseRequest, WorkspaceImageCacheInspection,

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -45,7 +45,8 @@ mod types;
 mod tests;
 
 pub(crate) use lifecycle::{
-    WorkspaceImageLease, WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
+    WorkspaceImageLease, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityFailure,
+    WorkspaceImagePromotionOutcome,
 };
 pub(crate) use types::{
     CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1343,6 +1343,211 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
 }
 
 #[tokio::test]
+async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let session_id = "sess-abandon-hit";
+    let cache_run_id = RunId::new_v4();
+    let cache_key = write_current_cache_entry(
+        &cache,
+        cache_run_id,
+        session_id,
+        "/workspace",
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let current = paths.session_workspace_cache_current_image(&cache_key);
+    let image_size_bytes = fs::metadata(&current).await.unwrap().len();
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
+    assert!(lease.consumed_cache_hit);
+    assert!(
+        !fs::try_exists(paths.session_workspace_cache_metadata(&cache_key))
+            .await
+            .unwrap()
+    );
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override: None,
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: "2026-05-02T00:00:00.000Z".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            promotable: true,
+        })
+        .unwrap();
+
+    assert!(
+        promotion
+            .abandon_unpublished("test abandoned cache hit")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !fs::try_exists(paths.session_workspace_cache_entry_dir(&cache_key))
+            .await
+            .unwrap()
+    );
+
+    let next = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(next.result(), WorkspaceCacheCheckoutResult::Miss);
+}
+
+#[tokio::test]
+async fn promotion_context_preserves_existing_newer_cache_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let session_id = "sess-preserve-existing";
+    let image_size_bytes = format!("image-{session_id}").len() as u64;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: Some(session_id),
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
+    let cache_key = write_current_cache_entry(
+        &cache,
+        RunId::new_v4(),
+        session_id,
+        "/workspace",
+        "2026-05-02T00:00:00.000Z",
+        "2026-05-02T00:00:00.000Z",
+    )
+    .await;
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override: None,
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: "2026-05-01T00:00:00.000Z".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            promotable: true,
+        })
+        .unwrap();
+
+    let outcome = promotion.promote().await.unwrap();
+
+    assert_eq!(outcome, WorkspaceImagePromotionOutcome::PreservedExisting);
+    drop(promotion);
+    let metadata = cache
+        .read_metadata_file(&paths.session_workspace_cache_metadata(&cache_key))
+        .await
+        .unwrap();
+    assert_eq!(metadata.last_completed_at, "2026-05-02T00:00:00.000Z");
+    assert!(
+        fs::try_exists(paths.session_workspace_cache_current_image(&cache_key))
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn no_lock_promotion_context_abandonment_preserves_existing_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let session_id = "sess-no-lock-abandon";
+    let cache_key = write_current_cache_entry(
+        &cache,
+        RunId::new_v4(),
+        session_id,
+        "/workspace",
+        "2026-05-02T00:00:00.000Z",
+        "2026-05-02T00:00:00.000Z",
+    )
+    .await;
+    let image_size_bytes = format!("image-{session_id}").len() as u64;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::NoSession);
+    let promotion = lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id,
+            cli_agent_session_id_override: Some(session_id),
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: "2026-05-01T00:00:00.000Z".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            promotable: true,
+        })
+        .unwrap();
+
+    assert!(
+        !promotion
+            .abandon_unpublished("test no lock abandon")
+            .await
+            .unwrap()
+    );
+    assert!(
+        fs::try_exists(paths.session_workspace_cache_metadata(&cache_key))
+            .await
+            .unwrap()
+    );
+    assert!(
+        fs::try_exists(paths.session_workspace_cache_current_image(&cache_key))
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
 async fn metadata_missing_current_present_is_not_a_cache_hit() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
@@ -4074,12 +4279,12 @@ async fn late_session_promotion_skips_when_entry_lock_is_busy() {
         .await
         .unwrap();
 
-    let promoted = tokio::time::timeout(std::time::Duration::from_secs(1), promotion.promote())
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), promotion.promote())
         .await
         .expect("late-session promotion must not block behind another runner's lock")
         .unwrap();
 
-    assert!(!promoted);
+    assert_eq!(outcome, WorkspaceImagePromotionOutcome::SkippedUnpublished);
     assert!(
         !paths
             .session_workspace_cache_current_image(&cache_key)

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1430,23 +1430,6 @@ async fn promotion_context_preserves_existing_newer_cache_entry() {
     tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
     let cache = SessionWorkspaceCache::new(paths.clone());
     let session_id = "sess-preserve-existing";
-    let image_size_bytes = format!("image-{session_id}").len() as u64;
-    let run_id = RunId::new_v4();
-    let sandbox_id = sandbox::SandboxId::new_v4();
-    let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id,
-                sandbox_id,
-                profile_name: TEST_PROFILE_NAME,
-                cli_agent_session_id: Some(session_id),
-                working_dir: "/workspace",
-                image_size_bytes,
-            },
-            workspace_drive_required: true,
-        })
-        .await;
-    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
     let cache_key = write_current_cache_entry(
         &cache,
         RunId::new_v4(),
@@ -1456,11 +1439,28 @@ async fn promotion_context_preserves_existing_newer_cache_entry() {
         "2026-05-02T00:00:00.000Z",
     )
     .await;
+    let image_size_bytes = format!("image-{session_id}").len() as u64;
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::NoSession);
     let promotion = lease
         .into_promotion_context(WorkspaceImagePromotionRequest {
             run_id,
             sandbox_id,
-            cli_agent_session_id_override: None,
+            cli_agent_session_id_override: Some(session_id),
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-01T00:00:00.000Z".into(),
             storage_fingerprints: StorageFingerprints::default(),

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -5,12 +5,20 @@ use sandbox::Sandbox;
 use tracing::warn;
 
 use crate::paths::diagnostic_session_fingerprint;
-use crate::workspace_image_cache::WorkspaceImagePromotionContext;
+use crate::workspace_image_cache::{
+    WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
+};
 use crate::workspace_mount::flush_and_unmount_workspace_drive;
+
+enum WorkspacePromotionAction {
+    Promoted,
+    PreservedExisting,
+    AbandonUnpublished,
+}
 
 pub(crate) async fn promote_workspace_image_from_active_sandbox(
     sandbox: &dyn Sandbox,
-    promotion: Option<&WorkspaceImagePromotionContext>,
+    promotion: Option<WorkspaceImagePromotionContext>,
     reason: &'static str,
 ) -> bool {
     let Some(promotion) = promotion else {
@@ -18,12 +26,17 @@ pub(crate) async fn promote_workspace_image_from_active_sandbox(
     };
 
     match AssertUnwindSafe(promote_workspace_image_from_active_sandbox_inner(
-        sandbox, promotion, reason,
+        sandbox, &promotion, reason,
     ))
     .catch_unwind()
     .await
     {
-        Ok(promoted) => promoted,
+        Ok(WorkspacePromotionAction::Promoted) => true,
+        Ok(WorkspacePromotionAction::PreservedExisting) => false,
+        Ok(WorkspacePromotionAction::AbandonUnpublished) => {
+            abandon_unpublished_workspace_promotion(Some(promotion), reason).await;
+            false
+        }
         Err(_) => {
             let session_fingerprint =
                 diagnostic_session_fingerprint(promotion.cli_agent_session_id());
@@ -35,6 +48,7 @@ pub(crate) async fn promote_workspace_image_from_active_sandbox(
                 reason,
                 "workspace image cache promotion panicked"
             );
+            abandon_unpublished_workspace_promotion(Some(promotion), reason).await;
             false
         }
     }
@@ -44,7 +58,7 @@ async fn promote_workspace_image_from_active_sandbox_inner(
     sandbox: &dyn Sandbox,
     promotion: &WorkspaceImagePromotionContext,
     reason: &'static str,
-) -> bool {
+) -> WorkspacePromotionAction {
     match flush_and_unmount_workspace_drive(sandbox, promotion.run_id()).await {
         Ok(()) => {}
         Err(e) => {
@@ -59,12 +73,18 @@ async fn promote_workspace_image_from_active_sandbox_inner(
                 error = %e,
                 "workspace image cache promotion skipped because guest unmount failed"
             );
-            return false;
+            return WorkspacePromotionAction::AbandonUnpublished;
         }
     }
 
     match promotion.promote().await {
-        Ok(promoted) => promoted,
+        Ok(WorkspaceImagePromotionOutcome::Promoted) => WorkspacePromotionAction::Promoted,
+        Ok(WorkspaceImagePromotionOutcome::PreservedExisting) => {
+            WorkspacePromotionAction::PreservedExisting
+        }
+        Ok(WorkspaceImagePromotionOutcome::SkippedUnpublished) => {
+            WorkspacePromotionAction::AbandonUnpublished
+        }
         Err(e) => {
             let session_fingerprint =
                 diagnostic_session_fingerprint(promotion.cli_agent_session_id());
@@ -77,14 +97,14 @@ async fn promote_workspace_image_from_active_sandbox_inner(
                 error = %e,
                 "workspace image cache promotion failed"
             );
-            false
+            WorkspacePromotionAction::AbandonUnpublished
         }
     }
 }
 
 pub(crate) async fn promote_workspace_image_from_parked_sandbox(
     sandbox: &mut dyn Sandbox,
-    promotion: Option<&WorkspaceImagePromotionContext>,
+    promotion: Option<WorkspaceImagePromotionContext>,
     reason: &'static str,
 ) -> bool {
     let Some(promotion) = promotion else {
@@ -105,6 +125,7 @@ pub(crate) async fn promote_workspace_image_from_parked_sandbox(
                 error = %e,
                 "workspace image cache promotion skipped because idle sandbox unpark failed"
             );
+            abandon_unpublished_workspace_promotion(Some(promotion), reason).await;
             return false;
         }
         Err(_) => {
@@ -118,11 +139,40 @@ pub(crate) async fn promote_workspace_image_from_parked_sandbox(
                 reason,
                 "workspace image cache promotion skipped because idle sandbox unpark panicked"
             );
+            abandon_unpublished_workspace_promotion(Some(promotion), reason).await;
             return false;
         }
     }
 
     promote_workspace_image_from_active_sandbox(sandbox, Some(promotion), reason).await
+}
+
+pub(crate) async fn abandon_unpublished_workspace_promotion(
+    promotion: Option<WorkspaceImagePromotionContext>,
+    reason: &'static str,
+) -> bool {
+    let Some(promotion) = promotion else {
+        return false;
+    };
+    let run_id = promotion.run_id();
+    let sandbox_id = promotion.sandbox_id();
+    let profile_name = promotion.profile_name().to_owned();
+    let session_fingerprint = diagnostic_session_fingerprint(promotion.cli_agent_session_id());
+    match promotion.abandon_unpublished(reason).await {
+        Ok(abandoned) => abandoned,
+        Err(e) => {
+            warn!(
+                run_id = %run_id,
+                sandbox_id = %sandbox_id,
+                profile_name,
+                session_fingerprint = %session_fingerprint,
+                reason,
+                error = %e,
+                "workspace image cache promotion context abandonment failed"
+            );
+            false
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -5,11 +5,13 @@ use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext, WorkspaceImagePromotionRequest,
+    SessionWorkspaceCache, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest, WorkspaceImagePromotionContext,
+    WorkspaceImagePromotionOutcome, WorkspaceImagePromotionRequest,
 };
 
 pub(crate) const TEST_COMPLETED_AT: &str = "2026-06-03T00:00:00.000Z";
+const TEST_WORKSPACE_IMAGE: &[u8] = b"workspace image";
 
 pub(crate) struct WorkspacePromotionFixture {
     pub(crate) _dir: tempfile::TempDir,
@@ -27,7 +29,6 @@ impl WorkspacePromotionFixture {
         let cache = SessionWorkspaceCache::new(paths.clone());
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
-        let image = b"workspace image";
         let workspace_image = cache
             .prepare(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
@@ -36,7 +37,7 @@ impl WorkspacePromotionFixture {
                     profile_name: "vm0/default",
                     cli_agent_session_id: Some(session_id),
                     working_dir: CANONICAL_WORKING_DIR,
-                    image_size_bytes: image.len() as u64,
+                    image_size_bytes: TEST_WORKSPACE_IMAGE.len() as u64,
                 },
                 workspace_drive_required: true,
             })
@@ -44,9 +45,12 @@ impl WorkspacePromotionFixture {
         tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
             .await
             .unwrap();
-        tokio::fs::write(paths.active_workspace_image(&sandbox_id), image)
-            .await
-            .unwrap();
+        tokio::fs::write(
+            paths.active_workspace_image(&sandbox_id),
+            TEST_WORKSPACE_IMAGE,
+        )
+        .await
+        .unwrap();
         let promotion = workspace_image
             .into_promotion_context(WorkspaceImagePromotionRequest {
                 run_id,
@@ -66,5 +70,77 @@ impl WorkspacePromotionFixture {
             sandbox_id,
             session_id: session_id.into(),
         }
+    }
+
+    pub(crate) async fn new_from_cache_hit(session_id: &str) -> Self {
+        let seed = Self::new(session_id).await;
+        assert_eq!(
+            seed.promotion.promote().await.unwrap(),
+            WorkspaceImagePromotionOutcome::Promoted
+        );
+        let Self {
+            _dir,
+            cache,
+            promotion,
+            sandbox_id: _,
+            session_id,
+        } = seed;
+        drop(promotion);
+
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some(&session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: TEST_WORKSPACE_IMAGE.len() as u64,
+                },
+                workspace_drive_required: true,
+            })
+            .await;
+        assert_eq!(workspace_image.result(), WorkspaceCacheCheckoutResult::Hit);
+        let promotion = workspace_image
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                cli_agent_session_id_override: Some(&session_id),
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-06-04T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+                promotable: true,
+            })
+            .expect("workspace image cache hit should be promotable");
+
+        Self {
+            _dir,
+            cache,
+            promotion,
+            sandbox_id,
+            session_id,
+        }
+    }
+
+    pub(crate) async fn checkout_result(
+        cache: &SessionWorkspaceCache,
+        session_id: &str,
+    ) -> WorkspaceCacheCheckoutResult {
+        cache
+            .prepare(WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id: RunId::new_v4(),
+                    sandbox_id: SandboxId::new_v4(),
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: TEST_WORKSPACE_IMAGE.len() as u64,
+                },
+                workspace_drive_required: true,
+            })
+            .await
+            .result()
     }
 }

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -13,6 +13,8 @@ use sandbox_mock::{ExecMatcher, MockSandboxFactory, MockSandboxOverrides};
 use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 
+use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
+
 async fn mock_sandbox_with_overrides(
     sandbox_id: SandboxId,
     overrides: Arc<MockSandboxOverrides>,
@@ -117,7 +119,7 @@ async fn parked_workspace_promotion_unparks_unmounts_and_promotes_cache_entry() 
 
     let promoted = promote_workspace_image_from_parked_sandbox(
         sandbox.as_mut(),
-        Some(&fixture.promotion),
+        Some(fixture.promotion),
         "test",
     )
     .await;
@@ -128,7 +130,6 @@ async fn parked_workspace_promotion_unparks_unmounts_and_promotes_cache_entry() 
     assert_eq!(exec_calls.len(), 1);
     assert!(exec_calls[0].sudo);
     assert!(exec_calls[0].cmd.contains("umount -- \"$workspace_dir\""));
-    drop(fixture.promotion);
     let states = fixture.cache.held_session_states().await;
     assert_eq!(states.len(), 1);
     assert_eq!(states[0].session_id, fixture.session_id);
@@ -146,7 +147,7 @@ async fn parked_workspace_promotion_unpark_error_skips_cache() {
 
     let promoted = promote_workspace_image_from_parked_sandbox(
         sandbox.as_mut(),
-        Some(&fixture.promotion),
+        Some(fixture.promotion),
         "test",
     )
     .await;
@@ -154,8 +155,34 @@ async fn parked_workspace_promotion_unpark_error_skips_cache() {
     assert!(!promoted);
     assert_eq!(overrides.unpark_call_count(), 1);
     assert!(overrides.exec_calls().is_empty());
-    drop(fixture.promotion);
     assert!(fixture.cache.held_session_states().await.is_empty());
+}
+
+#[tokio::test]
+async fn parked_workspace_promotion_unpark_error_abandons_consumed_cache_hit() {
+    let fixture = WorkspacePromotionFixture::new_from_cache_hit("sess-hit-unpark-error").await;
+    let cache = fixture.cache.clone();
+    let session_id = fixture.session_id.clone();
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated unpark failure".into(),
+    }));
+    let mut sandbox = mock_sandbox_with_overrides(fixture.sandbox_id, Arc::clone(&overrides)).await;
+
+    let promoted = promote_workspace_image_from_parked_sandbox(
+        sandbox.as_mut(),
+        Some(fixture.promotion),
+        "test",
+    )
+    .await;
+
+    assert!(!promoted);
+    assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(
+        WorkspacePromotionFixture::checkout_result(&cache, &session_id).await,
+        WorkspaceCacheCheckoutResult::Miss
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -171,7 +198,7 @@ async fn parked_workspace_promotion_warning_uses_session_fingerprint() {
 
     let (promoted, events) = capture_promotion_events(promote_workspace_image_from_parked_sandbox(
         sandbox.as_mut(),
-        Some(&fixture.promotion),
+        Some(fixture.promotion),
         "test",
     ))
     .await;
@@ -201,7 +228,7 @@ async fn parked_workspace_promotion_unpark_panic_skips_cache() {
 
     let promoted = promote_workspace_image_from_parked_sandbox(
         sandbox.as_mut(),
-        Some(&fixture.promotion),
+        Some(fixture.promotion),
         "test",
     )
     .await;
@@ -209,7 +236,6 @@ async fn parked_workspace_promotion_unpark_panic_skips_cache() {
     assert!(!promoted);
     assert_eq!(overrides.unpark_call_count(), 1);
     assert!(overrides.exec_calls().is_empty());
-    drop(fixture.promotion);
     assert!(fixture.cache.held_session_states().await.is_empty());
 }
 
@@ -227,7 +253,7 @@ async fn parked_workspace_promotion_guest_unmount_failure_skips_cache() {
 
     let promoted = promote_workspace_image_from_parked_sandbox(
         sandbox.as_mut(),
-        Some(&fixture.promotion),
+        Some(fixture.promotion),
         "test",
     )
     .await;
@@ -235,7 +261,6 @@ async fn parked_workspace_promotion_guest_unmount_failure_skips_cache() {
     assert!(!promoted);
     assert_eq!(overrides.unpark_call_count(), 1);
     assert_eq!(overrides.exec_calls().len(), 1);
-    drop(fixture.promotion);
     assert!(fixture.cache.held_session_states().await.is_empty());
 }
 
@@ -245,11 +270,10 @@ async fn parked_workspace_promotion_guest_exec_panic_skips_cache() {
     let mut sandbox = PanicExecSandbox::new("parked-exec-panic");
 
     let promoted =
-        promote_workspace_image_from_parked_sandbox(&mut sandbox, Some(&fixture.promotion), "test")
+        promote_workspace_image_from_parked_sandbox(&mut sandbox, Some(fixture.promotion), "test")
             .await;
 
     assert!(!promoted);
-    drop(fixture.promotion);
     assert!(fixture.cache.held_session_states().await.is_empty());
 }
 


### PR DESCRIPTION
## Summary
- add typed workspace promotion outcomes so skipped publication is distinct from preserving a newer cache entry
- consume promotion contexts at active/parked promotion boundaries and explicitly abandon unpublished owned cache state on failed unmount, unpark, panic, or skipped promotion
- preserve no-lock late-session entries and newer existing cache entries, with regression coverage for consumed cache-hit abandonment

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_promotion
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache
- cargo test --manifest-path crates/Cargo.toml -p runner idle_pool
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings

Closes #18449