### PR TITLE
chore: generate firewalls before rust bindings

### DIFF
--- a/turbo/packages/api-contracts/package.json
+++ b/turbo/packages/api-contracts/package.json
@@ -27,7 +27,7 @@
     "./firewalls/*": null
   },
   "scripts": {
-    "generate:rust": "tsx src/rust-bindings/generate.ts",
+    "generate:rust": "pnpm -F @vm0/firewalls-generator generate && tsx src/rust-bindings/generate.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",


### PR DESCRIPTION
## Summary
- run the firewall generator before `@vm0/api-contracts generate:rust`
- make Rust/Python generated bindings independent of install-time generated connector firewall files

## Verification
- `cd turbo && pnpm -F @vm0/api-contracts generate:rust`
- pre-commit: file size, connector firewall guard, prettier, knip