### PR TITLE
fix: separate Claude post-result cleanup lifecycle

### DIFF
--- a/crates/guest-agent/src/cli/framework.rs
+++ b/crates/guest-agent/src/cli/framework.rs
@@ -13,13 +13,41 @@ use std::time::Instant;
 pub struct ClaudeResultSummary {
     /// Claude Code's reported turn count for the run, when present.
     pub num_turns: Option<u64>,
+
+    /// Semantic status of Claude Code's terminal result event.
+    pub status: ClaudeResultStatus,
+}
+
+/// Semantic status derived from Claude Code's terminal `type=result` event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeResultStatus {
+    Success,
+    Error,
+    Unknown,
 }
 
 impl ClaudeResultSummary {
     pub(super) fn from_event(event: &serde_json::Value) -> Self {
         Self {
             num_turns: event.get("num_turns").and_then(|v| v.as_u64()),
+            status: ClaudeResultStatus::from_event(event),
         }
+    }
+}
+
+impl ClaudeResultStatus {
+    fn from_event(event: &serde_json::Value) -> Self {
+        let is_error = event.get("is_error").and_then(|v| v.as_bool());
+        let subtype = event.get("subtype").and_then(|v| v.as_str());
+
+        if is_error == Some(true) || subtype == Some("error") {
+            return Self::Error;
+        }
+        if is_error == Some(false) || subtype == Some("success") {
+            return Self::Success;
+        }
+
+        Self::Unknown
     }
 }
 
@@ -146,7 +174,54 @@ mod tests {
 
         assert_eq!(
             ClaudeResultSummary::from_event(&event),
-            ClaudeResultSummary { num_turns: Some(0) }
+            ClaudeResultSummary {
+                num_turns: Some(0),
+                status: ClaudeResultStatus::Success,
+            }
+        );
+    }
+
+    #[test]
+    fn claude_result_summary_marks_is_error_result_as_error() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 1,
+            "is_error": true,
+            "result": "Error."
+        });
+
+        assert_eq!(
+            ClaudeResultSummary::from_event(&event).status,
+            ClaudeResultStatus::Error
+        );
+    }
+
+    #[test]
+    fn claude_result_summary_marks_error_subtype_as_error() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 1,
+            "subtype": "error",
+            "result": "Error."
+        });
+
+        assert_eq!(
+            ClaudeResultSummary::from_event(&event).status,
+            ClaudeResultStatus::Error
+        );
+    }
+
+    #[test]
+    fn claude_result_summary_marks_ambiguous_result_as_unknown() {
+        let event = serde_json::json!({
+            "type": "result",
+            "num_turns": 1,
+            "result": "Done."
+        });
+
+        assert_eq!(
+            ClaudeResultSummary::from_event(&event).status,
+            ClaudeResultStatus::Unknown
         );
     }
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -26,7 +26,7 @@ mod termination;
 
 pub use codex_setup::setup_codex;
 pub use command::build_cli_command;
-pub use framework::ClaudeResultSummary;
+pub use framework::{ClaudeResultStatus, ClaudeResultSummary};
 
 use crate::active_input::{ActiveInputRuntime, ActiveInputWriter, ReplayUserEventAction};
 use crate::constants;
@@ -49,7 +49,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
-use termination::{TerminationReason, TerminationState};
+use termination::{PostResultCleanupState, TerminationReason, TerminationState};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::oneshot;
 
