### PR TITLE
refactor: isolate all-catalog firewall entrypoint

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -51,6 +51,7 @@ describe("firewall metadata import boundary", () => {
     for (const source of [
       `import { getConnectorFirewall } from "@vm0/connectors/firewalls";`,
       `import type { FirewallConnectorType } from "@vm0/connectors/firewalls";`,
+      `import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";`,
       `export { getConnectorFirewall } from "@vm0/connectors/firewalls";`,
       `await import("@vm0/connectors/firewalls/github.generated");`,
       `import "@vm0/connectors/firewalls";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/builtin-firewall-catalog.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/builtin-firewall-catalog.ts
@@ -1,5 +1,5 @@
 import type { Firewall, FirewallApi } from "@vm0/connectors/firewall-types";
-import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls";
+import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
 import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "../contracts/model-providers";
 
 type JsonValue =

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -52,6 +52,10 @@
       "import": "./src/firewalls/index.ts",
       "types": "./src/firewalls/index.ts"
     },
+    "./firewalls/all": {
+      "import": "./src/firewall-runtime-all.ts",
+      "types": "./src/firewall-runtime-all.ts"
+    },
     "./firewalls/runtime": {
       "import": "./src/firewall-runtime.ts",
       "types": "./src/firewall-runtime.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -38,13 +38,13 @@ import {
 import {
   BILLABLE_CONNECTORS,
   getAllBuiltinConnectorHosts,
-  getAllConnectorFirewalls,
   getDefaultFirewallPolicies,
   getPermissionCategories,
   groupPermissionsByCategory,
   resolveFirewallPolicies,
   type FirewallConnectorType,
 } from "../firewalls";
+import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
 
 const FORBIDDEN_METADATA_KEYS = new Set([
   "auth",

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -2,7 +2,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { getAllConnectorFirewalls, getConnectorFirewall } from "../firewalls";
+import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
+import { getConnectorFirewall } from "../firewalls";
 import {
   isRuntimeFirewallConnectorType,
   loadConnectorFirewall,
@@ -70,6 +71,30 @@ describe("firewall runtime loader", () => {
       types: "./src/firewall-runtime.ts",
     });
     expect(rootEntrypoint).not.toContain("firewalls/runtime");
+  });
+
+  it("keeps all-catalog access behind an explicit package subpath", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        "utf-8",
+      ),
+    ) as { exports: Record<string, unknown> };
+    const defaultFirewallEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../firewalls/index.ts"),
+      "utf-8",
+    );
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    expect(packageJson.exports["./firewalls/all"]).toStrictEqual({
+      import: "./src/firewall-runtime-all.ts",
+      types: "./src/firewall-runtime-all.ts",
+    });
+    expect(defaultFirewallEntrypoint).not.toContain("getAllConnectorFirewalls");
+    expect(rootEntrypoint).not.toContain("firewalls/all");
   });
 
   it("does not statically import the eager registry or connector runtime modules", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
+import * as defaultFirewallEntrypoint from "../firewalls";
 import { getConnectorFirewall } from "../firewalls";
 import {
   isRuntimeFirewallConnectorType,
@@ -80,10 +81,6 @@ describe("firewall runtime loader", () => {
         "utf-8",
       ),
     ) as { exports: Record<string, unknown> };
-    const defaultFirewallEntrypoint = fs.readFileSync(
-      path.resolve(import.meta.dirname, "../firewalls/index.ts"),
-      "utf-8",
-    );
     const rootEntrypoint = fs.readFileSync(
       path.resolve(import.meta.dirname, "../index.ts"),
       "utf-8",
@@ -93,8 +90,15 @@ describe("firewall runtime loader", () => {
       import: "./src/firewall-runtime-all.ts",
       types: "./src/firewall-runtime-all.ts",
     });
-    expect(defaultFirewallEntrypoint).not.toContain("getAllConnectorFirewalls");
-    expect(rootEntrypoint).not.toContain("firewalls/all");
+    expect(defaultFirewallEntrypoint).not.toHaveProperty(
+      "getAllConnectorFirewalls",
+    );
+    expect(staticValueModuleSpecifiers(rootEntrypoint)).not.toContain(
+      "./firewall-runtime-all",
+    );
+    expect(staticValueModuleSpecifiers(rootEntrypoint)).not.toContain(
+      "./firewalls/all",
+    );
   });
 
   it("does not statically import the eager registry or connector runtime modules", () => {

--- a/turbo/packages/connectors/src/firewall-runtime-all.ts
+++ b/turbo/packages/connectors/src/firewall-runtime-all.ts
@@ -1,0 +1,27 @@
+import { CONNECTOR_TYPES } from "./connectors";
+import type { FirewallConfig } from "./firewall-types";
+import {
+  getConnectorFirewall,
+  isFirewallConnectorType,
+  type FirewallConnectorType,
+} from "./firewalls";
+
+let connectorFirewalls: Readonly<
+  Record<FirewallConnectorType, FirewallConfig>
+> | null = null;
+
+export function getAllConnectorFirewalls(): Readonly<
+  Record<FirewallConnectorType, FirewallConfig>
+> {
+  if (connectorFirewalls === null) {
+    connectorFirewalls = Object.fromEntries(
+      Object.keys(CONNECTOR_TYPES)
+        .filter(isFirewallConnectorType)
+        .map((type) => {
+          return [type, getConnectorFirewall(type)];
+        }),
+    ) as Record<FirewallConnectorType, FirewallConfig>;
+  }
+
+  return connectorFirewalls;
+}

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -834,12 +834,6 @@ export function getConnectorFirewall(
   return EXPANDED_CONNECTOR_FIREWALLS[type];
 }
 
-export function getAllConnectorFirewalls(): Readonly<
-  typeof EXPANDED_CONNECTOR_FIREWALLS
-> {
-  return EXPANDED_CONNECTOR_FIREWALLS;
-}
-
 /**
  * Per-connector default-allowed permission lists.
  *


### PR DESCRIPTION
## Summary

- add the explicit `@vm0/connectors/firewalls/all` package subpath for full connector firewall catalog access
- remove `getAllConnectorFirewalls()` from the default `@vm0/connectors/firewalls` entrypoint
- migrate intentional full-catalog callers and add import-boundary coverage for the all-catalog subpath

Closes #18117.

## Tests

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts src/__tests__/firewall-metadata.test.ts`
- `pnpm -F api exec vitest run src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm knip --cache`
- pre-commit `turbo` hook, including `prettier`, `knip`, and full `pnpm check-types`
