### PR TITLE
ci: support arm64 cloudflared setup

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -24,12 +24,18 @@ runs:
       env:
         CLOUDFLARED_VERSION: ${{ inputs.cloudflared-version }}
       run: |
+        deb_arch="$(dpkg --print-architecture)"
+        case "$deb_arch" in
+          amd64) cloudflared_arch=amd64 ;;
+          arm64) cloudflared_arch=arm64 ;;
+          *) echo "Unsupported cloudflared architecture: ${deb_arch}" >&2; exit 1 ;;
+        esac
         curl -sfL \
           --retry 5 \
           --retry-delay 2 \
           --retry-max-time 60 \
           --retry-all-errors \
-          "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" \
+          "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${cloudflared_arch}.deb" \
           -o /tmp/cloudflared.deb
         if command -v sudo &>/dev/null; then
           sudo dpkg -i /tmp/cloudflared.deb


### PR DESCRIPTION
## Summary
- make the shared `setup-ssh-tunnel` action choose the cloudflared deb package from the current runner architecture
- keep existing amd64 behavior unchanged
- allow arm64 GitHub-hosted runners to install `cloudflared-linux-arm64.deb` instead of failing on the amd64 package

## Validation
- `git diff --check`
- YAML parse with `python3`
- pre-commit hook: applicable checks passed

## Notes
This PR intentionally does not include the runner-image ARM or 16-core runner experiments.
