### PR TITLE
refactor(runner): split codex session restore cleanup

### DIFF
--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -9,7 +9,9 @@ fn main() {
 
     // Rebuild when embedded files change (include_str! tracks deps for rustc,
     // but CI artifact caches may not — explicit rerun-if-changed ensures correctness).
+    println!("cargo::rerun-if-changed=scripts/agent-abnormal-exit-diagnostics.sh");
     println!("cargo::rerun-if-changed=scripts/build-template.sh");
+    println!("cargo::rerun-if-changed=scripts/codex-session-cleanup.sh");
     println!("cargo::rerun-if-changed=scripts/customize-rootfs.sh");
     println!("cargo::rerun-if-changed=scripts/mount-workspace-drive.sh");
     println!("cargo::rerun-if-changed=scripts/unmount-workspace-drive.sh");

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -24,9 +24,14 @@ check_restore_dir_component "$root"
 root_prefix="$root/"
 relative_dir="${restore_dir#$root_prefix}"
 current="$root"
-old_ifs="$IFS"
-IFS=/
-for component in $relative_dir; do
+remaining="$relative_dir"
+while [ -n "$remaining" ]; do
+  component="${remaining%%/*}"
+  if [ "$component" = "$remaining" ]; then
+    remaining=""
+  else
+    remaining="${remaining#*/}"
+  fi
   case "$component" in
     ""|"."|"..")
       echo "invalid codex restore path component: $component" >&2
@@ -36,7 +41,6 @@ for component in $relative_dir; do
   current="$current/$component"
   check_restore_dir_component "$current"
 done
-IFS="$old_ifs"
 id="$VM0_CODEX_RESTORE_SESSION_ID"
 id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
 case "$id_no_dashes" in

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -37,19 +37,19 @@ for component in $relative_dir; do
   check_restore_dir_component "$current"
 done
 IFS="$old_ifs"
-if [ -d "$root" ]; then
-  id="$VM0_CODEX_RESTORE_SESSION_ID"
-  id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
-  case "$id_no_dashes" in
-    ""|*[!0123456789abcdef]*)
-      echo "invalid codex restore session id" >&2
-      exit 1
-      ;;
-  esac
-  if [ "${#id_no_dashes}" -ne 32 ]; then
+id="$VM0_CODEX_RESTORE_SESSION_ID"
+id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
+case "$id_no_dashes" in
+  ""|*[!0123456789abcdefABCDEF]*)
     echo "invalid codex restore session id" >&2
     exit 1
-  fi
+    ;;
+esac
+if [ "${#id_no_dashes}" -ne 32 ]; then
+  echo "invalid codex restore session id" >&2
+  exit 1
+fi
+if [ -d "$root" ]; then
   find "$root" \( -type f -o -type l \) \( \
     -iname "*${id}*.jsonl" -o \
     -iname "*${id}*.jsonl.zst" -o \

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -40,6 +40,16 @@ IFS="$old_ifs"
 if [ -d "$root" ]; then
   id="$VM0_CODEX_RESTORE_SESSION_ID"
   id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
+  case "$id_no_dashes" in
+    ""|*[!0123456789abcdef]*)
+      echo "invalid codex restore session id" >&2
+      exit 1
+      ;;
+  esac
+  if [ "${#id_no_dashes}" -ne 32 ]; then
+    echo "invalid codex restore session id" >&2
+    exit 1
+  fi
   find "$root" \( -type f -o -type l \) \( \
     -iname "*${id}*.jsonl" -o \
     -iname "*${id}*.jsonl.zst" -o \

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -1,0 +1,53 @@
+root="$codex_home/sessions"
+restore_path="$VM0_CODEX_RESTORE_SESSION_PATH"
+restore_dir="${restore_path%/*}"
+case "$restore_dir" in
+  "$root"/*/*/*) ;;
+  *)
+    echo "invalid codex restore directory: $restore_dir" >&2
+    exit 1
+    ;;
+esac
+check_restore_dir_component() {
+  path="$1"
+  if [ -L "$path" ]; then
+    echo "codex restore directory is a symlink: $path" >&2
+    exit 1
+  fi
+  if [ -e "$path" ] && [ ! -d "$path" ]; then
+    echo "codex restore path component is not a directory: $path" >&2
+    exit 1
+  fi
+}
+check_restore_dir_component "$codex_home"
+check_restore_dir_component "$root"
+root_prefix="$root/"
+relative_dir="${restore_dir#$root_prefix}"
+current="$root"
+old_ifs="$IFS"
+IFS=/
+for component in $relative_dir; do
+  case "$component" in
+    ""|"."|"..")
+      echo "invalid codex restore path component: $component" >&2
+      exit 1
+      ;;
+  esac
+  current="$current/$component"
+  check_restore_dir_component "$current"
+done
+IFS="$old_ifs"
+if [ -d "$root" ]; then
+  id="$VM0_CODEX_RESTORE_SESSION_ID"
+  id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
+  find "$root" \( -type f -o -type l \) \( \
+    -iname "*${id}*.jsonl" -o \
+    -iname "*${id}*.jsonl.zst" -o \
+    -iname "*${id}*.jsonl.vm0tmp-*" -o \
+    -iname "*${id}*.jsonl.zst.vm0tmp-*" -o \
+    -iname "*${id_no_dashes}*.jsonl" -o \
+    -iname "*${id_no_dashes}*.jsonl.zst" -o \
+    -iname "*${id_no_dashes}*.jsonl.vm0tmp-*" -o \
+    -iname "*${id_no_dashes}*.jsonl.zst.vm0tmp-*" \
+  \) -delete
+fi

