### PR TITLE
feat: add Codex app-server event adapter

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -21,6 +21,8 @@ use tokio::task::JoinHandle;
 
 use crate::error::AgentError;
 
+pub use super::codex_app_server_events::CodexAppServerEventError;
+
 use super::{child_env, diagnostics};
 
 const METHOD_NOT_FOUND: i64 = -32601;
@@ -72,6 +74,12 @@ pub struct JsonRpcError {
 pub struct ServerNotification {
     pub method: String,
     pub params: Option<Value>,
+}
+
+impl ServerNotification {
+    pub fn to_codex_event(&self) -> Result<Option<Value>, CodexAppServerEventError> {
+        super::codex_app_server_events::notification_to_codex_event(self)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -21,8 +21,6 @@ use tokio::task::JoinHandle;
 
 use crate::error::AgentError;
 
-pub use super::codex_app_server_events::CodexAppServerEventError;
-
 use super::{child_env, diagnostics};
 
 const METHOD_NOT_FOUND: i64 = -32601;
@@ -74,12 +72,6 @@ pub struct JsonRpcError {
 pub struct ServerNotification {
     pub method: String,
     pub params: Option<Value>,
-}
-
-impl ServerNotification {
-    pub fn to_codex_event(&self) -> Result<Option<Value>, CodexAppServerEventError> {
-        super::codex_app_server_events::notification_to_codex_event(self)
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -473,6 +473,8 @@ fn normalize_optional_error(error: &Value) -> Value {
 
 fn normalize_error(error: &Map<String, Value>) -> Value {
     let mut normalized = Map::new();
+    copy_optional_field(&mut normalized, "code", error, "code");
+    copy_optional_field(&mut normalized, "error", error, "error");
     copy_optional_field(&mut normalized, "message", error, "message");
     copy_optional_field(
         &mut normalized,
@@ -481,6 +483,8 @@ fn normalize_error(error: &Map<String, Value>) -> Value {
         "additionalDetails",
     );
     copy_optional_field(&mut normalized, "codex_error_info", error, "codexErrorInfo");
+    copy_optional_field(&mut normalized, "connectors", error, "connectors");
+    copy_optional_field(&mut normalized, "failureReason", error, "failureReason");
     Value::Object(normalized)
 }
 
@@ -1275,6 +1279,74 @@ mod tests {
         );
         assert_eq!(diagnostic.event_type, "error");
         assert_eq!(diagnostic.message, "server rejected request");
+    }
+
+    #[test]
+    fn error_preserves_code_for_failure_reason_classification() {
+        let event = mapped_event(
+            "error",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "willRetry": false,
+                "error": {
+                    "code": "invalid_api_key",
+                    "message": "Incorrect API key provided"
+                }
+            }),
+        );
+        let diagnostic =
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+                .expect("error event should produce a diagnostic");
+
+        assert_eq!(
+            event.pointer("/error/code"),
+            Some(&json!("invalid_api_key"))
+        );
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::InvalidApiKey)
+        );
+    }
+
+    #[test]
+    fn failed_turn_preserves_refresh_failure_fields_for_classification() {
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {
+                        "code": "TOKEN_REFRESH_FAILED",
+                        "message": "Access token expired and refresh failed for: codex-oauth-token.",
+                        "connectors": ["codex-oauth-token"],
+                        "failureReason": "reconnect_required"
+                    }
+                }
+            }),
+        );
+        let diagnostic =
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+                .expect("failed turn should produce a diagnostic");
+
+        assert_eq!(
+            event.pointer("/turn/error/code"),
+            Some(&json!("TOKEN_REFRESH_FAILED"))
+        );
+        assert_eq!(
+            event.pointer("/turn/error/connectors"),
+            Some(&json!(["codex-oauth-token"]))
+        );
+        assert_eq!(
+            event.pointer("/turn/error/failureReason"),
+            Some(&json!("reconnect_required"))
+        );
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::ReconnectRequired)
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -278,9 +278,10 @@ fn map_error(notification: &ServerNotification) -> Result<Value, CodexAppServerE
     let error = required_object_field(params, &notification.method, "error")?;
     let message = required_string_field(error, &notification.method, "error.message")?;
     let normalized_error = normalize_error(error);
+    let event_type = if will_retry { "warning" } else { "error" };
 
     Ok(json!({
-        "type": "error",
+        "type": event_type,
         "thread_id": thread_id,
         "turn_id": turn_id,
         "will_retry": will_retry,
@@ -1425,6 +1426,43 @@ mod tests {
         );
         assert_eq!(diagnostic.event_type, "error");
         assert_eq!(diagnostic.message, "server rejected request");
+    }
+
+    #[test]
+    fn retryable_error_maps_to_non_failure_warning() {
+        let event = mapped_event(
+            "error",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "willRetry": true,
+                "error": {
+                    "message": "temporary stream disconnect",
+                    "codexErrorInfo": "serverOverloaded",
+                    "additionalDetails": "retrying"
+                }
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "warning",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "will_retry": true,
+                "message": "temporary stream disconnect",
+                "error": {
+                    "message": "temporary stream disconnect",
+                    "codex_error_info": "serverOverloaded",
+                    "additional_details": "retrying"
+                }
+            })
+        );
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            None
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -281,6 +281,7 @@ fn normalize_item(
     let item_type = required_string_field(item, method, "item.type")?;
     match item_type {
         "agentMessage" => normalize_agent_message(item, method).map(Some),
+        "plan" => normalize_plan(item, method).map(Some),
         "reasoning" => normalize_reasoning(item, method).map(Some),
         "commandExecution" => normalize_command_execution(item, method).map(Some),
         "fileChange" => normalize_file_change_item(item, method).map(Some),
@@ -293,6 +294,16 @@ fn normalize_agent_message(
     method: &str,
 ) -> Result<Value, CodexAppServerEventError> {
     let mut normalized = base_item(item, method, "agent_message")?;
+    let text = required_string_field(item, method, "item.text")?;
+    normalized.insert("text".to_string(), Value::String(text.to_string()));
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_plan(
+    item: &Map<String, Value>,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let mut normalized = base_item(item, method, "plan")?;
     let text = required_string_field(item, method, "item.text")?;
     normalized.insert("text".to_string(), Value::String(text.to_string()));
     Ok(Value::Object(normalized))
@@ -807,6 +818,38 @@ mod tests {
         assert_eq!(
             event.pointer("/item/text").and_then(Value::as_str),
             Some("")
+        );
+    }
+
+    #[test]
+    fn plan_completed_maps_to_visible_plan_item() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "plan",
+                    "id": "plan-1",
+                    "text": "1. Inspect logs\n2. Patch retry"
+                }
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "item.completed",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "completed_at_ms": 42,
+                "item": {
+                    "id": "plan-1",
+                    "type": "plan",
+                    "text": "1. Inspect logs\n2. Patch retry"
+                }
+            })
         );
     }
 

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -29,7 +29,7 @@ pub enum CodexAppServerEventError {
     InvalidField { method: String, field: &'static str },
 }
 
-pub(super) fn notification_to_codex_event(
+pub fn notification_to_codex_event(
     notification: &ServerNotification,
 ) -> Result<Option<Value>, CodexAppServerEventError> {
     match notification.method.as_str() {
@@ -94,11 +94,11 @@ fn map_item(
     let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
     let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
     let item = required_object_field(params, &notification.method, "item")?;
+    let timestamp =
+        required_number_field(params_object, &notification.method, input_timestamp_field)?;
     let Some(normalized_item) = normalize_item(item, &notification.method)? else {
         return Ok(None);
     };
-    let timestamp =
-        required_number_field(params_object, &notification.method, input_timestamp_field)?;
 
     let mut event = Map::new();
     event.insert("type".to_string(), Value::String(event_type.to_string()));
@@ -528,8 +528,7 @@ mod tests {
     }
 
     fn mapped_event(method: &str, params: Value) -> Value {
-        notification(method, params)
-            .to_codex_event()
+        notification_to_codex_event(&notification(method, params))
             .expect("notification should map")
             .expect("notification should produce an event")
     }
@@ -910,6 +909,27 @@ mod tests {
             json!({"threadId": "thread-1"}),
         ))
         .expect("unknown notification should not fail");
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn unsupported_item_variant_is_ignored_after_payload_validation() {
+        let result = notification_to_codex_event(&notification(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "webSearch",
+                    "id": "search-1",
+                    "query": "codex app-server",
+                    "action": null
+                }
+            }),
+        ))
+        .expect("unsupported item variant should not fail");
 
         assert_eq!(result, None);
     }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -236,7 +236,7 @@ fn map_warning(notification: &ServerNotification) -> Result<Value, CodexAppServe
         .ok_or_else(|| invalid_field(notification, "params"))?;
     let message = required_string_field(params_object, &notification.method, "message")?;
     let thread_id =
-        required_nullable_string_field(params_object, &notification.method, "threadId")?;
+        optional_nullable_string_field(params_object, &notification.method, "threadId")?;
 
     let mut event = Map::new();
     event.insert("type".to_string(), Value::String("warning".to_string()));
@@ -303,8 +303,13 @@ fn normalize_reasoning(
     method: &str,
 ) -> Result<Value, CodexAppServerEventError> {
     let mut normalized = base_item(item, method, "reasoning")?;
-    let mut text_parts = string_array_field(item, method, "summary", "item.summary")?;
-    text_parts.extend(string_array_field(item, method, "content", "item.content")?);
+    let mut text_parts = optional_string_array_field(item, method, "summary", "item.summary")?;
+    text_parts.extend(optional_string_array_field(
+        item,
+        method,
+        "content",
+        "item.content",
+    )?);
     if !text_parts.is_empty() {
         normalized.insert("text".to_string(), Value::String(text_parts.join("\n")));
     }
@@ -539,15 +544,15 @@ fn required_string_field<'a>(
         .ok_or_else(|| invalid_field_for_method(method, field))
 }
 
-fn required_nullable_string_field<'a>(
+fn optional_nullable_string_field<'a>(
     object: &'a Map<String, Value>,
     method: &str,
     field: &'static str,
 ) -> Result<Option<&'a str>, CodexAppServerEventError> {
     let key = field.rsplit('.').next().unwrap_or(field);
-    let value = object
-        .get(key)
-        .ok_or_else(|| missing_field(method, field))?;
+    let Some(value) = object.get(key) else {
+        return Ok(None);
+    };
     if value.is_null() {
         return Ok(None);
     }
@@ -623,15 +628,16 @@ fn required_lifecycle_item_status_field(
     }
 }
 
-fn string_array_field(
+fn optional_string_array_field(
     object: &Map<String, Value>,
     method: &str,
     key: &'static str,
     field: &'static str,
 ) -> Result<Vec<String>, CodexAppServerEventError> {
-    let values = object
-        .get(key)
-        .ok_or_else(|| missing_field(method, field))?
+    let Some(values) = object.get(key) else {
+        return Ok(Vec::new());
+    };
+    let values = values
         .as_array()
         .ok_or_else(|| invalid_field_for_method(method, field))?;
 
@@ -963,6 +969,28 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_omits_text_when_summary_and_content_default_empty() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "reasoning",
+                    "id": "reason-1"
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/item/type").and_then(Value::as_str),
+            Some("reasoning")
+        );
+        assert_eq!(event.pointer("/item/text"), None);
+    }
+
+    #[test]
     fn completed_turn_preserves_completed_event_shape() {
         let event = mapped_event(
             "turn/completed",
@@ -1236,6 +1264,24 @@ mod tests {
             "warning",
             json!({
                 "threadId": null,
+                "message": "global warning"
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "warning",
+                "message": "global warning"
+            })
+        );
+    }
+
+    #[test]
+    fn warning_without_thread_id_omits_thread_id() {
+        let event = mapped_event(
+            "warning",
+            json!({
                 "message": "global warning"
             }),
         );

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -533,7 +533,7 @@ fn base_item(
     item_type: &'static str,
 ) -> Result<Map<String, Value>, CodexAppServerEventError> {
     let mut normalized = Map::new();
-    let id = required_string_field(item, method, "item.id")?;
+    let id = required_non_empty_string_field(item, method, "item.id")?;
     normalized.insert("id".to_string(), Value::String(id.to_string()));
     normalized.insert("type".to_string(), Value::String(item_type.to_string()));
     Ok(normalized)
@@ -633,6 +633,18 @@ fn required_string_field<'a>(
         .ok_or_else(|| missing_field(method, field))?
         .as_str()
         .ok_or_else(|| invalid_field_for_method(method, field))
+}
+
+fn required_non_empty_string_field<'a>(
+    object: &'a Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<&'a str, CodexAppServerEventError> {
+    let value = required_string_field(object, method, field)?.trim();
+    if value.is_empty() {
+        return Err(invalid_field_for_method(method, field));
+    }
+    Ok(value)
 }
 
 fn optional_nullable_string_field<'a>(
@@ -1764,6 +1776,40 @@ mod tests {
             CodexAppServerEventError::MissingField {
                 method: "item/completed".to_string(),
                 field: "completedAtMs"
+            }
+        );
+    }
+
+    #[test]
+    fn item_notification_empty_item_id_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/started".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "startedAtMs": 42,
+                "item": {
+                    "type": "commandExecution",
+                    "id": " ",
+                    "command": "echo hi",
+                    "cwd": "/workspaces/vm0",
+                    "processId": null,
+                    "source": "exec",
+                    "status": "inProgress",
+                    "commandActions": [],
+                    "aggregatedOutput": null,
+                    "exitCode": null,
+                    "durationMs": null
+                }
+            })),
+        })
+        .expect_err("empty item id should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/started".to_string(),
+                field: "item.id"
             }
         );
     }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -19,6 +19,29 @@ const DELTA_NOTIFICATION_METHODS: &[&str] = &[
     "thread/realtime/outputAudio/delta",
 ];
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TurnStatus {
+    Completed,
+    Interrupted,
+    Failed,
+    InProgress,
+}
+
+impl TurnStatus {
+    fn normalized(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Interrupted => "interrupted",
+            Self::Failed => "failed",
+            Self::InProgress => "in_progress",
+        }
+    }
+
+    fn is_failure(self) -> bool {
+        matches!(self, Self::Failed | Self::Interrupted)
+    }
+}
+
 /// Error returned when a supported Codex app-server notification is malformed.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CodexAppServerEventError {
@@ -95,15 +118,15 @@ fn map_turn_completed(
         .ok_or_else(|| invalid_field(notification, "params"))?;
     let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
     let turn = required_object_field(params, &notification.method, "turn")?;
-    let status = required_string_field(turn, &notification.method, "turn.status")?;
-    let normalized_turn = normalize_turn(turn, &notification.method)?;
+    let status = required_turn_status_field(turn, &notification.method, "turn.status")?;
+    let normalized_turn = normalize_turn_with_status(turn, &notification.method, status)?;
 
-    if matches!(status, "failed" | "interrupted") {
+    if status.is_failure() {
         return Ok(json!({
             "type": "turn.failed",
             "thread_id": thread_id,
             "turn": normalized_turn,
-            "error": turn_failure_message(turn, status),
+            "error": turn_failure_message(turn, status.normalized()),
         }));
     }
 
@@ -194,13 +217,22 @@ fn normalize_turn(
     turn: &Map<String, Value>,
     method: &str,
 ) -> Result<Value, CodexAppServerEventError> {
+    let status = required_turn_status_field(turn, method, "turn.status")?;
+    normalize_turn_with_status(turn, method, status)
+}
+
+fn normalize_turn_with_status(
+    turn: &Map<String, Value>,
+    method: &str,
+    status: TurnStatus,
+) -> Result<Value, CodexAppServerEventError> {
     let mut normalized = Map::new();
     let id = required_string_field(turn, method, "turn.id")?;
     normalized.insert("id".to_string(), Value::String(id.to_string()));
 
     normalized.insert(
         "status".to_string(),
-        required_status_field(turn, method, "turn.status")?,
+        Value::String(status.normalized().to_string()),
     );
     if let Some(error) = turn.get("error") {
         normalized.insert("error".to_string(), normalize_optional_error(error));
@@ -256,7 +288,7 @@ fn normalize_command_execution(
     let mut normalized = base_item(item, method, "command_execution")?;
     let command = required_string_field(item, method, "item.command")?;
     normalized.insert("command".to_string(), Value::String(command.to_string()));
-    let status = required_status_field(item, method, "item.status")?;
+    let status = required_item_status_field(item, method, "item.status")?;
     normalized.insert("status".to_string(), status);
     copy_optional_field(&mut normalized, "cwd", item, "cwd");
     copy_optional_field(
@@ -275,7 +307,7 @@ fn normalize_file_change_item(
     method: &str,
 ) -> Result<Value, CodexAppServerEventError> {
     let mut normalized = base_item(item, method, "file_change")?;
-    let status = required_status_field(item, method, "item.status")?;
+    let status = required_item_status_field(item, method, "item.status")?;
     normalized.insert("status".to_string(), status);
 
     let changes = item
@@ -488,27 +520,35 @@ fn required_number_field(
     Err(invalid_field_for_method(method, field))
 }
 
-fn required_status_field(
+fn required_turn_status_field(
+    object: &Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<TurnStatus, CodexAppServerEventError> {
+    let status = required_string_field(object, method, field)?;
+    match status {
+        "completed" => Ok(TurnStatus::Completed),
+        "interrupted" => Ok(TurnStatus::Interrupted),
+        "failed" => Ok(TurnStatus::Failed),
+        "inProgress" => Ok(TurnStatus::InProgress),
+        _ => Err(invalid_field_for_method(method, field)),
+    }
+}
+
+fn required_item_status_field(
     object: &Map<String, Value>,
     method: &str,
     field: &'static str,
 ) -> Result<Value, CodexAppServerEventError> {
-    let key = field.rsplit('.').next().unwrap_or(field);
-    let status = object
-        .get(key)
-        .ok_or_else(|| missing_field(method, field))?;
-    normalize_status_value(status, method, field)
-}
-
-fn normalize_status_value(
-    status: &Value,
-    method: &str,
-    field: &'static str,
-) -> Result<Value, CodexAppServerEventError> {
-    let status = status
-        .as_str()
-        .ok_or_else(|| invalid_field_for_method(method, field))?;
-    Ok(Value::String(camel_to_snake(status)))
+    let status = required_string_field(object, method, field)?;
+    let normalized = match status {
+        "inProgress" => "in_progress",
+        "completed" => "completed",
+        "failed" => "failed",
+        "declined" => "declined",
+        _ => return Err(invalid_field_for_method(method, field)),
+    };
+    Ok(Value::String(normalized.to_string()))
 }
 
 fn string_array_field(
@@ -1155,6 +1195,102 @@ mod tests {
             CodexAppServerEventError::MissingField {
                 method: "turn/completed".to_string(),
                 field: "turn.status"
+            }
+        );
+    }
+
+    #[test]
+    fn turn_notification_unknown_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "cancelled",
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            })),
+        })
+        .expect_err("unknown turn status should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/completed".to_string(),
+                field: "turn.status"
+            }
+        );
+    }
+
+    #[test]
+    fn command_execution_unknown_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "commandExecution",
+                    "id": "cmd-1",
+                    "command": "echo hi",
+                    "cwd": "/workspaces/vm0",
+                    "processId": null,
+                    "source": "exec",
+                    "status": "queued",
+                    "commandActions": [],
+                    "aggregatedOutput": null,
+                    "exitCode": null,
+                    "durationMs": null
+                }
+            })),
+        })
+        .expect_err("unknown command status should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/completed".to_string(),
+                field: "item.status"
+            }
+        );
+    }
+
+    #[test]
+    fn file_change_unknown_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "queued",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": {"type": "update", "move_path": null},
+                            "diff": "@@"
+                        }
+                    ]
+                }
+            })),
+        })
+        .expect_err("unknown file change status should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/completed".to_string(),
+                field: "item.status"
             }
         );
     }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -340,12 +340,16 @@ fn normalize_item(
     method: &str,
 ) -> Result<Option<Value>, CodexAppServerEventError> {
     let item_type = required_string_field(item, method, "item.type")?;
-    match item_type {
-        "agentMessage" => normalize_agent_message(item, method).map(Some),
-        "plan" => normalize_plan(item, method).map(Some),
-        "reasoning" => normalize_reasoning(item, method).map(Some),
-        "commandExecution" => normalize_command_execution(item, method).map(Some),
-        "fileChange" => normalize_file_change_item(item, method).map(Some),
+    match (method, item_type) {
+        ("item/started", "agentMessage") => normalize_agent_message(item, method).map(|_| None),
+        ("item/started", "plan") => normalize_plan(item, method).map(|_| None),
+        ("item/started", "reasoning") => normalize_reasoning(item, method).map(|_| None),
+        ("item/started", "fileChange") => normalize_file_change_item(item, method).map(|_| None),
+        (_, "agentMessage") => normalize_agent_message(item, method).map(Some),
+        (_, "plan") => normalize_plan(item, method).map(Some),
+        (_, "reasoning") => normalize_reasoning(item, method).map(Some),
+        (_, "commandExecution") => normalize_command_execution(item, method).map(Some),
+        (_, "fileChange") => normalize_file_change_item(item, method).map(Some),
         _ => Ok(None),
     }
 }
@@ -928,6 +932,65 @@ mod tests {
             event.pointer("/item/text").and_then(Value::as_str),
             Some("")
         );
+    }
+
+    #[test]
+    fn display_item_started_notifications_are_ignored() {
+        let items = [
+            (
+                "agent message with text",
+                json!({
+                    "type": "agentMessage",
+                    "id": "message-1",
+                    "text": "partial response"
+                }),
+            ),
+            (
+                "plan with text",
+                json!({
+                    "type": "plan",
+                    "id": "plan-1",
+                    "text": "1. Inspect\n2. Patch"
+                }),
+            ),
+            (
+                "reasoning with summary",
+                json!({
+                    "type": "reasoning",
+                    "id": "reason-1",
+                    "summary": ["thinking"]
+                }),
+            ),
+            (
+                "file change with changes",
+                json!({
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "inProgress",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": "modify"
+                        }
+                    ]
+                }),
+            ),
+        ];
+
+        for (name, item) in items {
+            let result = notification_to_codex_event(&notification(
+                "item/started",
+                json!({
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "startedAtMs": 42,
+                    "item": item
+                }),
+            ))
+            .expect("started display item should not fail");
+
+            assert_eq!(result, None, "{name} should not emit a visible event");
+        }
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -120,7 +120,7 @@ fn map_thread_started(
 ) -> Result<Value, CodexAppServerEventError> {
     let params = required_params(notification)?;
     let thread = required_object_field(params, &notification.method, "thread")?;
-    let thread_id = required_string_field(thread, &notification.method, "thread.id")?;
+    let thread_id = required_non_empty_string_field(thread, &notification.method, "thread.id")?;
 
     Ok(json!({
         "type": "thread.started",
@@ -136,7 +136,8 @@ fn map_turn(
     let params_object = params
         .as_object()
         .ok_or_else(|| invalid_field(notification, "params"))?;
-    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let thread_id =
+        required_non_empty_string_field(params_object, &notification.method, "threadId")?;
     let turn = required_object_field(params, &notification.method, "turn")?;
     let status = required_turn_status_field(turn, &notification.method, "turn.status")?;
     if event_type == "turn.started" && status != TurnStatus::InProgress {
@@ -163,7 +164,8 @@ fn map_turn_completed(
     let params_object = params
         .as_object()
         .ok_or_else(|| invalid_field(notification, "params"))?;
-    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let thread_id =
+        required_non_empty_string_field(params_object, &notification.method, "threadId")?;
     let turn = required_object_field(params, &notification.method, "turn")?;
     let status = required_turn_status_field(turn, &notification.method, "turn.status")?;
     if status == TurnStatus::InProgress {
@@ -200,8 +202,9 @@ fn map_turn_plan_updated(
     let params_object = params
         .as_object()
         .ok_or_else(|| invalid_field(notification, "params"))?;
-    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
-    let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let thread_id =
+        required_non_empty_string_field(params_object, &notification.method, "threadId")?;
+    let turn_id = required_non_empty_string_field(params_object, &notification.method, "turnId")?;
     let explanation =
         optional_nullable_string_field(params_object, &notification.method, "explanation")?;
     let plan = params_object
@@ -245,8 +248,9 @@ fn map_item(
     let params_object = params
         .as_object()
         .ok_or_else(|| invalid_field(notification, "params"))?;
-    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
-    let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let thread_id =
+        required_non_empty_string_field(params_object, &notification.method, "threadId")?;
+    let turn_id = required_non_empty_string_field(params_object, &notification.method, "turnId")?;
     let item = required_object_field(params, &notification.method, "item")?;
     let timestamp =
         required_number_field(params_object, &notification.method, input_timestamp_field)?;
@@ -272,8 +276,9 @@ fn map_error(notification: &ServerNotification) -> Result<Value, CodexAppServerE
     let params_object = params
         .as_object()
         .ok_or_else(|| invalid_field(notification, "params"))?;
-    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
-    let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let thread_id =
+        required_non_empty_string_field(params_object, &notification.method, "threadId")?;
+    let turn_id = required_non_empty_string_field(params_object, &notification.method, "turnId")?;
     let will_retry = required_bool_field(params_object, &notification.method, "willRetry")?;
     let error = required_object_field(params, &notification.method, "error")?;
     let message = required_string_field(error, &notification.method, "error.message")?;
@@ -318,7 +323,7 @@ fn normalize_turn_with_status(
     status: TurnStatus,
 ) -> Result<Value, CodexAppServerEventError> {
     let mut normalized = Map::new();
-    let id = required_string_field(turn, method, "turn.id")?;
+    let id = required_non_empty_string_field(turn, method, "turn.id")?;
     normalized.insert("id".to_string(), Value::String(id.to_string()));
 
     normalized.insert(
@@ -1817,6 +1822,23 @@ mod tests {
     }
 
     #[test]
+    fn thread_started_empty_thread_id_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "thread/started".to_string(),
+            params: Some(json!({"thread": {"id": " "}})),
+        })
+        .expect_err("empty thread id should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "thread/started".to_string(),
+                field: "thread.id"
+            }
+        );
+    }
+
+    #[test]
     fn item_notification_missing_required_timestamp_returns_error() {
         let error = notification_to_codex_event(&ServerNotification {
             method: "item/completed".to_string(),
@@ -1841,6 +1863,56 @@ mod tests {
                 field: "completedAtMs"
             }
         );
+    }
+
+    #[test]
+    fn item_notification_empty_thread_or_turn_id_returns_error() {
+        for (field, params) in [
+            (
+                "threadId",
+                json!({
+                    "threadId": "",
+                    "turnId": "turn-1",
+                    "completedAtMs": 42,
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "item-1",
+                        "text": "hello",
+                        "phase": null,
+                        "memoryCitation": null
+                    }
+                }),
+            ),
+            (
+                "turnId",
+                json!({
+                    "threadId": "thread-1",
+                    "turnId": " ",
+                    "completedAtMs": 42,
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "item-1",
+                        "text": "hello",
+                        "phase": null,
+                        "memoryCitation": null
+                    }
+                }),
+            ),
+        ] {
+            let error = notification_to_codex_event(&ServerNotification {
+                method: "item/completed".to_string(),
+                params: Some(params),
+            })
+            .expect_err("empty item notification id should fail");
+
+            assert_eq!(
+                error,
+                CodexAppServerEventError::InvalidField {
+                    method: "item/completed".to_string(),
+                    field
+                }
+            );
+        }
     }
 
     #[test]
@@ -1873,6 +1945,35 @@ mod tests {
             CodexAppServerEventError::InvalidField {
                 method: "item/started".to_string(),
                 field: "item.id"
+            }
+        );
+    }
+
+    #[test]
+    fn turn_notification_empty_turn_id_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "completed",
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            })),
+        })
+        .expect_err("empty turn id should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/completed".to_string(),
+                field: "turn.id"
             }
         );
     }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -458,7 +458,6 @@ fn normalize_file_update_change(
         .as_object()
         .ok_or_else(|| invalid_field_for_method(method, "item.changes[]"))?;
     let path = required_string_field(change, method, "item.changes[].path")?;
-    let diff = required_string_field(change, method, "item.changes[].diff")?;
     let kind = change
         .get("kind")
         .ok_or_else(|| missing_field(method, "item.changes[].kind"))?;
@@ -470,7 +469,9 @@ fn normalize_file_update_change(
         "kind".to_string(),
         Value::String(normalized_kind.to_string()),
     );
-    normalized.insert("diff".to_string(), Value::String(diff.to_string()));
+    if let Some(diff) = change.get("diff").and_then(Value::as_str) {
+        normalized.insert("diff".to_string(), Value::String(diff.to_string()));
+    }
     if normalized_kind == "modify"
         && let Some(move_path) = optional_patch_move_path(kind, method)?
     {
@@ -501,6 +502,7 @@ fn normalize_patch_kind(
     match kind {
         "add" => Ok("add"),
         "delete" => Ok("delete"),
+        "modify" => Ok("modify"),
         "update" => Ok("modify"),
         _ => Err(invalid_field_for_method(method, field)),
     }
@@ -740,6 +742,9 @@ fn optional_string_array_field(
     let Some(values) = object.get(key) else {
         return Ok(Vec::new());
     };
+    if values.is_null() {
+        return Ok(Vec::new());
+    }
     let values = values
         .as_array()
         .ok_or_else(|| invalid_field_for_method(method, field))?;
@@ -1136,6 +1141,57 @@ mod tests {
     }
 
     #[test]
+    fn file_change_ignores_missing_and_malformed_optional_diff() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "completed",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": "modify"
+                        },
+                        {
+                            "path": "src/new.rs",
+                            "kind": {"type": "add"},
+                            "diff": null
+                        },
+                        {
+                            "path": "src/generated.rs",
+                            "kind": {"type": "add"},
+                            "diff": {"unexpected": true}
+                        }
+                    ]
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/item/changes"),
+            Some(&json!([
+                {
+                    "path": "src/lib.rs",
+                    "kind": "modify"
+                },
+                {
+                    "path": "src/new.rs",
+                    "kind": "add"
+                },
+                {
+                    "path": "src/generated.rs",
+                    "kind": "add"
+                }
+            ]))
+        );
+    }
+
+    #[test]
     fn reasoning_joins_summary_and_content() {
         let event = mapped_event(
             "item/completed",
@@ -1173,6 +1229,30 @@ mod tests {
                 "item": {
                     "type": "reasoning",
                     "id": "reason-1"
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/item/type").and_then(Value::as_str),
+            Some("reasoning")
+        );
+        assert_eq!(event.pointer("/item/text"), None);
+    }
+
+    #[test]
+    fn reasoning_omits_text_when_summary_and_content_are_null() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "reasoning",
+                    "id": "reason-1",
+                    "summary": null,
+                    "content": null
                 }
             }),
         );

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -585,6 +585,8 @@ fn invalid_field_for_method(method: &str, field: &'static str) -> CodexAppServer
 mod tests {
     use serde_json::{Value, json};
 
+    use agent_diagnostics::FailureReason;
+
     use crate::events;
     use crate::masker::SecretMasker;
 
@@ -919,6 +921,10 @@ mod tests {
         );
         assert_eq!(diagnostic.event_type, "turn.failed");
         assert_eq!(diagnostic.message, "turn failed (capacity)");
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::ProviderOverloaded)
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -119,6 +119,12 @@ fn map_turn_completed(
     let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
     let turn = required_object_field(params, &notification.method, "turn")?;
     let status = required_turn_status_field(turn, &notification.method, "turn.status")?;
+    if status == TurnStatus::InProgress {
+        return Err(invalid_field_for_method(
+            &notification.method,
+            "turn.status",
+        ));
+    }
     let normalized_turn = normalize_turn_with_status(turn, &notification.method, status)?;
 
     if status.is_failure() {
@@ -339,35 +345,64 @@ fn normalize_file_update_change(
 
     let mut normalized = Map::new();
     normalized.insert("path".to_string(), Value::String(path.to_string()));
+    let normalized_kind = normalize_patch_kind(kind, method)?;
     normalized.insert(
         "kind".to_string(),
-        Value::String(normalize_patch_kind(kind, method)?),
+        Value::String(normalized_kind.to_string()),
     );
     normalized.insert("diff".to_string(), Value::String(diff.to_string()));
-    if let Some(move_path) = kind
-        .as_object()
-        .and_then(|kind| kind.get("move_path"))
-        .filter(|move_path| !move_path.is_null())
+    if normalized_kind == "modify"
+        && let Some(move_path) = optional_patch_move_path(kind, method)?
     {
-        normalized.insert("move_path".to_string(), move_path.clone());
+        normalized.insert(
+            "move_path".to_string(),
+            Value::String(move_path.to_string()),
+        );
     }
 
     Ok(Value::Object(normalized))
 }
 
-fn normalize_patch_kind(kind: &Value, method: &str) -> Result<String, CodexAppServerEventError> {
-    let kind = match kind {
-        Value::String(kind) => kind.as_str(),
-        Value::Object(kind) => required_string_field(kind, method, "item.changes[].kind.type")?,
-        _ => return Err(invalid_field_for_method(method, "item.changes[].kind")),
+fn normalize_patch_kind(
+    kind: &Value,
+    method: &str,
+) -> Result<&'static str, CodexAppServerEventError> {
+    let (kind, field) = match kind {
+        Value::String(kind) => (kind.as_str(), "item.changes[].kind"),
+        Value::Object(kind) => (
+            required_string_field(kind, method, "item.changes[].kind.type")?,
+            "item.changes[].kind.type",
+        ),
+        _ => {
+            return Err(invalid_field_for_method(method, "item.changes[].kind"));
+        }
     };
 
-    Ok(match kind {
-        "add" => "add".to_string(),
-        "delete" => "delete".to_string(),
-        "update" => "modify".to_string(),
-        other => camel_to_snake(other),
-    })
+    match kind {
+        "add" => Ok("add"),
+        "delete" => Ok("delete"),
+        "update" => Ok("modify"),
+        _ => Err(invalid_field_for_method(method, field)),
+    }
+}
+
+fn optional_patch_move_path<'a>(
+    kind: &'a Value,
+    method: &str,
+) -> Result<Option<&'a str>, CodexAppServerEventError> {
+    let Some(kind) = kind.as_object() else {
+        return Ok(None);
+    };
+    let Some(move_path) = kind.get("move_path") else {
+        return Ok(None);
+    };
+    if move_path.is_null() {
+        return Ok(None);
+    }
+    move_path
+        .as_str()
+        .map(Some)
+        .ok_or_else(|| invalid_field_for_method(method, "item.changes[].kind.move_path"))
 }
 
 fn base_item(
@@ -828,7 +863,7 @@ mod tests {
                     "changes": [
                         {
                             "path": "src/lib.rs",
-                            "kind": {"type": "update", "move_path": null},
+                            "kind": {"type": "update", "move_path": "src/renamed.rs"},
                             "diff": "@@"
                         },
                         {
@@ -847,6 +882,7 @@ mod tests {
                 {
                     "path": "src/lib.rs",
                     "kind": "modify",
+                    "move_path": "src/renamed.rs",
                     "diff": "@@"
                 },
                 {
@@ -1229,6 +1265,35 @@ mod tests {
     }
 
     #[test]
+    fn turn_completed_in_progress_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "inProgress",
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": null,
+                    "durationMs": null
+                }
+            })),
+        })
+        .expect_err("completed notification cannot carry an in-progress turn");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/completed".to_string(),
+                field: "turn.status"
+            }
+        );
+    }
+
+    #[test]
     fn command_execution_unknown_status_returns_error() {
         let error = notification_to_codex_event(&ServerNotification {
             method: "item/completed".to_string(),
@@ -1291,6 +1356,72 @@ mod tests {
             CodexAppServerEventError::InvalidField {
                 method: "item/completed".to_string(),
                 field: "item.status"
+            }
+        );
+    }
+
+    #[test]
+    fn file_change_unknown_kind_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "completed",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": {"type": "rename"},
+                            "diff": "@@"
+                        }
+                    ]
+                }
+            })),
+        })
+        .expect_err("unknown file change kind should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/completed".to_string(),
+                field: "item.changes[].kind.type"
+            }
+        );
+    }
+
+    #[test]
+    fn file_change_non_string_move_path_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "completed",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": {"type": "update", "move_path": 7},
+                            "diff": "@@"
+                        }
+                    ]
+                }
+            })),
+        })
+        .expect_err("non-string move path should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/completed".to_string(),
+                field: "item.changes[].kind.move_path"
             }
         );
     }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -42,6 +42,25 @@ impl TurnStatus {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ItemStatus {
+    InProgress,
+    Completed,
+    Failed,
+    Declined,
+}
+
+impl ItemStatus {
+    fn normalized(self) -> &'static str {
+        match self {
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Declined => "declined",
+        }
+    }
+}
+
 /// Error returned when a supported Codex app-server notification is malformed.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CodexAppServerEventError {
