### PR TITLE
fix: respect safe area in artifact fullscreen

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -50,6 +50,8 @@ describe("platform entrypoint safe area behavior", () => {
     expect(globalCss).toMatch(
       /--sab-raw:\s*env\(safe-area-inset-bottom,\s*0px\);/,
     );
+    expect(globalCss).toMatch(/--sar:\s*env\(safe-area-inset-right,\s*0px\);/);
+    expect(globalCss).toMatch(/--sal:\s*env\(safe-area-inset-left,\s*0px\);/);
     expect(globalCss).toMatch(/--sab:\s*var\(--sab-raw\);/);
     expect(globalCss).toMatch(
       /:root:has\([\s\S]*:focus-visible[\s\S]*\)\s*{\s*--sab:\s*0px;\s*}/,
@@ -73,6 +75,14 @@ describe("platform entrypoint safe area behavior", () => {
     );
     expect(globalCss).toMatch(
       /\.zero-viewport-shell\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);[\s\S]*max-height:\s*var\(--zero-viewport-height\);[\s\S]*overflow:\s*hidden;/,
+    );
+  });
+
+  it("exposes a reusable fullscreen safe-area class", () => {
+    const globalCss = readGlobalCss();
+
+    expect(globalCss).toMatch(
+      /\.zero-safe-area-fullscreen\s*{[\s\S]*padding:\s*var\(--sat\)\s+var\(--sar\)\s+var\(--sab\)\s+var\(--sal\);[\s\S]*}/,
     );
   });
 });

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -47,11 +47,14 @@
 
 /* Safe area insets as CSS custom properties — more reliable than direct env() in inline
    styles across WebKit versions, including iOS 26+ standalone PWA mode.
-   Use var(--sat) / var(--sab) in components instead of env() directly. */
+   Use var(--sat) / var(--sar) / var(--sab) / var(--sal) in components
+   instead of env() directly. */
 :root {
   --sat: env(safe-area-inset-top, 0px);
+  --sar: env(safe-area-inset-right, 0px);
   --sab-raw: env(safe-area-inset-bottom, 0px);
   --sab: var(--sab-raw);
+  --sal: env(safe-area-inset-left, 0px);
   --zero-viewport-height: 100dvh;
   --zero-desktop-titlebar-height: 48px;
 }
@@ -116,6 +119,10 @@ body {
   min-height: var(--zero-viewport-height);
   max-height: var(--zero-viewport-height);
   overflow: hidden;
+}
+
+.zero-safe-area-fullscreen {
+  padding: var(--sat) var(--sar) var(--sab) var(--sal);
 }
 
 @media (display-mode: standalone) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -699,6 +699,39 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("keeps fullscreen artifact surfaces inside the safe area", async () => {
+    const markdownUrl =
+      "https://cdn.vm7.io/artifacts/test/run-1/release-notes.md";
+    context.mocks.http.get(markdownUrl, () => {
+      return new Response("# Release notes\n\nThe artifact is ready.", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+    setupChatThread({
+      artifactFiles: [artifactFile(markdownUrl)],
+      content: "Artifacts are ready.",
+      path: `${THREAD_PATH}?artifacts=${THREAD_ID}&artifact=${encodeURIComponent(markdownUrl)}&artifact-fullscreen=1`,
+    });
+
+    await waitFor(() => {
+      const sidebar = screen.getByTestId("artifact-sidebar");
+      expect(sidebar).toHaveClass("fixed", "inset-0");
+      expect(sidebar).toHaveClass("zero-safe-area-fullscreen");
+    });
+
+    click(screen.getByLabelText("Back to all artifacts"));
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-inbox")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Enter fullscreen"));
+    await waitFor(() => {
+      const inbox = screen.getByTestId("artifact-inbox");
+      expect(inbox).toHaveClass("fixed", "inset-0");
+      expect(inbox).toHaveClass("zero-safe-area-fullscreen");
+    });
+  });
+
   it("shares an artifact and exposes download destinations from the sidebar", async () => {
     const user = userEvent.setup({ delay: null });
     const markdownUrl =

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -185,7 +185,7 @@ function ArtifactSidebarContent({
       <div
         className={cn(
           fullscreen
-            ? "fixed inset-0 z-[100] flex flex-col bg-background pt-[env(safe-area-inset-top)]"
+            ? "fixed inset-0 z-[100] flex flex-col bg-background zero-safe-area-fullscreen"
             : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
           "animate-in fade-in duration-[180ms] ease",
         )}
@@ -233,7 +233,7 @@ function ArtifactSidebarContent({
     <div
       className={cn(
         fullscreen
-          ? "fixed inset-0 z-[100] flex flex-col bg-background pt-[env(safe-area-inset-top)]"
+          ? "fixed inset-0 z-[100] flex flex-col bg-background zero-safe-area-fullscreen"
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
         "animate-in fade-in duration-[180ms] ease",
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1897,7 +1897,7 @@ function ChatArtifactInboxList({ thread }: { thread: ChatThreadSignals }) {
     <div
       className={cn(
         fullscreen
-          ? "fixed inset-0 z-[100] flex flex-col bg-background"
+          ? "fixed inset-0 z-[100] flex flex-col bg-background zero-safe-area-fullscreen"
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
         "animate-in fade-in duration-[180ms] ease",
       )}
@@ -2484,7 +2484,7 @@ export function ZeroChatThreadPage() {
       className={cn(
         "flex min-w-0 overflow-hidden bg-background",
         artifactFullscreen
-          ? "fixed inset-0 z-[100] min-h-0 flex-col pt-[var(--sat)] pb-[var(--sab)]"
+          ? "fixed inset-0 z-[100] min-h-0 flex-col zero-safe-area-fullscreen"
           : "h-full w-full flex-1",
       )}
     >


### PR DESCRIPTION
## Summary
- add reusable fullscreen safe-area padding using top, right, bottom, and left insets
- apply it to artifact preview, artifact inbox, and presentation editor fullscreen shells
- cover fullscreen artifact surfaces and safe-area CSS with targeted tests

## Tests
- pnpm exec prettier --check apps/platform/src/views/css/index.css apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app check-types
- pnpm exec vitest run apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx