### PR TITLE
fix: separate ably attach resume state from channel serial

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -560,6 +560,7 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut oneshot::Receiver<()
         &p.channel,
         p.channel_params.as_ref(),
         p.session.channel_serial(),
+        p.session.attach_mode(),
     ) {
         Ok(data) => data,
         Err(e) => {
@@ -948,6 +949,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
                 &p.channel,
                 p.channel_params.as_ref(),
                 p.session.channel_serial(),
+                p.session.attach_mode(),
             )?;
             ws_write
                 .send(tungstenite::Message::Binary(data.into()))
@@ -974,6 +976,7 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
                         &p.channel,
                         p.channel_params.as_ref(),
                         p.session.channel_serial(),
+                        p.session.attach_mode(),
                     )?;
                     ws_write
                         .send(tungstenite::Message::Binary(data.into()))

--- a/crates/ably-subscriber/src/connection/handshake.rs
+++ b/crates/ably-subscriber/src/connection/handshake.rs
@@ -4,7 +4,8 @@ use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite;
 
 use crate::protocol::{
-    ErrorInfo, ProtocolMessage, action, build_attach_msg, decode_msg, encode_msg, error_code,
+    AttachMode, ErrorInfo, ProtocolMessage, action, build_attach_msg, decode_msg, encode_msg,
+    error_code,
 };
 use crate::types::{Error, TimingConfig, TokenDetails};
 
@@ -158,8 +159,9 @@ pub(super) fn encode_attach_for_channel(
     channel: &str,
     channel_params: Option<&HashMap<String, String>>,
     channel_serial: Option<&str>,
+    attach_mode: AttachMode,
 ) -> Result<Vec<u8>, Error> {
-    let attach = build_attach_msg(channel, channel_params, channel_serial);
+    let attach = build_attach_msg(channel, channel_params, channel_serial, attach_mode);
     encode_msg(&attach)
 }
 
