### PR TITLE
ci: run app deploy for playwright web e2e

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1268,11 +1268,14 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260525
     needs: [prepare]
-    # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
+    # Deploy if job-ref is set (PR or main), not a release-please commit, and
+    # browser/playwright E2E may need a matching app preview.
     if: >-
       ${{
         (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
         needs.prepare.outputs.job-ref != '' && (
+          needs.prepare.outputs.web-changed == 'true' ||
+          needs.prepare.outputs.cli-changed == 'true' ||
           needs.prepare.outputs.platform-changed == 'true' ||
           needs.prepare.outputs.e2e-changed == 'true' ||
           needs.prepare.outputs.ci-changed == 'true'


### PR DESCRIPTION
## Summary
- Run the app preview deploy whenever browser/playwright E2E can be triggered by web or CLI changes.
- Keep the Playwright job's app-preview dependency strict so it does not run against a missing pr-*-app alias.

## Problem
A web-only workflow change can trigger cli-e2e-02-playwright, but deploy-app was previously skipped for web-only changes. Because cli-e2e-02-playwright requires deploy-app to succeed, the job skipped instead of testing the matching preview environment.

## Verification
- cd turbo && pnpm exec prettier --check ../.github/workflows/turbo.yml
- git diff --check -- .github/workflows/turbo.yml
- actionlint .github/workflows/turbo.yml