### PR TITLE
fix: respect mobile safe areas in toasts and artifacts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -415,6 +415,12 @@ async function backToArtifactInbox(): Promise<void> {
   });
 }
 
+function expectFullscreenSafeAreaClass(element: HTMLElement): void {
+  const className = element.getAttribute("class") ?? "";
+  expect(className).toContain("pt-[var(--sat)]");
+  expect(className).toContain("pb-[var(--sab)]");
+}
+
 function menuItemByText(text: string): HTMLElement {
   const menuItems = queryAllByRoleFast("menuitem");
   const item = menuItems.find((element) => {
@@ -670,6 +676,7 @@ describe("zero artifact sidebar", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
     });
+    expectFullscreenSafeAreaClass(screen.getByTestId("artifact-sidebar"));
 
     await user.click(screen.getByLabelText("Exit fullscreen"));
     await waitFor(() => {
@@ -690,6 +697,7 @@ describe("zero artifact sidebar", () => {
         screen.getByText("Unsupported artifact reference."),
       ).toBeInTheDocument();
       expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
+      expectFullscreenSafeAreaClass(screen.getByTestId("artifact-sidebar"));
     });
 
     click(screen.getByLabelText("Close artifact"));
@@ -1464,7 +1472,7 @@ ${openFencedHostedSiteUrl}`,
 
     click(screen.getByLabelText("Open artifacts"));
 
-    const inbox = await waitFor(() => {
+    let inbox = await waitFor(() => {
       const element = screen.getByTestId("artifact-inbox");
       expect(screen.getByText("release-notes.md")).toBeInTheDocument();
       expect(screen.getByText("launch-chart.png")).toBeInTheDocument();
@@ -1488,6 +1496,18 @@ ${openFencedHostedSiteUrl}`,
     expect(
       screen.getByTestId("artifact-html-preview-badge"),
     ).toBeInTheDocument();
+
+    click(screen.getByTestId("artifact-inbox-fullscreen-toggle"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
+    });
+    expectFullscreenSafeAreaClass(screen.getByTestId("artifact-inbox"));
+
+    click(screen.getByTestId("artifact-inbox-fullscreen-toggle"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enter fullscreen")).toBeInTheDocument();
+    });
+    inbox = screen.getByTestId("artifact-inbox");
 
     click(getArtifactTab(inbox, "Media"));
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -73,6 +73,9 @@ import {
 // fullscreen toggle that swaps to a full-viewport layout.
 // ---------------------------------------------------------------------------
 
+const ARTIFACT_FULLSCREEN_SHELL_CLASSNAME =
+  "fixed inset-0 z-[100] flex min-h-0 flex-col bg-background pt-[var(--sat)] pb-[var(--sab)]";
+
 export function ArtifactSidebar({
   artifactRef,
   onBack,
@@ -185,7 +188,7 @@ function ArtifactSidebarContent({
       <div
         className={cn(
           fullscreen
-            ? "fixed inset-0 z-[100] flex flex-col bg-background pt-[env(safe-area-inset-top)]"
+            ? ARTIFACT_FULLSCREEN_SHELL_CLASSNAME
             : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
           "animate-in fade-in duration-[180ms] ease",
         )}
@@ -233,7 +236,7 @@ function ArtifactSidebarContent({
     <div
       className={cn(
         fullscreen
-          ? "fixed inset-0 z-[100] flex flex-col bg-background pt-[env(safe-area-inset-top)]"
+          ? ARTIFACT_FULLSCREEN_SHELL_CLASSNAME
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
         "animate-in fade-in duration-[180ms] ease",
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1440,6 +1440,9 @@ const CHAT_INLINE_MEDIA_PREVIEW_CLASS =
 const CHAT_INLINE_IMAGE_PREVIEW_CLASS =
   "aspect-[10/9] w-[50px] max-w-full cursor-pointer rounded-lg border border-foreground/10 bg-muted/30 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
 
+const ARTIFACT_FULLSCREEN_SHELL_CLASSNAME =
+  "fixed inset-0 z-[100] flex min-h-0 flex-col bg-background pt-[var(--sat)] pb-[var(--sab)]";
+
 function ChatImagePreviewLink({
   alt,
   ariaLabel,
@@ -1897,7 +1900,7 @@ function ChatArtifactInboxList({ thread }: { thread: ChatThreadSignals }) {
     <div
       className={cn(
         fullscreen
-          ? "fixed inset-0 z-[100] flex flex-col bg-background"
+          ? ARTIFACT_FULLSCREEN_SHELL_CLASSNAME
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
         "animate-in fade-in duration-[180ms] ease",
       )}
@@ -2484,7 +2487,7 @@ export function ZeroChatThreadPage() {
       className={cn(
         "flex min-w-0 overflow-hidden bg-background",
         artifactFullscreen
-          ? "fixed inset-0 z-[100] min-h-0 flex-col pt-[var(--sat)] pb-[var(--sab)]"
+          ? ARTIFACT_FULLSCREEN_SHELL_CLASSNAME
           : "h-full w-full flex-1",
       )}
     >

--- a/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/sonner.test.tsx
@@ -18,4 +18,27 @@ describe("Toaster", () => {
     expect(container.contains(toaster)).toBeFalsy();
     expect(toaster).toHaveStyle({ zIndex: "2147483647" });
   });
+
+  it("keeps mobile toast placement aligned with the viewport safe area", async () => {
+    render(<Toaster />);
+
+    toast.success("Saved");
+
+    await screen.findByText("Saved");
+    const toaster = document.querySelector("[data-sonner-toaster]");
+    expect(toaster).toBeInTheDocument();
+    expect(toaster).toHaveStyle({ zIndex: "2147483647" });
+    expect(
+      (toaster as HTMLElement).style.getPropertyValue("--mobile-offset-top"),
+    ).toBe("calc(var(--sat, 0px) + 12px)");
+    expect(
+      (toaster as HTMLElement).style.getPropertyValue("--mobile-offset-left"),
+    ).toBe("0px");
+    expect(
+      (toaster as HTMLElement).style.getPropertyValue("--mobile-offset-right"),
+    ).toBe("0px");
+    expect(
+      (toaster as HTMLElement).style.getPropertyValue("--mobile-offset-bottom"),
+    ).toBe("calc(var(--sab, 0px) + 16px)");
+  });
 });

--- a/turbo/packages/ui/src/components/ui/sonner.tsx
+++ b/turbo/packages/ui/src/components/ui/sonner.tsx
@@ -3,12 +3,31 @@ import { Toaster as Sonner, toast } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
+const DEFAULT_TOASTER_OFFSET = {
+  top: "calc(var(--sat, 0px) + 24px)",
+  bottom: "calc(var(--sab, 0px) + 24px)",
+} satisfies ToasterProps["offset"];
+
+const DEFAULT_TOASTER_MOBILE_OFFSET = {
+  top: "calc(var(--sat, 0px) + 12px)",
+  right: "0px",
+  bottom: "calc(var(--sab, 0px) + 16px)",
+  left: "0px",
+} satisfies ToasterProps["mobileOffset"];
+
 function Toaster({ ...props }: ToasterProps) {
-  const { style, ...rest } = props;
+  const {
+    mobileOffset = DEFAULT_TOASTER_MOBILE_OFFSET,
+    offset = DEFAULT_TOASTER_OFFSET,
+    style,
+    ...rest
+  } = props;
   const toaster = (
     <Sonner
       className="toaster group !flex !flex-col !items-center"
       duration={3000}
+      mobileOffset={mobileOffset}
+      offset={offset}
       style={{
         ...style,
         zIndex: 2147483647,
@@ -16,7 +35,7 @@ function Toaster({ ...props }: ToasterProps) {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=error]_[data-icon]]:text-red-500",
+            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:!rounded-[10px] group-[.toaster]:!text-sm group-[.toaster]:!font-medium group-[.toaster]:!w-auto group-[.toaster]:!max-w-[calc(100dvw-2rem)] sm:group-[.toaster]:!max-w-none group-[.toaster]:!whitespace-normal sm:group-[.toaster]:!whitespace-nowrap group-[.toaster]:!left-auto group-[.toaster]:!top-auto group-[.toaster]:!relative [&_[data-icon]]:text-green-600 [&[data-type=error]_[data-icon]]:text-red-500",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
## Summary
- make the shared toaster safe-area-aware on mobile and keep centered toasts from shifting or overflowing
- apply the platform safe-area variables to artifact sidebar, artifact inbox, and presentation editor fullscreen shells
- cover toast mobile offsets and artifact fullscreen safe-area classes in targeted tests

## Verification
- pnpm -F @vm0/ui exec vitest run src/components/ui/__tests__/sonner.test.tsx --reporter=verbose
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx --reporter=verbose
- pnpm -F @vm0/ui check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/ui lint
- pnpm -F @vm0/app lint
- pnpm exec prettier --check apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx packages/ui/src/components/ui/__tests__/sonner.test.tsx packages/ui/src/components/ui/sonner.tsx