### PR TITLE
fix: unblock 0480 workflow migration duplicate rows

### DIFF
--- a/turbo/packages/db/src/__tests__/migrations/0480_agent_scoped_workflows.test.ts
+++ b/turbo/packages/db/src/__tests__/migrations/0480_agent_scoped_workflows.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migrationSql = readFileSync(
+  new URL("../../migrations/0480_agent_scoped_workflows.sql", import.meta.url),
+  "utf8",
+);
+
+describe("migration 0480 agent-scoped workflows", () => {
+  it("drops the old org/name unique index before duplicating multi-bound workflows", () => {
+    const dropOrgNameIndex = migrationSql.search(
+      /DROP INDEX(?: IF EXISTS)? "idx_zero_workflows_org_name"/,
+    );
+    const duplicateMultiBoundWorkflows = migrationSql.indexOf(
+      'INSERT INTO "zero_workflows"',
+    );
+
+    expect(dropOrgNameIndex).toBeGreaterThanOrEqual(0);
+    expect(duplicateMultiBoundWorkflows).toBeGreaterThanOrEqual(0);
+    expect(dropOrgNameIndex).toBeLessThan(duplicateMultiBoundWorkflows);
+  });
+});

--- a/turbo/packages/db/src/migrations/0480_agent_scoped_workflows.sql
+++ b/turbo/packages/db/src/migrations/0480_agent_scoped_workflows.sql
@@ -23,7 +23,11 @@ FROM (
 ) sub
 WHERE w."id" = sub."workflow_id" AND w."agent_id" IS NULL;--> statement-breakpoint
 
--- 3. Duplicate multi-bound workflows: one independent row per additional agent.
+-- 3. slug (name) is no longer unique per org. Drop this before duplicating
+--    multi-bound workflows because those rows intentionally keep the same slug.
+DROP INDEX IF EXISTS "idx_zero_workflows_org_name";--> statement-breakpoint
+
+-- 4. Duplicate multi-bound workflows: one independent row per additional agent.
 INSERT INTO "zero_workflows" (
   "org_id", "agent_id", "name", "visibility", "request_to_publish", "type",
   "active", "preference", "instruction", "owner_user_id", "display_name",
@@ -37,7 +41,7 @@ FROM "zero_workflow_agents" wa
 JOIN "zero_workflows" w ON w."id" = wa."workflow_id"
 WHERE wa."agent_id" <> w."agent_id";--> statement-breakpoint
 
--- 4. Backfill agent_id from triggers for rows with no junction (goals, whose
+-- 5. Backfill agent_id from triggers for rows with no junction (goals, whose
 --    only agent link is their thread-idle trigger, and any workflow whose
 --    junction row was lost but whose trigger still points at an agent).
 UPDATE "zero_workflows" w
@@ -50,17 +54,14 @@ FROM (
 ) sub
 WHERE w."id" = sub."workflow_id" AND w."agent_id" IS NULL;--> statement-breakpoint
 
--- 5. Delete true-orphan workflows (no junction, no trigger agent). Goals are
+-- 6. Delete true-orphan workflows (no junction, no trigger agent). Goals are
 --    never deleted here; a goal without an agent is a separate bug to fix.
 DELETE FROM "zero_workflows" WHERE "type" = 'workflow' AND "agent_id" IS NULL;--> statement-breakpoint
 
--- 6. Enforce hard 1:N ownership.
+-- 7. Enforce hard 1:N ownership.
 ALTER TABLE "zero_workflows" ALTER COLUMN "agent_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "zero_workflows" ADD CONSTRAINT "zero_workflows_agent_id_zero_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."zero_agents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "idx_zero_workflows_agent" ON "zero_workflows" USING btree ("agent_id","name");--> statement-breakpoint
-
--- 7. slug (name) is no longer unique per org.
-DROP INDEX "idx_zero_workflows_org_name";--> statement-breakpoint
 
 -- 8. The agent link now lives only on the workflow row.
 ALTER TABLE "zero_workflow_triggers" DROP CONSTRAINT "zero_workflow_triggers_agent_id_zero_agents_id_fk";--> statement-breakpoint


### PR DESCRIPTION
## Summary
- drop the old zero_workflows org/name unique index before duplicating multi-bound workflow rows in migration 0480
- add a regression test that asserts the index drop stays before the duplicate insert

## Why
Production migration failed while duplicating a multi-bound workflow with the same org/name slug because idx_zero_workflows_org_name was still present.

## Test
- DATABASE_URL=postgresql://unused:unused@127.0.0.1:5432/unused pnpm --filter @vm0/db test src/__tests__/migrations/0480_agent_scoped_workflows.test.ts