### PR TITLE
chore: expose cli termination diagnostics

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -120,13 +120,15 @@ impl CliTerminationDiagnostic {
         signal_pgid: Option<i32>,
         signal_grace_ms: Option<u64>,
     ) -> Self {
-        if matches!(
+        let should_update = matches!(
             (self.signal_sent, signal_sent),
-            (
-                Some(CliTerminationSignal::Sigkill),
-                CliTerminationSignal::Sigterm
-            )
-        ) {
+            (None, _)
+                | (
+                    Some(CliTerminationSignal::Sigterm),
+                    CliTerminationSignal::Sigkill
+                )
+        );
+        if !should_update {
             return self;
         }
         if matches!(signal_sent, CliTerminationSignal::Sigkill) {
@@ -485,14 +487,14 @@ mod tests {
     }
 
     #[test]
-    fn cli_termination_repeated_sigterm_does_not_mark_escalated() {
+    fn cli_termination_repeated_sigterm_does_not_overwrite_original_signal() {
         let diagnostic = CliTerminationDiagnostic::new(CliTerminationReason::HeartbeatError)
             .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(1_000))
             .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(2_000));
 
         assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigterm));
         assert_eq!(diagnostic.signal_pgid, Some(42));
-        assert_eq!(diagnostic.signal_grace_ms, Some(2_000));
+        assert_eq!(diagnostic.signal_grace_ms, Some(1_000));
         assert!(!diagnostic.escalated);
     }
 

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -11,6 +11,7 @@ pub struct FailureDiagnostic {
     pub failure_class: FailureClass,
     pub framework: AgentFramework,
     pub cli_exit_code: Option<i32>,
+    pub cli_termination: Option<CliTerminationDiagnostic>,
     pub claude_num_turns: Option<u64>,
     pub failure_detail_source: Option<FailureDetailSource>,
     pub failure_reason: Option<FailureReason>,
@@ -32,6 +33,7 @@ impl FailureDiagnostic {
             failure_class,
             framework,
             cli_exit_code: None,
+            cli_termination: None,
             claude_num_turns: None,
             failure_detail_source: None,
             failure_reason: None,
@@ -45,6 +47,12 @@ impl FailureDiagnostic {
     #[must_use]
     pub fn with_cli_exit_code(mut self, cli_exit_code: i32) -> Self {
         self.cli_exit_code = Some(cli_exit_code);
+        self
+    }
+
+    #[must_use]
+    pub fn with_cli_termination(mut self, cli_termination: CliTerminationDiagnostic) -> Self {
+        self.cli_termination = Some(cli_termination);
         self
     }
 
@@ -76,6 +84,110 @@ impl FailureDiagnostic {
     ) -> Self {
         self.session_history_status = session_history_status;
         self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliTerminationDiagnostic {
+    pub initiator: CliTerminationInitiator,
+    pub reason: CliTerminationReason,
+    pub signal_sent: Option<CliTerminationSignal>,
+    pub signal_pgid: Option<i32>,
+    pub signal_grace_ms: Option<u64>,
+    pub escalated: bool,
+    pub observed_exit_code: Option<i32>,
+}
+
+impl CliTerminationDiagnostic {
+    #[must_use]
+    pub const fn new(reason: CliTerminationReason) -> Self {
+        Self {
+            initiator: CliTerminationInitiator::GuestAgent,
+            reason,
+            signal_sent: None,
+            signal_pgid: None,
+            signal_grace_ms: None,
+            escalated: false,
+            observed_exit_code: None,
+        }
+    }
+
+    #[must_use]
+    pub fn record_signal(
+        mut self,
+        signal_sent: CliTerminationSignal,
+        signal_pgid: Option<i32>,
+        signal_grace_ms: Option<u64>,
+    ) -> Self {
+        if self.signal_sent.is_some() || matches!(signal_sent, CliTerminationSignal::Sigkill) {
+            self.escalated = true;
+        }
+        self.signal_sent = Some(signal_sent);
+        self.signal_pgid = signal_pgid;
+        self.signal_grace_ms = signal_grace_ms;
+        self
+    }
+
+    #[must_use]
+    pub fn with_observed_exit_code(mut self, observed_exit_code: i32) -> Self {
+        self.observed_exit_code = Some(observed_exit_code);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliTerminationInitiator {
+    GuestAgent,
+}
+
+impl CliTerminationInitiator {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::GuestAgent => "guest_agent",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliTerminationReason {
+    PostResultReap,
+    StuckToolWatchdog,
+    HeartbeatError,
+    HeartbeatPanic,
+    InitialPromptStdin,
+}
+
+impl CliTerminationReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PostResultReap => "post_result_reap",
+            Self::StuckToolWatchdog => "stuck_tool_watchdog",
+            Self::HeartbeatError => "heartbeat_error",
+            Self::HeartbeatPanic => "heartbeat_panic",
+            Self::InitialPromptStdin => "initial_prompt_stdin",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliTerminationSignal {
+    Sigterm,
+    Sigkill,
+}
+
+impl CliTerminationSignal {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sigterm => "sigterm",
+            Self::Sigkill => "sigkill",
+        }
     }
 }
 
@@ -308,6 +420,62 @@ mod tests {
     }
 
     #[test]
+    fn failure_diagnostic_serializes_cli_termination() {
+        let cli_termination = CliTerminationDiagnostic::new(CliTerminationReason::PostResultReap)
+            .record_signal(CliTerminationSignal::Sigterm, Some(1401), Some(10_000))
+            .with_observed_exit_code(143);
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(143)
+        .with_cli_termination(cli_termination);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(
+            json["cliTermination"],
+            serde_json::json!({
+                "initiator": "guest_agent",
+                "reason": "post_result_reap",
+                "signalSent": "sigterm",
+                "signalPgid": 1401,
+                "signalGraceMs": 10_000,
+                "escalated": false,
+                "observedExitCode": 143
+            })
+        );
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_reason_and_cli_termination_reason_are_independent() {
+        let cli_termination =
+            CliTerminationDiagnostic::new(CliTerminationReason::StuckToolWatchdog)
+                .record_signal(CliTerminationSignal::Sigkill, Some(234), Some(1_000))
+                .with_observed_exit_code(137);
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(137)
+        .with_failure_reason(FailureReason::ProviderOverloaded)
+        .with_cli_termination(cli_termination);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "provider_overloaded");
+        assert_eq!(json["cliTermination"]["reason"], "stuck_tool_watchdog");
+        assert_eq!(json["cliTermination"]["signalSent"], "sigkill");
+        assert_eq!(json["cliTermination"]["escalated"], true);
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
     fn failure_diagnostic_serializes_usage_limit_reason() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -415,5 +583,6 @@ mod tests {
 
         assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
+        assert_eq!(diagnostic.cli_termination, None);
     }
 }

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -113,6 +113,11 @@ impl CliTerminationDiagnostic {
         }
     }
 
+    /// Record the first attempted signal, then only update on SIGTERM -> SIGKILL escalation.
+    ///
+    /// Multiple watchdog paths may observe the same child before `wait()` completes. Keeping this
+    /// monotonic prevents a later duplicate signal from rewriting the original termination
+    /// attribution fields.
     #[must_use]
     pub fn record_signal(
         mut self,
@@ -504,6 +509,19 @@ mod tests {
             .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(10_000))
             .record_signal(CliTerminationSignal::Sigkill, Some(42), Some(1_000))
             .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(10_000));
+
+        assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigkill));
+        assert_eq!(diagnostic.signal_pgid, Some(42));
+        assert_eq!(diagnostic.signal_grace_ms, Some(1_000));
+        assert!(diagnostic.escalated);
+    }
+
+    #[test]
+    fn cli_termination_repeated_sigkill_does_not_overwrite_escalation_signal() {
+        let diagnostic = CliTerminationDiagnostic::new(CliTerminationReason::StuckToolWatchdog)
+            .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(10_000))
+            .record_signal(CliTerminationSignal::Sigkill, Some(42), Some(1_000))
+            .record_signal(CliTerminationSignal::Sigkill, Some(99), Some(2_000));
 
         assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigkill));
         assert_eq!(diagnostic.signal_pgid, Some(42));

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -120,7 +120,16 @@ impl CliTerminationDiagnostic {
         signal_pgid: Option<i32>,
         signal_grace_ms: Option<u64>,
     ) -> Self {
-        if self.signal_sent.is_some() || matches!(signal_sent, CliTerminationSignal::Sigkill) {
+        if matches!(
+            (self.signal_sent, signal_sent),
+            (
+                Some(CliTerminationSignal::Sigkill),
+                CliTerminationSignal::Sigterm
+            )
+        ) {
+            return self;
+        }
+        if matches!(signal_sent, CliTerminationSignal::Sigkill) {
             self.escalated = true;
         }
         self.signal_sent = Some(signal_sent);
@@ -473,6 +482,31 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn cli_termination_repeated_sigterm_does_not_mark_escalated() {
+        let diagnostic = CliTerminationDiagnostic::new(CliTerminationReason::HeartbeatError)
+            .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(1_000))
+            .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(2_000));
+
+        assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigterm));
+        assert_eq!(diagnostic.signal_pgid, Some(42));
+        assert_eq!(diagnostic.signal_grace_ms, Some(2_000));
+        assert!(!diagnostic.escalated);
+    }
+
+    #[test]
+    fn cli_termination_sigkill_is_not_downgraded_by_late_sigterm() {
+        let diagnostic = CliTerminationDiagnostic::new(CliTerminationReason::PostResultReap)
+            .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(10_000))
+            .record_signal(CliTerminationSignal::Sigkill, Some(42), Some(1_000))
+            .record_signal(CliTerminationSignal::Sigterm, Some(42), Some(10_000));
+
+        assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigkill));
+        assert_eq!(diagnostic.signal_pgid, Some(42));
+        assert_eq!(diagnostic.signal_grace_ms, Some(1_000));
+        assert!(diagnostic.escalated);
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -36,7 +36,10 @@ use crate::http::HttpClient;
 use crate::masker::SecretMasker;
 use crate::paths;
 use crate::timing;
