### PR TITLE
feat: style permission allow button as neutral-dark primary

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -79,8 +79,9 @@ async function waitForButtonByText(
 async function confirmPermissionAction(
   user: ReturnType<typeof userEvent.setup>,
   card: HTMLElement,
+  label = "Allow",
 ): Promise<void> {
-  await user.click(await waitForButtonByText("Confirm", card));
+  await user.click(await waitForButtonByText(label, card));
 }
 
 describe("chat message action cards", () => {
@@ -216,7 +217,7 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText("Allow messages.write"),
     ).toBeInTheDocument();
 
-    await waitForButtonByText("Confirm", permissionCard);
+    await waitForButtonByText("Allow", permissionCard);
     expect(listRequests).toBe(2);
     expect(
       within(permissionCard).queryByText("Failed to load permissions"),
@@ -346,7 +347,7 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
-    await waitForButtonByText("Confirm", permissionCard);
+    await waitForButtonByText("Allow", permissionCard);
     await user.click(
       within(permissionCard).getByLabelText("Permission duration"),
     );
@@ -533,7 +534,7 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText("Deny admin.analytics:read"),
     ).toBeInTheDocument();
 
-    await confirmPermissionAction(user, permissionCard);
+    await confirmPermissionAction(user, permissionCard, "Deny");
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4475,6 +4475,7 @@ function permissionActionVerb(action: PermissionAction): string {
 
 function permissionActionButtonLabel(
   state: PermissionActionButtonState,
+  action: PermissionAction,
 ): string {
   if (state.loading) {
     return "Checking permissions";
@@ -4488,7 +4489,7 @@ function permissionActionButtonLabel(
   if (state.saving) {
     return "Saving...";
   }
-  return "Confirm";
+  return permissionActionVerb(action);
 }
 
 function permissionActionButtonDisabled(
@@ -4535,15 +4536,21 @@ function PermissionActionButton({
     );
   }
 
+  const allowClassName =
+    "border-transparent bg-foreground text-background hover:bg-foreground/90";
+  const denyClassName =
+    "border-border bg-background text-foreground hover:bg-accent";
   return (
     <button
       type="button"
       disabled={permissionActionButtonDisabled(state)}
       onClick={onClick}
-      className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent sm:w-auto"
+      className={`inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border px-3 text-[0.9375rem] font-medium transition-colors sm:w-auto ${
+        action === "allow" ? allowClassName : denyClassName
+      }`}
     >
       {state.saving && <IconLoader2 size={15} className="animate-spin" />}
-      {permissionActionButtonLabel(state)}
+      {permissionActionButtonLabel(state, action)}
     </button>
   );
 }


### PR DESCRIPTION
## What

Minimal restyle of the in-chat permission approval card to match the agreed Zero design direction.

- The action button is now labeled by its **verb** — **Allow** / **Deny** — instead of the generic "Confirm" (reuses the existing `permissionActionVerb` helper that already powers the card subline).
- The **allow** action uses the neutral-dark page primary (`bg-foreground text-background`); the **deny** action keeps the existing outline treatment.

No layout, copy, or interaction changes beyond the button. The duration select, connector icon, title, and subline are untouched.

## Why

Design pass on the permission approval row landed on a neutral-dark Allow + outline Deny as the standard. This is the smallest change that brings the shipped card to that look.

## Scope

`PermissionActionButton` in `zero-chat-thread-page.tsx` + the three test assertions that referenced the old "Confirm" label.

Prettier and oxlint pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)