@@ -193,6 +193,11 @@ pub struct CliExecutionResult {
     /// Claude Code's final result metadata, when a terminal result event was
     /// observed. Codex uses its own event schema and leaves this unset.
     pub claude_result: Option<ClaudeResultSummary>,
+
+    /// Claude Code result that armed post-result cleanup, when cleanup was
+    /// armed. This is intentionally separate from `claude_result` because late
+    /// drained stdout may contain another result event after cleanup starts.
+    pub post_result_cleanup_result: Option<ClaudeResultSummary>,
 
     /// Best-effort, secret-masked terminal failure diagnostic parsed from CLI
     /// stdout JSONL.
@@ -450,6 +455,8 @@ async fn execute_cli_inner(
     let mut last_read_event_at: Option<Instant> = None;
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
+    let mut post_result_cleanup_result = None;
+    let mut post_result_cleanup = None;
     let mut failure_diagnostic = None;
     let mut session_metadata_capture = events::SessionMetadataCapture::new();
     let event_result: Result<(), AgentError> = loop {
@@ -477,12 +484,13 @@ async fn execute_cli_inner(
                             TerminationReason::InitialPromptStdin,
                             CliTerminationSignal::Sigterm,
                             pgid,
-                            env::post_result_sigkill_grace_secs(),
+                            Duration::from_secs(env::post_result_sigkill_grace_secs()),
                         );
                         if let Some(pid) = pgid {
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
                         }
                         termination_error = Some(error);
+                        post_result_cleanup = None;
                         termination_state = TerminationState::SigkillPending {
                             reason: TerminationReason::InitialPromptStdin,
                         };
@@ -506,7 +514,7 @@ async fn execute_cli_inner(
                             TerminationReason::InitialPromptStdin,
                             CliTerminationSignal::Sigterm,
                             pgid,
-                            env::post_result_sigkill_grace_secs(),
+                            Duration::from_secs(env::post_result_sigkill_grace_secs()),
                         );
                         if let Some(pid) = pgid {
                             unsafe { libc::kill(-pid, libc::SIGTERM); }
@@ -514,6 +522,7 @@ async fn execute_cli_inner(
                         termination_error = Some(AgentError::Execution(format!(
                             "Claude stdin writer task failed: {error}"
                         )));
+                        post_result_cleanup = None;
                         termination_state = TerminationState::SigkillPending {
                             reason: TerminationReason::InitialPromptStdin,
                         };
@@ -574,6 +583,8 @@ async fn execute_cli_inner(
                                 }
                             }
 
+                            let post_result_cleanup_was_armed = post_result_cleanup.is_some();
+
                             let _ = log_file.write_all(line.as_bytes()).await;
                             let _ = log_file.write_all(b"\n").await;
 
@@ -594,7 +605,8 @@ async fn execute_cli_inner(
                             session_metadata_capture.capture_event(&event, masker);
                             // Print Claude Code final result to stdout if applicable.
                             if behavior.handles_claude_result_event(&event) {
-                                claude_result = Some(ClaudeResultSummary::from_event(&event));
+                                let result_summary = ClaudeResultSummary::from_event(&event);
+                                claude_result = Some(result_summary);
                                 if let Some(diagnostic) =
                                     events::masked_claude_failure_diagnostic(&event, masker)
                                 {
@@ -627,15 +639,22 @@ async fn execute_cli_inner(
                                     && termination_state
                                         .should_arm_post_result(cli_status.is_some())
                                 {
-                                    termination_state = TerminationState::SigtermPending {
-                                        reason: TerminationReason::PostResult,
-                                    };
-                                    termination_deadline.as_mut().reset(
-                                        tokio::time::Instant::now()
-                                            + Duration::from_secs(
-                                                env::post_result_sigterm_grace_secs(),
-                                            ),
+                                    let now = tokio::time::Instant::now();
+                                    let cleanup = PostResultCleanupState::arm(
+                                        now,
+                                        Duration::from_secs(
+                                            env::post_result_sigterm_grace_secs(),
+                                        ),
+                                        Duration::from_secs(env::post_result_total_cap_secs()),
                                     );
+                                    if let Some(next_deadline) = cleanup.next_deadline() {
+                                        termination_state = TerminationState::SigtermPending {
+                                            reason: TerminationReason::PostResult,
+                                        };
+                                        termination_deadline.as_mut().reset(next_deadline);
+                                        post_result_cleanup = Some(cleanup);
+                                        post_result_cleanup_result = Some(result_summary);
+                                    }
                                 }
                             }
                             // Extract tool info BEFORE masking (masker may replace tool names).
@@ -660,6 +679,23 @@ async fn execute_cli_inner(
                                     candidate,
                                 ) {
                                     failure_diagnostic = Some(selected);
+                                }
+                            }
+                            if post_result_cleanup_was_armed
+                                && matches!(
+                                    termination_state,
+                                    TerminationState::SigtermPending {
+                                        reason: TerminationReason::PostResult
+                                    }
+                                )
+                                && let Some(cleanup) = post_result_cleanup.as_mut()
+                            {
+                                let next_deadline = cleanup.record_meaningful_event(
+                                    tokio::time::Instant::now(),
+                                    Duration::from_secs(env::post_result_sigterm_grace_secs()),
+                                );
+                                if let Some(next_deadline) = next_deadline {
+                                    termination_deadline.as_mut().reset(next_deadline);
                                 }
                             }
                             // Prepare event payload (mask secrets, add seq) and enqueue
@@ -706,6 +742,7 @@ async fn execute_cli_inner(
                         // SIGTERM). Park the termination FSM so it can't
                         // re-arm on any late `type=result` event.
                         termination_state = TerminationState::Done;
+                        post_result_cleanup = None;
                         if stdout_eof {
                             break Ok(());
                         }
@@ -726,18 +763,52 @@ async fn execute_cli_inner(
                 // the signal fails to take effect in time.
                 match termination_state {
                     TerminationState::SigtermPending { reason } => {
-                        let grace = env::post_result_sigterm_grace_secs();
+                        let now = tokio::time::Instant::now();
+                        let cleanup_timeout =
+                            (reason == TerminationReason::PostResult)
+                                .then(|| {
+                                    post_result_cleanup
+                                        .as_mut()
+                                        .and_then(|cleanup| cleanup.mark_signal_sent(now))
+                                })
+                                .flatten();
+                        let grace = cleanup_timeout
+                            .map(|timeout| timeout.elapsed)
+                            .unwrap_or_else(|| {
+                                Duration::from_secs(env::post_result_sigterm_grace_secs())
+                            });
                         if let Some(pid) = pgid {
                             if reason == TerminationReason::PostResult {
-                                log_warn!(
-                                    LOG_TAG,
-                                    "CLI still running {grace}s after type=result, SIGTERM pgid={pid} (likely a leaked backgrounded Bash task)"
-                                );
+                                if let Some(timeout) = cleanup_timeout {
+                                    let trigger = timeout.trigger.label();
+                                    let elapsed_ms = timeout.elapsed.as_millis();
+                                    let quiet_ms = timeout.quiet_for.as_millis();
+                                    let meaningful_events = timeout.meaningful_event_count;
+                                    let detail = format!(
+                                        "trigger={trigger} signal=sigterm elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
+                                    );
+                                    log_warn!(
+                                        LOG_TAG,
+                                        "Post-result cleanup {trigger} reached after {elapsed_ms}ms (quiet {quiet_ms}ms, meaningful events {meaningful_events}), SIGTERM pgid={pid}"
+                                    );
+                                    record_sandbox_op(
+                                        "post_result_cleanup_terminated",
+                                        timeout.elapsed,
+                                        true,
+                                        Some(&detail),
+                                    );
+                                } else {
+                                    log_warn!(
+                                        LOG_TAG,
+                                        "Post-result cleanup deadline fired without state, SIGTERM pgid={pid}"
+                                    );
+                                }
                             } else {
                                 log_warn!(
                                     LOG_TAG,
-                                    "CLI still running after {} sigterm grace {grace}s, SIGTERM pgid={pid}",
-                                    reason.label()
+                                    "CLI still running after {} sigterm grace {}ms, SIGTERM pgid={pid}",
+                                    reason.label(),
+                                    grace.as_millis()
                                 );
                             }
                             record_cli_termination_signal(
@@ -756,13 +827,32 @@ async fn execute_cli_inner(
                         );
                     }
                     TerminationState::SigkillPending { reason } => {
-                        let grace = env::post_result_sigkill_grace_secs();
+                        let grace = Duration::from_secs(env::post_result_sigkill_grace_secs());
+                        let now = tokio::time::Instant::now();
                         if let Some(pid) = pgid {
                             log_warn!(
                                 LOG_TAG,
-                                "CLI did not exit after {} SIGTERM+{grace}s, SIGKILL pgid={pid}",
-                                reason.label()
+                                "CLI did not exit after {} SIGTERM+{}ms, SIGKILL pgid={pid}",
+                                reason.label(),
+                                grace.as_millis()
                             );
+                            if reason == TerminationReason::PostResult
+                                && let Some(cleanup) = post_result_cleanup
+                            {
+                                let elapsed = cleanup.elapsed(now);
+                                let quiet_ms = cleanup.quiet_for(now).as_millis();
+                                let meaningful_events = cleanup.meaningful_event_count();
+                                let elapsed_ms = elapsed.as_millis();
+                                let detail = format!(
+                                    "trigger=sigkill_escalation signal=sigkill elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
+                                );
+                                record_sandbox_op(
+                                    "post_result_cleanup_terminated",
+                                    elapsed,
+                                    true,
+                                    Some(&detail),
+                                );
+                            }
                             record_cli_termination_signal(
                                 &mut cli_termination,
                                 reason,
@@ -772,6 +862,7 @@ async fn execute_cli_inner(
                             );
                             unsafe { libc::kill(-pid, libc::SIGKILL); }
                         }
+                        post_result_cleanup = None;
                         termination_state = TerminationState::Done;
                     }
                     // Unreachable by the is_pending() guard. Log in
@@ -826,12 +917,13 @@ async fn execute_cli_inner(
                         TerminationReason::StuckTool,
                         CliTerminationSignal::Sigterm,
                         pgid,
-                        env::post_result_sigkill_grace_secs(),
+                        Duration::from_secs(env::post_result_sigkill_grace_secs()),
                     );
                     if let Some(pid) = pgid {
                         unsafe { libc::kill(-pid, libc::SIGTERM); }
                     }
                     termination_error = Some(timeout_error);
+                    post_result_cleanup = None;
                     termination_state = TerminationState::SigkillPending {
                         reason: TerminationReason::StuckTool,
                     };
@@ -865,12 +957,13 @@ async fn execute_cli_inner(
                                 TerminationReason::HeartbeatError,
                                 CliTerminationSignal::Sigterm,
                                 pgid,
-                                env::post_result_sigkill_grace_secs(),
+                                Duration::from_secs(env::post_result_sigkill_grace_secs()),
                             );
                             if let Some(pid) = pgid {
                                 unsafe { libc::kill(-pid, libc::SIGTERM); }
                             }
                             termination_error = Some(e);
+                            post_result_cleanup = None;
                             termination_state = TerminationState::SigkillPending {
                                 reason: TerminationReason::HeartbeatError,
                             };
@@ -897,12 +990,13 @@ async fn execute_cli_inner(
                                 TerminationReason::HeartbeatPanic,
                                 CliTerminationSignal::Sigterm,
                                 pgid,
-                                env::post_result_sigkill_grace_secs(),
+                                Duration::from_secs(env::post_result_sigkill_grace_secs()),
                             );
                             if let Some(pid) = pgid {
                                 unsafe { libc::kill(-pid, libc::SIGTERM); }
                             }
                             termination_error = Some(error);
+                            post_result_cleanup = None;
                             termination_state = TerminationState::SigkillPending {
                                 reason: TerminationReason::HeartbeatPanic,
                             };
@@ -925,12 +1019,13 @@ async fn execute_cli_inner(
                                 TerminationReason::HeartbeatPanic,
                                 CliTerminationSignal::Sigterm,
                                 pgid,
-                                env::post_result_sigkill_grace_secs(),
+                                Duration::from_secs(env::post_result_sigkill_grace_secs()),
                             );
                             if let Some(pid) = pgid {
                                 unsafe { libc::kill(-pid, libc::SIGTERM); }
                             }
                             termination_error = Some(error);
+                            post_result_cleanup = None;
                             termination_state = TerminationState::SigkillPending {
                                 reason: TerminationReason::HeartbeatPanic,
                             };
@@ -1069,6 +1164,7 @@ async fn execute_cli_inner(
         stderr_lines: masked_stderr_lines,
         last_event_sequence,
         claude_result,
+        post_result_cleanup_result,
         failure_diagnostic,
         control_error: termination_error,
         cli_termination,
@@ -1080,13 +1176,13 @@ fn record_cli_termination_signal(
     reason: TerminationReason,
     signal: CliTerminationSignal,
     pgid: Option<i32>,
-    grace_secs: u64,
+    grace: Duration,
 ) {
     let diagnostic = cli_termination
         .take()
         .unwrap_or_else(|| CliTerminationDiagnostic::new(diagnostic_termination_reason(reason)));
-    *cli_termination =
-        Some(diagnostic.record_signal(signal, pgid, Some(grace_secs.saturating_mul(1000))));
+    let grace_ms = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
+    *cli_termination = Some(diagnostic.record_signal(signal, pgid, Some(grace_ms)));
 }
 
 fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTerminationReason {
@@ -1174,6 +1270,7 @@ mod tests {
     use agent_diagnostics::{
         CliTerminationReason, CliTerminationSignal, FailureDetailSource, FailureReason,
     };
+    use std::time::Duration;
 
     #[test]
     fn claude_initial_prompt_frame_matches_stream_json_user_shape() {
@@ -1217,7 +1314,7 @@ mod tests {
             TerminationReason::InitialPromptStdin,
             CliTerminationSignal::Sigterm,
             Some(42),
-            1,
+            Duration::from_secs(1),
         );
 
         let first = diagnostic.expect("diagnostic after SIGTERM");
@@ -1233,7 +1330,7 @@ mod tests {
             TerminationReason::InitialPromptStdin,
             CliTerminationSignal::Sigkill,
             Some(42),
-            2,
+            Duration::from_secs(2),
         );
 
         let escalated = diagnostic.expect("diagnostic after SIGKILL");

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -3,6 +3,9 @@
 //! Signal sending, deadline reset timing, and child wait ordering remain in
 //! `execute_cli`; this module only owns the FSM state and guards.
 
+use std::time::Duration;
+use tokio::time::Instant;
+
 /// State machine driving forced CLI process-group termination. A single
 /// pinned deadline is resettable across phases; the enum value tells the
 /// lone select! branch what to do when the deadline fires.
@@ -66,6 +69,118 @@ impl TerminationState {
     }
 }
 
+/// Bounded cleanup window after Claude Code emits a terminal result.
+///
+/// The quiet deadline extends when post-result meaningful events arrive; the
+/// total cap is fixed from the initial arm time so a noisy child cannot keep the
+/// sandbox alive indefinitely.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PostResultCleanupState {
+    started_at: Instant,
+    last_meaningful_event_at: Instant,
+    quiet_deadline: Instant,
+    total_cap_deadline: Instant,
+    meaningful_event_count: u64,
+    signal_sent: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PostResultCleanupTimeout {
+    pub(super) trigger: PostResultCleanupTrigger,
+    pub(super) elapsed: Duration,
+    pub(super) quiet_for: Duration,
+    pub(super) meaningful_event_count: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PostResultCleanupTrigger {
+    Quiet,
+    TotalCap,
+}
+
+impl PostResultCleanupTrigger {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Quiet => "quiet_timeout",
+            Self::TotalCap => "total_cap",
+        }
+    }
+}
+
+impl PostResultCleanupState {
+    pub(super) fn arm(now: Instant, quiet: Duration, total_cap: Duration) -> Self {
+        Self {
+            started_at: now,
+            last_meaningful_event_at: now,
+            quiet_deadline: now + quiet,
+            total_cap_deadline: now + total_cap,
+            meaningful_event_count: 0,
+            signal_sent: false,
+        }
+    }
+
+    pub(super) fn next_deadline(self) -> Option<Instant> {
+        if self.signal_sent {
+            return None;
+        }
+        Some(self.quiet_deadline.min(self.total_cap_deadline))
+    }
+
+    pub(super) fn record_meaningful_event(
+        &mut self,
+        now: Instant,
+        quiet: Duration,
+    ) -> Option<Instant> {
+        if self.signal_sent {
+            return None;
+        }
+        self.last_meaningful_event_at = now;
+        self.quiet_deadline = now + quiet;
+        self.meaningful_event_count = self.meaningful_event_count.saturating_add(1);
+        self.next_deadline()
+    }
+
+    pub(super) fn mark_signal_sent(&mut self, now: Instant) -> Option<PostResultCleanupTimeout> {
+        if self.signal_sent {
+            return None;
+        }
+        self.signal_sent = true;
+        self.timeout_due(now)
+    }
+
+    pub(super) fn timeout_due(self, now: Instant) -> Option<PostResultCleanupTimeout> {
+        let trigger =
+            if now >= self.total_cap_deadline && self.total_cap_deadline <= self.quiet_deadline {
+                PostResultCleanupTrigger::TotalCap
+            } else if now >= self.quiet_deadline {
+                PostResultCleanupTrigger::Quiet
+            } else if now >= self.total_cap_deadline {
+                PostResultCleanupTrigger::TotalCap
+            } else {
+                return None;
+            };
+
+        Some(PostResultCleanupTimeout {
+            trigger,
+            elapsed: self.elapsed(now),
+            quiet_for: self.quiet_for(now),
+            meaningful_event_count: self.meaningful_event_count,
+        })
+    }
+
+    pub(super) fn elapsed(self, now: Instant) -> Duration {
+        now.saturating_duration_since(self.started_at)
+    }
+
+    pub(super) fn quiet_for(self, now: Instant) -> Duration {
+        now.saturating_duration_since(self.last_meaningful_event_at)
+    }
+
+    pub(super) fn meaningful_event_count(self) -> u64 {
+        self.meaningful_event_count
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +235,110 @@ mod tests {
 
         // Done is sticky.
         assert!(!TerminationState::Done.should_arm_post_result(false));
+    }
+
+    #[test]
+    fn post_result_cleanup_arm_uses_earliest_deadline() {
+        let now = Instant::now();
+        let cleanup =
+            PostResultCleanupState::arm(now, Duration::from_secs(10), Duration::from_secs(3));
+
+        assert_eq!(cleanup.next_deadline(), Some(now + Duration::from_secs(3)));
+    }
+
+    #[test]
+    fn post_result_cleanup_meaningful_event_refreshes_quiet_deadline_only() {
+        let now = Instant::now();
+        let mut cleanup =
+            PostResultCleanupState::arm(now, Duration::from_secs(2), Duration::from_secs(10));
+        let event_at = now + Duration::from_secs(1);
+
+        assert_eq!(
+            cleanup.record_meaningful_event(event_at, Duration::from_secs(2)),
+            Some(now + Duration::from_secs(3))
+        );
+        assert_eq!(cleanup.meaningful_event_count, 1);
+        assert_eq!(
+            cleanup.timeout_due(now + Duration::from_secs(2)),
+            None,
+            "old quiet deadline must not fire after a meaningful event"
+        );
+        assert_eq!(
+            cleanup.timeout_due(now + Duration::from_secs(3)),
+            Some(PostResultCleanupTimeout {
+                trigger: PostResultCleanupTrigger::Quiet,
+                elapsed: Duration::from_secs(3),
+                quiet_for: Duration::from_secs(2),
+                meaningful_event_count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn post_result_cleanup_total_cap_is_not_refreshed_by_events() {
+        let now = Instant::now();
+        let mut cleanup =
+            PostResultCleanupState::arm(now, Duration::from_secs(2), Duration::from_secs(3));
+        let event_at = now + Duration::from_secs(2);
+
+        assert_eq!(
+            cleanup.record_meaningful_event(event_at, Duration::from_secs(2)),
+            Some(now + Duration::from_secs(3))
+        );
+        assert_eq!(
+            cleanup.timeout_due(now + Duration::from_secs(3)),
+            Some(PostResultCleanupTimeout {
+                trigger: PostResultCleanupTrigger::TotalCap,
+                elapsed: Duration::from_secs(3),
+                quiet_for: Duration::from_secs(1),
+                meaningful_event_count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn post_result_cleanup_does_not_refresh_after_signal() {
+        let now = Instant::now();
+        let mut cleanup =
+            PostResultCleanupState::arm(now, Duration::from_secs(1), Duration::from_secs(5));
+
+        assert_eq!(
+            cleanup.mark_signal_sent(now + Duration::from_secs(1)),
+            Some(PostResultCleanupTimeout {
+                trigger: PostResultCleanupTrigger::Quiet,
+                elapsed: Duration::from_secs(1),
+                quiet_for: Duration::from_secs(1),
+                meaningful_event_count: 0,
+            })
+        );
+        assert_eq!(
+            cleanup.record_meaningful_event(now + Duration::from_secs(2), Duration::from_secs(1)),
+            None
+        );
+        assert_eq!(cleanup.next_deadline(), None);
+    }
+
+    #[test]
+    fn child_exit_or_stronger_termination_parks_cleanup_driver_state() {
+        let mut state = TerminationState::SigtermPending {
+            reason: TerminationReason::PostResult,
+        };
+        assert!(state.is_pending());
+        state = TerminationState::Done;
+        assert!(!state.is_pending());
+
+        let mut state = TerminationState::SigtermPending {
+            reason: TerminationReason::PostResult,
+        };
+        assert!(state.is_pending());
+        state = TerminationState::SigkillPending {
+            reason: TerminationReason::HeartbeatError,
+        };
+        assert_eq!(
+            state,
+            TerminationState::SigkillPending {
+                reason: TerminationReason::HeartbeatError
+            }
+        );
     }
 }

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -48,6 +48,10 @@ pub const STDOUT_DRAIN_DEADLINE_SECS: u64 = 5;
 /// See: https://github.com/vm0-ai/vm0/issues/10879
 pub const POST_RESULT_SIGTERM_GRACE_SECS: u64 = 10;
 
+/// Absolute cap after observing a `type=result` event before SIGTERM-ing the
+/// CLI process group, even if meaningful post-result events keep arriving.
+pub const POST_RESULT_TOTAL_CAP_SECS: u64 = 60;
+
 /// Follow-up window after SIGTERM before escalating to SIGKILL when the CLI
 /// process group ignores the graceful signal.
 pub const POST_RESULT_SIGKILL_GRACE_SECS: u64 = 5;

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -50,7 +50,7 @@ pub const POST_RESULT_SIGTERM_GRACE_SECS: u64 = 10;
 
 /// Absolute cap after observing a `type=result` event before SIGTERM-ing the
 /// CLI process group, even if meaningful post-result events keep arriving.
-pub const POST_RESULT_TOTAL_CAP_SECS: u64 = 60;
+pub const POST_RESULT_TOTAL_CAP_SECS: u64 = 120;
 
 /// Follow-up window after SIGTERM before escalating to SIGKILL when the CLI
 /// process group ignores the graceful signal.

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -188,6 +188,15 @@ static POST_RESULT_SIGTERM_GRACE: LazyLock<u64> = LazyLock::new(|| {
     )
 });
 
+/// Absolute post-result cap. Unlike the quiet grace, this is fixed from the
+/// terminal result time and does not refresh on later stdout events.
+static POST_RESULT_TOTAL_CAP: LazyLock<u64> = LazyLock::new(|| {
+    u64_env_or(
+        guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+        constants::POST_RESULT_TOTAL_CAP_SECS,
+    )
+});
+
 /// Follow-up grace after SIGTERM before escalating to SIGKILL. Same
 /// override rationale as `POST_RESULT_SIGTERM_GRACE`.
 static POST_RESULT_SIGKILL_GRACE: LazyLock<u64> = LazyLock::new(|| {
@@ -521,6 +530,13 @@ pub fn stuck_tool_timeout_secs() -> u64 {
 /// also log a warning.
 pub fn post_result_sigterm_grace_secs() -> u64 {
     *POST_RESULT_SIGTERM_GRACE
+}
+/// Absolute cap after `type=result`, from `VM0_POST_RESULT_TOTAL_CAP_SECS`.
+///
+/// Unset or unparseable values use the compiled default; unparseable values
+/// also log a warning.
+pub fn post_result_total_cap_secs() -> u64 {
+    *POST_RESULT_TOTAL_CAP
 }
 /// Grace period before SIGKILL after SIGTERM, from
 /// `VM0_POST_RESULT_SIGKILL_GRACE_SECS`.

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -226,6 +226,11 @@ async fn execute(
                 );
                 let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
                 (cli_exit_code, 1, msg, false, Some(diagnostic), false)
+            } else if preserves_successful_post_result_cleanup(
+                env::Framework::from_env(),
+                &cli_result,
+            ) {
+                (cli_exit_code, 0, String::new(), false, None, true)
             } else if cli_exit_code != 0 {
                 let failure_message = cli_failure_message(
                     cli_exit_code,
@@ -332,9 +337,31 @@ fn is_claude_zero_turn_result(
 ) -> bool {
     matches!(framework, env::Framework::ClaudeCode)
         && cli_result.exit_code == 0
+        && cli_result.claude_result.is_some_and(|result| {
+            result.status == cli::ClaudeResultStatus::Success && result.num_turns == Some(0)
+        })
+}
+
+fn preserves_successful_post_result_cleanup(
+    framework: env::Framework,
+    cli_result: &cli::CliExecutionResult,
+) -> bool {
+    matches!(framework, env::Framework::ClaudeCode)
+        && cli_result.control_error.is_none()
+        && cli_result.exit_code != 0
         && cli_result
             .claude_result
-            .is_some_and(|result| result.num_turns == Some(0))
+            .is_some_and(|result| result.status == cli::ClaudeResultStatus::Success)
+        && cli_result
+            .post_result_cleanup_result
+            .is_some_and(|result| result.status == cli::ClaudeResultStatus::Success)
+        && cli_result
+            .cli_termination
+            .as_ref()
+            .is_some_and(|termination| {
+                termination.reason == agent_diagnostics::CliTerminationReason::PostResultReap
+                    && termination.observed_exit_code == Some(cli_result.exit_code)
+            })
 }
 
 fn with_cli_termination(
@@ -779,7 +806,7 @@ async fn complete_execution(
         exit_code = 1;
     }
 
-    if cli_exit_code == 0 && exit_code == 0 {
+    if exit_code == 0 {
         log_info!(LOG_TAG, "✓ Execution complete ({}s)", cli_elapsed.as_secs());
     } else {
         log_info!(LOG_TAG, "✗ Execution failed ({}s)", cli_elapsed.as_secs());
@@ -791,7 +818,7 @@ async fn complete_execution(
     // pass runs from the top-level shutdown path after telemetry producers
     // stop, so it can safely catch checkpoint and `/complete` logs.
     let agent_type = env::Framework::from_env().agent_type();
-    if should_create_success_checkpoint(cli_exit_code, exit_code) && http.has_api() {
+    if should_create_success_checkpoint(exit_code) && http.has_api() {
         log_info!(LOG_TAG, "{agent_type} completed successfully");
 
         log_info!(LOG_TAG, "▷ Checkpoint");
@@ -854,7 +881,7 @@ async fn complete_execution(
             }
         }
     } else {
-        if cli_exit_code == 0 && exit_code == 0 {
+        if exit_code == 0 {
             log_info!(LOG_TAG, "{agent_type} completed successfully");
         } else if state.skip_recovery_checkpoint_for_no_history {
             log_info!(
@@ -943,8 +970,8 @@ async fn stop_heartbeat(handle: tokio::task::JoinHandle<()>) {
     }
 }
 
-fn should_create_success_checkpoint(cli_exit_code: i32, exit_code: i32) -> bool {
-    cli_exit_code == 0 && exit_code == 0
+fn should_create_success_checkpoint(exit_code: i32) -> bool {
+    exit_code == 0
 }
 
 fn setup_working_dir(path: impl AsRef<Path>) -> std::io::Result<()> {
@@ -1874,7 +1901,11 @@ mod tests {
             exit_code: 0,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
-            claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(0) }),
+            claude_result: Some(cli::ClaudeResultSummary {
+                num_turns: Some(0),
+                status: cli::ClaudeResultStatus::Success,
+            }),
+            post_result_cleanup_result: None,
             failure_diagnostic: None,
             control_error: None,
             cli_termination: None,
@@ -1883,7 +1914,11 @@ mod tests {
             exit_code: 0,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
-            claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(1) }),
+            claude_result: Some(cli::ClaudeResultSummary {
+                num_turns: Some(1),
+                status: cli::ClaudeResultStatus::Success,
+            }),
+            post_result_cleanup_result: None,
             failure_diagnostic: None,
             control_error: None,
             cli_termination: None,
@@ -1892,7 +1927,24 @@ mod tests {
             exit_code: 1,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
-            claude_result: Some(cli::ClaudeResultSummary { num_turns: Some(0) }),
+            claude_result: Some(cli::ClaudeResultSummary {
+                num_turns: Some(0),
+                status: cli::ClaudeResultStatus::Success,
+            }),
+            post_result_cleanup_result: None,
+            failure_diagnostic: None,
+            control_error: None,
+            cli_termination: None,
+        };
+        let unknown_zero_turn = cli::CliExecutionResult {
+            exit_code: 0,
+            stderr_lines: Vec::new(),
+            last_event_sequence: None,
+            claude_result: Some(cli::ClaudeResultSummary {
+                num_turns: Some(0),
+                status: cli::ClaudeResultStatus::Unknown,
+            }),
+            post_result_cleanup_result: None,
             failure_diagnostic: None,
             control_error: None,
             cli_termination: None,
@@ -1914,6 +1966,73 @@ mod tests {
             env::Framework::ClaudeCode,
             &failed_zero_turn,
         ));
+        assert!(!is_claude_zero_turn_result(
+            env::Framework::ClaudeCode,
+            &unknown_zero_turn,
+        ));
+    }
+
+    #[test]
+    fn successful_post_result_cleanup_preserves_semantic_success_only_for_narrow_case() {
+        let success_result = cli::ClaudeResultSummary {
+            num_turns: Some(1),
+            status: cli::ClaudeResultStatus::Success,
+        };
+        let make_result =
+            |claude_result: cli::ClaudeResultSummary,
+             termination_reason: agent_diagnostics::CliTerminationReason| {
+                let termination = CliTerminationDiagnostic::new(termination_reason)
+                    .record_signal(
+                        agent_diagnostics::CliTerminationSignal::Sigterm,
+                        Some(42),
+                        Some(1_000),
+                    )
+                    .with_observed_exit_code(143);
+                cli::CliExecutionResult {
+                    exit_code: 143,
+                    stderr_lines: Vec::new(),
+                    last_event_sequence: None,
+                    claude_result: Some(claude_result),
+                    post_result_cleanup_result: Some(success_result),
+                    failure_diagnostic: None,
+                    control_error: None,
+                    cli_termination: Some(termination),
+                }
+            };
+        let successful_cleanup = make_result(
+            success_result,
+            agent_diagnostics::CliTerminationReason::PostResultReap,
+        );
+
+        assert!(preserves_successful_post_result_cleanup(
+            env::Framework::ClaudeCode,
+            &successful_cleanup,
+        ));
+        assert!(!preserves_successful_post_result_cleanup(
+            env::Framework::Codex,
+            &successful_cleanup,
+        ));
+
+        let error_cleanup = make_result(
+            cli::ClaudeResultSummary {
+                num_turns: Some(1),
+                status: cli::ClaudeResultStatus::Error,
+            },
+            agent_diagnostics::CliTerminationReason::PostResultReap,
+        );
+        assert!(!preserves_successful_post_result_cleanup(
+            env::Framework::ClaudeCode,
+            &error_cleanup,
+        ));
+
+        let stronger_termination = make_result(
+            success_result,
+            agent_diagnostics::CliTerminationReason::StuckToolWatchdog,
+        );
+        assert!(!preserves_successful_post_result_cleanup(
+            env::Framework::ClaudeCode,
+            &stronger_termination,
+        ));
     }
 
     #[test]
@@ -1934,10 +2053,9 @@ mod tests {
     }
 
     #[test]
-    fn success_checkpoint_requires_cli_and_run_success() {
-        assert!(should_create_success_checkpoint(0, 0));
-        assert!(!should_create_success_checkpoint(0, 1));
-        assert!(!should_create_success_checkpoint(1, 1));
+    fn success_checkpoint_follows_semantic_run_success() {
+        assert!(should_create_success_checkpoint(0));
+        assert!(!should_create_success_checkpoint(1));
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -350,9 +350,6 @@ fn preserves_successful_post_result_cleanup(
         && cli_result.control_error.is_none()
         && cli_result.exit_code != 0
         && cli_result
-            .claude_result
-            .is_some_and(|result| result.status == cli::ClaudeResultStatus::Success)
-        && cli_result
             .post_result_cleanup_result
             .is_some_and(|result| result.status == cli::ClaudeResultStatus::Success)
         && cli_result
@@ -1980,6 +1977,7 @@ mod tests {
         };
         let make_result =
             |claude_result: cli::ClaudeResultSummary,
+             cleanup_result: cli::ClaudeResultSummary,
              termination_reason: agent_diagnostics::CliTerminationReason| {
                 let termination = CliTerminationDiagnostic::new(termination_reason)
                     .record_signal(
@@ -1993,13 +1991,14 @@ mod tests {
                     stderr_lines: Vec::new(),
                     last_event_sequence: None,
                     claude_result: Some(claude_result),
-                    post_result_cleanup_result: Some(success_result),
+                    post_result_cleanup_result: Some(cleanup_result),
                     failure_diagnostic: None,
                     control_error: None,
                     cli_termination: Some(termination),
                 }
             };
         let successful_cleanup = make_result(
+            success_result,
             success_result,
             agent_diagnostics::CliTerminationReason::PostResultReap,
         );
@@ -2013,7 +2012,21 @@ mod tests {
             &successful_cleanup,
         ));
 
+        let late_error_result_after_successful_cleanup = make_result(
+            cli::ClaudeResultSummary {
+                num_turns: Some(1),
+                status: cli::ClaudeResultStatus::Error,
+            },
+            success_result,
+            agent_diagnostics::CliTerminationReason::PostResultReap,
+        );
+        assert!(preserves_successful_post_result_cleanup(
+            env::Framework::ClaudeCode,
+            &late_error_result_after_successful_cleanup,
+        ));
+
         let error_cleanup = make_result(
+            success_result,
             cli::ClaudeResultSummary {
                 num_turns: Some(1),
                 status: cli::ClaudeResultStatus::Error,
@@ -2026,6 +2039,7 @@ mod tests {
         ));
 
         let stronger_termination = make_result(
+            success_result,
             success_result,
             agent_diagnostics::CliTerminationReason::StuckToolWatchdog,
         );

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -433,6 +433,9 @@ pub fn build_and_locate_mock() -> Result<PathBuf, String> {
 /// `prompt` decides which mock-claude test prefix runs:
 /// - `@hang-after-result` → SIGTERM path
 /// - `@hang-after-result-deaf` → SIGKILL escalation path
+/// - `@hang-after-result-then-event` → post-result quiet refresh path
+/// - `@hang-after-result-periodic-events` → post-result total cap path
+/// - `@hang-after-error-result` → error result followed by post-result cleanup
 /// - `@exit-after-result` → happy path (no signal ever fires)
 /// - `@fail-no-newline:<message>` → stderr EOF without trailing newline
 /// - `@fail-invalid-utf8` → stderr bytes that are not valid UTF-8
@@ -476,6 +479,7 @@ pub unsafe fn setup_env(
             "VM0_POST_RESULT_SIGKILL_GRACE_SECS",
             sigkill_grace_secs.to_string(),
         );
+        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "60");
         // Derive run_id from the test binary's filename (which cargo
         // hashes per target) so the three reap test binaries running
         // concurrently don't collide on the run-scoped files that

--- a/crates/guest-agent/tests/post_result_reap_error_result.rs
+++ b/crates/guest-agent/tests/post_result_reap_error_result.rs
@@ -1,0 +1,58 @@
+//! End-to-end: a Claude error `type=result` followed by cleanup termination
+//! remains a semantic failure source instead of falling back to exit 143.
+
+mod common;
+
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal, FailureDetailSource};
+use guest_agent::cli::ClaudeResultStatus;
+use std::time::Duration;
+
+#[tokio::test]
+async fn post_result_reap_preserves_error_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@hang-after-error-result", 1, 1)?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = common::spawn_dummy_heartbeat();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(8),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
+    )
+    .await
+    .expect("execute_cli did not return within 8s");
+
+    let result = result.expect("execute_cli returned Err");
+    assert_eq!(result.exit_code, common::SIGTERM_EXIT);
+    assert_eq!(
+        result.claude_result.map(|summary| summary.status),
+        Some(ClaudeResultStatus::Error)
+    );
+    assert_eq!(
+        result
+            .post_result_cleanup_result
+            .map(|summary| summary.status),
+        Some(ClaudeResultStatus::Error)
+    );
+
+    let diagnostic = result
+        .failure_diagnostic
+        .expect("error result should attach CLI failure diagnostic");
+    assert_eq!(diagnostic.message, "Mock Claude error.");
+    assert_eq!(diagnostic.source, FailureDetailSource::ClaudeResult);
+
+    let termination = result
+        .cli_termination
+        .expect("post-result reap should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_refresh.rs
+++ b/crates/guest-agent/tests/post_result_reap_refresh.rs
@@ -1,0 +1,46 @@
+//! End-to-end: a meaningful JSONL event after `type=result` refreshes the
+//! post-result quiet deadline before the hung CLI is reaped.
+
+mod common;
+
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn post_result_reap_refreshes_quiet_deadline_on_meaningful_event()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(&mock, tmp.path(), "@hang-after-result-then-event", 2, 1)?;
+        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "10");
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = common::spawn_dummy_heartbeat();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(12),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
+    )
+    .await
+    .expect("execute_cli did not return within 12s");
+
+    let result = result.expect("execute_cli returned Err");
+    assert_eq!(result.exit_code, common::SIGTERM_EXIT);
+    let termination = result
+        .cli_termination
+        .expect("post-result reap should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+
+    let ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
+    assert!(ops.contains("trigger=quiet_timeout"), "{ops}");
+    assert!(ops.contains("meaningful_events=1"), "{ops}");
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_total_cap.rs
+++ b/crates/guest-agent/tests/post_result_reap_total_cap.rs
@@ -1,0 +1,51 @@
+//! End-to-end: periodic meaningful JSONL events after `type=result` refresh the
+//! quiet deadline but cannot refresh the absolute post-result total cap.
+
+mod common;
+
+use agent_diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+#[tokio::test]
+async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    unsafe {
+        common::setup_env(
+            &mock,
+            tmp.path(),
+            "@hang-after-result-periodic-events",
+            2,
+            1,
+        )?;
+        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "1");
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let heartbeat = common::spawn_dummy_heartbeat();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(8),
+        guest_agent::cli::execute_cli(
+            &masker,
+            heartbeat,
+            guest_agent::http::HttpClient::new().unwrap(),
+        ),
+    )
+    .await
+    .expect("execute_cli did not return within 8s");
+
+    let result = result.expect("execute_cli returned Err");
+    assert_eq!(result.exit_code, common::SIGTERM_EXIT);
+    let termination = result
+        .cli_termination
+        .expect("post-result reap should attach CLI termination diagnostic");
+    assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+
+    let ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
+    assert!(ops.contains("trigger=total_cap"), "{ops}");
+    Ok(())
+}

--- a/crates/guest-agent/tests/post_result_reap_total_cap.rs
+++ b/crates/guest-agent/tests/post_result_reap_total_cap.rs
@@ -19,7 +19,7 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
             2,
             1,
         )?;
-        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "1");
+        std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "3");
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -46,6 +46,11 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
     assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
 
     let ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
-    assert!(ops.contains("trigger=total_cap"), "{ops}");
+    let cleanup_line = ops
+        .lines()
+        .find(|line| line.contains("post_result_cleanup_terminated"))
+        .expect("post-result cleanup telemetry should be recorded");
+    assert!(cleanup_line.contains("trigger=total_cap"), "{ops}");
+    assert!(!cleanup_line.contains("meaningful_events=0"), "{ops}");
     Ok(())
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -137,6 +137,14 @@ pub const STUCK_TOOL_TIMEOUT_SECS_ENV: &str = "VM0_STUCK_TOOL_TIMEOUT_SECS";
 /// unset or unparseable values use the compiled default.
 pub const POST_RESULT_SIGTERM_GRACE_SECS_ENV: &str = "VM0_POST_RESULT_SIGTERM_GRACE_SECS";
 
+/// Guest-agent absolute cap in seconds before sending SIGTERM after the CLI
+/// reports a final result, regardless of later post-result stdout events.
+///
+/// This is a tuning key: local execution may pass it through user env via
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The guest-agent parses the value as `u64`;
+/// unset or unparseable values use the compiled default.
+pub const POST_RESULT_TOTAL_CAP_SECS_ENV: &str = "VM0_POST_RESULT_TOTAL_CAP_SECS";
+
 /// Guest-agent grace period in seconds before escalating from SIGTERM to
 /// SIGKILL after the CLI reports a final result.
 ///
@@ -183,6 +191,7 @@ pub const WORKING_DIR_ENV: &str = "VM0_WORKING_DIR";
 pub const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
     STUCK_TOOL_TIMEOUT_SECS_ENV,
     POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+    POST_RESULT_TOTAL_CAP_SECS_ENV,
     POST_RESULT_SIGKILL_GRACE_SECS_ENV,
 ];
 
@@ -321,6 +330,9 @@ mod tests {
         assert!(is_guest_agent_tuning_env_key(STUCK_TOOL_TIMEOUT_SECS_ENV));
         assert!(is_guest_agent_tuning_env_key(
             POST_RESULT_SIGTERM_GRACE_SECS_ENV
+        ));
+        assert!(is_guest_agent_tuning_env_key(
+            POST_RESULT_TOTAL_CAP_SECS_ENV
         ));
         assert!(is_guest_agent_tuning_env_key(
             POST_RESULT_SIGKILL_GRACE_SECS_ENV

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -26,6 +26,13 @@
 //!   @hang-after-result-deaf   - Same, but ignores SIGTERM so only SIGKILL
 //!                               can terminate it; tests the
 //!                               SigkillPending->Done escalation path
+//!   @hang-after-result-then-event
+//!                             - Emit result, later emit a meaningful event,
+//!                               then hang
+//!   @hang-after-result-periodic-events
+//!                             - Emit result, then keep emitting meaningful
+//!                               events until reaped
+//!   @hang-after-error-result  - Emit an error result, then hang
 //!   @exit-after-result        - Emit result event, exit(0) immediately;
 //!                               tests that reap stays no-op on the
 //!                               happy path

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -128,6 +128,13 @@ fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -
         MockScenario::HangAfterResult { deaf } => {
             run_hang_after_result_scenario(output_format, deaf)
         }
+        MockScenario::HangAfterResultThenEvent => {
+            run_hang_after_result_then_event_scenario(output_format)
+        }
+        MockScenario::HangAfterResultPeriodicEvents => {
+            run_hang_after_result_periodic_events_scenario(output_format)
+        }
+        MockScenario::HangAfterErrorResult => run_hang_after_error_result_scenario(output_format),
         MockScenario::ExitAfterResult => {
             if output_format == "stream-json" {
                 emit_post_result_pair();
@@ -324,13 +331,18 @@ fn run_echo_jsonl_mode(payload: &str) -> ExitCode {
 /// session history checkpoint file. Caller decides which post-result
 /// behavior follows (hang / exit / ignore SIGTERM / orphan stdout).
 fn emit_post_result_pair() {
+    let _ = emit_result_pair(false, "Done.");
+}
+
+fn emit_result_pair(is_error: bool, result: &str) -> String {
     let session_id = generate_session_id();
     let mut transcript = JsonlTranscript::default();
     transcript.emit_value(init_event(&session_id, &["Bash"]));
-    transcript.emit_value(result_event(&session_id, false, "Done."));
+    transcript.emit_value(result_event(&session_id, is_error, result));
     transcript.write_session_history(&session_id);
 
     let _ = std::io::stdout().flush();
+    session_id
 }
 
 fn emit_stuck_tool_events() {
@@ -399,6 +411,43 @@ fn run_hang_after_result_scenario(output_format: &str, deaf: bool) -> ExitCode {
         }
         // Hang this process forever. guest-agent's post-result reap SIGTERMs
         // it within POST_RESULT_SIGTERM_GRACE_SECS unless SIGTERM is ignored.
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+fn run_hang_after_result_then_event_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        let session_id = emit_result_pair(false, "Done.");
+        thread::sleep(Duration::from_millis(1_000));
+        let mut transcript = JsonlTranscript::default();
+        transcript.emit_value(assistant_text_event(&session_id, "post-result event"));
+        let _ = std::io::stdout().flush();
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+fn run_hang_after_result_periodic_events_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        let session_id = emit_result_pair(false, "Done.");
+        let mut transcript = JsonlTranscript::default();
+        for index in 0..20 {
+            thread::sleep(Duration::from_millis(250));
+            transcript.emit_value(assistant_text_event(
+                &session_id,
+                &format!("post-result periodic event {index}"),
+            ));
+            let _ = std::io::stdout().flush();
+        }
+        hang_until_reaped();
+    }
+    ExitCode::SUCCESS
+}
+
+fn run_hang_after_error_result_scenario(output_format: &str) -> ExitCode {
+    if output_format == "stream-json" {
+        let _ = emit_result_pair(true, "Mock Claude error.");
         hang_until_reaped();
     }
     ExitCode::SUCCESS

--- a/crates/guest-mock-claude/src/scenario.rs
+++ b/crates/guest-mock-claude/src/scenario.rs
@@ -11,6 +11,9 @@ const STUCK_TOOL_DEAF_MARKER: &str = "@stuck-tool-deaf";
 const STUCK_TOOL_MARKER: &str = "@stuck-tool";
 const ORPHAN_PIPE_MARKER: &str = "@orphan-pipe";
 const HANG_AFTER_RESULT_DEAF_MARKER: &str = "@hang-after-result-deaf";
+const HANG_AFTER_RESULT_THEN_EVENT_MARKER: &str = "@hang-after-result-then-event";
+const HANG_AFTER_RESULT_PERIODIC_EVENTS_MARKER: &str = "@hang-after-result-periodic-events";
+const HANG_AFTER_ERROR_RESULT_MARKER: &str = "@hang-after-error-result";
 const EXIT_AFTER_RESULT_MARKER: &str = "@exit-after-result";
 const WRITE_ENV_JSON_MARKER: &str = "@write-env-json:";
 const HANG_AFTER_RESULT_MARKER: &str = "@hang-after-result";
@@ -27,6 +30,9 @@ pub(crate) enum MockScenario<'a> {
     StuckTool { deaf: bool, close_stdout: bool },
     OrphanPipe,
     HangAfterResult { deaf: bool },
+    HangAfterResultThenEvent,
+    HangAfterResultPeriodicEvents,
+    HangAfterErrorResult,
     ExitAfterResult,
     WriteEnvJson(&'a str),
     Shell,
@@ -51,6 +57,9 @@ enum ScenarioKind {
     StuckTool { deaf: bool, close_stdout: bool },
     OrphanPipe,
     HangAfterResult { deaf: bool },
+    HangAfterResultThenEvent,
+    HangAfterResultPeriodicEvents,
+    HangAfterErrorResult,
     ExitAfterResult,
     WriteEnvJson,
 }
@@ -133,6 +142,21 @@ const SCENARIO_RULES: &[ScenarioRule] = &[
         scenario_kind: ScenarioKind::HangAfterResult { deaf: true },
     },
     ScenarioRule {
+        marker: HANG_AFTER_RESULT_THEN_EVENT_MARKER,
+        match_kind: ScenarioMatchKind::Prefix,
+        scenario_kind: ScenarioKind::HangAfterResultThenEvent,
+    },
+    ScenarioRule {
+        marker: HANG_AFTER_RESULT_PERIODIC_EVENTS_MARKER,
+        match_kind: ScenarioMatchKind::Prefix,
+        scenario_kind: ScenarioKind::HangAfterResultPeriodicEvents,
+    },
+    ScenarioRule {
+        marker: HANG_AFTER_ERROR_RESULT_MARKER,
+        match_kind: ScenarioMatchKind::Prefix,
+        scenario_kind: ScenarioKind::HangAfterErrorResult,
+    },
+    ScenarioRule {
         marker: EXIT_AFTER_RESULT_MARKER,
         match_kind: ScenarioMatchKind::Prefix,
         scenario_kind: ScenarioKind::ExitAfterResult,
@@ -192,6 +216,15 @@ impl ScenarioKind {
             (Self::OrphanPipe, ScenarioMatch::Marker) => MockScenario::OrphanPipe,
             (Self::HangAfterResult { deaf }, ScenarioMatch::Marker) => {
                 MockScenario::HangAfterResult { deaf }
+            }
+            (Self::HangAfterResultThenEvent, ScenarioMatch::Marker) => {
+                MockScenario::HangAfterResultThenEvent
+            }
+            (Self::HangAfterResultPeriodicEvents, ScenarioMatch::Marker) => {
+                MockScenario::HangAfterResultPeriodicEvents
+            }
+            (Self::HangAfterErrorResult, ScenarioMatch::Marker) => {
+                MockScenario::HangAfterErrorResult
             }
             (Self::ExitAfterResult, ScenarioMatch::Marker) => MockScenario::ExitAfterResult,
             _ => return None,
@@ -312,6 +345,18 @@ mod tests {
                 "@hang-after-result-deaf",
                 MockScenario::HangAfterResult { deaf: true },
             ),
+            (
+                "@hang-after-result-then-event",
+                MockScenario::HangAfterResultThenEvent,
+            ),
+            (
+                "@hang-after-result-periodic-events",
+                MockScenario::HangAfterResultPeriodicEvents,
+            ),
+            (
+                "@hang-after-error-result",
+                MockScenario::HangAfterErrorResult,
+            ),
             ("@exit-after-result", MockScenario::ExitAfterResult),
             (
                 "@write-env-json:/tmp/env.json",
@@ -345,6 +390,14 @@ mod tests {
         assert!(marker_position(STUCK_TOOL_DEAF_MARKER) < marker_position(STUCK_TOOL_MARKER));
         assert!(
             marker_position(HANG_AFTER_RESULT_DEAF_MARKER)
+                < marker_position(HANG_AFTER_RESULT_MARKER)
+        );
+        assert!(
+            marker_position(HANG_AFTER_RESULT_THEN_EVENT_MARKER)
+                < marker_position(HANG_AFTER_RESULT_MARKER)
+        );
+        assert!(
+            marker_position(HANG_AFTER_RESULT_PERIODIC_EVENTS_MARKER)
                 < marker_position(HANG_AFTER_RESULT_MARKER)
         );
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -644,6 +644,7 @@ fn build_env_json_preserves_guest_agent_tuning_env() {
     ctx.environment = Some(HashMap::from([
         ("VM0_STUCK_TOOL_TIMEOUT_SECS".into(), "3".into()),
         ("VM0_POST_RESULT_SIGTERM_GRACE_SECS".into(), "1".into()),
+        ("VM0_POST_RESULT_TOTAL_CAP_SECS".into(), "4".into()),
         ("VM0_POST_RESULT_SIGKILL_GRACE_SECS".into(), "2".into()),
     ]));
 
@@ -651,6 +652,7 @@ fn build_env_json_preserves_guest_agent_tuning_env() {
 
     assert_eq!(env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
     assert_eq!(env.get("VM0_POST_RESULT_SIGTERM_GRACE_SECS").unwrap(), "1");
+    assert_eq!(env.get("VM0_POST_RESULT_TOTAL_CAP_SECS").unwrap(), "4");
     assert_eq!(env.get("VM0_POST_RESULT_SIGKILL_GRACE_SECS").unwrap(), "2");
 }
 


### PR DESCRIPTION
## Summary

Fixes #18509.

- Add explicit Claude result status metadata and keep the result that armed post-result cleanup separate from later drained result events.
- Replace the fixed post-result reap countdown with a bounded cleanup state machine: meaningful post-result JSONL refreshes the quiet deadline, while a total cap remains fixed.
- Preserve semantic success only for narrow successful Claude result + guest-agent post_result_reap cleanup cases, while keeping error/unknown/stronger termination paths as failures.
- Add mock Claude scenarios and integration tests for quiet refresh and total-cap behavior.

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude
- cargo test --manifest-path crates/Cargo.toml -p runner build_env_json_preserves_guest_agent_tuning_env
- cargo test --manifest-path crates/Cargo.toml -p runner job_execution_failed
- cargo test --manifest-path crates/Cargo.toml -p guest-contracts guest_agent_tuning_keys_are_explicit
- cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics

Pre-commit hook also passed cargo-fmt, cargo-doc, and cargo-clippy.