@@ -174,7 +176,7 @@ pub(crate) async fn connect_and_attach(
     let (mut ws_write, mut ws_read) = connect_and_split(&ws_url).await?;
     let connected_msg = wait_for_connected(&mut ws_read).await?;
     let mut conn_state = ConnState::from_connected(&connected_msg, token, timing);
-    let encoded = encode_attach_for_channel(channel, channel_params, None)?;
+    let encoded = encode_attach_for_channel(channel, channel_params, None, AttachMode::Clean)?;
     ws_write
         .send(tungstenite::Message::Binary(encoded.into()))
         .await?;

--- a/crates/ably-subscriber/src/connection/session.rs
+++ b/crates/ably-subscriber/src/connection/session.rs
@@ -12,7 +12,7 @@ use super::state::{
     ChannelLifecycleState, ConnState, ConnectionLifecycleState, RealtimeStateMachine,
     checked_deadline_after, checked_deadline_from, retry_delay,
 };
-use crate::protocol::ProtocolMessage;
+use crate::protocol::{AttachMode, ProtocolMessage};
 use crate::types::TokenDetails;
 
 /// Mutable session state owned by the realtime event loop.
@@ -49,6 +49,11 @@ pub(crate) struct SessionState {
     /// message unless channel failure or suspended cleanup clears the pending
     /// marker.
     connected_event_pending: bool,
+    /// Whether automatic channel attaches should be encoded as non-clean
+    /// attaches with ATTACH_RESUME. This is independent of channel_serial:
+    /// suspended retry clears the serial but still continues the same
+    /// subscription attachment.
+    attach_resume: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +72,7 @@ impl SessionState {
             channel_retry_count: 0,
             channel_operation_deadline: None,
             connected_event_pending: false,
+            attach_resume: true,
         }
     }
 
@@ -96,6 +102,14 @@ impl SessionState {
 
     pub(super) fn channel_serial(&self) -> Option<&str> {
         self.conn_state.channel_serial.as_deref()
+    }
+
+    pub(super) fn attach_mode(&self) -> AttachMode {
+        if self.attach_resume {
+            AttachMode::Resume
+        } else {
+            AttachMode::Clean
+        }
     }
 
     pub(super) fn token(&self) -> &str {
@@ -169,6 +183,7 @@ impl SessionState {
     // backoff from zero for the next suspension.
     pub(super) fn mark_channel_attached(&mut self) {
         self.lifecycle.notify_channel_attached();
+        self.attach_resume = true;
         self.channel_retry_at = None;
         self.channel_retry_count = 0;
         self.channel_operation_deadline = None;
@@ -176,6 +191,7 @@ impl SessionState {
 
     pub(super) fn enter_channel_failed(&mut self) {
         self.conn_state.channel_serial = None;
+        self.attach_resume = false;
         self.lifecycle.notify_channel_failed();
         self.channel_retry_at = None;
         self.channel_operation_deadline = None;
@@ -227,16 +243,19 @@ impl SessionState {
     }
 
     pub(super) fn request_closing(&mut self) {
+        self.attach_resume = false;
         self.lifecycle.request_closing();
     }
 
     pub(super) fn mark_closed(&mut self) {
+        self.attach_resume = false;
         self.lifecycle.notify_closed();
     }
 
     pub(super) fn enter_connection_failed(&mut self) {
         self.lifecycle.notify_failed();
         self.conn_state.channel_serial = None;
+        self.attach_resume = false;
         self.channel_retry_at = None;
         self.channel_operation_deadline = None;
     }
@@ -269,6 +288,7 @@ impl SessionState {
 
         if failures >= max_failures {
             self.lifecycle.notify_failed();
+            self.attach_resume = false;
             return TokenRenewalFailure::Fatal { failures };
         }
 
@@ -304,6 +324,7 @@ impl SessionState {
         self.commit_connected_transport_state(connected_msg, token, token_renewal_margin);
         self.token_renewal_failures = 0;
         self.connected_event_pending = false;
+        self.attach_resume = true;
         self.lifecycle.notify_connected();
     }
 
@@ -324,6 +345,7 @@ impl SessionState {
 
     pub(super) fn commit_reconnect_closed(&mut self) {
         self.conn_state.channel_serial = None;
+        self.attach_resume = false;
         self.lifecycle.notify_closed();
     }
 
@@ -369,7 +391,7 @@ impl SessionState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{ConnectionDetails, action};
+    use crate::protocol::{AttachMode, ConnectionDetails, action};
     use crate::types::{TimingConfig, TokenDetails};
 
     fn test_token() -> TokenDetails {
@@ -421,6 +443,7 @@ mod tests {
         assert_eq!(state.connection_id(), None);
         assert_eq!(state.connection_key(), None);
         assert_eq!(state.channel_serial(), None);
+        assert_eq!(state.attach_mode(), AttachMode::Resume);
         assert_eq!(state.channel_retry_at(), None);
         assert_eq!(state.channel_operation_deadline(), None);
         assert!(!state.connected_event_pending);
@@ -455,9 +478,29 @@ mod tests {
 
         assert!(state.connected_event_pending);
         assert_eq!(state.channel_serial(), None);
+        assert_eq!(state.attach_mode(), AttachMode::Resume);
         assert_eq!(state.connection_id(), Some("conn-2"));
         assert_eq!(state.channel_state(), ChannelLifecycleState::Suspended);
         assert!(state.channel_retry_at().is_some());
+    }
+
+    #[test]
+    fn terminal_channel_states_clear_attach_resume_intent() {
+        let mut closed_state = SessionState::connected(test_conn_state());
+        closed_state.request_closing();
+        closed_state.mark_closed();
+
+        assert_eq!(closed_state.attach_mode(), AttachMode::Clean);
+
+        let mut channel_failed_state = SessionState::connected(test_conn_state());
+        channel_failed_state.enter_channel_failed();
+
+        assert_eq!(channel_failed_state.attach_mode(), AttachMode::Clean);
+
+        let mut connection_failed_state = SessionState::connected(test_conn_state());
+        connection_failed_state.enter_connection_failed();
+
+        assert_eq!(connection_failed_state.attach_mode(), AttachMode::Clean);
     }
 
     #[test]
@@ -469,5 +512,6 @@ mod tests {
 
         assert!(matches!(result, TokenRenewalFailure::Fatal { failures: 1 }));
         assert_eq!(state.lifecycle.connection, ConnectionLifecycleState::Failed);
+        assert_eq!(state.attach_mode(), AttachMode::Clean);
     }
 }

--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -220,22 +220,26 @@ fn rmpv_to_json(value: rmpv::Value) -> serde_json::Value {
 // Helper to build an ATTACH message
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachMode {
+    Clean,
+    Resume,
+}
+
 pub fn build_attach_msg(
     channel: &str,
     params: Option<&HashMap<String, String>>,
     channel_serial: Option<&str>,
+    attach_mode: AttachMode,
 ) -> ProtocolMessage {
-    let (cs, f) = match channel_serial {
-        Some(s) => (
-            Some(s.to_string()),
-            flags::MODE_SUBSCRIBE | flags::ATTACH_RESUME,
-        ),
-        None => (None, flags::MODE_SUBSCRIBE),
-    };
+    let mut f = flags::MODE_SUBSCRIBE;
+    if attach_mode == AttachMode::Resume {
+        f |= flags::ATTACH_RESUME;
+    }
     ProtocolMessage {
         action: action::ATTACH,
         channel: Some(channel.to_string()),
-        channel_serial: cs,
+        channel_serial: channel_serial.map(str::to_string),
         flags: Some(f),
         params: params.cloned(),
         ..Default::default()
@@ -473,7 +477,7 @@ mod tests {
 
     #[test]
     fn build_attach_msg_basic() {
-        let msg = build_attach_msg("my-channel", None, None);
+        let msg = build_attach_msg("my-channel", None, None, AttachMode::Clean);
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("my-channel"));
         assert_eq!(msg.flags, Some(flags::MODE_SUBSCRIBE));
@@ -485,7 +489,7 @@ mod tests {
     fn build_attach_msg_with_rewind() {
         let mut params = HashMap::new();
         params.insert("rewind".to_string(), "2m".to_string());
-        let msg = build_attach_msg("run:abc", Some(&params), None);
+        let msg = build_attach_msg("run:abc", Some(&params), None, AttachMode::Clean);
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("run:abc"));
         assert_eq!(
@@ -498,8 +502,8 @@ mod tests {
     }
 
     #[test]
-    fn build_attach_msg_with_channel_serial() {
-        let msg = build_attach_msg("my-channel", None, Some("serial-abc"));
+    fn build_attach_msg_resume_with_channel_serial() {
+        let msg = build_attach_msg("my-channel", None, Some("serial-abc"), AttachMode::Resume);
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel_serial.as_deref(), Some("serial-abc"));
         let f = msg.flags.unwrap();
@@ -508,10 +512,19 @@ mod tests {
     }
 
     #[test]
-    fn build_attach_msg_without_channel_serial_no_resume_flag() {
-        let msg = build_attach_msg("my-channel", None, None);
+    fn build_attach_msg_clean_without_channel_serial_no_resume_flag() {
+        let msg = build_attach_msg("my-channel", None, None, AttachMode::Clean);
         let f = msg.flags.unwrap();
         assert_eq!(f & flags::ATTACH_RESUME, 0);
+        assert_ne!(f & flags::MODE_SUBSCRIBE, 0);
+    }
+
+    #[test]
+    fn build_attach_msg_resume_without_channel_serial_sets_resume_flag() {
+        let msg = build_attach_msg("my-channel", None, None, AttachMode::Resume);
+        assert!(msg.channel_serial.is_none());
+        let f = msg.flags.unwrap();
+        assert_ne!(f & flags::ATTACH_RESUME, 0);
         assert_ne!(f & flags::MODE_SUBSCRIBE, 0);
     }
 }

--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -232,14 +232,17 @@ pub fn build_attach_msg(
     channel_serial: Option<&str>,
     attach_mode: AttachMode,
 ) -> ProtocolMessage {
-    let mut f = flags::MODE_SUBSCRIBE;
-    if attach_mode == AttachMode::Resume {
-        f |= flags::ATTACH_RESUME;
-    }
+    let (channel_serial, f) = match attach_mode {
+        AttachMode::Clean => (None, flags::MODE_SUBSCRIBE),
+        AttachMode::Resume => (
+            channel_serial.map(str::to_string),
+            flags::MODE_SUBSCRIBE | flags::ATTACH_RESUME,
+        ),
+    };
     ProtocolMessage {
         action: action::ATTACH,
         channel: Some(channel.to_string()),
-        channel_serial: channel_serial.map(str::to_string),
+        channel_serial,
         flags: Some(f),
         params: params.cloned(),
         ..Default::default()
@@ -514,6 +517,15 @@ mod tests {
     #[test]
     fn build_attach_msg_clean_without_channel_serial_no_resume_flag() {
         let msg = build_attach_msg("my-channel", None, None, AttachMode::Clean);
+        let f = msg.flags.unwrap();
+        assert_eq!(f & flags::ATTACH_RESUME, 0);
+        assert_ne!(f & flags::MODE_SUBSCRIBE, 0);
+    }
+
+    #[test]
+    fn build_attach_msg_clean_with_channel_serial_omits_serial_and_resume_flag() {
+        let msg = build_attach_msg("my-channel", None, Some("serial-abc"), AttachMode::Clean);
+        assert!(msg.channel_serial.is_none());
         let f = msg.flags.unwrap();
         assert_eq!(f & flags::ATTACH_RESUME, 0);
         assert_ne!(f & flags::MODE_SUBSCRIBE, 0);

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2820,6 +2820,149 @@ async fn retry_enters_suspended_after_connection_state_ttl() {
     }
 }
 
+#[tokio::test]
+async fn suspended_retry_reconnect_attach_uses_resume_without_serial() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (suspended_seen_tx, suspended_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (message_seen_tx, message_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    connection_state_ttl_ms: 20,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        drop(conn);
+
+        let mut suspended_seen_rx = suspended_seen_rx;
+        loop {
+            tokio::select! {
+                biased;
+                result = &mut suspended_seen_rx => {
+                    result.unwrap();
+                    break;
+                }
+                accept_result = ws.listener.accept() => {
+                    let (tcp, _) = accept_result.unwrap();
+                    drop(tcp);
+                }
+            }
+        }
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for suspended retry ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-after-suspended-retry".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-suspended-retry",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(message_seen_rx, "after-suspended-retry message").await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    timing.suspended_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+            .await
+            .expect("timed out waiting for suspended retry transition")
+            .unwrap();
+        match event {
+            Event::Disconnected { reason }
+                if reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("connection state expired")) =>
+            {
+                suspended_seen_tx.send(()).unwrap();
+                break;
+            }
+            Event::Disconnected { .. } => {}
+            other => panic!("expected Disconnected while retrying, got {other:?}"),
+        }
+    }
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected after suspended retry")
+        .unwrap();
+    assert!(
+        matches!(event, Event::Connected),
+        "expected Connected after suspended retry, got {event:?}"
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after suspended retry")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-suspended-retry"));
+            message_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 21: token renewal failures become fatal (fast with TimingConfig)
 // ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -4163,6 +4163,8 @@ async fn resumed_connection_reattaches_channel() {
             "client must send ATTACH on resume"
         );
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
         let _ = attach_tx.send(true);
 
         // Send ATTACHED
@@ -4274,6 +4276,8 @@ async fn detached_during_reconnect_attach_retries_channel_on_same_transport() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let detached = ProtocolMessage {
             action: action::DETACHED,
@@ -4298,6 +4302,8 @@ async fn detached_during_reconnect_attach_retries_channel_on_same_transport() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
 
         let attached = ProtocolMessage {
             action: action::ATTACHED,
@@ -4403,6 +4409,8 @@ async fn superseded_error_during_reconnect_attach_retries_on_same_transport() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let superseded = ProtocolMessage {
             action: action::ERROR,
@@ -4427,6 +4435,8 @@ async fn superseded_error_during_reconnect_attach_retries_on_same_transport() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let attached = ProtocolMessage {
             action: action::ATTACHED,
@@ -4531,6 +4541,8 @@ async fn other_channel_error_during_reconnect_attach_is_ignored() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let other_channel_error = ProtocolMessage {
             action: action::ERROR,
@@ -4658,6 +4670,8 @@ async fn disconnected_during_reconnect_attach_retries_with_new_connection() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let disconnected = ProtocolMessage {
             action: action::DISCONNECTED,
@@ -4774,6 +4788,8 @@ async fn closed_during_reconnect_attach_stops_subscription() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let closed = ProtocolMessage {
             action: action::CLOSED,
@@ -4856,6 +4872,8 @@ async fn superseded_reconnect_attach_timeout_retries_channel_on_same_transport()
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let superseded = ProtocolMessage {
             action: action::ERROR,
@@ -4880,6 +4898,8 @@ async fn superseded_reconnect_attach_timeout_retries_channel_on_same_transport()
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
             .await
@@ -4887,6 +4907,8 @@ async fn superseded_reconnect_attach_timeout_retries_channel_on_same_transport()
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
 
         let attached = ProtocolMessage {
             action: action::ATTACHED,
@@ -4994,6 +5016,8 @@ async fn close_during_reconnect_attach_wait_closes_temporary_socket() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
         attach_sent_tx.send(()).unwrap();
 
         expect_websocket_closed(&mut conn2).await.unwrap();
@@ -5071,6 +5095,8 @@ async fn reconnect_attach_timeout_retries_channel_on_same_transport() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         // Do not answer the first ATTACH. The client should treat this as a
         // channel attach timeout, keep conn-2 connected, and retry ATTACH on
@@ -5081,6 +5107,8 @@ async fn reconnect_attach_timeout_retries_channel_on_same_transport() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
 
         let attached = ProtocolMessage {
             action: action::ATTACHED,

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -4585,6 +4585,151 @@ async fn resumed_connection_reattaches_channel() {
 }
 
 #[tokio::test]
+async fn reconnect_attached_without_serial_preserves_resume_serial_for_next_reattach() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (connected_seen_tx, connected_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (message_seen_tx, message_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        wait_for_test_observation(connected_seen_rx, "initial Connected event").await;
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-1".into()),
+            connection_key: Some("conn-1!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-1!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&connected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let attached_without_serial = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached_without_serial).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for reattach after reconnect ATTACHED without serial")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        send_message(
+            &mut conn,
+            "ch",
+            "after-reconnect-attached-without-serial",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(
+            message_seen_rx,
+            "after reconnect attached without serial message",
+        )
+        .await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    connected_seen_tx.send(()).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(matches!(event, Event::Disconnected { .. }));
+
+    let event = tokio::time::timeout(Duration::from_secs(10), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(matches!(event, Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reconnect attached without serial")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(
+                msg.name.as_deref(),
+                Some("after-reconnect-attached-without-serial")
+            );
+            message_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn detached_during_reconnect_attach_retries_channel_on_same_transport() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2858,8 +2858,17 @@ async fn suspended_retry_reconnect_attach_uses_resume_without_serial() {
             }
         }
 
-        let (tcp, _) = ws.listener.accept().await.unwrap();
-        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let mut conn2 = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let (tcp, _) = ws.listener.accept().await.unwrap();
+                match tokio_tungstenite::accept_async(tcp).await {
+                    Ok(conn) => break conn,
+                    Err(_) => continue,
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for post-suspended reconnect");
         let connected = ProtocolMessage {
             action: action::CONNECTED,
             connection_id: Some("conn-2".into()),

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -1927,6 +1927,117 @@ async fn message_without_serial_preserves_resume_serial_for_reattach() {
 }
 
 #[tokio::test]
+async fn attached_without_serial_preserves_resume_serial_for_next_reattach() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (after_second_reattach_seen_tx, after_second_reattach_seen_rx) =
+        tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for first reattach")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let attached_without_serial = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached_without_serial).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for second reattach")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        send_message(
+            &mut conn,
+            "ch",
+            "after-attached-without-serial",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(
+            after_second_reattach_seen_rx,
+            "after attached without serial message",
+        )
+        .await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after attached without serial")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-attached-without-serial"));
+            after_second_reattach_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn huge_realtime_request_timeout_allows_detached_reattach() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2338,6 +2338,90 @@ async fn detached_with_client_error_reattaches() {
     server_task.await.unwrap();
 }
 
+#[tokio::test]
+async fn superseded_error_after_attached_without_serial_keeps_resume_intent() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (after_reattach_seen_tx, after_reattach_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    attached_channel_serial: None,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let superseded = ProtocolMessage {
+            action: action::ERROR,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80016,
+                status_code: Some(400),
+                message: "operation attempted on superseded transport".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&superseded).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH after 80016")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-after-80016".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        send_message(&mut conn, "ch", "after-80016", serde_json::json!("ok"))
+            .await
+            .unwrap();
+        wait_for_test_observation(after_reattach_seen_rx, "after-80016 message").await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after 80016 reattach")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-80016"));
+            after_reattach_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Test 16: server sends CLOSED → event loop stops
 // ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use ably_subscriber::protocol::{
     AblyMessage, ConnectionDetails, ErrorInfo, ProtocolMessage, action, decode_msg, encode_msg,
-    error_code,
+    error_code, flags,
 };
 use ably_subscriber::{Event, SubscribeConfig, TimingConfig, subscribe};
 use futures_util::{SinkExt, StreamExt};
@@ -32,6 +32,7 @@ type WsStream = tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>;
 struct HandshakeOptions {
     max_idle_interval_ms: i64,
     connection_state_ttl_ms: i64,
+    attached_channel_serial: Option<&'static str>,
 }
 
 impl Default for HandshakeOptions {
@@ -39,6 +40,7 @@ impl Default for HandshakeOptions {
         Self {
             max_idle_interval_ms: 15_000,
             connection_state_ttl_ms: 120_000,
+            attached_channel_serial: Some("serial-0"),
         }
     }
 }
@@ -101,7 +103,7 @@ impl MockAblyServer {
         let attached = ProtocolMessage {
             action: action::ATTACHED,
             channel: Some(channel.into()),
-            channel_serial: Some("serial-0".into()),
+            channel_serial: opts.attached_channel_serial.map(str::to_string),
             ..Default::default()
         };
         ws.send(tungstenite::Message::Binary(encode_msg(&attached)?.into()))
@@ -116,6 +118,11 @@ impl MockAblyServer {
         let ws = tokio_tungstenite::accept_async(tcp).await?;
         Ok(ws)
     }
+}
+
+fn assert_attach_resume(msg: &ProtocolMessage, expected: bool) {
+    let has_resume = msg.flags.unwrap_or(0) & flags::ATTACH_RESUME != 0;
+    assert_eq!(has_resume, expected, "unexpected ATTACH_RESUME flag");
 }
 
 async fn read_protocol_msg(
@@ -195,10 +202,20 @@ async fn send_message(
     name: &str,
     data: serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    send_message_with_channel_serial(ws, channel, name, data, Some("serial-1")).await
+}
+
+async fn send_message_with_channel_serial(
+    ws: &mut WsStream,
+    channel: &str,
+    name: &str,
+    data: serde_json::Value,
+    channel_serial: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let msg = ProtocolMessage {
         action: action::MESSAGE,
         channel: Some(channel.into()),
-        channel_serial: Some("serial-1".into()),
+        channel_serial: channel_serial.map(str::to_string),
         messages: Some(vec![AblyMessage {
             id: Some("msg-1".into()),
             name: Some(name.into()),
@@ -1722,6 +1739,194 @@ async fn server_sends_detached_reattach() {
 }
 
 #[tokio::test]
+async fn reattach_after_attached_without_serial_keeps_resume_intent() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (after_reattach_seen_tx, after_reattach_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    attached_channel_serial: None,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        send_message(&mut conn, "ch", "after-reattach", serde_json::json!("ok"))
+            .await
+            .unwrap();
+        wait_for_test_observation(after_reattach_seen_rx, "after-reattach message").await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reattach")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-reattach"));
+            after_reattach_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn message_without_serial_preserves_resume_serial_for_reattach() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (message_seen_tx, message_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (after_reattach_seen_tx, after_reattach_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+
+        send_message_with_channel_serial(
+            &mut conn,
+            "ch",
+            "without-serial",
+            serde_json::json!("ok"),
+            None,
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(message_seen_rx, "message without serial").await;
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        send_message(
+            &mut conn,
+            "ch",
+            "after-preserved-serial",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(after_reattach_seen_rx, "after preserved serial message").await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message without serial")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("without-serial"));
+            message_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after reattach")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(msg.name.as_deref(), Some("after-preserved-serial"));
+            after_reattach_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn huge_realtime_request_timeout_allows_detached_reattach() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
@@ -2854,6 +3059,8 @@ async fn detached_while_attaching_suspends_and_retries_attach() {
             .expect("timed out waiting for ATTACH")
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
 
         // Second DETACHED before ATTACHED means the channel is currently
         // attaching. ably-js moves it to suspended and retries ATTACH on the
@@ -2870,6 +3077,8 @@ async fn detached_while_attaching_suspends_and_retries_attach() {
             .unwrap();
         assert_eq!(msg.action, action::ATTACH);
         assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, true);
 
         let attached = ProtocolMessage {
             action: action::ATTACHED,

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -5224,6 +5224,164 @@ async fn other_channel_error_during_reconnect_attach_is_ignored() {
 }
 
 #[tokio::test]
+async fn other_channel_attach_outcomes_during_reconnect_attach_are_ignored() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (connected_seen_tx, connected_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (other_channel_frames_sent_tx, other_channel_frames_sent_rx) =
+        tokio::sync::oneshot::channel::<()>();
+    let (noise_checked_tx, noise_checked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (message_seen_tx, message_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
+        wait_for_test_observation(connected_seen_rx, "initial Connected event").await;
+        drop(conn);
+
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 = tokio_tungstenite::accept_async(tcp).await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-2".into()),
+            connection_key: Some("conn-2!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-2!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn2))
+            .await
+            .expect("timed out waiting for reconnect ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let other_channel_attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("other-channel".into()),
+            channel_serial: Some("other-serial".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&other_channel_attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let other_channel_detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("other-channel".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "other channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&other_channel_detached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        other_channel_frames_sent_tx.send(()).unwrap();
+        wait_for_test_observation(noise_checked_rx, "other-channel noise check").await;
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-ok".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        send_message(
+            &mut conn2,
+            "ch",
+            "after-other-channel-attach-outcomes",
+            serde_json::json!("ok"),
+        )
+        .await
+        .unwrap();
+        wait_for_test_observation(
+            message_seen_rx,
+            "after other-channel attach outcomes message",
+        )
+        .await;
+    });
+
+    let mut timing = TimingConfig::default();
+    timing.disconnected_retry_timeout = Duration::from_millis(10);
+    let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    connected_seen_tx.send(()).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Disconnected")
+        .unwrap();
+    assert!(matches!(event, Event::Disconnected { .. }));
+
+    wait_for_test_observation(
+        other_channel_frames_sent_rx,
+        "other-channel attach outcome frames",
+    )
+    .await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), sub.next())
+            .await
+            .is_err(),
+        "other-channel ATTACHED/DETACHED should not finish reconnect attach"
+    );
+    noise_checked_tx.send(()).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .unwrap();
+    assert!(matches!(event, Event::Connected));
+
+    let event = tokio::time::timeout(Duration::from_secs(5), sub.next())
+        .await
+        .expect("timed out waiting for message after other-channel attach outcomes")
+        .unwrap();
+    match event {
+        Event::Message(msg) => {
+            assert_eq!(
+                msg.name.as_deref(),
+                Some("after-other-channel-attach-outcomes")
+            );
+            message_seen_tx.send(()).unwrap();
+        }
+        other => panic!("expected Message, got {other:?}"),
+    }
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn disconnected_during_reconnect_attach_retries_with_new_connection() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -469,7 +469,7 @@ async fn initial_attach_is_clean_without_resume_or_serial() {
 }
 
 #[tokio::test]
-async fn message_without_channel_is_ignored() {
+async fn non_target_channel_events_do_not_pollute_resume_serial() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
     mock_token_endpoint(&http, "testKey.testId");
@@ -494,6 +494,40 @@ async fn message_without_channel_is_ignored() {
         ))
         .await
         .unwrap();
+
+        let other_channel_attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("other-channel".into()),
+            channel_serial: Some("other-serial".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&other_channel_attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let other_channel_detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("other-channel".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "other channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&other_channel_detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), conn.next())
+                .await
+                .is_err(),
+            "other-channel ATTACHED/DETACHED should not trigger ATTACH"
+        );
 
         let detached = ProtocolMessage {
             action: action::DETACHED,

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -408,6 +408,67 @@ async fn connect_and_receive_message() {
 }
 
 #[tokio::test]
+async fn initial_attach_is_clean_without_resume_or_serial() {
+    let http = MockServer::start();
+    let ws = MockAblyServer::start().await.unwrap();
+    mock_token_endpoint(&http, "testKey.testId");
+
+    let ws_port = ws.port;
+    let (connected_seen_tx, connected_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        let mut conn = ws.accept_raw().await.unwrap();
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-1".into()),
+            connection_key: Some("conn-1!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-1!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&connected).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for initial ATTACH")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert!(msg.channel_serial.is_none());
+        assert_attach_resume(&msg, false);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-0".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        wait_for_test_observation(connected_seen_rx, "initial Connected event").await;
+    });
+
+    let mut sub = subscribe(test_config(ws_port, http.port(), "ch"))
+        .await
+        .unwrap();
+
+    assert!(matches!(sub.next().await.unwrap(), Event::Connected));
+    connected_seen_tx.send(()).unwrap();
+
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn message_without_channel_is_ignored() {
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();

--- a/crates/ably-subscriber/tests/integration.rs
+++ b/crates/ably-subscriber/tests/integration.rs
@@ -494,6 +494,44 @@ async fn message_without_channel_is_ignored() {
         ))
         .await
         .unwrap();
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            error: Some(ErrorInfo {
+                code: 80003,
+                status_code: Some(500),
+                message: "channel detached".into(),
+            }),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), read_protocol_msg(&mut conn))
+            .await
+            .expect("timed out waiting for ATTACH after ignored message")
+            .unwrap();
+        assert_eq!(msg.action, action::ATTACH);
+        assert_eq!(msg.channel.as_deref(), Some("ch"));
+        assert_eq!(msg.channel_serial.as_deref(), Some("serial-0"));
+        assert_attach_resume(&msg, true);
+
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-2".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+
         send_message(&mut conn, "ch", "expected", serde_json::json!("ok"))
             .await
             .unwrap();


### PR DESCRIPTION
## Summary
- separate Ably ATTACH_RESUME intent from channel serial presence
- keep resume intent through suspended channel retries even when channel serial is cleared or absent
- add regression coverage for reattach without serial and message frames that omit channel serial

## Tests
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber build_attach_msg
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber session::tests
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber reattach_after_attached_without_serial_keeps_resume_intent
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber detached_while_attaching_suspends_and_retries_attach
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber message_without_serial_preserves_resume_serial_for_reattach
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p ably-subscriber
- cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber -- -D warnings

Closes #18495