### PR TITLE
Guard so frontend rewrites by method

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -58,6 +58,7 @@ vi.mock("next-intl/middleware", () => {
 });
 
 let middleware: typeof import("../proxy").default;
+let reloadEnv: typeof import("../src/env").reloadEnv;
 
 function createMockEvent() {
   return {
@@ -69,10 +70,16 @@ function createMockEvent() {
 describe("proxy middleware: public routes", () => {
   beforeAll(async () => {
     middleware = (await import("../proxy")).default;
+    reloadEnv = (await import("../src/env")).reloadEnv;
   });
 
   beforeEach(() => {
     clerkState.protectedPaths = [];
+    vi.unstubAllEnvs();
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_test_proxy");
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_proxy");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.vm0.ai");
+    reloadEnv();
   });
 
   it("keeps locale-prefixed web design gallery public", async () => {
@@ -81,6 +88,42 @@ describe("proxy middleware: public routes", () => {
     await middleware(request, createMockEvent());
 
     expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("rejects non-GET requests for so frontend rewrite pages when forwarding is enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const request = new NextRequest("https://www.vm0.ai/en/pricing", {
+      method: "POST",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("GET, HEAD");
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("allows non-GET requests through when so frontend forwarding is disabled", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/pricing", {
+      method: "POST",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(response.status).not.toBe(405);
+  });
+
+  it("does not reject app-only functional routes when so forwarding is enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const request = new NextRequest("https://www.vm0.ai/connector/success", {
+      method: "POST",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(response.status).not.toBe(405);
   });
 
   it("keeps locale-less web design gallery public", async () => {

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSoFrontendRewrites,
+  matchesSoFrontendRewritePath,
   resolveSoFrontendUrl,
 } from "../so-frontend-rewrites";
 
@@ -70,5 +71,18 @@ describe("so frontend rewrites", () => {
     expect(sources.has("/connector/:path*")).toBe(false);
     expect(sources.has("/export")).toBe(false);
     expect(sources.has("/sign-in-token")).toBe(false);
+  });
+
+  it("matches configured so frontend rewrite paths", () => {
+    expect(matchesSoFrontendRewritePath("/pricing")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/en/pricing")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/en/blog/posts/example")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/docs/getting-started")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/sign-in/sso-callback")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/assets/vm0-logo.svg")).toBe(true);
+
+    expect(matchesSoFrontendRewritePath("/connector/success")).toBe(false);
+    expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(false);
+    expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(false);
   });
 });

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -16,6 +16,10 @@ import {
   matchesApiBackendRewritePath,
   matchesOAuthWebOriginRewritePath,
 } from "./api-backend-rewrites";
+import {
+  matchesSoFrontendRewritePath,
+  resolveSoFrontendUrl,
+} from "./so-frontend-rewrites.js";
 
 // ---------------------------------------------------------------------------
 // Clerk-specific route config
@@ -96,6 +100,7 @@ const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
 const TEST_ENDPOINT_BYPASS_HEADER = "x-vm0-test-endpoint-bypass";
 const OAUTH_WEB_ORIGIN_HEADER = "x-vm0-web-origin";
+const SO_FRONTEND_ALLOWED_PAGE_METHODS = new Set(["GET", "HEAD"]);
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
@@ -177,6 +182,22 @@ export default async function middleware(
   // from returning our 200 directly.
   if (isApiRoute && request.method === "OPTIONS") {
     return handleCors(request);
+  }
+
+  if (
+    resolveSoFrontendUrl({
+      NEXT_PUBLIC_PAID_ONBOARDING_URL: env().NEXT_PUBLIC_PAID_ONBOARDING_URL,
+      VERCEL_ENV: env().VERCEL_ENV,
+    }) &&
+    matchesSoFrontendRewritePath(request.nextUrl.pathname) &&
+    !SO_FRONTEND_ALLOWED_PAGE_METHODS.has(request.method)
+  ) {
+    return new NextResponse(null, {
+      status: 405,
+      headers: {
+        Allow: "GET, HEAD",
+      },
+    });
   }
 
   const authHeader = request.headers.get("authorization");

--- a/turbo/apps/web/so-frontend-rewrites.d.ts
+++ b/turbo/apps/web/so-frontend-rewrites.d.ts
@@ -1,0 +1,20 @@
+export interface SoFrontendRewriteEnv {
+  readonly PAID_ONBOARDING_URL?: string;
+  readonly NEXT_PUBLIC_PAID_ONBOARDING_URL?: string;
+  readonly VERCEL_ENV?: string;
+}
+
+export interface SoFrontendRewrite {
+  readonly source: string;
+  readonly destination: string;
+}
+
+export function resolveSoFrontendUrl(
+  env: SoFrontendRewriteEnv,
+): string | undefined;
+
+export function matchesSoFrontendRewritePath(pathname: string): boolean;
+
+export function buildSoFrontendRewrites(
+  env: SoFrontendRewriteEnv,
+): SoFrontendRewrite[];

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -85,6 +85,38 @@ function localizedExactRewrite(locale, source, destinationPrefix) {
   };
 }
 
+function rewriteSourceMatchesPath(source, pathname) {
+  const wildcardSuffix = "/:path*";
+  if (!source.endsWith(wildcardSuffix)) {
+    return source === pathname;
+  }
+
+  const prefix = source.slice(0, -wildcardSuffix.length);
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+export function matchesSoFrontendRewritePath(pathname) {
+  const localizedContentPaths = [
+    ...SO_FRONTEND_EXACT_PATHS,
+    ...SO_FRONTEND_WILDCARD_PATHS,
+  ];
+  const sources = [
+    ...SO_FRONTEND_EXACT_PATHS,
+    ...SO_FRONTEND_WILDCARD_PATHS,
+    ...LOCALES.flatMap((locale) => {
+      return localizedContentPaths.map((source) => {
+        return `/${locale}${source === "/" ? "" : source}`;
+      });
+    }),
+    ...SO_FRONTEND_AUTH_PATHS,
+    ...SO_FRONTEND_ASSET_PATHS,
+  ];
+
+  return sources.some((source) => {
+    return rewriteSourceMatchesPath(source, pathname);
+  });
+}
+
 export function buildSoFrontendRewrites(env) {
   const soFrontendUrl = resolveSoFrontendUrl(env);
   if (!soFrontendUrl) {


### PR DESCRIPTION
## Summary
- add a shared matcher for paths forwarded to the so frontend
- return 405 for non-GET/HEAD page requests before the Next config rewrite can proxy them to so
- cover the matcher and middleware behavior with tests

## Testing
- pnpm --filter web lint
- pnpm --filter web test -- __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts