### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]


### PR DESCRIPTION
## Summary

- Updated the Rust workspace lockfile under `crates/` with `cargo update --verbose`.
- Updated 1 dependency: `quote` `1.0.45` -> `1.0.46`.
- No `Cargo.toml` dependency version specifiers were changed.

## Dependencies not updated

- `generic-array` remained at `0.14.7` while `0.14.9` is available. An explicit `cargo update -p generic-array --precise 0.14.9 --verbose` fails because transitive dependency `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`. The path is `runner` -> `aws-sdk-s3` -> `aws-smithy-checksums` -> `crc-fast` -> `digest 0.10.7` -> `crypto-common 0.1.7` -> `generic-array`.

## Manual version bumps

- None. I did not find a safe minor/patch `Cargo.toml` version constraint bump to make; the remaining blocked dependency is pinned by a transitive crate rather than this workspace's manifests.

## Test status

Failed in this constrained local runtime; no dependency-related compile errors were observed.

Commands attempted:

- `cargo test --workspace` failed before tests with `No space left on device` on the 7.8 GB root filesystem.
- Retried with `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test --workspace`; it still failed with `No space left on device` while linking/building large test artifacts.
- Per-crate fallback passed for: `ably-subscriber`, `agent-diagnostics`, `api-contracts`, `guest-common`, `guest-contracts`, `process-control-ipc`, `vsock-guest`, and `vsock-proto`.
- Retried the full workspace with `CARGO_TARGET_DIR=/dev/shm/vm0-rust-target CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test --workspace`; this reached `runner` but the kernel OOM-killed `rustc` while compiling the runner test binary.
- Retried `runner` alone with `CARGO_TARGET_DIR=/tmp/vm0-rust-runner-target CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p runner --bin runner`; it built and ran, but failed 540 of 2026 runner unit tests. The first failures were filesystem-safety errors such as `lock directory component /tmp/.tmp... is group/other writable without the sticky bit`.
- `cargo test --workspace --exclude runner` also failed locally with `No space left on device` while linking a `guest-agent` test binary.

Given this PR only updates `quote` by a patch release, the runner test failures look environmental or pre-existing rather than caused by this dependency update, but I am leaving the test status explicit for CI to validate.
