### PR TITLE
refactor: remove runtime firewall root exports

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
@@ -16,60 +17,135 @@ function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-function staticValueImportSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  for (const match of source.matchAll(
-    /^\s*import\s+(?!type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
-  )) {
-    specifiers.push(match[1]!);
-  }
-  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
-    specifiers.push(match[1]!);
-  }
-  return specifiers;
+function parseSource(source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    "source.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
 }
 
-function staticValueExportSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  for (const match of source.matchAll(
-    /^\s*export(?:\s+\*(?:\s+as\s+\w+)?|\s+\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
-  )) {
-    specifiers.push(match[1]!);
+function stringLiteralText(node: ts.Node | undefined): string | null {
+  if (
+    node === undefined ||
+    (!ts.isStringLiteral(node) && !ts.isNoSubstitutionTemplateLiteral(node))
+  ) {
+    return null;
   }
-  return specifiers;
+
+  return node.text;
 }
 
-function staticModuleSpecifiers(source: string): string[] {
+function importDeclarationHasValue(statement: ts.ImportDeclaration): boolean {
+  const clause = statement.importClause;
+  if (clause === undefined) {
+    return true;
+  }
+  if (clause.isTypeOnly || clause.name !== undefined) {
+    return !clause.isTypeOnly;
+  }
+
+  const namedBindings = clause.namedBindings;
+  if (namedBindings === undefined || ts.isNamespaceImport(namedBindings)) {
+    return true;
+  }
+
+  return (
+    namedBindings.elements.length === 0 ||
+    namedBindings.elements.some((element) => {
+      return !element.isTypeOnly;
+    })
+  );
+}
+
+function exportDeclarationHasValue(statement: ts.ExportDeclaration): boolean {
+  if (statement.isTypeOnly) {
+    return false;
+  }
+
+  const exportClause = statement.exportClause;
+  if (exportClause === undefined || ts.isNamespaceExport(exportClause)) {
+    return true;
+  }
+
+  return (
+    exportClause.elements.length === 0 ||
+    exportClause.elements.some((element) => {
+      return !element.isTypeOnly;
+    })
+  );
+}
+
+function staticModuleSpecifiers(
+  source: string,
+  options: { includeTypeOnly: boolean },
+): string[] {
   const specifiers: string[] = [];
-  for (const match of source.matchAll(
-    /^\s*import\s+(?:type\s+)?[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
-  )) {
-    specifiers.push(match[1]!);
-  }
-  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
-    specifiers.push(match[1]!);
-  }
-  for (const match of source.matchAll(
-    /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+\w+)?|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
-  )) {
-    specifiers.push(match[1]!);
+  for (const statement of parseSource(source).statements) {
+    if (ts.isImportDeclaration(statement)) {
+      if (!options.includeTypeOnly && !importDeclarationHasValue(statement)) {
+        continue;
+      }
+      const specifier = stringLiteralText(statement.moduleSpecifier);
+      if (specifier !== null) {
+        specifiers.push(specifier);
+      }
+    }
+    if (ts.isExportDeclaration(statement)) {
+      if (!options.includeTypeOnly && !exportDeclarationHasValue(statement)) {
+        continue;
+      }
+      const specifier = stringLiteralText(statement.moduleSpecifier);
+      if (specifier !== null) {
+        specifiers.push(specifier);
+      }
+    }
   }
   return specifiers;
 }
 
 function staticValueModuleSpecifiers(source: string): string[] {
-  return [
-    ...staticValueImportSpecifiers(source),
-    ...staticValueExportSpecifiers(source),
-  ];
+  return staticModuleSpecifiers(source, { includeTypeOnly: false });
+}
+
+function callModuleSpecifiers(
+  source: string,
+  predicate: (expression: ts.Expression) => boolean,
+): string[] {
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && predicate(node.expression)) {
+      const specifier = stringLiteralText(node.arguments[0]);
+      if (specifier !== null) {
+        specifiers.push(specifier);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(parseSource(source));
+  return specifiers;
 }
 
 function dynamicImportSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  for (const match of source.matchAll(/import\(\s*["']([^"']+)["']\s*\)/g)) {
-    specifiers.push(match[1]!);
-  }
-  return specifiers;
+  return callModuleSpecifiers(source, (expression) => {
+    return expression.kind === ts.SyntaxKind.ImportKeyword;
+  });
+}
+
+function requireSpecifiers(source: string): string[] {
+  return callModuleSpecifiers(source, (expression) => {
+    return ts.isIdentifier(expression) && expression.text === "require";
+  });
+}
+
+function moduleSpecifiers(source: string): string[] {
+  return [
+    ...staticModuleSpecifiers(source, { includeTypeOnly: true }),
+    ...dynamicImportSpecifiers(source),
+    ...requireSpecifiers(source),
+  ];
 }
 
 describe("firewall runtime loader", () => {
@@ -97,7 +173,7 @@ describe("firewall runtime loader", () => {
       path.resolve(import.meta.dirname, "../index.ts"),
       "utf-8",
     );
-    const rootSpecifiers = staticModuleSpecifiers(rootEntrypoint);
+    const rootSpecifiers = moduleSpecifiers(rootEntrypoint);
 
     for (const specifier of rootSpecifiers) {
       expect(specifier).not.toMatch(/^\.\/firewalls(?:\/|$)/);

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -32,17 +32,25 @@ function staticValueImportSpecifiers(source: string): string[] {
 function staticValueExportSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
   for (const match of source.matchAll(
-    /^\s*export(?:\s+\*|\s+\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+    /^\s*export(?:\s+\*(?:\s+as\s+\w+)?|\s+\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
   )) {
     specifiers.push(match[1]!);
   }
   return specifiers;
 }
 
-function staticExportSpecifiers(source: string): string[] {
+function staticModuleSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
   for (const match of source.matchAll(
-    /^\s*export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+    /^\s*import\s+(?:type\s+)?[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
+  )) {
+    specifiers.push(match[1]!);
+  }
+  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
+    specifiers.push(match[1]!);
+  }
+  for (const match of source.matchAll(
+    /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+\w+)?|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
   )) {
     specifiers.push(match[1]!);
   }
@@ -89,9 +97,9 @@ describe("firewall runtime loader", () => {
       path.resolve(import.meta.dirname, "../index.ts"),
       "utf-8",
     );
-    const rootExportSpecifiers = staticExportSpecifiers(rootEntrypoint);
+    const rootSpecifiers = staticModuleSpecifiers(rootEntrypoint);
 
-    for (const specifier of rootExportSpecifiers) {
+    for (const specifier of rootSpecifiers) {
       expect(specifier).not.toMatch(/^\.\/firewalls(?:\/|$)/);
     }
   });

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -74,6 +74,18 @@ describe("firewall runtime loader", () => {
     expect(rootEntrypoint).not.toContain("firewalls/runtime");
   });
 
+  it("keeps runtime firewalls out of the package root entrypoint", () => {
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+    const rootSpecifiers = staticValueModuleSpecifiers(rootEntrypoint);
+
+    expect(rootSpecifiers).not.toContain("./firewalls");
+    expect(rootSpecifiers).not.toContain("./firewalls/all");
+    expect(rootSpecifiers).not.toContain("./firewalls/runtime");
+  });
+
   it("keeps all-catalog access behind an explicit package subpath", () => {
     const packageJson = JSON.parse(
       fs.readFileSync(

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -39,6 +39,16 @@ function staticValueExportSpecifiers(source: string): string[] {
   return specifiers;
 }
 
+function staticExportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+  )) {
+    specifiers.push(match[1]!);
+  }
+  return specifiers;
+}
+
 function staticValueModuleSpecifiers(source: string): string[] {
   return [
     ...staticValueImportSpecifiers(source),
@@ -79,11 +89,11 @@ describe("firewall runtime loader", () => {
       path.resolve(import.meta.dirname, "../index.ts"),
       "utf-8",
     );
-    const rootSpecifiers = staticValueModuleSpecifiers(rootEntrypoint);
+    const rootExportSpecifiers = staticExportSpecifiers(rootEntrypoint);
 
-    expect(rootSpecifiers).not.toContain("./firewalls");
-    expect(rootSpecifiers).not.toContain("./firewalls/all");
-    expect(rootSpecifiers).not.toContain("./firewalls/runtime");
+    for (const specifier of rootExportSpecifiers) {
+      expect(specifier).not.toMatch(/^\.\/firewalls(?:\/|$)/);
+    }
   });
 
   it("keeps all-catalog access behind an explicit package subpath", () => {

--- a/turbo/packages/connectors/src/index.ts
+++ b/turbo/packages/connectors/src/index.ts
@@ -4,4 +4,3 @@ export * from "./feature-switch-key";
 export * from "./firewall-expander";
 export * from "./firewall-rule-matcher";
 export * from "./firewall-types";
-export * from "./firewalls";

--- a/turbo/packages/core/package.json
+++ b/turbo/packages/core/package.json
@@ -24,6 +24,7 @@
     "check-types": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^24.3.0",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
     "eslint": "^9.34.0",

--- a/turbo/packages/core/package.json
+++ b/turbo/packages/core/package.json
@@ -15,10 +15,6 @@
     "./contracts": {
       "import": "./src/contracts/index.ts",
       "types": "./src/contracts/index.ts"
-    },
-    "./firewalls": {
-      "import": "./src/firewalls/index.ts",
-      "types": "./src/firewalls/index.ts"
     }
   },
   "scripts": {

--- a/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
@@ -23,7 +23,7 @@ function staticModuleSpecifiers(source: string): string[] {
     }
   }
   for (const match of source.matchAll(
-    /^\s*export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+    /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+\w+)?|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
   )) {
     const specifier = match[1];
     if (specifier !== undefined) {

--- a/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import packageJson from "../../package.json";
+
+function staticValueImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*import\s+(?!type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
+  )) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
+
+function staticValueExportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*export(?:\s+\*|\s+\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+  )) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
+
+function staticValueModuleSpecifiers(source: string): string[] {
+  return [
+    ...staticValueImportSpecifiers(source),
+    ...staticValueExportSpecifiers(source),
+  ];
+}
+
+describe("core firewall import boundary", () => {
+  it("keeps runtime firewalls out of the package root entrypoint", async () => {
+    const { default: rootEntrypoint } = await import("../index.ts?raw");
+
+    expect(staticValueModuleSpecifiers(rootEntrypoint)).not.toContain(
+      "./firewalls",
+    );
+    expect(rootEntrypoint).not.toContain("@vm0/connectors/firewalls");
+  });
+
+  it("does not expose the core firewall alias subpath", () => {
+    expect(packageJson.exports).not.toHaveProperty("./firewalls");
+  });
+});

--- a/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
@@ -1,28 +1,58 @@
+/// <reference types="node" />
+
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import * as coreRoot from "../index";
 import packageJson from "../../package.json";
 
-const runtimeFirewallRootExports = [
-  "getPermissionCategories",
-  "groupPermissionsByCategory",
-  "isFirewallConnectorType",
-  "getConnectorFirewall",
-  "getDefaultFirewallPolicies",
-  "resolveFirewallPolicies",
-  "getAllBuiltinConnectorHosts",
-  "getBuiltinConnectorDisplayName",
-  "BILLABLE_CONNECTORS",
-] as const;
+function staticModuleSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*import\s+(?:type\s+)?[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
+  )) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  for (const match of source.matchAll(
+    /^\s*export\s+(?:type\s+)?(?:\*|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
+  )) {
+    const specifier = match[1];
+    if (specifier !== undefined) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
 
 describe("core firewall import boundary", () => {
-  it("does not expose runtime firewall helpers from the package root", () => {
-    for (const exportName of runtimeFirewallRootExports) {
-      expect(coreRoot).not.toHaveProperty(exportName);
+  it("keeps runtime firewalls out of the package root source", () => {
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    for (const specifier of staticModuleSpecifiers(rootEntrypoint)) {
+      expect(specifier).not.toMatch(/^\.\/firewalls(?:\/|$)/);
+      expect(specifier).not.toMatch(/^@vm0\/connectors\/firewalls(?:\/|$)/);
     }
   });
 
-  it("does not expose the core firewall alias subpath", () => {
+  it("does not expose the core firewall alias subpath or source file", () => {
     expect(packageJson.exports).not.toHaveProperty("./firewalls");
+    expect(
+      fs.existsSync(path.resolve(import.meta.dirname, "../firewalls.ts")),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.resolve(import.meta.dirname, "../firewalls/index.ts")),
+    ).toBe(false);
   });
 });

--- a/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
@@ -1,54 +1,25 @@
 import { describe, expect, it } from "vitest";
 
+import * as coreRoot from "../index";
 import packageJson from "../../package.json";
 
-function staticValueImportSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  for (const match of source.matchAll(
-    /^\s*import\s+(?!type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
-  )) {
-    const specifier = match[1];
-    if (specifier !== undefined) {
-      specifiers.push(specifier);
-    }
-  }
-  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
-    const specifier = match[1];
-    if (specifier !== undefined) {
-      specifiers.push(specifier);
-    }
-  }
-  return specifiers;
-}
-
-function staticValueExportSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  for (const match of source.matchAll(
-    /^\s*export(?:\s+\*|\s+\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
-  )) {
-    const specifier = match[1];
-    if (specifier !== undefined) {
-      specifiers.push(specifier);
-    }
-  }
-  return specifiers;
-}
-
-function staticValueModuleSpecifiers(source: string): string[] {
-  return [
-    ...staticValueImportSpecifiers(source),
-    ...staticValueExportSpecifiers(source),
-  ];
-}
+const runtimeFirewallRootExports = [
+  "getPermissionCategories",
+  "groupPermissionsByCategory",
+  "isFirewallConnectorType",
+  "getConnectorFirewall",
+  "getDefaultFirewallPolicies",
+  "resolveFirewallPolicies",
+  "getAllBuiltinConnectorHosts",
+  "getBuiltinConnectorDisplayName",
+  "BILLABLE_CONNECTORS",
+] as const;
 
 describe("core firewall import boundary", () => {
-  it("keeps runtime firewalls out of the package root entrypoint", async () => {
-    const { default: rootEntrypoint } = await import("../index.ts?raw");
-
-    expect(staticValueModuleSpecifiers(rootEntrypoint)).not.toContain(
-      "./firewalls",
-    );
-    expect(rootEntrypoint).not.toContain("@vm0/connectors/firewalls");
+  it("does not expose runtime firewall helpers from the package root", () => {
+    for (const exportName of runtimeFirewallRootExports) {
+      expect(coreRoot).not.toHaveProperty(exportName);
+    }
   });
 
   it("does not expose the core firewall alias subpath", () => {

--- a/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-import-boundary.test.ts
@@ -2,34 +2,57 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 import packageJson from "../../package.json";
 
-function staticModuleSpecifiers(source: string): string[] {
+function parseSource(source: string): ts.SourceFile {
+  return ts.createSourceFile(
+    "source.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function stringLiteralText(node: ts.Node | undefined): string | null {
+  if (
+    node === undefined ||
+    (!ts.isStringLiteral(node) && !ts.isNoSubstitutionTemplateLiteral(node))
+  ) {
+    return null;
+  }
+
+  return node.text;
+}
+
+function moduleSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
-  for (const match of source.matchAll(
-    /^\s*import\s+(?:type\s+)?[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
-  )) {
-    const specifier = match[1];
-    if (specifier !== undefined) {
-      specifiers.push(specifier);
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const specifier = stringLiteralText(node.moduleSpecifier);
+      if (specifier !== null) {
+        specifiers.push(specifier);
+      }
     }
-  }
-  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
-    const specifier = match[1];
-    if (specifier !== undefined) {
-      specifiers.push(specifier);
+    if (ts.isCallExpression(node)) {
+      const expression = node.expression;
+      const isModuleCall =
+        expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(expression) && expression.text === "require");
+      if (isModuleCall) {
+        const specifier = stringLiteralText(node.arguments[0]);
+        if (specifier !== null) {
+          specifiers.push(specifier);
+        }
+      }
     }
-  }
-  for (const match of source.matchAll(
-    /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+\w+)?|\{[\s\S]*?\})\s+from\s+["']([^"']+)["'];?/gm,
-  )) {
-    const specifier = match[1];
-    if (specifier !== undefined) {
-      specifiers.push(specifier);
-    }
-  }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(parseSource(source));
   return specifiers;
 }
 
@@ -40,7 +63,7 @@ describe("core firewall import boundary", () => {
       "utf-8",
     );
 
-    for (const specifier of staticModuleSpecifiers(rootEntrypoint)) {
+    for (const specifier of moduleSpecifiers(rootEntrypoint)) {
       expect(specifier).not.toMatch(/^\.\/firewalls(?:\/|$)/);
       expect(specifier).not.toMatch(/^@vm0\/connectors\/firewalls(?:\/|$)/);
     }

--- a/turbo/packages/core/src/__tests__/raw-imports.d.ts
+++ b/turbo/packages/core/src/__tests__/raw-imports.d.ts
@@ -1,0 +1,4 @@
+declare module "*.ts?raw" {
+  const source: string;
+  export default source;
+}

--- a/turbo/packages/core/src/__tests__/raw-imports.d.ts
+++ b/turbo/packages/core/src/__tests__/raw-imports.d.ts
@@ -1,4 +1,0 @@
-declare module "*.ts?raw" {
-  const source: string;
-  export default source;
-}

--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -1,1 +1,0 @@
-export * from "@vm0/connectors/firewalls";

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -842,24 +842,6 @@ export {
   type SkillFrontmatter,
 } from "./skill-frontmatter";
 export { stripMetadataFrontmatter } from "./instructions-frontmatter";
-export {
-  getPermissionCategories,
-  groupPermissionsByCategory,
-  isFirewallConnectorType,
-  getConnectorFirewall,
-  getDefaultFirewallPolicies,
-  resolveFirewallPolicies,
-  getAllBuiltinConnectorHosts,
-  getBuiltinConnectorDisplayName,
-  BILLABLE_CONNECTORS,
-  type ConnectorCategories,
-  type PermissionGroup,
-  type FirewallConnectorType,
-  type BillableConnector,
-  type PermissionNamesOf,
-  type NonFirewallConnectorType,
-  type ConnectorTypeCoverage,
-} from "./firewalls";
 export { getGmtOffset } from "./timezone";
 export { getModelDisplayName } from "./model-display-name";
 export { formatMessage, serializeError, extractFields } from "./log-utils";

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -927,6 +927,9 @@ importers:
         specifier: '>=2.8.3'
         version: 2.8.3
     devDependencies:
+      '@types/node':
+        specifier: 24.3.0
+        version: 24.3.0
       '@vm0/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config


### PR DESCRIPTION
## Summary

- remove runtime firewall catalog re-exports from the `@vm0/connectors` package root; callers must use explicit firewall subpaths
- remove `@vm0/core` root firewall helper exports and the `@vm0/core/firewalls` alias so the core root no longer pulls connector runtime catalogs
- add AST-based import-boundary guards for the core and connectors package roots, plus downstream API/platform boundary coverage

Closes #18118.

## Tests

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts`
- `pnpm -F @vm0/core exec vitest run src/__tests__/firewall-import-boundary.test.ts`
- `pnpm -F api exec vitest run src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/firewall-metadata-import-boundary.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/core lint`
- `git diff --check`
- pre-commit hook: `knip` and `pnpm check-types`
