### PR TITLE
fix: refine browser automation setup

### DIFF
--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -401,6 +401,7 @@ describe("Desktop renderer bridge integration", () => {
       });
     });
     expect(await screen.findByText("Online")).toBeTruthy();
+    expect(screen.queryByText("Browser Automation")).toBeNull();
     // The online hero labels this Mac by its friendly device name.
     expect(await screen.findByText("lisa")).toBeTruthy();
     expect(auth.getState).toHaveBeenCalled();
@@ -408,25 +409,61 @@ describe("Desktop renderer bridge integration", () => {
   });
 
   it("probes browser automation from an explicit user action", async () => {
-    const { computerUse } = installDesktopBridges();
+    const { computerUse } = installDesktopBridges({
+      computerUseState: createComputerUseState({
+        permissions: { accessibility: false, screenRecording: true },
+      }),
+    });
     renderDesktopApp();
 
     expect(await screen.findByText("Browser Automation")).toBeTruthy();
-    expect(await screen.findByText("Google Chrome")).toBeTruthy();
-    expect(screen.getAllByText("Not tested")).toHaveLength(2);
+    expect(
+      await screen.findByText(
+        "Optional for browser control. Test only the browser you use.",
+      ),
+    ).toBeTruthy();
+    expect(await screen.findByText("Not tested")).toBeTruthy();
     expect(computerUse.probeAutomationPermission).not.toHaveBeenCalled();
 
-    const chromeTestButton = screen.getAllByText("Test")[0]?.closest("button");
-    if (!(chromeTestButton instanceof HTMLButtonElement)) {
-      throw new Error("Could not find Chrome Automation test button");
-    }
-    fireEvent.click(chromeTestButton);
+    fireEvent.click(buttonForText("Test Chrome"));
 
     await waitFor(() => {
       expect(computerUse.probeAutomationPermission).toHaveBeenCalledWith(
         "chrome",
       );
     });
+  });
+
+  it("treats browser automation as ready when one browser is approved", async () => {
+    installDesktopBridges({
+      computerUseState: createComputerUseState({
+        permissions: {
+          accessibility: false,
+          screenRecording: true,
+          automation: {
+            chrome: {
+              status: "granted",
+              updatedAt: "2026-06-22T00:00:00.000Z",
+              reason: null,
+            },
+            safari: {
+              status: "denied",
+              updatedAt: "2026-06-22T00:00:00.000Z",
+              reason: "Automation denied",
+            },
+          },
+        },
+      }),
+    });
+    renderDesktopApp();
+
+    expect(
+      await screen.findByText(
+        "Google Chrome ready. Other browsers can be approved later.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Needs approval")).toBeNull();
+    expect(screen.queryByText("Test Safari")).toBeNull();
   });
 
   it("keeps offline account actions in the overflow menu until it is opened", async () => {

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -92,6 +92,11 @@ const AUTOMATION_PERMISSION_STATUS_LABELS = {
   not_running: "Open browser",
 } as const satisfies Record<ComputerUseAutomationPermissionStatus, string>;
 
+const AUTOMATION_PERMISSION_TEST_LABELS = {
+  chrome: "Test Chrome",
+  safari: "Test Safari",
+} as const satisfies Record<ComputerUseAutomationPermissionTarget, string>;
+
 const RUNTIME_ERROR_SOURCE_LABELS = {
   start: "Start",
   stop: "Stop",
@@ -573,79 +578,47 @@ function PermissionSetupRow({
   );
 }
 
-function automationPermissionMeta(
-  target: ComputerUseAutomationPermissionTarget,
-  status: ComputerUseAutomationPermissionStatus,
-): string {
-  const label = COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS[target].label;
-  switch (status) {
-    case "granted":
-      return "Automation allowed";
-    case "denied":
-      return `Allow Zero to control ${label} in System Settings`;
-    case "not_installed":
-      return `Install ${label} to test browser automation`;
-    case "not_running":
-      return `Open ${label}, then test again`;
-    case "unknown":
-      return `Test when ${label} is open`;
+function browserAutomationReadyLabels(
+  automation: ReturnType<typeof computerUseAutomationPermissionState>,
+): readonly string[] {
+  return COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS.filter((target) => {
+    return automation[target].status === "granted";
+  }).map((target) => {
+    return COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS[target].label;
+  });
+}
+
+function browserAutomationHasDeniedTarget(
+  automation: ReturnType<typeof computerUseAutomationPermissionState>,
+): boolean {
+  return COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS.some((target) => {
+    return automation[target].status === "denied";
+  });
+}
+
+function formatBrowserAutomationTargets(labels: readonly string[]): string {
+  if (labels.length <= 1) {
+    return labels[0] ?? "a browser";
   }
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
 }
 
-function AutomationPermissionRow({
-  disabled,
-  onOpenSettings,
-  onProbe,
-  status,
-  target,
-}: {
-  readonly disabled: boolean;
-  readonly onOpenSettings: () => void;
-  readonly onProbe: () => void;
-  readonly status: ComputerUseAutomationPermissionStatus;
-  readonly target: ComputerUseAutomationPermissionTarget;
-}) {
-  const label = COMPUTER_USE_AUTOMATION_PERMISSION_TARGET_DETAILS[target].label;
-  return (
-    <div className="permission-row">
-      <div>
-        <div className="row-title">{label}</div>
-        <div className="row-meta">
-          {automationPermissionMeta(target, status)}
-        </div>
-      </div>
-      <div className="row-actions">
-        <span className={`automation-pill automation-pill-${status}`}>
-          {status === "granted" ? (
-            <IconCheck size={14} />
-          ) : (
-            <IconAlertCircle size={14} />
-          )}
-          {AUTOMATION_PERMISSION_STATUS_LABELS[status]}
-        </span>
-        {status !== "granted" && (
-          <IconButton
-            icon={<IconShieldCheck size={15} />}
-            onClick={onProbe}
-            disabled={disabled}
-          >
-            Test
-          </IconButton>
-        )}
-        {status === "denied" && (
-          <IconButton
-            icon={<IconExternalLink size={15} />}
-            onClick={onOpenSettings}
-          >
-            Settings
-          </IconButton>
-        )}
-      </div>
-    </div>
-  );
+function browserAutomationMeta(
+  automation: ReturnType<typeof computerUseAutomationPermissionState>,
+): string {
+  const readyLabels = browserAutomationReadyLabels(automation);
+  if (readyLabels.length > 0) {
+    return `${formatBrowserAutomationTargets(
+      readyLabels,
+    )} ready. Other browsers can be approved later.`;
+  }
+  if (browserAutomationHasDeniedTarget(automation)) {
+    return "Allow Zero to control the browser you use in System Settings";
+  }
+  return "Optional for browser control. Test only the browser you use.";
 }
 
-function BrowserAutomationPanel({
+function BrowserAutomationSetupRow({
   state,
 }: {
   readonly state: DesktopComputerUseState;
@@ -656,42 +629,53 @@ function BrowserAutomationPanel({
   );
   const [, openAutomationSettings] = useLoadableSet(openAutomationSettings$);
   const disabled = probeLoadable.state === "loading";
-
-  if (!hasRequiredComputerUsePermissions(state.permissions)) {
-    return null;
-  }
+  const readyLabels = browserAutomationReadyLabels(automation);
+  const ready = readyLabels.length > 0;
+  const needsApproval = !ready && browserAutomationHasDeniedTarget(automation);
+  const pillStatus: ComputerUseAutomationPermissionStatus = ready
+    ? "granted"
+    : needsApproval
+      ? "denied"
+      : "unknown";
 
   return (
-    <section className="step-card step-card-expanded browser-automation-card">
-      <div className="step-card-main">
-        <div className="step-kicker">
-          <StepIndex step={3} />
-          <span>Browser Automation</span>
-        </div>
-        <div className="step-heading">
-          <h2>Check browser automation</h2>
-          <p>Chrome and Safari use separate macOS Automation approval.</p>
-        </div>
-        <div className="permission-list">
-          {COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS.map((target) => {
+    <div className="permission-row browser-automation-row">
+      <div>
+        <div className="row-title">Browser Automation</div>
+        <div className="row-meta">{browserAutomationMeta(automation)}</div>
+      </div>
+      <div className="row-actions">
+        <span className={`automation-pill automation-pill-${pillStatus}`}>
+          {ready ? <IconCheck size={14} /> : <IconAlertCircle size={14} />}
+          {AUTOMATION_PERMISSION_STATUS_LABELS[pillStatus]}
+        </span>
+        {!ready &&
+          COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS.map((target) => {
             return (
-              <AutomationPermissionRow
+              <IconButton
                 key={target}
+                icon={<IconShieldCheck size={15} />}
                 disabled={disabled}
-                onOpenSettings={() => {
-                  void openAutomationSettings();
-                }}
-                onProbe={() => {
+                onClick={() => {
                   void probeAutomation(target);
                 }}
-                status={automation[target].status}
-                target={target}
-              />
+              >
+                {AUTOMATION_PERMISSION_TEST_LABELS[target]}
+              </IconButton>
             );
           })}
-        </div>
+        {needsApproval && (
+          <IconButton
+            icon={<IconExternalLink size={15} />}
+            onClick={() => {
+              void openAutomationSettings();
+            }}
+          >
+            Settings
+          </IconButton>
+        )}
       </div>
-    </section>
+    </div>
   );
 }
 
@@ -775,6 +759,7 @@ function PermissionsStepCard({
               void openScreenRecording();
             }}
           />
+          <BrowserAutomationSetupRow state={state} />
         </div>
       </div>
     </section>
@@ -1192,7 +1177,6 @@ function ReadyExperience({
         <OfflineHero authState={authState} state={state} />
       )}
       {!running && <PermissionAutoRefresh />}
-      <BrowserAutomationPanel state={state} />
       {developerToolsEnabled && (
         <>
           <RuntimePanel state={state} />

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -393,8 +393,8 @@ button {
   background: rgba(249, 250, 251, 0.76);
 }
 
-.browser-automation-card {
-  margin-top: 10px;
+.permission-row > div:first-child {
+  min-width: 0;
 }
 
 .checkbox-row {


### PR DESCRIPTION
## Summary
- move Browser Automation into the Computer Use permissions setup card instead of a separate step
- treat Chrome and Safari as alternatives, with one approved browser making the row ready
- keep the ready/online hero clear of the browser automation setup panel

## Tests
- pnpm -F @vm0/desktop exec vitest run src/renderer/App.test.tsx
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop build:renderer