### PR TITLE
fix: use color swatch chat template icon

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1455,11 +1455,13 @@ describe("chat composer templates", () => {
       },
     });
 
-    click(
-      await waitFor(() => {
-        return screen.getByLabelText("Template");
-      }),
-    );
+    const templateButton = await waitFor(() => {
+      return screen.getByLabelText("Template");
+    });
+    expect(templateButton.querySelector("img")).toBeNull();
+    expect(templateButton.querySelector("svg")).toBeInTheDocument();
+
+    click(templateButton);
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -18,6 +18,7 @@ import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import {
   IconAlertTriangle,
   IconArrowUp,
+  IconColorSwatch,
   IconDeviceDesktop,
   IconDownload,
   IconPresentation,
@@ -127,7 +128,6 @@ import {
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
-import templatePickerIcon from "./assets/empty-templates.svg";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
   allConnectorTypes$,
@@ -4715,12 +4715,7 @@ function TemplatePickerButton({
                 setOpen(true);
               }}
             >
-              <img
-                src={templatePickerIcon}
-                alt=""
-                role="presentation"
-                className="h-[32px] w-[32px] object-contain"
-              />
+              <IconColorSwatch size={18} stroke={1.5} aria-hidden="true" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">


### PR DESCRIPTION
## Summary
- Replaces the Zero chat composer Template toolbar button's colorful SVG artwork with the outline color-swatch icon
- Keeps the existing toolbar button styling and popup behavior unchanged
- Adds a regression assertion that the Template button no longer renders the colorful image and now renders an SVG icon

## Verification
- `pnpm -F @vm0/app check-types`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`

## Screenshot
Visual verification of the toolbar icon shape:

![Chat template toolbar color-swatch icon](https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/53fd416d-b6dc-41f0-888e-dd4f133fdb69/chat-template-toolbar-color-swatch-18-15.png)
