### PR TITLE
Re-enable so auth rewrites in preview

### DIFF
--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,15 +1,12 @@
-import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
 import {
-  expect,
-  test,
-  type APIResponse,
-  type Locator,
-  type Page,
-} from "@playwright/test";
+  clerk,
+  clerkSetup,
+  setupClerkTestingToken,
+} from "@clerk/testing/playwright";
+import { expect, test, type APIResponse, type Page } from "@playwright/test";
 import { fillStripeCheckout } from "../lib/stripe-checkout";
 import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
 
-const TEST_OTP = "424242";
 const ONBOARDING_STATUS_PATH = "**/api/zero/onboarding/status";
 const READY_ONBOARDING_STATUS = JSON.stringify({
   needsOnboarding: false,
@@ -34,14 +31,11 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   await page.waitForURL((url) => url.pathname.includes("/sign-in"), {
     timeout: 30_000,
   });
+  const authUrl = page.url();
+  const redirectUrl = redirectUrlFromAuthUrl(new URL(authUrl));
 
   // Sign in
-  await signInWithEmailCode(
-    page,
-    email,
-    redirectUrlFromAuthUrl(new URL(page.url())),
-    60_000,
-  );
+  await signInWithClerkTestingHelper(page, email, appUrl, authUrl, redirectUrl);
 
   // Navigate to app — should land on the onboarding handoff or agents
   await page.goto(appUrl);
@@ -212,157 +206,53 @@ function deriveApiUrl(appUrl: string): string {
   return appUrl.replace(/-app\./, "-api.").replace(/\/\/app\./, "//api.");
 }
 
-async function signInWithEmailCode(
+async function signInWithClerkTestingHelper(
   page: Page,
   email: string,
+  appUrl: string,
+  authUrl: string,
   redirectUrl: string | null,
-  timeout: number,
 ): Promise<void> {
-  const deadline = Date.now() + timeout;
+  const helperUrl = new URL("/_/skeleton", appUrl);
+  await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => Boolean(window.Clerk?.loaded), undefined, {
+    timeout: 30_000,
+  });
+  const clerkStateBefore = await page.evaluate(() => {
+    return {
+      hasLoadedClerk: Boolean(window.Clerk?.loaded),
+      hasSession: Boolean(window.Clerk?.session),
+      hasUser: Boolean(window.Clerk?.user),
+    };
+  });
 
-  await waitForVisible(
-    page.locator('input[name="identifier"]').first(),
-    remainingTimeout(deadline, 20_000),
-  );
-  await clickIfVisible(page.getByRole("button", { name: "Accept" }), 2_000);
+  console.log("[smoke] signing in with Clerk testing helper", {
+    currentUrl: page.url(),
+    authUrl,
+    email,
+    redirectUrl,
+    ...clerkStateBefore,
+  });
 
-  await page.locator('input[name="identifier"]').first().fill(email);
-  await page.getByRole("button", { name: "Continue" }).click();
+  await clerk.signIn({ page, emailAddress: email });
+  await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
+    timeout: 30_000,
+  });
 
-  const flow = await waitForEmailCodeFlow(
-    page,
-    remainingTimeout(deadline, 15_000),
-  );
-  if (flow === "alt") {
-    await page
-      .locator("a, button")
-      .filter({ hasText: "Use another method" })
-      .first()
-      .click();
-    await page
-      .locator("button")
-      .filter({ hasText: "Email code" })
-      .first()
-      .click();
-  }
+  const clerkState = await page.evaluate(() => {
+    return {
+      hasSession: Boolean(window.Clerk?.session),
+      hasUser: Boolean(window.Clerk?.user),
+    };
+  });
+  console.log("[smoke] Clerk testing helper completed", {
+    currentUrl: page.url(),
+    ...clerkState,
+  });
 
-  if (flow !== "redirected") {
-    await submitEmailCode(page, remainingTimeout(deadline, 30_000));
-  }
-
-  if (redirectUrl && !isOnboardingOrChatUrl(new URL(page.url()))) {
+  if (redirectUrl) {
     await page.goto(redirectUrl, { waitUntil: "domcontentloaded" });
   }
-}
-
-async function clickIfVisible(
-  locator: Locator,
-  timeout: number,
-): Promise<void> {
-  if (await waitForVisible(locator, timeout)) {
-    await locator.click();
-  }
-}
-
-async function waitForEmailCodeFlow(
-  page: Page,
-  timeout: number,
-): Promise<"otp" | "alt" | "redirected"> {
-  const result = await page.waitForFunction(
-    () => {
-      const { pathname } = window.location;
-      if (!pathname.includes("/sign-up") && !pathname.includes("/sign-in")) {
-        return "redirected";
-      }
-
-      const hasOtp = Boolean(
-        document.querySelector('input[data-input-otp="true"]'),
-      );
-      const hasAltMethod = Array.from(
-        document.querySelectorAll("a, button"),
-      ).some((element) => {
-        return element.textContent?.includes("Use another method") ?? false;
-      });
-
-      if (hasOtp) {
-        return "otp";
-      }
-      if (hasAltMethod) {
-        return "alt";
-      }
-      return false;
-    },
-    undefined,
-    { timeout },
-  );
-  const flow = await result.jsonValue();
-  if (flow === "otp" || flow === "alt" || flow === "redirected") {
-    return flow;
-  }
-  throw new Error(`Unexpected Clerk sign-in flow: ${String(flow)}`);
-}
-
-async function submitEmailCode(page: Page, timeout: number): Promise<void> {
-  const deadline = Date.now() + timeout;
-  const otpInput = page.locator('input[data-input-otp="true"]').first();
-  await waitForVisible(otpInput, remainingTimeout(deadline, 15_000));
-
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const navigation = waitForNonAuthUrl(
-      page,
-      remainingTimeout(deadline, 15_000),
-    );
-    await otpInput.click();
-    await otpInput.type(TEST_OTP);
-
-    if (await navigation) {
-      return;
-    }
-
-    if (!isAuthUrl(new URL(page.url()))) {
-      return;
-    }
-
-    await otpInput.click({ clickCount: 3 });
-    await page.keyboard.press("Backspace");
-  }
-
-  throw new Error(`Authentication failed after OTP attempts: ${page.url()}`);
-}
-
-async function waitForVisible(
-  locator: Locator,
-  timeout: number,
-): Promise<boolean> {
-  return await locator
-    .waitFor({ state: "visible", timeout })
-    .then(() => true)
-    .catch(() => false);
-}
-
-async function waitForNonAuthUrl(
-  page: Page,
-  timeout: number,
-): Promise<boolean> {
-  return await page
-    .waitForURL((url) => !isAuthUrl(url), {
-      timeout,
-      waitUntil: "domcontentloaded",
-    })
-    .then(() => true)
-    .catch(() => false);
-}
-
-function remainingTimeout(deadline: number, maxTimeout: number): number {
-  return Math.max(1, Math.min(maxTimeout, deadline - Date.now()));
-}
-
-function isAuthUrl(url: URL): boolean {
-  return url.pathname.includes("/sign-up") || url.pathname.includes("/sign-in");
-}
-
-function isChatUrl(url: URL): boolean {
-  return /\/agents\/.*\/chat/.test(url.pathname);
 }
 
 function redirectUrlFromAuthUrl(url: URL): string | null {
@@ -379,8 +269,4 @@ function redirectUrlFromAuthUrl(url: URL): string | null {
   return new URLSearchParams(url.hash.slice(hashQueryStart + 1)).get(
     "redirect_url",
   );
-}
-
-function isOnboardingOrChatUrl(url: URL): boolean {
-  return url.pathname.includes("/onboarding") || isChatUrl(url);
 }

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,38 +1,74 @@
+import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { resolveWebAuthUrl, resolveWebOrigin } from "../auth.ts";
 
-function setLocation(url: string): void {
+import { detachedSetupPage } from "../../__tests__/page-helper.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+function setBrowserUrl(url: string): void {
   window.location.href = url;
 }
 
-describe("platform auth URLs", () => {
-  it("derives the web origin from the app origin", () => {
-    setLocation("https://pr-18532-app.vm6.ai/agents");
+describe("platform auth redirects", () => {
+  it("redirects unauthenticated preview users to web sign-in with API domain override", async () => {
+    setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
-    expect(resolveWebOrigin()).toBe("https://pr-18532-www.vm6.ai");
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      session: null,
+      user: null,
+    });
+
+    await waitFor(() => {
+      const url = new URL(window.location.href);
+      expect(url.origin).toBe("https://pr-18532-www.vm6.ai");
+      expect(url.pathname).toBe("/sign-in");
+      expect(url.searchParams.get("domain")).toBe("pr-18532-api.vm6.ai");
+      expect(url.searchParams.get("redirect_url")).toBe(
+        "https://pr-18532-app.vm6.ai/agents",
+      );
+    });
   });
 
-  it("adds the PR API domain override to vm6 auth URLs", () => {
-    setLocation("https://pr-18532-app.vm6.ai/agents");
+  it("redirects preview users who need org selection with API domain override", async () => {
+    setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
-    expect(resolveWebAuthUrl("/sign-in")).toBe(
-      "https://pr-18532-www.vm6.ai/sign-in?domain=pr-18532-api.vm6.ai",
-    );
-    expect(resolveWebAuthUrl("/sign-in/tasks/choose-organization")).toBe(
-      "https://pr-18532-www.vm6.ai/sign-in/tasks/choose-organization?domain=pr-18532-api.vm6.ai",
-    );
-    expect(
-      resolveWebAuthUrl("/sign-in", {
-        redirectUrl: "https://pr-18532-app.vm6.ai/",
-      }),
-    ).toBe(
-      "https://pr-18532-www.vm6.ai/sign-in?domain=pr-18532-api.vm6.ai&redirect_url=https%3A%2F%2Fpr-18532-app.vm6.ai%2F",
-    );
+    detachedSetupPage({
+      context,
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_member" }],
+      },
+      path: "/agents",
+    });
+
+    await waitFor(() => {
+      const url = new URL(window.location.href);
+      expect(url.origin).toBe("https://pr-18532-www.vm6.ai");
+      expect(url.pathname).toBe("/sign-in/tasks/choose-organization");
+      expect(url.searchParams.get("domain")).toBe("pr-18532-api.vm6.ai");
+    });
   });
 
-  it("does not add a domain override outside vm6 preview origins", () => {
-    setLocation("https://app.vm0.ai/agents");
+  it("redirects non-preview org selection without an API domain override", async () => {
+    setBrowserUrl("https://app.vm0.ai/agents");
 
-    expect(resolveWebAuthUrl("/sign-in")).toBe("https://www.vm0.ai/sign-in");
+    detachedSetupPage({
+      context,
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_member" }],
+      },
+      path: "/agents",
+    });
+
+    await waitFor(() => {
+      const url = new URL(window.location.href);
+      expect(url.origin).toBe("https://www.vm0.ai");
+      expect(url.pathname).toBe("/sign-in/tasks/choose-organization");
+      expect(url.searchParams.has("domain")).toBeFalsy();
+    });
   });
 });

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveWebAuthUrl, resolveWebOrigin } from "../auth.ts";
+
+function setLocation(url: string): void {
+  window.location.href = url;
+}
+
+describe("platform auth URLs", () => {
+  it("derives the web origin from the app origin", () => {
+    setLocation("https://pr-18532-app.vm6.ai/agents");
+
+    expect(resolveWebOrigin()).toBe("https://pr-18532-www.vm6.ai");
+  });
+
+  it("adds the PR API domain override to vm6 auth URLs", () => {
+    setLocation("https://pr-18532-app.vm6.ai/agents");
+
+    expect(resolveWebAuthUrl("/sign-in")).toBe(
+      "https://pr-18532-www.vm6.ai/sign-in?domain=pr-18532-api.vm6.ai",
+    );
+    expect(resolveWebAuthUrl("/sign-in/tasks/choose-organization")).toBe(
+      "https://pr-18532-www.vm6.ai/sign-in/tasks/choose-organization?domain=pr-18532-api.vm6.ai",
+    );
+    expect(
+      resolveWebAuthUrl("/sign-in", {
+        redirectUrl: "https://pr-18532-app.vm6.ai/",
+      }),
+    ).toBe(
+      "https://pr-18532-www.vm6.ai/sign-in?domain=pr-18532-api.vm6.ai&redirect_url=https%3A%2F%2Fpr-18532-app.vm6.ai%2F",
+    );
+  });
+
+  it("does not add a domain override outside vm6 preview origins", () => {
+    setLocation("https://app.vm0.ai/agents");
+
+    expect(resolveWebAuthUrl("/sign-in")).toBe("https://www.vm0.ai/sign-in");
+  });
+});

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -21,6 +21,41 @@ export function resolveWebOrigin(): string {
   return url.origin;
 }
 
+function resolveDomainOverride(): string | null {
+  const origin = location.origin;
+  if (!origin || origin === "null") {
+    return null;
+  }
+  const url = new URL(origin);
+  if (!url.hostname.endsWith(".vm6.ai")) {
+    return null;
+  }
+  const apiHostname = url.hostname.replace(
+    /(^|-)(platform|app|www)\./,
+    "$1api.",
+  );
+  return apiHostname === url.hostname ? null : apiHostname;
+}
+
+export function resolveWebAuthUrl(
+  path: `/sign-${string}`,
+  options: { redirectUrl?: string } = {},
+): string {
+  const webOrigin = resolveWebOrigin();
+  if (!webOrigin) {
+    return path;
+  }
+  const url = new URL(path, webOrigin);
+  const domainOverride = resolveDomainOverride();
+  if (domainOverride) {
+    url.searchParams.set("domain", domainOverride);
+  }
+  if (options.redirectUrl) {
+    url.searchParams.set("redirect_url", options.redirectUrl);
+  }
+  return url.toString();
+}
+
 /**
  * Clerk instance signal.
  *
@@ -40,12 +75,11 @@ export const clerk$ = computed(async () => {
   // Moving it to a separate async chunk avoids blocking initial JS parsing.
   const { Clerk } = await import("@clerk/clerk-js");
 
-  const webOrigin = resolveWebOrigin();
   const clerkInstance = new Clerk(publishableKey);
   await clerkInstance.load({
-    signInUrl: `${webOrigin}/sign-in`,
-    signUpUrl: `${webOrigin}/sign-up`,
-    afterSignOutUrl: `${webOrigin}/sign-in`,
+    signInUrl: resolveWebAuthUrl("/sign-in"),
+    signUpUrl: resolveWebAuthUrl("/sign-up"),
+    afterSignOutUrl: resolveWebAuthUrl("/sign-in"),
   });
   return clerkInstance;
 });

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
 import type { RoutePath } from "../types/route.ts";
-import { clerk$, needsOrgSelection$, resolveWebOrigin } from "./auth.ts";
+import { clerk$, needsOrgSelection$, resolveWebAuthUrl } from "./auth.ts";
 import { pathname, pushState, replaceState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
@@ -269,6 +269,24 @@ export const setupAuthPageWrapper = (
     signal.throwIfAborted();
 
     if (!clerk.user) {
+      const signInUrl = new URL(
+        resolveWebAuthUrl("/sign-in", { redirectUrl: location.href }),
+        location.origin,
+      );
+      if (signInUrl.searchParams.has("domain")) {
+        L.info("redirect unauthenticated preview user to web sign-in", {
+          currentUrl: location.href,
+          signInUrl: signInUrl.toString(),
+          domain: signInUrl.searchParams.get("domain"),
+          redirectUrl: signInUrl.searchParams.get("redirect_url"),
+        });
+        window.location.href = signInUrl.toString();
+        return;
+      }
+      L.info("redirect unauthenticated user with Clerk helper", {
+        currentUrl: location.href,
+        signInUrl: signInUrl.toString(),
+      });
       await clerk.redirectToSignIn();
       signal.throwIfAborted();
       return;
@@ -281,7 +299,9 @@ export const setupAuthPageWrapper = (
       L.debug(
         "redirect to choose-organization because org selection is needed",
       );
-      window.location.href = `${resolveWebOrigin()}/sign-in/tasks/choose-organization`;
+      window.location.href = resolveWebAuthUrl(
+        "/sign-in/tasks/choose-organization",
+      );
       return;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { clerk$, resolveWebOrigin } from "../auth.ts";
+import { clerk$, resolveWebAuthUrl } from "../auth.ts";
 import { searchParams$ } from "../route.ts";
 import {
   zeroOnboardingStatus$,
@@ -79,7 +79,9 @@ export const onboardGuard$ = command(
       signal.throwIfAborted();
       const memberships = clerk.user?.organizationMemberships ?? [];
       if (memberships.length > 0) {
-        window.location.href = `${resolveWebOrigin()}/sign-in/tasks/choose-organization`;
+        window.location.href = resolveWebAuthUrl(
+          "/sign-in/tasks/choose-organization",
+        );
         return true;
       }
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -32,7 +32,7 @@ import {
 import {
   clerk$,
   currentUserInfo$,
-  resolveWebOrigin,
+  resolveWebAuthUrl,
 } from "../../signals/auth.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -465,9 +465,10 @@ export function AccountDropdown({
   const handleAccountAction = (action: ZeroAccountAction) => {
     if (action === "signout") {
       const sessionId = clerk?.session?.id;
-      const signInUrl = `${resolveWebOrigin()}/sign-in?redirect_url=${encodeURIComponent(location.href)}`;
+      const signInUrl = new URL(resolveWebAuthUrl("/sign-in"));
+      signInUrl.searchParams.set("redirect_url", location.href);
       detach(
-        clerk?.signOut({ sessionId, redirectUrl: signInUrl }),
+        clerk?.signOut({ sessionId, redirectUrl: signInUrl.toString() }),
         Reason.DomCallback,
       );
       return;

--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
+import { HttpResponse, http } from "msw";
+import { server } from "../src/mocks/server";
 
 const clerkState = vi.hoisted(() => {
   return {
@@ -67,6 +69,31 @@ function createMockEvent() {
   } as never;
 }
 
+interface ForwardedRequest {
+  readonly headers: Headers;
+  readonly method: string;
+  readonly url: string;
+}
+
+function captureForwardedRequests(
+  method: "post",
+  url: string,
+  response: Response,
+): ForwardedRequest[] {
+  const requests: ForwardedRequest[] = [];
+  server.use(
+    http[method](url, ({ request }) => {
+      requests.push({
+        headers: request.headers,
+        method: request.method,
+        url: request.url,
+      });
+      return response;
+    }),
+  );
+  return requests;
+}
+
 describe("proxy middleware: public routes", () => {
   beforeAll(async () => {
     middleware = (await import("../proxy")).default;
@@ -94,15 +121,16 @@ describe("proxy middleware: public routes", () => {
   it("proxies non-GET requests for so frontend rewrite pages when forwarding is enabled", async () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     reloadEnv();
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return new Response("proxied", {
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://so.vm0.ai/en",
+      new HttpResponse("proxied", {
         status: 202,
         headers: {
           "x-so-frontend": "1",
         },
-      });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+      }),
+    );
 
     const request = new NextRequest("https://www.vm0.ai/en?from=signout", {
       method: "POST",
@@ -118,15 +146,15 @@ describe("proxy middleware: public routes", () => {
 
     const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
-    expect(String(targetUrl)).toBe("https://so.vm0.ai/en?from=signout");
-    expect(init?.method).toBe("POST");
-    expect(init?.headers).toBeInstanceOf(Headers);
-    expect((init as RequestInit & { duplex?: string })?.duplex).toBe("half");
-    const proxiedHeaders = init?.headers as Headers;
-    expect(proxiedHeaders.get("connection")).toBeNull();
-    expect(proxiedHeaders.get("content-length")).toBeNull();
+    expect(forwardedRequests).toHaveLength(1);
+    const [forwardedRequest] = forwardedRequests;
+    if (!forwardedRequest) {
+      throw new Error("Expected forwarded request");
+    }
+    expect(forwardedRequest.url).toBe("https://so.vm0.ai/en?from=signout");
+    expect(forwardedRequest.method).toBe("POST");
+    expect(forwardedRequest.headers).toBeInstanceOf(Headers);
+    const proxiedHeaders = forwardedRequest.headers;
     expect(proxiedHeaders.get("origin")).toBe("https://so.vm0.ai");
     expect(proxiedHeaders.get("referer")).toBe(
       "https://so.vm0.ai/en?from=signout",
@@ -176,15 +204,12 @@ describe("proxy middleware: public routes", () => {
   });
 
   it("does not proxy non-GET requests when so frontend forwarding is disabled", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
     const request = new NextRequest("https://www.vm0.ai/en", {
       method: "POST",
     });
 
     const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).not.toHaveBeenCalled();
     expect(response).toBeDefined();
     if (!response) {
       throw new Error("Expected middleware response");
@@ -196,10 +221,11 @@ describe("proxy middleware: public routes", () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://staging-so.vm6.ai");
     vi.stubEnv("VERCEL_ENV", "preview");
     reloadEnv();
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return new Response("preview auth proxied", { status: 202 });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://staging-so.vm6.ai/sign-in/factor-one",
+      new HttpResponse("preview auth proxied", { status: 202 }),
+    );
     const request = new NextRequest(
       "https://pr-18518-www.vm6.ai/sign-in/factor-one",
       {
@@ -209,9 +235,8 @@ describe("proxy middleware: public routes", () => {
 
     const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [targetUrl] = fetchMock.mock.calls[0] ?? [];
-    expect(String(targetUrl)).toBe(
+    expect(forwardedRequests).toHaveLength(1);
+    expect(forwardedRequests[0]?.url).toBe(
       "https://staging-so.vm6.ai/sign-in/factor-one",
     );
     expect(response).toBeDefined();
@@ -225,19 +250,21 @@ describe("proxy middleware: public routes", () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     vi.stubEnv("VERCEL_ENV", "production");
     reloadEnv();
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return new Response("auth proxied", { status: 202 });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://so.vm0.ai/sign-in/factor-one",
+      new HttpResponse("auth proxied", { status: 202 }),
+    );
     const request = new NextRequest("https://www.vm0.ai/sign-in/factor-one", {
       method: "POST",
     });
 
     const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [targetUrl] = fetchMock.mock.calls[0] ?? [];
-    expect(String(targetUrl)).toBe("https://so.vm0.ai/sign-in/factor-one");
+    expect(forwardedRequests).toHaveLength(1);
+    expect(forwardedRequests[0]?.url).toBe(
+      "https://so.vm0.ai/sign-in/factor-one",
+    );
     expect(response).toBeDefined();
     if (!response) {
       throw new Error("Expected auth proxy response");
@@ -248,15 +275,18 @@ describe("proxy middleware: public routes", () => {
   it("does not proxy app-only functional routes when so forwarding is enabled", async () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     reloadEnv();
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://so.vm0.ai/connector/success",
+      new HttpResponse("unexpected proxy", { status: 500 }),
+    );
     const request = new NextRequest("https://www.vm0.ai/connector/success", {
       method: "POST",
     });
 
     await middleware(request, createMockEvent());
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(forwardedRequests).toEqual([]);
   });
 
   it("keeps locale-less web design gallery public", async () => {

--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -192,11 +192,13 @@ describe("proxy middleware: public routes", () => {
     expect(response.status).not.toBe(202);
   });
 
-  it("does not proxy auth routes to so in preview", async () => {
+  it("proxies auth routes to so in preview", async () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://staging-so.vm6.ai");
     vi.stubEnv("VERCEL_ENV", "preview");
     reloadEnv();
-    const fetchMock = vi.fn();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("preview auth proxied", { status: 202 });
+    });
     vi.stubGlobal("fetch", fetchMock);
     const request = new NextRequest(
       "https://pr-18518-www.vm6.ai/sign-in/factor-one",
@@ -205,9 +207,18 @@ describe("proxy middleware: public routes", () => {
       },
     );
 
-    await middleware(request, createMockEvent());
+    const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [targetUrl] = fetchMock.mock.calls[0] ?? [];
+    expect(String(targetUrl)).toBe(
+      "https://staging-so.vm6.ai/sign-in/factor-one",
+    );
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected preview auth proxy response");
+    }
+    expect(response.status).toBe(202);
   });
 
   it("proxies auth routes to so in production", async () => {

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -22,7 +22,7 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendUrl({ VERCEL_ENV: "preview" })).toBeUndefined();
   });
 
-  it("rewrites marketing content to so in preview", () => {
+  it("rewrites marketing content and auth routes to so in preview", () => {
     const rewrites = buildSoFrontendRewrites({
       PAID_ONBOARDING_URL: "https://pr-123-so.vm6.ai",
       VERCEL_ENV: "preview",
@@ -52,20 +52,20 @@ describe("so frontend rewrites", () => {
       source: "/en/models/:path*",
       destination: "https://pr-123-so.vm6.ai/en/models/:path*",
     });
-    expect(rewrites).not.toContainEqual({
+    expect(rewrites).toContainEqual({
       source: "/sign-in",
       destination: "https://pr-123-so.vm6.ai/sign-in",
     });
-    expect(rewrites).not.toContainEqual({
+    expect(rewrites).toContainEqual({
       source: "/sign-up",
       destination: "https://pr-123-so.vm6.ai/sign-up",
     });
   });
 
-  it("rewrites sign-in/sign-up to so only in production", () => {
+  it("rewrites sign-in/sign-up when a so frontend target is configured", () => {
     const rewrites = buildSoFrontendRewrites({
       PAID_ONBOARDING_URL: "https://so.vm0.ai",
-      VERCEL_ENV: "production",
+      VERCEL_ENV: "preview",
     });
 
     expect(rewrites).toContainEqual({
@@ -104,12 +104,7 @@ describe("so frontend rewrites", () => {
     expect(matchesSoFrontendRewritePath("/docs/getting-started")).toBe(true);
     expect(matchesSoFrontendRewritePath("/assets/vm0-logo.svg")).toBe(true);
 
-    expect(matchesSoFrontendRewritePath("/sign-in/sso-callback")).toBe(false);
-    expect(
-      matchesSoFrontendRewritePath("/sign-in/sso-callback", {
-        VERCEL_ENV: "production",
-      }),
-    ).toBe(true);
+    expect(matchesSoFrontendRewritePath("/sign-in/sso-callback")).toBe(true);
     expect(matchesSoFrontendRewritePath("/connector/success")).toBe(false);
     expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(false);
     expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(
@@ -127,12 +122,9 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendRewritePath("/en/docs/reference/api")).toBe(
       "/en/docs/reference/api",
     );
-    expect(resolveSoFrontendRewritePath("/sign-in/factor-one")).toBeUndefined();
-    expect(
-      resolveSoFrontendRewritePath("/sign-in/factor-one", {
-        VERCEL_ENV: "production",
-      }),
-    ).toBe("/sign-in/factor-one");
+    expect(resolveSoFrontendRewritePath("/sign-in/factor-one")).toBe(
+      "/sign-in/factor-one",
+    );
     expect(resolveSoFrontendRewritePath("/connector/success")).toBeUndefined();
   });
 });

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -51,12 +51,8 @@ const SO_FRONTEND_ASSET_PATHS = [
   "/checkmark-primary.svg",
 ];
 
-function shouldRewriteAuthPaths(env) {
-  return env.VERCEL_ENV === "production";
-}
-
-function authRewritePaths(env) {
-  return shouldRewriteAuthPaths(env) ? SO_FRONTEND_AUTH_PATHS : [];
+function authRewritePaths() {
+  return SO_FRONTEND_AUTH_PATHS;
 }
 
 function withoutTrailingSlash(value) {


### PR DESCRIPTION
## Summary
- Re-enable /sign-in and /sign-up rewrites to the so frontend when a so target is configured, including preview
- Update proxy/rewrite tests to assert preview auth requests are forwarded to staging-so
- Touch platform time helper comment so platform/e2e CI runs for this PR

## Tests
- pnpm --filter web test -- __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts
- pnpm --filter web lint
- pnpm --filter @vm0/app lint
- ./scripts/changed.sh origin/main