### PR TITLE
refactor: statically import firewall metadata loader

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -265,7 +265,7 @@ const RESOLVER_METADATA = {
 } satisfies FirewallPermissionDetailMetadata;
 
 describe("firewall metadata", () => {
-  it("keeps the public entrypoint summary-first", () => {
+  it("keeps the public entrypoint off detail modules", () => {
     const entrypoint = path.resolve(
       import.meta.dirname,
       "../firewall-metadata/index.ts",
@@ -274,6 +274,7 @@ describe("firewall metadata", () => {
 
     expect(staticImportSpecifiers(source).sort(compareStrings)).toStrictEqual([
       "../firewall-types",
+      "./loader.generated",
       "./policy-resolver",
       "./summary.generated",
       "./types",
@@ -282,9 +283,7 @@ describe("firewall metadata", () => {
       "./policy-resolver",
       "./types",
     ]);
-    expect(dynamicImportSpecifiers(source)).toStrictEqual([
-      "./loader.generated",
-    ]);
+    expect(dynamicImportSpecifiers(source)).toStrictEqual([]);
   });
 
   it("keeps server metadata behind an explicit package subpath", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -286,6 +286,23 @@ describe("firewall metadata", () => {
     expect(dynamicImportSpecifiers(source)).toStrictEqual([]);
   });
 
+  it("keeps permission detail metadata behind connector-specific dynamic imports", () => {
+    const loader = path.resolve(
+      import.meta.dirname,
+      "../firewall-metadata/loader.generated.ts",
+    );
+    const source = fs.readFileSync(loader, "utf-8");
+    const dynamicSpecifiers = dynamicImportSpecifiers(source);
+
+    expect(staticImportSpecifiers(source)).toStrictEqual(["./types"]);
+    expect(dynamicSpecifiers).toContain("./details/slack.generated");
+    expect(dynamicSpecifiers).toContain("./details/github.generated");
+    expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
+    for (const specifier of dynamicSpecifiers) {
+      expect(specifier).toMatch(/^\.\/details\/[a-z0-9][a-z0-9-]*\.generated$/);
+    }
+  });
+
   it("keeps server metadata behind an explicit package subpath", () => {
     const rootEntrypoint = fs.readFileSync(
       path.resolve(import.meta.dirname, "../index.ts"),

--- a/turbo/packages/connectors/src/firewall-metadata/index.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/index.ts
@@ -4,6 +4,7 @@ import {
   type FirewallPolicy,
   type FirewallPolicyValue,
 } from "../firewall-types";
+import { loadGeneratedFirewallPermissionMetadata } from "./loader.generated";
 import { createFirewallMetadataPolicyResolver } from "./policy-resolver";
 import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./summary.generated";
 import type {
@@ -74,8 +75,6 @@ export async function loadFirewallPermissionMetadata(
   if (!isFirewallMetadataConnectorType(type)) {
     return null;
   }
-  const { loadGeneratedFirewallPermissionMetadata } =
-    await import("./loader.generated");
   return await loadGeneratedFirewallPermissionMetadata(type);
 }
 

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -3,6 +3,7 @@ import {
   type FirewallPolicies,
   type FirewallPolicyValue,
 } from "../firewall-types";
+import { loadGeneratedFirewallPermissionMetadata } from "./loader.generated";
 import {
   createFirewallMetadataPolicyResolver,
   type FirewallMetadataPolicyResolver,
@@ -145,8 +146,6 @@ export function getBuiltinConnectorHostOwner(
 async function loadFirewallPermissionDetail(
   type: FirewallServerMetadataConnectorType,
 ): Promise<FirewallPermissionDetailMetadata> {
-  const { loadGeneratedFirewallPermissionMetadata } =
-    await import("./loader.generated");
   const detail = await loadGeneratedFirewallPermissionMetadata(type);
   if (!detail) {
     throw new Error(`Missing firewall permission metadata: ${type}`);


### PR DESCRIPTION
## Summary
- statically import the generated firewall metadata loader from browser and server metadata entrypoints
- keep per-connector metadata detail modules dynamically imported
- update the metadata entrypoint guard test to assert no dynamic loader chunk remains

## Testing
- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-metadata.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pre-commit: knip + full pnpm check-types