@@ -101,11 +120,21 @@ fn map_turn(
         .ok_or_else(|| invalid_field(notification, "params"))?;
     let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
     let turn = required_object_field(params, &notification.method, "turn")?;
+    let status = required_turn_status_field(turn, &notification.method, "turn.status")?;
+    if event_type == "turn.started" && status != TurnStatus::InProgress {
+        return Err(invalid_field_for_method(
+            &notification.method,
+            "turn.status",
+        ));
+    }
+    if status == TurnStatus::InProgress && non_null_field(turn, "error") {
+        return Err(invalid_field_for_method(&notification.method, "turn.error"));
+    }
 
     Ok(json!({
         "type": event_type,
         "thread_id": thread_id,
-        "turn": normalize_turn(turn, &notification.method)?,
+        "turn": normalize_turn_with_status(turn, &notification.method, status)?,
     }))
 }
 
@@ -124,6 +153,9 @@ fn map_turn_completed(
             &notification.method,
             "turn.status",
         ));
+    }
+    if status == TurnStatus::Completed && non_null_field(turn, "error") {
+        return Err(invalid_field_for_method(&notification.method, "turn.error"));
     }
     let normalized_turn = normalize_turn_with_status(turn, &notification.method, status)?;
 
@@ -219,14 +251,6 @@ fn map_warning(notification: &ServerNotification) -> Result<Value, CodexAppServe
     Ok(Value::Object(event))
 }
 
-fn normalize_turn(
-    turn: &Map<String, Value>,
-    method: &str,
-) -> Result<Value, CodexAppServerEventError> {
-    let status = required_turn_status_field(turn, method, "turn.status")?;
-    normalize_turn_with_status(turn, method, status)
-}
-
 fn normalize_turn_with_status(
     turn: &Map<String, Value>,
     method: &str,
@@ -294,8 +318,11 @@ fn normalize_command_execution(
     let mut normalized = base_item(item, method, "command_execution")?;
     let command = required_string_field(item, method, "item.command")?;
     normalized.insert("command".to_string(), Value::String(command.to_string()));
-    let status = required_item_status_field(item, method, "item.status")?;
-    normalized.insert("status".to_string(), status);
+    let status = required_lifecycle_item_status_field(item, method, "item.status")?;
+    normalized.insert(
+        "status".to_string(),
+        Value::String(status.normalized().to_string()),
+    );
     copy_optional_field(&mut normalized, "cwd", item, "cwd");
     copy_optional_field(
         &mut normalized,
@@ -313,8 +340,11 @@ fn normalize_file_change_item(
     method: &str,
 ) -> Result<Value, CodexAppServerEventError> {
     let mut normalized = base_item(item, method, "file_change")?;
-    let status = required_item_status_field(item, method, "item.status")?;
-    normalized.insert("status".to_string(), status);
+    let status = required_lifecycle_item_status_field(item, method, "item.status")?;
+    normalized.insert(
+        "status".to_string(),
+        Value::String(status.normalized().to_string()),
+    );
 
     let changes = item
         .get("changes")
@@ -570,20 +600,27 @@ fn required_turn_status_field(
     }
 }
 
-fn required_item_status_field(
+fn required_lifecycle_item_status_field(
     object: &Map<String, Value>,
     method: &str,
     field: &'static str,
-) -> Result<Value, CodexAppServerEventError> {
+) -> Result<ItemStatus, CodexAppServerEventError> {
     let status = required_string_field(object, method, field)?;
-    let normalized = match status {
-        "inProgress" => "in_progress",
-        "completed" => "completed",
-        "failed" => "failed",
-        "declined" => "declined",
+    let status = match status {
+        "inProgress" => ItemStatus::InProgress,
+        "completed" => ItemStatus::Completed,
+        "failed" => ItemStatus::Failed,
+        "declined" => ItemStatus::Declined,
         _ => return Err(invalid_field_for_method(method, field)),
     };
-    Ok(Value::String(normalized.to_string()))
+    match (method, status) {
+        ("item/started", ItemStatus::InProgress) => Ok(status),
+        ("item/completed", ItemStatus::Completed | ItemStatus::Failed | ItemStatus::Declined) => {
+            Ok(status)
+        }
+        ("item/started" | "item/completed", _) => Err(invalid_field_for_method(method, field)),
+        _ => Ok(status),
+    }
 }
 
 fn string_array_field(
@@ -618,6 +655,10 @@ fn copy_optional_field(
     if let Some(value) = input.get(input_key) {
         output.insert(output_key.to_string(), value.clone());
     }
+}
+
+fn non_null_field(object: &Map<String, Value>, key: &'static str) -> bool {
+    object.get(key).is_some_and(|value| !value.is_null())
 }
 
 fn camel_to_snake(value: &str) -> String {
@@ -954,6 +995,101 @@ mod tests {
                     "duration_ms": 1000
                 }
             })
+        );
+    }
+
+    #[test]
+    fn turn_started_completed_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/started".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "completed",
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            })),
+        })
+        .expect_err("started turn must be in progress");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/started".to_string(),
+                field: "turn.status"
+            }
+        );
+    }
+
+    #[test]
+    fn turn_started_with_error_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/started".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "inProgress",
+                    "error": {
+                        "message": "should not be present",
+                        "codexErrorInfo": "badRequest",
+                        "additionalDetails": null
+                    },
+                    "startedAt": 1,
+                    "completedAt": null,
+                    "durationMs": null
+                }
+            })),
+        })
+        .expect_err("in-progress turn cannot carry a failure error");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/started".to_string(),
+                field: "turn.error"
+            }
+        );
+    }
+
+    #[test]
+    fn completed_turn_with_error_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "completed",
+                    "error": {
+                        "message": "should not be present",
+                        "codexErrorInfo": "badRequest",
+                        "additionalDetails": null
+                    },
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            })),
+        })
+        .expect_err("completed turn cannot carry a failure error");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/completed".to_string(),
+                field: "turn.error"
+            }
         );
     }
 
@@ -1322,6 +1458,73 @@ mod tests {
             error,
             CodexAppServerEventError::InvalidField {
                 method: "item/completed".to_string(),
+                field: "item.status"
+            }
+        );
+    }
+
+    #[test]
+    fn item_completed_in_progress_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "commandExecution",
+                    "id": "cmd-1",
+                    "command": "echo hi",
+                    "cwd": "/workspaces/vm0",
+                    "processId": null,
+                    "source": "exec",
+                    "status": "inProgress",
+                    "commandActions": [],
+                    "aggregatedOutput": null,
+                    "exitCode": null,
+                    "durationMs": null
+                }
+            })),
+        })
+        .expect_err("completed item cannot remain in progress");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/completed".to_string(),
+                field: "item.status"
+            }
+        );
+    }
+
+    #[test]
+    fn item_started_completed_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/started".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "startedAtMs": 42,
+                "item": {
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "completed",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": {"type": "update", "move_path": null},
+                            "diff": "@@"
+                        }
+                    ]
+                }
+            })),
+        })
+        .expect_err("started item must be in progress");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "item/started".to_string(),
                 field: "item.status"
             }
         );

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -19,6 +19,7 @@ const DELTA_NOTIFICATION_METHODS: &[&str] = &[
     "thread/realtime/outputAudio/delta",
 ];
 
+/// Error returned when a supported Codex app-server notification is malformed.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CodexAppServerEventError {
     #[error("codex app-server notification {method} missing params")]