--- a/crates/runner/src/executor/cli_framework.rs
+++ b/crates/runner/src/executor/cli_framework.rs
@@ -1,0 +1,23 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum EffectiveCliFramework {
+    ClaudeCode,
+    Codex,
+}
+
+pub(super) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFramework {
+    if normalized_cli_agent_type(cli_agent_type) == "codex" {
+        EffectiveCliFramework::Codex
+    } else {
+        // Guest-agent currently falls back unknown CLI_AGENT_TYPE values to
+        // Claude Code. Keep runner env gating aligned with that behavior.
+        EffectiveCliFramework::ClaudeCode
+    }
+}
+
+pub(super) fn normalized_cli_agent_type(cli_agent_type: &str) -> &str {
+    if cli_agent_type.is_empty() {
+        "claude-code"
+    } else {
+        cli_agent_type
+    }
+}

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -34,7 +34,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tracing::{info, warn};
 
 use super::env::is_runner_owned_env_key;
-use super::session_restore::is_valid_session_id;
+use super::session_id::is_valid_session_id;
 use super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT, AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT,
     AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, AGENT_ENV_KEY_MAX_CHARS, BOOTSTRAP_SENSITIVE_ENV_KEYS,

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
 use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 
-use super::session_restore::{canonical_codex_thread_id, is_valid_session_id};
+use super::cli_framework::{
+    EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
+};
+use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{
     DEFAULT_EXEC_TIMEOUT, GUEST_USER_ENV_DIR_NAME, GUEST_USER_ENV_FILENAME, RunnerError,
     RunnerResult, guest_runtime_dir, guest_runtime_path,
@@ -506,22 +509,6 @@ impl HostEnv {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum EffectiveCliFramework {
-    ClaudeCode,
-    Codex,
-}
-
-pub(super) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFramework {
-    if normalized_cli_agent_type(cli_agent_type) == "codex" {
-        EffectiveCliFramework::Codex
-    } else {
-        // Guest-agent currently falls back unknown CLI_AGENT_TYPE values to
-        // Claude Code. Keep runner env gating aligned with that behavior.
-        EffectiveCliFramework::ClaudeCode
-    }
-}
-
 pub(super) fn is_runner_owned_env_key(key: &str) -> bool {
     // The entire VM0_ namespace is runner-owned, including retired keys such
     // as VM0_WORKING_DIR. Non-VM0 keys must stay explicit.
@@ -623,13 +610,5 @@ pub(super) fn insert_codex_env(
         && !context.debug_no_mock_codex.unwrap_or(false)
     {
         env.insert(guest_contracts::env::USE_MOCK_CODEX_ENV.into(), val.clone());
-    }
-}
-
-pub(super) fn normalized_cli_agent_type(cli_agent_type: &str) -> &str {
-    if cli_agent_type.is_empty() {
-        "claude-code"
-    } else {
-        cli_agent_type
     }
 }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -25,10 +25,12 @@ use tokio_util::sync::CancellationToken;
 
 mod active_input;
 mod agent_run;
+mod cli_framework;
 mod diagnostics;
 mod env;
 mod guest_state;
 mod sandbox_run;
+mod session_id;
 mod session_restore;
 mod storage;
 mod telemetry;

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -8,12 +8,14 @@ use sandbox::{Sandbox, SandboxConfig, SandboxFactory, SandboxId};
 use tracing::{info, warn};
 
 use super::agent_run::{AgentExecutionResult, RunControls, RunStart, run_in_sandbox};
+use super::cli_framework::{
+    EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
+};
 use super::diagnostics::{
     AgentStdoutStreamDiagnostics, append_stdout_stream_diagnostics_to_stream_log, copy_guest_logs,
     read_guest_cli_agent_session_id,
 };
-use super::env::{EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type};
-use super::session_restore::{canonical_codex_thread_id, is_valid_session_id};
+use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::telemetry::record_workspace_cache_result;
 use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,

--- a/crates/runner/src/executor/session_id.rs
+++ b/crates/runner/src/executor/session_id.rs
@@ -1,0 +1,18 @@
+const MAX_SESSION_ID_LEN: usize = 128;
+
+/// Returns true if the session ID is short enough for guest filenames and
+/// contains only safe characters (alphanumeric, dash, underscore).
+pub(super) fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_SESSION_ID_LEN
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+pub(super) fn canonical_codex_thread_id(id: &str) -> Option<String> {
+    if !is_valid_session_id(id) {
+        return None;
+    }
+    uuid::Uuid::parse_str(id).ok().map(|uuid| uuid.to_string())
+}

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -1,10 +1,13 @@
 //! CLI session restore helpers for guest agent frameworks.
 
-use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox, SandboxError};
+mod codex;
+
+use sandbox::{Sandbox, SandboxError};
 use tracing::{info, warn};
 
-use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
-use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
+use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
+use super::session_id::is_valid_session_id;
+use super::{RunnerError, RunnerResult};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -14,8 +17,6 @@ const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
 const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
 const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
 const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
-const MAX_SESSION_ID_LEN: usize = 128;
-
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
@@ -29,16 +30,19 @@ pub(super) async fn restore_session(
         return Err(RunnerError::Internal("invalid session_id".into()));
     }
 
-    match context.cli_agent_type.as_str() {
-        "" | "claude-code" => restore_claude_session(sandbox, context, session).await,
-        "codex" => restore_codex_session(sandbox, context, session).await,
-        other => {
-            warn!(
-                run_id = %context.run_id,
-                framework = %other,
-                "restoring session as claude-code for unknown framework"
-            );
+    match effective_cli_framework(&context.cli_agent_type) {
+        EffectiveCliFramework::ClaudeCode => {
+            if !matches!(context.cli_agent_type.as_str(), "" | "claude-code") {
+                warn!(
+                    run_id = %context.run_id,
+                    framework = %context.cli_agent_type,
+                    "restoring session as claude-code for unknown framework"
+                );
+            }
             restore_claude_session(sandbox, context, session).await
+        }
+        EffectiveCliFramework::Codex => {
+            codex::restore_codex_session(sandbox, context, session).await
         }
     }
 }
@@ -68,199 +72,6 @@ pub(super) async fn restore_claude_session(
         session_fingerprint = %diagnostic_session_fingerprint(&session.cli_agent_session_id),
         bytes_in = session.session_history.len(),
         "restored session history"
-    );
-    Ok(())
-}
-
-pub(super) fn codex_restore_rollout_path(
-    session_id: &str,
-    session_history: &str,
-    fallback_timestamp: chrono::DateTime<chrono::Utc>,
-) -> String {
-    let timestamp = codex_session_meta_timestamp(session_history).unwrap_or(fallback_timestamp);
-    format!(
-        "/home/user/.codex/sessions/{}/{}/{}/rollout-{}-{session_id}.jsonl",
-        timestamp.format("%Y"),
-        timestamp.format("%m"),
-        timestamp.format("%d"),
-        timestamp.format("%Y-%m-%dT%H-%M-%S"),
-    )
-}
-
-pub(super) fn codex_session_meta_timestamp(
-    session_history: &str,
-) -> Option<chrono::DateTime<chrono::Utc>> {
-    for line in session_history.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
-            continue;
-        }
-
-        if let Some(timestamp) = value
-            .get("payload")
-            .and_then(|payload| payload.get("timestamp"))
-            .and_then(|timestamp| timestamp.as_str())
-            .and_then(parse_codex_rollout_timestamp)
-        {
-            return Some(timestamp);
-        }
-
-        if let Some(timestamp) = value
-            .get("timestamp")
-            .and_then(|timestamp| timestamp.as_str())
-            .and_then(parse_codex_rollout_timestamp)
-        {
-            return Some(timestamp);
-        }
-    }
-
-    None
-}
-
-pub(super) fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    chrono::DateTime::parse_from_rfc3339(raw)
-        .ok()
-        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
-        .or_else(|| {
-            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H-%M-%S")
-                .ok()
-                .map(|timestamp| {
-                    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
-                        timestamp,
-                        chrono::Utc,
-                    )
-                })
-        })
-}
-
-/// Write a Codex session history file as plain JSONL at
-/// `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-{thread_id}.jsonl`.
-///
-/// Codex 0.137 filters filesystem resume candidates through its canonical
-/// rollout filename parser, so a bare `{thread_id}.jsonl` is ignored.
-pub(super) async fn restore_codex_session(
-    sandbox: &dyn Sandbox,
-    context: &ExecutionContext,
-    session: &ResumeSession,
-) -> RunnerResult<()> {
-    let session_id = canonical_codex_thread_id(&session.cli_agent_session_id)
-        .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
-
-    let session_path =
-        codex_restore_rollout_path(&session_id, &session.session_history, chrono::Utc::now());
-
-    cleanup_existing_codex_session_files(sandbox, context, &session_id, &session_path).await?;
-
-    write_session_history_file(
-        sandbox,
-        &session_path,
-        &[&session_id, &session.cli_agent_session_id],
-        &session.session_history,
-    )
-    .await?;
-
-    info!(
-        run_id = %context.run_id,
-        framework = "codex",
-        session_fingerprint = %diagnostic_session_fingerprint(&session_id),
-        bytes_in = session.session_history.len(),
-        "restored session history",
-    );
-    Ok(())
-}
-
-async fn cleanup_existing_codex_session_files(
-    sandbox: &dyn Sandbox,
-    context: &ExecutionContext,
-    session_id: &str,
-    session_path: &str,
-) -> RunnerResult<()> {
-    let cleanup_cmd = r#"codex_home=/home/user/.codex
-root="$codex_home/sessions"
-restore_path="$VM0_CODEX_RESTORE_SESSION_PATH"
-restore_dir="${restore_path%/*}"
-case "$restore_dir" in
-  "$root"/*/*/*) ;;
-  *)
-    echo "invalid codex restore directory: $restore_dir" >&2
-    exit 1
-    ;;
-esac
-check_restore_dir_component() {
-  path="$1"
-  if [ -L "$path" ]; then
-    echo "codex restore directory is a symlink: $path" >&2
-    exit 1
-  fi
-  if [ -e "$path" ] && [ ! -d "$path" ]; then
-    echo "codex restore path component is not a directory: $path" >&2
-    exit 1
-  fi
-}
-check_restore_dir_component "$codex_home"
-check_restore_dir_component "$root"
-root_prefix="$root/"
-relative_dir="${restore_dir#$root_prefix}"
-current="$root"
-old_ifs="$IFS"
-IFS=/
-for component in $relative_dir; do
-  case "$component" in
-    ""|"."|"..")
-      echo "invalid codex restore path component: $component" >&2
-      exit 1
-      ;;
-  esac
-  current="$current/$component"
-  check_restore_dir_component "$current"
-done
-IFS="$old_ifs"
-if [ -d "$root" ]; then
-  id="$VM0_CODEX_RESTORE_SESSION_ID"
-  id_no_dashes="$(printf '%s' "$id" | tr -d '-')"
-  find "$root" \( -type f -o -type l \) \( \
-    -iname "*${id}*.jsonl" -o \
-    -iname "*${id}*.jsonl.zst" -o \
-    -iname "*${id}*.jsonl.vm0tmp-*" -o \
-    -iname "*${id}*.jsonl.zst.vm0tmp-*" -o \
-    -iname "*${id_no_dashes}*.jsonl" -o \
-    -iname "*${id_no_dashes}*.jsonl.zst" -o \
-    -iname "*${id_no_dashes}*.jsonl.vm0tmp-*" -o \
-    -iname "*${id_no_dashes}*.jsonl.zst.vm0tmp-*" \
-  \) -delete
-fi"#;
-    let env = [
-        ("VM0_CODEX_RESTORE_SESSION_ID", session_id),
-        ("VM0_CODEX_RESTORE_SESSION_PATH", session_path),
-    ];
-    let result = sandbox
-        .exec(&ExecRequest {
-            cmd: cleanup_cmd,
-            timeout: DEFAULT_EXEC_TIMEOUT,
-            env: &env,
-            sudo: false,
-            stdin_bytes: None,
-            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-        })
-        .await?;
-    if !helper_exec_succeeded(&result) {
-        return Err(RunnerError::Internal(redact_session_restore_diagnostic(
-            format_helper_exec_failure("codex session cleanup", &result),
-            &[session_id],
-            session_path,
-        )));
-    }
-    info!(
-        run_id = %context.run_id,
-        session_fingerprint = %diagnostic_session_fingerprint(session_id),
-        "cleaned up existing codex session files before restore",
     );
     Ok(())
 }
