### PR TITLE
chore: update toolchain images to 20260622

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260525",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260622",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-neon-branches:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -100,7 +100,7 @@ jobs:
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     outputs:
       any-changed: ${{ steps.detect.outputs.any-changed }}
       ci-changed: ${{ steps.detect.outputs.ci-changed }}
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
     if: needs.detect.outputs.any-changed == 'true'
     steps:
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     needs: [detect]
     if: |
       needs.detect.outputs.ci-changed == 'true' ||
@@ -378,7 +378,7 @@ jobs:
   nbd-cow-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     needs: [detect]
     if: |
       needs.detect.outputs.metal-job-ref != '' && (

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -505,7 +505,7 @@ jobs:
       needs.builds-complete.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     permissions:
       contents: read
     environment: production
@@ -703,7 +703,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -821,7 +821,7 @@ jobs:
     if: ${{ needs.release-please.outputs.api_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -1010,7 +1010,7 @@ jobs:
       group: deploy-host-worker-production
       cancel-in-progress: false
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     permissions:
       contents: read
     environment: production
@@ -1163,7 +1163,7 @@ jobs:
        needs.promote-api-production.result == 'success')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       deployment_url: ${{ needs.build-web-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -1290,7 +1290,7 @@ jobs:
       needs.migrate-production.result == 'success'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       deployment_url: ${{ needs.build-api-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -1408,7 +1408,7 @@ jobs:
     if: ${{ needs.release-please.outputs.app_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -1529,7 +1529,7 @@ jobs:
        needs.promote-api-production.result == 'success')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       deployment_url: ${{ needs.build-app-production.outputs.deployment_url }}
       vercel_dashboard_url: ${{ steps.vercel-dashboard.outputs.url }}
@@ -2066,7 +2066,7 @@ jobs:
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     permissions:
       contents: write
     environment: production
@@ -2304,7 +2304,7 @@ jobs:
        needs.promote-api-production.result == 'success')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     permissions:
       contents: read
     environment: production
@@ -2471,7 +2471,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     permissions:
       contents: read
     environment: production
@@ -2495,7 +2495,7 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     permissions:
       contents: read
     steps:

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -50,7 +50,7 @@ jobs:
   rollback:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     permissions:
       contents: read
     environment: production

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -200,7 +200,7 @@ jobs:
   build:
     runs-on: ubuntu-latest-8-cores
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     permissions:
       contents: read
     needs: [prepare]

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -359,7 +359,7 @@ jobs:
     timeout-minutes: 10
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
         with:
@@ -386,7 +386,7 @@ jobs:
     timeout-minutes: 15
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -405,7 +405,7 @@ jobs:
     timeout-minutes: 15
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -430,7 +430,7 @@ jobs:
     timeout-minutes: 8
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -444,7 +444,7 @@ jobs:
     timeout-minutes: 10
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -459,7 +459,7 @@ jobs:
     timeout-minutes: 10
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
         image: postgres:17-alpine
@@ -512,7 +512,7 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/main')
       )
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
         image: postgres:17-alpine
@@ -558,7 +558,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
         image: postgres:17-alpine
@@ -627,7 +627,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -659,7 +659,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -691,7 +691,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     services:
       postgres:
         image: postgres:17-alpine
@@ -740,7 +740,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
@@ -771,7 +771,7 @@ jobs:
       group: deploy-api-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and anything
     # that needs a live API preview or E2E API token changed.
@@ -1088,7 +1088,7 @@ jobs:
       group: deploy-web-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and
     # web-facing changes or runner OAuth E2E need a web preview.
@@ -1266,7 +1266,7 @@ jobs:
       group: deploy-app-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
     if: >-
@@ -1560,7 +1560,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -2230,7 +2230,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260525
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary
- update CI workflow references for vm0-toolchain and vm0-toolchain-rust to the 20260622 image tag
- update the devcontainer vm0-dev image to the same published tag

## Validation
- confirmed Docker Toolchain Publish run 27939313874 completed successfully for amd64 and arm64 and created manifests
- verified GHCR manifests for vm0-toolchain:20260622, vm0-toolchain-rust:20260622, and vm0-dev:20260622 return HTTP 200 and include linux/amd64 and linux/arm64
- ran git diff --check