@@ -29,6 +30,10 @@ pub enum CodexAppServerEventError {
     InvalidField { method: String, field: &'static str },
 }
 
+/// Convert a Codex app-server notification into the existing Codex JSONL event shape.
+///
+/// Unsupported notifications and app-server delta notifications return `Ok(None)`.
+/// Supported notifications with malformed required fields return an error.
 pub fn notification_to_codex_event(
     notification: &ServerNotification,
 ) -> Result<Option<Value>, CodexAppServerEventError> {

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -29,7 +29,7 @@ pub enum CodexAppServerEventError {
     InvalidField { method: String, field: &'static str },
 }
 
-pub fn notification_to_codex_event(
+pub(super) fn notification_to_codex_event(
     notification: &ServerNotification,
 ) -> Result<Option<Value>, CodexAppServerEventError> {
     match notification.method.as_str() {
@@ -97,6 +97,8 @@ fn map_item(
     let Some(normalized_item) = normalize_item(item, &notification.method)? else {
         return Ok(None);
     };
+    let timestamp =
+        required_number_field(params_object, &notification.method, input_timestamp_field)?;
 
     let mut event = Map::new();
     event.insert("type".to_string(), Value::String(event_type.to_string()));
@@ -106,12 +108,7 @@ fn map_item(
     );
     event.insert("turn_id".to_string(), Value::String(turn_id.to_string()));
     event.insert("item".to_string(), normalized_item);
-    copy_optional_field(
-        &mut event,
-        output_timestamp_field,
-        params_object,
-        input_timestamp_field,
-    );
+    event.insert(output_timestamp_field.to_string(), timestamp);
 
     Ok(Some(Value::Object(event)))
 }
@@ -123,6 +120,7 @@ fn map_error(notification: &ServerNotification) -> Result<Value, CodexAppServerE
         .ok_or_else(|| invalid_field(notification, "params"))?;
     let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
     let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let will_retry = required_bool_field(params_object, &notification.method, "willRetry")?;
     let error = required_object_field(params, &notification.method, "error")?;
     let message = required_string_field(error, &notification.method, "error.message")?;
     let normalized_error = normalize_error(error);
@@ -131,7 +129,7 @@ fn map_error(notification: &ServerNotification) -> Result<Value, CodexAppServerE
         "type": "error",
         "thread_id": thread_id,
         "turn_id": turn_id,
-        "will_retry": params_object.get("willRetry").and_then(Value::as_bool).unwrap_or(false),
+        "will_retry": will_retry,
         "message": message,
         "error": normalized_error,
     }))
@@ -143,12 +141,17 @@ fn map_warning(notification: &ServerNotification) -> Result<Value, CodexAppServe
         .as_object()
         .ok_or_else(|| invalid_field(notification, "params"))?;
     let message = required_string_field(params_object, &notification.method, "message")?;
+    let thread_id =
+        required_nullable_string_field(params_object, &notification.method, "threadId")?;
 
     let mut event = Map::new();
     event.insert("type".to_string(), Value::String("warning".to_string()));
     event.insert("message".to_string(), Value::String(message.to_string()));
-    if let Some(thread_id) = params_object.get("threadId") {
-        event.insert("thread_id".to_string(), thread_id.clone());
+    if let Some(thread_id) = thread_id {
+        event.insert(
+            "thread_id".to_string(),
+            Value::String(thread_id.to_string()),
+        );
     }
 
     Ok(Value::Object(event))
@@ -162,12 +165,10 @@ fn normalize_turn(
     let id = required_string_field(turn, method, "turn.id")?;
     normalized.insert("id".to_string(), Value::String(id.to_string()));
 
-    if let Some(status) = turn.get("status") {
-        normalized.insert(
-            "status".to_string(),
-            normalize_status_value(status, method, "turn.status")?,
-        );
-    }
+    normalized.insert(
+        "status".to_string(),
+        required_status_field(turn, method, "turn.status")?,
+    );
     if let Some(error) = turn.get("error") {
         normalized.insert("error".to_string(), normalize_optional_error(error));
     }
@@ -371,6 +372,52 @@ fn required_string_field<'a>(
         .ok_or_else(|| invalid_field_for_method(method, field))
 }
 
+fn required_nullable_string_field<'a>(
+    object: &'a Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<Option<&'a str>, CodexAppServerEventError> {
+    let key = field.rsplit('.').next().unwrap_or(field);
+    let value = object
+        .get(key)
+        .ok_or_else(|| missing_field(method, field))?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_str()
+        .map(Some)
+        .ok_or_else(|| invalid_field_for_method(method, field))
+}
+
+fn required_bool_field(
+    object: &Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<bool, CodexAppServerEventError> {
+    let key = field.rsplit('.').next().unwrap_or(field);
+    object
+        .get(key)
+        .ok_or_else(|| missing_field(method, field))?
+        .as_bool()
+        .ok_or_else(|| invalid_field_for_method(method, field))
+}
+
+fn required_number_field(
+    object: &Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<Value, CodexAppServerEventError> {
+    let key = field.rsplit('.').next().unwrap_or(field);
+    let value = object
+        .get(key)
+        .ok_or_else(|| missing_field(method, field))?;
+    if value.is_number() {
+        return Ok(value.clone());
+    }
+    Err(invalid_field_for_method(method, field))
+}
+
 fn required_status_field(
     object: &Map<String, Value>,
     method: &str,
@@ -481,7 +528,8 @@ mod tests {
     }
 
     fn mapped_event(method: &str, params: Value) -> Value {
-        notification_to_codex_event(&notification(method, params))
+        notification(method, params)
+            .to_codex_event()
             .expect("notification should map")
             .expect("notification should produce an event")
     }
@@ -819,6 +867,25 @@ mod tests {
     }
 
     #[test]
+    fn warning_with_null_thread_id_omits_thread_id() {
+        let event = mapped_event(
+            "warning",
+            json!({
+                "threadId": null,
+                "message": "global warning"
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "warning",
+                "message": "global warning"
+            })
+        );
+    }
+
+    #[test]
     fn delta_notifications_do_not_produce_visible_events() {
         for method in DELTA_NOTIFICATION_METHODS {
             let result = notification_to_codex_event(&notification(
@@ -860,6 +927,86 @@ mod tests {
             CodexAppServerEventError::MissingField {
                 method: "thread/started".to_string(),
                 field: "thread.id"
+            }
+        );
+    }
+
+    #[test]
+    fn item_notification_missing_required_timestamp_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "item/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {
+                    "type": "agentMessage",
+                    "id": "item-1",
+                    "text": "hello",
+                    "phase": null,
+                    "memoryCitation": null
+                }
+            })),
+        })
+        .expect_err("missing completedAtMs should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::MissingField {
+                method: "item/completed".to_string(),
+                field: "completedAtMs"
+            }
+        );
+    }
+
+    #[test]
+    fn turn_notification_missing_required_status_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "turn/completed".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            })),
+        })
+        .expect_err("missing turn status should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::MissingField {
+                method: "turn/completed".to_string(),
+                field: "turn.status"
+            }
+        );
+    }
+
+    #[test]
+    fn error_notification_missing_required_will_retry_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "error".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "error": {
+                    "message": "server rejected request",
+                    "codexErrorInfo": "badRequest",
+                    "additionalDetails": "policy denied"
+                }
+            })),
+        })
+        .expect_err("missing willRetry should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::MissingField {
+                method: "error".to_string(),
+                field: "willRetry"
             }
         );
     }

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1,0 +1,882 @@
+//! Compatibility mapping from Codex app-server notifications to Codex JSONL events.
+
+use serde_json::{Map, Value, json};
+
+use super::codex_app_server::ServerNotification;
+
+const DELTA_NOTIFICATION_METHODS: &[&str] = &[
+    "command/exec/outputDelta",
+    "process/outputDelta",
+    "item/agentMessage/delta",
+    "item/plan/delta",
+    "item/commandExecution/outputDelta",
+    "item/fileChange/outputDelta",
+    "item/fileChange/patchUpdated",
+    "item/reasoning/summaryTextDelta",
+    "item/reasoning/summaryPartAdded",
+    "item/reasoning/textDelta",
+    "thread/realtime/transcript/delta",
+    "thread/realtime/outputAudio/delta",
+];
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CodexAppServerEventError {
+    #[error("codex app-server notification {method} missing params")]
+    MissingParams { method: String },
+    #[error("codex app-server notification {method} missing field {field}")]
+    MissingField { method: String, field: &'static str },
+    #[error("codex app-server notification {method} has invalid field {field}")]
+    InvalidField { method: String, field: &'static str },
+}
+
+pub fn notification_to_codex_event(
+    notification: &ServerNotification,
+) -> Result<Option<Value>, CodexAppServerEventError> {
+    match notification.method.as_str() {
+        "thread/started" => map_thread_started(notification).map(Some),
+        "turn/started" => map_turn(notification, "turn.started").map(Some),
+        "turn/completed" => map_turn(notification, "turn.completed").map(Some),
+        "item/started" => map_item(notification, "item.started", "started_at_ms", "startedAtMs"),
+        "item/completed" => map_item(
+            notification,
+            "item.completed",
+            "completed_at_ms",
+            "completedAtMs",
+        ),
+        "error" => map_error(notification).map(Some),
+        "warning" => map_warning(notification).map(Some),
+        method if DELTA_NOTIFICATION_METHODS.contains(&method) => Ok(None),
+        _ => Ok(None),
+    }
+}
+
+fn map_thread_started(
+    notification: &ServerNotification,
+) -> Result<Value, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let thread = required_object_field(params, &notification.method, "thread")?;
+    let thread_id = required_string_field(thread, &notification.method, "thread.id")?;
+
+    Ok(json!({
+        "type": "thread.started",
+        "thread_id": thread_id,
+    }))
+}
+
+fn map_turn(
+    notification: &ServerNotification,
+    event_type: &'static str,
+) -> Result<Value, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let params_object = params
+        .as_object()
+        .ok_or_else(|| invalid_field(notification, "params"))?;
+    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let turn = required_object_field(params, &notification.method, "turn")?;
+
+    Ok(json!({
+        "type": event_type,
+        "thread_id": thread_id,
+        "turn": normalize_turn(turn, &notification.method)?,
+    }))
+}
+
+fn map_item(
+    notification: &ServerNotification,
+    event_type: &'static str,
+    output_timestamp_field: &'static str,
+    input_timestamp_field: &'static str,
+) -> Result<Option<Value>, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let params_object = params
+        .as_object()
+        .ok_or_else(|| invalid_field(notification, "params"))?;
+    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let item = required_object_field(params, &notification.method, "item")?;
+    let Some(normalized_item) = normalize_item(item, &notification.method)? else {
+        return Ok(None);
+    };
+
+    let mut event = Map::new();
+    event.insert("type".to_string(), Value::String(event_type.to_string()));
+    event.insert(
+        "thread_id".to_string(),
+        Value::String(thread_id.to_string()),
+    );
+    event.insert("turn_id".to_string(), Value::String(turn_id.to_string()));
+    event.insert("item".to_string(), normalized_item);
+    copy_optional_field(
+        &mut event,
+        output_timestamp_field,
+        params_object,
+        input_timestamp_field,
+    );
+
+    Ok(Some(Value::Object(event)))
+}
+
+fn map_error(notification: &ServerNotification) -> Result<Value, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let params_object = params
+        .as_object()
+        .ok_or_else(|| invalid_field(notification, "params"))?;
+    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let error = required_object_field(params, &notification.method, "error")?;
+    let message = required_string_field(error, &notification.method, "error.message")?;
+    let normalized_error = normalize_error(error);
+
+    Ok(json!({
+        "type": "error",
+        "thread_id": thread_id,
+        "turn_id": turn_id,
+        "will_retry": params_object.get("willRetry").and_then(Value::as_bool).unwrap_or(false),
+        "message": message,
+        "error": normalized_error,
+    }))
+}
+
+fn map_warning(notification: &ServerNotification) -> Result<Value, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let params_object = params
+        .as_object()
+        .ok_or_else(|| invalid_field(notification, "params"))?;
+    let message = required_string_field(params_object, &notification.method, "message")?;
+
+    let mut event = Map::new();
+    event.insert("type".to_string(), Value::String("warning".to_string()));
+    event.insert("message".to_string(), Value::String(message.to_string()));
+    if let Some(thread_id) = params_object.get("threadId") {
+        event.insert("thread_id".to_string(), thread_id.clone());
+    }
+
+    Ok(Value::Object(event))
+}
+
+fn normalize_turn(
+    turn: &Map<String, Value>,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let mut normalized = Map::new();
+    let id = required_string_field(turn, method, "turn.id")?;
+    normalized.insert("id".to_string(), Value::String(id.to_string()));
+
+    if let Some(status) = turn.get("status") {
+        normalized.insert(
+            "status".to_string(),
+            normalize_status_value(status, method, "turn.status")?,
+        );
+    }
+    if let Some(error) = turn.get("error") {
+        normalized.insert("error".to_string(), normalize_optional_error(error));
+    }
+    copy_optional_field(&mut normalized, "started_at", turn, "startedAt");
+    copy_optional_field(&mut normalized, "completed_at", turn, "completedAt");
+    copy_optional_field(&mut normalized, "duration_ms", turn, "durationMs");
+
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_item(
+    item: &Map<String, Value>,
+    method: &str,
+) -> Result<Option<Value>, CodexAppServerEventError> {
+    let item_type = required_string_field(item, method, "item.type")?;
+    match item_type {
+        "agentMessage" => normalize_agent_message(item, method).map(Some),
+        "reasoning" => normalize_reasoning(item, method).map(Some),
+        "commandExecution" => normalize_command_execution(item, method).map(Some),
+        "fileChange" => normalize_file_change_item(item, method).map(Some),
+        _ => Ok(None),
+    }
+}
+
+fn normalize_agent_message(
+    item: &Map<String, Value>,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let mut normalized = base_item(item, method, "agent_message")?;
+    let text = required_string_field(item, method, "item.text")?;
+    normalized.insert("text".to_string(), Value::String(text.to_string()));
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_reasoning(
+    item: &Map<String, Value>,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let mut normalized = base_item(item, method, "reasoning")?;
+    let mut text_parts = string_array_field(item, method, "summary", "item.summary")?;
+    text_parts.extend(string_array_field(item, method, "content", "item.content")?);
+    if !text_parts.is_empty() {
+        normalized.insert("text".to_string(), Value::String(text_parts.join("\n")));
+    }
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_command_execution(
+    item: &Map<String, Value>,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let mut normalized = base_item(item, method, "command_execution")?;
+    let command = required_string_field(item, method, "item.command")?;
+    normalized.insert("command".to_string(), Value::String(command.to_string()));
+    let status = required_status_field(item, method, "item.status")?;
+    normalized.insert("status".to_string(), status);
+    copy_optional_field(&mut normalized, "cwd", item, "cwd");
+    copy_optional_field(
+        &mut normalized,
+        "aggregated_output",
+        item,
+        "aggregatedOutput",
+    );
+    copy_optional_field(&mut normalized, "exit_code", item, "exitCode");
+    copy_optional_field(&mut normalized, "duration_ms", item, "durationMs");
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_file_change_item(
+    item: &Map<String, Value>,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let mut normalized = base_item(item, method, "file_change")?;
+    let status = required_status_field(item, method, "item.status")?;
+    normalized.insert("status".to_string(), status);
+
+    let changes = item
+        .get("changes")
+        .ok_or_else(|| missing_field(method, "item.changes"))?
+        .as_array()
+        .ok_or_else(|| invalid_field_for_method(method, "item.changes"))?;
+    let normalized_changes = changes
+        .iter()
+        .map(|change| normalize_file_update_change(change, method))
+        .collect::<Result<Vec<_>, _>>()?;
+    normalized.insert("changes".to_string(), Value::Array(normalized_changes));
+
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_file_update_change(
+    change: &Value,
+    method: &str,
+) -> Result<Value, CodexAppServerEventError> {
+    let change = change
+        .as_object()
+        .ok_or_else(|| invalid_field_for_method(method, "item.changes[]"))?;
+    let path = required_string_field(change, method, "item.changes[].path")?;
+    let diff = required_string_field(change, method, "item.changes[].diff")?;
+    let kind = change
+        .get("kind")
+        .ok_or_else(|| missing_field(method, "item.changes[].kind"))?;
+
+    let mut normalized = Map::new();
+    normalized.insert("path".to_string(), Value::String(path.to_string()));
+    normalized.insert(
+        "kind".to_string(),
+        Value::String(normalize_patch_kind(kind, method)?),
+    );
+    normalized.insert("diff".to_string(), Value::String(diff.to_string()));
+    if let Some(move_path) = kind
+        .as_object()
+        .and_then(|kind| kind.get("move_path"))
+        .filter(|move_path| !move_path.is_null())
+    {
+        normalized.insert("move_path".to_string(), move_path.clone());
+    }
+
+    Ok(Value::Object(normalized))
+}
+
+fn normalize_patch_kind(kind: &Value, method: &str) -> Result<String, CodexAppServerEventError> {
+    let kind = match kind {
+        Value::String(kind) => kind.as_str(),
+        Value::Object(kind) => required_string_field(kind, method, "item.changes[].kind.type")?,
+        _ => return Err(invalid_field_for_method(method, "item.changes[].kind")),
+    };
+
+    Ok(match kind {
+        "add" => "add".to_string(),
+        "delete" => "delete".to_string(),
+        "update" => "modify".to_string(),
+        other => camel_to_snake(other),
+    })
+}
+
+fn base_item(
+    item: &Map<String, Value>,
+    method: &str,
+    item_type: &'static str,
+) -> Result<Map<String, Value>, CodexAppServerEventError> {
+    let mut normalized = Map::new();
+    let id = required_string_field(item, method, "item.id")?;
+    normalized.insert("id".to_string(), Value::String(id.to_string()));
+    normalized.insert("type".to_string(), Value::String(item_type.to_string()));
+    Ok(normalized)
+}
+
+fn normalize_optional_error(error: &Value) -> Value {
+    match error {
+        Value::Object(error) => normalize_error(error),
+        Value::Null => Value::Null,
+        value => value.clone(),
+    }
+}
+
+fn normalize_error(error: &Map<String, Value>) -> Value {
+    let mut normalized = Map::new();
+    copy_optional_field(&mut normalized, "message", error, "message");
+    copy_optional_field(
+        &mut normalized,
+        "additional_details",
+        error,
+        "additionalDetails",
+    );
+    copy_optional_field(&mut normalized, "codex_error_info", error, "codexErrorInfo");
+    Value::Object(normalized)
+}
+
+fn required_params(notification: &ServerNotification) -> Result<&Value, CodexAppServerEventError> {
+    notification
+        .params
+        .as_ref()
+        .ok_or_else(|| CodexAppServerEventError::MissingParams {
+            method: notification.method.clone(),
+        })
+}
+
+fn required_object_field<'a>(
+    value: &'a Value,
+    method: &str,
+    field: &'static str,
+) -> Result<&'a Map<String, Value>, CodexAppServerEventError> {
+    value
+        .pointer(&format!("/{}", field.replace('.', "/")))
+        .ok_or_else(|| missing_field(method, field))?
+        .as_object()
+        .ok_or_else(|| invalid_field_for_method(method, field))
+}
+
+fn required_string_field<'a>(
+    object: &'a Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<&'a str, CodexAppServerEventError> {
+    let key = field.rsplit('.').next().unwrap_or(field);
+    object
+        .get(key)
+        .ok_or_else(|| missing_field(method, field))?
+        .as_str()
+        .ok_or_else(|| invalid_field_for_method(method, field))
+}
+
+fn required_status_field(
+    object: &Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<Value, CodexAppServerEventError> {
+    let key = field.rsplit('.').next().unwrap_or(field);
+    let status = object
+        .get(key)
+        .ok_or_else(|| missing_field(method, field))?;
+    normalize_status_value(status, method, field)
+}
+
+fn normalize_status_value(
+    status: &Value,
+    method: &str,
+    field: &'static str,
+) -> Result<Value, CodexAppServerEventError> {
+    let status = status
+        .as_str()
+        .ok_or_else(|| invalid_field_for_method(method, field))?;
+    Ok(Value::String(camel_to_snake(status)))
+}
+
+fn string_array_field(
+    object: &Map<String, Value>,
+    method: &str,
+    key: &'static str,
+    field: &'static str,
+) -> Result<Vec<String>, CodexAppServerEventError> {
+    let values = object
+        .get(key)
+        .ok_or_else(|| missing_field(method, field))?
+        .as_array()
+        .ok_or_else(|| invalid_field_for_method(method, field))?;
+
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| invalid_field_for_method(method, field))
+        })
+        .collect()
+}
+
+fn copy_optional_field(
+    output: &mut Map<String, Value>,
+    output_key: &'static str,
+    input: &Map<String, Value>,
+    input_key: &'static str,
+) {
+    if let Some(value) = input.get(input_key) {
+        output.insert(output_key.to_string(), value.clone());
+    }
+}
+
+fn camel_to_snake(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    for (index, character) in value.chars().enumerate() {
+        if character.is_ascii_uppercase() {
+            if index > 0 {
+                output.push('_');
+            }
+            output.push(character.to_ascii_lowercase());
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+fn missing_field(method: &str, field: &'static str) -> CodexAppServerEventError {
+    CodexAppServerEventError::MissingField {
+        method: method.to_string(),
+        field,
+    }
+}
+
+fn invalid_field(
+    notification: &ServerNotification,
+    field: &'static str,
+) -> CodexAppServerEventError {
+    invalid_field_for_method(&notification.method, field)
+}
+
+fn invalid_field_for_method(method: &str, field: &'static str) -> CodexAppServerEventError {
+    CodexAppServerEventError::InvalidField {
+        method: method.to_string(),
+        field,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use crate::events;
+    use crate::masker::SecretMasker;
+
+    use super::*;
+
+    fn notification(method: &str, params: Value) -> ServerNotification {
+        ServerNotification {
+            method: method.to_string(),
+            params: Some(params),
+        }
+    }
+
+    fn mapped_event(method: &str, params: Value) -> Value {
+        notification_to_codex_event(&notification(method, params))
+            .expect("notification should map")
+            .expect("notification should produce an event")
+    }
+
+    #[test]
+    fn thread_started_maps_to_top_level_thread_id() {
+        let event = mapped_event(
+            "thread/started",
+            json!({
+                "thread": {
+                    "id": "thread-1",
+                    "name": "demo"
+                }
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "thread.started",
+                "thread_id": "thread-1"
+            })
+        );
+    }
+
+    #[test]
+    fn item_completed_agent_message_maps_to_existing_output_shape() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "agentMessage",
+                    "id": "item-1",
+                    "text": "hello",
+                    "phase": null,
+                    "memoryCitation": null
+                }
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "item.completed",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "completed_at_ms": 42,
+                "item": {
+                    "id": "item-1",
+                    "type": "agent_message",
+                    "text": "hello"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn blank_agent_message_text_preserves_agent_message_shape() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "agentMessage",
+                    "id": "item-1",
+                    "text": "",
+                    "phase": null,
+                    "memoryCitation": null
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/item/type").and_then(Value::as_str),
+            Some("agent_message")
+        );
+        assert_eq!(
+            event.pointer("/item/text").and_then(Value::as_str),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn command_execution_started_and_completed_are_normalized() {
+        let started = mapped_event(
+            "item/started",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "startedAtMs": 12,
+                "item": {
+                    "type": "commandExecution",
+                    "id": "cmd-1",
+                    "command": "echo hi",
+                    "cwd": "/workspaces/vm0",
+                    "processId": null,
+                    "source": "exec",
+                    "status": "inProgress",
+                    "commandActions": [],
+                    "aggregatedOutput": null,
+                    "exitCode": null,
+                    "durationMs": null
+                }
+            }),
+        );
+        let completed = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 34,
+                "item": {
+                    "type": "commandExecution",
+                    "id": "cmd-1",
+                    "command": "echo hi",
+                    "cwd": "/workspaces/vm0",
+                    "processId": null,
+                    "source": "exec",
+                    "status": "completed",
+                    "commandActions": [],
+                    "aggregatedOutput": "hi\n",
+                    "exitCode": 0,
+                    "durationMs": 5
+                }
+            }),
+        );
+
+        assert_eq!(
+            started,
+            json!({
+                "type": "item.started",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "started_at_ms": 12,
+                "item": {
+                    "id": "cmd-1",
+                    "type": "command_execution",
+                    "command": "echo hi",
+                    "status": "in_progress",
+                    "cwd": "/workspaces/vm0",
+                    "aggregated_output": null,
+                    "exit_code": null,
+                    "duration_ms": null
+                }
+            })
+        );
+        assert_eq!(
+            completed,
+            json!({
+                "type": "item.completed",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "completed_at_ms": 34,
+                "item": {
+                    "id": "cmd-1",
+                    "type": "command_execution",
+                    "command": "echo hi",
+                    "status": "completed",
+                    "cwd": "/workspaces/vm0",
+                    "aggregated_output": "hi\n",
+                    "exit_code": 0,
+                    "duration_ms": 5
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn file_change_maps_changes_to_existing_shape() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "fileChange",
+                    "id": "file-1",
+                    "status": "completed",
+                    "changes": [
+                        {
+                            "path": "src/lib.rs",
+                            "kind": {"type": "update", "move_path": null},
+                            "diff": "@@"
+                        },
+                        {
+                            "path": "src/new.rs",
+                            "kind": {"type": "add"},
+                            "diff": "+++"
+                        }
+                    ]
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/item/changes"),
+            Some(&json!([
+                {
+                    "path": "src/lib.rs",
+                    "kind": "modify",
+                    "diff": "@@"
+                },
+                {
+                    "path": "src/new.rs",
+                    "kind": "add",
+                    "diff": "+++"
+                }
+            ]))
+        );
+    }
+
+    #[test]
+    fn reasoning_joins_summary_and_content() {
+        let event = mapped_event(
+            "item/completed",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": {
+                    "type": "reasoning",
+                    "id": "reason-1",
+                    "summary": ["checked schema"],
+                    "content": ["mapped final item"]
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/item/type").and_then(Value::as_str),
+            Some("reasoning")
+        );
+        assert_eq!(
+            event.pointer("/item/text").and_then(Value::as_str),
+            Some("checked schema\nmapped final item")
+        );
+    }
+
+    #[test]
+    fn failed_turn_completed_preserves_diagnostic_shape() {
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "failed",
+                    "error": {
+                        "message": "turn failed",
+                        "codexErrorInfo": "serverOverloaded",
+                        "additionalDetails": "capacity"
+                    },
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            }),
+        );
+        let diagnostic =
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+                .expect("failed turn should produce a diagnostic");
+
+        assert_eq!(diagnostic.event_type, "turn.completed");
+        assert_eq!(diagnostic.message, "turn failed (capacity)");
+    }
+
+    #[test]
+    fn error_maps_to_existing_error_diagnostic_shape() {
+        let event = mapped_event(
+            "error",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "willRetry": false,
+                "error": {
+                    "message": "server rejected request",
+                    "codexErrorInfo": "badRequest",
+                    "additionalDetails": "policy denied"
+                }
+            }),
+        );
+        let diagnostic =
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
+                .expect("error event should produce a diagnostic");
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "error",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "will_retry": false,
+                "message": "server rejected request",
+                "error": {
+                    "message": "server rejected request",
+                    "codex_error_info": "badRequest",
+                    "additional_details": "policy denied"
+                }
+            })
+        );
+        assert_eq!(diagnostic.event_type, "error");
+        assert_eq!(diagnostic.message, "server rejected request");
+    }
+
+    #[test]
+    fn warning_maps_to_non_failure_event() {
+        let event = mapped_event(
+            "warning",
+            json!({
+                "threadId": "thread-1",
+                "message": "configuration warning"
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "warning",
+                "thread_id": "thread-1",
+                "message": "configuration warning"
+            })
+        );
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            None
+        );
+    }
+
+    #[test]
+    fn delta_notifications_do_not_produce_visible_events() {
+        for method in DELTA_NOTIFICATION_METHODS {
+            let result = notification_to_codex_event(&notification(
+                method,
+                json!({
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "itemId": "item-1",
+                    "delta": "partial"
+                }),
+            ))
+            .expect("delta notification should be ignored without error");
+
+            assert_eq!(result, None, "method should not emit an event: {method}");
+        }
+    }
+
+    #[test]
+    fn unknown_notification_method_is_ignored() {
+        let result = notification_to_codex_event(&notification(
+            "thread/status/changed",
+            json!({"threadId": "thread-1"}),
+        ))
+        .expect("unknown notification should not fail");
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn malformed_supported_notification_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "thread/started".to_string(),
+            params: Some(json!({"thread": {}})),
+        })
+        .expect_err("missing thread id should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::MissingField {
+                method: "thread/started".to_string(),
+                field: "thread.id"
+            }
+        );
+    }
+
+    #[test]
+    fn supported_notification_missing_params_returns_error() {
+        let error = notification_to_codex_event(&ServerNotification {
+            method: "warning".to_string(),
+            params: None,
+        })
+        .expect_err("missing params should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::MissingParams {
+                method: "warning".to_string()
+            }
+        );
+    }
+}

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -61,6 +61,23 @@ impl ItemStatus {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PlanStepStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+impl PlanStepStatus {
+    fn normalized(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+        }
+    }
+}
+
 /// Error returned when a supported Codex app-server notification is malformed.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CodexAppServerEventError {
@@ -83,6 +100,7 @@ pub fn notification_to_codex_event(
         "thread/started" => map_thread_started(notification).map(Some),
         "turn/started" => map_turn(notification, "turn.started").map(Some),
         "turn/completed" => map_turn_completed(notification).map(Some),
+        "turn/plan/updated" => map_turn_plan_updated(notification).map(Some),
         "item/started" => map_item(notification, "item.started", "started_at_ms", "startedAtMs"),
         "item/completed" => map_item(
             notification,
@@ -173,6 +191,48 @@ fn map_turn_completed(
         "thread_id": thread_id,
         "turn": normalized_turn,
     }))
+}
+
+fn map_turn_plan_updated(
+    notification: &ServerNotification,
+) -> Result<Value, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let params_object = params
+        .as_object()
+        .ok_or_else(|| invalid_field(notification, "params"))?;
+    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let turn_id = required_string_field(params_object, &notification.method, "turnId")?;
+    let explanation =
+        optional_nullable_string_field(params_object, &notification.method, "explanation")?;
+    let plan = params_object
+        .get("plan")
+        .ok_or_else(|| missing_field(&notification.method, "plan"))?
+        .as_array()
+        .ok_or_else(|| invalid_field_for_method(&notification.method, "plan"))?;
+    let plan = plan
+        .iter()
+        .map(|step| normalize_turn_plan_step(step, &notification.method))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut event = Map::new();
+    event.insert(
+        "type".to_string(),
+        Value::String("turn.plan.updated".to_string()),
+    );
+    event.insert(
+        "thread_id".to_string(),
+        Value::String(thread_id.to_string()),
+    );
+    event.insert("turn_id".to_string(), Value::String(turn_id.to_string()));
+    event.insert("plan".to_string(), Value::Array(plan));
+    if let Some(explanation) = explanation {
+        event.insert(
+            "explanation".to_string(),
+            Value::String(explanation.to_string()),
+        );
+    }
+
+    Ok(Value::Object(event))
 }
 
 fn map_item(
@@ -287,6 +347,19 @@ fn normalize_item(
         "fileChange" => normalize_file_change_item(item, method).map(Some),
         _ => Ok(None),
     }
+}
+
+fn normalize_turn_plan_step(step: &Value, method: &str) -> Result<Value, CodexAppServerEventError> {
+    let step = step
+        .as_object()
+        .ok_or_else(|| invalid_field_for_method(method, "plan[]"))?;
+    let text = required_string_field(step, method, "plan[].step")?;
+    let status = required_plan_step_status_field(step, method, "plan[].status")?;
+
+    Ok(json!({
+        "step": text,
+        "status": status.normalized(),
+    }))
 }
 
 fn normalize_agent_message(
@@ -620,6 +693,20 @@ fn required_turn_status_field(
     }
 }
 
+fn required_plan_step_status_field(
+    object: &Map<String, Value>,
+    method: &str,
+    field: &'static str,
+) -> Result<PlanStepStatus, CodexAppServerEventError> {
+    let status = required_string_field(object, method, field)?;
+    match status {
+        "pending" => Ok(PlanStepStatus::Pending),
+        "inProgress" => Ok(PlanStepStatus::InProgress),
+        "completed" => Ok(PlanStepStatus::Completed),
+        _ => Err(invalid_field_for_method(method, field)),
+    }
+}
+
 fn required_lifecycle_item_status_field(
     object: &Map<String, Value>,
     method: &str,
@@ -854,6 +941,65 @@ mod tests {
                     "text": "1. Inspect logs\n2. Patch retry"
                 }
             })
+        );
+    }
+
+    #[test]
+    fn turn_plan_updated_maps_to_visible_plan_event() {
+        let event = mapped_event(
+            "turn/plan/updated",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "explanation": "Current plan",
+                "plan": [
+                    {"step": "Inspect logs", "status": "completed"},
+                    {"step": "Patch retry", "status": "inProgress"},
+                    {"step": "Run tests", "status": "pending"}
+                ]
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "turn.plan.updated",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "explanation": "Current plan",
+                "plan": [
+                    {"step": "Inspect logs", "status": "completed"},
+                    {"step": "Patch retry", "status": "in_progress"},
+                    {"step": "Run tests", "status": "pending"}
+                ]
+            })
+        );
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            None
+        );
+    }
+
+    #[test]
+    fn turn_plan_updated_unknown_step_status_returns_error() {
+        let error = notification_to_codex_event(&notification(
+            "turn/plan/updated",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "plan": [
+                    {"step": "Inspect logs", "status": "cancelled"}
+                ]
+            }),
+        ))
+        .expect_err("unknown plan step status should fail");
+
+        assert_eq!(
+            error,
+            CodexAppServerEventError::InvalidField {
+                method: "turn/plan/updated".to_string(),
+                field: "plan[].status"
+            }
         );
     }
 

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -40,7 +40,7 @@ pub fn notification_to_codex_event(
     match notification.method.as_str() {
         "thread/started" => map_thread_started(notification).map(Some),
         "turn/started" => map_turn(notification, "turn.started").map(Some),
-        "turn/completed" => map_turn(notification, "turn.completed").map(Some),
+        "turn/completed" => map_turn_completed(notification).map(Some),
         "item/started" => map_item(notification, "item.started", "started_at_ms", "startedAtMs"),
         "item/completed" => map_item(
             notification,
@@ -83,6 +83,34 @@ fn map_turn(
         "type": event_type,
         "thread_id": thread_id,
         "turn": normalize_turn(turn, &notification.method)?,
+    }))
+}
+
+fn map_turn_completed(
+    notification: &ServerNotification,
+) -> Result<Value, CodexAppServerEventError> {
+    let params = required_params(notification)?;
+    let params_object = params
+        .as_object()
+        .ok_or_else(|| invalid_field(notification, "params"))?;
+    let thread_id = required_string_field(params_object, &notification.method, "threadId")?;
+    let turn = required_object_field(params, &notification.method, "turn")?;
+    let status = required_string_field(turn, &notification.method, "turn.status")?;
+    let normalized_turn = normalize_turn(turn, &notification.method)?;
+
+    if matches!(status, "failed" | "interrupted") {
+        return Ok(json!({
+            "type": "turn.failed",
+            "thread_id": thread_id,
+            "turn": normalized_turn,
+            "error": turn_failure_message(turn, status),
+        }));
+    }
+
+    Ok(json!({
+        "type": "turn.completed",
+        "thread_id": thread_id,
+        "turn": normalized_turn,
     }))
 }
 
@@ -341,6 +369,43 @@ fn normalize_error(error: &Map<String, Value>) -> Value {
     );
     copy_optional_field(&mut normalized, "codex_error_info", error, "codexErrorInfo");
     Value::Object(normalized)
+}
+
+fn turn_failure_message(turn: &Map<String, Value>, status: &str) -> String {
+    turn.get("error")
+        .and_then(error_message)
+        .unwrap_or_else(|| format!("turn {}", camel_to_snake(status).replace('_', " ")))
+}
+
+fn error_message(error: &Value) -> Option<String> {
+    match error {
+        Value::String(message) => trimmed_message(message),
+        Value::Object(error) => combined_message_and_details(
+            error.get("message").and_then(Value::as_str),
+            error.get("additionalDetails").and_then(Value::as_str),
+        ),
+        _ => None,
+    }
+}
+
+fn combined_message_and_details(message: Option<&str>, details: Option<&str>) -> Option<String> {
+    match (
+        message.and_then(trimmed_message),
+        details.and_then(trimmed_message),
+    ) {
+        (Some(message), Some(details)) => Some(format!("{message} ({details})")),
+        (Some(message), None) => Some(message),
+        (None, Some(details)) => Some(details),
+        (None, None) => None,
+    }
+}
+
+fn trimmed_message(message: &str) -> Option<String> {
+    let message = message.trim();
+    if message.is_empty() {
+        return None;
+    }
+    Some(message.to_string())
 }
 
 fn required_params(notification: &ServerNotification) -> Result<&Value, CodexAppServerEventError> {
@@ -779,7 +844,43 @@ mod tests {
     }
 
     #[test]
-    fn failed_turn_completed_preserves_diagnostic_shape() {
+    fn completed_turn_preserves_completed_event_shape() {
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "completed",
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            }),
+        );
+
+        assert_eq!(
+            event,
+            json!({
+                "type": "turn.completed",
+                "thread_id": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "completed",
+                    "error": null,
+                    "started_at": 1,
+                    "completed_at": 2,
+                    "duration_ms": 1000
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn failed_turn_completed_maps_to_existing_failure_shape() {
         let event = mapped_event(
             "turn/completed",
             json!({
@@ -804,8 +905,49 @@ mod tests {
             events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw(""))
                 .expect("failed turn should produce a diagnostic");
 
-        assert_eq!(diagnostic.event_type, "turn.completed");
+        assert_eq!(
+            event.pointer("/type").and_then(Value::as_str),
+            Some("turn.failed")
+        );
+        assert_eq!(
+            event.pointer("/error").and_then(Value::as_str),
+            Some("turn failed (capacity)")
+        );
+        assert_eq!(
+            event.pointer("/turn/error/codex_error_info"),
+            Some(&json!("serverOverloaded"))
+        );
+        assert_eq!(diagnostic.event_type, "turn.failed");
         assert_eq!(diagnostic.message, "turn failed (capacity)");
+    }
+
+    #[test]
+    fn interrupted_turn_completed_maps_to_failure_shape() {
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "items": [],
+                    "itemsView": {"type": "complete"},
+                    "status": "interrupted",
+                    "error": null,
+                    "startedAt": 1,
+                    "completedAt": 2,
+                    "durationMs": 1000
+                }
+            }),
+        );
+
+        assert_eq!(
+            event.pointer("/type").and_then(Value::as_str),
+            Some("turn.failed")
+        );
+        assert_eq!(
+            event.pointer("/error").and_then(Value::as_str),
+            Some("turn interrupted")
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -17,7 +17,7 @@
 
 mod child_env;
 pub mod codex_app_server;
-pub mod codex_app_server_events;
+mod codex_app_server_events;
 mod codex_setup;
 mod command;
 mod diagnostics;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -17,6 +17,7 @@
 
 mod child_env;
 pub mod codex_app_server;
+pub mod codex_app_server_events;
 mod codex_setup;
 mod command;
 mod diagnostics;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -25,6 +25,7 @@ mod event_delivery;
 mod framework;
 mod termination;
 
+pub use codex_app_server_events::{CodexAppServerEventError, notification_to_codex_event};
 pub use codex_setup::setup_codex;
 pub use command::build_cli_command;
 pub use framework::ClaudeResultSummary;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -4,6 +4,7 @@
 //! private submodules own focused execution policies:
 //!
 //! - `codex_setup`: pre-exec Codex auth/bootstrap.
+//! - `codex_app_server_events`: Codex app-server notification compatibility mapping.
 //! - `command`: Claude Code and Codex command construction.
 //! - `diagnostics`: bounded stderr tail collection.
 //! - `event_delivery`: event sender watermark state.

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -138,7 +138,7 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
         }
         "turn.failed" => {
             let error = event.get("error");
-            let structured_error = event.pointer("/turn/error").or(error);
+            let structured_error = codex_nested_turn_error(event).or(error);
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
                 message: codex_error_message(error).unwrap_or_else(|| "turn failed".into()),
@@ -147,7 +147,7 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
         }
         "turn.completed" => {
             let status = codex_turn_completed_failure_status(event)?;
-            let error = event.pointer("/turn/error").or_else(|| event.get("error"));
+            let error = codex_nested_turn_error(event).or_else(|| event.get("error"));
             Some(CodexFailureDiagnostic {
                 event_type: "turn.completed",
                 message: codex_error_message(error).unwrap_or_else(|| format!("turn {status}")),
@@ -156,6 +156,12 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
         }
         _ => None,
     }
+}
+
+fn codex_nested_turn_error(event: &Value) -> Option<&Value> {
+    event
+        .pointer("/turn/error")
+        .filter(|error| !error.is_null())
 }
 
 fn extract_claude_failure_diagnostic(event: &Value) -> Option<ClaudeFailureDiagnostic> {
@@ -891,6 +897,27 @@ mod tests {
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
                 message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::InvalidApiKey),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_null_nested_turn_error_uses_top_level_error() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "code": "invalid_api_key",
+                "message": "Incorrect API key provided"
+            },
+            "turn": {"error": null}
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "Incorrect API key provided".to_string(),
                 failure_reason: Some(FailureReason::InvalidApiKey),
             })
         );

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -138,10 +138,11 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
         }
         "turn.failed" => {
             let error = event.get("error");
+            let structured_error = event.pointer("/turn/error").or(error);
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
                 message: codex_error_message(error).unwrap_or_else(|| "turn failed".into()),
-                failure_reason: codex_event_failure_reason(event, error),
+                failure_reason: codex_event_failure_reason(event, structured_error),
             })
         }
         "turn.completed" => {
@@ -213,6 +214,9 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     {
         return Some(FailureReason::ReconnectRequired);
     }
+    if let Some(reason) = codex_error_info_failure_reason(error) {
+        return Some(reason);
+    }
     if codex_error_message(Some(error))
         .as_deref()
         .is_some_and(is_codex_model_capacity_message)
@@ -220,6 +224,21 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
         return Some(FailureReason::ProviderOverloaded);
     }
     None
