### PR TITLE
fix: show goal objective briefs in markers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -14,6 +14,7 @@ import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { now } from "../../external/time";
@@ -224,6 +225,10 @@ function markerContent(
 }
 
 describe("zero goals", () => {
+  beforeEach(() => {
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+  });
+
   it("rejects goal writes while the feature switch is disabled", async () => {
     const fixture = await seedGoalApiFixture({ featureEnabled: false });
 
@@ -500,11 +505,13 @@ describe("zero goals", () => {
 
   it("publishes goal-state markers into the thread on each transition", async () => {
     const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    const objective =
+      "Ship goal workflows by auditing every implementation detail, creating a release plan, coordinating the rollout across the web app and CLI, and continuing without waiting for more input.";
 
     await accept(
       goalsClient().create({
         headers: headers(fixture),
-        body: { objective: "ship goal workflows" },
+        body: { objective },
       }),
       [201],
     );
@@ -517,15 +524,19 @@ describe("zero goals", () => {
       expect(marker.runId).toBeNull();
     }
     // Creating a goal publishes both dimensions active; the workflow marker
-    // carries the objective and the trigger marker carries the trigger id (for
-    // the client fold + cancel control).
+    // carries the objective brief and the trigger marker carries the trigger id
+    // (for the client fold + cancel control).
     expect(eventIds(afterCreate)).toStrictEqual([
       "goal-trigger:active",
       "goal-workflow:active",
     ]);
-    expect(markerContent(afterCreate, "goal-workflow:active")).toStrictEqual([
-      "ship goal workflows",
-    ]);
+    const [workflowMarkerContent] = markerContent(
+      afterCreate,
+      "goal-workflow:active",
+    );
+    expect(workflowMarkerContent).not.toBe(objective);
+    expect(workflowMarkerContent?.length ?? 0).toBeLessThanOrEqual(140);
+    expect(workflowMarkerContent).toMatch(/\.\.\.$/);
     expect(markerContent(afterCreate, "goal-trigger:active")).toStrictEqual([
       goalRows!.triggerId,
     ]);
@@ -555,17 +566,19 @@ describe("zero goals", () => {
       }),
       [201],
     );
+    const objective =
+      "Ship goal workflows v2 by verifying every backend state transition, updating the visible marker copy, coordinating the CLI behavior, and keeping the autonomous continuation prompt unchanged.";
 
     const edited = await accept(
       goalsClient().edit({
         headers: headers(fixture, ["goal-objective:write"]),
-        body: { objective: "ship goal workflows v2", tokenBudget: 5000 },
+        body: { objective, tokenBudget: 5000 },
       }),
       [200],
     );
     expect(edited.body).toStrictEqual({
       active: true,
-      objective: "ship goal workflows v2",
+      objective,
       status: "active",
       tokenBudget: 5000,
     });
@@ -576,10 +589,22 @@ describe("zero goals", () => {
     );
     expect(read.body).toStrictEqual({
       active: true,
-      objective: "ship goal workflows v2",
+      objective,
       status: "active",
       tokenBudget: 5000,
     });
+    const workflowMarkerContents = markerContent(
+      await loadGoalMarkers(fixture),
+      "goal-workflow:active",
+    );
+    expect(workflowMarkerContents).toHaveLength(2);
+    expect(workflowMarkerContents).toContain("ship goal workflows");
+    const editedMarkerContent = workflowMarkerContents.find((content) => {
+      return content !== "ship goal workflows";
+    });
+    expect(editedMarkerContent).not.toBe(objective);
+    expect(editedMarkerContent?.length ?? 0).toBeLessThanOrEqual(140);
+    expect(editedMarkerContent).toMatch(/\.\.\.$/);
   });
 
   it("auto-resumes a blocked goal when edited and clears stopReason", async () => {

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -14,11 +14,11 @@ import type { Db } from "../external/db";
  * These are control rows, not conversation: the client filters them out of the
  * rendered transcript, and they are excluded from unread and search via
  * `excludeGoalMarkerCondition` so they never light up a thread or surface as a
- * search hit. The marker `content` carries the fold's payload: the objective on
- * workflow-active markers (so the row can render it), and the trigger id on
+ * search hit. The marker `content` carries the fold's payload: the objective
+ * brief on workflow-active markers (so the row can render it), and the trigger id on
  * trigger-active markers (so the composer's cancel control can disable it).
  */
-const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
+export const GOAL_WORKFLOW_ACTIVE_EVENT_ID = "goal-workflow:active";
 export const GOAL_WORKFLOW_INACTIVE_EVENT_ID = "goal-workflow:inactive";
 export const GOAL_TRIGGER_ACTIVE_EVENT_ID = "goal-trigger:active";
 export const GOAL_TRIGGER_INACTIVE_EVENT_ID = "goal-trigger:inactive";
@@ -57,20 +57,20 @@ export async function appendGoalStateMarker(
 
 /**
  * Publish a newly created goal's initial state: the workflow is active (the
- * marker carries the objective so the client fold can render it) and its
+ * marker carries the objective brief so the client fold can render it) and its
  * trigger is enabled (the marker carries the trigger id so the composer's
  * cancel control can disable it).
  */
 export async function appendGoalCreatedMarkers(
   tx: Pick<Db, "insert">,
   chatThreadId: string,
-  objective: string,
+  objectiveBrief: string,
   triggerId: string,
 ): Promise<void> {
   await appendGoalStateMarker(tx, {
     chatThreadId,
     eventId: GOAL_WORKFLOW_ACTIVE_EVENT_ID,
-    content: objective,
+    content: objectiveBrief,
   });
   await appendGoalStateMarker(tx, {
     chatThreadId,

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief.service.ts
@@ -1,0 +1,81 @@
+import { logger } from "../../lib/log";
+import { generateText } from "../external/openrouter";
+import { settle } from "../utils";
+
+const log = logger("api:zero-goal-objective-brief");
+const OBJECTIVE_BRIEF_MODEL = "google/gemini-3.1-flash-lite-preview";
+const OBJECTIVE_CONTEXT_CHAR_CAP = 4000;
+const OBJECTIVE_BRIEF_MAX_CHARS = 140;
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^["'](.+)["']$/, "$1")
+    .trim();
+}
+
+function compactText(text: string): string {
+  return stripMarkdown(text).replace(/\s+/g, " ").trim();
+}
+
+function capText(text: string): string {
+  if (text.length <= OBJECTIVE_BRIEF_MAX_CHARS) {
+    return text;
+  }
+  return `${text.slice(0, OBJECTIVE_BRIEF_MAX_CHARS - 3).trimEnd()}...`;
+}
+
+function fallbackObjectiveBrief(objective: string): string {
+  const firstNonEmptyLine = objective
+    .split(/\r?\n/)
+    .map((line) => {
+      return compactText(line);
+    })
+    .find((line) => {
+      return line.length > 0;
+    });
+  return capText(firstNonEmptyLine ?? compactText(objective));
+}
+
+export async function generateGoalObjectiveBrief(
+  objective: string,
+): Promise<string> {
+  const fallback = fallbackObjectiveBrief(objective);
+  const generated = await settle(
+    generateText(
+      OBJECTIVE_BRIEF_MODEL,
+      [
+        {
+          role: "system",
+          content:
+            "Rewrite the goal objective into a short objective brief. Focus only on what outcome the goal is trying to achieve, not how to execute it. Keep the original language. Return one short sentence or phrase, max 140 characters, as plain text only. No markdown, no quotes.",
+        },
+        {
+          role: "user",
+          content: `Objective:\n${objective.slice(0, OBJECTIVE_CONTEXT_CHAR_CAP)}`,
+        },
+      ],
+      80,
+    ),
+  );
+
+  if (!generated.ok) {
+    log.warn("Failed to generate goal objective brief", {
+      error:
+        generated.error instanceof Error
+          ? generated.error.message
+          : String(generated.error),
+    });
+    return fallback;
+  }
+  if (generated.value === null) {
+    return fallback;
+  }
+
+  const brief = capText(compactText(generated.value));
+  return brief.length > 0 ? brief : fallback;
+}

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -25,10 +25,12 @@ import {
 import {
   GOAL_TRIGGER_ACTIVE_EVENT_ID,
   GOAL_TRIGGER_INACTIVE_EVENT_ID,
+  GOAL_WORKFLOW_ACTIVE_EVENT_ID,
   GOAL_WORKFLOW_INACTIVE_EVENT_ID,
   appendGoalCreatedMarkers,
   appendGoalStateMarker,
 } from "./zero-chat-goal-marker.service";
+import { generateGoalObjectiveBrief } from "./zero-goal-objective-brief.service";
 import type { TriggerRow } from "./zero-workflow-trigger-run.service";
 
 export type GoalResult =
@@ -224,6 +226,7 @@ export async function createGoalForCurrentThread(
   }
 
   const createdAt = nowDate();
+  const objectiveBrief = await generateGoalObjectiveBrief(args.objective);
   const preference = {
     version: 1 as const,
     objective: args.objective,
@@ -314,8 +317,8 @@ export async function createGoalForCurrentThread(
     }
 
     // Publish the new goal's state so the composer can fold it from the message
-    // stream (active workflow carrying the objective + enabled trigger).
-    await appendGoalCreatedMarkers(tx, threadId, args.objective, trigger.id);
+    // stream (active workflow carrying the objective brief + enabled trigger).
+    await appendGoalCreatedMarkers(tx, threadId, objectiveBrief, trigger.id);
 
     return {
       row: {
@@ -547,6 +550,10 @@ export async function editCurrentGoal(
   // re-enable the trigger, reset the failure counter, and clear stopReason.
   const autoResume = !goal.row.triggerEnabled;
   const editedAt = nowDate();
+  const objectiveBrief =
+    args.objective === undefined
+      ? null
+      : await generateGoalObjectiveBrief(args.objective);
   const nextPreference = mergeGoalPreference(goal.row.preference, {
     ...(args.objective !== undefined ? { objective: args.objective } : {}),
     ...(args.tokenBudget !== undefined
@@ -561,6 +568,13 @@ export async function editCurrentGoal(
       .update(zeroWorkflows)
       .set({ preference: nextPreference, updatedAt: editedAt })
       .where(eq(zeroWorkflows.id, goal.row.workflowId));
+    if (objectiveBrief !== null) {
+      await appendGoalStateMarker(tx, {
+        chatThreadId: goal.threadId,
+        eventId: GOAL_WORKFLOW_ACTIVE_EVENT_ID,
+        content: objectiveBrief,
+      });
+    }
     if (autoResume) {
       await tx
         .update(zeroWorkflowTriggers)


### PR DESCRIPTION
## Summary
- generate a short objective brief for goal marker content while keeping the full objective in goal preference/API state
- write brief markers on goal creation and objective edits so composer display stays concise and current
- update goal route tests to assert marker content uses brief payloads

## Checks
- pnpm exec prettier --write apps/api/src/signals/services/zero-goal-objective-brief.service.ts apps/api/src/signals/services/zero-chat-goal-marker.service.ts apps/api/src/signals/services/zero-goal.service.ts apps/api/src/signals/routes/__tests__/zero-goals.test.ts
- pnpm -F api exec oxlint src/signals/services/zero-goal-objective-brief.service.ts src/signals/services/zero-chat-goal-marker.service.ts src/signals/services/zero-goal.service.ts src/signals/routes/__tests__/zero-goals.test.ts
- pnpm -F api exec oxlint src/signals/services/zero-goal-objective-brief.service.ts src/signals/services/zero-chat-goal-marker.service.ts src/signals/services/zero-goal.service.ts src/signals/routes/__tests__/zero-goals.test.ts --type-aware -c ../../.oxlintrc.typeaware.json
- pnpm -F api exec eslint src/signals/services/zero-goal-objective-brief.service.ts src/signals/services/zero-chat-goal-marker.service.ts src/signals/services/zero-goal.service.ts src/signals/routes/__tests__/zero-goals.test.ts --max-warnings 0
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types

## Notes
- `pnpm vitest --run apps/api/src/signals/routes/__tests__/zero-goals.test.ts` could not complete locally because this runtime has no Postgres listening on 127.0.0.1:5432 / ::1:5432.
- Full `pnpm -F api lint` reached ordinary oxlint cleanly, then the type-aware tsgolint subprocess was SIGKILLed by the runtime; the changed files passed targeted oxlint, type-aware oxlint, and eslint.
