### PR TITLE
refactor: centralize codex thread id contract

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1298,6 +1298,7 @@ version = "0.2.2"
 dependencies = [
  "libc",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -380,9 +380,8 @@ async fn create_checkpoint_impl_with_artifacts(
     record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
 
     // Read session history. The persisted or derived marker payload is either
-    // a literal jsonl path (Claude) or a `CODEX_SEARCH:{dir}:{id}` marker
-    // (codex) — `session_history` abstracts the difference and decompresses
-    // zstd-compressed codex sessions.
+    // a literal jsonl path (Claude) or a codex marker. `session_history`
+    // abstracts the difference and decompresses zstd-compressed codex sessions.
     let history_read_start = std::time::Instant::now();
     let history_marker_payload =
         match crate::session_metadata::resolve_history_marker_payload(&cli_agent_session_id) {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -365,7 +365,7 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 ///
 /// The on-disk format of `session_history_path_file()` differs by framework:
 /// - Claude: literal `~/.claude/projects/-{cwd}/{session_id}.jsonl` path.
-/// - Codex: length-prefixed `CODEX_SEARCH_V2:{dir_len}:{sessions_dir}:{thread_id}`
+/// - Codex: length-prefixed `CODEX_SEARCH:{dir_len}:{sessions_dir}:{thread_id}`
 ///   marker — codex doesn't write the session file until turn-completion, so
 ///   resolution is deferred to checkpoint time.
 pub(crate) struct SessionMetadataCapture {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -497,7 +497,7 @@ fn raw_claude_session_id(event: &Value) -> Option<&str> {
 /// marker pointing at `${HOME}/.codex/sessions` plus the thread_id.
 fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
     let thread_id = raw_codex_thread_id(event)?;
-    let thread_id = crate::session_history::canonical_codex_thread_id(thread_id)?;
+    let thread_id = guest_contracts::codex_thread_id::canonical_codex_thread_id(thread_id)?;
     let marker = session_metadata::codex_history_marker_payload(&thread_id);
 
     Some((thread_id, marker))

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -365,9 +365,9 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 ///
 /// The on-disk format of `session_history_path_file()` differs by framework:
 /// - Claude: literal `~/.claude/projects/-{cwd}/{session_id}.jsonl` path.
-/// - Codex: `CODEX_SEARCH:{sessions_dir}:{thread_id}` marker — codex
-///   doesn't write the session file until turn-completion, so resolution
-///   is deferred to checkpoint time.
+/// - Codex: length-prefixed `CODEX_SEARCH_V2:{dir_len}:{sessions_dir}:{thread_id}`
+///   marker — codex doesn't write the session file until turn-completion, so
+///   resolution is deferred to checkpoint time.
 pub(crate) struct SessionMetadataCapture {
     existing_session_id_seeded: bool,
 }

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -28,6 +28,7 @@
 use crate::error::AgentError;
 #[cfg(target_os = "linux")]
 use crate::nofollow_fs::Dir;
+use guest_contracts::codex_thread_id::codex_thread_id_filename_key;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -97,23 +98,13 @@ fn read_codex_session_history(
     sessions_dir: &Path,
     thread_id: &str,
 ) -> Result<Option<Vec<u8>>, AgentError> {
-    let Some(id_norm) = normalize_codex_thread_id(thread_id) else {
+    let Some(id_norm) = codex_thread_id_filename_key(thread_id) else {
         return Ok(None);
     };
     if !codex_sessions_parent_is_usable(sessions_dir)? {
         return Ok(None);
     }
     read_codex_session_history_impl(sessions_dir, &id_norm)
-}
-
-pub(crate) fn normalize_codex_thread_id(thread_id: &str) -> Option<String> {
-    Some(canonical_codex_thread_id(thread_id)?.replace('-', ""))
-}
-
-pub(crate) fn canonical_codex_thread_id(thread_id: &str) -> Option<String> {
-    uuid::Uuid::parse_str(thread_id)
-        .ok()
-        .map(|uuid| uuid.to_string())
 }
 
 fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentError> {

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -1,5 +1,5 @@
 //! Session-history reader — abstracts over Claude (literal jsonl path) and
-//! codex (`CODEX_SEARCH_V2:{dir_len}:{dir}:{id}` marker → recursive scan +
+//! codex (`CODEX_SEARCH:{dir_len}:{dir}:{id}` marker → recursive scan +
 //! optional zstd decode).
 //!
 //! The event metadata capture path writes one of two payloads to
@@ -7,7 +7,7 @@
 //!
 //! - Claude: a literal filesystem path to the `.jsonl` history file.
 //! - Codex:  a length-prefixed
-//!   `CODEX_SEARCH_V2:{dir_len}:{sessions_dir}:{thread_id}` marker. The codex
+//!   `CODEX_SEARCH:{dir_len}:{sessions_dir}:{thread_id}` marker. The codex
 //!   CLI only writes the session file out at turn-completion time, so we defer
 //!   resolution until checkpoint time when the file is on disk.
 //!
@@ -38,20 +38,20 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::{fs::File, io::Read};
 
-const CODEX_MARKER_V2_PREFIX: &str = "CODEX_SEARCH_V2:";
+const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
 
 /// Build the persisted Codex session-history marker payload.
 pub(crate) fn codex_marker_payload(sessions_dir: &Path, thread_id: &str) -> String {
     let sessions_dir = sessions_dir.display().to_string();
     format!(
-        "{CODEX_MARKER_V2_PREFIX}{}:{sessions_dir}:{thread_id}",
+        "{CODEX_MARKER_PREFIX}{}:{sessions_dir}:{thread_id}",
         sessions_dir.len()
     )
 }
 
 /// Return whether a persisted session-history payload is a Codex marker.
 pub(crate) fn is_codex_marker(payload: &str) -> bool {
-    payload.starts_with(CODEX_MARKER_V2_PREFIX)
+    payload.starts_with(CODEX_MARKER_PREFIX)
 }
 
 /// Read the session history bytes pointed to by `path_file`.
@@ -92,7 +92,7 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
 /// Parse a Codex marker into `(dir, thread_id)`. Markers are length-prefixed so
 /// paths containing `:` cannot be confused with decorated thread IDs.
 fn decode_marker(content: &str) -> Option<(PathBuf, &str)> {
-    if let Some(rest) = content.strip_prefix(CODEX_MARKER_V2_PREFIX) {
+    if let Some(rest) = content.strip_prefix(CODEX_MARKER_PREFIX) {
         return decode_len_prefixed_marker(rest);
     }
 

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -1,13 +1,15 @@
 //! Session-history reader — abstracts over Claude (literal jsonl path) and
-//! codex (`CODEX_SEARCH:{dir}:{id}` marker → recursive scan + optional zstd decode).
+//! codex (`CODEX_SEARCH_V2:{dir_len}:{dir}:{id}` marker → recursive scan +
+//! optional zstd decode).
 //!
 //! The event metadata capture path writes one of two payloads to
 //! `paths::session_history_path_file()`:
 //!
 //! - Claude: a literal filesystem path to the `.jsonl` history file.
-//! - Codex:  a `CODEX_SEARCH:{sessions_dir}:{thread_id}` marker. The codex
-//!   CLI only writes the session file out at turn-completion time, so we
-//!   defer resolution until checkpoint time when the file is on disk.
+//! - Codex:  a length-prefixed
+//!   `CODEX_SEARCH_V2:{dir_len}:{sessions_dir}:{thread_id}` marker. The codex
+//!   CLI only writes the session file out at turn-completion time, so we defer
+//!   resolution until checkpoint time when the file is on disk.
 //!
 //! `read_session_history` is the file-backed entry point. Checkpoint resolves
 //! missing marker payloads first, then calls `read_session_history_from_payload`.
@@ -37,25 +39,27 @@ use std::path::{Path, PathBuf};
 use std::{fs::File, io::Read};
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
+const CODEX_MARKER_V2_PREFIX: &str = "CODEX_SEARCH_V2:";
 
 /// Build the persisted Codex session-history marker payload.
 pub(crate) fn codex_marker_payload(sessions_dir: &Path, thread_id: &str) -> String {
+    let sessions_dir = sessions_dir.display().to_string();
     format!(
-        "{CODEX_MARKER_PREFIX}{}:{thread_id}",
-        sessions_dir.display()
+        "{CODEX_MARKER_V2_PREFIX}{}:{sessions_dir}:{thread_id}",
+        sessions_dir.len()
     )
 }
 
 /// Return whether a persisted session-history payload is a Codex marker.
 pub(crate) fn is_codex_marker(payload: &str) -> bool {
-    payload.starts_with(CODEX_MARKER_PREFIX)
+    payload.starts_with(CODEX_MARKER_V2_PREFIX) || payload.starts_with(CODEX_MARKER_PREFIX)
 }
 
 /// Read the session history bytes pointed to by `path_file`.
 ///
 /// The file content is either a literal path (Claude) or a
-/// `CODEX_SEARCH:{dir}:{id}` marker (codex). Returns the file contents,
-/// decompressed if the resolved path ends in `.zst`.
+/// codex marker. Returns the file contents, decompressed if the resolved path
+/// ends in `.zst`.
 pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
     let raw = std::fs::read_to_string(path_file).map_err(|e| {
         AgentError::Checkpoint(format!("Failed to read history-path file {path_file}: {e}"))
@@ -66,9 +70,14 @@ pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
 /// Read session history bytes from an already-resolved marker payload.
 ///
 /// The payload is either a literal path (Claude) or a
-/// `CODEX_SEARCH:{dir}:{id}` marker (codex).
+/// codex marker.
 pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>, AgentError> {
-    if let Some((sessions_dir, thread_id)) = decode_marker(payload) {
+    if is_codex_marker(payload) {
+        let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
+            return Err(AgentError::Checkpoint(
+                "Invalid Codex session history marker".to_string(),
+            ));
+        };
         return read_codex_session_history(&sessions_dir, thread_id)?.ok_or_else(|| {
             AgentError::Checkpoint(format!(
                 "Codex session file not found under {}",
@@ -81,13 +90,37 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
     read_history_bytes(&session_path)
 }
 
-/// Parse `CODEX_SEARCH:{dir}:{thread_id}` into `(dir, thread_id)`. Returns
-/// `None` for any input that doesn't carry the prefix (Claude path).
+/// Parse a Codex marker into `(dir, thread_id)`. Current markers are length
+/// prefixed so paths containing `:` cannot be confused with decorated thread
+/// IDs. Legacy `CODEX_SEARCH:{dir}:{thread_id}` markers are parsed
+/// conservatively because the old format cannot represent both colon-bearing
+/// directories and colon-bearing invalid thread IDs unambiguously.
 fn decode_marker(content: &str) -> Option<(PathBuf, &str)> {
+    if let Some(rest) = content.strip_prefix(CODEX_MARKER_V2_PREFIX) {
+        return decode_len_prefixed_marker(rest);
+    }
+
     let rest = content.strip_prefix(CODEX_MARKER_PREFIX)?;
-    let last_colon = rest.rfind(':')?;
-    let (dir, id_with_colon) = rest.split_at(last_colon);
-    let thread_id = &id_with_colon[1..];
+    decode_legacy_marker(rest)
+}
+
+fn decode_len_prefixed_marker(rest: &str) -> Option<(PathBuf, &str)> {
+    let (dir_len, payload) = rest.split_once(':')?;
+    let dir_len: usize = dir_len.parse().ok()?;
+    if dir_len == 0 || payload.len() <= dir_len || !payload.is_char_boundary(dir_len) {
+        return None;
+    }
+
+    let (dir, delimiter_and_thread_id) = payload.split_at(dir_len);
+    let thread_id = delimiter_and_thread_id.strip_prefix(':')?;
+    if thread_id.is_empty() {
+        return None;
+    }
+    Some((PathBuf::from(dir), thread_id))
+}
+
+fn decode_legacy_marker(rest: &str) -> Option<(PathBuf, &str)> {
+    let (dir, thread_id) = rest.split_once(':')?;
     if dir.is_empty() || thread_id.is_empty() {
         return None;
     }

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -38,7 +38,6 @@ use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::{fs::File, io::Read};
 
-const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
 const CODEX_MARKER_V2_PREFIX: &str = "CODEX_SEARCH_V2:";
 
 /// Build the persisted Codex session-history marker payload.
@@ -52,7 +51,7 @@ pub(crate) fn codex_marker_payload(sessions_dir: &Path, thread_id: &str) -> Stri
 
 /// Return whether a persisted session-history payload is a Codex marker.
 pub(crate) fn is_codex_marker(payload: &str) -> bool {
-    payload.starts_with(CODEX_MARKER_V2_PREFIX) || payload.starts_with(CODEX_MARKER_PREFIX)
+    payload.starts_with(CODEX_MARKER_V2_PREFIX)
 }
 
 /// Read the session history bytes pointed to by `path_file`.
@@ -90,18 +89,14 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
     read_history_bytes(&session_path)
 }
 
-/// Parse a Codex marker into `(dir, thread_id)`. Current markers are length
-/// prefixed so paths containing `:` cannot be confused with decorated thread
-/// IDs. Legacy `CODEX_SEARCH:{dir}:{thread_id}` markers are parsed
-/// conservatively because the old format cannot represent both colon-bearing
-/// directories and colon-bearing invalid thread IDs unambiguously.
+/// Parse a Codex marker into `(dir, thread_id)`. Markers are length-prefixed so
+/// paths containing `:` cannot be confused with decorated thread IDs.
 fn decode_marker(content: &str) -> Option<(PathBuf, &str)> {
     if let Some(rest) = content.strip_prefix(CODEX_MARKER_V2_PREFIX) {
         return decode_len_prefixed_marker(rest);
     }
 
-    let rest = content.strip_prefix(CODEX_MARKER_PREFIX)?;
-    decode_legacy_marker(rest)
+    None
 }
 
 fn decode_len_prefixed_marker(rest: &str) -> Option<(PathBuf, &str)> {
@@ -114,14 +109,6 @@ fn decode_len_prefixed_marker(rest: &str) -> Option<(PathBuf, &str)> {
     let (dir, delimiter_and_thread_id) = payload.split_at(dir_len);
     let thread_id = delimiter_and_thread_id.strip_prefix(':')?;
     if thread_id.is_empty() {
-        return None;
-    }
-    Some((PathBuf::from(dir), thread_id))
-}
-
-fn decode_legacy_marker(rest: &str) -> Option<(PathBuf, &str)> {
-    let (dir, thread_id) = rest.split_once(':')?;
-    if dir.is_empty() || thread_id.is_empty() {
         return None;
     }
     Some((PathBuf::from(dir), thread_id))

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -9,6 +9,7 @@ use crate::error::AgentError;
 use crate::paths;
 use crate::session_history;
 use guest_common::{log_error, log_info};
+use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use std::io;
 use std::path::{Component, Path};
 
@@ -18,7 +19,7 @@ pub(crate) fn history_marker_payload_for_session_id(session_id: &str) -> Option<
     match Framework::from_env() {
         Framework::ClaudeCode => claude_history_path_payload(session_id),
         Framework::Codex => {
-            let thread_id = session_history::canonical_codex_thread_id(session_id)?;
+            let thread_id = canonical_codex_thread_id(session_id)?;
             Some(codex_history_marker_payload(&thread_id))
         }
     }

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -149,7 +149,7 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
     let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
         .expect("history-path file written");
     assert!(
-        marker.starts_with("CODEX_SEARCH_V2:"),
+        marker.starts_with("CODEX_SEARCH:"),
         "codex framework should write a marker, got: {marker}"
     );
     assert!(

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -347,7 +347,12 @@ fn send_event_codex_ignores_malformed_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
 
-    for thread_id in ["abc", "0193-abcd-ef01-7234-89abcdef01234567"] {
+    for thread_id in [
+        "abc",
+        "0193-abcd-ef01-7234-89abcdef01234567",
+        "{0193abcd-ef01-7234-89ab-cdef01234567}",
+        "urn:uuid:0193abcd-ef01-7234-89ab-cdef01234567",
+    ] {
         reset_session_files();
 
         let masker = SecretMasker::from_raw("");

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -149,7 +149,7 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
     let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
         .expect("history-path file written");
     assert!(
-        marker.starts_with("CODEX_SEARCH:"),
+        marker.starts_with("CODEX_SEARCH_V2:"),
         "codex framework should write a marker, got: {marker}"
     );
     assert!(
@@ -172,7 +172,7 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
         "system log must not contain the raw thread id, got: {system_log}"
     );
     assert!(
-        !system_log.contains("CODEX_SEARCH:"),
+        !system_log.contains("CODEX_SEARCH"),
         "system log must not contain the codex marker payload, got: {system_log}"
     );
     assert!(

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -319,6 +319,34 @@ fn read_session_history_codex_marker_rejects_short_thread_id() {
 }
 
 #[test]
+fn read_session_history_codex_marker_rejects_decorated_thread_id() {
+    for thread_id in [
+        "{0193abcd-ef01-7234-89ab-cdef01234567}",
+        "urn:uuid:0193abcd-ef01-7234-89ab-cdef01234567",
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        write_session_file(
+            &sessions_dir,
+            &["2026", "04", "28"],
+            &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+            b"history\n",
+        )
+        .unwrap();
+
+        let path_file = write_codex_marker_path_file(tmp.path(), &sessions_dir, thread_id).unwrap();
+
+        let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+            .expect_err("decorated codex thread id must not match canonical history files");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Codex session file not found"),
+            "expected decorated thread id to fail fast, got: {msg}"
+        );
+    }
+}
+
+#[test]
 fn read_session_history_read_error_omits_literal_session_path() {
     let tmp = tempfile::tempdir().unwrap();
     let session_id = "sess-secret-123";

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -320,30 +320,26 @@ fn read_session_history_codex_marker_rejects_short_thread_id() {
 
 #[test]
 fn read_session_history_codex_marker_rejects_decorated_thread_id() {
-    for thread_id in [
-        "{0193abcd-ef01-7234-89ab-cdef01234567}",
-        "urn:uuid:0193abcd-ef01-7234-89ab-cdef01234567",
-    ] {
-        let tmp = tempfile::tempdir().unwrap();
-        let sessions_dir = tmp.path().join("sessions");
-        write_session_file(
-            &sessions_dir,
-            &["2026", "04", "28"],
-            &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
-            b"history\n",
-        )
-        .unwrap();
+    let thread_id = "{0193abcd-ef01-7234-89ab-cdef01234567}";
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+        b"history\n",
+    )
+    .unwrap();
 
-        let path_file = write_codex_marker_path_file(tmp.path(), &sessions_dir, thread_id).unwrap();
+    let path_file = write_codex_marker_path_file(tmp.path(), &sessions_dir, thread_id).unwrap();
 
-        let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
-            .expect_err("decorated codex thread id must not match canonical history files");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Codex session file not found"),
-            "expected decorated thread id to fail fast, got: {msg}"
-        );
-    }
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("decorated codex thread id must not match canonical history files");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected decorated thread id to fail fast, got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -433,26 +433,32 @@ fn read_session_history_codex_marker_rejects_short_thread_id() {
 
 #[test]
 fn read_session_history_codex_marker_rejects_decorated_thread_id() {
-    let thread_id = "{0193abcd-ef01-7234-89ab-cdef01234567}";
-    let tmp = tempfile::tempdir().unwrap();
-    let sessions_dir = tmp.path().join("sessions");
-    write_session_file(
-        &sessions_dir,
-        &["2026", "04", "28"],
-        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
-        b"history\n",
-    )
-    .unwrap();
+    for thread_id in [
+        "{0193abcd-ef01-7234-89ab-cdef01234567}".to_string(),
+        format!("{VALID_CODEX_THREAD_ID}:suffix"),
+        format!("{VALID_CODEX_THREAD_ID}/suffix"),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        write_session_file(
+            &sessions_dir,
+            &["2026", "04", "28"],
+            &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+            b"history\n",
+        )
+        .unwrap();
 
-    let path_file = write_codex_marker_path_file(tmp.path(), &sessions_dir, thread_id).unwrap();
+        let path_file =
+            write_codex_marker_path_file(tmp.path(), &sessions_dir, &thread_id).unwrap();
 
-    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
-        .expect_err("decorated codex thread id must not match canonical history files");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Codex session file not found"),
-        "expected decorated thread id to fail fast, got: {msg}"
-    );
+        let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+            .expect_err("decorated codex thread id must not match canonical history files");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Codex session file not found"),
+            "expected decorated thread id {thread_id:?} to fail fast, got: {msg}"
+        );
+    }
 }
 
 #[test]

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -122,7 +122,7 @@ fn read_session_history_resolves_legacy_codex_marker_end_to_end() {
 #[test]
 fn read_session_history_resolves_codex_marker_with_colon_in_sessions_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    let sessions_dir = tmp.path().join("sessions:with:colon");
+    let sessions_dir = tmp.path().join("sessions:with:colon-π");
     let history = b"{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";
     write_session_file(
         &sessions_dir,
@@ -138,6 +138,32 @@ fn read_session_history_resolves_codex_marker_with_colon_in_sessions_dir() {
     let bytes =
         guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
     assert_eq!(bytes, history);
+}
+
+#[test]
+fn read_session_history_legacy_codex_marker_rejects_urn_thread_id_with_colons() {
+    let thread_id = format!("urn:uuid:{VALID_CODEX_THREAD_ID}");
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let misleading_dir = tmp.path().join("sessions:urn:uuid");
+    write_session_file(
+        &misleading_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+        b"history\n",
+    )
+    .unwrap();
+
+    let path_file =
+        write_legacy_codex_marker_path_file(tmp.path(), &sessions_dir, &thread_id).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("legacy urn codex thread id must not be split into a directory suffix");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected legacy urn thread id to fail fast, got: {msg}"
+    );
 }
 
 #[test]

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -37,7 +37,7 @@ fn write_codex_marker_path_file(
     let path_file = root.join("path.txt");
     let sessions_dir = sessions_dir.to_string_lossy();
     let marker = format!(
-        "CODEX_SEARCH_V2:{}:{sessions_dir}:{thread_id}",
+        "CODEX_SEARCH:{}:{sessions_dir}:{thread_id}",
         sessions_dir.len()
     );
     std::fs::write(&path_file, marker.as_bytes())
@@ -106,12 +106,12 @@ fn read_session_history_resolves_codex_marker_with_colon_in_sessions_dir() {
 #[test]
 fn read_session_history_rejects_malformed_codex_markers_without_literal_read() {
     for marker in [
-        format!("CODEX_SEARCH_V2:not-a-length:/tmp:{VALID_CODEX_THREAD_ID}"),
-        format!("CODEX_SEARCH_V2:999:/tmp:{VALID_CODEX_THREAD_ID}"),
-        "CODEX_SEARCH_V2:0::0193abcd-ef01-7234-89ab-cdef01234567".to_string(),
-        "CODEX_SEARCH_V2:4:/tmp".to_string(),
-        "CODEX_SEARCH_V2:4:/tmp:".to_string(),
-        format!("CODEX_SEARCH_V2:1:π:{VALID_CODEX_THREAD_ID}"),
+        format!("CODEX_SEARCH:not-a-length:/tmp:{VALID_CODEX_THREAD_ID}"),
+        format!("CODEX_SEARCH:999:/tmp:{VALID_CODEX_THREAD_ID}"),
+        "CODEX_SEARCH:0::0193abcd-ef01-7234-89ab-cdef01234567".to_string(),
+        "CODEX_SEARCH:4:/tmp".to_string(),
+        "CODEX_SEARCH:4:/tmp:".to_string(),
+        format!("CODEX_SEARCH:1:π:{VALID_CODEX_THREAD_ID}"),
     ] {
         let tmp = tempfile::tempdir().unwrap();
         let path_file = tmp.path().join("path.txt");

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -35,6 +35,22 @@ fn write_codex_marker_path_file(
     thread_id: &str,
 ) -> Result<PathBuf, String> {
     let path_file = root.join("path.txt");
+    let sessions_dir = sessions_dir.to_string_lossy();
+    let marker = format!(
+        "CODEX_SEARCH_V2:{}:{sessions_dir}:{thread_id}",
+        sessions_dir.len()
+    );
+    std::fs::write(&path_file, marker.as_bytes())
+        .map_err(|e| format!("write {}: {e}", path_file.display()))?;
+    Ok(path_file)
+}
+
+fn write_legacy_codex_marker_path_file(
+    root: &Path,
+    sessions_dir: &Path,
+    thread_id: &str,
+) -> Result<PathBuf, String> {
+    let path_file = root.join("path.txt");
     let marker = format!(
         "CODEX_SEARCH:{}:{thread_id}",
         sessions_dir.to_string_lossy()
@@ -79,6 +95,72 @@ fn read_session_history_resolves_literal_codex_marker_end_to_end() {
     let bytes =
         guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
     assert_eq!(bytes, history);
+}
+
+#[test]
+fn read_session_history_resolves_legacy_codex_marker_end_to_end() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let history = b"{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+        history,
+    )
+    .unwrap();
+
+    let path_file =
+        write_legacy_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID)
+            .unwrap();
+
+    let bytes =
+        guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
+    assert_eq!(bytes, history);
+}
+
+#[test]
+fn read_session_history_resolves_codex_marker_with_colon_in_sessions_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions:with:colon");
+    let history = b"{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";
+    write_session_file(
+        &sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+        history,
+    )
+    .unwrap();
+
+    let path_file =
+        write_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID).unwrap();
+
+    let bytes =
+        guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
+    assert_eq!(bytes, history);
+}
+
+#[test]
+fn read_session_history_rejects_malformed_codex_marker_without_literal_read() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path_file = tmp.path().join("path.txt");
+    std::fs::write(
+        &path_file,
+        format!("CODEX_SEARCH_V2:not-a-length:/tmp:{VALID_CODEX_THREAD_ID}"),
+    )
+    .unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("malformed codex marker must not fall back to literal path reads");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Invalid Codex session history marker"),
+        "expected invalid marker error, got: {msg}"
+    );
+    assert!(
+        !msg.contains(VALID_CODEX_THREAD_ID),
+        "invalid marker error must not expose the thread id, got: {msg}"
+    );
 }
 
 #[test]
@@ -339,6 +421,31 @@ fn read_session_history_codex_marker_rejects_decorated_thread_id() {
     assert!(
         msg.contains("Codex session file not found"),
         "expected decorated thread id to fail fast, got: {msg}"
+    );
+}
+
+#[test]
+fn read_session_history_codex_marker_rejects_urn_thread_id_with_colons() {
+    let thread_id = format!("urn:uuid:{VALID_CODEX_THREAD_ID}");
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let misleading_dir = tmp.path().join("sessions:urn:uuid");
+    write_session_file(
+        &misleading_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+        b"history\n",
+    )
+    .unwrap();
+
+    let path_file = write_codex_marker_path_file(tmp.path(), &sessions_dir, &thread_id).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("urn codex thread id must not be split into a directory suffix");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Codex session file not found"),
+        "expected urn thread id to fail fast, got: {msg}"
     );
 }
 

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -45,21 +45,6 @@ fn write_codex_marker_path_file(
     Ok(path_file)
 }
 
-fn write_legacy_codex_marker_path_file(
-    root: &Path,
-    sessions_dir: &Path,
-    thread_id: &str,
-) -> Result<PathBuf, String> {
-    let path_file = root.join("path.txt");
-    let marker = format!(
-        "CODEX_SEARCH:{}:{thread_id}",
-        sessions_dir.to_string_lossy()
-    );
-    std::fs::write(&path_file, marker.as_bytes())
-        .map_err(|e| format!("write {}: {e}", path_file.display()))?;
-    Ok(path_file)
-}
-
 fn assert_error_contains_without_secret(
     error: impl std::fmt::Display,
     expected: &str,
@@ -98,28 +83,6 @@ fn read_session_history_resolves_literal_codex_marker_end_to_end() {
 }
 
 #[test]
-fn read_session_history_resolves_legacy_codex_marker_end_to_end() {
-    let tmp = tempfile::tempdir().unwrap();
-    let sessions_dir = tmp.path().join("sessions");
-    let history = b"{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";
-    write_session_file(
-        &sessions_dir,
-        &["2026", "04", "28"],
-        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
-        history,
-    )
-    .unwrap();
-
-    let path_file =
-        write_legacy_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID)
-            .unwrap();
-
-    let bytes =
-        guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
-    assert_eq!(bytes, history);
-}
-
-#[test]
 fn read_session_history_resolves_codex_marker_with_colon_in_sessions_dir() {
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions:with:colon-π");
@@ -138,32 +101,6 @@ fn read_session_history_resolves_codex_marker_with_colon_in_sessions_dir() {
     let bytes =
         guest_agent::session_history::read_session_history(path_file.to_str().unwrap()).unwrap();
     assert_eq!(bytes, history);
-}
-
-#[test]
-fn read_session_history_legacy_codex_marker_rejects_urn_thread_id_with_colons() {
-    let thread_id = format!("urn:uuid:{VALID_CODEX_THREAD_ID}");
-    let tmp = tempfile::tempdir().unwrap();
-    let sessions_dir = tmp.path().join("sessions");
-    let misleading_dir = tmp.path().join("sessions:urn:uuid");
-    write_session_file(
-        &misleading_dir,
-        &["2026", "04", "28"],
-        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
-        b"history\n",
-    )
-    .unwrap();
-
-    let path_file =
-        write_legacy_codex_marker_path_file(tmp.path(), &sessions_dir, &thread_id).unwrap();
-
-    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
-        .expect_err("legacy urn codex thread id must not be split into a directory suffix");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Codex session file not found"),
-        "expected legacy urn thread id to fail fast, got: {msg}"
-    );
 }
 
 #[test]
@@ -195,7 +132,7 @@ fn read_session_history_rejects_malformed_codex_markers_without_literal_read() {
 }
 
 #[test]
-fn read_session_history_decodes_legacy_zstd_session() {
+fn read_session_history_decodes_zstd_session() {
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions");
     let history = b"{\"type\":\"thread.started\",\"thread_id\":\"x\"}\n";

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -167,26 +167,31 @@ fn read_session_history_legacy_codex_marker_rejects_urn_thread_id_with_colons() 
 }
 
 #[test]
-fn read_session_history_rejects_malformed_codex_marker_without_literal_read() {
-    let tmp = tempfile::tempdir().unwrap();
-    let path_file = tmp.path().join("path.txt");
-    std::fs::write(
-        &path_file,
+fn read_session_history_rejects_malformed_codex_markers_without_literal_read() {
+    for marker in [
         format!("CODEX_SEARCH_V2:not-a-length:/tmp:{VALID_CODEX_THREAD_ID}"),
-    )
-    .unwrap();
+        format!("CODEX_SEARCH_V2:999:/tmp:{VALID_CODEX_THREAD_ID}"),
+        "CODEX_SEARCH_V2:0::0193abcd-ef01-7234-89ab-cdef01234567".to_string(),
+        "CODEX_SEARCH_V2:4:/tmp".to_string(),
+        "CODEX_SEARCH_V2:4:/tmp:".to_string(),
+        format!("CODEX_SEARCH_V2:1:π:{VALID_CODEX_THREAD_ID}"),
+    ] {
+        let tmp = tempfile::tempdir().unwrap();
+        let path_file = tmp.path().join("path.txt");
+        std::fs::write(&path_file, marker.as_bytes()).unwrap();
 
-    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
-        .expect_err("malformed codex marker must not fall back to literal path reads");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Invalid Codex session history marker"),
-        "expected invalid marker error, got: {msg}"
-    );
-    assert!(
-        !msg.contains(VALID_CODEX_THREAD_ID),
-        "invalid marker error must not expose the thread id, got: {msg}"
-    );
+        let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+            .expect_err("malformed codex marker must not fall back to literal path reads");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Invalid Codex session history marker"),
+            "expected invalid marker error for {marker:?}, got: {msg}"
+        );
+        assert!(
+            !msg.contains(VALID_CODEX_THREAD_ID),
+            "invalid marker error must not expose the thread id for {marker:?}, got: {msg}"
+        );
+    }
 }
 
 #[test]

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -6,6 +6,7 @@ description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
 libc.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/guest-contracts/src/codex_thread_id.rs
+++ b/crates/guest-contracts/src/codex_thread_id.rs
@@ -1,0 +1,131 @@
+//! Shared Codex thread ID identity contract.
+//!
+//! Codex thread IDs are accepted as standard UUID text, either hyphenated or
+//! compact. Decorative forms accepted by `uuid::Uuid::parse_str`, such as
+//! `urn:uuid:*` and brace-wrapped UUIDs, are intentionally outside this
+//! runner/guest contract.
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CodexThreadId {
+    canonical: String,
+}
+
+impl CodexThreadId {
+    pub fn parse(raw: &str) -> Option<Self> {
+        if !has_contract_shape(raw) {
+            return None;
+        }
+
+        uuid::Uuid::parse_str(raw).ok().map(|uuid| Self {
+            canonical: uuid.to_string(),
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.canonical
+    }
+
+    pub fn into_string(self) -> String {
+        self.canonical
+    }
+
+    pub fn filename_key(&self) -> String {
+        self.canonical.replace('-', "")
+    }
+}
+
+pub fn canonical_codex_thread_id(raw: &str) -> Option<String> {
+    CodexThreadId::parse(raw).map(CodexThreadId::into_string)
+}
+
+pub fn codex_thread_id_filename_key(raw: &str) -> Option<String> {
+    CodexThreadId::parse(raw).map(|thread_id| thread_id.filename_key())
+}
+
+fn has_contract_shape(raw: &str) -> bool {
+    match raw.len() {
+        32 => raw.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        36 => raw.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        }),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CANONICAL: &str = "019e9154-c304-70f0-adde-36efb1be1701";
+    const NO_DASH: &str = "019e9154c30470f0adde36efb1be1701";
+
+    #[test]
+    fn parses_dashed_lowercase_uuid() {
+        let thread_id = CodexThreadId::parse(CANONICAL).expect("valid codex thread id");
+
+        assert_eq!(thread_id.as_str(), CANONICAL);
+    }
+
+    #[test]
+    fn canonicalizes_dashed_uppercase_uuid() {
+        let thread_id = CodexThreadId::parse("019E9154-C304-70F0-ADDE-36EFB1BE1701")
+            .expect("valid codex thread id");
+
+        assert_eq!(thread_id.as_str(), CANONICAL);
+    }
+
+    #[test]
+    fn canonicalizes_no_dash_uppercase_uuid() {
+        let thread_id =
+            CodexThreadId::parse("019E9154C30470F0ADDE36EFB1BE1701").expect("valid codex id");
+
+        assert_eq!(thread_id.as_str(), CANONICAL);
+    }
+
+    #[test]
+    fn returns_filename_key() {
+        let thread_id = CodexThreadId::parse(CANONICAL).expect("valid codex thread id");
+
+        assert_eq!(thread_id.filename_key(), NO_DASH);
+    }
+
+    #[test]
+    fn canonical_free_function_returns_canonical_text() {
+        assert_eq!(
+            canonical_codex_thread_id("019E9154C30470F0ADDE36EFB1BE1701"),
+            Some(CANONICAL.to_string())
+        );
+    }
+
+    #[test]
+    fn filename_key_free_function_returns_no_dash_text() {
+        assert_eq!(
+            codex_thread_id_filename_key("019E9154-C304-70F0-ADDE-36EFB1BE1701"),
+            Some(NO_DASH.to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_contract_forms() {
+        for raw in [
+            "",
+            "abc",
+            "---",
+            "019e9154_c304_70f0_adde_36efb1be1701",
+            "019e9154-c304-70f0-adde36efb1be1701",
+            "{019e9154-c304-70f0-adde-36efb1be1701}",
+            "urn:uuid:019e9154-c304-70f0-adde-36efb1be1701",
+            " 019e9154-c304-70f0-adde-36efb1be1701",
+            "019e9154-c304-70f0-adde-36efb1be1701 ",
+        ] {
+            assert!(
+                CodexThreadId::parse(raw).is_none(),
+                "expected rejection for {raw:?}"
+            );
+        }
+    }
+}

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -3,5 +3,6 @@
 //! Keep guest-only runtime helpers in `guest-common`. This crate is for names,
 //! values, and filesystem layout helpers both sides must keep in lockstep.
 
+pub mod codex_thread_id;
 pub mod env;
 pub mod runtime_paths;

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -42,7 +42,7 @@ while [ -n "$remaining" ]; do
   check_restore_dir_component "$current"
 done
 id="$VM0_CODEX_RESTORE_SESSION_ID"
-id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
+id_no_dashes="$VM0_CODEX_RESTORE_SESSION_FILENAME_KEY"
 case "$id_no_dashes" in
   ""|*[!0123456789abcdefABCDEF]*)
     echo "invalid codex restore session id" >&2

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -42,6 +42,16 @@ while [ -n "$remaining" ]; do
   check_restore_dir_component "$current"
 done
 id="$VM0_CODEX_RESTORE_SESSION_ID"
+case "$id" in
+  ""|*[!0123456789abcdefABCDEF-]*)
+    echo "invalid codex restore session id" >&2
+    exit 1
+    ;;
+esac
+if [ "${#id}" -ne 36 ]; then
+  echo "invalid codex restore session id" >&2
+  exit 1
+fi
 id_no_dashes="$VM0_CODEX_RESTORE_SESSION_FILENAME_KEY"
 case "$id_no_dashes" in
   ""|*[!0123456789abcdefABCDEF]*)

--- a/crates/runner/src/executor/session_id.rs
+++ b/crates/runner/src/executor/session_id.rs
@@ -11,8 +11,5 @@ pub(super) fn is_valid_session_id(id: &str) -> bool {
 }
 
 pub(super) fn canonical_codex_thread_id(id: &str) -> Option<String> {
-    if !is_valid_session_id(id) {
-        return None;
-    }
-    uuid::Uuid::parse_str(id).ok().map(|uuid| uuid.to_string())
+    guest_contracts::codex_thread_id::canonical_codex_thread_id(id)
 }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -207,6 +207,20 @@ mod tests {
         session_id: &str,
     ) -> Output {
         let session_filename_key = session_id.replace('-', "");
+        run_cleanup_with_session_identity(
+            codex_home,
+            restore_path,
+            session_id,
+            &session_filename_key,
+        )
+    }
+
+    fn run_cleanup_with_session_identity(
+        codex_home: &Path,
+        restore_path: &Path,
+        session_id: &str,
+        session_filename_key: &str,
+    ) -> Output {
         Command::new("sh")
             .arg("-c")
             .arg(codex_session_cleanup_command(
@@ -396,6 +410,30 @@ mod tests {
 
         assert_failure_contains(&output, "invalid codex restore session id");
         assert!(existing_session.exists());
+    }
+
+    #[test]
+    fn cleanup_script_rejects_invalid_session_id_with_valid_filename_key_without_deleting_sessions()
+    {
+        for invalid_session_id in ["", "*"] {
+            let temp = tempfile::tempdir().unwrap();
+            let codex_home = temp.path().join(".codex");
+            let restore_path = restore_path(&codex_home);
+            let restore_dir = restore_path.parent().unwrap();
+            fs::create_dir_all(restore_dir).unwrap();
+            let existing_session = restore_dir.join("rollout-existing-session.jsonl");
+            create_file(&existing_session);
+
+            let output = run_cleanup_with_session_identity(
+                &codex_home,
+                &restore_path,
+                invalid_session_id,
+                SESSION_ID_NO_DASHES,
+            );
+
+            assert_failure_contains(&output, "invalid codex restore session id");
+            assert!(existing_session.exists());
+        }
     }
 
     #[test]

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -6,8 +6,8 @@ use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::{ExecutionContext, ResumeSession};
 
-use super::super::session_id::canonical_codex_thread_id;
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
+use guest_contracts::codex_thread_id::CodexThreadId;
 
 const CODEX_HOME: &str = "/home/user/.codex";
 const CODEX_SESSION_CLEANUP_SCRIPT: &str =
@@ -89,18 +89,27 @@ pub(super) async fn restore_codex_session(
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<()> {
-    let session_id = canonical_codex_thread_id(&session.cli_agent_session_id)
+    let thread_id = CodexThreadId::parse(&session.cli_agent_session_id)
         .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
+    let session_id = thread_id.as_str();
+    let session_filename_key = thread_id.filename_key();
 
     let session_path =
-        codex_restore_rollout_path(&session_id, &session.session_history, chrono::Utc::now());
+        codex_restore_rollout_path(session_id, &session.session_history, chrono::Utc::now());
 
-    cleanup_existing_codex_session_files(sandbox, context, &session_id, &session_path).await?;
+    cleanup_existing_codex_session_files(
+        sandbox,
+        context,
+        session_id,
+        &session_filename_key,
+        &session_path,
+    )
+    .await?;
 
     write_session_history_file(
         sandbox,
         &session_path,
-        &[&session_id, &session.cli_agent_session_id],
+        &[session_id, &session.cli_agent_session_id],
         &session.session_history,
     )
     .await?;
@@ -119,11 +128,16 @@ async fn cleanup_existing_codex_session_files(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session_id: &str,
+    session_filename_key: &str,
     session_path: &str,
 ) -> RunnerResult<()> {
     let cleanup_cmd = codex_session_cleanup_command(CODEX_HOME);
     let env = [
         ("VM0_CODEX_RESTORE_SESSION_ID", session_id),
+        (
+            "VM0_CODEX_RESTORE_SESSION_FILENAME_KEY",
+            session_filename_key,
+        ),
         ("VM0_CODEX_RESTORE_SESSION_PATH", session_path),
     ];
     let result = sandbox
@@ -192,12 +206,17 @@ mod tests {
         restore_path: &Path,
         session_id: &str,
     ) -> Output {
+        let session_filename_key = session_id.replace('-', "");
         Command::new("sh")
             .arg("-c")
             .arg(codex_session_cleanup_command(
                 codex_home.to_str().expect("test path should be utf-8"),
             ))
             .env("VM0_CODEX_RESTORE_SESSION_ID", session_id)
+            .env(
+                "VM0_CODEX_RESTORE_SESSION_FILENAME_KEY",
+                session_filename_key,
+            )
             .env(
                 "VM0_CODEX_RESTORE_SESSION_PATH",
                 restore_path.to_str().expect("test path should be utf-8"),

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -117,7 +117,7 @@ pub(super) async fn restore_codex_session(
     info!(
         run_id = %context.run_id,
         framework = "codex",
-        session_fingerprint = %diagnostic_session_fingerprint(&session_id),
+        session_fingerprint = %diagnostic_session_fingerprint(session_id),
         bytes_in = session.session_history.len(),
         "restored session history",
     );

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -229,17 +229,6 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
         !restore_event.fields.contains_key("path"),
         "restore diagnostic must not include a path embedding the session id: {restore_event:#?}"
     );
-    let cleanup_event = captured_event(
-        &events,
-        "cleaned up existing codex session files before restore",
-    );
-    assert_eq!(
-        cleanup_event
-            .fields
-            .get("session_fingerprint")
-            .map(String::as_str),
-        Some(diagnostic_session_fingerprint(raw_session_id).as_str())
-    );
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -13,7 +13,7 @@ use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_wri
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::ResumeSession;
 
-static RESTORE_EVENT_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+static RESTORE_SESSION_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn session_id_validation_rejects_path_traversal() {
@@ -62,8 +62,8 @@ fn codex_thread_id_canonicalizes_uuid_spellings() {
     assert!(canonical_codex_thread_id("codex-safe-but-not-uuid").is_none());
 }
 
-#[tokio::test]
-async fn restore_session_writes_history() {
+#[test]
+fn restore_session_writes_history() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -71,7 +71,7 @@ async fn restore_session_writes_history() {
         cli_agent_session_id: "sess-abc-123".into(),
         session_history: r#"{"type":"init"}"#.into(),
     };
-    restore_session(&sandbox, &ctx, &session).await.unwrap();
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 }
 
 #[tokio::test]
@@ -122,8 +122,8 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
     );
 }
 
-#[tokio::test]
-async fn restore_session_unknown_framework_uses_claude_fallback() {
+#[test]
+fn restore_session_unknown_framework_uses_claude_fallback() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "custom-agent".into();
@@ -132,7 +132,7 @@ async fn restore_session_unknown_framework_uses_claude_fallback() {
         session_history: "data".into(),
     };
 
-    restore_session(&sandbox, &ctx, &session).await.unwrap();
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
@@ -143,8 +143,8 @@ async fn restore_session_unknown_framework_uses_claude_fallback() {
     assert_eq!(writes[0].content, b"data");
 }
 
-#[tokio::test]
-async fn restore_session_allows_empty_agent_type() {
+#[test]
+fn restore_session_allows_empty_agent_type() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = String::new(); // empty defaults to claude-code
@@ -153,11 +153,11 @@ async fn restore_session_allows_empty_agent_type() {
         session_history: "{}".into(),
     };
     // Should proceed (empty agent type treated as claude-code).
-    restore_session(&sandbox, &ctx, &session).await.unwrap();
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 }
 
-#[tokio::test]
-async fn restore_session_writes_codex_session() {
+#[test]
+fn restore_session_writes_codex_session() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -182,7 +182,7 @@ async fn restore_session_writes_codex_session() {
             }),
         ),
     };
-    restore_session(&sandbox, &ctx, &session).await.unwrap();
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     assert_codex_cleanup_call(&sandbox);
 
@@ -242,8 +242,8 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
     );
 }
 
-#[tokio::test]
-async fn restore_session_writes_codex_session_with_canonical_fallback_filename() {
+#[test]
+fn restore_session_writes_codex_session_with_canonical_fallback_filename() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -252,7 +252,7 @@ async fn restore_session_writes_codex_session_with_canonical_fallback_filename()
         session_history: "{\"type\":\"thread.started\"}\n{not-json}\n".into(),
     };
 
-    restore_session(&sandbox, &ctx, &session).await.unwrap();
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     assert_codex_cleanup_call(&sandbox);
 
@@ -279,8 +279,8 @@ async fn restore_session_writes_codex_session_with_canonical_fallback_filename()
     assert_eq!(writes[0].content, session.session_history.as_bytes());
 }
 
-#[tokio::test]
-async fn restore_session_canonicalizes_codex_session_id() {
+#[test]
+fn restore_session_canonicalizes_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -289,7 +289,7 @@ async fn restore_session_canonicalizes_codex_session_id() {
         session_history: "{}\n".into(),
     };
 
-    restore_session(&sandbox, &ctx, &session).await.unwrap();
+    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     assert_codex_cleanup_call(&sandbox);
 
@@ -805,20 +805,37 @@ fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
 where
     F: std::future::Future,
 {
-    let _capture_guard = RESTORE_EVENT_CAPTURE_LOCK
+    let _capture_guard = RESTORE_SESSION_LOG_CALLSITE_LOCK
         .lock()
-        .expect("restore event capture lock poisoned");
+        .expect("restore session log callsite lock poisoned");
     let captured = CapturedEvents::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("build restore event capture runtime");
-    let output = runtime.block_on(future);
+    let output = block_on_restore_session(future);
     drop(guard);
     (output, captured.entries())
+}
+
+fn run_restore_session<F>(future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    let _capture_guard = RESTORE_SESSION_LOG_CALLSITE_LOCK
+        .lock()
+        .expect("restore session log callsite lock poisoned");
+    block_on_restore_session(future)
+}
+
+fn block_on_restore_session<F>(future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build restore session test runtime")
+        .block_on(future)
 }
 
 fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -3,6 +3,7 @@ use sandbox::{
     SandboxOperation,
 };
 use sandbox_mock::MockSandbox;
+use std::sync::Mutex;
 use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
@@ -11,6 +12,8 @@ use super::super::session_restore::restore_session;
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::ResumeSession;
+
+static RESTORE_EVENT_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn session_id_validation_rejects_path_traversal() {
@@ -89,8 +92,8 @@ async fn restore_session_rejects_invalid_session_id() {
     );
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
+#[test]
+fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -100,7 +103,7 @@ async fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
         session_history: r#"{"type":"init"}"#.into(),
     };
 
-    let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session)).await;
+    let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
     result.unwrap();
     assert_captured_events_do_not_contain(&events, raw_session_id);
@@ -195,8 +198,8 @@ async fn restore_session_writes_codex_session() {
     assert_eq!(writes[0].content, session.session_history.as_bytes());
 }
 
-#[tokio::test(flavor = "current_thread")]
-async fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
+#[test]
+fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -206,7 +209,7 @@ async fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
         session_history: "{}\n".into(),
     };
 
-    let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session)).await;
+    let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
     result.unwrap();
     assert_captured_events_do_not_contain(&events, raw_session_id);
@@ -798,15 +801,22 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(exec_calls[0].cmd.contains("-delete"));
 }
 
-async fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
 where
     F: std::future::Future,
 {
+    let _capture_guard = RESTORE_EVENT_CAPTURE_LOCK
+        .lock()
+        .expect("restore event capture lock poisoned");
     let captured = CapturedEvents::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
-    let output = future.await;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build restore event capture runtime");
+    let output = runtime.block_on(future);
     drop(guard);
     (output, captured.entries())
 }

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -339,6 +339,33 @@ async fn restore_session_rejects_short_codex_session_id_without_cleanup() {
 }
 
 #[tokio::test]
+async fn restore_session_rejects_decorated_codex_session_id_without_cleanup() {
+    for raw_session_id in [
+        "{019e9154-c304-70f0-adde-36efb1be1701}",
+        "urn:uuid:019e9154-c304-70f0-adde-36efb1be1701",
+    ] {
+        let sandbox = MockSandbox::new("test");
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = "codex".into();
+        let session = ResumeSession {
+            cli_agent_session_id: raw_session_id.into(),
+            session_history: "{}".into(),
+        };
+
+        let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("invalid session_id"), "got: {err}");
+        assert!(
+            !message.contains(raw_session_id),
+            "invalid codex error must not echo raw session id: {message}"
+        );
+        assert!(sandbox.exec_calls().is_empty());
+        assert!(sandbox.write_file_calls().is_empty());
+    }
+}
+
+#[tokio::test]
 async fn restore_session_fails_when_codex_cleanup_fails() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
@@ -732,6 +759,7 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
         exec_calls[0].env_keys,
         [
             "VM0_CODEX_RESTORE_SESSION_ID".to_string(),
+            "VM0_CODEX_RESTORE_SESSION_FILENAME_KEY".to_string(),
             "VM0_CODEX_RESTORE_SESSION_PATH".to_string()
         ]
     );
@@ -761,6 +789,12 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
     assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
     assert!(exec_calls[0].cmd.contains(".jsonl.vm0tmp-*"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("VM0_CODEX_RESTORE_SESSION_FILENAME_KEY")
+    );
+    assert!(!exec_calls[0].cmd.contains("tr -d"));
     assert!(exec_calls[0].cmd.contains("-delete"));
 }
 


### PR DESCRIPTION
## Summary

- Add a strict shared Codex thread ID contract in `guest-contracts`
- Migrate runner restore/env/parking and guest-agent metadata/history paths to the shared contract
- Reject decorated UUID inputs consistently while preserving dashed/no-dash UUID support

Fixes #18490

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_restore`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test session_history_read`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_session_resume`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p runner -p guest-agent --all-targets -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc
