### PR TITLE
test(mitm-addon): rehome usage delivery tests

### DIFF
--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import usage
-from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 
@@ -113,11 +112,11 @@ class TestUsagePendingCounter:
         usage.write_pending_snapshot(flush_request_id="request-2")
         assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
 
-    def test_buffered_usage_blocks_pending_until_flush(
-        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_buffered_usage_blocks_pending_until_flush(self, tmp_path, real_flow, mitm_ctx):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
+        enqueue = RecordingEnqueue(return_value=True)
+        usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
@@ -126,100 +125,18 @@ class TestUsagePendingCounter:
         flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
         flow.metadata["model_provider_usage"] = {"tokens.input": 1}
 
-        with usage_webhook_api() as webhook:
+        with mitm_ctx(api_url="https://api.test"):
             usage.report_model_provider_usage(flow, "run-1")
             usage.write_pending_snapshot(flush_request_id="request-1")
             assert_pending(
                 pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1"
             )
-            assert webhook.request_count == 0
+            enqueue.assert_not_called()
 
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
-
+            assert usage.flush_usage_events(trigger="test") == 1
+        enqueue.assert_called_once()
         assert_current_pending(
             pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2"
-        )
-
-    def test_enqueue_logs_body_free_payload_summary(self, tmp_path):
-        proxy_log = tmp_path / "proxy.jsonl"
-        payload = {
-            "url": "payload-url",
-            "type": "payload-type",
-            "attempt": 99,
-            "error": "payload-error",
-            "runId": "run-1",
-            "events": [],
-        }
-
-        try:
-            with patch.object(usage.webhook.usage_executor, "submit") as mock_submit:
-                usage.webhook._enqueue_webhook(
-                    "https://api.vm0.ai/api/webhooks/agent/usage-event",
-                    "tok",
-                    payload,
-                    str(proxy_log),
-                    "usage_event",
-                )
-            mock_submit.assert_called_once()
-        finally:
-            usage.counters.decrement_pending_reports()
-
-        [entry] = read_jsonl_entries_after_flush(proxy_log)
-        assert entry["url"] == "https://api.vm0.ai/api/webhooks/agent/usage-event"
-        assert entry["type"] == "usage_event"
-        assert entry["payload_run_id"] == "run-1"
-        assert entry["payload_event_count"] == 0
-        assert "payload" not in entry
-        assert "payload_bytes" not in entry
-        assert "events" not in entry
-        assert "idempotencyKey" not in json.dumps(entry)
-
-    def test_submit_failure_rolls_back_pending_report(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-
-        with (
-            patch.object(usage.webhook.usage_executor, "submit", side_effect=OSError("no threads")),
-            pytest.raises(OSError, match="no threads"),
-        ):
-            usage.webhook._enqueue_webhook(
-                "https://api.vm0.ai/api/webhooks/agent/usage-event",
-                "tok",
-                {"runId": "run-1", "events": [{"category": "tokens.input", "quantity": 1}]},
-                "",
-                "usage_event",
-            )
-
-        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
-        )
-
-    def test_sync_fallback_log_failure_rolls_back_pending_report(self, tmp_path):
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-
-        with (
-            patch.object(
-                usage.webhook.usage_executor, "submit", side_effect=RuntimeError("shutdown")
-            ),
-            patch.object(
-                usage.webhook, "log_proxy_entry", side_effect=[None, OSError("disk full")]
-            ),
-            pytest.raises(OSError, match="disk full"),
-        ):
-            usage.webhook._enqueue_webhook(
-                "https://api.vm0.ai/api/webhooks/agent/usage-event",
-                "tok",
-                {"runId": "run-1", "events": [{"category": "tokens.input", "quantity": 1}]},
-                str(tmp_path / "proxy.jsonl"),
-                "usage_event",
-            )
-
-        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
         )
 
     def test_saturated_usage_flush_keeps_buffered_pending_snapshot(self, tmp_path):
@@ -375,82 +292,3 @@ class TestUsagePendingCounter:
             patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
         ):
             usage.write_pending_snapshot(flush_request_id="request-1")  # should not raise
