### PR TITLE
ci: test runner image build on 16 cores

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -24,12 +24,18 @@ runs:
       env:
         CLOUDFLARED_VERSION: ${{ inputs.cloudflared-version }}
       run: |
+        deb_arch="$(dpkg --print-architecture)"
+        case "$deb_arch" in
+          amd64) cloudflared_arch=amd64 ;;
+          arm64) cloudflared_arch=arm64 ;;
+          *) echo "Unsupported cloudflared architecture: ${deb_arch}" >&2; exit 1 ;;
+        esac
         curl -sfL \
           --retry 5 \
           --retry-delay 2 \
           --retry-max-time 60 \
           --retry-all-errors \
-          "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" \
+          "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${cloudflared_arch}.deb" \
           -o /tmp/cloudflared.deb
         if command -v sudo &>/dev/null; then
           sudo dpkg -i /tmp/cloudflared.deb

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -198,7 +198,7 @@ jobs:
         run: .github/scripts/runner-image-context.sh artifact-name
 
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-24.04-arm
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:
@@ -238,7 +238,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          shared-key: aarch64-musl-ci
+          shared-key: aarch64-musl-ci-arm64-host
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup SSH via Cloudflare Tunnel

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -198,7 +198,7 @@ jobs:
         run: .github/scripts/runner-image-context.sh artifact-name
 
   build:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest-16-cores
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
     permissions:
@@ -238,7 +238,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: crates -> target
-          shared-key: aarch64-musl-ci-arm64-host
+          shared-key: aarch64-musl-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup SSH via Cloudflare Tunnel


### PR DESCRIPTION
## Summary
- run the runner-image build job on the x64 larger runner label `ubuntu-latest-16-cores`
- keep the target triple as `aarch64-unknown-linux-musl`, so the runner and guest binaries remain the same target artifacts
- keep the existing x64 Rust cache shared key (`aarch64-musl-ci`) for a fair comparison with the current `ubuntu-latest-8-cores` path
- make `setup-ssh-tunnel` install the matching cloudflared deb for `amd64` or `arm64`, preserving the compatibility issue found during the ARM runner experiment

## Validation
- `git diff --check`
- YAML parse with `python3`
- pre-commit hook: applicable checks passed

## Measurement
This PR is intended to let CI measure whether the `ubuntu-latest-16-cores` runner-image build is faster than the current `ubuntu-latest-8-cores` cross-compile job.
