### PR TITLE
feat: enable computer use by default

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -190,17 +190,12 @@ describe("auth tokens", () => {
   });
 
   it("gates computer-use capability on an explicit host grant", () => {
-    const defaultToken = generateZeroToken(
-      "user_zero",
-      "run_zero",
-      "org_zero",
-      { [FeatureSwitchKey.ComputerUse]: true },
-    );
+    const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
     const scopedToken = generateZeroToken(
       "user_zero",
       "run_zero",
       "org_zero",
-      { [FeatureSwitchKey.ComputerUse]: true },
+      undefined,
       { computerUseHostId: "00000000-0000-4000-8000-000000000001" },
     );
 

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -24,7 +24,6 @@ const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
 
 const CONDITIONAL_CAPABILITIES = [
-  ["computer-use:write", FeatureSwitchKey.ComputerUse],
   ["banking:read", FeatureSwitchKey.Banking],
   ["goal:read", FeatureSwitchKey.GoalWorkflows],
   ["goal:write", FeatureSwitchKey.GoalWorkflows],

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -19,9 +19,7 @@ import {
   getModelProviderFirewall,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { secrets } from "@vm0/db/schema/secret";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
@@ -360,23 +358,6 @@ async function overwriteOrgModelProviderSecret(
         eq(secrets.type, "model-provider"),
       ),
     );
-}
-
-async function updateFeatureSwitches(
-  actor: ApiTestUser,
-  switches: Partial<Record<FeatureSwitchKey, boolean>>,
-): Promise<void> {
-  await accept(
-    setupApp({ context })(zeroFeatureSwitchesContract).update({
-      headers: sessionHeaders(actor),
-      body: { switches },
-    }),
-    [200],
-  );
-}
-
-async function disableComputerUse(actor: ApiTestUser): Promise<void> {
-  await updateFeatureSwitches(actor, { [FeatureSwitchKey.ComputerUse]: false });
 }
 
 async function readThreadComputerUseHostId(
@@ -2183,7 +2164,6 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
   it("grants computer-use capability only for a selected host", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
-    await cu.enableComputerUse(actor);
     const { hostId, hostToken } = await cu.startComputerUseHost(actor);
 
     // The thread's sticky host is not exposed by any read route, so the
@@ -2289,22 +2269,6 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
       displayName: "Computer-use guard agent",
     });
 
-    // Feature disabled: explicit selections are rejected outright.
-    const featureDisabled = await chat.requestSendMessage(
-      actor,
-      {
-        agentId: agent.agentId,
-        prompt: "use a host without the feature",
-        computerUseHostId: randomUUID(),
-      },
-      [403],
-    );
-    expectApiError(featureDisabled.body);
-    expect(featureDisabled.body.error.message).toBe(
-      "Computer use is not enabled",
-    );
-
-    await cu.enableComputerUse(actor);
     const unknownHost = await chat.requestSendMessage(
       actor,
       {
@@ -2418,13 +2382,13 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     );
     expect(clearedSend.body).toMatchObject({ threadId: pinned.body.threadId });
 
-    // Disabling the feature keeps non-explicit sends working without a grant.
+    // A valid sticky host remains usable for later non-explicit sends.
     const survivor = await cu.startComputerUseHost(actor);
     const survivorThread = await chat.requestSendMessage(
       actor,
       {
         agentId: agent.agentId,
-        prompt: "pin a host before the feature is disabled",
+        prompt: "pin a host for a later sticky send",
         computerUseHostId: survivor.hostId,
       },
       [201],
@@ -2432,20 +2396,6 @@ describe("CHAT-02/FILE-03: computer-use host grants", () => {
     if (survivorThread.status !== 201) {
       throw new Error("Expected the survivor send to be accepted");
     }
-    await disableComputerUse(actor);
-    const disabledStickySend = await chat.requestSendMessage(
-      actor,
-      {
-        agentId: agent.agentId,
-        threadId: survivorThread.body.threadId,
-        prompt: "send with the feature disabled",
-      },
-      [201],
-    );
-    expect(disabledStickySend.body).toMatchObject({
-      threadId: survivorThread.body.threadId,
-    });
-    await cu.enableComputerUse(actor);
 
     // A host that stopped heartbeating goes stale-offline (status still
     // online, not revoked), but explicit selections are still accepted so the

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -561,16 +561,6 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       title: "Computer Use",
     });
 
-    const disabled = await chat.requestUpdateThreadComputerUseHost(
-      actor,
-      thread.id,
-      randomUUID(),
-      [403],
-    );
-    expectApiError(disabled.body);
-    expect(disabled.body.error.message).toBe("Computer use is not enabled");
-
-    await cu.enableComputerUse(actor);
     const host = await cu.startComputerUseHost(actor);
     await chat.updateThreadComputerUseHost(actor, thread.id, host.hostId);
     await expect(readThreadComputerUseHostId(thread.id)).resolves.toBe(

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -34,60 +34,6 @@ afterEach(() => {
 });
 
 describe("FILE-03 desktop computer-use runtime", () => {
-  it("keeps disabled desktop computer-use routes behind the public feature switch", async () => {
-    const actor = bdd.user();
-    const missingId = randomUUID();
-
-    const hosts = await api.requestListComputerUseHosts(actor, [403]);
-    expectApiError(hosts.body);
-    expect(hosts.body.error.message).toBe("Computer use is not enabled");
-
-    const startHost = await api.requestStartComputerUseHost(actor, [403]);
-    expectApiError(startHost.body);
-    expect(startHost.body.error.message).toBe("Computer use is not enabled");
-
-    const deleteHost = await api.requestDeleteComputerUseHost(
-      actor,
-      missingId,
-      [403],
-    );
-    expectApiError(deleteHost.body);
-    expect(deleteHost.body.error.message).toBe("Computer use is not enabled");
-
-    const createCommand = await api.requestCreateComputerUseWriteCommand(
-      actor,
-      [403],
-    );
-    expectApiError(createCommand.body);
-    expect(createCommand.body.error.message).toBe(
-      "Computer use is not enabled",
-    );
-
-    const readCommand = await api.requestReadComputerUseCommand(
-      actor,
-      missingId,
-      [403],
-    );
-    expectApiError(readCommand.body);
-    expect(readCommand.body.error.message).toBe("Computer use is not enabled");
-
-    const screenshot = await api.requestComputerUseScreenshot(
-      actor,
-      missingId,
-      [403],
-    );
-    expectApiError(screenshot.body);
-    expect(screenshot.body.error.message).toBe("Computer use is not enabled");
-
-    const audit = await api.requestListComputerUseAuditEvents(
-      actor,
-      { commandId: missingId },
-      [403],
-    );
-    expectApiError(audit.body);
-    expect(audit.body.error.message).toBe("Computer use is not enabled");
-  });
-
   it("does not expose the legacy computer-use command approval route", async () => {
     const app = createApp({ signal: context.signal });
     const response = await app.request(
@@ -107,7 +53,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
     const actor = bdd.user({ orgId });
     const peer = bdd.user({ orgId });
 
-    await api.enableComputerUse(actor);
     const initialHosts = await api.listComputerUseHosts(actor);
     expect(initialHosts.hosts).toStrictEqual([]);
 
@@ -188,7 +133,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
 
   it("keeps multiple active hosts and lets stale heartbeats recover", async () => {
     const actor = bdd.user();
-    await api.enableComputerUse(actor);
     const base = now();
     mockNow(base);
 
@@ -253,7 +197,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
 
   it("keeps installation hosts stable across stop and restart", async () => {
     const actor = bdd.user();
-    await api.enableComputerUse(actor);
     const installationId = randomUUID();
 
     const started = await api.startComputerUseHost(actor, {
@@ -299,7 +242,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
 
   it("publishes computer-use host list changes", async () => {
     const actor = bdd.user();
-    await api.enableComputerUse(actor);
     const base = now();
     mockNow(base);
 
@@ -433,7 +375,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
     const orgId = `org_${randomUUID()}`;
     const userId = `user_${randomUUID()}`;
     const actor = bdd.user({ orgId, userId });
-    await api.enableComputerUse(actor);
 
     const noHost = await api.requestCreateComputerUseReadCommand(
       actor,
@@ -648,7 +589,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
 
   it("times out stale running commands and reports completion failures", async () => {
     const actor = bdd.user();
-    await api.enableComputerUse(actor);
     const base = now();
     mockNow(base);
     const host = await api.startComputerUseHost(actor);
@@ -748,8 +688,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
     const userId = `user_${randomUUID()}`;
     const actor = bdd.user({ orgId, userId });
     const peer = bdd.user();
-    await api.enableComputerUse(actor);
-    await api.enableComputerUse(peer);
 
     mockNow(now() - 40 * 24 * 60 * 60 * 1000);
     const host = await api.startComputerUseHost(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -18,8 +18,6 @@ import {
   type ComputerUseReadCommandKind,
   type ComputerUseWriteCommandKind,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { now } from "../../../../lib/time";
 import {
@@ -235,10 +233,6 @@ export function createComputerUseBddApi(context: TestContext) {
     return { authorization: "Bearer clerk-session" };
   }
 
-  function featureSwitchesClient() {
-    return setupApp({ context })(zeroFeatureSwitchesContract);
-  }
-
   function hostsClient() {
     return setupApp({ context })(zeroComputerUseHostsContract);
   }
@@ -317,16 +311,6 @@ export function createComputerUseBddApi(context: TestContext) {
       });
 
       return { puts, deletedKeys };
-    },
-
-    async enableComputerUse(actor: ApiTestUser): Promise<void> {
-      await accept(
-        featureSwitchesClient().update({
-          headers: authenticate(actor),
-          body: { switches: { [FeatureSwitchKey.ComputerUse]: true } },
-        }),
-        [200],
-      );
     },
 
     async startComputerUseHost(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1699,7 +1699,6 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ComputerUse]: true,
       [FeatureSwitchKey.SandboxIoLimiters]: true,
     });
 
@@ -1740,13 +1739,12 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(queued.runId);
     expect(claim.featureFlags).toMatchObject({
-      [FeatureSwitchKey.ComputerUse]: true,
       [FeatureSwitchKey.SandboxIoLimiters]: true,
     });
     expect(claim.apiStartTime).toBe(promotedAt);
 
-    // Even with the computer-use switch on, a run-scoped zero token issued
-    // without a host binding cannot reach computer-use write routes.
+    // A run-scoped zero token issued without a host binding cannot reach
+    // computer-use write routes.
     const zeroToken = claim.environment?.ZERO_TOKEN;
     if (!zeroToken) {
       throw new Error("Expected the promoted claim to expose the zero token");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2707,7 +2707,7 @@ describe("RUN-04: agent run telemetry families", () => {
             },
             featureFlags: { legacyIgnored: true },
             featureFlagEntries: [
-              { name: "computerUse", enabled: true },
+              { name: "sandboxIoLimiters", enabled: true },
               { name: "dummy", enabled: null },
               { enabled: true },
             ],
@@ -2762,7 +2762,7 @@ describe("RUN-04: agent run telemetry families", () => {
           unknownPolicy: "allow",
         },
       },
-      featureFlags: { computerUse: true },
+      featureFlags: { sandboxIoLimiters: true },
       artifact: { vasStorageName: "art-1" },
     });
     expect(contextRead.body.environment).toStrictEqual({

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1,8 +1,6 @@
 import { randomBytes } from "node:crypto";
 
 import { command } from "ccstate";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import {
   chatMessagesContract,
   type AttachFile,
@@ -50,7 +48,6 @@ import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
 import type { AuthContext } from "../../types/auth";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import {
   cancelRun$,
   dispatchCancelSideEffects$,
@@ -1260,23 +1257,6 @@ function hasComputerUseHostSelection(body: NormalSendBody): boolean {
   return Object.prototype.hasOwnProperty.call(body, "computerUseHostId");
 }
 
-async function computerUseFeatureEnabled(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<boolean> {
-  const context = await loadUserFeatureSwitchContext(
-    params.db,
-    params.orgId,
-    params.userId,
-  );
-  return isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
-    orgId: params.orgId,
-    userId: params.userId,
-    overrides: context.overrides,
-  });
-}
-
 async function updateThreadComputerUseHost(params: {
   readonly db: Db;
   readonly threadId: string;
@@ -1344,19 +1324,6 @@ async function resolveComputerUseHostGrant(params: {
         userId: params.userId,
         hostId: null,
       });
-    }
-    return null;
-  }
-
-  if (
-    !(await computerUseFeatureEnabled({
-      db: params.db,
-      orgId: params.orgId,
-      userId: params.userId,
-    }))
-  ) {
-    if (explicitSelection) {
-      return forbidden("Computer use is not enabled");
     }
     return null;
   }

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-computer-use-host.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-computer-use-host.ts
@@ -1,8 +1,6 @@
 import { command } from "ccstate";
 import { and, eq, isNull } from "drizzle-orm";
 import { chatThreadComputerUseHostContract } from "@vm0/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { computerUseHosts } from "@vm0/db/schema/computer-use-host";
 
@@ -13,32 +11,7 @@ import { writeDb$, type Db } from "../external/db";
 import { publishThreadListChanged } from "../external/realtime";
 import { nowDate } from "../external/time";
 import { notFound } from "../../lib/error";
-import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route";
-
-function forbidden(message: string) {
-  return {
-    status: 403 as const,
-    body: { error: { message, code: "FORBIDDEN" } },
-  };
-}
-
-async function computerUseFeatureEnabled(params: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-}): Promise<boolean> {
-  const context = await loadUserFeatureSwitchContext(
-    params.db,
-    params.orgId,
-    params.userId,
-  );
-  return isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
-    orgId: params.orgId,
-    userId: params.userId,
-    overrides: context.overrides,
-  });
-}
 
 async function threadExists(params: {
   readonly db: Db;
@@ -107,17 +80,6 @@ const updateComputerUseHostInner$ = command(
 
     const hostId = body.data.computerUseHostId;
     if (hostId !== null) {
-      if (
-        !(await computerUseFeatureEnabled({
-          db,
-          orgId: auth.orgId,
-          userId: auth.userId,
-        }))
-      ) {
-        return forbidden("Computer use is not enabled");
-      }
-      signal.throwIfAborted();
-
       if (
         !(await computerUseHostExists({
           db,

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -7,14 +7,11 @@ import {
   zeroComputerUseHostsContract,
   zeroComputerUseWriteCommandContract,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { authorization$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   claimNextComputerUseHostCommand$,
   completeComputerUseHostCommand$,
@@ -29,16 +26,6 @@ import {
   stopComputerUseHost$,
 } from "../services/zero-computer-use.service";
 import type { RouteEntry } from "../route";
-
-const computerUseDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Computer use is not enabled",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
 
 const computerUseHostNotAuthorized = Object.freeze({
   status: 403 as const,
@@ -93,26 +80,9 @@ function parseBearerToken(authorization: string | undefined): string | null {
   return token.length > 0 ? token : null;
 }
 
-const computerUseEnabled$ = command(async ({ get }) => {
-  const auth = get(organizationAuthContext$);
-  const overrides = await get(
-    userFeatureSwitchOverrides(auth.orgId, auth.userId),
-  );
-  return isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
-    orgId: auth.orgId,
-    userId: auth.userId,
-    overrides,
-  });
-});
-
 const hostStartBody$ = bodyResultOf(zeroComputerUseHostsContract.start);
 const hostStartInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (!(await set(computerUseEnabled$))) {
-    return computerUseDisabled;
-  }
-  signal.throwIfAborted();
-
   const bodyResult = await get(hostStartBody$);
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -192,11 +162,6 @@ const hostStopInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 const hostsListInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (!(await set(computerUseEnabled$))) {
-    return computerUseDisabled;
-  }
-  signal.throwIfAborted();
-
   const result = await set(
     listComputerUseHosts$,
     { orgId: auth.orgId, userId: auth.userId },
@@ -210,11 +175,6 @@ const hostsListInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const hostDeleteParams$ = pathParamsOf(zeroComputerUseHostsContract.delete);
 const hostDeleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (!(await set(computerUseEnabled$))) {
-    return computerUseDisabled;
-  }
-  signal.throwIfAborted();
-
   const params = get(hostDeleteParams$);
   const result = await set(
     deleteComputerUseHost$,
@@ -233,11 +193,6 @@ const commandCreateBody$ = bodyResultOf(zeroComputerUseCommandContract.create);
 const commandCreateInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    if (!(await set(computerUseEnabled$))) {
-      return computerUseDisabled;
-    }
-    signal.throwIfAborted();
-
     const bodyResult = await get(commandCreateBody$);
     signal.throwIfAborted();
     if (!bodyResult.ok) {
@@ -292,11 +247,6 @@ const writeCommandCreateBody$ = bodyResultOf(
 const writeCommandCreateInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    if (!(await set(computerUseEnabled$))) {
-      return computerUseDisabled;
-    }
-    signal.throwIfAborted();
-
     const bodyResult = await get(writeCommandCreateBody$);
     signal.throwIfAborted();
     if (!bodyResult.ok) {
@@ -348,11 +298,6 @@ const writeCommandCreateInner$ = command(
 const commandGetParams$ = pathParamsOf(zeroComputerUseCommandContract.get);
 const commandGetInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  if (!(await set(computerUseEnabled$))) {
-    return computerUseDisabled;
-  }
-  signal.throwIfAborted();
-
   const params = get(commandGetParams$);
   const hostId = auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
   if (auth.tokenType === "zero" && !hostId) {
@@ -382,11 +327,6 @@ const screenshotGetParams$ = pathParamsOf(
 const screenshotGetInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    if (!(await set(computerUseEnabled$))) {
-      return computerUseDisabled;
-    }
-    signal.throwIfAborted();
-
     const params = get(screenshotGetParams$);
     const hostId =
       auth.tokenType === "zero" ? auth.computerUseHostId : undefined;
@@ -519,11 +459,6 @@ const auditEventsQuery$ = queryOf(zeroComputerUseAuditEventsContract.list);
 const auditEventsListInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    if (!(await set(computerUseEnabled$))) {
-      return computerUseDisabled;
-    }
-    signal.throwIfAborted();
-
     const query = get(auditEventsQuery$);
     const result = await set(
       listComputerUseAuditEvents$,

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -1,5 +1,3 @@
-export const COMPUTER_USE_FEATURE_SWITCH_KEY = "computerUse";
-
 export const COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS = [
   "chrome",
   "safari",
@@ -119,7 +117,6 @@ export interface DesktopKeepAwakeState {
 }
 
 export interface DesktopComputerUseState {
-  readonly featureSwitchKey: typeof COMPUTER_USE_FEATURE_SWITCH_KEY;
   readonly platform: NodeJS.Platform;
   readonly supported: boolean;
   /**

--- a/turbo/apps/desktop/src/desktop-computer-use-autostart.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-autostart.test.ts
@@ -10,7 +10,6 @@ function computerUseState(
   status: ComputerUseHostRuntimeStatus,
 ): DesktopComputerUseState {
   return {
-    featureSwitchKey: "computerUse",
     platform: "darwin",
     supported: true,
     permissions: { accessibility: true, screenRecording: true },

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -4,7 +4,6 @@ import type {
   ComputerUseAutomationPermissionTarget,
   DesktopComputerUseState,
 } from "./computer-use-types";
-import { COMPUTER_USE_FEATURE_SWITCH_KEY } from "./computer-use-types";
 import type { DesktopAuthState } from "./desktop-bridge";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
@@ -313,7 +312,6 @@ function createDesktopDeveloperToolsApi(): {
 
 function createComputerUseState(): DesktopComputerUseState {
   return {
-    featureSwitchKey: COMPUTER_USE_FEATURE_SWITCH_KEY,
     platform: "darwin",
     supported: true,
     permissions: {

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -48,7 +48,6 @@ function computerUseState(
   },
 ): DesktopComputerUseState {
   return {
-    featureSwitchKey: "computerUse",
     platform: "darwin",
     supported: true,
     permissions,

--- a/turbo/apps/desktop/src/desktop-tray.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray.test.ts
@@ -120,7 +120,6 @@ function computerUseState(
   options: ComputerUseStateOptions = {},
 ): DesktopComputerUseState {
   return {
-    featureSwitchKey: "computerUse",
     platform: "darwin",
     supported: true,
     permissions: {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -32,7 +32,6 @@ import {
   resolveComputerUseApiBaseUrl,
 } from "./computer-use-host";
 import {
-  COMPUTER_USE_FEATURE_SWITCH_KEY,
   OFFLINE_COMPUTER_USE_HOST_STATE,
   hasRequiredComputerUsePermissions,
   type ComputerUseAutomationPermissionTarget,
@@ -438,7 +437,6 @@ function friendlyDeviceName(): string | null {
 
 function getComputerUseBridgeState(): DesktopComputerUseState {
   return {
-    featureSwitchKey: COMPUTER_USE_FEATURE_SWITCH_KEY,
     platform: process.platform,
     supported: process.platform === "darwin",
     deviceName: friendlyDeviceName(),

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -11,7 +11,6 @@ import { createStore } from "ccstate";
 import { StoreProvider } from "ccstate-react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  COMPUTER_USE_FEATURE_SWITCH_KEY,
   type ComputerUseHostRuntimeStatus,
   type ComputerUsePermissionState,
   type DesktopComputerUseState,
@@ -62,7 +61,6 @@ function createComputerUseState({
   readonly status?: ComputerUseHostRuntimeStatus;
 } = {}): DesktopComputerUseState {
   return {
-    featureSwitchKey: COMPUTER_USE_FEATURE_SWITCH_KEY,
     platform: "darwin",
     supported: true,
     deviceName,

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -30,8 +30,6 @@ import {
 import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
-import { subscribeComputerUseHostsChanged$ } from "./computer-use-hosts.ts";
-import { detach, Reason } from "../utils.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -110,12 +108,5 @@ export const setupAgentChatPage$ = command(
     if (queue === "1") {
       set(openQueueDrawer$, signal);
     }
-
-    // eslint-disable-next-line ccstate/no-detach-in-signals -- route-scoped realtime subscription runs until the chat route signal aborts
-    detach(
-      set(subscribeComputerUseHostsChanged$, signal),
-      Reason.Entrance,
-      "computer use hosts subscription",
-    );
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -31,6 +31,7 @@ import { reloadUserModelPreference$ } from "../external/user-model-preference.ts
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
 import { subscribeComputerUseHostsChanged$ } from "./computer-use-hosts.ts";
+import { detach, Reason } from "../utils.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -110,6 +111,11 @@ export const setupAgentChatPage$ = command(
       set(openQueueDrawer$, signal);
     }
 
-    await set(subscribeComputerUseHostsChanged$, signal);
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- route-scoped realtime subscription runs until the chat route signal aborts
+    detach(
+      set(subscribeComputerUseHostsChanged$, signal),
+      Reason.Entrance,
+      "computer use hosts subscription",
+    );
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -3,11 +3,9 @@ import {
   zeroComputerUseHostsContract,
   type ComputerUseHost,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForNavigation } from "../api-base.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 
 const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
@@ -27,12 +25,7 @@ const reloadComputerUseHosts$ = command(({ set }) => {
 });
 
 export const subscribeComputerUseHostsChanged$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const switches = get(featureSwitch$);
-    if (!switches[FeatureSwitchKey.ComputerUse]) {
-      return;
-    }
-
+  async ({ set }, signal: AbortSignal) => {
     const onChanged$ = command(({ set }) => {
       set(reloadComputerUseHosts$);
       return false;
@@ -81,10 +74,6 @@ export function visibleComputerUseHosts(
 export const computerUseHosts$ = computed(
   async (get): Promise<ListedComputerUseHost[]> => {
     get(computerUseHostsReload$);
-    const switches = get(featureSwitch$);
-    if (!switches[FeatureSwitchKey.ComputerUse]) {
-      return [];
-    }
 
     const client = get(zeroClient$)(zeroComputerUseHostsContract);
     const result = await accept(client.list({}), [200, 403], {

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -7,6 +7,7 @@ import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForNavigation } from "../api-base.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { onRef } from "../utils.ts";
 
 const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
   "/api/zero/desktop/updates/stable/darwin/arm64/dmg";
@@ -32,6 +33,16 @@ export const subscribeComputerUseHostsChanged$ = command(
     });
     await set(setAblyLoop$, "computerUseHostsChanged", onChanged$, signal);
   },
+);
+
+const subscribeComputerUseHostsChangedOnRef$ = command(
+  async ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+    await set(subscribeComputerUseHostsChanged$, signal);
+  },
+);
+
+export const subscribeComputerUseHostsChangedRef$ = onRef(
+  subscribeComputerUseHostsChangedOnRef$,
 );
 
 interface ListedComputerUseHost extends Pick<

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4517,7 +4517,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));
@@ -4547,7 +4546,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));
@@ -4599,7 +4597,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));
@@ -4648,7 +4645,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await waitFor(() => {
@@ -4722,7 +4718,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));
@@ -4800,7 +4795,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));
@@ -4855,7 +4849,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));
@@ -4884,7 +4877,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: { [FeatureSwitchKey.ComputerUse]: true },
     });
 
     await user.click(await screen.findByLabelText("Connectors"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -22,6 +22,7 @@ import {
   zeroRunsCancelContract,
   zeroRunsByIdContract,
 } from "@vm0/api-contracts/contracts/zero-runs";
+import { zeroComputerUseHostsContract } from "@vm0/api-contracts/contracts/zero-computer-use";
 import { zeroQueuePositionContract } from "@vm0/api-contracts/contracts/zero-queue-position";
 import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
@@ -139,6 +140,9 @@ export function mockSubagentThread(context: TestContext, threadId: string) {
       });
     }
     return respond(200, agent);
+  });
+  context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
   });
 }
 
@@ -763,6 +767,9 @@ export function mockChatLifecycle(
   });
   context.mocks.api(zeroQueuePositionContract.getPosition, ({ respond }) => {
     return respond(200, { position: queuePosition, total: 0 });
+  });
+  context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
   });
 
   return {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -11,7 +11,6 @@ import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -75,7 +74,6 @@ import {
 } from "../../signals/view-component-state.ts";
 import { modelFirstPersonalOauthState$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import { updateUserModelPreference$ } from "../../signals/external/user-model-preference.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   resolveChatComposerSubmitBlocker,
   usePersonalOauthConfigurationAction,
@@ -421,8 +419,6 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
 }
 
 function useNewThreadComputerUse() {
-  const features = useLastResolved(featureSwitch$);
-  const computerUseEnabled = features?.[FeatureSwitchKey.ComputerUse] ?? false;
   const computerUseHostsLoadable = useLastLoadable(computerUseHosts$);
   const lastResolvedComputerUseHosts = useLastResolved(computerUseHosts$) ?? [];
   const computerUseHosts =
@@ -441,23 +437,19 @@ function useNewThreadComputerUse() {
   const setComputerUseHostId = useSet(setNewThreadComputerUseHostId$);
 
   return {
-    selectedComputerUseHostId: computerUseEnabled
-      ? selectedComputerUseHostId
-      : null,
+    selectedComputerUseHostId,
     clearComputerUseHostId: () => {
       setComputerUseHostId(null);
     },
-    computerUse: computerUseEnabled
-      ? {
-          hosts: visibleHosts,
-          loading:
-            computerUseHostsLoadable.state === "loading" &&
-            computerUseHosts.length === 0,
-          selectedHostId: selectedComputerUseHostId,
-          onChange: setComputerUseHostId,
-          downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
-        }
-      : undefined,
+    computerUse: {
+      hosts: visibleHosts,
+      loading:
+        computerUseHostsLoadable.state === "loading" &&
+        computerUseHosts.length === 0,
+      selectedHostId: selectedComputerUseHostId,
+      onChange: setComputerUseHostId,
+      downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
+    },
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -58,6 +58,7 @@ import {
 import {
   computerUseHosts$,
   selectedComputerUseHostId as resolveSelectedComputerUseHostId,
+  subscribeComputerUseHostsChangedRef$,
   visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
@@ -474,6 +475,9 @@ export function AgentChatPage() {
     useNewThreadComputerUse();
   const rootSignal = useGet(rootSignal$);
   const pageSignal = useGet(pageSignal$);
+  const subscribeComputerUseHostsChangedRef = useSet(
+    subscribeComputerUseHostsChangedRef$,
+  );
   const {
     modelSelection,
     modelPicker,
@@ -550,6 +554,7 @@ export function AgentChatPage() {
 
   return (
     <div className="relative flex flex-1 flex-col min-h-0">
+      <span ref={subscribeComputerUseHostsChangedRef} hidden />
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
         <div className="flex justify-end items-center gap-2">
           <InviteButton pageSignal={pageSignal} />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3703,8 +3703,6 @@ function useChatThreadComputerUse(
   thread: ChatThreadSignals,
   pageSignal: AbortSignal,
 ) {
-  const features = useLastResolved(featureSwitch$);
-  const computerUseEnabled = features?.[FeatureSwitchKey.ComputerUse] ?? false;
   const computerUseHostsLoadable = useLastLoadable(computerUseHosts$);
   const lastResolvedComputerUseHosts = useLastResolved(computerUseHosts$) ?? [];
   const computerUseHosts =
@@ -3736,24 +3734,18 @@ function useChatThreadComputerUse(
   };
 
   return {
-    selectedComputerUseHostId: computerUseEnabled
-      ? selectedComputerUseHostId
-      : null,
-    computerUseHostIdForSend: computerUseEnabled
-      ? computerUseHostIdForSend
-      : undefined,
+    selectedComputerUseHostId,
+    computerUseHostIdForSend,
     clearComputerUseHostOverride,
-    computerUse: computerUseEnabled
-      ? {
-          hosts: visibleHosts,
-          loading:
-            computerUseHostsLoadable.state === "loading" &&
-            computerUseHosts.length === 0,
-          selectedHostId: selectedComputerUseHostId,
-          onChange: handleComputerUseHostChange,
-          downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
-        }
-      : undefined,
+    computerUse: {
+      hosts: visibleHosts,
+      loading:
+        computerUseHostsLoadable.state === "loading" &&
+        computerUseHosts.length === 0,
+      selectedHostId: selectedComputerUseHostId,
+      onChange: handleComputerUseHostChange,
+      downloadUrl: ZERO_DESKTOP_DOWNLOAD_URL,
+    },
   };
 }
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -33,7 +33,6 @@ export enum FeatureSwitchKey {
   SpotifyConnector = "spotifyConnector",
   GitHubIntegration = "githubIntegration",
   ZeroDebug = "zeroDebug",
-  ComputerUse = "computerUse",
   Banking = "banking",
   Lab = "lab",
   WorkflowsViewer = "workflowsViewer",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -182,11 +182,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Reveal activity debug surfaces, activity log navigation, appended system prompts, and Debug preferences",
     enabled: false,
   },
-  [FeatureSwitchKey.ComputerUse]: {
-    maintainer: "lancy@vm0.ai",
-    description: "Enable remote desktop host registration",
-    enabled: false,
-  },
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the Computer Use feature switch key and registry entry so Computer Use is enabled by default.
- Drop API and platform UI rollout gates that returned or rendered disabled states for Computer Use.
- Keep the real authorization boundary: run-scoped ZERO_TOKENs only receive `computer-use:write` when a Computer Use host grant is present.
- Remove the desktop bridge feature-switch key field and update tests for the GA behavior.

## Verification
- `pnpm format`
- `pnpm -F @vm0/core check-types && pnpm -F api check-types && pnpm -F @vm0/app check-types && pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F api exec vitest run src/signals/auth/__tests__/tokens.test.ts src/signals/routes/__tests__/computer-use.bdd.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/chat-messages.bdd.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/run-reads.bdd.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/desktop exec vitest run src/desktop-computer-use-autostart.test.ts src/desktop-tray-menu.test.ts src/desktop-tray.test.ts src/desktop-ipc-boundary.test.ts src/renderer/App.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core lint && pnpm -F api lint && pnpm -F @vm0/app lint && pnpm -F @vm0/desktop lint`
- pre-commit hook: prettier, knip, full `pnpm check-types`