-
-    def test_report_decrements_after_completion(
-        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
-        """Retry exhaustion decrements reports but keeps the usage flush buffered."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok"
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["model_provider_usage"] = {"tokens.input": 1}
-
-        with (
-            usage_webhook_api() as webhook,
-            patch.object(usage.webhook.time, "sleep"),
-        ):
-            webhook.queue_response(500)
-            webhook.queue_response(500)
-            usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
-
-        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert_current_pending(
-            pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1"
-        )
-
-    def test_enqueue_increments_and_drains_reports(
-        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
-        """Public entry increments pending on enqueue; executor drain decrements to 0."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok"
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["model_provider_usage"] = {"tokens.input": 1}
-
-        with usage_webhook_api():
-            usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
-
-        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
-        )
-
-    def test_sync_fallback_decrements_reports(
-        self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
-        """When the executor is already shut down, the sync fallback still decrements."""
-        pending_path = tmp_path / "usage-pending"
-        usage.set_pending_path(str(pending_path))
-        # Shut down the executor so _enqueue_webhook takes the sync fallback.
-        usage.flush_usage_events(trigger="test")
-        usage.webhook.usage_executor.shutdown(wait=True)
-
-        flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok"
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["model_provider_usage"] = {"tokens.input": 1}
-
-        with usage_webhook_api():
-            usage.report_model_provider_usage(flow, "run-1")
-            usage.flush_usage_events(trigger="test")
-
-        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
-        assert_current_pending(
-            pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
-        )

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -342,6 +342,89 @@ class TestUsageWebhookDelivery:
         with pytest.raises(ValueError, match="absolute http"):
             sync_usage_executor.shutdown(wait=True)
 
+    def test_enqueue_logs_body_free_payload_summary(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        executor = _QueuedUsageExecutor()
+        payload = {
+            "url": "payload-url",
+            "type": "payload-type",
+            "attempt": 99,
+            "error": "payload-error",
+            "runId": "run-1",
+            "events": [],
+        }
+
+        try:
+            with patch.object(usage.webhook, "usage_executor", executor):
+                assert usage.webhook._enqueue_webhook(
+                    "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                    "tok",
+                    payload,
+                    str(proxy_log),
+                    "usage_event",
+                )
+            assert len(executor.submissions) == 1
+        finally:
+            usage.counters.decrement_pending_reports()
+            usage.webhook.reset_delivery_capacity_for_tests()
+
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
+        assert entry["url"] == "https://api.vm0.ai/api/webhooks/agent/usage-event"
+        assert entry["type"] == "usage_event"
+        _assert_body_free_webhook_entry(entry, run_id="run-1", event_count=0)
+        assert "payload_bytes" not in entry
+
+    def test_submit_failure_rolls_back_pending_report(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        with (
+            patch.object(usage.webhook.usage_executor, "submit", side_effect=OSError("no threads")),
+            pytest.raises(OSError, match="no threads"),
+        ):
+            usage.webhook._enqueue_webhook(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                {"runId": "run-1", "events": [{"category": "tokens.input", "quantity": 1}]},
+                "",
+                "usage_event",
+            )
+
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="submit-failed"
+        )
+
+    def test_sync_fallback_log_failure_rolls_back_pending_report(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        with (
+            patch.object(
+                usage.webhook.usage_executor, "submit", side_effect=RuntimeError("shutdown")
+            ),
+            patch.object(
+                usage.webhook, "log_proxy_entry", side_effect=[None, OSError("disk full")]
+            ),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            usage.webhook._enqueue_webhook(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                {"runId": "run-1", "events": [{"category": "tokens.input", "quantity": 1}]},
+                str(tmp_path / "proxy.jsonl"),
+                "usage_event",
+            )
+
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="fallback-log-failed",
+        )
+
     def test_sleeps_between_retries(
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
@@ -427,6 +510,8 @@ class TestUsageWebhookDelivery:
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         """After executor shutdown, delivery happens synchronously before return."""
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
         flow = self._model_flow(real_flow, tmp_path)
         flow.metadata["model_provider_usage"] = {"tokens.input": 42}
         usage.flush_usage_events(trigger="test")
@@ -441,6 +526,9 @@ class TestUsageWebhookDelivery:
         assert body["runId"] == "run-1"
         assert body["events"][0]["quantity"] == 42
         assert body["events"][0]["category"] == "tokens.input"
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="sync-fallback"
+        )
 
     def test_does_not_admit_when_delivery_capacity_is_saturated(self, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"


### PR DESCRIPTION
## Summary
- Moves webhook delivery edge-case coverage out of `test_counters.py` and into `test_webhook.py`.
- Keeps `test_counters.py` focused on pending snapshot and counter semantics by using a recording enqueue instead of webhook internals.
- Folds sync fallback pending-drain coverage into the existing webhook fallback test and relies on webhook-owned success/retry-exhaustion coverage.

Closes #18493

## Tests
- `python3 -m pytest tests/test_counters.py tests/test_webhook.py tests/test_usage_buffer_flush_failures.py`
- `python3 -m ruff check tests/test_counters.py tests/test_webhook.py tests/test_usage_buffer_flush_failures.py`
- `python3 -m ruff format --check tests/test_counters.py tests/test_webhook.py tests/test_usage_buffer_flush_failures.py`
- `python3 -m basedpyright -p .`

No production code changes.