### PR TITLE
Proxy so frontend non-GET requests

### DIFF
--- a/turbo/apps/platform/src/lib/time.ts
+++ b/turbo/apps/platform/src/lib/time.ts
@@ -1,3 +1,4 @@
+// Shared clock override used by platform tests that need deterministic time.
 function testOverride<T>(factory: () => T): {
   readonly get: () => T;
   readonly set: (value: T) => void;

--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -58,6 +58,7 @@ vi.mock("next-intl/middleware", () => {
 });
 
 let middleware: typeof import("../proxy").default;
+let reloadEnv: typeof import("../src/env").reloadEnv;
 
 function createMockEvent() {
   return {
@@ -69,10 +70,17 @@ function createMockEvent() {
 describe("proxy middleware: public routes", () => {
   beforeAll(async () => {
     middleware = (await import("../proxy")).default;
+    reloadEnv = (await import("../src/env")).reloadEnv;
   });
 
   beforeEach(() => {
     clerkState.protectedPaths = [];
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_test_proxy");
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_proxy");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.vm0.ai");
+    reloadEnv();
   });
 
   it("keeps locale-prefixed web design gallery public", async () => {
@@ -81,6 +89,121 @@ describe("proxy middleware: public routes", () => {
     await middleware(request, createMockEvent());
 
     expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("proxies non-GET requests for so frontend rewrite pages when forwarding is enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("proxied", {
+        status: 202,
+        headers: {
+          "x-so-frontend": "1",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("https://www.vm0.ai/en?from=signout", {
+      method: "POST",
+      headers: {
+        "content-type": "text/plain;charset=UTF-8",
+        cookie: "__session=test",
+      },
+      body: "payload",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(targetUrl)).toBe("https://so.vm0.ai/en?from=signout");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toBeInstanceOf(Headers);
+    const proxiedHeaders = init?.headers as Headers;
+    expect(proxiedHeaders.get("x-forwarded-host")).toBe("www.vm0.ai");
+    expect(proxiedHeaders.get("x-forwarded-proto")).toBe("https");
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected proxy response");
+    }
+    expect(response.status).toBe(202);
+    expect(response.headers.get("x-so-frontend")).toBe("1");
+    await expect(response.text()).resolves.toBe("proxied");
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("does not proxy non-GET requests when so frontend forwarding is disabled", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest("https://www.vm0.ai/en", {
+      method: "POST",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected middleware response");
+    }
+    expect(response.status).not.toBe(202);
+  });
+
+  it("does not proxy auth routes to so in preview", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://staging-so.vm6.ai");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    reloadEnv();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest(
+      "https://pr-18518-www.vm6.ai/sign-in/factor-one",
+      {
+        method: "POST",
+      },
+    );
+
+    await middleware(request, createMockEvent());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("proxies auth routes to so in production", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    vi.stubEnv("VERCEL_ENV", "production");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("auth proxied", { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest("https://www.vm0.ai/sign-in/factor-one", {
+      method: "POST",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [targetUrl] = fetchMock.mock.calls[0] ?? [];
+    expect(String(targetUrl)).toBe("https://so.vm0.ai/sign-in/factor-one");
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected auth proxy response");
+    }
+    expect(response.status).toBe(202);
+  });
+
+  it("does not proxy app-only functional routes when so forwarding is enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest("https://www.vm0.ai/connector/success", {
+      method: "POST",
+    });
+
+    await middleware(request, createMockEvent());
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("keeps locale-less web design gallery public", async () => {

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSoFrontendRewrites,
+  matchesSoFrontendRewritePath,
+  resolveSoFrontendRewritePath,
   resolveSoFrontendUrl,
 } from "../so-frontend-rewrites";
 
@@ -20,9 +22,10 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendUrl({ VERCEL_ENV: "preview" })).toBeUndefined();
   });
 
-  it("rewrites marketing content and sign-in/sign-up to so", () => {
+  it("rewrites marketing content to so in preview", () => {
     const rewrites = buildSoFrontendRewrites({
       PAID_ONBOARDING_URL: "https://pr-123-so.vm6.ai",
+      VERCEL_ENV: "preview",
     });
 
     expect(rewrites).toContainEqual({
@@ -45,13 +48,29 @@ describe("so frontend rewrites", () => {
       source: "/en/models/:path*",
       destination: "https://pr-123-so.vm6.ai/en/models/:path*",
     });
+    expect(rewrites).not.toContainEqual({
+      source: "/sign-in",
+      destination: "https://pr-123-so.vm6.ai/sign-in",
+    });
+    expect(rewrites).not.toContainEqual({
+      source: "/sign-up",
+      destination: "https://pr-123-so.vm6.ai/sign-up",
+    });
+  });
+
+  it("rewrites sign-in/sign-up to so only in production", () => {
+    const rewrites = buildSoFrontendRewrites({
+      PAID_ONBOARDING_URL: "https://so.vm0.ai",
+      VERCEL_ENV: "production",
+    });
+
     expect(rewrites).toContainEqual({
       source: "/sign-in/:path*",
-      destination: "https://pr-123-so.vm6.ai/sign-in/:path*",
+      destination: "https://so.vm0.ai/sign-in/:path*",
     });
     expect(rewrites).toContainEqual({
       source: "/sign-up",
-      destination: "https://pr-123-so.vm6.ai/sign-up",
+      destination: "https://so.vm0.ai/sign-up",
     });
   });
 
@@ -70,5 +89,43 @@ describe("so frontend rewrites", () => {
     expect(sources.has("/connector/:path*")).toBe(false);
     expect(sources.has("/export")).toBe(false);
     expect(sources.has("/sign-in-token")).toBe(false);
+  });
+
+  it("matches configured so frontend rewrite paths", () => {
+    expect(matchesSoFrontendRewritePath("/pricing")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/en/pricing")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/en/blog/posts/example")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/docs/getting-started")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/assets/vm0-logo.svg")).toBe(true);
+
+    expect(matchesSoFrontendRewritePath("/sign-in/sso-callback")).toBe(false);
+    expect(
+      matchesSoFrontendRewritePath("/sign-in/sso-callback", {
+        VERCEL_ENV: "production",
+      }),
+    ).toBe(true);
+    expect(matchesSoFrontendRewritePath("/connector/success")).toBe(false);
+    expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(false);
+    expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(
+      false,
+    );
+  });
+
+  it("resolves the matching so frontend destination path", () => {
+    expect(resolveSoFrontendRewritePath("/")).toBe("/en");
+    expect(resolveSoFrontendRewritePath("/report")).toBe("/en/report");
+    expect(resolveSoFrontendRewritePath("/docs/reference/api")).toBe(
+      "/en/docs/reference/api",
+    );
+    expect(resolveSoFrontendRewritePath("/en/docs/reference/api")).toBe(
+      "/en/docs/reference/api",
+    );
+    expect(resolveSoFrontendRewritePath("/sign-in/factor-one")).toBeUndefined();
+    expect(
+      resolveSoFrontendRewritePath("/sign-in/factor-one", {
+        VERCEL_ENV: "production",
+      }),
+    ).toBe("/sign-in/factor-one");
+    expect(resolveSoFrontendRewritePath("/connector/success")).toBeUndefined();
   });
 });

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -16,6 +16,10 @@ import {
   matchesApiBackendRewritePath,
   matchesOAuthWebOriginRewritePath,
 } from "./api-backend-rewrites";
+import {
+  resolveSoFrontendRewritePath,
+  resolveSoFrontendUrl,
+} from "./so-frontend-rewrites.js";
 
 // ---------------------------------------------------------------------------
 // Clerk-specific route config
@@ -96,6 +100,7 @@ const SANDBOX_TOKEN_PREFIX = "vm0_sandbox_";
 const PAT_TOKEN_PREFIX = "vm0_pat_";
 const TEST_ENDPOINT_BYPASS_HEADER = "x-vm0-test-endpoint-bypass";
 const OAUTH_WEB_ORIGIN_HEADER = "x-vm0-web-origin";
+const SO_FRONTEND_PAGE_METHODS = new Set(["GET", "HEAD"]);
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
@@ -119,6 +124,54 @@ function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
     request,
     NextResponse.next({ request: { headers: requestHeaders } }),
   );
+}
+
+function resolveSoFrontendProxyUrl(request: NextRequest): URL | undefined {
+  if (SO_FRONTEND_PAGE_METHODS.has(request.method)) {
+    return undefined;
+  }
+
+  const soFrontendEnv = {
+    NEXT_PUBLIC_PAID_ONBOARDING_URL: env().NEXT_PUBLIC_PAID_ONBOARDING_URL,
+    VERCEL_ENV: env().VERCEL_ENV,
+  };
+  const soFrontendUrl = resolveSoFrontendUrl(soFrontendEnv);
+  if (!soFrontendUrl) {
+    return undefined;
+  }
+
+  const destinationPath = resolveSoFrontendRewritePath(
+    request.nextUrl.pathname,
+    soFrontendEnv,
+  );
+  if (!destinationPath) {
+    return undefined;
+  }
+
+  const url = new URL(destinationPath, soFrontendUrl);
+  url.search = request.nextUrl.search;
+  return url;
+}
+
+async function proxySoFrontendRequest(
+  request: NextRequest,
+  targetUrl: URL,
+): Promise<Response> {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.delete("host");
+  requestHeaders.delete("content-length");
+  requestHeaders.set("x-forwarded-host", request.nextUrl.host);
+  requestHeaders.set(
+    "x-forwarded-proto",
+    request.nextUrl.protocol.slice(0, -1),
+  );
+
+  return fetch(targetUrl, {
+    method: request.method,
+    headers: requestHeaders,
+    body: request.body,
+    redirect: "manual",
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +230,11 @@ export default async function middleware(
   // from returning our 200 directly.
   if (isApiRoute && request.method === "OPTIONS") {
     return handleCors(request);
+  }
+
+  const soFrontendProxyUrl = resolveSoFrontendProxyUrl(request);
+  if (soFrontendProxyUrl) {
+    return proxySoFrontendRequest(request, soFrontendProxyUrl);
   }
 
   const authHeader = request.headers.get("authorization");

--- a/turbo/apps/web/so-frontend-rewrites.d.ts
+++ b/turbo/apps/web/so-frontend-rewrites.d.ts
@@ -1,0 +1,28 @@
+export interface SoFrontendRewriteEnv {
+  readonly PAID_ONBOARDING_URL?: string;
+  readonly NEXT_PUBLIC_PAID_ONBOARDING_URL?: string;
+  readonly VERCEL_ENV?: string;
+}
+
+export interface SoFrontendRewrite {
+  readonly source: string;
+  readonly destination: string;
+}
+
+export function resolveSoFrontendUrl(
+  env: SoFrontendRewriteEnv,
+): string | undefined;
+
+export function resolveSoFrontendRewritePath(
+  pathname: string,
+  env?: SoFrontendRewriteEnv,
+): string | undefined;
+
+export function matchesSoFrontendRewritePath(
+  pathname: string,
+  env?: SoFrontendRewriteEnv,
+): boolean;
+
+export function buildSoFrontendRewrites(
+  env: SoFrontendRewriteEnv,
+): SoFrontendRewrite[];

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -50,6 +50,14 @@ const SO_FRONTEND_ASSET_PATHS = [
   "/checkmark-primary.svg",
 ];
 
+function shouldRewriteAuthPaths(env) {
+  return env.VERCEL_ENV === "production";
+}
+
+function authRewritePaths(env) {
+  return shouldRewriteAuthPaths(env) ? SO_FRONTEND_AUTH_PATHS : [];
+}
+
 function withoutTrailingSlash(value) {
   return value.replace(/\/$/u, "");
 }
@@ -85,6 +93,79 @@ function localizedExactRewrite(locale, source, destinationPrefix) {
   };
 }
 
+function rewriteSourceMatchesPath(source, pathname) {
+  const wildcardSuffix = "/:path*";
+  if (!source.endsWith(wildcardSuffix)) {
+    return source === pathname;
+  }
+
+  const prefix = source.slice(0, -wildcardSuffix.length);
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function rewriteDestinationPath(source, destination, pathname) {
+  const wildcardSuffix = "/:path*";
+  if (!source.endsWith(wildcardSuffix)) {
+    return destination;
+  }
+
+  const sourcePrefix = source.slice(0, -wildcardSuffix.length);
+  const destinationPrefix = destination.slice(0, -wildcardSuffix.length);
+  return `${destinationPrefix}${pathname.slice(sourcePrefix.length)}`;
+}
+
+function rewriteSourceDefinitions(env) {
+  const localizedContentPaths = [
+    ...SO_FRONTEND_EXACT_PATHS,
+    ...SO_FRONTEND_WILDCARD_PATHS,
+  ];
+
+  return [
+    ...SO_FRONTEND_EXACT_PATHS.map((source) => {
+      return {
+        source,
+        destination: SO_FRONTEND_DESTINATION_OVERRIDES.get(source) ?? source,
+      };
+    }),
+    ...SO_FRONTEND_WILDCARD_PATHS.map((source) => {
+      return {
+        source,
+        destination: SO_FRONTEND_DESTINATION_OVERRIDES.get(source) ?? source,
+      };
+    }),
+    ...LOCALES.flatMap((locale) => {
+      return localizedContentPaths.map((source) => {
+        const localizedPath = `/${locale}${source === "/" ? "" : source}`;
+        return {
+          source: localizedPath,
+          destination: localizedPath,
+        };
+      });
+    }),
+    ...authRewritePaths(env).map((source) => {
+      return { source, destination: source };
+    }),
+    ...SO_FRONTEND_ASSET_PATHS.map((source) => {
+      return { source, destination: source };
+    }),
+  ];
+}
+
+export function resolveSoFrontendRewritePath(pathname, env = {}) {
+  const match = rewriteSourceDefinitions(env).find(({ source }) => {
+    return rewriteSourceMatchesPath(source, pathname);
+  });
+  if (!match) {
+    return undefined;
+  }
+
+  return rewriteDestinationPath(match.source, match.destination, pathname);
+}
+
+export function matchesSoFrontendRewritePath(pathname, env = {}) {
+  return resolveSoFrontendRewritePath(pathname, env) !== undefined;
+}
+
 export function buildSoFrontendRewrites(env) {
   const soFrontendUrl = resolveSoFrontendUrl(env);
   if (!soFrontendUrl) {
@@ -109,7 +190,7 @@ export function buildSoFrontendRewrites(env) {
         return localizedExactRewrite(locale, source, destinationPrefix);
       });
     }),
-    ...SO_FRONTEND_AUTH_PATHS.map((source) => {
+    ...authRewritePaths(env).map((source) => {
       return exactRewrite(source, destinationPrefix);
     }),
     ...SO_FRONTEND_ASSET_PATHS.map((source) => {


### PR DESCRIPTION
## Summary
- resolve so frontend rewrite paths in shared rewrite config
- proxy non-GET/HEAD requests for so frontend paths directly to the resolved so origin
- keep API and app-only routes such as /connector/* out of this proxy path
- keep /sign-in and /sign-up on the vm0 web preview/staging deployment; only production rewrites auth routes to so

This keeps sign-out/App Router POSTs on www behaving like the corresponding so frontend request, while preserving PR E2E Clerk OTP login on the web preview route.

## Testing
- pnpm --filter web lint
- pnpm --filter web test -- __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts