### PR TITLE
perf(mitm-addon): reuse auth base tls context

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -12,6 +12,7 @@ import http.client as http_client
 import ipaddress
 import socket
 import ssl
+import threading
 import urllib.parse
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import suppress
@@ -99,13 +100,18 @@ _forward_request_admission_state: (
     tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None
 ) = None
 _forward_request_accepting = True
+_https_context: ssl.SSLContext | None = None
+_https_context_lock = threading.Lock()
 
 
 def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
     global _forward_request_accepting
+    global _https_context
 
     shutdown_forward_request_executor(wait=True)
+    with _https_context_lock:
+        _https_context = None
     _forward_request_accepting = True
 
 
@@ -171,6 +177,21 @@ def _create_https_context() -> ssl.SSLContext:
     return context
 
 
+def _get_https_context() -> ssl.SSLContext:
+    global _https_context
+
+    context = _https_context
+    if context is not None:
+        return context
+
+    with _https_context_lock:
+        context = _https_context
+        if context is None:
+            context = _create_https_context()
+            _https_context = context
+        return context
+
+
 class _ValidatedTLSConnection(http_client.HTTPConnection):
     default_port = DEFAULT_HTTPS_PORT
 
@@ -184,7 +205,7 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
     ) -> None:
         super().__init__(host, port=port, timeout=timeout)
         self._validated_addresses = validated_addresses
-        self._context = _create_https_context()
+        self._context = _get_https_context()
 
     def connect(self) -> None:
         raw_sock = _connect_to_validated_addresses(self._validated_addresses)(

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -144,6 +144,41 @@ class TestAuthBaseForwarderSecurity:
         assert upstream.socket.request_lines()[0] == "GET /path HTTP/1.1"
         assert upstream.socket.request_header_values("Host") == ["hooks.example.com"]
 
+    async def test_reuses_https_context_without_reusing_connections(self):
+        with fake_forwarder_upstream() as upstream:
+            first_status, first_body, _first_headers = await forwarder.forward_request(
+                "https://example.com/one",
+                "GET",
+                [],
+                None,
+            )
+            second_status, second_body, _second_headers = await forwarder.forward_request(
+                "https://example.com/two",
+                "GET",
+                [],
+                None,
+            )
+
+        assert first_status == 200
+        assert first_body == b"ok"
+        assert second_status == 200
+        assert second_body == b"ok"
+        assert len(upstream.contexts) == 1
+        assert upstream.contexts[0].server_hostnames == ["example.com", "example.com"]
+        assert upstream.getaddrinfo_calls == [
+            ("example.com", 443),
+            ("example.com", 443),
+        ]
+        assert upstream.create_connection_calls == [
+            (("93.184.216.34", 443), 30, None),
+            (("93.184.216.34", 443), 30, None),
+        ]
+        assert [socket.request_lines()[0] for socket in upstream.sockets] == [
+            "GET /one HTTP/1.1",
+            "GET /two HTTP/1.1",
+        ]
+        assert [socket.closed for socket in upstream.sockets] == [True, True]
+
     @pytest.mark.parametrize(
         "url",
         [


### PR DESCRIPTION
## Summary

- Cache the auth.base HTTPS client SSLContext lazily per process
- Keep per-request DNS validation, socket creation, and connection close behavior unchanged
- Add coverage that repeated forwards reuse TLS context without reusing connections

## Tests

- python3 -m ruff check src/auth_base_forwarder.py tests/test_auth_base_forwarder.py
- python3 -m pytest tests/test_auth_base_forwarder.py tests/test_done_hook.py

Closes #18477