@@ -386,21 +197,4 @@ fn session_redaction_variants(session_id: &str) -> Vec<String> {
     .into_iter()
     .filter(|variant| !variant.is_empty())
     .collect()
-}
-
-/// Returns true if the session ID is short enough for guest filenames and
-/// contains only safe characters (alphanumeric, dash, underscore).
-pub(super) fn is_valid_session_id(id: &str) -> bool {
-    !id.is_empty()
-        && id.len() <= MAX_SESSION_ID_LEN
-        && id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
-
-pub(super) fn canonical_codex_thread_id(id: &str) -> Option<String> {
-    if !is_valid_session_id(id) {
-        return None;
-    }
-    uuid::Uuid::parse_str(id).ok().map(|uuid| uuid.to_string())
 }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -277,6 +277,26 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_script_accepts_uppercase_session_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+        create_file(&matching_jsonl);
+
+        let output = run_cleanup_with_session_id(
+            &codex_home,
+            &restore_path,
+            &SESSION_ID.to_ascii_uppercase(),
+        );
+
+        assert_success(&output);
+        assert!(!matching_jsonl.exists());
+    }
+
+    #[test]
     fn cleanup_script_rejects_restore_path_outside_sessions_root() {
         let temp = tempfile::tempdir().unwrap();
         let codex_home = temp.path().join(".codex");

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -1,0 +1,337 @@
+use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+use tracing::info;
+
+use super::{redact_session_restore_diagnostic, write_session_history_file};
+use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
+use crate::paths::diagnostic_session_fingerprint;
+use crate::types::{ExecutionContext, ResumeSession};
+
+use super::super::session_id::canonical_codex_thread_id;
+use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
+
+const CODEX_HOME: &str = "/home/user/.codex";
+const CODEX_SESSION_CLEANUP_SCRIPT: &str =
+    include_str!("../../../scripts/codex-session-cleanup.sh");
+
+fn codex_restore_rollout_path(
+    session_id: &str,
+    session_history: &str,
+    fallback_timestamp: chrono::DateTime<chrono::Utc>,
+) -> String {
+    let timestamp = codex_session_meta_timestamp(session_history).unwrap_or(fallback_timestamp);
+    format!(
+        "{CODEX_HOME}/sessions/{}/{}/{}/rollout-{}-{session_id}.jsonl",
+        timestamp.format("%Y"),
+        timestamp.format("%m"),
+        timestamp.format("%d"),
+        timestamp.format("%Y-%m-%dT%H-%M-%S"),
+    )
+}
+
+fn codex_session_meta_timestamp(session_history: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    for line in session_history.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
+            continue;
+        }
+
+        if let Some(timestamp) = value
+            .get("payload")
+            .and_then(|payload| payload.get("timestamp"))
+            .and_then(|timestamp| timestamp.as_str())
+            .and_then(parse_codex_rollout_timestamp)
+        {
+            return Some(timestamp);
+        }
+
+        if let Some(timestamp) = value
+            .get("timestamp")
+            .and_then(|timestamp| timestamp.as_str())
+            .and_then(parse_codex_rollout_timestamp)
+        {
+            return Some(timestamp);
+        }
+    }
+
+    None
+}
+
+fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H-%M-%S")
+                .ok()
+                .map(|timestamp| {
+                    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+                        timestamp,
+                        chrono::Utc,
+                    )
+                })
+        })
+}
+
+/// Write a Codex session history file as plain JSONL at
+/// `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-{thread_id}.jsonl`.
+///
+/// Codex 0.137 filters filesystem resume candidates through its canonical
+/// rollout filename parser, so a bare `{thread_id}.jsonl` is ignored.
+pub(super) async fn restore_codex_session(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    session: &ResumeSession,
+) -> RunnerResult<()> {
+    let session_id = canonical_codex_thread_id(&session.cli_agent_session_id)
+        .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
+
+    let session_path =
+        codex_restore_rollout_path(&session_id, &session.session_history, chrono::Utc::now());
+
+    cleanup_existing_codex_session_files(sandbox, context, &session_id, &session_path).await?;
+
+    write_session_history_file(
+        sandbox,
+        &session_path,
+        &[&session_id, &session.cli_agent_session_id],
+        &session.session_history,
+    )
+    .await?;
+
+    info!(
+        run_id = %context.run_id,
+        framework = "codex",
+        session_fingerprint = %diagnostic_session_fingerprint(&session_id),
+        bytes_in = session.session_history.len(),
+        "restored session history",
+    );
+    Ok(())
+}
+
+async fn cleanup_existing_codex_session_files(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    session_id: &str,
+    session_path: &str,
+) -> RunnerResult<()> {
+    let cleanup_cmd = codex_session_cleanup_command(CODEX_HOME);
+    let env = [
+        ("VM0_CODEX_RESTORE_SESSION_ID", session_id),
+        ("VM0_CODEX_RESTORE_SESSION_PATH", session_path),
+    ];
+    let result = sandbox
+        .exec(&ExecRequest {
+            cmd: &cleanup_cmd,
+            timeout: DEFAULT_EXEC_TIMEOUT,
+            env: &env,
+            sudo: false,
+            stdin_bytes: None,
+            output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+        })
+        .await?;
+    if !helper_exec_succeeded(&result) {
+        return Err(RunnerError::Internal(redact_session_restore_diagnostic(
+            format_helper_exec_failure("codex session cleanup", &result),
+            &[session_id],
+            session_path,
+        )));
+    }
+    info!(
+        run_id = %context.run_id,
+        session_fingerprint = %diagnostic_session_fingerprint(session_id),
+        "cleaned up existing codex session files before restore",
+    );
+    Ok(())
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn codex_session_cleanup_command(codex_home: &str) -> String {
+    let codex_home = shell_quote(codex_home);
+    format!("codex_home={codex_home}\n{CODEX_SESSION_CLEANUP_SCRIPT}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Output};
+
+    const SESSION_ID: &str = "019e9154-c304-70f0-adde-36efb1be1701";
+    const SESSION_ID_NO_DASHES: &str = "019e9154c30470f0adde36efb1be1701";
+
+    fn restore_path(codex_home: &Path) -> PathBuf {
+        codex_home.join(format!(
+            "sessions/2026/06/04/rollout-2026-06-04T07-18-08-{SESSION_ID}.jsonl"
+        ))
+    }
+
+    fn create_file(path: &Path) {
+        fs::create_dir_all(path.parent().expect("test path should have parent")).unwrap();
+        fs::write(path, "test").unwrap();
+    }
+
+    fn run_cleanup(codex_home: &Path, restore_path: &Path) -> Output {
+        Command::new("sh")
+            .arg("-c")
+            .arg(codex_session_cleanup_command(
+                codex_home.to_str().expect("test path should be utf-8"),
+            ))
+            .env("VM0_CODEX_RESTORE_SESSION_ID", SESSION_ID)
+            .env(
+                "VM0_CODEX_RESTORE_SESSION_PATH",
+                restore_path.to_str().expect("test path should be utf-8"),
+            )
+            .output()
+            .unwrap()
+    }
+
+    fn assert_success(output: &Output) {
+        assert!(
+            output.status.success(),
+            "stderr={} stdout={}",
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    fn assert_failure_contains(output: &Output, expected: &str) {
+        assert!(
+            !output.status.success(),
+            "expected command to fail; stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(expected),
+            "expected stderr to contain {expected:?}, got {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn cleanup_command_uses_fixed_codex_home_prelude() {
+        let command = codex_session_cleanup_command(CODEX_HOME);
+
+        assert!(command.contains("codex_home='/home/user/.codex'"));
+        assert!(command.contains("root=\"$codex_home/sessions\""));
+        assert!(command.contains("find \"$root\" \\( -type f -o -type l \\)"));
+    }
+
+    #[test]
+    fn cleanup_script_deletes_matching_session_files_and_symlinks() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+
+        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+        let matching_zst = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl.zst"));
+        let matching_tmp = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl.vm0tmp-123"));
+        let matching_no_dash = codex_home.join("sessions/2026/06/05").join(format!(
+            "rollout-b-{SESSION_ID_NO_DASHES}.jsonl.zst.vm0tmp-456"
+        ));
+        let matching_symlink = restore_dir.join(format!("rollout-link-{SESSION_ID}.jsonl"));
+        let matching_directory = restore_dir.join(format!("rollout-dir-{SESSION_ID}.jsonl"));
+        let unrelated = restore_dir.join("rollout-other-session.jsonl");
+
+        create_file(&matching_jsonl);
+        create_file(&matching_zst);
+        create_file(&matching_tmp);
+        create_file(&matching_no_dash);
+        create_file(&unrelated);
+        fs::create_dir(&matching_directory).unwrap();
+        symlink(&unrelated, &matching_symlink).unwrap();
+
+        let output = run_cleanup(&codex_home, &restore_path);
+
+        assert_success(&output);
+        assert!(!matching_jsonl.exists());
+        assert!(!matching_zst.exists());
+        assert!(!matching_tmp.exists());
+        assert!(!matching_no_dash.exists());
+        assert!(!matching_symlink.exists());
+        assert!(matching_directory.exists());
+        assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn cleanup_script_rejects_restore_path_outside_sessions_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        fs::create_dir_all(codex_home.join("sessions")).unwrap();
+        let outside_restore_path = temp
+            .path()
+            .join(format!("outside/rollout-{SESSION_ID}.jsonl"));
+
+        let output = run_cleanup(&codex_home, &outside_restore_path);
+
+        assert_failure_contains(&output, "invalid codex restore directory");
+    }
+
+    #[test]
+    fn cleanup_script_rejects_symlink_codex_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let real_codex_home = temp.path().join("real-codex");
+        let codex_home = temp.path().join(".codex");
+        fs::create_dir_all(real_codex_home.join("sessions/2026/06/04")).unwrap();
+        symlink(&real_codex_home, &codex_home).unwrap();
+        let restore_path = restore_path(&codex_home);
+
+        let output = run_cleanup(&codex_home, &restore_path);
+
+        assert_failure_contains(&output, "codex restore directory is a symlink");
+    }
+
+    #[test]
+    fn cleanup_script_rejects_non_directory_restore_component() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let root = codex_home.join("sessions");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("2026"), "not a directory").unwrap();
+        let restore_path = restore_path(&codex_home);
+
+        let output = run_cleanup(&codex_home, &restore_path);
+
+        assert_failure_contains(&output, "codex restore path component is not a directory");
+    }
+
+    #[test]
+    fn cleanup_script_succeeds_when_sessions_root_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        fs::create_dir_all(&codex_home).unwrap();
+        let restore_path = restore_path(&codex_home);
+
+        let output = run_cleanup(&codex_home, &restore_path);
+
+        assert_success(&output);
+    }
+
+    #[test]
+    fn cleanup_script_rejects_restore_path_without_date_depth() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let root = codex_home.join("sessions");
+        fs::create_dir_all(&root).unwrap();
+        let shallow_restore_path = root.join(format!("rollout-{SESSION_ID}.jsonl"));
+
+        let output = run_cleanup(&codex_home, &shallow_restore_path);
+
+        assert_failure_contains(&output, "invalid codex restore directory");
+    }
+}

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -184,12 +184,20 @@ mod tests {
     }
 
     fn run_cleanup(codex_home: &Path, restore_path: &Path) -> Output {
+        run_cleanup_with_session_id(codex_home, restore_path, SESSION_ID)
+    }
+
+    fn run_cleanup_with_session_id(
+        codex_home: &Path,
+        restore_path: &Path,
+        session_id: &str,
+    ) -> Output {
         Command::new("sh")
             .arg("-c")
             .arg(codex_session_cleanup_command(
                 codex_home.to_str().expect("test path should be utf-8"),
             ))
-            .env("VM0_CODEX_RESTORE_SESSION_ID", SESSION_ID)
+            .env("VM0_CODEX_RESTORE_SESSION_ID", session_id)
             .env(
                 "VM0_CODEX_RESTORE_SESSION_PATH",
                 restore_path.to_str().expect("test path should be utf-8"),
@@ -333,5 +341,37 @@ mod tests {
         let output = run_cleanup(&codex_home, &shallow_restore_path);
 
         assert_failure_contains(&output, "invalid codex restore directory");
+    }
+
+    #[test]
+    fn cleanup_script_rejects_empty_session_id_without_deleting_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let existing_session = restore_dir.join("rollout-existing-session.jsonl");
+        create_file(&existing_session);
+
+        let output = run_cleanup_with_session_id(&codex_home, &restore_path, "");
+
+        assert_failure_contains(&output, "invalid codex restore session id");
+        assert!(existing_session.exists());
+    }
+
+    #[test]
+    fn cleanup_script_rejects_glob_session_id_without_deleting_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let existing_session = restore_dir.join("rollout-existing-session.jsonl");
+        create_file(&existing_session);
+
+        let output = run_cleanup_with_session_id(&codex_home, &restore_path, "*");
+
+        assert_failure_contains(&output, "invalid codex restore session id");
+        assert!(existing_session.exists());
     }
 }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -7,6 +7,9 @@ use api_contracts::generated::types::runners::storage::{
 use sandbox::{ExecResult, ExecTermination, SandboxId};
 use sandbox_mock::MockSandbox;
 
+use super::super::cli_framework::{
+    EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
+};
 use super::super::env::{
     HostEnv, build_env_json_with_host_env, build_user_env_json, is_runner_owned_env_key,
     validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
@@ -33,6 +36,30 @@ fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
         &sandbox_id,
         SandboxReuseResult::Reused,
     )
+}
+
+#[test]
+fn effective_cli_framework_matches_guest_agent_fallback_semantics() {
+    assert_eq!(normalized_cli_agent_type(""), "claude-code");
+    assert_eq!(normalized_cli_agent_type("claude-code"), "claude-code");
+    assert_eq!(normalized_cli_agent_type("custom-agent"), "custom-agent");
+
+    assert_eq!(
+        effective_cli_framework(""),
+        EffectiveCliFramework::ClaudeCode
+    );
+    assert_eq!(
+        effective_cli_framework("claude-code"),
+        EffectiveCliFramework::ClaudeCode
+    );
+    assert_eq!(
+        effective_cli_framework("custom-agent"),
+        EffectiveCliFramework::ClaudeCode
+    );
+    assert_eq!(
+        effective_cli_framework("codex"),
+        EffectiveCliFramework::Codex
+    );
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -1,8 +1,13 @@
-use sandbox::{ExecResult, SandboxError, SandboxInvalidStateContext, SandboxOperation};
+use sandbox::{
+    EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, SandboxError, SandboxInvalidStateContext,
+    SandboxOperation,
+};
 use sandbox_mock::MockSandbox;
 use tracing_subscriber::prelude::*;
 
-use super::super::session_restore::{is_valid_session_id, restore_session};
+use super::super::DEFAULT_EXEC_TIMEOUT;
+use super::super::session_id::{canonical_codex_thread_id, is_valid_session_id};
+use super::super::session_restore::restore_session;
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::ResumeSession;
@@ -39,6 +44,19 @@ fn session_id_validation_accepts_valid_ids() {
     for id in valid_ids {
         assert!(is_valid_session_id(id), "expected acceptance for: {id:?}");
     }
+}
+
+#[test]
+fn codex_thread_id_canonicalizes_uuid_spellings() {
+    assert_eq!(
+        canonical_codex_thread_id("019E9154C30470F0ADDE36EFB1BE1701").as_deref(),
+        Some("019e9154-c304-70f0-adde-36efb1be1701")
+    );
+    assert_eq!(
+        canonical_codex_thread_id("019e9154-c304-70f0-adde-36efb1be1701").as_deref(),
+        Some("019e9154-c304-70f0-adde-36efb1be1701")
+    );
+    assert!(canonical_codex_thread_id("codex-safe-but-not-uuid").is_none());
 }
 
 #[tokio::test]
@@ -717,9 +735,11 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             "VM0_CODEX_RESTORE_SESSION_PATH".to_string()
         ]
     );
+    assert_eq!(exec_calls[0].timeout, DEFAULT_EXEC_TIMEOUT);
+    assert_eq!(exec_calls[0].output_limits, EXEC_OUTPUT_LIMIT_64_KIB);
     assert!(!exec_calls[0].sudo);
     assert!(exec_calls[0].stdin_bytes.is_none());
-    assert!(exec_calls[0].cmd.contains("codex_home=/home/user/.codex"));
+    assert!(exec_calls[0].cmd.contains("codex_home='/home/user/.codex'"));
     assert!(exec_calls[0].cmd.contains("root=\"$codex_home/sessions\""));
     assert!(exec_calls[0].cmd.contains("check_restore_dir_component"));
     assert!(


### PR DESCRIPTION
## Summary
- move shared CLI framework and session ID semantics out of session restore internals
- split Codex session restore and cleanup command construction into a focused module
- move Codex cleanup shell into crates/runner/scripts and add filesystem behavior coverage

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner session_restore
- cargo test --manifest-path crates/Cargo.toml -p runner env_tests
- cargo test --manifest-path crates/Cargo.toml -p runner execution_diagnostics
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings

Closes #18491