-use agent_diagnostics::{FailureDetailSource, FailureReason};
+use agent_diagnostics::{
+    CliTerminationDiagnostic, CliTerminationReason as DiagnosticTerminationReason,
+    CliTerminationSignal, FailureDetailSource, FailureReason,
+};
 use event_delivery::{AckedEventPrefix, PreparedEvent};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
@@ -158,7 +161,7 @@ pub struct CliFailureDiagnostic {
 ///
 /// The guest agent uses this summary to report final run status and to persist
 /// the event-drain watermark consumed by host/API clients.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct CliExecutionResult {
     /// Process exit code for the CLI.
     ///
@@ -197,6 +200,14 @@ pub struct CliExecutionResult {
     /// stderr. Keeping the diagnostic here lets the guest-agent surface the
     /// actual failure reason in its final run error.
     pub failure_diagnostic: Option<CliFailureDiagnostic>,
+
+    /// Guest-agent control-path error that caused the CLI process group to be
+    /// terminated after a meaningful process summary could still be collected.
+    pub control_error: Option<AgentError>,
+
+    /// Structured attribution for guest-agent initiated CLI process-group
+    /// termination.
+    pub cli_termination: Option<CliTerminationDiagnostic>,
 }
 
 /// Heartbeat completion signal observed by [`execute_cli`].
@@ -387,6 +398,7 @@ async fn execute_cli_inner(
     tokio::pin!(termination_deadline);
     let mut termination_state = TerminationState::Idle;
     let mut termination_error: Option<AgentError> = None;
+    let mut cli_termination: Option<CliTerminationDiagnostic> = None;
 
     // Stuck-tool watchdog: workaround for Claude Code bug where
     // WebSearch/WebFetch hang indefinitely. Track all in-flight tool calls;
@@ -459,9 +471,17 @@ async fn execute_cli_inner(
                             "Claude stdin writer failed, SIGTERM pgid={}: {error}",
                             pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                         );
+                        record_cli_termination_signal(
+                            &mut cli_termination,
+                            TerminationReason::InitialPromptStdin,
+                            CliTerminationSignal::Sigterm,
+                            pgid,
+                            env::post_result_sigkill_grace_secs(),
+                        );
                         if let Some(pid) = pgid {
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
+                        termination_error = Some(error);
                         termination_state = TerminationState::SigkillPending {
                             reason: TerminationReason::InitialPromptStdin,
                         };
@@ -480,9 +500,19 @@ async fn execute_cli_inner(
                             "Claude stdin writer task failed, SIGTERM pgid={}: {error}",
                             pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                         );
+                        record_cli_termination_signal(
+                            &mut cli_termination,
+                            TerminationReason::InitialPromptStdin,
+                            CliTerminationSignal::Sigterm,
+                            pgid,
+                            env::post_result_sigkill_grace_secs(),
+                        );
                         if let Some(pid) = pgid {
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
+                        termination_error = Some(AgentError::Execution(format!(
+                            "Claude stdin writer task failed: {error}"
+                        )));
                         termination_state = TerminationState::SigkillPending {
                             reason: TerminationReason::InitialPromptStdin,
                         };
@@ -709,6 +739,13 @@ async fn execute_cli_inner(
                                     reason.label()
                                 );
                             }
+                            record_cli_termination_signal(
+                                &mut cli_termination,
+                                reason,
+                                CliTerminationSignal::Sigterm,
+                                pgid,
+                                grace,
+                            );
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
                         termination_state = TerminationState::SigkillPending { reason };
@@ -724,6 +761,13 @@ async fn execute_cli_inner(
                                 LOG_TAG,
                                 "CLI did not exit after {} SIGTERM+{grace}s, SIGKILL pgid={pid}",
                                 reason.label()
+                            );
+                            record_cli_termination_signal(
+                                &mut cli_termination,
+                                reason,
+                                CliTerminationSignal::Sigkill,
+                                pgid,
+                                grace,
                             );
                             unsafe { libc::kill(-pid, libc::SIGKILL); }
                         }
@@ -776,6 +820,13 @@ async fn execute_cli_inner(
                         "Tool timeout: {name} stuck for {elapsed}s, SIGTERM pgid={}",
                         pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                     );
+                    record_cli_termination_signal(
+                        &mut cli_termination,
+                        TerminationReason::StuckTool,
+                        CliTerminationSignal::Sigterm,
+                        pgid,
+                        env::post_result_sigkill_grace_secs(),
+                    );
                     if let Some(pid) = pgid {
                         unsafe { libc::kill(-pid, libc::SIGTERM); }
                     }
@@ -808,6 +859,13 @@ async fn execute_cli_inner(
                                 "Heartbeat failed, SIGTERM pgid={}",
                                 pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                             );
+                            record_cli_termination_signal(
+                                &mut cli_termination,
+                                TerminationReason::HeartbeatError,
+                                CliTerminationSignal::Sigterm,
+                                pgid,
+                                env::post_result_sigkill_grace_secs(),
+                            );
                             if let Some(pid) = pgid {
                                 unsafe { libc::kill(-pid, libc::SIGTERM); }
                             }
@@ -833,6 +891,13 @@ async fn execute_cli_inner(
                                 "Heartbeat task panicked, SIGTERM pgid={}",
                                 pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
                             );
+                            record_cli_termination_signal(
+                                &mut cli_termination,
+                                TerminationReason::HeartbeatPanic,
+                                CliTerminationSignal::Sigterm,
+                                pgid,
+                                env::post_result_sigkill_grace_secs(),
+                            );
                             if let Some(pid) = pgid {
                                 unsafe { libc::kill(-pid, libc::SIGTERM); }
                             }
@@ -853,6 +918,13 @@ async fn execute_cli_inner(
                                 LOG_TAG,
                                 "Heartbeat task stopped before reporting status, SIGTERM pgid={}",
                                 pgid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+                            );
+                            record_cli_termination_signal(
+                                &mut cli_termination,
+                                TerminationReason::HeartbeatPanic,
+                                CliTerminationSignal::Sigterm,
+                                pgid,
+                                env::post_result_sigkill_grace_secs(),
                             );
                             if let Some(pid) = pgid {
                                 unsafe { libc::kill(-pid, libc::SIGTERM); }
@@ -897,9 +969,11 @@ async fn execute_cli_inner(
         }
     }
 
-    let event_result = match termination_error {
-        Some(err) => Err(err),
-        None => event_result,
+    let has_control_error = termination_error.is_some();
+    let event_error = if has_control_error {
+        None
+    } else {
+        event_result.err()
     };
 
     // Close the channel so the background sender can finish.
@@ -907,7 +981,7 @@ async fn execute_cli_inner(
     // so we drop unsent events to avoid stalling on retries.
     drop(event_tx);
     let mut last_event_sequence = None;
-    if event_result.is_ok() {
+    if event_error.is_none() && !has_control_error {
         match event_sender.await {
             Ok(sequence) => {
                 last_event_sequence = sequence;
@@ -982,8 +1056,12 @@ async fn execute_cli_inner(
     };
     let masked_stderr_lines = masker.mask_diagnostic_lines(stderr_lines);
 
-    // If event loop had an error, propagate it
-    event_result?;
+    let cli_termination =
+        cli_termination.map(|diagnostic| diagnostic.with_observed_exit_code(exit_code));
+
+    if let Some(err) = event_error {
+        return Err(err);
+    }
 
     Ok(CliExecutionResult {
         exit_code,
@@ -991,7 +1069,33 @@ async fn execute_cli_inner(
         last_event_sequence,
         claude_result,
         failure_diagnostic,
+        control_error: termination_error,
+        cli_termination,
     })
+}
+
+fn record_cli_termination_signal(
+    cli_termination: &mut Option<CliTerminationDiagnostic>,
+    reason: TerminationReason,
+    signal: CliTerminationSignal,
+    pgid: Option<i32>,
+    grace_secs: u64,
+) {
+    let diagnostic = cli_termination
+        .take()
+        .unwrap_or_else(|| CliTerminationDiagnostic::new(diagnostic_termination_reason(reason)));
+    *cli_termination =
+        Some(diagnostic.record_signal(signal, pgid, Some(grace_secs.saturating_mul(1000))));
+}
+
+fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTerminationReason {
+    match reason {
+        TerminationReason::PostResult => DiagnosticTerminationReason::PostResultReap,
+        TerminationReason::InitialPromptStdin => DiagnosticTerminationReason::InitialPromptStdin,
+        TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,
+        TerminationReason::HeartbeatError => DiagnosticTerminationReason::HeartbeatError,
+        TerminationReason::HeartbeatPanic => DiagnosticTerminationReason::HeartbeatPanic,
+    }
 }
 
 fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<(), AgentError> {
@@ -1062,10 +1166,13 @@ fn with_carried_failure_reason(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliFailureDiagnostic, claude_initial_prompt_frame, select_failure_diagnostic,
-        set_cli_current_dir, with_carried_failure_reason,
+        CliFailureDiagnostic, TerminationReason, claude_initial_prompt_frame,
+        record_cli_termination_signal, select_failure_diagnostic, set_cli_current_dir,
+        with_carried_failure_reason,
     };
-    use agent_diagnostics::{FailureDetailSource, FailureReason};
+    use agent_diagnostics::{
+        CliTerminationReason, CliTerminationSignal, FailureDetailSource, FailureReason,
+    };
 
     #[test]
     fn claude_initial_prompt_frame_matches_stream_json_user_shape() {
@@ -1098,6 +1205,42 @@ mod tests {
             .and_then(serde_json::Value::as_str)
             .expect("uuid");
         uuid::Uuid::parse_str(uuid).expect("valid uuid");
+    }
+
+    #[test]
+    fn cli_termination_signal_records_initial_prompt_stdin_and_escalation() {
+        let mut diagnostic = None;
+
+        record_cli_termination_signal(
+            &mut diagnostic,
+            TerminationReason::InitialPromptStdin,
+            CliTerminationSignal::Sigterm,
+            Some(42),
+            1,
+        );
+
+        let first = diagnostic.expect("diagnostic after SIGTERM");
+        assert_eq!(first.reason, CliTerminationReason::InitialPromptStdin);
+        assert_eq!(first.signal_sent, Some(CliTerminationSignal::Sigterm));
+        assert_eq!(first.signal_pgid, Some(42));
+        assert_eq!(first.signal_grace_ms, Some(1_000));
+        assert!(!first.escalated);
+
+        let mut diagnostic = Some(first);
+        record_cli_termination_signal(
+            &mut diagnostic,
+            TerminationReason::InitialPromptStdin,
+            CliTerminationSignal::Sigkill,
+            Some(42),
+            2,
+        );
+
+        let escalated = diagnostic.expect("diagnostic after SIGKILL");
+        assert_eq!(escalated.reason, CliTerminationReason::InitialPromptStdin);
+        assert_eq!(escalated.signal_sent, Some(CliTerminationSignal::Sigkill));
+        assert_eq!(escalated.signal_pgid, Some(42));
+        assert_eq!(escalated.signal_grace_ms, Some(2_000));
+        assert!(escalated.escalated);
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -205,6 +205,7 @@ async fn execute(
         error_message,
         skip_recovery_checkpoint_for_no_history,
         failure_diagnostic,
+        cli_execution_succeeded,
     ) = match cli::execute_cli_with_active_input(
         masker,
         heartbeat_monitor,
@@ -224,7 +225,7 @@ async fn execute(
                     cli_result.claude_result,
                 );
                 let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
-                (cli_exit_code, 1, msg, false, Some(diagnostic))
+                (cli_exit_code, 1, msg, false, Some(diagnostic), false)
             } else if cli_exit_code != 0 {
                 let failure_message = cli_failure_message(
                     cli_exit_code,
@@ -249,6 +250,7 @@ async fn execute(
                     failure_message.message,
                     false,
                     Some(diagnostic),
+                    false,
                 )
             } else if http.has_api()
                 && is_claude_zero_turn_result(env::Framework::from_env(), &cli_result)
@@ -268,12 +270,19 @@ async fn execute(
                         .with_cli_exit_code(cli_exit_code)
                         .with_claude_num_turns(Some(0))
                         .with_session_history_status(session_history_status);
-                    (cli_exit_code, 1, msg.to_string(), true, Some(diagnostic))
+                    (
+                        cli_exit_code,
+                        1,
+                        msg.to_string(),
+                        true,
+                        Some(diagnostic),
+                        true,
+                    )
                 } else {
-                    (0, 0, String::new(), false, None)
+                    (0, 0, String::new(), false, None, true)
                 }
             } else {
-                (0, 0, String::new(), false, None)
+                (0, 0, String::new(), false, None, true)
             }
         }
         Err(e) => {
@@ -285,6 +294,7 @@ async fn execute(
                 msg,
                 false,
                 Some(base_failure_diagnostic(FailureClass::CliExecutionError)),
+                false,
             )
         }
     };
@@ -292,11 +302,11 @@ async fn execute(
     record_sandbox_op(
         "cli_execution",
         cli_elapsed,
-        cli_exit_code == 0,
-        if cli_exit_code != 0 {
-            Some(error_message.as_str())
-        } else {
+        cli_execution_succeeded,
+        if cli_execution_succeeded {
             None
+        } else {
+            Some(error_message.as_str())
         },
     );
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -15,8 +15,8 @@ use guest_agent::session_metadata;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
 use agent_diagnostics::{
-    AgentFramework, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
-    PromptMetadata, SessionHistoryStatus,
+    AgentFramework, CliTerminationDiagnostic, FailureClass, FailureDetailSource, FailureDiagnostic,
+    FailureReason, PromptMetadata, SessionHistoryStatus,
 };
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
@@ -216,7 +216,16 @@ async fn execute(
         Ok(cli_result) => {
             last_event_sequence = cli_result.last_event_sequence;
             let cli_exit_code = cli_result.exit_code;
-            if cli_exit_code != 0 {
+            if let Some(control_error) = cli_result.control_error.as_ref() {
+                let msg = control_error.to_string();
+                let diagnostic = cli_result_failure_diagnostic(
+                    FailureClass::CliExecutionError,
+                    cli_exit_code,
+                    cli_result.claude_result,
+                );
+                let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
+                (cli_exit_code, 1, msg, false, Some(diagnostic))
+            } else if cli_exit_code != 0 {
                 let failure_message = cli_failure_message(
                     cli_exit_code,
                     &cli_result.stderr_lines,
@@ -228,6 +237,7 @@ async fn execute(
                     cli_result.claude_result,
                 )
                 .with_failure_detail_source(failure_message.source);
+                let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
                 let diagnostic = with_cli_failure_reason(
                     diagnostic,
                     failure_message.message.as_str(),
@@ -315,6 +325,17 @@ fn is_claude_zero_turn_result(
         && cli_result
             .claude_result
             .is_some_and(|result| result.num_turns == Some(0))
+}
+
+fn with_cli_termination(
+    diagnostic: FailureDiagnostic,
+    cli_termination: Option<CliTerminationDiagnostic>,
+) -> FailureDiagnostic {
+    if let Some(cli_termination) = cli_termination {
+        diagnostic.with_cli_termination(cli_termination)
+    } else {
+        diagnostic
+    }
 }
 
 fn cli_result_failure_diagnostic(
@@ -1737,6 +1758,36 @@ mod tests {
     }
 
     #[test]
+    fn cli_termination_is_attached_without_changing_failure_reason() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(143)
+        .with_failure_reason(FailureReason::ProviderOverloaded);
+        let termination =
+            CliTerminationDiagnostic::new(agent_diagnostics::CliTerminationReason::PostResultReap)
+                .record_signal(
+                    agent_diagnostics::CliTerminationSignal::Sigterm,
+                    Some(1401),
+                    Some(10_000),
+                )
+                .with_observed_exit_code(143);
+
+        let with_termination = with_cli_termination(diagnostic.clone(), Some(termination));
+        let unchanged = with_cli_termination(diagnostic.clone(), None);
+
+        assert_eq!(with_termination.failure_class, FailureClass::CliNonzero);
+        assert_eq!(
+            with_termination.failure_reason,
+            Some(FailureReason::ProviderOverloaded)
+        );
+        assert_eq!(with_termination.cli_termination, Some(termination));
+        assert_eq!(unchanged, diagnostic);
+    }
+
+    #[test]
     fn is_claude_zero_turn_result_requires_all_guards() {
         let zero_turn = cli::CliExecutionResult {
             exit_code: 0,
@@ -1744,14 +1795,26 @@ mod tests {
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(0) }),
             failure_diagnostic: None,
+            control_error: None,
+            cli_termination: None,
         };
         let one_turn = cli::CliExecutionResult {
+            exit_code: 0,
+            stderr_lines: Vec::new(),
+            last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(1) }),
-            ..zero_turn.clone()
+            failure_diagnostic: None,
+            control_error: None,
+            cli_termination: None,
         };
         let failed_zero_turn = cli::CliExecutionResult {
             exit_code: 1,
-            ..zero_turn.clone()
+            stderr_lines: Vec::new(),
+            last_event_sequence: None,
+            claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(0) }),
+            failure_diagnostic: None,
+            control_error: None,
+            cli_termination: None,
         };
 
         assert!(is_claude_zero_turn_result(

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
 use guest_agent::error::AgentError;
 use std::time::Duration;
 
@@ -39,13 +40,21 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
     .await
     .expect("execute_cli did not return within 15s - heartbeat panic reap likely broken");
 
-    let err = match result {
-        Ok(_) => return Err("heartbeat panic should fail the run".into()),
-        Err(err) => err,
-    };
+    let result = result.expect("execute_cli returned Err before collecting controlled termination");
+    let err = result
+        .control_error
+        .as_ref()
+        .expect("heartbeat panic should preserve a controlled execution error");
     assert!(
         err.to_string().contains("heartbeat task panicked"),
         "expected heartbeat panic error, got {err}"
     );
+    let termination = result
+        .cli_termination
+        .expect("heartbeat panic should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::HeartbeatPanic);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
     Ok(())
 }

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
 use guest_agent::error::AgentError;
 use std::time::Duration;
 
@@ -42,13 +43,21 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
     .await
     .expect("execute_cli did not return within 15s - heartbeat reap escalation likely broken");
 
-    let err = match result {
-        Ok(_) => return Err("heartbeat failure should fail the run".into()),
-        Err(err) => err,
-    };
+    let result = result.expect("execute_cli returned Err before collecting controlled termination");
+    let err = result
+        .control_error
+        .as_ref()
+        .expect("heartbeat failure should preserve a controlled execution error");
     assert!(
         err.to_string().contains("heartbeat failed for reap test"),
         "expected heartbeat error, got {err}"
     );
+    let termination = result
+        .cli_termination
+        .expect("heartbeat failure should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::HeartbeatError);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
     Ok(())
 }

--- a/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
@@ -1,0 +1,63 @@
+//! Initial prompt stdin failures should preserve controlled termination context.
+
+mod common;
+
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+#[tokio::test]
+async fn initial_prompt_stdin_failure_reap_escalates_to_sigkill()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let mock = tmp.path().join("closed-stdin-claude");
+    std::fs::write(
+        &mock,
+        r#"#!/bin/sh
+exec 0<&-
+trap '' TERM
+tail -f /dev/null
+"#,
+    )?;
+    let mut permissions = std::fs::metadata(&mock)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&mock, permissions)?;
+
+    let large_prompt = "x".repeat(2 * 1024 * 1024);
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &large_prompt, 3, 1)?;
+    }
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(15),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli did not return within 15s - stdin failure reap likely broken");
+
+    let result = result.expect("execute_cli returned Err before collecting controlled termination");
+    let err = result
+        .control_error
+        .as_ref()
+        .expect("stdin writer failure should preserve a controlled execution error");
+    assert!(
+        err.to_string().contains("Broken pipe"),
+        "expected broken pipe stdin error, got {err}"
+    );
+    let termination = result
+        .cli_termination
+        .expect("stdin writer failure should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::InitialPromptStdin);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap.rs
+++ b/crates/guest-agent/tests/post_result_reap.rs
@@ -6,6 +6,7 @@
 
 mod common;
 
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
 use std::time::Duration;
 
 #[tokio::test]
@@ -46,5 +47,16 @@ async fn post_result_reap_sigterm_kills_hung_cli() -> Result<(), Box<dyn std::er
         "expected SIGTERM exit ({}) for the post-result reap path, got {exit_code}; SIGKILL escalation is covered by post_result_reap_sigkill",
         common::SIGTERM_EXIT
     );
+    assert!(
+        result.control_error.is_none(),
+        "post-result reap should not set a controlled execution error"
+    );
+    let termination = result
+        .cli_termination
+        .expect("post-result reap should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
     Ok(())
 }

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -10,6 +10,7 @@
 
 mod common;
 
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
 use std::time::Duration;
 
 #[tokio::test]
@@ -50,5 +51,16 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
         "expected SIGKILL exit ({}), got {exit_code} — SigkillPending escalation path is not firing",
         common::SIGKILL_EXIT
     );
+    assert!(
+        result.control_error.is_none(),
+        "post-result reap should not set a controlled execution error"
+    );
+    let termination = result
+        .cli_termination
+        .expect("post-result SIGKILL escalation should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
     Ok(())
 }

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
 use std::time::Duration;
 
 #[tokio::test]
@@ -39,13 +40,21 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
         "mock did not install SIGTERM ignore marker"
     );
 
-    let err = match result {
-        Ok(_) => return Err("stuck tool timeout should fail the run".into()),
-        Err(err) => err,
-    };
+    let result = result.expect("execute_cli returned Err before collecting controlled termination");
+    let err = result
+        .control_error
+        .as_ref()
+        .expect("stuck tool timeout should preserve a controlled execution error");
     assert!(
         err.to_string().contains("Tool timeout: WebFetch"),
         "expected stuck tool timeout error, got {err}"
     );
+    let termination = result
+        .cli_termination
+        .expect("stuck tool timeout should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::StuckToolWatchdog);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
     Ok(())
 }

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
 use std::time::Duration;
 
 #[tokio::test]
@@ -38,13 +39,21 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
         "mock did not install SIGTERM ignore marker"
     );
 
-    let err = match result {
-        Ok(_) => return Err("stuck tool timeout should fail the run".into()),
-        Err(err) => err,
-    };
+    let result = result.expect("execute_cli returned Err before collecting controlled termination");
+    let err = result
+        .control_error
+        .as_ref()
+        .expect("stuck tool timeout should preserve a controlled execution error");
     assert!(
         err.to_string().contains("Tool timeout: WebFetch"),
         "expected stuck tool timeout error, got {err}"
     );
+    let termination = result
+        .cli_termination
+        .expect("stuck tool timeout should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::StuckToolWatchdog);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigkill));
+    assert!(termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGKILL_EXIT));
     Ok(())
 }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -7,7 +7,7 @@
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
-use agent_diagnostics::{FailureClass, FailureDiagnostic, FailureReason};
+use agent_diagnostics::{CliTerminationDiagnostic, FailureClass, FailureDiagnostic, FailureReason};
 use futures_util::FutureExt;
 use sandbox::SandboxId;
 use tokio::sync::mpsc;
@@ -670,6 +670,8 @@ fn log_job_execution_failed(
                 .failure_detail_source
                 .map(|source| source.as_str());
             let failure_reason = diagnostic.failure_reason.map(|reason| reason.as_str());
+            let cli_termination_fields =
+                JobCliTerminationLogFields::from(diagnostic.cli_termination.as_ref());
             error!(
                 run_id = %run_id,
                 exit_code,
@@ -684,6 +686,13 @@ fn log_job_execution_failed(
                 failure_claude_num_turns = diagnostic.claude_num_turns,
                 failure_detail_source,
                 failure_reason,
+                cli_termination_initiator = cli_termination_fields.initiator,
+                cli_termination_reason = cli_termination_fields.reason,
+                cli_termination_signal_sent = cli_termination_fields.signal_sent,
+                cli_termination_signal_pgid = cli_termination_fields.signal_pgid,
+                cli_termination_signal_grace_ms = cli_termination_fields.signal_grace_ms,
+                cli_termination_escalated = cli_termination_fields.escalated,
+                cli_termination_observed_exit_code = cli_termination_fields.observed_exit_code,
                 session_history_status = diagnostic.session_history_status.as_str(),
                 prompt_shape = diagnostic.prompt_shape.as_str(),
                 prompt_bytes = diagnostic.prompt_bytes,
@@ -720,6 +729,8 @@ fn log_job_execution_failed(
             .failure_detail_source
             .map(|source| source.as_str());
         let failure_reason = diagnostic.failure_reason.map(|reason| reason.as_str());
+        let cli_termination_fields =
+            JobCliTerminationLogFields::from(diagnostic.cli_termination.as_ref());
         macro_rules! log_with_diagnostic {
             ($level:ident) => {
                 $level!(
@@ -733,6 +744,13 @@ fn log_job_execution_failed(
                     failure_claude_num_turns = diagnostic.claude_num_turns,
                     failure_detail_source,
                     failure_reason,
+                    cli_termination_initiator = cli_termination_fields.initiator,
+                    cli_termination_reason = cli_termination_fields.reason,
+                    cli_termination_signal_sent = cli_termination_fields.signal_sent,
+                    cli_termination_signal_pgid = cli_termination_fields.signal_pgid,
+                    cli_termination_signal_grace_ms = cli_termination_fields.signal_grace_ms,
+                    cli_termination_escalated = cli_termination_fields.escalated,
+                    cli_termination_observed_exit_code = cli_termination_fields.observed_exit_code,
                     session_history_status = diagnostic.session_history_status.as_str(),
                     prompt_shape = diagnostic.prompt_shape.as_str(),
                     prompt_bytes = diagnostic.prompt_bytes,
@@ -773,6 +791,31 @@ struct JobResourceLogFields {
     guest_root_fs_available_kb: Option<u64>,
     guest_workspace_fs_used_percent: Option<u64>,
     guest_memory_available_mb: Option<u64>,
+}
+
+struct JobCliTerminationLogFields {
+    initiator: Option<&'static str>,
+    reason: Option<&'static str>,
+    signal_sent: Option<&'static str>,
+    signal_pgid: Option<i32>,
+    signal_grace_ms: Option<u64>,
+    escalated: Option<bool>,
+    observed_exit_code: Option<i32>,
+}
+
+impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
+    fn from(diagnostic: Option<&CliTerminationDiagnostic>) -> Self {
+        Self {
+            initiator: diagnostic.map(|diagnostic| diagnostic.initiator.as_str()),
+            reason: diagnostic.map(|diagnostic| diagnostic.reason.as_str()),
+            signal_sent: diagnostic
+                .and_then(|diagnostic| diagnostic.signal_sent.map(|signal| signal.as_str())),
+            signal_pgid: diagnostic.and_then(|diagnostic| diagnostic.signal_pgid),
+            signal_grace_ms: diagnostic.and_then(|diagnostic| diagnostic.signal_grace_ms),
+            escalated: diagnostic.map(|diagnostic| diagnostic.escalated),
+            observed_exit_code: diagnostic.and_then(|diagnostic| diagnostic.observed_exit_code),
+        }
+    }
 }
 
 impl From<Option<executor::ResourceFailureDiagnostics>> for JobResourceLogFields {
@@ -870,7 +913,8 @@ mod tests {
     use std::time::Duration;
 
     use agent_diagnostics::{
-        AgentFramework, FailureClass, FailureDetailSource, PromptMetadata, SessionHistoryStatus,
+        AgentFramework, CliTerminationDiagnostic, CliTerminationReason, CliTerminationSignal,
+        FailureClass, FailureDetailSource, PromptMetadata, SessionHistoryStatus,
     };
     use sandbox::{SandboxFactory, SandboxId};
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
@@ -902,6 +946,12 @@ mod tests {
             diagnostic = diagnostic.with_failure_reason(reason);
         }
         diagnostic
+    }
+
+    fn post_result_cli_termination() -> CliTerminationDiagnostic {
+        CliTerminationDiagnostic::new(CliTerminationReason::PostResultReap)
+            .record_signal(CliTerminationSignal::Sigterm, Some(1401), Some(10_000))
+            .with_observed_exit_code(143)
     }
 
     fn capture_job_failure_log(failure: &executor::ExecutionFailure) -> CapturedEvent {
@@ -1064,6 +1114,30 @@ mod tests {
             Some("job execution failed")
         );
         assert!(!event.fields.contains_key("failure_reason"));
+        assert!(!event.fields.contains_key("cli_termination_reason"));
+    }
+
+    #[test]
+    fn diagnostic_failure_logs_cli_termination_fields() {
+        let diagnostic =
+            job_failure_diagnostic(None).with_cli_termination(post_result_cli_termination());
+        let failure =
+            executor::ExecutionFailure::new(143, "Agent exited with code 143", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+        assert_field_eq(&event, "cli_termination_initiator", "guest_agent");
+        assert_field_eq(&event, "cli_termination_reason", "post_result_reap");
+        assert_field_eq(&event, "cli_termination_signal_sent", "sigterm");
+        assert_field_eq(&event, "cli_termination_signal_pgid", "1401");
+        assert_field_eq(&event, "cli_termination_signal_grace_ms", "10000");
+        assert_field_eq(&event, "cli_termination_escalated", "false");
+        assert_field_eq(&event, "cli_termination_observed_exit_code", "143");
     }
 
     #[test]
@@ -1162,7 +1236,8 @@ mod tests {
 
     #[test]
     fn runner_job_timeout_preserves_diagnostic_fields() {
-        let diagnostic = job_failure_diagnostic(Some(FailureReason::UsageLimit));
+        let diagnostic = job_failure_diagnostic(Some(FailureReason::UsageLimit))
+            .with_cli_termination(post_result_cli_termination());
         let failure = executor::ExecutionFailure::runner_job_timeout(
             124,
             "Timeout",
@@ -1187,6 +1262,13 @@ mod tests {
         assert_field_eq(&event, "failure_framework", "codex");
         assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
         assert_field_eq(&event, "session_history_status", "not_applicable");
+        assert_field_eq(&event, "cli_termination_initiator", "guest_agent");
+        assert_field_eq(&event, "cli_termination_reason", "post_result_reap");
+        assert_field_eq(&event, "cli_termination_signal_sent", "sigterm");
+        assert_field_eq(&event, "cli_termination_signal_pgid", "1401");
+        assert_field_eq(&event, "cli_termination_signal_grace_ms", "10000");
+        assert_field_eq(&event, "cli_termination_escalated", "false");
+        assert_field_eq(&event, "cli_termination_observed_exit_code", "143");
     }
 
     async fn status_idle_sessions_and_active_runs(


### PR DESCRIPTION
## Summary
- Add structured CLI termination diagnostics to guest failure diagnostics without reusing failure_reason.
- Preserve guest-agent initiated termination context across post-result reap and controlled error paths.
- Expand runner failure logs with queryable cli_termination_* fields.

Fixes #18461

## Tests
- cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo test --manifest-path crates/Cargo.toml -p runner
- git diff --check