### PR TITLE
feat(desktop): add check for updates menu

### DIFF
--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -3,11 +3,15 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopConfig } from "./config";
 import { OFFLINE_COMPUTER_USE_HOST_STATE } from "./computer-use-types";
 import type { ComputerUseHostRuntimeState } from "./computer-use-types";
-import { installDesktopAutoUpdates } from "./desktop-auto-updates";
+import {
+  checkForDesktopUpdates,
+  installDesktopAutoUpdates,
+} from "./desktop-auto-updates";
 
 const mocks = vi.hoisted(() => ({
   app: { isPackaged: true },
   autoUpdater: {
+    checkForUpdates: vi.fn<() => void>(),
     quitAndInstall: vi.fn(),
   },
   dialog: {
@@ -131,6 +135,31 @@ describe("desktop auto-updates", () => {
       expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
     });
     expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("checks for updates on request", () => {
+    expect(checkForDesktopUpdates()).toBe(true);
+
+    expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs failed requested update checks", () => {
+    const error = new Error("feed unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(checkForDesktopUpdates()).toBe(false);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Desktop update check failed",
+      error,
+    );
+
+    consoleError.mockRestore();
   });
 
   it("prompts instead of silently restarting during recent command activity", async () => {

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -8,17 +8,41 @@ import {
   installDesktopAutoUpdates,
 } from "./desktop-auto-updates";
 
-const mocks = vi.hoisted(() => ({
-  app: { isPackaged: true },
-  autoUpdater: {
-    checkForUpdates: vi.fn<() => void>(),
-    quitAndInstall: vi.fn(),
-  },
-  dialog: {
-    showMessageBox: vi.fn<() => Promise<{ response: number }>>(),
-  },
-  updateElectronApp: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  type AutoUpdaterListener = (...args: readonly unknown[]) => void;
+  const autoUpdaterListeners = new Map<string, Set<AutoUpdaterListener>>();
+
+  function addAutoUpdaterListener(
+    eventName: string,
+    listener: AutoUpdaterListener,
+  ): void {
+    const listeners = autoUpdaterListeners.get(eventName) ?? new Set();
+    listeners.add(listener);
+    autoUpdaterListeners.set(eventName, listeners);
+  }
+
+  function removeAutoUpdaterListener(
+    eventName: string,
+    listener: AutoUpdaterListener,
+  ): void {
+    autoUpdaterListeners.get(eventName)?.delete(listener);
+  }
+
+  return {
+    app: { isPackaged: true },
+    autoUpdater: {
+      checkForUpdates: vi.fn<() => void>(),
+      quitAndInstall: vi.fn(),
+      once: vi.fn(addAutoUpdaterListener),
+      removeListener: vi.fn(removeAutoUpdaterListener),
+    },
+    autoUpdaterListeners,
+    dialog: {
+      showMessageBox: vi.fn<() => Promise<{ response: number }>>(),
+    },
+    updateElectronApp: vi.fn(),
+  };
+});
 
 vi.mock("electron", () => ({
   app: mocks.app,
@@ -100,6 +124,17 @@ function installAndCaptureUpdateOptions(
   };
 }
 
+function emitAutoUpdaterEvent(
+  eventName: string,
+  ...args: readonly unknown[]
+): void {
+  const listeners = [...(mocks.autoUpdaterListeners.get(eventName) ?? [])];
+  mocks.autoUpdaterListeners.delete(eventName);
+  listeners.forEach((listener) => {
+    listener(...args);
+  });
+}
+
 async function flushDownloadedUpdateCallback(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
   await Promise.resolve();
@@ -108,6 +143,7 @@ async function flushDownloadedUpdateCallback(): Promise<void> {
 describe("desktop auto-updates", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.autoUpdaterListeners.clear();
     mocks.app.isPackaged = true;
     mocks.dialog.showMessageBox.mockResolvedValue({ response: 1 });
     stubDesktopAutoUpdatePlatform();
@@ -143,7 +179,21 @@ describe("desktop auto-updates", () => {
     expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
-  it("logs failed requested update checks", () => {
+  it("shows when requested update checks find no update", async () => {
+    expect(checkForDesktopUpdates()).toBe(true);
+
+    emitAutoUpdaterEvent("update-not-available");
+    await flushDownloadedUpdateCallback();
+
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "No Updates Available",
+        message: "Zero Computer Use is up to date.",
+      }),
+    );
+  });
+
+  it("shows when requested update checks fail", async () => {
     const error = new Error("feed unavailable");
     const consoleError = vi
       .spyOn(console, "error")
@@ -153,10 +203,18 @@ describe("desktop auto-updates", () => {
     });
 
     expect(checkForDesktopUpdates()).toBe(false);
+    await flushDownloadedUpdateCallback();
 
     expect(consoleError).toHaveBeenCalledWith(
       "Desktop update check failed",
       error,
+    );
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Unable to Check for Updates",
+        message: "Zero Computer Use could not check for updates.",
+        detail: "feed unavailable",
+      }),
     );
 
     consoleError.mockRestore();

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -49,6 +49,28 @@ async function promptToRestartForUpdate(
   await restartForUpdate(prepareForQuitAndInstall);
 }
 
+async function notifyNoDesktopUpdatesFound(): Promise<void> {
+  await dialog.showMessageBox({
+    type: "info",
+    buttons: ["OK"],
+    defaultId: 0,
+    title: "No Updates Available",
+    message: "Zero Computer Use is up to date.",
+  });
+}
+
+async function notifyDesktopUpdateCheckFailed(error: unknown): Promise<void> {
+  console.error("Desktop update check failed", error);
+  await dialog.showMessageBox({
+    type: "error",
+    buttons: ["OK"],
+    defaultId: 0,
+    title: "Unable to Check for Updates",
+    message: "Zero Computer Use could not check for updates.",
+    detail: error instanceof Error ? error.message : undefined,
+  });
+}
+
 function shouldPromptForDownloadedUpdate(
   getComputerUseHostState: () => ComputerUseHostRuntimeState,
 ): boolean {
@@ -109,11 +131,40 @@ export function installDesktopAutoUpdates(
 }
 
 export function checkForDesktopUpdates(): boolean {
+  const handleNoUpdate = (): void => {
+    cleanup();
+    void notifyNoDesktopUpdatesFound().catch((error) => {
+      console.error("Desktop update status dialog failed", error);
+    });
+  };
+  const handleUpdateAvailable = (): void => {
+    cleanup();
+  };
+  const handleError = (error: Error): void => {
+    cleanup();
+    void notifyDesktopUpdateCheckFailed(error).catch((dialogError) => {
+      console.error("Desktop update failure dialog failed", dialogError);
+    });
+  };
+
+  function cleanup(): void {
+    autoUpdater.removeListener("update-not-available", handleNoUpdate);
+    autoUpdater.removeListener("update-available", handleUpdateAvailable);
+    autoUpdater.removeListener("error", handleError);
+  }
+
+  autoUpdater.once("update-not-available", handleNoUpdate);
+  autoUpdater.once("update-available", handleUpdateAvailable);
+  autoUpdater.once("error", handleError);
+
   try {
     autoUpdater.checkForUpdates();
     return true;
   } catch (error) {
-    console.error("Desktop update check failed", error);
+    cleanup();
+    void notifyDesktopUpdateCheckFailed(error).catch((dialogError) => {
+      console.error("Desktop update failure dialog failed", dialogError);
+    });
     return false;
   }
 }

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -107,3 +107,13 @@ export function installDesktopAutoUpdates(
   });
   return true;
 }
+
+export function checkForDesktopUpdates(): boolean {
+  try {
+    autoUpdater.checkForUpdates();
+    return true;
+  } catch (error) {
+    console.error("Desktop update check failed", error);
+    return false;
+  }
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -55,7 +55,10 @@ import {
 } from "./computer-use-permissions";
 import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
-import { installDesktopAutoUpdates } from "./desktop-auto-updates";
+import {
+  checkForDesktopUpdates,
+  installDesktopAutoUpdates,
+} from "./desktop-auto-updates";
 import { DesktopComputerUseAutoStartSupervisor } from "./desktop-computer-use-autostart";
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
 import { readOrCreateComputerUseInstallationId } from "./desktop-computer-use-installation";
@@ -145,6 +148,7 @@ let developerToolsAvailable = false;
 let developerToolsEnabled = false;
 let developerToolsRefresh: Promise<void> | null = null;
 let developerToolsRefreshRequested = false;
+let desktopAutoUpdatesInstalled = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
 let computerUseBlockedHostState: ComputerUseHostRuntimeState | null = null;
@@ -725,9 +729,22 @@ function requestDesktopQuit(): void {
   });
 }
 
+function requestDesktopUpdateCheck(): void {
+  if (!desktopAutoUpdatesInstalled) {
+    return;
+  }
+
+  checkForDesktopUpdates();
+}
+
 function applyApplicationMenu(): void {
   const appSubmenu: MenuItemConstructorOptions[] = [
     { role: "about" },
+    {
+      label: "Check for Updates...",
+      enabled: desktopAutoUpdatesInstalled,
+      click: requestDesktopUpdateCheck,
+    },
     { type: "separator" },
   ];
   if (developerToolsAvailable) {
@@ -1211,15 +1228,15 @@ if (!hasSingleInstanceLock) {
   void app.whenReady().then(async () => {
     applyDockIcon();
     hideDockForInactiveMainWindow();
-    applyApplicationMenu();
     registerDesktopAuthProtocol();
     installDesktopRendererProtocol();
-    installDesktopAutoUpdates({
+    desktopAutoUpdatesInstalled = installDesktopAutoUpdates({
       config,
       apiBaseUrl: desktopApiBaseUrl,
       getComputerUseHostState: () => getComputerUseBridgeState().host,
       prepareForQuitAndInstall,
     });
+    applyApplicationMenu();
     installKeepAwake();
     installComputerUse();
     installDesktopDeveloperTools();


### PR DESCRIPTION
## Summary
- add a macOS app menu item for checking Desktop updates on demand
- route manual checks through Electron autoUpdater while keeping existing automatic update behavior
- cover requested update checks and failure logging in desktop auto-update tests

## Tests
- pnpm -F @vm0/desktop exec vitest run src/desktop-auto-updates.test.ts src/desktop-update-feed.test.ts src/desktop-auto-update-policy.test.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop build:electron