+}
+
+fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
+    match error
+        .get("codex_error_info")
+        .or_else(|| error.get("codexErrorInfo"))?
+    {
+        Value::String(info) => match info.as_str() {
+            "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
+            "usageLimitExceeded" => Some(FailureReason::UsageLimit),
+            _ => None,
+        },
+        Value::Object(_) => None,
+        _ => None,
+    }
 }
 
 fn codex_event_failure_reason(event: &Value, error: Option<&Value>) -> Option<FailureReason> {
@@ -855,6 +874,29 @@ mod tests {
     }
 
     #[test]
+    fn codex_turn_failed_uses_nested_turn_error_for_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": "turn failed from server",
+            "turn": {
+                "error": {
+                    "code": "invalid_api_key",
+                    "message": "Incorrect API key provided"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::InvalidApiKey),
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_failed_model_capacity_yields_failure_reason() {
         let event = serde_json::json!({
             "type": "turn.failed",
@@ -869,6 +911,46 @@ mod tests {
                 event_type: "turn.failed",
                 message: "Selected model is at capacity. Please try a different model.".to_string(),
                 failure_reason: Some(FailureReason::ProviderOverloaded),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_info_server_overloaded_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "codex_error_info": "serverOverloaded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::ProviderOverloaded),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_info_usage_limit_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "codex_error_info": "usageLimitExceeded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::UsageLimit),
             })
         );
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -115,7 +115,10 @@ pub(crate) fn masked_claude_failure_diagnostic(
 }
 
 pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
-    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
+    matches!(
+        message.trim().to_ascii_lowercase().as_str(),
+        "error" | "turn failed" | "turn interrupted" | "unknown error" | "codex error"
+    )
 }
 
 pub fn is_codex_model_capacity_message(message: &str) -> bool {
@@ -946,7 +949,7 @@ mod tests {
     fn codex_turn_failed_uses_nested_turn_error_for_message_when_top_level_error_is_generic() {
         let event = serde_json::json!({
             "type": "turn.failed",
-            "error": "turn failed",
+            "error": "Turn failed",
             "turn": {
                 "error": {
                     "message": "nested turn failure",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -141,9 +141,7 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
             let structured_error = codex_nested_turn_error(event).or(error);
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
-                message: codex_error_message(error)
-                    .or_else(|| codex_error_message(structured_error))
-                    .unwrap_or_else(|| "turn failed".into()),
+                message: codex_turn_failed_message(error, structured_error),
                 failure_reason: codex_event_failure_reason(event, structured_error),
             })
         }
@@ -164,6 +162,21 @@ fn codex_nested_turn_error(event: &Value) -> Option<&Value> {
     event
         .pointer("/turn/error")
         .filter(|error| !error.is_null())
+}
+
+fn codex_turn_failed_message(error: Option<&Value>, structured_error: Option<&Value>) -> String {
+    let top_level_message = codex_error_message(error);
+    let structured_message = codex_error_message(structured_error);
+    match (top_level_message, structured_message) {
+        (Some(message), Some(structured_message))
+            if is_generic_codex_failure_diagnostic(&message) =>
+        {
+            structured_message
+        }
+        (Some(message), _) => message,
+        (None, Some(structured_message)) => structured_message,
+        (None, None) => "turn failed".into(),
+    }
 }
 
 fn extract_claude_failure_diagnostic(event: &Value) -> Option<ClaudeFailureDiagnostic> {
@@ -911,6 +924,29 @@ mod tests {
     fn codex_turn_failed_uses_nested_turn_error_for_message_when_top_level_error_missing() {
         let event = serde_json::json!({
             "type": "turn.failed",
+            "turn": {
+                "error": {
+                    "message": "nested turn failure",
+                    "additionalDetails": "quota exhausted"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "nested turn failure (quota exhausted)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_uses_nested_turn_error_for_message_when_top_level_error_is_generic() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": "turn failed",
             "turn": {
                 "error": {
                     "message": "nested turn failure",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -141,7 +141,9 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
             let structured_error = codex_nested_turn_error(event).or(error);
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
-                message: codex_error_message(error).unwrap_or_else(|| "turn failed".into()),
+                message: codex_error_message(error)
+                    .or_else(|| codex_error_message(structured_error))
+                    .unwrap_or_else(|| "turn failed".into()),
                 failure_reason: codex_event_failure_reason(event, structured_error),
             })
         }
@@ -205,7 +207,10 @@ fn codex_error_message(error: Option<&Value>) -> Option<String> {
     }
 
     let message = error.get("message").and_then(Value::as_str);
-    let details = error.get("additional_details").and_then(Value::as_str);
+    let details = error
+        .get("additional_details")
+        .or_else(|| error.get("additionalDetails"))
+        .and_then(Value::as_str);
     combined_message_and_details(message, details)
 }
 
@@ -903,6 +908,28 @@ mod tests {
     }
 
     #[test]
+    fn codex_turn_failed_uses_nested_turn_error_for_message_when_top_level_error_missing() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "turn": {
+                "error": {
+                    "message": "nested turn failure",
+                    "additionalDetails": "quota exhausted"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "nested turn failure (quota exhausted)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_failed_null_nested_turn_error_uses_top_level_error() {
         let event = serde_json::json!({
             "type": "turn.failed",
@@ -1046,6 +1073,26 @@ mod tests {
             "error": {
                 "message": "turn failed from server",
                 "additional_details": "rate limit exceeded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server (rate limit exceeded)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_appends_camel_case_additional_details() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "additionalDetails": "rate limit exceeded"
             }
         });
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -713,7 +713,10 @@ fn cli_failure_message(
 }
 
 fn is_generic_stdout_failure_diagnostic(message: &str) -> bool {
-    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
+    matches!(
+        message.trim().to_ascii_lowercase().as_str(),
+        "error" | "turn failed" | "turn interrupted" | "unknown error" | "codex error"
+    )
 }
 
 fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
@@ -1188,7 +1191,7 @@ mod tests {
     #[test]
     fn cli_failure_message_uses_stderr_over_generic_codex_failure_diagnostic() {
         let stderr_lines = vec!["specific stderr failure".to_string()];
-        let diagnostic = cli_diagnostic("turn failed", FailureDetailSource::CodexJsonl);
+        let diagnostic = cli_diagnostic("Unknown error", FailureDetailSource::CodexJsonl);
         let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
 
         assert_eq!(msg.source, FailureDetailSource::Stderr);

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -463,6 +463,11 @@ pub unsafe fn setup_env(
     sigterm_grace_secs: u64,
     sigkill_grace_secs: u64,
 ) -> Result<(), String> {
+    std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
+    // Create any host-owned test mountpoint before setting VM0_PROMPT. Some
+    // tests intentionally use multi-MiB prompts, and subprocesses such as sudo
+    // inherit the process environment.
+    ensure_canonical_workspace_for_test()?;
     unsafe {
         // Route the CLI binary resolution to the cargo-built mock.
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
@@ -499,8 +504,6 @@ pub unsafe fn setup_env(
         // accumulating in the dev's real ~/.claude on every run.
         std::env::set_var("HOME", workdir);
     }
-    std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
-    ensure_canonical_workspace_for_test()?;
     std::env::set_current_dir(workdir).map_err(|e| format!("set_current_dir: {e}"))?;
     Ok(())
 }

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -645,6 +645,137 @@ describe("logs command", () => {
       expect(logCalls).toContain("pnpm test");
     });
 
+    it("should keep pairing when text appears between tool_use and tool_result", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Read",
+                          id: "tool-123",
+                          input: { file_path: "/test/file.ts" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "text",
+                          text: "checking the file contents",
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "tool-123",
+                          content: "File content here",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("checking the file contents");
+      expect(logCalls).toContain("Read");
+      expect(logCalls).toContain("File content here");
+      expect(logCalls).not.toContain("Tool result");
+    });
+
+    it("should render malformed tool_use events without ids without overwriting them", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          input: { command: "echo first" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          input: { command: "echo second" },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("echo first");
+      expect(logCalls).toContain("echo second");
+    });
+
     it("should render orphan tool_result events", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2174,6 +2174,66 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("API connection failed");
     });
 
+    it("should collapse paired Codex error and turn.failed across intervening events", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "warning",
+                    message: "cleanup in progress",
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Rate limit exceeded",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("[warning] cleanup in progress");
+      expect(logCalls).toContain("Rate limit exceeded");
+      expect(logCalls).not.toContain("API connection failed");
+    });
+
     it("should preserve top-level Codex error detail when paired turn.failed is generic", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2234,6 +2234,67 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("API connection failed");
     });
 
+    it("should not collapse Codex failures from different turns", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-a",
+                    message: "Previous turn lost connection",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.started",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "turn.started",
+                    turn: { id: "turn-b" },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "turn.failed",
+                    turn: { id: "turn-b" },
+                    error: "New turn quota failed",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
+      expect(logCalls).toContain("Previous turn lost connection");
+      expect(logCalls).toContain("New turn quota failed");
+    });
+
     it("should preserve top-level Codex error detail when paired turn.failed is generic", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -888,6 +888,59 @@ describe("logs command", () => {
       expect(logCalls).toContain("ls: cannot access '/nonexistent'");
     });
 
+    it("should mark command_execution with failed status as error", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "apply_patch",
+                      status: "in_progress",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "apply_patch",
+                      status: "failed",
+                      exit_code: 0,
+                      output: "patch failed",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("apply_patch");
+      expect(logCalls).toContain("✗");
+      expect(logCalls).toContain("patch failed");
+    });
+
     it("should render file_edit, file_write, and file_read tools", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1001,6 +1001,50 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("failed");
     });
 
+    it("should skip codex events with malformed type fields", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: 123,
+                    item: {
+                      id: "message-1",
+                      type: "agent_message",
+                      text: "this malformed event should be skipped",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "warning",
+                    message: "later event still renders",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("this malformed event should be skipped");
+      expect(logCalls).toContain("[warning] later event still renders");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2032,6 +2032,53 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("[object Object]");
     });
 
+    it("should render nested turn.error when turn.failed top-level error is generic", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Turn failed",
+                    turn: {
+                      error: {
+                        message: "Nested Codex failure",
+                        additionalDetails: "quota exhausted",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("Nested Codex failure (quota exhausted)");
+      expect(logCalls).not.toContain("Error: Turn failed");
+    });
+
     it("should render top-level error event as a failure result", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2262,11 +2262,16 @@ describe("logs command", () => {
                 },
                 {
                   sequenceNumber: 3,
-                  eventType: "turn.started",
+                  eventType: "item.completed",
                   createdAt: "2024-01-15T10:30:02Z",
                   eventData: {
-                    type: "turn.started",
-                    turn: { id: "turn-b" },
+                    type: "item.completed",
+                    turn_id: "turn-b",
+                    item: {
+                      id: "msg-b",
+                      type: "agent_message",
+                      text: "New turn started work",
+                    },
                   },
                 },
                 {
@@ -2292,7 +2297,11 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
       expect(logCalls).toContain("Previous turn lost connection");
+      expect(logCalls).toContain("New turn started work");
       expect(logCalls).toContain("New turn quota failed");
+      expect(logCalls.indexOf("Previous turn lost connection")).toBeLessThan(
+        logCalls.indexOf("New turn started work"),
+      );
     });
 
     it("should preserve top-level Codex error detail when paired turn.failed is generic", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1605,6 +1605,7 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("Rate limit exceeded (try again later)");
       expect(logCalls).not.toContain("[object Object]");
     });
 
@@ -1648,6 +1649,7 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("API connection failed (network unreachable)");
       expect(logCalls).not.toContain("[object Object]");
     });
 
@@ -1697,6 +1699,57 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("Rate limit exceeded");
+      expect(logCalls).not.toContain("API connection failed");
+    });
+
+    it("should preserve top-level Codex error detail when paired turn.failed is generic", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "turn.failed",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("API connection failed");
+      expect(logCalls).not.toContain("Turn failed");
     });
 
     it("should collapse paired Codex error and turn.failed when default tail order is descending", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1329,6 +1329,69 @@ describe("logs command", () => {
       expect(logCalls).toContain("Deleted: /workspace/old.ts");
     });
 
+    it("should tolerate malformed file_change payloads", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "change_1",
+                      type: "file_change",
+                      changes: "not an array",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "change_2",
+                      type: "file_change",
+                      changes: [
+                        null,
+                        { kind: "unknown", path: "/workspace/changed.ts" },
+                        { kind: "add", path: "" },
+                        { kind: "modify", path: 7 },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "warning",
+                    message: "later event still renders",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Changed: /workspace/changed.ts");
+      expect(logCalls).toContain("[warning] later event still renders");
+      expect(logCalls).not.toContain("not an array");
+    });
+
     it("should render turn.failed as Codex Failed", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1414,7 +1414,10 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:01Z",
                   eventData: {
                     type: "turn.failed",
-                    error: "Rate limit exceeded",
+                    error: {
+                      message: "Rate limit exceeded",
+                      additionalDetails: "try again later",
+                    },
                   },
                 },
               ],
@@ -1429,6 +1432,7 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).not.toContain("[object Object]");
     });
 
     it("should render top-level error event as a failure result", async () => {
@@ -1453,7 +1457,10 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:01Z",
                   eventData: {
                     type: "error",
-                    message: "API connection failed",
+                    error: {
+                      message: "API connection failed",
+                      additional_details: "network unreachable",
+                    },
                   },
                 },
               ],
@@ -1468,6 +1475,7 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).not.toContain("[object Object]");
     });
 
     it("should collapse paired top-level error and turn.failed into one Codex failure", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1045,6 +1045,94 @@ describe("logs command", () => {
       expect(logCalls).toContain("[warning] later event still renders");
     });
 
+    it("should skip codex tool events without valid item ids", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      type: "command_execution",
+                      command: "echo missing-id",
+                      status: "in_progress",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      type: "command_execution",
+                      output: "missing id output",
+                      exit_code: 0,
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: 123,
+                      type: "command_execution",
+                      command: "echo numeric-id",
+                      status: "in_progress",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: 123,
+                      type: "command_execution",
+                      output: "numeric id output",
+                      exit_code: 0,
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 5,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:04Z",
+                  eventData: {
+                    type: "warning",
+                    message: "later event still renders",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("missing-id");
+      expect(logCalls).not.toContain("missing id output");
+      expect(logCalls).not.toContain("numeric-id");
+      expect(logCalls).not.toContain("numeric id output");
+      expect(logCalls).toContain("[warning] later event still renders");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -605,6 +605,90 @@ describe("logs command", () => {
       expect(logCalls).toContain("File content here");
     });
 
+    it("should render unmatched trailing tool_use events", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          id: "tool-123",
+                          input: { command: "pnpm test" },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "1"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Bash");
+      expect(logCalls).toContain("pnpm test");
+    });
+
+    it("should render orphan tool_result events", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "tool-123",
+                          content: {
+                            output: "File content outside fetched range",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "1"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Tool result");
+      expect(logCalls).toContain(
+        '{"output":"File content outside fetched range"}',
+      );
+      expect(logCalls).not.toContain("[object Object]");
+    });
+
     it("should handle tool_result events", async () => {
       server.use(
         http.get(
@@ -1321,6 +1405,44 @@ describe("logs command", () => {
       expect(logCalls).toContain("apply_patch");
       expect(logCalls).toContain("✗");
       expect(logCalls).toContain("patch failed");
+    });
+
+    it("should render codex command results without matching started event", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd_1",
+                      type: "command_execution",
+                      command: "pnpm test",
+                      status: "completed",
+                      exit_code: 0,
+                      aggregated_output: "tests passed",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "1"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Tool result");
+      expect(logCalls).toContain("tests passed");
     });
 
     it("should render file_edit, file_write, and file_read tools", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -946,6 +946,61 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("[plan] 123");
     });
 
+    it("should render warnings as text without failing the run", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "warning",
+                    message: "temporary stream disconnect",
+                    will_retry: true,
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "warning",
+                    message: 123,
+                    error: {
+                      message: "retry queued",
+                      additional_details: "server overloaded",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:05Z",
+                  eventData: {
+                    type: "turn.completed",
+                    usage: {},
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[warning] temporary stream disconnect");
+      expect(logCalls).toContain("[warning] retry queued (server overloaded)");
+      expect(logCalls).not.toContain("failed");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1989,6 +1989,20 @@ describe("logs command", () => {
                     },
                   },
                 },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "change_failed",
+                      type: "file_change",
+                      status: "failed",
+                      changes: [],
+                    },
+                  },
+                },
               ],
               framework: "codex",
               hasMore: false,
@@ -2004,6 +2018,7 @@ describe("logs command", () => {
       expect(logCalls).toContain("Created: /workspace/new.ts");
       expect(logCalls).toContain("Modified: /workspace/existing.ts");
       expect(logCalls).toContain("Deleted: /workspace/old.ts");
+      expect(logCalls).toContain("File changes failed");
     });
 
     it("should tolerate malformed file_change payloads", async () => {
@@ -2022,6 +2037,7 @@ describe("logs command", () => {
                     item: {
                       id: "change_1",
                       type: "file_change",
+                      status: "declined",
                       changes: "not an array",
                     },
                   },
@@ -2064,6 +2080,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("File changes declined");
       expect(logCalls).toContain("Changed: /workspace/changed.ts");
       expect(logCalls).toContain("[warning] later event still renders");
       expect(logCalls).not.toContain("not an array");

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -720,6 +720,176 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("Tool result");
     });
 
+    it("should not pair tool results across session init events", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "system",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "system",
+                    subtype: "init",
+                    session_id: "session-1",
+                    model: "claude-sonnet-4-5",
+                    tools: ["Read"],
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Read",
+                          id: "tool-123",
+                          input: { file_path: "/first/session.ts" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "system",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "system",
+                    subtype: "init",
+                    session_id: "session-2",
+                    model: "claude-sonnet-4-5",
+                    tools: ["Read"],
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "tool-123",
+                          content: "second session result",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("/first/session.ts");
+      expect(logCalls).toContain("Tool result");
+      expect(logCalls).toContain("second session result");
+    });
+
+    it("should not drop pending tool uses when a duplicate id is received", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "system",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "system",
+                    subtype: "init",
+                    session_id: "session-1",
+                    model: "claude-sonnet-4-5",
+                    tools: ["Read"],
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Read",
+                          id: "tool-123",
+                          input: { file_path: "/first/path.ts" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Read",
+                          id: "tool-123",
+                          input: { file_path: "/second/path.ts" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "tool-123",
+                          content: "second result",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("/first/path.ts");
+      expect(logCalls).toContain("/second/path.ts");
+      expect(logCalls).toContain("second result");
+    });
+
     it("should render malformed tool_use events without ids without overwriting them", async () => {
       server.use(
         http.get(
@@ -1884,6 +2054,7 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:01Z",
                   eventData: {
                     type: "error",
+                    message: "unknown error",
                     error: {
                       message: "API connection failed",
                       additional_details: "network unreachable",

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1133,6 +1133,91 @@ describe("logs command", () => {
       expect(logCalls).toContain("[warning] later event still renders");
     });
 
+    it("should skip malformed codex scalar item fields", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: { value: "thread-object" },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "message-1",
+                      type: "agent_message",
+                      text: { value: "object text" },
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd-1",
+                      type: "command_execution",
+                      command: { value: "object command" },
+                      status: "in_progress",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd-1",
+                      type: "command_execution",
+                      output: { value: "object output" },
+                      exit_code: 0,
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 5,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:04Z",
+                  eventData: {
+                    type: "warning",
+                    message: "later event still renders",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("[object Object]");
+      expect(logCalls).not.toContain("object text");
+      expect(logCalls).not.toContain("object command");
+      expect(logCalls).not.toContain("object output");
+      expect(logCalls).not.toContain("thread-object");
+      expect(logCalls).toContain("[warning] later event still renders");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2054,7 +2054,7 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:01Z",
                   eventData: {
                     type: "error",
-                    message: "unknown error",
+                    message: "turn interrupted",
                     error: {
                       message: "API connection failed",
                       additional_details: "network unreachable",
@@ -2158,6 +2158,7 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:02Z",
                   eventData: {
                     type: "turn.failed",
+                    message: "unknown error",
                   },
                 },
               ],
@@ -2173,7 +2174,7 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
       expect(logCalls).toContain("API connection failed");
-      expect(logCalls).not.toContain("Turn failed");
+      expect(logCalls).not.toContain("unknown error");
     });
 
     it("should collapse paired Codex error and turn.failed when default tail order is descending", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -871,6 +871,44 @@ describe("logs command", () => {
       expect(logCalls).toContain("2. Patch retry");
     });
 
+    it("should render turn plan updates as text", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "turn.plan.updated",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "turn.plan.updated",
+                    explanation: "Current plan",
+                    plan: [
+                      { step: "Inspect logs", status: "completed" },
+                      { step: "Patch retry", status: "in_progress" },
+                      { step: "Run tests", status: "pending" },
+                    ],
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[plan] Current plan");
+      expect(logCalls).toContain("- [completed] Inspect logs");
+      expect(logCalls).toContain("- [in progress] Patch retry");
+      expect(logCalls).toContain("- [pending] Run tests");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -836,6 +836,41 @@ describe("logs command", () => {
       expect(logCalls).toContain("README.md");
     });
 
+    it("should render plan items as text", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "plan_1",
+                      type: "plan",
+                      text: "1. Inspect logs\n2. Patch retry",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[plan] 1. Inspect logs");
+      expect(logCalls).toContain("2. Patch retry");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1850,6 +1850,87 @@ describe("logs command", () => {
       expect(logCalls).toContain("/workspace/package.json");
     });
 
+    it("should mark failed file operation statuses as errors", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "edit_1",
+                      type: "file_edit",
+                      path: "/workspace/src/main.ts",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "edit_1",
+                      type: "file_edit",
+                      path: "/workspace/src/main.ts",
+                      status: "failed",
+                      output: "edit failed: stale file",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "read_1",
+                      type: "file_read",
+                      path: "/workspace/private.txt",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "read_1",
+                      type: "file_read",
+                      path: "/workspace/private.txt",
+                      status: "declined",
+                      output: "read declined by policy",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("/workspace/src/main.ts");
+      expect(logCalls).toContain("edit failed: stale file");
+      expect(logCalls).toContain("/workspace/private.txt");
+      expect(logCalls).toContain("read declined by policy");
+      expect(countOccurrences(logCalls, "✗")).toBe(2);
+    });
+
     it("should render reasoning items with [thinking] prefix", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -909,6 +909,43 @@ describe("logs command", () => {
       expect(logCalls).toContain("- [pending] Run tests");
     });
 
+    it("should tolerate malformed turn plan update fields", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "turn.plan.updated",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "turn.plan.updated",
+                    explanation: 123,
+                    plan: [
+                      null,
+                      { step: "", status: "completed" },
+                      { step: "Run tests", status: "pending" },
+                    ],
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[plan]");
+      expect(logCalls).toContain("- [pending] Run tests");
+      expect(logCalls).not.toContain("[plan] 123");
+    });
+
     it("should mark command_execution with non-zero exit_code as error", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -491,6 +491,7 @@ async function showAgentEvents(
   for (const parsed of normalizer.flush()) {
     renderer.render(parsed);
   }
+  renderer.flush();
 
   console.log(chalk.dim(`View on platform: ${platformUrl}`));
 }

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -496,6 +496,7 @@ export async function pollEvents(
     for (const parsed of normalizer.flush()) {
       renderer.render(parsed);
     }
+    renderer.flush();
   };
 
   for (;;) {

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -73,6 +73,7 @@ async function showAgentEvents(
   for (const parsed of normalizer.flush()) {
     renderer.render(parsed);
   }
+  renderer.flush();
 }
 
 export const zeroLogsCommand = new Command()

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -48,7 +48,7 @@ interface CodexItem {
   exit_code?: number;
   output?: string;
   aggregated_output?: string;
-  // For agent_message
+  // For agent_message, plan, and reasoning
   text?: string;
   // For file operations
   path?: string;
@@ -175,6 +175,13 @@ export class CodexEventParser {
 
     if (itemType === "agent_message" && item.text) {
       return { type: "text", timestamp: new Date(), data: { text: item.text } };
+    }
+    if (itemType === "plan" && item.text) {
+      return {
+        type: "text",
+        timestamp: new Date(),
+        data: { text: `[plan] ${item.text}` },
+      };
     }
     if (itemType === "command_execution") {
       return this.parseCommandExecution(event);

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -477,7 +477,24 @@ function formatCodexEventMessage(
   message: unknown,
   error: unknown,
 ): string | null {
-  return formatCodexString(message) ?? formatCodexErrorMessage(error);
+  const messageText = formatCodexString(message);
+  const errorText = formatCodexErrorMessage(error);
+
+  if (!messageText) {
+    return errorText;
+  }
+  if (!errorText) {
+    return messageText;
+  }
+  if (
+    errorText === messageText ||
+    errorText.startsWith(`${messageText} (`) ||
+    isGenericCodexFailureMessage(messageText)
+  ) {
+    return errorText;
+  }
+
+  return messageText;
 }
 
 function formatCodexString(value: unknown): string | null {
@@ -505,6 +522,16 @@ function formatCodexErrorMessage(error: unknown): string | null {
   }
 
   return message || details || null;
+}
+
+function isGenericCodexFailureMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized === "turn failed" ||
+    normalized === "unknown error" ||
+    normalized === "codex error" ||
+    normalized === "error"
+  );
 }
 
 function formatCodexPlanUpdate(

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -42,8 +42,8 @@ interface TurnPlanUpdatedEvent {
 }
 
 interface FileChange {
-  kind: "add" | "modify" | "delete";
-  path: string;
+  kind?: unknown;
+  path?: unknown;
 }
 
 interface CodexItem {
@@ -339,21 +339,26 @@ export class CodexEventParser {
   }
 
   private static parseFileChange(item: CodexItem): ParsedEvent | null {
-    if (!item.changes || item.changes.length === 0) {
+    if (!Array.isArray(item.changes) || item.changes.length === 0) {
       return null;
     }
 
     const changes = item.changes
-      .map((c) => {
-        const action =
-          c.kind === "add"
-            ? "Created"
-            : c.kind === "modify"
-              ? "Modified"
-              : "Deleted";
-        return `${action}: ${c.path}`;
+      .flatMap((change) => {
+        if (!isRecord(change)) {
+          return [];
+        }
+        const path = getStringField(change, "path")?.trim();
+        if (!path) {
+          return [];
+        }
+        const action = formatFileChangeAction(change.kind);
+        return [`${action}: ${path}`];
       })
       .join("\n");
+    if (!changes) {
+      return null;
+    }
 
     return {
       type: "text",
@@ -411,6 +416,19 @@ function getStringField(
 ): string | undefined {
   const value = record[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function formatFileChangeAction(kind: unknown): string {
+  switch (kind) {
+    case "add":
+      return "Created";
+    case "modify":
+      return "Modified";
+    case "delete":
+      return "Deleted";
+    default:
+      return "Changed";
+  }
 }
 
 function formatCodexWarningMessage(event: WarningEvent): string | null {

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -528,6 +528,7 @@ function isGenericCodexFailureMessage(message: string): boolean {
   const normalized = message.toLowerCase();
   return (
     normalized === "turn failed" ||
+    normalized === "turn interrupted" ||
     normalized === "unknown error" ||
     normalized === "codex error" ||
     normalized === "error"

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -260,7 +260,7 @@ export class CodexEventParser {
         data: {
           toolUseId,
           result: output,
-          isError: isCommandExecutionError(item),
+          isError: isCodexItemError(item),
         },
       };
     }
@@ -292,13 +292,17 @@ export class CodexEventParser {
     }
 
     if (eventType === "item.completed") {
+      const isError = isCodexItemError(item);
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
           toolUseId,
-          result: getStringField(item, "diff") ?? "File operation completed",
-          isError: false,
+          result:
+            getStringField(item, "diff") ??
+            getStringField(item, "output") ??
+            (isError ? "File operation failed" : "File operation completed"),
+          isError,
         },
       };
     }
@@ -329,13 +333,16 @@ export class CodexEventParser {
     }
 
     if (eventType === "item.completed") {
+      const isError = isCodexItemError(item);
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
           toolUseId,
-          result: "File read completed",
-          isError: false,
+          result:
+            (isError ? getStringField(item, "output") : undefined) ??
+            (isError ? "File read failed" : "File read completed"),
+          isError,
         },
       };
     }
@@ -406,7 +413,7 @@ export class CodexEventParser {
   }
 }
 
-function isCommandExecutionError(item: Record<string, unknown>): boolean {
+function isCodexItemError(item: Record<string, unknown>): boolean {
   const status = getStringField(item, "status");
   if (status === "failed" || status === "declined") {
     return true;

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -30,6 +30,7 @@ interface TurnFailedEvent {
   type: "turn.failed";
   message?: unknown;
   error?: unknown;
+  turn?: unknown;
 }
 
 interface TurnPlanUpdatedEvent {
@@ -156,7 +157,11 @@ export class CodexEventParser {
       data: {
         success: false,
         result:
-          formatCodexEventMessage(event.message, event.error) ?? "Turn failed",
+          formatCodexEventMessage(
+            event.message,
+            event.error,
+            getCodexTurnError(event.turn),
+          ) ?? "Turn failed",
         durationMs: 0,
         numTurns: 1,
         cost: 0,
@@ -476,10 +481,27 @@ function formatCodexWarningMessage(event: WarningEvent): string | null {
 function formatCodexEventMessage(
   message: unknown,
   error: unknown,
+  fallbackError?: unknown,
 ): string | null {
   const messageText = formatCodexString(message);
   const errorText = formatCodexErrorMessage(error);
+  const fallbackErrorText = formatCodexErrorMessage(fallbackError);
 
+  const result = selectCodexEventMessage(messageText, errorText);
+  if (!result) {
+    return fallbackErrorText;
+  }
+  if (fallbackErrorText && isGenericCodexFailureMessage(result)) {
+    return fallbackErrorText;
+  }
+
+  return result;
+}
+
+function selectCodexEventMessage(
+  messageText: string | null,
+  errorText: string | null,
+): string | null {
   if (!messageText) {
     return errorText;
   }
@@ -495,6 +517,13 @@ function formatCodexEventMessage(
   }
 
   return messageText;
+}
+
+function getCodexTurnError(turn: unknown): unknown {
+  if (!isRecord(turn)) {
+    return undefined;
+  }
+  return turn.error;
 }
 
 function formatCodexString(value: unknown): string | null {

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -222,7 +222,7 @@ export class CodexEventParser {
         data: {
           toolUseId: item.id,
           result: output,
-          isError: item.exit_code !== 0,
+          isError: isCommandExecutionError(item),
         },
       };
     }
@@ -328,4 +328,14 @@ export class CodexEventParser {
       },
     };
   }
+}
+
+function isCommandExecutionError(item: CodexItem): boolean {
+  if (item.status === "failed" || item.status === "declined") {
+    return true;
+  }
+  if (item.status === "completed") {
+    return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
+  }
+  return item.exit_code !== 0;
 }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -353,32 +353,43 @@ export class CodexEventParser {
   private static parseFileChange(
     item: Record<string, unknown>,
   ): ParsedEvent | null {
+    const statusText = formatFileChangeStatus(getStringField(item, "status"));
     const changesValue = item.changes;
-    if (!Array.isArray(changesValue) || changesValue.length === 0) {
+    if (!Array.isArray(changesValue)) {
+      return statusText
+        ? {
+            type: "text",
+            timestamp: new Date(),
+            data: { text: `[files]\n${statusText}` },
+          }
+        : null;
+    }
+
+    const changes = changesValue.flatMap((change) => {
+      if (!isRecord(change)) {
+        return [];
+      }
+      const path = getStringField(change, "path")?.trim();
+      if (!path) {
+        return [];
+      }
+      const action = formatFileChangeAction(change.kind);
+      return [`${action}: ${path}`];
+    });
+    if (changes.length === 0 && !statusText) {
       return null;
     }
 
-    const changes = changesValue
-      .flatMap((change) => {
-        if (!isRecord(change)) {
-          return [];
-        }
-        const path = getStringField(change, "path")?.trim();
-        if (!path) {
-          return [];
-        }
-        const action = formatFileChangeAction(change.kind);
-        return [`${action}: ${path}`];
+    const text = ["[files]", statusText, ...changes]
+      .filter((line): line is string => {
+        return Boolean(line);
       })
       .join("\n");
-    if (!changes) {
-      return null;
-    }
 
     return {
       type: "text",
       timestamp: new Date(),
-      data: { text: `[files]\n${changes}` },
+      data: { text },
     };
   }
 
@@ -478,6 +489,17 @@ function formatFileChangeAction(kind: unknown): string {
       return "Deleted";
     default:
       return "Changed";
+  }
+}
+
+function formatFileChangeStatus(status: string | undefined): string | null {
+  switch (status) {
+    case "failed":
+      return "File changes failed";
+    case "declined":
+      return "File changes declined";
+    default:
+      return null;
   }
 }
 

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -6,6 +6,7 @@
  * - thread.started: Session initialization
  * - turn.started/turn.completed/turn.failed/turn.plan.updated: Turn lifecycle
  * - item.started/item.updated/item.completed: Individual items (messages, commands, etc.)
+ * - warning: Recoverable warnings
  * - error: Unrecoverable errors
  */
 
@@ -75,6 +76,12 @@ interface ErrorEvent {
   error?: string;
 }
 
+interface WarningEvent {
+  type: "warning";
+  message?: unknown;
+  error?: unknown;
+}
+
 type RawCodexEvent =
   | ThreadStartedEvent
   | TurnStartedEvent
@@ -82,6 +89,7 @@ type RawCodexEvent =
   | TurnFailedEvent
   | TurnPlanUpdatedEvent
   | ItemEvent
+  | WarningEvent
   | ErrorEvent
   | Record<string, unknown>;
 
@@ -114,6 +122,10 @@ export class CodexEventParser {
 
     if (eventType === "turn.plan.updated") {
       return this.parseTurnPlanUpdated(rawEvent as TurnPlanUpdatedEvent);
+    }
+
+    if (eventType === "warning") {
+      return this.parseWarningEvent(rawEvent as WarningEvent);
     }
 
     // Item events (started, updated, completed)
@@ -361,6 +373,19 @@ export class CodexEventParser {
       },
     };
   }
+
+  private static parseWarningEvent(event: WarningEvent): ParsedEvent | null {
+    const message = formatCodexWarningMessage(event);
+    if (!message) {
+      return null;
+    }
+
+    return {
+      type: "text",
+      timestamp: new Date(),
+      data: { text: `[warning] ${message}` },
+    };
+  }
 }
 
 function isCommandExecutionError(item: CodexItem): boolean {
@@ -383,6 +408,37 @@ function getStringField(
 ): string | undefined {
   const value = record[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function formatCodexWarningMessage(event: WarningEvent): string | null {
+  if (typeof event.message === "string") {
+    const message = event.message.trim();
+    if (message) {
+      return message;
+    }
+  }
+
+  return formatCodexErrorMessage(event.error);
+}
+
+function formatCodexErrorMessage(error: unknown): string | null {
+  if (typeof error === "string") {
+    return error.trim() || null;
+  }
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const message = getStringField(error, "message")?.trim();
+  const details =
+    getStringField(error, "additional_details")?.trim() ??
+    getStringField(error, "additionalDetails")?.trim();
+
+  if (message && details) {
+    return `${message} (${details})`;
+  }
+
+  return message || details || null;
 }
 
 function formatCodexPlanUpdate(

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -344,5 +344,5 @@ function isCommandExecutionError(item: CodexItem): boolean {
   if (item.status === "completed") {
     return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
   }
-  return item.exit_code !== 0;
+  return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
 }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -251,6 +251,10 @@ export class CodexEventParser {
 
   private static parseCommandExecution(event: ItemEvent): ParsedEvent | null {
     const item = event.item;
+    const toolUseId = getCodexItemId(item);
+    if (!toolUseId) {
+      return null;
+    }
 
     if (event.type === "item.started" && item.command) {
       return {
@@ -258,7 +262,7 @@ export class CodexEventParser {
         timestamp: new Date(),
         data: {
           tool: "Bash",
-          toolUseId: item.id,
+          toolUseId,
           input: { command: item.command },
         },
       };
@@ -270,7 +274,7 @@ export class CodexEventParser {
         type: "tool_result",
         timestamp: new Date(),
         data: {
-          toolUseId: item.id,
+          toolUseId,
           result: output,
           isError: isCommandExecutionError(item),
         },
@@ -282,6 +286,10 @@ export class CodexEventParser {
 
   private static parseFileEditOrWrite(event: ItemEvent): ParsedEvent | null {
     const item = event.item;
+    const toolUseId = getCodexItemId(item);
+    if (!toolUseId) {
+      return null;
+    }
 
     if (event.type === "item.started" && item.path) {
       return {
@@ -289,7 +297,7 @@ export class CodexEventParser {
         timestamp: new Date(),
         data: {
           tool: item.type === "file_edit" ? "Edit" : "Write",
-          toolUseId: item.id,
+          toolUseId,
           input: { file_path: item.path },
         },
       };
@@ -300,7 +308,7 @@ export class CodexEventParser {
         type: "tool_result",
         timestamp: new Date(),
         data: {
-          toolUseId: item.id,
+          toolUseId,
           result: item.diff || "File operation completed",
           isError: false,
         },
@@ -312,6 +320,10 @@ export class CodexEventParser {
 
   private static parseFileRead(event: ItemEvent): ParsedEvent | null {
     const item = event.item;
+    const toolUseId = getCodexItemId(item);
+    if (!toolUseId) {
+      return null;
+    }
 
     if (event.type === "item.started" && item.path) {
       return {
@@ -319,7 +331,7 @@ export class CodexEventParser {
         timestamp: new Date(),
         data: {
           tool: "Read",
-          toolUseId: item.id,
+          toolUseId,
           input: { file_path: item.path },
         },
       };
@@ -330,7 +342,7 @@ export class CodexEventParser {
         type: "tool_result",
         timestamp: new Date(),
         data: {
-          toolUseId: item.id,
+          toolUseId,
           result: "File read completed",
           isError: false,
         },
@@ -412,6 +424,14 @@ function isCommandExecutionError(item: CodexItem): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getCodexItemId(item: CodexItem): string | null {
+  if (typeof item.id !== "string") {
+    return null;
+  }
+  const id = item.id.trim();
+  return id || null;
 }
 
 function getStringField(

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -14,7 +14,7 @@ import type { ParsedEvent } from "./claude-event-parser";
 
 interface ThreadStartedEvent {
   type: "thread.started";
-  thread_id: string;
+  thread_id?: unknown;
 }
 
 interface TurnStartedEvent {
@@ -23,11 +23,7 @@ interface TurnStartedEvent {
 
 interface TurnCompletedEvent {
   type: "turn.completed";
-  usage?: {
-    input_tokens?: number;
-    cached_input_tokens?: number;
-    output_tokens?: number;
-  };
+  usage?: unknown;
 }
 
 interface TurnFailedEvent {
@@ -42,33 +38,9 @@ interface TurnPlanUpdatedEvent {
   plan?: unknown;
 }
 
-interface FileChange {
-  kind?: unknown;
-  path?: unknown;
-}
-
-interface CodexItem {
-  id: string;
-  type: string;
-  status?: string;
-  // For command_execution
-  command?: string;
-  exit_code?: number;
-  output?: string;
-  aggregated_output?: string;
-  // For agent_message, plan, and reasoning
-  text?: string;
-  // For file operations
-  path?: string;
-  diff?: string;
-  // For file_change
-  changes?: FileChange[];
-  // For reasoning (text field is used)
-}
-
 interface ItemEvent {
   type: "item.started" | "item.updated" | "item.completed";
-  item: CodexItem;
+  item?: unknown;
 }
 
 interface ErrorEvent {
@@ -154,7 +126,7 @@ export class CodexEventParser {
       timestamp: new Date(),
       data: {
         framework: "codex",
-        sessionId: event.thread_id,
+        sessionId: formatCodexString(event.thread_id) ?? "",
         tools: [],
       },
     };
@@ -172,7 +144,7 @@ export class CodexEventParser {
         durationMs: 0,
         numTurns: 1,
         cost: 0,
-        usage: event.usage || {},
+        usage: parseCodexUsage(event.usage),
       },
     };
   }
@@ -210,66 +182,73 @@ export class CodexEventParser {
 
   private static parseItemEvent(event: ItemEvent): ParsedEvent | null {
     const item = event.item;
-    if (!item) {
+    if (!isRecord(item)) {
       return null;
     }
 
-    const itemType = item.type;
+    const itemType = getStringField(item, "type");
+    const text = getStringField(item, "text");
 
-    if (itemType === "agent_message" && item.text) {
-      return { type: "text", timestamp: new Date(), data: { text: item.text } };
+    if (itemType === "agent_message" && text) {
+      return { type: "text", timestamp: new Date(), data: { text } };
     }
-    if (itemType === "plan" && item.text) {
+    if (itemType === "plan" && text) {
       return {
         type: "text",
         timestamp: new Date(),
-        data: { text: `[plan] ${item.text}` },
+        data: { text: `[plan] ${text}` },
       };
     }
     if (itemType === "command_execution") {
-      return this.parseCommandExecution(event);
+      return this.parseCommandExecution(event.type, item);
     }
     if (itemType === "file_edit" || itemType === "file_write") {
-      return this.parseFileEditOrWrite(event);
+      return this.parseFileEditOrWrite(event.type, item, itemType);
     }
     if (itemType === "file_read") {
-      return this.parseFileRead(event);
+      return this.parseFileRead(event.type, item);
     }
     if (itemType === "file_change") {
       return this.parseFileChange(item);
     }
-    if (itemType === "reasoning" && item.text) {
+    if (itemType === "reasoning" && text) {
       return {
         type: "text",
         timestamp: new Date(),
-        data: { text: `[thinking] ${item.text}` },
+        data: { text: `[thinking] ${text}` },
       };
     }
 
     return null;
   }
 
-  private static parseCommandExecution(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseCommandExecution(
+    eventType: ItemEvent["type"],
+    item: Record<string, unknown>,
+  ): ParsedEvent | null {
     const toolUseId = getCodexItemId(item);
     if (!toolUseId) {
       return null;
     }
 
-    if (event.type === "item.started" && item.command) {
+    const command = getStringField(item, "command");
+    if (eventType === "item.started" && command) {
       return {
         type: "tool_use",
         timestamp: new Date(),
         data: {
           tool: "Bash",
           toolUseId,
-          input: { command: item.command },
+          input: { command },
         },
       };
     }
 
-    if (event.type === "item.completed") {
-      const output = item.aggregated_output ?? item.output ?? "";
+    if (eventType === "item.completed") {
+      const output =
+        getStringField(item, "aggregated_output") ??
+        getStringField(item, "output") ??
+        "";
       return {
         type: "tool_result",
         timestamp: new Date(),
@@ -284,32 +263,36 @@ export class CodexEventParser {
     return null;
   }
 
-  private static parseFileEditOrWrite(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseFileEditOrWrite(
+    eventType: ItemEvent["type"],
+    item: Record<string, unknown>,
+    itemType: string,
+  ): ParsedEvent | null {
     const toolUseId = getCodexItemId(item);
     if (!toolUseId) {
       return null;
     }
 
-    if (event.type === "item.started" && item.path) {
+    const path = getStringField(item, "path");
+    if (eventType === "item.started" && path) {
       return {
         type: "tool_use",
         timestamp: new Date(),
         data: {
-          tool: item.type === "file_edit" ? "Edit" : "Write",
+          tool: itemType === "file_edit" ? "Edit" : "Write",
           toolUseId,
-          input: { file_path: item.path },
+          input: { file_path: path },
         },
       };
     }
 
-    if (event.type === "item.completed") {
+    if (eventType === "item.completed") {
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
           toolUseId,
-          result: item.diff || "File operation completed",
+          result: getStringField(item, "diff") ?? "File operation completed",
           isError: false,
         },
       };
@@ -318,26 +301,29 @@ export class CodexEventParser {
     return null;
   }
 
-  private static parseFileRead(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseFileRead(
+    eventType: ItemEvent["type"],
+    item: Record<string, unknown>,
+  ): ParsedEvent | null {
     const toolUseId = getCodexItemId(item);
     if (!toolUseId) {
       return null;
     }
 
-    if (event.type === "item.started" && item.path) {
+    const path = getStringField(item, "path");
+    if (eventType === "item.started" && path) {
       return {
         type: "tool_use",
         timestamp: new Date(),
         data: {
           tool: "Read",
           toolUseId,
-          input: { file_path: item.path },
+          input: { file_path: path },
         },
       };
     }
 
-    if (event.type === "item.completed") {
+    if (eventType === "item.completed") {
       return {
         type: "tool_result",
         timestamp: new Date(),
@@ -352,12 +338,15 @@ export class CodexEventParser {
     return null;
   }
 
-  private static parseFileChange(item: CodexItem): ParsedEvent | null {
-    if (!Array.isArray(item.changes) || item.changes.length === 0) {
+  private static parseFileChange(
+    item: Record<string, unknown>,
+  ): ParsedEvent | null {
+    const changesValue = item.changes;
+    if (!Array.isArray(changesValue) || changesValue.length === 0) {
       return null;
     }
 
-    const changes = item.changes
+    const changes = changesValue
       .flatMap((change) => {
         if (!isRecord(change)) {
           return [];
@@ -412,25 +401,24 @@ export class CodexEventParser {
   }
 }
 
-function isCommandExecutionError(item: CodexItem): boolean {
-  if (item.status === "failed" || item.status === "declined") {
+function isCommandExecutionError(item: Record<string, unknown>): boolean {
+  const status = getStringField(item, "status");
+  if (status === "failed" || status === "declined") {
     return true;
   }
-  if (item.status === "completed") {
-    return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
+  const exitCode = getNumberField(item, "exit_code");
+  if (status === "completed") {
+    return typeof exitCode === "number" ? exitCode !== 0 : false;
   }
-  return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
+  return typeof exitCode === "number" ? exitCode !== 0 : false;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function getCodexItemId(item: CodexItem): string | null {
-  if (typeof item.id !== "string") {
-    return null;
-  }
-  const id = item.id.trim();
+function getCodexItemId(item: Record<string, unknown>): string | null {
+  const id = getStringField(item, "id")?.trim();
   return id || null;
 }
 
@@ -440,6 +428,32 @@ function getStringField(
 ): string | undefined {
   const value = record[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function getNumberField(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function parseCodexUsage(value: unknown): Record<string, number> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return {
+    ...(typeof value.input_tokens === "number"
+      ? { input_tokens: value.input_tokens }
+      : {}),
+    ...(typeof value.cached_input_tokens === "number"
+      ? { cached_input_tokens: value.cached_input_tokens }
+      : {}),
+    ...(typeof value.output_tokens === "number"
+      ? { output_tokens: value.output_tokens }
+      : {}),
+  };
 }
 
 function formatFileChangeAction(kind: unknown): string {

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -34,15 +34,10 @@ interface TurnFailedEvent {
   error?: string;
 }
 
-interface CodexPlanStep {
-  step?: string;
-  status?: string;
-}
-
 interface TurnPlanUpdatedEvent {
   type: "turn.plan.updated";
-  explanation?: string | null;
-  plan?: CodexPlanStep[];
+  explanation?: unknown;
+  plan?: unknown;
 }
 
 interface FileChange {
@@ -378,16 +373,31 @@ function isCommandExecutionError(item: CodexItem): boolean {
   return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getStringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
 function formatCodexPlanUpdate(
-  plan: CodexPlanStep[] | undefined,
-  explanation: string | null | undefined,
+  plan: unknown,
+  explanation: unknown,
 ): string | null {
-  const header = explanation?.trim()
-    ? `[plan] ${explanation.trim()}`
-    : "[plan]";
+  const explanationText =
+    typeof explanation === "string" ? explanation.trim() : "";
+  const header = explanationText ? `[plan] ${explanationText}` : "[plan]";
   const steps = Array.isArray(plan)
     ? plan.flatMap((step) => {
-        const text = step.step?.trim();
+        if (!isRecord(step)) {
+          return [];
+        }
+        const text = getStringField(step, "step")?.trim();
         if (!text) {
           return [];
         }
@@ -395,14 +405,14 @@ function formatCodexPlanUpdate(
       })
     : [];
 
-  if (steps.length === 0 && !explanation?.trim()) {
+  if (steps.length === 0 && !explanationText) {
     return null;
   }
 
   return [header, ...steps].join("\n");
 }
 
-function formatCodexPlanStatus(status: string | undefined): string {
+function formatCodexPlanStatus(status: unknown): string {
   switch (status) {
     case "completed":
     case "pending":
@@ -411,6 +421,8 @@ function formatCodexPlanStatus(status: string | undefined): string {
     case "in_progress":
       return "in progress";
     default:
-      return status?.trim() || "unknown";
+      return typeof status === "string"
+        ? status.trim() || "unknown"
+        : "unknown";
   }
 }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -103,7 +103,10 @@ export class CodexEventParser {
       return null;
     }
 
-    const eventType = rawEvent.type as string;
+    const eventType = rawEvent.type;
+    if (typeof eventType !== "string") {
+      return null;
+    }
 
     // Thread started = init event
     if (eventType === "thread.started") {

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -4,7 +4,7 @@
  *
  * Codex event types:
  * - thread.started: Session initialization
- * - turn.started/turn.completed/turn.failed: Turn lifecycle
+ * - turn.started/turn.completed/turn.failed/turn.plan.updated: Turn lifecycle
  * - item.started/item.updated/item.completed: Individual items (messages, commands, etc.)
  * - error: Unrecoverable errors
  */
@@ -32,6 +32,17 @@ interface TurnCompletedEvent {
 interface TurnFailedEvent {
   type: "turn.failed";
   error?: string;
+}
+
+interface CodexPlanStep {
+  step?: string;
+  status?: string;
+}
+
+interface TurnPlanUpdatedEvent {
+  type: "turn.plan.updated";
+  explanation?: string | null;
+  plan?: CodexPlanStep[];
 }
 
 interface FileChange {
@@ -74,6 +85,7 @@ type RawCodexEvent =
   | TurnStartedEvent
   | TurnCompletedEvent
   | TurnFailedEvent
+  | TurnPlanUpdatedEvent
   | ItemEvent
   | ErrorEvent
   | Record<string, unknown>;
@@ -103,6 +115,10 @@ export class CodexEventParser {
     // Turn failed = result event with error
     if (eventType === "turn.failed") {
       return this.parseTurnFailed(rawEvent as TurnFailedEvent);
+    }
+
+    if (eventType === "turn.plan.updated") {
+      return this.parseTurnPlanUpdated(rawEvent as TurnPlanUpdatedEvent);
     }
 
     // Item events (started, updated, completed)
@@ -162,6 +178,21 @@ export class CodexEventParser {
         cost: 0,
         usage: {},
       },
+    };
+  }
+
+  private static parseTurnPlanUpdated(
+    event: TurnPlanUpdatedEvent,
+  ): ParsedEvent | null {
+    const text = formatCodexPlanUpdate(event.plan, event.explanation);
+    if (!text) {
+      return null;
+    }
+
+    return {
+      type: "text",
+      timestamp: new Date(),
+      data: { text },
     };
   }
 
@@ -345,4 +376,41 @@ function isCommandExecutionError(item: CodexItem): boolean {
     return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
   }
   return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
+}
+
+function formatCodexPlanUpdate(
+  plan: CodexPlanStep[] | undefined,
+  explanation: string | null | undefined,
+): string | null {
+  const header = explanation?.trim()
+    ? `[plan] ${explanation.trim()}`
+    : "[plan]";
+  const steps = Array.isArray(plan)
+    ? plan.flatMap((step) => {
+        const text = step.step?.trim();
+        if (!text) {
+          return [];
+        }
+        return [`- [${formatCodexPlanStatus(step.status)}] ${text}`];
+      })
+    : [];
+
+  if (steps.length === 0 && !explanation?.trim()) {
+    return null;
+  }
+
+  return [header, ...steps].join("\n");
+}
+
+function formatCodexPlanStatus(status: string | undefined): string {
+  switch (status) {
+    case "completed":
+    case "pending":
+      return status;
+    case "inProgress":
+    case "in_progress":
+      return "in progress";
+    default:
+      return status?.trim() || "unknown";
+  }
 }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -32,7 +32,8 @@ interface TurnCompletedEvent {
 
 interface TurnFailedEvent {
   type: "turn.failed";
-  error?: string;
+  message?: unknown;
+  error?: unknown;
 }
 
 interface TurnPlanUpdatedEvent {
@@ -72,8 +73,8 @@ interface ItemEvent {
 
 interface ErrorEvent {
   type: "error";
-  message?: string;
-  error?: string;
+  message?: unknown;
+  error?: unknown;
 }
 
 interface WarningEvent {
@@ -182,7 +183,8 @@ export class CodexEventParser {
       timestamp: new Date(),
       data: {
         success: false,
-        result: event.error || "Turn failed",
+        result:
+          formatCodexEventMessage(event.message, event.error) ?? "Turn failed",
         durationMs: 0,
         numTurns: 1,
         cost: 0,
@@ -373,7 +375,9 @@ export class CodexEventParser {
       timestamp: new Date(),
       data: {
         success: false,
-        result: event.message || event.error || "Unknown error",
+        result:
+          formatCodexEventMessage(event.message, event.error) ??
+          "Unknown error",
         durationMs: 0,
         numTurns: 0,
         cost: 0,
@@ -432,14 +436,21 @@ function formatFileChangeAction(kind: unknown): string {
 }
 
 function formatCodexWarningMessage(event: WarningEvent): string | null {
-  if (typeof event.message === "string") {
-    const message = event.message.trim();
-    if (message) {
-      return message;
-    }
-  }
+  return formatCodexEventMessage(event.message, event.error);
+}
 
-  return formatCodexErrorMessage(event.error);
+function formatCodexEventMessage(
+  message: unknown,
+  error: unknown,
+): string | null {
+  return formatCodexString(message) ?? formatCodexErrorMessage(error);
+}
+
+function formatCodexString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  return value.trim() || null;
 }
 
 function formatCodexErrorMessage(error: unknown): string | null {

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -90,11 +90,9 @@ export class EventRenderer {
 
     switch (event.type) {
       case "init":
-        this.flush();
         this.renderInit(event, timestampPrefix);
         break;
       case "text":
-        this.flush();
         this.renderText(event, timestampPrefix);
         break;
       case "tool_use":
@@ -197,6 +195,11 @@ export class EventRenderer {
     const input = (event.data.input as Record<string, unknown>) || {};
     const toolUseData: ToolUseData = { tool, input };
 
+    if (!toolUseId) {
+      this.renderToolUseOnly(toolUseData, prefix);
+      return;
+    }
+
     // When buffered (default), store for later grouping
     // When not buffered, render immediately
     if (this.options.buffered !== false) {
@@ -238,6 +241,11 @@ export class EventRenderer {
     const toolUseId = String(event.data.toolUseId || "");
     const result = EventRenderer.formatDisplayValue(event.data.result);
     const isError = Boolean(event.data.isError);
+
+    if (!toolUseId) {
+      this.renderStandaloneToolResult({ result, isError }, prefix);
+      return;
+    }
 
     const pending = this.pendingToolUse.get(toolUseId);
 

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -90,9 +90,11 @@ export class EventRenderer {
 
     switch (event.type) {
       case "init":
+        this.flush();
         this.renderInit(event, timestampPrefix);
         break;
       case "text":
+        this.flush();
         this.renderText(event, timestampPrefix);
         break;
       case "tool_use":
@@ -102,9 +104,24 @@ export class EventRenderer {
         this.handleToolResult(event, timestampPrefix);
         break;
       case "result":
+        this.flush();
         this.renderResult(event, timestampPrefix);
         break;
     }
+  }
+
+  /**
+   * Render buffered tool uses that never received a matching result.
+   */
+  flush(): void {
+    if (this.pendingToolUse.size === 0) {
+      return;
+    }
+
+    for (const pending of this.pendingToolUse.values()) {
+      this.renderToolUseOnly(pending.toolUse, pending.prefix);
+    }
+    this.pendingToolUse.clear();
   }
 
   /**
@@ -219,7 +236,7 @@ export class EventRenderer {
    */
   private handleToolResult(event: ParsedEvent, prefix: string): void {
     const toolUseId = String(event.data.toolUseId || "");
-    const result = String(event.data.result || "");
+    const result = EventRenderer.formatDisplayValue(event.data.result);
     const isError = Boolean(event.data.isError);
 
     const pending = this.pendingToolUse.get(toolUseId);
@@ -228,8 +245,10 @@ export class EventRenderer {
       // Render grouped output
       this.renderGroupedTool(pending.toolUse, { result, isError }, prefix);
       this.pendingToolUse.delete(toolUseId);
+      return;
     }
-    // Skip orphan tool_results (no matching tool_use in buffer)
+
+    this.renderStandaloneToolResult({ result, isError }, prefix);
   }
 
   /**
@@ -270,6 +289,27 @@ export class EventRenderer {
       console.log(cont + line);
     }
     console.log(); // Empty line after each group
+    this.lastEventType = "tool";
+  }
+
+  private renderStandaloneToolResult(
+    result: ToolResultData,
+    prefix: string,
+  ): void {
+    if (this.lastEventType === "text") {
+      console.log();
+    }
+
+    const cont = this.getContinuationPrefix();
+    console.log(prefix + "● Tool result");
+    for (const line of formatToolResult(
+      { tool: "Tool result", input: {} },
+      result,
+      this.options.verbose ?? false,
+    )) {
+      console.log(cont + line);
+    }
+    console.log();
     this.lastEventType = "tool";
   }
 
@@ -366,5 +406,18 @@ export class EventRenderer {
       return String(value);
     }
     return null;
+  }
+
+  private static formatDisplayValue(value: unknown): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value === null || value === undefined) {
+      return "";
+    }
+    if (Array.isArray(value) || typeof value === "object") {
+      return JSON.stringify(value) ?? "";
+    }
+    return String(value);
   }
 }

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -90,6 +90,7 @@ export class EventRenderer {
 
     switch (event.type) {
       case "init":
+        this.flush();
         this.renderInit(event, timestampPrefix);
         break;
       case "text":
@@ -203,6 +204,10 @@ export class EventRenderer {
     // When buffered (default), store for later grouping
     // When not buffered, render immediately
     if (this.options.buffered !== false) {
+      const pending = this.pendingToolUse.get(toolUseId);
+      if (pending) {
+        this.renderToolUseOnly(pending.toolUse, pending.prefix);
+      }
       this.pendingToolUse.set(toolUseId, { toolUse: toolUseData, prefix });
     } else {
       // Non-buffered: render tool_use header immediately

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -312,6 +312,10 @@ export class EventRenderer {
       );
     } else {
       console.log(prefix + chalk.bold(`◆ ${this.frameworkDisplayName} Failed`));
+      const errorText = EventRenderer.formatResultMessage(event.data.result);
+      if (errorText) {
+        console.log(`  Error: ${chalk.red(errorText)}`);
+      }
     }
 
     const durationMs = Number(event.data.durationMs || 0);
@@ -352,5 +356,15 @@ export class EventRenderer {
     }
     // For "latest" or other formats, show as-is
     return version;
+  }
+
+  private static formatResultMessage(value: unknown): string | null {
+    if (typeof value === "string") {
+      return value.trim() || null;
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+    return null;
   }
 }

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -61,7 +61,7 @@ export class EventStreamNormalizer {
       return parsed ? [parsed] : [];
     }
 
-    const output = this.flush();
+    const output = parsed?.type === "result" ? this.flush() : [];
     if (parsed) {
       output.push(parsed);
     }

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -103,9 +103,12 @@ function getResultText(event: ParsedEvent | null): string | null {
 }
 
 function isGenericCodexFailureResult(result: string): boolean {
+  const normalized = result.toLowerCase();
   return (
-    result === "Turn failed" ||
-    result === "Unknown error" ||
-    result === "Codex error"
+    normalized === "error" ||
+    normalized === "turn failed" ||
+    normalized === "turn interrupted" ||
+    normalized === "unknown error" ||
+    normalized === "codex error"
   );
 }

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -67,7 +67,7 @@ export class EventStreamNormalizer {
       return this.processCodexTurnFailed(turnId, parsed);
     }
 
-    if (this.shouldFlushPendingCodexErrorBefore(eventType, turnId)) {
+    if (this.shouldFlushPendingCodexErrorBefore(turnId)) {
       const output = this.flush();
       if (parsed) {
         output.push(parsed);
@@ -115,13 +115,9 @@ export class EventStreamNormalizer {
     return output;
   }
 
-  private shouldFlushPendingCodexErrorBefore(
-    eventType: string | undefined,
-    turnId: string | null,
-  ): boolean {
+  private shouldFlushPendingCodexErrorBefore(turnId: string | null): boolean {
     return (
-      Boolean(this.pendingCodexError) &&
-      eventType === "turn.started" &&
+      Boolean(this.pendingCodexError?.turnId) &&
       Boolean(turnId) &&
       this.pendingCodexError?.turnId !== turnId
     );

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -20,7 +20,10 @@ function getEventType(
  * presentation fixes that require one-event lookahead.
  */
 export class EventStreamNormalizer {
-  private pendingCodexError: ParsedEvent | null = null;
+  private pendingCodexError: {
+    event: ParsedEvent;
+    turnId: string | null;
+  } | null = null;
 
   process(
     rawEvent: unknown,
@@ -30,35 +33,46 @@ export class EventStreamNormalizer {
     const isCodex = framework === "codex";
     const rawRecord = asRecord(rawEvent);
     const eventType = getEventType(rawRecord);
+    const turnId = getCodexTurnId(rawRecord);
     const parsed = rawRecord ? parseEvent(rawRecord, framework) : null;
     if (parsed && timestamp) {
       parsed.timestamp = timestamp;
     }
 
     if (!isCodex) {
+      return this.processNonCodexEvent(parsed);
+    }
+
+    return this.processCodexEvent(eventType, turnId, parsed);
+  }
+
+  private processNonCodexEvent(parsed: ParsedEvent | null): ParsedEvent[] {
+    const output = this.flush();
+    if (parsed) {
+      output.push(parsed);
+    }
+    return output;
+  }
+
+  private processCodexEvent(
+    eventType: string | undefined,
+    turnId: string | null,
+    parsed: ParsedEvent | null,
+  ): ParsedEvent[] {
+    if (eventType === "error" && parsed?.type === "result") {
+      return this.processCodexError(parsed, turnId);
+    }
+
+    if (eventType === "turn.failed") {
+      return this.processCodexTurnFailed(turnId, parsed);
+    }
+
+    if (this.shouldFlushPendingCodexErrorBefore(eventType, turnId)) {
       const output = this.flush();
       if (parsed) {
         output.push(parsed);
       }
       return output;
-    }
-
-    if (eventType === "error" && parsed?.type === "result") {
-      const output = this.flush();
-      this.pendingCodexError = parsed;
-      return output;
-    }
-
-    if (eventType === "turn.failed") {
-      const pendingCodexError = this.pendingCodexError;
-      this.pendingCodexError = null;
-      if (
-        pendingCodexError &&
-        shouldPreferPendingCodexError(pendingCodexError, parsed)
-      ) {
-        return [pendingCodexError];
-      }
-      return parsed ? [parsed] : [];
     }
 
     const output = parsed?.type === "result" ? this.flush() : [];
@@ -68,14 +82,88 @@ export class EventStreamNormalizer {
     return output;
   }
 
+  private processCodexError(
+    parsed: ParsedEvent,
+    turnId: string | null,
+  ): ParsedEvent[] {
+    const output = this.flush();
+    this.pendingCodexError = { event: parsed, turnId };
+    return output;
+  }
+
+  private processCodexTurnFailed(
+    turnId: string | null,
+    parsed: ParsedEvent | null,
+  ): ParsedEvent[] {
+    const pendingCodexError = this.pendingCodexError;
+    this.pendingCodexError = null;
+
+    if (
+      pendingCodexError &&
+      shouldPairCodexFailureEvents(pendingCodexError.turnId, turnId)
+    ) {
+      if (shouldPreferPendingCodexError(pendingCodexError.event, parsed)) {
+        return [pendingCodexError.event];
+      }
+      return parsed ? [parsed] : [];
+    }
+
+    const output = pendingCodexError ? [pendingCodexError.event] : [];
+    if (parsed) {
+      output.push(parsed);
+    }
+    return output;
+  }
+
+  private shouldFlushPendingCodexErrorBefore(
+    eventType: string | undefined,
+    turnId: string | null,
+  ): boolean {
+    return (
+      Boolean(this.pendingCodexError) &&
+      eventType === "turn.started" &&
+      Boolean(turnId) &&
+      this.pendingCodexError?.turnId !== turnId
+    );
+  }
+
   flush(): ParsedEvent[] {
     if (!this.pendingCodexError) {
       return [];
     }
-    const output = [this.pendingCodexError];
+    const output = [this.pendingCodexError.event];
     this.pendingCodexError = null;
     return output;
   }
+}
+
+function getCodexTurnId(
+  rawEvent: Record<string, unknown> | null,
+): string | null {
+  const topLevelTurnId = getTrimmedString(rawEvent?.turn_id);
+  if (topLevelTurnId) {
+    return topLevelTurnId;
+  }
+
+  const turn = asRecord(rawEvent?.turn);
+  return getTrimmedString(turn?.id);
+}
+
+function getTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  return value.trim() || null;
+}
+
+function shouldPairCodexFailureEvents(
+  pendingTurnId: string | null,
+  turnFailedTurnId: string | null,
+): boolean {
+  if (pendingTurnId && turnFailedTurnId) {
+    return pendingTurnId === turnFailedTurnId;
+  }
+  return true;
 }
 
 function shouldPreferPendingCodexError(

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -50,7 +50,14 @@ export class EventStreamNormalizer {
     }
 
     if (eventType === "turn.failed") {
+      const pendingCodexError = this.pendingCodexError;
       this.pendingCodexError = null;
+      if (
+        pendingCodexError &&
+        shouldPreferPendingCodexError(pendingCodexError, parsed)
+      ) {
+        return [pendingCodexError];
+      }
       return parsed ? [parsed] : [];
     }
 
@@ -69,4 +76,36 @@ export class EventStreamNormalizer {
     this.pendingCodexError = null;
     return output;
   }
+}
+
+function shouldPreferPendingCodexError(
+  pendingCodexError: ParsedEvent,
+  turnFailedEvent: ParsedEvent | null,
+): boolean {
+  const pendingResult = getResultText(pendingCodexError);
+  const turnFailedResult = getResultText(turnFailedEvent);
+  if (!turnFailedResult) {
+    return pendingResult !== null;
+  }
+  return (
+    pendingResult !== null &&
+    !isGenericCodexFailureResult(pendingResult) &&
+    isGenericCodexFailureResult(turnFailedResult)
+  );
+}
+
+function getResultText(event: ParsedEvent | null): string | null {
+  const result = event?.data.result;
+  if (typeof result !== "string") {
+    return null;
+  }
+  return result.trim() || null;
+}
+
+function isGenericCodexFailureResult(result: string): boolean {
+  return (
+    result === "Turn failed" ||
+    result === "Unknown error" ||
+    result === "Codex error"
+  );
 }

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1133,6 +1133,15 @@ function codexFallbackActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 8,
+      eventType: "turn.failed",
+      eventData: {
+        type: "turn.failed",
+        message: "Codex failed with message-only detail.",
+      },
+      createdAt: "2026-03-10T15:30:09Z",
+    },
+    {
+      sequenceNumber: 9,
       eventType: "error",
       eventData: {
         type: "error",
@@ -1141,7 +1150,7 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           additional_details: "stdio closed",
         },
       },
-      createdAt: "2026-03-10T15:30:09Z",
+      createdAt: "2026-03-10T15:30:10Z",
     },
   ];
 }
@@ -2303,6 +2312,9 @@ describe("activity detail polling", () => {
     expect(screen.getByText("File read completed")).toBeInTheDocument();
     expect(
       screen.getByText("Codex build failed before retry. (quota exhausted)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Codex failed with message-only detail."),
     ).toBeInTheDocument();
     expect(
       screen.getAllByText("Codex stream disconnected. (stdio closed)"),

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -805,7 +805,8 @@ function codexActivityEvents(): AgentEvent[] {
         item: {
           id: "cmd-1",
           type: "command_execution",
-          exit_code: 1,
+          status: "failed",
+          exit_code: 0,
           aggregated_output:
             "billing worker failed\nstack line 1\nstack line 2\nstack line 3\nstack line 4",
         },

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1207,9 +1207,12 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
-        error: {
-          message: "Codex build failed before retry.",
-          additionalDetails: "quota exhausted",
+        error: "Turn failed",
+        turn: {
+          error: {
+            message: "Codex build failed before retry.",
+            additionalDetails: "quota exhausted",
+          },
         },
         usage: {
           input_tokens: 10,

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1179,8 +1179,9 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventData: {
         type: "item.started",
         item: {
-          type: "command_execution",
-          command: "echo missing-id",
+          id: "write-failed",
+          type: "file_write",
+          path: "src/problem.ts",
         },
       },
       createdAt: "2026-03-10T15:30:08Z",
@@ -1191,9 +1192,10 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventData: {
         type: "item.completed",
         item: {
-          type: "command_execution",
-          aggregated_output: "missing id output",
-          exit_code: 0,
+          id: "write-failed",
+          type: "file_write",
+          status: "failed",
+          output: "write failed: stale generation",
         },
       },
       createdAt: "2026-03-10T15:30:09Z",
@@ -1204,15 +1206,67 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventData: {
         type: "item.started",
         item: {
-          id: " ",
+          id: "read-declined",
           type: "file_read",
-          path: "src/blank-id.ts",
+          path: "src/private.ts",
         },
       },
       createdAt: "2026-03-10T15:30:10Z",
     },
     {
       sequenceNumber: 10,
+      eventType: "item.completed",
+      eventData: {
+        type: "item.completed",
+        item: {
+          id: "read-declined",
+          type: "file_read",
+          status: "declined",
+          output: "read declined by policy",
+        },
+      },
+      createdAt: "2026-03-10T15:30:11Z",
+    },
+    {
+      sequenceNumber: 11,
+      eventType: "item.started",
+      eventData: {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          command: "echo missing-id",
+        },
+      },
+      createdAt: "2026-03-10T15:30:12Z",
+    },
+    {
+      sequenceNumber: 12,
+      eventType: "item.completed",
+      eventData: {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          aggregated_output: "missing id output",
+          exit_code: 0,
+        },
+      },
+      createdAt: "2026-03-10T15:30:13Z",
+    },
+    {
+      sequenceNumber: 13,
+      eventType: "item.started",
+      eventData: {
+        type: "item.started",
+        item: {
+          id: " ",
+          type: "file_read",
+          path: "src/blank-id.ts",
+        },
+      },
+      createdAt: "2026-03-10T15:30:14Z",
+    },
+    {
+      sequenceNumber: 14,
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
@@ -1228,19 +1282,19 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           output_tokens: 2,
         },
       },
-      createdAt: "2026-03-10T15:30:11Z",
+      createdAt: "2026-03-10T15:30:15Z",
     },
     {
-      sequenceNumber: 11,
+      sequenceNumber: 15,
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
         message: "Codex failed with message-only detail.",
       },
-      createdAt: "2026-03-10T15:30:12Z",
+      createdAt: "2026-03-10T15:30:16Z",
     },
     {
-      sequenceNumber: 12,
+      sequenceNumber: 16,
       eventType: "error",
       eventData: {
         type: "error",
@@ -1250,10 +1304,10 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           additional_details: "stdio closed",
         },
       },
-      createdAt: "2026-03-10T15:30:13Z",
+      createdAt: "2026-03-10T15:30:17Z",
     },
     {
-      sequenceNumber: 13,
+      sequenceNumber: 17,
       eventType: "error",
       eventData: {
         type: "error",
@@ -1263,47 +1317,47 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           additional_details: "refresh token expired",
         },
       },
-      createdAt: "2026-03-10T15:30:14Z",
+      createdAt: "2026-03-10T15:30:18Z",
     },
     {
-      sequenceNumber: 14,
+      sequenceNumber: 18,
       eventType: "error",
       eventData: {
         type: "error",
         message: "API connection failed",
       },
-      createdAt: "2026-03-10T15:30:15Z",
+      createdAt: "2026-03-10T15:30:19Z",
     },
     {
-      sequenceNumber: 15,
+      sequenceNumber: 19,
       eventType: "warning",
       eventData: {
         type: "warning",
         message: "cleanup in progress",
       },
-      createdAt: "2026-03-10T15:30:16Z",
+      createdAt: "2026-03-10T15:30:20Z",
     },
     {
-      sequenceNumber: 16,
+      sequenceNumber: 20,
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
         error: "Rate limit exceeded",
       },
-      createdAt: "2026-03-10T15:30:17Z",
+      createdAt: "2026-03-10T15:30:21Z",
     },
     {
-      sequenceNumber: 17,
+      sequenceNumber: 21,
       eventType: "error",
       eventData: {
         type: "error",
         turn_id: "turn-a",
         message: "Previous turn lost connection",
       },
-      createdAt: "2026-03-10T15:30:18Z",
+      createdAt: "2026-03-10T15:30:22Z",
     },
     {
-      sequenceNumber: 18,
+      sequenceNumber: 22,
       eventType: "item.completed",
       eventData: {
         type: "item.completed",
@@ -1314,17 +1368,17 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           text: "New turn started work",
         },
       },
-      createdAt: "2026-03-10T15:30:19Z",
+      createdAt: "2026-03-10T15:30:23Z",
     },
     {
-      sequenceNumber: 19,
+      sequenceNumber: 23,
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
         turn: { id: "turn-b" },
         error: "New turn quota failed",
       },
-      createdAt: "2026-03-10T15:30:20Z",
+      createdAt: "2026-03-10T15:30:24Z",
     },
   ];
 }
@@ -2505,6 +2559,12 @@ describe("activity detail polling", () => {
     expect(screen.getAllByText("Read")).not.toHaveLength(0);
     expect(screen.getByText("src/edge.ts")).toBeInTheDocument();
     expect(screen.getByText("File read completed")).toBeInTheDocument();
+    expect(screen.getByText("src/problem.ts")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("write failed: stale generation"),
+    ).not.toHaveLength(0);
+    expect(screen.getByText("src/private.ts")).toBeInTheDocument();
+    expect(screen.getAllByText("read declined by policy")).not.toHaveLength(0);
     expect(screen.queryByText("echo missing-id")).not.toBeInTheDocument();
     expect(screen.queryByText("missing id output")).not.toBeInTheDocument();
     expect(screen.queryByText("src/blank-id.ts")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -924,6 +924,16 @@ function codexActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 14,
+      eventType: "warning",
+      eventData: {
+        type: "warning",
+        message: "temporary stream disconnect",
+        will_retry: true,
+      },
+      createdAt: "2026-03-10T15:00:15Z",
+    },
+    {
+      sequenceNumber: 15,
       eventType: "turn.completed",
       eventData: {
         type: "turn.completed",
@@ -934,7 +944,7 @@ function codexActivityEvents(): AgentEvent[] {
           reasoning_output_tokens: 4,
         },
       },
-      createdAt: "2026-03-10T15:00:15Z",
+      createdAt: "2026-03-10T15:00:16Z",
     },
   ];
 }
@@ -1877,6 +1887,9 @@ describe("activity detail polling", () => {
     expect(screen.getByText("[completed] Inspect logs")).toBeInTheDocument();
     expect(screen.getByText("[in progress] Patch retry")).toBeInTheDocument();
     expect(screen.getByText("[pending] Run tests")).toBeInTheDocument();
+    expect(
+      screen.getByText("[warning] temporary stream disconnect"),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Bash")).not.toHaveLength(0);
     expect(
       screen.getAllByText("pnpm test --filter billing-worker"),

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1295,10 +1295,15 @@ function codexFallbackActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 18,
-      eventType: "turn.started",
+      eventType: "item.completed",
       eventData: {
-        type: "turn.started",
-        turn: { id: "turn-b" },
+        type: "item.completed",
+        turn_id: "turn-b",
+        item: {
+          id: "msg-b",
+          type: "agent_message",
+          text: "New turn started work",
+        },
       },
       createdAt: "2026-03-10T15:30:19Z",
     },
@@ -2511,6 +2516,14 @@ describe("activity detail polling", () => {
     expect(
       screen.getByText("Previous turn lost connection"),
     ).toBeInTheDocument();
+    const previousTurnFailure = screen.getByText(
+      "Previous turn lost connection",
+    );
+    const newTurnMessage = screen.getByText("New turn started work");
+    expect(
+      previousTurnFailure.compareDocumentPosition(newTurnMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.getByText("New turn quota failed")).toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -173,6 +173,67 @@ function detailedActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 7,
+      eventType: "assistant",
+      eventData: {
+        message: {
+          content: {
+            type: "text",
+            text: "malformed assistant text should be ignored",
+          },
+        },
+      },
+      createdAt: "2026-03-10T14:56:07.100Z",
+    },
+    {
+      sequenceNumber: 8,
+      eventType: "assistant",
+      eventData: {
+        message: {
+          content: [
+            null,
+            "invalid content block",
+            {
+              type: "tool_use",
+              id: "malformed-tool-without-name",
+              input: { command: "should not render missing name" },
+            },
+            {
+              type: "tool_use",
+              name: "Bash",
+              input: { command: "should not render missing id" },
+            },
+            {
+              type: "tool_use",
+              id: "tool-string-input",
+              name: "Bash",
+              input: "not an object",
+            },
+            {
+              type: "text",
+              text: "Malformed content did not break grouping.",
+            },
+          ],
+        },
+      },
+      createdAt: "2026-03-10T14:56:07.200Z",
+    },
+    {
+      sequenceNumber: 9,
+      eventType: "user",
+      eventData: {
+        message: {
+          content: {
+            type: "tool_result",
+            tool_use_id: "tool-string-input",
+            content: "bad non-array result should be ignored",
+            is_error: false,
+          },
+        },
+      },
+      createdAt: "2026-03-10T14:56:07.300Z",
+    },
+    {
+      sequenceNumber: 10,
       eventType: "result",
       eventData: {
         type: "result",
@@ -1367,6 +1428,18 @@ describe("activity detail polling", () => {
     expect(
       screen.getByText("I will inspect the checkout failure."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Malformed content did not break grouping."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("malformed assistant text should be ignored"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("should not render missing name"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("bad non-array result should be ignored"),
+    ).not.toBeInTheDocument();
     expect(screen.getAllByText("Bash")).not.toHaveLength(0);
     expect(
       screen.getAllByText("pnpm test -- --filter checkout"),

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -248,6 +248,14 @@ function detailedActivityEvents(): AgentEvent[] {
               content: "second orphan tool result without id",
               is_error: false,
             },
+            {
+              type: "tool_result",
+              content: {
+                status: "ok",
+                count: 2,
+              },
+              is_error: false,
+            },
           ],
         },
       },
@@ -1482,6 +1490,8 @@ describe("activity detail polling", () => {
     expect(
       screen.getByText("second orphan tool result without id"),
     ).toBeInTheDocument();
+    expect(screen.getByText('{"status":"ok","count":2}')).toBeInTheDocument();
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
     expect(screen.getAllByText("Bash")).not.toHaveLength(0);
     expect(
       screen.getAllByText("pnpm test -- --filter checkout"),

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1245,7 +1245,7 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventType: "error",
       eventData: {
         type: "error",
-        message: "unknown error",
+        message: "turn interrupted",
         error: {
           message: "Codex auth failed.",
           additional_details: "refresh token expired",

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -234,6 +234,27 @@ function detailedActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 10,
+      eventType: "user",
+      eventData: {
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              content: "first orphan tool result without id",
+              is_error: false,
+            },
+            {
+              type: "tool_result",
+              content: "second orphan tool result without id",
+              is_error: false,
+            },
+          ],
+        },
+      },
+      createdAt: "2026-03-10T14:56:07.400Z",
+    },
+    {
+      sequenceNumber: 11,
       eventType: "result",
       eventData: {
         type: "result",
@@ -1440,6 +1461,12 @@ describe("activity detail polling", () => {
     expect(
       screen.queryByText("bad non-array result should be ignored"),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("first orphan tool result without id"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("second orphan tool result without id"),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Bash")).not.toHaveLength(0);
     expect(
       screen.getAllByText("pnpm test -- --filter checkout"),

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1380,6 +1380,20 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       },
       createdAt: "2026-03-10T15:30:24Z",
     },
+    {
+      sequenceNumber: 24,
+      eventType: "item.completed",
+      eventData: {
+        type: "item.completed",
+        item: {
+          id: "files-failed",
+          type: "file_change",
+          status: "failed",
+          changes: [],
+        },
+      },
+      createdAt: "2026-03-10T15:30:25Z",
+    },
   ];
 }
 
@@ -2553,6 +2567,7 @@ describe("activity detail polling", () => {
     expect(screen.getByText("Codex item.completed")).toBeInTheDocument();
     expect(screen.getByText(/Codex agent_message/u)).toBeInTheDocument();
     expect(screen.getByText("[files] Files changed")).toBeInTheDocument();
+    expect(screen.getByText("[files] File changes failed")).toBeInTheDocument();
     expect(screen.getAllByText("Write")).not.toHaveLength(0);
     expect(screen.getByText("src/generated.ts")).toBeInTheDocument();
     expect(screen.getByText("File operation completed")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1232,12 +1232,26 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventType: "error",
       eventData: {
         type: "error",
+        message: "Codex stream disconnected.",
         error: {
           message: "Codex stream disconnected.",
           additional_details: "stdio closed",
         },
       },
       createdAt: "2026-03-10T15:30:13Z",
+    },
+    {
+      sequenceNumber: 13,
+      eventType: "error",
+      eventData: {
+        type: "error",
+        message: "unknown error",
+        error: {
+          message: "Codex auth failed.",
+          additional_details: "refresh token expired",
+        },
+      },
+      createdAt: "2026-03-10T15:30:14Z",
     },
   ];
 }
@@ -2426,6 +2440,9 @@ describe("activity detail polling", () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByText("Codex stream disconnected. (stdio closed)"),
+    ).not.toHaveLength(0);
+    expect(
+      screen.getAllByText("Codex auth failed. (refresh token expired)"),
     ).not.toHaveLength(0);
   });
 

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { logsByIdContract } from "@vm0/api-contracts/contracts/logs";
 import type { NetworkLogEntry } from "@vm0/api-contracts/contracts/runs";
 import {
@@ -638,7 +638,18 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
               type: "tool_use",
               id: "tool-empty-todos",
               name: "TodoWrite",
-              input: { todos: "not an array" },
+              input: {
+                todos: [
+                  {
+                    content: { value: "object todo content" },
+                    status: { value: "object todo status" },
+                  },
+                  {
+                    content: "Recover release queue",
+                    status: "in_progress",
+                  },
+                ],
+              },
             },
           ],
         },
@@ -658,14 +669,15 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 7,
-      eventType: "assistant",
+      eventType: "user",
       eventData: {
         parent_tool_use_id: "tool-child-task",
         message: {
           content: [
             {
-              type: "text",
-              text: "Child task found one risky deployment.",
+              type: "tool_result",
+              content: "early child orphan result",
+              is_error: false,
             },
           ],
         },
@@ -680,10 +692,8 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
         message: {
           content: [
             {
-              type: "tool_use",
-              id: "tool-child-bash",
-              name: "Bash",
-              input: { command: "zero deploy status --json" },
+              type: "text",
+              text: "Child task found one risky deployment.",
             },
           ],
         },
@@ -692,6 +702,24 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 9,
+      eventType: "assistant",
+      eventData: {
+        parent_tool_use_id: "tool-child-task",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-child-bash",
+              name: "Bash",
+              input: { command: "zero deploy status --json" },
+            },
+          ],
+        },
+      },
+      createdAt: "2026-03-10T17:00:10Z",
+    },
+    {
+      sequenceNumber: 10,
       eventType: "user",
       eventData: {
         parent_tool_use_id: "tool-child-task",
@@ -706,10 +734,10 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
           ],
         },
       },
-      createdAt: "2026-03-10T17:00:10Z",
+      createdAt: "2026-03-10T17:00:11Z",
     },
     {
-      sequenceNumber: 10,
+      sequenceNumber: 11,
       eventType: "result",
       eventData: {
         type: "result",
@@ -718,7 +746,7 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
         num_turns: 1,
         duration_ms: 1000,
       },
-      createdAt: "2026-03-10T17:00:11Z",
+      createdAt: "2026-03-10T17:00:12Z",
     },
   ];
 }
@@ -1676,11 +1704,24 @@ describe("activity detail polling", () => {
       screen.getAllByText(/Ask release assistant to verify the deployment/u),
     ).not.toHaveLength(0);
     expect(
+      screen.getByText('{"value":"object todo content"}'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Recover release queue")).not.toHaveLength(0);
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+    expect(
       screen.getByText(
         "Collect incident channel status and deployment owner notes",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Inspect release child task")).toBeInTheDocument();
+    const childTaskDetails = screen
+      .getByText("Inspect release child task")
+      .closest("details");
+    expect(childTaskDetails).not.toBeNull();
+    if (childTaskDetails) {
+      expect(
+        within(childTaskDetails).getByText("early child orphan result"),
+      ).toBeInTheDocument();
+    }
     expect(
       screen.getByText("Child task found one risky deployment."),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1120,7 +1120,10 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
-        error: "Codex build failed before retry.",
+        error: {
+          message: "Codex build failed before retry.",
+          additionalDetails: "quota exhausted",
+        },
         usage: {
           input_tokens: 10,
           output_tokens: 2,
@@ -1133,7 +1136,10 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       eventType: "error",
       eventData: {
         type: "error",
-        message: "Codex stream disconnected.",
+        error: {
+          message: "Codex stream disconnected.",
+          additional_details: "stdio closed",
+        },
       },
       createdAt: "2026-03-10T15:30:09Z",
     },
@@ -2296,11 +2302,11 @@ describe("activity detail polling", () => {
     expect(screen.getByText("src/edge.ts")).toBeInTheDocument();
     expect(screen.getByText("File read completed")).toBeInTheDocument();
     expect(
-      screen.getByText("Codex build failed before retry."),
+      screen.getByText("Codex build failed before retry. (quota exhausted)"),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("Codex stream disconnected.")).not.toHaveLength(
-      0,
-    );
+    expect(
+      screen.getAllByText("Codex stream disconnected. (stdio closed)"),
+    ).not.toHaveLength(0);
   });
 
   it("shows a not-found state for an inaccessible activity", async () => {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -651,6 +651,19 @@ function edgeGroupedActivityEvents(): AgentEvent[] {
                 ],
               },
             },
+            {
+              type: "tool_use",
+              id: "tool-second-todos",
+              name: "TodoWrite",
+              input: {
+                todos: [
+                  {
+                    content: "Queue release owner approval",
+                    status: "pending",
+                  },
+                ],
+              },
+            },
           ],
         },
       },
@@ -1153,6 +1166,44 @@ function codexFallbackActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 7,
+      eventType: "item.started",
+      eventData: {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          command: "echo missing-id",
+        },
+      },
+      createdAt: "2026-03-10T15:30:08Z",
+    },
+    {
+      sequenceNumber: 8,
+      eventType: "item.completed",
+      eventData: {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          aggregated_output: "missing id output",
+          exit_code: 0,
+        },
+      },
+      createdAt: "2026-03-10T15:30:09Z",
+    },
+    {
+      sequenceNumber: 9,
+      eventType: "item.started",
+      eventData: {
+        type: "item.started",
+        item: {
+          id: " ",
+          type: "file_read",
+          path: "src/blank-id.ts",
+        },
+      },
+      createdAt: "2026-03-10T15:30:10Z",
+    },
+    {
+      sequenceNumber: 10,
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
@@ -1165,19 +1216,19 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           output_tokens: 2,
         },
       },
-      createdAt: "2026-03-10T15:30:08Z",
+      createdAt: "2026-03-10T15:30:11Z",
     },
     {
-      sequenceNumber: 8,
+      sequenceNumber: 11,
       eventType: "turn.failed",
       eventData: {
         type: "turn.failed",
         message: "Codex failed with message-only detail.",
       },
-      createdAt: "2026-03-10T15:30:09Z",
+      createdAt: "2026-03-10T15:30:12Z",
     },
     {
-      sequenceNumber: 9,
+      sequenceNumber: 12,
       eventType: "error",
       eventData: {
         type: "error",
@@ -1186,7 +1237,7 @@ function codexFallbackActivityEvents(): AgentEvent[] {
           additional_details: "stdio closed",
         },
       },
-      createdAt: "2026-03-10T15:30:10Z",
+      createdAt: "2026-03-10T15:30:13Z",
     },
   ];
 }
@@ -1704,9 +1755,12 @@ describe("activity detail polling", () => {
       screen.getAllByText(/Ask release assistant to verify the deployment/u),
     ).not.toHaveLength(0);
     expect(
-      screen.getByText('{"value":"object todo content"}'),
-    ).toBeInTheDocument();
+      screen.getAllByText('{"value":"object todo content"}'),
+    ).not.toHaveLength(0);
     expect(screen.getAllByText("Recover release queue")).not.toHaveLength(0);
+    expect(
+      screen.getAllByText("Queue release owner approval"),
+    ).not.toHaveLength(0);
     expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
     expect(
       screen.getByText(
@@ -2361,6 +2415,9 @@ describe("activity detail polling", () => {
     expect(screen.getAllByText("Read")).not.toHaveLength(0);
     expect(screen.getByText("src/edge.ts")).toBeInTheDocument();
     expect(screen.getByText("File read completed")).toBeInTheDocument();
+    expect(screen.queryByText("echo missing-id")).not.toBeInTheDocument();
+    expect(screen.queryByText("missing id output")).not.toBeInTheDocument();
+    expect(screen.queryByText("src/blank-id.ts")).not.toBeInTheDocument();
     expect(
       screen.getByText("Codex build failed before retry. (quota exhausted)"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -786,6 +786,19 @@ function codexActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 4,
+      eventType: "item.completed",
+      eventData: {
+        type: "item.completed",
+        item: {
+          id: "plan-1",
+          type: "plan",
+          text: "1. Inspect logs\n2. Patch retry",
+        },
+      },
+      createdAt: "2026-03-10T15:00:05Z",
+    },
+    {
+      sequenceNumber: 5,
       eventType: "item.started",
       eventData: {
         type: "item.started",
@@ -795,10 +808,10 @@ function codexActivityEvents(): AgentEvent[] {
           command: "pnpm test --filter billing-worker",
         },
       },
-      createdAt: "2026-03-10T15:00:05Z",
+      createdAt: "2026-03-10T15:00:06Z",
     },
     {
-      sequenceNumber: 5,
+      sequenceNumber: 6,
       eventType: "item.completed",
       eventData: {
         type: "item.completed",
@@ -811,10 +824,10 @@ function codexActivityEvents(): AgentEvent[] {
             "billing worker failed\nstack line 1\nstack line 2\nstack line 3\nstack line 4",
         },
       },
-      createdAt: "2026-03-10T15:00:06Z",
+      createdAt: "2026-03-10T15:00:07Z",
     },
     {
-      sequenceNumber: 6,
+      sequenceNumber: 7,
       eventType: "item.started",
       eventData: {
         type: "item.started",
@@ -824,10 +837,10 @@ function codexActivityEvents(): AgentEvent[] {
           path: "src/billing/worker.ts",
         },
       },
-      createdAt: "2026-03-10T15:00:07Z",
+      createdAt: "2026-03-10T15:00:08Z",
     },
     {
-      sequenceNumber: 7,
+      sequenceNumber: 8,
       eventType: "item.completed",
       eventData: {
         type: "item.completed",
@@ -837,10 +850,10 @@ function codexActivityEvents(): AgentEvent[] {
           output: "export const worker = true;",
         },
       },
-      createdAt: "2026-03-10T15:00:08Z",
+      createdAt: "2026-03-10T15:00:09Z",
     },
     {
-      sequenceNumber: 8,
+      sequenceNumber: 9,
       eventType: "item.started",
       eventData: {
         type: "item.started",
@@ -850,10 +863,10 @@ function codexActivityEvents(): AgentEvent[] {
           path: "src/billing/worker.ts",
         },
       },
-      createdAt: "2026-03-10T15:00:09Z",
+      createdAt: "2026-03-10T15:00:10Z",
     },
     {
-      sequenceNumber: 9,
+      sequenceNumber: 10,
       eventType: "item.completed",
       eventData: {
         type: "item.completed",
@@ -863,10 +876,10 @@ function codexActivityEvents(): AgentEvent[] {
           diff: "- old retry\n+ new retry",
         },
       },
-      createdAt: "2026-03-10T15:00:10Z",
+      createdAt: "2026-03-10T15:00:11Z",
     },
     {
-      sequenceNumber: 10,
+      sequenceNumber: 11,
       eventType: "item.completed",
       eventData: {
         type: "item.completed",
@@ -879,10 +892,10 @@ function codexActivityEvents(): AgentEvent[] {
           ],
         },
       },
-      createdAt: "2026-03-10T15:00:11Z",
+      createdAt: "2026-03-10T15:00:12Z",
     },
     {
-      sequenceNumber: 11,
+      sequenceNumber: 12,
       eventType: "item.completed",
       eventData: {
         type: "item.completed",
@@ -893,10 +906,10 @@ function codexActivityEvents(): AgentEvent[] {
           title: "Unknown codex item surfaced",
         },
       },
-      createdAt: "2026-03-10T15:00:12Z",
+      createdAt: "2026-03-10T15:00:13Z",
     },
     {
-      sequenceNumber: 12,
+      sequenceNumber: 13,
       eventType: "turn.completed",
       eventData: {
         type: "turn.completed",
@@ -907,7 +920,7 @@ function codexActivityEvents(): AgentEvent[] {
           reasoning_output_tokens: 4,
         },
       },
-      createdAt: "2026-03-10T15:00:13Z",
+      createdAt: "2026-03-10T15:00:14Z",
     },
   ];
 }
@@ -1836,6 +1849,15 @@ describe("activity detail polling", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText("[thinking] Follow the failed retry through the logs."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => {
+        return (
+          element?.tagName.toLowerCase() === "p" &&
+          element?.textContent?.includes("[plan] 1. Inspect logs") === true &&
+          element.textContent.includes("2. Patch retry")
+        );
+      }),
     ).toBeInTheDocument();
     expect(screen.getAllByText("Bash")).not.toHaveLength(0);
     expect(

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1283,6 +1283,35 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       },
       createdAt: "2026-03-10T15:30:17Z",
     },
+    {
+      sequenceNumber: 17,
+      eventType: "error",
+      eventData: {
+        type: "error",
+        turn_id: "turn-a",
+        message: "Previous turn lost connection",
+      },
+      createdAt: "2026-03-10T15:30:18Z",
+    },
+    {
+      sequenceNumber: 18,
+      eventType: "turn.started",
+      eventData: {
+        type: "turn.started",
+        turn: { id: "turn-b" },
+      },
+      createdAt: "2026-03-10T15:30:19Z",
+    },
+    {
+      sequenceNumber: 19,
+      eventType: "turn.failed",
+      eventData: {
+        type: "turn.failed",
+        turn: { id: "turn-b" },
+        error: "New turn quota failed",
+      },
+      createdAt: "2026-03-10T15:30:20Z",
+    },
   ];
 }
 
@@ -2479,6 +2508,10 @@ describe("activity detail polling", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Rate limit exceeded")).toBeInTheDocument();
     expect(screen.queryByText("API connection failed")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Previous turn lost connection"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("New turn quota failed")).toBeInTheDocument();
   });
 
   it("shows a not-found state for an inaccessible activity", async () => {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -521,6 +521,15 @@ function complexGroupedActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 12,
+      eventType: "error",
+      eventData: {
+        type: "error",
+        message: "Non-Codex raw error should not render as Codex",
+      },
+      createdAt: "2026-03-10T16:00:12Z",
+    },
+    {
+      sequenceNumber: 13,
       eventType: "result",
       eventData: {
         type: "result",
@@ -1781,6 +1790,9 @@ describe("activity detail polling", () => {
     expect(
       screen.getByText("Release automation still needs a deploy token."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Non-Codex raw error should not render as Codex"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows edge-shaped grouped steps", async () => {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -1256,6 +1256,33 @@ function codexFallbackActivityEvents(): AgentEvent[] {
       },
       createdAt: "2026-03-10T15:30:14Z",
     },
+    {
+      sequenceNumber: 14,
+      eventType: "error",
+      eventData: {
+        type: "error",
+        message: "API connection failed",
+      },
+      createdAt: "2026-03-10T15:30:15Z",
+    },
+    {
+      sequenceNumber: 15,
+      eventType: "warning",
+      eventData: {
+        type: "warning",
+        message: "cleanup in progress",
+      },
+      createdAt: "2026-03-10T15:30:16Z",
+    },
+    {
+      sequenceNumber: 16,
+      eventType: "turn.failed",
+      eventData: {
+        type: "turn.failed",
+        error: "Rate limit exceeded",
+      },
+      createdAt: "2026-03-10T15:30:17Z",
+    },
   ];
 }
 
@@ -2447,6 +2474,11 @@ describe("activity detail polling", () => {
     expect(
       screen.getAllByText("Codex auth failed. (refresh token expired)"),
     ).not.toHaveLength(0);
+    expect(
+      screen.getByText("[warning] cleanup in progress"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Rate limit exceeded")).toBeInTheDocument();
+    expect(screen.queryByText("API connection failed")).not.toBeInTheDocument();
   });
 
   it("shows a not-found state for an inaccessible activity", async () => {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-polling.test.tsx
@@ -910,6 +910,20 @@ function codexActivityEvents(): AgentEvent[] {
     },
     {
       sequenceNumber: 13,
+      eventType: "turn.plan.updated",
+      eventData: {
+        type: "turn.plan.updated",
+        explanation: "Current plan",
+        plan: [
+          { step: "Inspect logs", status: "completed" },
+          { step: "Patch retry", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
+      },
+      createdAt: "2026-03-10T15:00:14Z",
+    },
+    {
+      sequenceNumber: 14,
       eventType: "turn.completed",
       eventData: {
         type: "turn.completed",
@@ -920,7 +934,7 @@ function codexActivityEvents(): AgentEvent[] {
           reasoning_output_tokens: 4,
         },
       },
-      createdAt: "2026-03-10T15:00:14Z",
+      createdAt: "2026-03-10T15:00:15Z",
     },
   ];
 }
@@ -1859,6 +1873,10 @@ describe("activity detail polling", () => {
         );
       }),
     ).toBeInTheDocument();
+    expect(screen.getByText("[plan] Current plan")).toBeInTheDocument();
+    expect(screen.getByText("[completed] Inspect logs")).toBeInTheDocument();
+    expect(screen.getByText("[in progress] Patch retry")).toBeInTheDocument();
+    expect(screen.getByText("[pending] Run tests")).toBeInTheDocument();
     expect(screen.getAllByText("Bash")).not.toHaveLength(0);
     expect(
       screen.getAllByText("pnpm test --filter billing-worker"),

--- a/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
+++ b/turbo/apps/platform/src/views/activity-page/activity-inspect-page.tsx
@@ -130,12 +130,12 @@ function StepsTab({
 }) {
   const stepSearch = useGet(inspectStepSearch$);
   const setStepSearch = useSet(setInspectStepSearch$);
-  const { events, prompt, appendSystemPrompt } = prepared;
+  const { detail, events, prompt, appendSystemPrompt } = prepared;
   const showSystemPrompt = appendSystemPrompt.trim().length > 0;
 
-  const allMessages = groupEventsIntoMessages(events);
+  const allMessages = groupEventsIntoMessages(events, detail.framework);
   const visibleMessages = allMessages.filter((message, index) => {
-    return isVisibleMessage(message, allMessages[index + 1]);
+    return isVisibleMessage(message, allMessages[index + 1], detail.framework);
   });
   const messages = visibleMessages.filter((m) => {
     return groupedMessageMatchesSearch(m, stepSearch.trim());

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -217,7 +217,24 @@ function formatCodexEventMessage(
   message: unknown,
   error: unknown,
 ): string | undefined {
-  return formatCodexString(message) ?? formatCodexErrorMessage(error);
+  const messageText = formatCodexString(message);
+  const errorText = formatCodexErrorMessage(error);
+
+  if (!messageText) {
+    return errorText;
+  }
+  if (!errorText) {
+    return messageText;
+  }
+  if (
+    errorText === messageText ||
+    errorText.startsWith(`${messageText} (`) ||
+    isGenericCodexFailureMessage(messageText)
+  ) {
+    return errorText;
+  }
+
+  return messageText;
 }
 
 function formatCodexString(value: unknown): string | undefined {
@@ -245,6 +262,16 @@ function formatCodexErrorMessage(error: unknown): string | undefined {
   }
 
   return message || details || undefined;
+}
+
+function isGenericCodexFailureMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized === "turn failed" ||
+    normalized === "unknown error" ||
+    normalized === "codex error" ||
+    normalized === "error"
+  );
 }
 
 function parseCodexUsage(value: unknown): CodexUsage | undefined {
@@ -625,7 +652,9 @@ function normalizeCodexErrorEvent(
   return makeCodexResultEvent({
     event,
     success: false,
-    result: codexEvent?.message ?? codexEvent?.error ?? "Codex error",
+    result:
+      formatCodexEventMessage(codexEvent?.message, codexEvent?.error) ??
+      "Codex error",
     usage: codexEvent?.usage,
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -203,6 +203,40 @@ function getNumberField(
   return typeof value === "number" ? value : undefined;
 }
 
+function formatCodexEventMessage(
+  message: unknown,
+  error: unknown,
+): string | undefined {
+  return formatCodexString(message) ?? formatCodexErrorMessage(error);
+}
+
+function formatCodexString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return value.trim() || undefined;
+}
+
+function formatCodexErrorMessage(error: unknown): string | undefined {
+  if (typeof error === "string") {
+    return error.trim() || undefined;
+  }
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  const message = getStringField(error, "message")?.trim();
+  const details =
+    getStringField(error, "additional_details")?.trim() ??
+    getStringField(error, "additionalDetails")?.trim();
+
+  if (message && details) {
+    return `${message} (${details})`;
+  }
+
+  return message || details || undefined;
+}
+
 function parseCodexUsage(value: unknown): CodexUsage | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -279,8 +313,8 @@ function parseCodexEventData(value: unknown): CodexEventData | undefined {
     plan: parseCodexPlanSteps(value.plan),
     usage: parseCodexUsage(value.usage),
     item: parseCodexItem(value.item),
-    error: getStringField(value, "error"),
-    message: getStringField(value, "message"),
+    error: formatCodexErrorMessage(value.error),
+    message: formatCodexString(value.message),
   };
 }
 
@@ -450,12 +484,9 @@ function formatCodexPlanUpdate(
 function formatCodexWarningMessage(
   codexEvent: CodexEventData | undefined,
 ): string | null {
-  const message = codexEvent?.message?.trim();
-  if (message) {
-    return message;
-  }
-
-  return codexEvent?.error?.trim() || null;
+  return (
+    formatCodexEventMessage(codexEvent?.message, codexEvent?.error) ?? null
+  );
 }
 
 function formatCodexPlanStatus(status: string | undefined): string {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -190,6 +190,7 @@ interface CodexEventData {
   usage?: CodexUsage;
   item?: CodexItem;
   error?: string;
+  turn_error?: string;
   message?: string;
 }
 
@@ -216,10 +217,27 @@ function getNumberField(
 function formatCodexEventMessage(
   message: unknown,
   error: unknown,
+  fallbackError?: unknown,
 ): string | undefined {
   const messageText = formatCodexString(message);
   const errorText = formatCodexErrorMessage(error);
+  const fallbackErrorText = formatCodexErrorMessage(fallbackError);
 
+  const result = selectCodexEventMessage(messageText, errorText);
+  if (!result) {
+    return fallbackErrorText;
+  }
+  if (fallbackErrorText && isGenericCodexFailureMessage(result)) {
+    return fallbackErrorText;
+  }
+
+  return result;
+}
+
+function selectCodexEventMessage(
+  messageText: string | undefined,
+  errorText: string | undefined,
+): string | undefined {
   if (!messageText) {
     return errorText;
   }
@@ -235,6 +253,13 @@ function formatCodexEventMessage(
   }
 
   return messageText;
+}
+
+function getCodexTurnError(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return value.error;
 }
 
 function formatCodexString(value: unknown): string | undefined {
@@ -352,6 +377,7 @@ function parseCodexEventData(value: unknown): CodexEventData | undefined {
     usage: parseCodexUsage(value.usage),
     item: parseCodexItem(value.item),
     error: formatCodexErrorMessage(value.error),
+    turn_error: formatCodexErrorMessage(getCodexTurnError(value.turn)),
     message: formatCodexString(value.message),
   };
 }
@@ -622,8 +648,11 @@ function normalizeCodexFailedTurnEvent(
     event,
     success: false,
     result:
-      formatCodexEventMessage(codexEvent?.message, codexEvent?.error) ??
-      "Turn failed",
+      formatCodexEventMessage(
+        codexEvent?.message,
+        codexEvent?.error,
+        codexEvent?.turn_error,
+      ) ?? "Turn failed",
     usage: codexEvent?.usage,
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -894,6 +894,23 @@ function getCodexEventType(event: AgentEvent): string | undefined {
   return codexType && isCodexEventType(codexType) ? codexType : undefined;
 }
 
+function getCodexTurnId(event: AgentEvent): string | undefined {
+  if (!isRecord(event.eventData)) {
+    return undefined;
+  }
+
+  const topLevelTurnId = getStringField(event.eventData, "turn_id")?.trim();
+  if (topLevelTurnId) {
+    return topLevelTurnId;
+  }
+
+  const turn = event.eventData.turn;
+  if (!isRecord(turn)) {
+    return undefined;
+  }
+  return getStringField(turn, "id")?.trim() || undefined;
+}
+
 function getResultText(event: AgentEvent | null): string | undefined {
   if (event?.eventType !== "result") {
     return undefined;
@@ -920,20 +937,34 @@ function shouldPreferPendingCodexError(
   );
 }
 
+function shouldPairCodexFailureEvents(
+  pendingTurnId: string | undefined,
+  turnFailedTurnId: string | undefined,
+): boolean {
+  if (pendingTurnId && turnFailedTurnId) {
+    return pendingTurnId === turnFailedTurnId;
+  }
+  return true;
+}
+
 function normalizeEventsForGrouping(events: AgentEvent[]): AgentEvent[] {
   const normalizedEvents: AgentEvent[] = [];
-  let pendingCodexError: AgentEvent | null = null;
+  let pendingCodexError: {
+    event: AgentEvent;
+    turnId: string | undefined;
+  } | null = null;
 
   const flushPendingCodexError = () => {
     if (!pendingCodexError) {
       return;
     }
-    normalizedEvents.push(pendingCodexError);
+    normalizedEvents.push(pendingCodexError.event);
     pendingCodexError = null;
   };
 
   for (const rawEvent of events) {
     const codexType = getCodexEventType(rawEvent);
+    const turnId = getCodexTurnId(rawEvent);
     const normalized = normalizeCodexEventForGrouping(rawEvent);
     if (!normalized) {
       continue;
@@ -941,19 +972,35 @@ function normalizeEventsForGrouping(events: AgentEvent[]): AgentEvent[] {
 
     if (codexType === "error" && normalized.eventType === "result") {
       flushPendingCodexError();
-      pendingCodexError = normalized;
+      pendingCodexError = { event: normalized, turnId };
       continue;
     }
 
     if (codexType === "turn.failed") {
       const pending = pendingCodexError;
       pendingCodexError = null;
-      if (pending && shouldPreferPendingCodexError(pending, normalized)) {
-        normalizedEvents.push(pending);
+      if (pending && shouldPairCodexFailureEvents(pending.turnId, turnId)) {
+        normalizedEvents.push(
+          shouldPreferPendingCodexError(pending.event, normalized)
+            ? pending.event
+            : normalized,
+        );
+      } else if (pending) {
+        normalizedEvents.push(pending.event);
+        normalizedEvents.push(normalized);
       } else {
         normalizedEvents.push(normalized);
       }
       continue;
+    }
+
+    if (
+      pendingCodexError &&
+      codexType === "turn.started" &&
+      turnId &&
+      pendingCodexError.turnId !== turnId
+    ) {
+      flushPendingCodexError();
     }
 
     if (normalized.eventType === "result") {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -656,6 +656,10 @@ function normalizeCodexCommandEvent(
   return null;
 }
 
+function hasCodexToolItemId(item: CodexItem): boolean {
+  return Boolean(item.id?.trim());
+}
+
 function isCodexCommandExecutionError(item: CodexItem): boolean {
   if (item.status === "failed" || item.status === "declined") {
     return true;
@@ -717,6 +721,28 @@ function normalizeCodexFileReadEvent(
   return null;
 }
 
+function normalizeCodexToolItemEvent(
+  event: AgentEvent,
+  codexType: string,
+  item: CodexItem,
+): AgentEvent | null {
+  if (!hasCodexToolItemId(item)) {
+    return null;
+  }
+
+  const normalized =
+    item.type === "command_execution"
+      ? normalizeCodexCommandEvent(event, codexType, item)
+      : item.type === "file_read"
+        ? normalizeCodexFileReadEvent(event, codexType, item)
+        : normalizeCodexFileMutationEvent(event, codexType, item);
+
+  return (
+    normalized ??
+    makeCodexAssistantTextEvent(event, formatGenericCodexItem(codexType, item))
+  );
+}
+
 function normalizeCodexItemEvent(
   event: AgentEvent,
   codexType: string,
@@ -755,32 +781,14 @@ function normalizeCodexItemEvent(
           );
     }
     case "command_execution": {
-      return (
-        normalizeCodexCommandEvent(event, codexType, item) ??
-        makeCodexAssistantTextEvent(
-          event,
-          formatGenericCodexItem(codexType, item),
-        )
-      );
+      return normalizeCodexToolItemEvent(event, codexType, item);
     }
     case "file_edit":
     case "file_write": {
-      return (
-        normalizeCodexFileMutationEvent(event, codexType, item) ??
-        makeCodexAssistantTextEvent(
-          event,
-          formatGenericCodexItem(codexType, item),
-        )
-      );
+      return normalizeCodexToolItemEvent(event, codexType, item);
     }
     case "file_read": {
-      return (
-        normalizeCodexFileReadEvent(event, codexType, item) ??
-        makeCodexAssistantTextEvent(
-          event,
-          formatGenericCodexItem(codexType, item),
-        )
-      );
+      return normalizeCodexToolItemEvent(event, codexType, item);
     }
     case "file_change": {
       return codexType === "item.completed"
@@ -1313,10 +1321,10 @@ function processAssistantEvent(
   }
 
   // Create standalone todo card for each TodoWrite
-  for (const todoOp of todoWriteOps) {
+  for (const [todoIndex, todoOp] of todoWriteOps.entries()) {
     const todoMessage: GroupedMessage = {
       type: "todo",
-      sequenceNumber: event.sequenceNumber + 0.01,
+      sequenceNumber: event.sequenceNumber + (todoIndex + 1) / 1_000_000,
       createdAt: event.createdAt,
       todoState: Array.from(ctx.todoState.values()),
       eventData: {},

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -583,7 +583,9 @@ function normalizeCodexFailedTurnEvent(
   return makeCodexResultEvent({
     event,
     success: false,
-    result: codexEvent?.error ?? "Turn failed",
+    result:
+      formatCodexEventMessage(codexEvent?.message, codexEvent?.error) ??
+      "Turn failed",
     usage: codexEvent?.usage,
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -103,6 +103,11 @@ interface CodexFileChange {
   path?: string;
 }
 
+interface CodexPlanStep {
+  step?: string;
+  status?: string;
+}
+
 interface CodexItem {
   id?: string;
   type?: string;
@@ -124,6 +129,9 @@ interface CodexItem {
 interface CodexEventData {
   type?: string;
   thread_id?: string;
+  turn_id?: string;
+  explanation?: string;
+  plan?: CodexPlanStep[];
   usage?: CodexUsage;
   item?: CodexItem;
   error?: string;
@@ -176,6 +184,19 @@ function parseCodexChanges(value: unknown): CodexFileChange[] | undefined {
   });
 }
 
+function parseCodexPlanSteps(value: unknown): CodexPlanStep[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.filter(isRecord).map((step) => {
+    return {
+      step: getStringField(step, "step"),
+      status: getStringField(step, "status"),
+    };
+  });
+}
+
 function parseCodexItem(value: unknown): CodexItem | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -208,6 +229,9 @@ function parseCodexEventData(value: unknown): CodexEventData | undefined {
   return {
     type: getStringField(value, "type"),
     thread_id: getStringField(value, "thread_id"),
+    turn_id: getStringField(value, "turn_id"),
+    explanation: getStringField(value, "explanation"),
+    plan: parseCodexPlanSteps(value.plan),
     usage: parseCodexUsage(value.usage),
     item: parseCodexItem(value.item),
     error: getStringField(value, "error"),
@@ -221,6 +245,7 @@ function isCodexEventType(eventType: string): boolean {
     eventType === "turn.started" ||
     eventType === "turn.completed" ||
     eventType === "turn.failed" ||
+    eventType === "turn.plan.updated" ||
     eventType === "error" ||
     eventType.startsWith("item.")
   );
@@ -352,6 +377,43 @@ function formatCodexFileChanges(changes: CodexFileChange[]): string {
   return ["[files] Files changed:", ...lines].join("\n");
 }
 
+function formatCodexPlanUpdate(
+  plan: CodexPlanStep[] | undefined,
+  explanation: string | undefined,
+): string | null {
+  const header = explanation?.trim()
+    ? `[plan] ${explanation.trim()}`
+    : "[plan]";
+  const steps = Array.isArray(plan)
+    ? plan.flatMap((step) => {
+        const text = step.step?.trim();
+        if (!text) {
+          return [];
+        }
+        return [`- [${formatCodexPlanStatus(step.status)}] ${text}`];
+      })
+    : [];
+
+  if (steps.length === 0 && !explanation?.trim()) {
+    return null;
+  }
+
+  return [header, ...steps].join("\n");
+}
+
+function formatCodexPlanStatus(status: string | undefined): string {
+  switch (status) {
+    case "completed":
+    case "pending":
+      return status;
+    case "inProgress":
+    case "in_progress":
+      return "in progress";
+    default:
+      return status?.trim() || "unknown";
+  }
+}
+
 function formatGenericCodexItem(
   eventType: string,
   item: CodexItem | undefined,
@@ -412,6 +474,13 @@ function normalizeCodexRunEvent(
         result: codexEvent?.error ?? "Turn failed",
         usage: codexEvent?.usage,
       });
+    }
+    case "turn.plan.updated": {
+      const text = formatCodexPlanUpdate(
+        codexEvent?.plan,
+        codexEvent?.explanation,
+      );
+      return text ? makeCodexAssistantTextEvent(event, text) : null;
     }
     case "error": {
       return makeCodexResultEvent({

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -708,7 +708,7 @@ function normalizeCodexCommandEvent(
       event,
       item,
       content: item.aggregated_output ?? item.output ?? "",
-      isError: isCodexCommandExecutionError(item),
+      isError: isCodexItemError(item),
     });
   }
 
@@ -719,7 +719,7 @@ function hasCodexToolItemId(item: CodexItem): boolean {
   return Boolean(item.id?.trim());
 }
 
-function isCodexCommandExecutionError(item: CodexItem): boolean {
+function isCodexItemError(item: CodexItem): boolean {
   if (item.status === "failed" || item.status === "declined") {
     return true;
   }
@@ -745,10 +745,15 @@ function normalizeCodexFileMutationEvent(
   }
 
   if (codexType === "item.completed") {
+    const isError = isCodexItemError(item);
     return makeCodexToolResultEvent({
       event,
       item,
-      content: item.diff ?? "File operation completed",
+      content:
+        item.diff ??
+        item.output ??
+        (isError ? "File operation failed" : "File operation completed"),
+      isError,
     });
   }
 
@@ -770,10 +775,13 @@ function normalizeCodexFileReadEvent(
   }
 
   if (codexType === "item.completed") {
+    const isError = isCodexItemError(item);
     return makeCodexToolResultEvent({
       event,
       item,
-      content: item.output ?? "File read completed",
+      content:
+        item.output ?? (isError ? "File read failed" : "File read completed"),
+      isError,
     });
   }
 

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -26,6 +26,10 @@ interface ToolResultContent {
  * The API may return non-string values that need to be converted.
  */
 function normalizeToolResultContent(content: unknown): string {
+  return formatUnknownContent(content);
+}
+
+function formatUnknownContent(content: unknown): string {
   if (typeof content === "string") {
     return content;
   }
@@ -1048,15 +1052,36 @@ function processTodoWrite(
   }
   let newInProgressTask: string | null = null;
   for (const todo of todos) {
-    const item = todo as { content?: string; status?: string };
-    const content = item.content ?? String(todo);
-    const status = item.status ?? "pending";
-    todoState.set(content, { content, status });
-    if (status === "in_progress") {
-      newInProgressTask = content;
+    const item = normalizeTodoItem(todo);
+    if (!item) {
+      continue;
+    }
+    todoState.set(item.content, item);
+    if (item.status === "in_progress") {
+      newInProgressTask = item.content;
     }
   }
   return newInProgressTask;
+}
+
+function normalizeTodoItem(todo: unknown): TodoItem | null {
+  if (!isRecord(todo)) {
+    const content = formatUnknownContent(todo);
+    return content ? { content, status: "pending" } : null;
+  }
+
+  const rawContent = todo.content;
+  const content =
+    typeof rawContent === "string"
+      ? rawContent
+      : formatUnknownContent(rawContent ?? todo);
+  if (!content) {
+    return null;
+  }
+  return {
+    content,
+    status: getStringField(todo, "status")?.trim() || "pending",
+  };
 }
 
 interface GroupingContext {
@@ -1311,7 +1336,7 @@ function processUserEvent(
 ): void {
   // Child user events belong to a task — route orphan results there
   const parentTask = findParentTask(eventData, ctx);
-  const target = parentTask?.childMessages ?? ctx.grouped;
+  const target = parentTask ? (parentTask.childMessages ??= []) : ctx.grouped;
 
   const contents = getMessageContents(eventData);
   const toolMeta = eventData.tool_use_result;

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -8,7 +8,7 @@ interface TextContent {
 
 interface ToolUseContent {
   type: "tool_use";
-  id?: string;
+  id: string;
   name: string;
   input: Record<string, unknown>;
 }
@@ -81,7 +81,7 @@ interface GroupingEventData {
   subtype?: string;
   parent_tool_use_id?: string;
   message?: {
-    content: MessageContent[] | null;
+    content?: unknown;
   };
   tool_use_result?: ToolResultMeta;
   tools?: string[];
@@ -89,6 +89,51 @@ interface GroupingEventData {
   slash_commands?: string[];
   result?: string | null;
   is_error?: boolean;
+}
+
+function getMessageContents(eventData: GroupingEventData): MessageContent[] {
+  const contents = eventData.message?.content;
+  if (!Array.isArray(contents)) {
+    return [];
+  }
+  return contents.filter(isRecord).flatMap((content): MessageContent[] => {
+    const type = getStringField(content, "type");
+    if (type === "text") {
+      return [
+        {
+          type,
+          text: getStringField(content, "text") ?? "",
+        } satisfies TextContent,
+      ];
+    }
+    if (type === "tool_use") {
+      const id = getStringField(content, "id");
+      const name = getStringField(content, "name");
+      if (!id || !name) {
+        return [];
+      }
+      const input = isRecord(content.input) ? content.input : {};
+      return [
+        {
+          type,
+          id,
+          name,
+          input,
+        } satisfies ToolUseContent,
+      ];
+    }
+    if (type === "tool_result") {
+      return [
+        {
+          type,
+          tool_use_id: getStringField(content, "tool_use_id"),
+          content: content.content,
+          is_error: content.is_error === true,
+        } satisfies ToolResultContent,
+      ];
+    }
+    return [];
+  });
 }
 
 interface CodexUsage {
@@ -836,9 +881,8 @@ function parseAssistantContent(contents: MessageContent[]): {
     } else if (content.type === "tool_use") {
       foundToolUse = true;
       const toolContent = content as ToolUseContent;
-      const toolUseId = toolContent.id ?? `unknown-${Math.random()}`;
       toolOperations.push({
-        toolUseId,
+        toolUseId: toolContent.id,
         toolName: toolContent.name,
         keyParam: extractKeyParam(toolContent.name, toolContent.input),
         input: toolContent.input,
@@ -1106,7 +1150,7 @@ function processChildAssistantEvent(
   parentTask: GroupedMessage,
   ctx: GroupingContext,
 ): void {
-  const contents = eventData.message?.content ?? [];
+  const contents = getMessageContents(eventData);
   const { textParts, toolOperations } = parseAssistantContent(contents);
   const hasText = textParts.length > 0;
   const hasTools = toolOperations.length > 0;
@@ -1150,7 +1194,7 @@ function processAssistantEvent(
     return;
   }
 
-  const contents = eventData.message?.content ?? [];
+  const contents = getMessageContents(eventData);
   const { textParts, toolOperations } = parseAssistantContent(contents);
   const hasText = textParts.length > 0;
 
@@ -1220,7 +1264,7 @@ function processUserEvent(
   const parentTask = findParentTask(eventData, ctx);
   const target = parentTask?.childMessages ?? ctx.grouped;
 
-  const contents = eventData.message?.content ?? [];
+  const contents = getMessageContents(eventData);
   const toolMeta = eventData.tool_use_result;
 
   for (const content of contents) {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -446,12 +446,21 @@ function normalizeCodexCommandEvent(
       event,
       item,
       content: item.aggregated_output ?? item.output ?? "",
-      isError:
-        typeof item.exit_code === "number" ? item.exit_code !== 0 : false,
+      isError: isCodexCommandExecutionError(item),
     });
   }
 
   return null;
+}
+
+function isCodexCommandExecutionError(item: CodexItem): boolean {
+  if (item.status === "failed" || item.status === "declined") {
+    return true;
+  }
+  if (item.status === "completed") {
+    return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
+  }
+  return typeof item.exit_code === "number" ? item.exit_code !== 0 : false;
 }
 
 function normalizeCodexFileMutationEvent(

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -543,6 +543,14 @@ function normalizeCodexItemEvent(
             formatGenericCodexItem(codexType, item),
           );
     }
+    case "plan": {
+      return item.text
+        ? makeCodexAssistantTextEvent(event, `[plan] ${item.text}`)
+        : makeCodexAssistantTextEvent(
+            event,
+            formatGenericCodexItem(codexType, item),
+          );
+    }
     case "command_execution": {
       return (
         normalizeCodexCommandEvent(event, codexType, item) ??

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -1012,6 +1012,30 @@ function normalizeEventsForGrouping(events: AgentEvent[]): AgentEvent[] {
   return normalizedEvents;
 }
 
+function isUnambiguousCodexEventType(eventType: string | undefined): boolean {
+  return (
+    eventType === "thread.started" ||
+    eventType === "turn.started" ||
+    eventType === "turn.completed" ||
+    eventType === "turn.failed" ||
+    eventType === "turn.plan.updated" ||
+    eventType?.startsWith("item.") === true
+  );
+}
+
+function shouldNormalizeCodexEvents(
+  events: AgentEvent[],
+  framework: string | null | undefined,
+): boolean {
+  if (framework) {
+    return framework === "codex";
+  }
+
+  return events.some((event) => {
+    return isUnambiguousCodexEventType(getCodexEventType(event));
+  });
+}
+
 /**
  * Shape of task-related system event data (task_started, task_notification, task_progress).
  */
@@ -1557,6 +1581,7 @@ function processUserEvent(
  */
 export function groupEventsIntoMessages(
   events: AgentEvent[],
+  framework?: string | null,
 ): GroupedMessage[] {
   const sorted = [...events].sort((a, b) => {
     return a.sequenceNumber - b.sequenceNumber;
@@ -1579,7 +1604,11 @@ export function groupEventsIntoMessages(
     taskByToolUseId: new Map(),
   };
 
-  for (const event of normalizeEventsForGrouping(deduped)) {
+  const groupingEvents = shouldNormalizeCodexEvents(deduped, framework)
+    ? normalizeEventsForGrouping(deduped)
+    : deduped;
+
+  for (const event of groupingEvents) {
     const eventData = event.eventData as GroupingEventData;
 
     if (event.eventType === "system") {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -896,16 +896,25 @@ function parseAssistantContent(contents: MessageContent[]): {
 /**
  * Process a tool_result content block and attach to pending tool use or create orphan.
  */
-function processToolResult(
-  resultContent: ToolResultContent,
-  toolMeta: ToolResultMeta | undefined,
+function processToolResult(params: {
+  resultContent: ToolResultContent;
+  toolMeta: ToolResultMeta | undefined;
   pendingToolUses: Map<
     string,
     { operation: ToolOperation; message: GroupedMessage }
-  >,
-  event: AgentEvent,
-  grouped: GroupedMessage[],
-): void {
+  >;
+  event: AgentEvent;
+  grouped: GroupedMessage[];
+  contentIndex: number;
+}): void {
+  const {
+    resultContent,
+    toolMeta,
+    pendingToolUses,
+    event,
+    grouped,
+    contentIndex,
+  } = params;
   const toolUseId = resultContent.tool_use_id;
   const pending = toolUseId ? pendingToolUses.get(toolUseId) : undefined;
 
@@ -925,11 +934,12 @@ function processToolResult(
   // Orphan tool_result - create standalone message
   grouped.push({
     type: "assistant",
-    sequenceNumber: event.sequenceNumber,
+    sequenceNumber: event.sequenceNumber + (contentIndex + 1) / 1_000_000,
     createdAt: event.createdAt,
     toolOperations: [
       {
-        toolUseId: toolUseId ?? `orphan-${Math.random()}`,
+        toolUseId:
+          toolUseId ?? `orphan-${event.sequenceNumber}-${contentIndex}`,
         toolName: "Unknown",
         keyParam: "",
         input: {},
@@ -1267,15 +1277,16 @@ function processUserEvent(
   const contents = getMessageContents(eventData);
   const toolMeta = eventData.tool_use_result;
 
-  for (const content of contents) {
+  for (const [contentIndex, content] of contents.entries()) {
     if (content.type === "tool_result") {
-      processToolResult(
-        content as ToolResultContent,
+      processToolResult({
+        resultContent: content as ToolResultContent,
         toolMeta,
-        ctx.pendingToolUses,
+        pendingToolUses: ctx.pendingToolUses,
         event,
-        target,
-      );
+        grouped: target,
+        contentIndex,
+      });
     }
   }
 }

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -29,7 +29,13 @@ function normalizeToolResultContent(content: unknown): string {
   if (typeof content === "string") {
     return content;
   }
-  return String(content ?? "");
+  if (content === null || content === undefined) {
+    return "";
+  }
+  if (Array.isArray(content) || isRecord(content)) {
+    return JSON.stringify(content);
+  }
+  return String(content);
 }
 
 type MessageContent = TextContent | ToolUseContent | ToolResultContent;

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -886,6 +886,86 @@ function normalizeCodexEventForGrouping(event: AgentEvent): AgentEvent | null {
   return normalizeCodexRunEvent(event, codexType, codexEvent);
 }
 
+function getCodexEventType(event: AgentEvent): string | undefined {
+  const codexEvent = parseCodexEventData(event.eventData);
+  const codexType = isCodexEventType(event.eventType)
+    ? event.eventType
+    : codexEvent?.type;
+  return codexType && isCodexEventType(codexType) ? codexType : undefined;
+}
+
+function getResultText(event: AgentEvent | null): string | undefined {
+  if (event?.eventType !== "result") {
+    return undefined;
+  }
+  if (!isRecord(event.eventData)) {
+    return undefined;
+  }
+  return getStringField(event.eventData, "result")?.trim() || undefined;
+}
+
+function shouldPreferPendingCodexError(
+  pendingCodexError: AgentEvent,
+  turnFailedEvent: AgentEvent | null,
+): boolean {
+  const pendingResult = getResultText(pendingCodexError);
+  const turnFailedResult = getResultText(turnFailedEvent);
+  if (!turnFailedResult) {
+    return pendingResult !== undefined;
+  }
+  return (
+    pendingResult !== undefined &&
+    !isGenericCodexFailureMessage(pendingResult) &&
+    isGenericCodexFailureMessage(turnFailedResult)
+  );
+}
+
+function normalizeEventsForGrouping(events: AgentEvent[]): AgentEvent[] {
+  const normalizedEvents: AgentEvent[] = [];
+  let pendingCodexError: AgentEvent | null = null;
+
+  const flushPendingCodexError = () => {
+    if (!pendingCodexError) {
+      return;
+    }
+    normalizedEvents.push(pendingCodexError);
+    pendingCodexError = null;
+  };
+
+  for (const rawEvent of events) {
+    const codexType = getCodexEventType(rawEvent);
+    const normalized = normalizeCodexEventForGrouping(rawEvent);
+    if (!normalized) {
+      continue;
+    }
+
+    if (codexType === "error" && normalized.eventType === "result") {
+      flushPendingCodexError();
+      pendingCodexError = normalized;
+      continue;
+    }
+
+    if (codexType === "turn.failed") {
+      const pending = pendingCodexError;
+      pendingCodexError = null;
+      if (pending && shouldPreferPendingCodexError(pending, normalized)) {
+        normalizedEvents.push(pending);
+      } else {
+        normalizedEvents.push(normalized);
+      }
+      continue;
+    }
+
+    if (normalized.eventType === "result") {
+      flushPendingCodexError();
+    }
+    normalizedEvents.push(normalized);
+  }
+
+  flushPendingCodexError();
+  return normalizedEvents;
+}
+
 /**
  * Shape of task-related system event data (task_started, task_notification, task_progress).
  */
@@ -1453,11 +1533,7 @@ export function groupEventsIntoMessages(
     taskByToolUseId: new Map(),
   };
 
-  for (const rawEvent of deduped) {
-    const event = normalizeCodexEventForGrouping(rawEvent);
-    if (!event) {
-      continue;
-    }
+  for (const event of normalizeEventsForGrouping(deduped)) {
     const eventData = event.eventData as GroupingEventData;
 
     if (event.eventType === "system") {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -995,8 +995,7 @@ function normalizeEventsForGrouping(events: AgentEvent[]): AgentEvent[] {
     }
 
     if (
-      pendingCodexError &&
-      codexType === "turn.started" &&
+      pendingCodexError?.turnId &&
       turnId &&
       pendingCodexError.turnId !== turnId
     ) {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -268,6 +268,7 @@ function isGenericCodexFailureMessage(message: string): boolean {
   const normalized = message.toLowerCase();
   return (
     normalized === "turn failed" ||
+    normalized === "turn interrupted" ||
     normalized === "unknown error" ||
     normalized === "codex error" ||
     normalized === "error"

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -246,6 +246,7 @@ function isCodexEventType(eventType: string): boolean {
     eventType === "turn.completed" ||
     eventType === "turn.failed" ||
     eventType === "turn.plan.updated" ||
+    eventType === "warning" ||
     eventType === "error" ||
     eventType.startsWith("item.")
   );
@@ -401,16 +402,30 @@ function formatCodexPlanUpdate(
   return [header, ...steps].join("\n");
 }
 
+function formatCodexWarningMessage(
+  codexEvent: CodexEventData | undefined,
+): string | null {
+  const message = codexEvent?.message?.trim();
+  if (message) {
+    return message;
+  }
+
+  return codexEvent?.error?.trim() || null;
+}
+
 function formatCodexPlanStatus(status: string | undefined): string {
   switch (status) {
     case "completed":
-    case "pending":
+    case "pending": {
       return status;
+    }
     case "inProgress":
-    case "in_progress":
+    case "in_progress": {
       return "in progress";
-    default:
+    }
+    default: {
       return status?.trim() || "unknown";
+    }
   }
 }
 
@@ -468,32 +483,63 @@ function normalizeCodexRunEvent(
       });
     }
     case "turn.failed": {
-      return makeCodexResultEvent({
-        event,
-        success: false,
-        result: codexEvent?.error ?? "Turn failed",
-        usage: codexEvent?.usage,
-      });
+      return normalizeCodexFailedTurnEvent(event, codexEvent);
     }
     case "turn.plan.updated": {
-      const text = formatCodexPlanUpdate(
-        codexEvent?.plan,
-        codexEvent?.explanation,
-      );
-      return text ? makeCodexAssistantTextEvent(event, text) : null;
+      return normalizeCodexPlanUpdateEvent(event, codexEvent);
+    }
+    case "warning": {
+      return normalizeCodexWarningEvent(event, codexEvent);
     }
     case "error": {
-      return makeCodexResultEvent({
-        event,
-        success: false,
-        result: codexEvent?.message ?? codexEvent?.error ?? "Codex error",
-        usage: codexEvent?.usage,
-      });
+      return normalizeCodexErrorEvent(event, codexEvent);
     }
     default: {
       return event;
     }
   }
+}
+
+function normalizeCodexFailedTurnEvent(
+  event: AgentEvent,
+  codexEvent: CodexEventData | undefined,
+): AgentEvent {
+  return makeCodexResultEvent({
+    event,
+    success: false,
+    result: codexEvent?.error ?? "Turn failed",
+    usage: codexEvent?.usage,
+  });
+}
+
+function normalizeCodexPlanUpdateEvent(
+  event: AgentEvent,
+  codexEvent: CodexEventData | undefined,
+): AgentEvent | null {
+  const text = formatCodexPlanUpdate(codexEvent?.plan, codexEvent?.explanation);
+  return text ? makeCodexAssistantTextEvent(event, text) : null;
+}
+
+function normalizeCodexWarningEvent(
+  event: AgentEvent,
+  codexEvent: CodexEventData | undefined,
+): AgentEvent | null {
+  const message = formatCodexWarningMessage(codexEvent);
+  return message
+    ? makeCodexAssistantTextEvent(event, `[warning] ${message}`)
+    : null;
+}
+
+function normalizeCodexErrorEvent(
+  event: AgentEvent,
+  codexEvent: CodexEventData | undefined,
+): AgentEvent {
+  return makeCodexResultEvent({
+    event,
+    success: false,
+    result: codexEvent?.message ?? codexEvent?.error ?? "Codex error",
+    usage: codexEvent?.usage,
+  });
 }
 
 function normalizeCodexCommandEvent(

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -507,9 +507,13 @@ function makeCodexToolResultEvent(params: {
   };
 }
 
-function formatCodexFileChanges(changes: CodexFileChange[]): string {
+function formatCodexFileChanges(
+  changes: CodexFileChange[],
+  status: string | undefined,
+): string {
+  const statusText = formatCodexFileChangeStatus(status);
   if (changes.length === 0) {
-    return "[files] Files changed";
+    return statusText ? `[files] ${statusText}` : "[files] Files changed";
   }
 
   const lines = changes.map((change) => {
@@ -518,7 +522,26 @@ function formatCodexFileChanges(changes: CodexFileChange[]): string {
     return `- ${kind} ${path}`;
   });
 
-  return ["[files] Files changed:", ...lines].join("\n");
+  const header = statusText
+    ? `[files] ${statusText}:`
+    : "[files] Files changed:";
+  return [header, ...lines].join("\n");
+}
+
+function formatCodexFileChangeStatus(
+  status: string | undefined,
+): string | null {
+  switch (status) {
+    case "failed": {
+      return "File changes failed";
+    }
+    case "declined": {
+      return "File changes declined";
+    }
+    default: {
+      return null;
+    }
+  }
 }
 
 function formatCodexPlanUpdate(
@@ -861,7 +884,7 @@ function normalizeCodexItemEvent(
       return codexType === "item.completed"
         ? makeCodexAssistantTextEvent(
             event,
-            formatCodexFileChanges(item.changes ?? []),
+            formatCodexFileChanges(item.changes ?? [], item.status),
           )
         : makeCodexAssistantTextEvent(
             event,

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -360,7 +360,7 @@ function prepareRenderData(
   features: Record<FeatureSwitchKey, boolean> | undefined,
 ) {
   const events: AgentEvent[] = rawEvents ?? [];
-  const allMessages = groupEventsIntoMessages(events);
+  const allMessages = groupEventsIntoMessages(events, detail.framework);
   const visibleMessages = allMessages.filter((message, index) => {
     return isVisibleMessage(message, allMessages[index + 1], detail.framework);
   });


### PR DESCRIPTION
## Summary

- Add a Codex app-server notification adapter that maps selected stable notifications to existing `codex exec --json`-style events.
- Normalize lifecycle, item, warning, and error event shapes used by vm0 session metadata, logs, chat/output consumers, and failure diagnostics.
- Keep app-server delta notifications from producing webhook-visible partial output.

## Non-goals

- Does not route production Codex execution through app-server.
- Does not enable active input.
- Does not change API/frontend consumers.
- Does not add stateful delta buffering or a full Rust app-server schema mirror.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent codex_app_server`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`

Closes #18371
