### PR TITLE
fix: update presentation R2 deck archives

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -27,7 +27,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "tool:presentation-deck-tools",
     versionId:
-      "5494156e07c650862e92beb7036ef532ed7b0774fda373c72c50e682b19a5e95",
+      "610da333cd83b2d5d5901316638f5f2ee625058e529ccb8100cd87e489c6a030",
   },
   {
     id: "design-system:business-data",
@@ -47,17 +47,17 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-botane-organic",
     versionId:
-      "d83cccffbd6d1d00f4fd2bc8826118033fc28c358c92dd94813caadc6a0a8be4",
+      "7438cf79bbf25501de0c7a91cc35a98e164e6e1e59c8e8571f0f2d4272a5158f",
   },
   {
     id: "template:html-ppt-playful-launch",
     versionId:
-      "309c6a2b0a89db310fd4479176725891f4bace374f3f9c08b06def05a22a8b1e",
+      "ff2dae6ef1f99d1c754903a7acc49ea220a5439f7408870f8a9074e4543de190",
   },
   {
     id: "template:html-ppt-business-data",
     versionId:
-      "09c8eff5a9e8f554955dbfccec3f2ea99e357d7f8592c363fc6f699aa1cf9298",
+      "dd820c04b1c913413555adc8402a759abad8da2f6e80dd8add8a2a5120249d1b",
   },
   {
     id: "design-system:crayon",
@@ -67,7 +67,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-crayon",
     versionId:
-      "7ac8468455b894a45c1c81faffde66b28505e0c4769e854a9c9f377f858d80be",
+      "23ee8a977f4e437c2ef5e82236822b5bb687077951fc2fa375de3b48b79bb205",
   },
   {
     id: "design-system:creative-agency",
@@ -77,7 +77,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-creative-agency",
     versionId:
-      "0b07366aaf83a87e5e43c076a5f0dbaea276ed68a9ba687029dfbcb60d8167f4",
+      "e8c07a3b33c3edd7dd64693890be854a45fec0b2cf6edece53108472e2a076aa",
   },
   {
     id: "design-system:data-report",
@@ -87,7 +87,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-data-report",
     versionId:
-      "5294d776ee5f9451ea938847b8daa4a8cc99cd90f7b37a9e0dfe3a0b18d3b50e",
+      "ecb1617127e5626726790b7e248722e2e0a81592413aa7a98a7da640649ece08",
   },
   {
     id: "design-system:editorial-magazine",
@@ -97,7 +97,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-editorial-magazine",
     versionId:
-      "d2cd24d759e7ebde294a46f2d17a560e017af501ec4c7d2042ecfe9ce507aa5a",
+      "ef93ddbd125dd9e85f060f61afe7eda17cc26560a0f436eafaa422fb5ad8f6a1",
   },
   {
     id: "design-system:landing-consulting",
@@ -107,7 +107,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-landing-consulting",
     versionId:
-      "cc009f54425b0178cfb46d2a12253ec255f93f6592bc4309707190f1f3677731",
+      "fa1f402e0b2c9e071a17cfebe547b11537030be066d4bbf04b1374678ec06d4d",
   },
   {
     id: "design-system:lumina",
@@ -117,7 +117,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-lumina",
     versionId:
-      "e848b5288f21e82697293eb8b5ca588f10b4a34547d5108bb05044d398cb81da",
+      "a39fcc27d8f5d6a712959cfccf1cb930627faa8877b8d990439ad9679adc4c5f",
   },
   {
     id: "design-system:mosaic-geometric",
@@ -127,7 +127,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-mosaic-geometric",
     versionId:
-      "48d7be42f3fefbb61106bfa427f8be8bd25ac748e6c7faa3d47f1b88d50bd199",
+      "3a09001e9455d10e96d9cbfd6dc66c2705cb26b7bdc41a9764cb8a20f65d74b1",
   },
   {
     id: "design-system:playful-pop",
@@ -142,7 +142,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-nocturne",
     versionId:
-      "3d5f86e3de61a3cb268206bb5ab8ee37cb5222f00ab3dc271344d18239be9068",
+      "b0bb3ef5e0fcc772ecfa67e27776e3be38fdff33b411b431d053544b5ffa4abc",
   },
   {
     id: "design-system:neo-brutalism",
@@ -152,7 +152,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-neo-brutalism",
     versionId:
-      "3751de9d792c738b7ef0deffb01495c8bf210e28862cbef0e9a3145205acab32",
+      "8d3ff7b69bbc1ec197f60688d92ffddf5fd5d3c3186aa69cce35d49ce057514c",
   },
   {
     id: "color-system:bauhaus-primary",
@@ -252,7 +252,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "template:html-ppt-playful-pop",
     versionId:
-      "ffc9dca27b1c56b6233129e46b48b81e04e37071171d2c37be13cb4f0433284a",
+      "6c5a931e683b359c5c8561aeda0b34f5b784da052b051d2e2cb2f155aae20097",
   },
 ] as const;
 

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -45,7 +45,7 @@ function storageServiceNotConfigured() {
 
 const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "tool:presentation-deck-tools":
-    "5494156e07c650862e92beb7036ef532ed7b0774fda373c72c50e682b19a5e95",
+    "610da333cd83b2d5d5901316638f5f2ee625058e529ccb8100cd87e489c6a030",
   "design-system:business-data":
     "c9f7a6246c31da8a50f8e0bedee769416af83fdea4047ec59ccf926b78f18fe9",
   "design-system:botane-organic":
@@ -111,31 +111,31 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "color-system:warm-sand":
     "e9ea329a25491e347cb3c1156735201a4ff7f8a299dd8990b024d31854b49050",
   "template:html-ppt-botane-organic":
-    "d83cccffbd6d1d00f4fd2bc8826118033fc28c358c92dd94813caadc6a0a8be4",
+    "7438cf79bbf25501de0c7a91cc35a98e164e6e1e59c8e8571f0f2d4272a5158f",
   "template:html-ppt-playful-launch":
-    "309c6a2b0a89db310fd4479176725891f4bace374f3f9c08b06def05a22a8b1e",
+    "ff2dae6ef1f99d1c754903a7acc49ea220a5439f7408870f8a9074e4543de190",
   "template:html-ppt-business-data":
-    "09c8eff5a9e8f554955dbfccec3f2ea99e357d7f8592c363fc6f699aa1cf9298",
+    "dd820c04b1c913413555adc8402a759abad8da2f6e80dd8add8a2a5120249d1b",
   "template:html-ppt-crayon":
-    "7ac8468455b894a45c1c81faffde66b28505e0c4769e854a9c9f377f858d80be",
+    "23ee8a977f4e437c2ef5e82236822b5bb687077951fc2fa375de3b48b79bb205",
   "template:html-ppt-creative-agency":
-    "0b07366aaf83a87e5e43c076a5f0dbaea276ed68a9ba687029dfbcb60d8167f4",
+    "e8c07a3b33c3edd7dd64693890be854a45fec0b2cf6edece53108472e2a076aa",
   "template:html-ppt-data-report":
-    "5294d776ee5f9451ea938847b8daa4a8cc99cd90f7b37a9e0dfe3a0b18d3b50e",
+    "ecb1617127e5626726790b7e248722e2e0a81592413aa7a98a7da640649ece08",
   "template:html-ppt-editorial-magazine":
-    "d2cd24d759e7ebde294a46f2d17a560e017af501ec4c7d2042ecfe9ce507aa5a",
+    "ef93ddbd125dd9e85f060f61afe7eda17cc26560a0f436eafaa422fb5ad8f6a1",
   "template:html-ppt-landing-consulting":
-    "cc009f54425b0178cfb46d2a12253ec255f93f6592bc4309707190f1f3677731",
+    "fa1f402e0b2c9e071a17cfebe547b11537030be066d4bbf04b1374678ec06d4d",
   "template:html-ppt-lumina":
-    "e848b5288f21e82697293eb8b5ca588f10b4a34547d5108bb05044d398cb81da",
+    "a39fcc27d8f5d6a712959cfccf1cb930627faa8877b8d990439ad9679adc4c5f",
   "template:html-ppt-mosaic-geometric":
-    "48d7be42f3fefbb61106bfa427f8be8bd25ac748e6c7faa3d47f1b88d50bd199",
+    "3a09001e9455d10e96d9cbfd6dc66c2705cb26b7bdc41a9764cb8a20f65d74b1",
   "template:html-ppt-playful-pop":
-    "ffc9dca27b1c56b6233129e46b48b81e04e37071171d2c37be13cb4f0433284a",
+    "6c5a931e683b359c5c8561aeda0b34f5b784da052b051d2e2cb2f155aae20097",
   "template:html-ppt-nocturne":
-    "3d5f86e3de61a3cb268206bb5ab8ee37cb5222f00ab3dc271344d18239be9068",
+    "b0bb3ef5e0fcc772ecfa67e27776e3be38fdff33b411b431d053544b5ffa4abc",
   "template:html-ppt-neo-brutalism":
-    "3751de9d792c738b7ef0deffb01495c8bf210e28862cbef0e9a3145205acab32",
+    "8d3ff7b69bbc1ec197f60688d92ffddf5fd5d3c3186aa69cce35d49ce057514c",
 } as const satisfies Record<string, string>;
 
 function privateRegistryResourceArchive(

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -133,53 +133,53 @@ const PRESENTATION_RESOURCE_ARCHIVE_SHA256 = {
     "b0ed1fa2b7daa5d543ae3b187edea17f95b0594d2a408d4cc197510caafc26ef",
   playfulEditorial:
     "c97ad47460cc43ca0a172c4ac7ccc471c4801d3e98b3f1f202b0f46eaee1eaaf",
-  aplocoto: "89326826cc850aae4f4dc0f4aa6bb9cbe562d00059ab1cc040060b840cdbf259",
+  aplocoto: "28a6fbda2f740dbf1cffa52cc0b636746eaf6ebe95aa37d47568980a5564816f",
   botaneOrganic:
-    "246f8f30a23bac6a5aaab879ec6a416700fdc7ea2d9093edab7fb97b50eff3fe",
+    "25feaef1ffd584ae8c09a48826a05ca86696b3731085fa7d06fc12a52eb8ddb6",
   businessData:
-    "d0df888f518eebdb7812a212a5fb0d571283dcf595621c9866b2cde9df900572",
+    "229516a65ebd66d48c789bb626da24f96a8658d313c72229c0d2cabe262248f1",
   presentationDeckTools:
-    "fbf86018b5d34fea84d805bade8dade68c610f09b8cd3a7b799f71a8a88bbea2",
+    "a0674e9238ce0819281fa01f39dd650ccda215b6498578decaaf2042ab8c4531",
   designSystemCrayon:
     "c2b891a40b672aa8f45bd72d7343309d097dd3aeb6653444fe10c5d4b62bbaca",
   templateCrayon:
-    "213e826ae2f41dcd63fd02e9f20e7eaec8bfaffb0c53d9e81f9f9043f34d5ef8",
+    "05b88b0490718c329f0cffd38384c7e08af222dcbdc4d58e6c4702bc92669595",
   designSystemCreativeAgency:
     "86f6fa6e022dd0125eb5cd9c57e6643126f471ee7705e910296ebc9f7eabf0da",
   templateCreativeAgency:
-    "896ce150fc69a3985a37fd3ffc123072661eecec78c0428a09dc307c879fc5d6",
+    "ec6aa675adf8486662cb653327fc2ec46a6622365ffeed06d4dba6b85bb73fa3",
   designSystemDataReport:
     "86f667797087d0abe40a85ebe277138eab88863b1e85a112bb2d9a8707c09393",
   templateDataReport:
-    "56e2e7d3da83f53dfe5a34667e926d9056198982398f9d6a22f9e20ecad4e872",
+    "256556de59fe261fb86a63767e83c339b98c3c2ca0872f5a0d99a3fe4fdb9282",
   designSystemEditorialMagazine:
     "221830d9da5e8baf7f59c9929f40f0ec97fcb3353f3e92961c6b1ae397b93520",
   templateEditorialMagazine:
-    "647f3aec98c6ec12bd587687f26003d68863f4625fb4a357426c2ade60a6ab51",
+    "f5f9500a31980be2e66362d5d6dc475c9435e5dec2b660c6356213596f77a8d2",
   designSystemLandingConsulting:
     "c1306603a1e4d547730d1b4d1827e48f5d1251d1a7df4446f8845e54eeb6ab83",
   templateLandingConsulting:
-    "ff2b342d126ebac1e173276267286c06dc299aa7ad34bf261cb8efc0fa24b474",
+    "4c3209355a076aef28aea8d70ad5a2b74f5decdd05e4ecfb8a8192148bf8ff7a",
   designSystemLumina:
     "45890f99d5c781c2be1d7266d6ec92bae8760f70c74201f20a04f32e4a0ed1de",
   templateLumina:
-    "4076ee669fb7c89aa589cc393bffc78b405548f8040b8df53a25c9c8016ac33e",
+    "599f4cbd8118a2347dd1a84435c6fdb1105b1d906ba49d2e3595fca54a77bee2",
   designSystemMosaicGeometric:
     "54cc95abeb0162d1ef2e6eb2ef2eefd0aefdac59d9dc179d53c661b91e7462f2",
   templateMosaicGeometric:
-    "58cf038a4e94e9b87ab0636e936bc952157216673dc75b3ec5f38e9bd1f054e1",
+    "112a0aabe92a20bd25427286d6a674725b926ab324e6c06b35574f1e511b911d",
   designSystemPlayfulPop:
     "0199f0a05ab40c9f9ef5c5b2bddb3b62b86a9e9577d33b852758759fd17ff431",
   templatePlayfulPop:
-    "4f281c2365b00cfd88c44a01d012b5f4bc908ae7b570fd432284d8cf4af90c32",
+    "10944b1b02421f7b2e792c4563a7e4e52ee752cb50b34cb31054afd94311906d",
   designSystemNocturne:
     "bc82f6665394cc99039fe34523e5c6095a9bbf5a2a3a81dee128540a43812dec",
   templateNocturne:
-    "4f94ba422af6c66e734e73b784902ed9e01beeefd9d69bc4e947ce645940de26",
+    "8fe867f43313ed8c99c0cd774ce61bef7b097f4912b7e3ef4bd5d228d05d2bde",
   designSystemNeoBrutalism:
     "a9bbb1cfc4a86259b9ad8f33d9eaa433eedd75b26ce0a6d4f65fa965d66a75c9",
   templateNeoBrutalism:
-    "b6e082199f3927a6bc6e5bf0b5e45d2716ade71e81f678f5d60302537229facb",
+    "cec2dde23a09f38c8a538e5cddcce9853e726cef1ee7bcfde46cd405f7dcd465",
   colorSystemBauhausPrimary:
     "f42a1d62462f24b1a411889f8011b07bd3f1bb1db82a339cc59cf5ab5be2f475",
   colorSystemBerryPop:


### PR DESCRIPTION
## Summary

- updates the private R2 archive sha values for the shared presentation deck tools and 13 R2-backed HTML presentation templates
- updates the registry resource download version ids to the newly uploaded storage versions
- keeps the registry resource download test fixture aligned with those new version ids

## Uploaded R2 resources

Updated archives were uploaded for:

- `tool:presentation-deck-tools`
- `template:html-ppt-botane-organic`
- `template:html-ppt-playful-launch`
- `template:html-ppt-business-data`
- `template:html-ppt-crayon`
- `template:html-ppt-creative-agency`
- `template:html-ppt-data-report`
- `template:html-ppt-editorial-magazine`
- `template:html-ppt-landing-consulting`
- `template:html-ppt-lumina`
- `template:html-ppt-mosaic-geometric`
- `template:html-ppt-playful-pop`
- `template:html-ppt-nocturne`
- `template:html-ppt-neo-brutalism`

## Verification

- Verified each newly uploaded storage version can be downloaded through `/api/storages/download`.
- Verified downloaded `archive.tar.gz` bytes match the sha256 values now in `resource-registry.ts`.
- Verified the uploaded resource metadata matches the core registry sha values, API version id map, and test fixtures.
- Ran `git diff --check`.

Targeted `vitest` / `prettier` were not run locally because this checkout has no `node_modules` and the commands are unavailable.
