### PR TITLE
ci: make runner image manifests target-aware

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/runner-image-target.sh"
+
 require_env() {
   local name=$1
   if [ -z "${!name:-}" ]; then
@@ -14,12 +17,13 @@ require_env HEAD_SHA
 require_env METAL_HOSTS
 require_env METAL_USER
 
-TARGET_TRIPLE="${TARGET_TRIPLE:-aarch64-unknown-linux-musl}"
+TARGET_TRIPLE="${TARGET_TRIPLE-aarch64-unknown-linux-musl}"
 PROFILE="${PROFILE:-vm0/default}"
 MANIFEST_PATH="${MANIFEST_PATH:-runner-image-manifest/manifest.json}"
 BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
 RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}"
 TARGET_DIR="crates/target/${TARGET_TRIPLE}/ci"
+EXPECTED_REMOTE_ARCH=$(runner_image_expected_uname_m "$TARGET_TRIPLE")
 
 mkdir -p "$(dirname "$MANIFEST_PATH")"
 
@@ -78,6 +82,16 @@ prepare_host() {
   local runner_name="${JOB_REF}-${host_index}"
   local remote="${METAL_USER}@${host}"
   echo "=== Preparing ${host} (runner: ${runner_name}) ==="
+
+  local remote_arch
+  if ! remote_arch=$(ssh "$remote" uname -m); then
+    return 1
+  fi
+  remote_arch=$(printf '%s\n' "$remote_arch" | tail -n1 | tr -d '\r')
+  if [ "$remote_arch" != "$EXPECTED_REMOTE_ARCH" ]; then
+    echo "runner target ${TARGET_TRIPLE} expects remote architecture ${EXPECTED_REMOTE_ARCH}, but ${host} reported ${remote_arch}" >&2
+    return 1
+  fi
 
   if ! ssh "$remote" bash -s -- "${BIN_DIR}" "${RUNNER_DIR}" "${runner_name}" <<'REMOTE_SCRIPT'
 set -euo pipefail

--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/runner-image-target.sh"
+
 usage() {
   cat <<'USAGE'
 Usage: runner-image-context.sh <resolve|turbo-consumer|crates-consumer|image-inputs|needed|artifact-name>
@@ -294,10 +297,14 @@ image_inputs() {
 artifact_name() {
   require_env HEAD_SHA
   require_env JOB_REF
-  local head_sha job_ref
+  require_env TARGET
+  local head_sha job_ref target
   head_sha=$(env_value HEAD_SHA)
   job_ref=$(env_value JOB_REF)
-  emit "artifact-name" "runner-image-manifest-${head_sha}-${job_ref}"
+  target=$(env_value TARGET)
+  local artifact_name
+  artifact_name=$(runner_image_artifact_name "$target" "$head_sha" "$job_ref")
+  emit "artifact-name" "$artifact_name"
 }
 
 cmd="${1:-}"

--- a/.github/scripts/runner-image-manifest.sh
+++ b/.github/scripts/runner-image-manifest.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/runner-image-target.sh"
+
 usage() {
   cat <<'USAGE'
 Usage: runner-image-manifest.sh validate
@@ -40,6 +43,8 @@ validate() {
   require_env TARGET
   require_env PROFILE
   require_env METAL_HOSTS
+
+  runner_image_validate_target "$TARGET"
 
   if [ ! -f "$MANIFEST_PATH" ]; then
     echo "manifest not found: ${MANIFEST_PATH}" >&2

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+runner_image_supported_targets_text() {
+  printf '%s\n' "aarch64-unknown-linux-musl, x86_64-unknown-linux-musl"
+}
+
+runner_image_validate_target() {
+  local target="${1:-}"
+  if [ -z "$target" ]; then
+    echo "missing runner image target" >&2
+    return 2
+  fi
+
+  case "$target" in
+    aarch64-unknown-linux-musl|x86_64-unknown-linux-musl)
+      return 0
+      ;;
+    *)
+      echo "unsupported runner image target: ${target} (expected one of: $(runner_image_supported_targets_text))" >&2
+      return 2
+      ;;
+  esac
+}
+
+runner_image_artifact_name() {
+  local target="${1:-}"
+  local head_sha="${2:-}"
+  local job_ref="${3:-}"
+
+  runner_image_validate_target "$target" || return $?
+  printf 'runner-image-manifest-%s-%s-%s\n' "$target" "$head_sha" "$job_ref"
+}
+
+runner_image_expected_uname_m() {
+  local target="${1:-}"
+
+  runner_image_validate_target "$target" || return $?
+  case "$target" in
+    aarch64-unknown-linux-musl)
+      printf '%s\n' "aarch64"
+      ;;
+    x86_64-unknown-linux-musl)
+      printf '%s\n' "x86_64"
+      ;;
+  esac
+}

--- a/.github/scripts/tests/prepare-runner-image-test.sh
+++ b/.github/scripts/tests/prepare-runner-image-test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREPARE="${SCRIPT_DIR}/prepare-runner-image.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+if JOB_REF=pr-123 \
+  HEAD_SHA=abc \
+  METAL_HOSTS=dev-1 \
+  METAL_USER=ci \
+  TARGET_TRIPLE= \
+  "$PREPARE" >"${TMPDIR}/empty.out" 2>"${TMPDIR}/empty.err"; then
+  fail "expected empty target to fail"
+fi
+grep -q "missing runner image target" "${TMPDIR}/empty.err" || fail "expected missing target message"
+
+if JOB_REF=pr-123 \
+  HEAD_SHA=abc \
+  METAL_HOSTS=dev-1 \
+  METAL_USER=ci \
+  TARGET_TRIPLE=powerpc-unknown-linux-musl \
+  "$PREPARE" >"${TMPDIR}/unsupported.out" 2>"${TMPDIR}/unsupported.err"; then
+  fail "expected unsupported target to fail"
+fi
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/unsupported.err" || fail "expected unsupported target message"
+
+echo "prepare-runner-image-test: ok"

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -273,7 +273,21 @@ assert_contains "$out" "turbo-runner-consumer-needed=false"
 assert_contains "$out" "runner-image-consumer-needed=false"
 assert_contains "$out" "current-runner-image-needed=false"
 
-out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 "$CONTEXT" artifact-name)
-assert_contains "$out" "artifact-name=runner-image-manifest-abc-pr-123"
+assert_fails "artifact-name requires TARGET" \
+  HEAD_SHA=abc \
+  JOB_REF=pr-123 \
+  "$CONTEXT" artifact-name
+
+assert_fails "artifact-name rejects unsupported TARGET" \
+  HEAD_SHA=abc \
+  JOB_REF=pr-123 \
+  TARGET=powerpc-unknown-linux-musl \
+  "$CONTEXT" artifact-name
+
+out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 TARGET=aarch64-unknown-linux-musl "$CONTEXT" artifact-name)
+assert_contains "$out" "artifact-name=runner-image-manifest-aarch64-unknown-linux-musl-abc-pr-123"
+
+out=$(run_clean HEAD_SHA=abc JOB_REF=pr-123 TARGET=x86_64-unknown-linux-musl "$CONTEXT" artifact-name)
+assert_contains "$out" "artifact-name=runner-image-manifest-x86_64-unknown-linux-musl-abc-pr-123"
 
 echo "runner-image-context-test: ok"

--- a/.github/scripts/tests/runner-image-manifest-test.sh
+++ b/.github/scripts/tests/runner-image-manifest-test.sh
@@ -69,10 +69,10 @@ if MANIFEST_PATH="${TMPDIR}/manifest.json" \
   TARGET=aarch64-unknown-linux-musl \
   PROFILE=vm0/default \
   METAL_HOSTS=dev-1 \
-  "$MANIFEST" validate >/tmp/manifest-test.out 2>/tmp/manifest-test.err; then
+  "$MANIFEST" validate >"${TMPDIR}/manifest-test.out" 2>"${TMPDIR}/manifest-test.err"; then
   fail "expected wrong HEAD_SHA to fail"
 fi
-grep -q "headSha mismatch" /tmp/manifest-test.err || fail "expected headSha mismatch"
+grep -q "headSha mismatch" "${TMPDIR}/manifest-test.err" || fail "expected headSha mismatch"
 
 if MANIFEST_PATH="${TMPDIR}/manifest.json" \
   HEAD_SHA=abc \
@@ -80,9 +80,31 @@ if MANIFEST_PATH="${TMPDIR}/manifest.json" \
   TARGET=aarch64-unknown-linux-musl \
   PROFILE=vm0/default \
   METAL_HOSTS=dev-3 \
-  "$MANIFEST" validate >/tmp/manifest-test.out 2>/tmp/manifest-test.err; then
+  "$MANIFEST" validate >"${TMPDIR}/manifest-test.out" 2>"${TMPDIR}/manifest-test.err"; then
   fail "expected missing host to fail"
 fi
-grep -q "manifest missing rootfsHash for dev-3" /tmp/manifest-test.err || fail "expected missing host message"
+grep -q "manifest missing rootfsHash for dev-3" "${TMPDIR}/manifest-test.err" || fail "expected missing host message"
+
+if MANIFEST_PATH="${TMPDIR}/manifest.json" \
+  HEAD_SHA=abc \
+  JOB_REF=pr-123 \
+  TARGET=x86_64-unknown-linux-musl \
+  PROFILE=vm0/default \
+  METAL_HOSTS=dev-1 \
+  "$MANIFEST" validate >"${TMPDIR}/manifest-test.out" 2>"${TMPDIR}/manifest-test.err"; then
+  fail "expected target mismatch to fail"
+fi
+grep -q "target mismatch: aarch64-unknown-linux-musl != x86_64-unknown-linux-musl" "${TMPDIR}/manifest-test.err" || fail "expected target mismatch"
+
+if MANIFEST_PATH="${TMPDIR}/manifest.json" \
+  HEAD_SHA=abc \
+  JOB_REF=pr-123 \
+  TARGET=powerpc-unknown-linux-musl \
+  PROFILE=vm0/default \
+  METAL_HOSTS=dev-1 \
+  "$MANIFEST" validate >"${TMPDIR}/manifest-test.out" 2>"${TMPDIR}/manifest-test.err"; then
+  fail "expected unsupported target to fail"
+fi
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/manifest-test.err" || fail "expected unsupported target message"
 
 echo "runner-image-manifest-test: ok"

--- a/.github/scripts/tests/wait-runner-image-test.sh
+++ b/.github/scripts/tests/wait-runner-image-test.sh
@@ -40,6 +40,7 @@ cat > "${TMPDIR}/manifest.json" <<'JSON'
   }
 }
 JSON
+sed 's/aarch64-unknown-linux-musl/x86_64-unknown-linux-musl/' "${TMPDIR}/manifest.json" > "${TMPDIR}/manifest-x86.json"
 
 cat > "${TMPDIR}/bin/gh" <<'BASH'
 #!/usr/bin/env bash
@@ -52,7 +53,7 @@ if [ "$1" = "api" ]; then
     printf '{"artifacts":[]}\n'
     exit 0
   fi
-  printf '{"artifacts":[{"id":123,"name":"runner-image-manifest-build-sha-pr-123","expired":false,"created_at":"2026-05-11T00:00:00Z","workflow_run":{"id":42,"head_sha":"head-sha"}}]}\n'
+  printf '{"artifacts":[{"id":123,"name":"%s","expired":false,"created_at":"2026-05-11T00:00:00Z","workflow_run":{"id":42,"head_sha":"head-sha"}}]}\n' "${EXPECTED_ARTIFACT_NAME}"
   exit 0
 fi
 
@@ -83,7 +84,7 @@ if [ "$1" = "run" ] && [ "$2" = "download" ]; then
         ;;
     esac
   done
-  [ "$artifact" = "runner-image-manifest-build-sha-pr-123" ] || exit 1
+  [ "$artifact" = "${EXPECTED_ARTIFACT_NAME}" ] || exit 1
   mkdir -p "$output_dir"
   cp "${FAKE_MANIFEST}" "${output_dir}/manifest.json"
   exit 0
@@ -97,6 +98,7 @@ chmod +x "${TMPDIR}/bin/gh"
 out=$(PATH="${TMPDIR}/bin:${PATH}" \
   GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
   FAKE_MANIFEST="${TMPDIR}/manifest.json" \
+  EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
   REPO=vm0-ai/vm0 \
   HEAD_SHA=build-sha \
   LOOKUP_SHA=head-sha \
@@ -108,18 +110,57 @@ out=$(PATH="${TMPDIR}/bin:${PATH}" \
   POLL_SECONDS=0 \
   "$WAIT")
 
-grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-build-sha-pr-123&per_page=100 --jq .' "${TMPDIR}/gh-args.log" || fail "expected artifact lookup by exact name"
+grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123&per_page=100 --jq .' "${TMPDIR}/gh-args.log" || fail "expected artifact lookup by exact name"
 if grep -q -- 'run list' "${TMPDIR}/gh-args.log"; then
   fail "expected artifact-first path to skip run list after artifact is found"
 fi
-grep -q -- 'run download 42 -n runner-image-manifest-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected artifact name to use HEAD_SHA"
+grep -q -- 'run download 42 -n runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected artifact name to include target and HEAD_SHA"
 grep -qxF 'producer-run-id=42' <<<"$out" || fail "expected producer-run-id output"
 grep -qxF 'bin-dir=/var/lib/vm0-runner/bin/pr-123' <<<"$out" || fail "expected manifest outputs"
+
+: > "${TMPDIR}/gh-args.log"
+out=$(PATH="${TMPDIR}/bin:${PATH}" \
+  GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
+  FAKE_MANIFEST="${TMPDIR}/manifest-x86.json" \
+  EXPECTED_ARTIFACT_NAME=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123 \
+  REPO=vm0-ai/vm0 \
+  HEAD_SHA=build-sha \
+  LOOKUP_SHA=head-sha \
+  JOB_REF=pr-123 \
+  METAL_HOSTS=dev-1 \
+  TARGET=x86_64-unknown-linux-musl \
+  PROFILE=vm0/default \
+  OUTPUT_DIR="${TMPDIR}/out-x86" \
+  POLL_SECONDS=0 \
+  "$WAIT")
+grep -q -- 'api repos/vm0-ai/vm0/actions/artifacts?name=runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123&per_page=100 --jq .' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact lookup by exact name"
+grep -q -- 'run download 42 -n runner-image-manifest-x86_64-unknown-linux-musl-build-sha-pr-123' "${TMPDIR}/gh-args.log" || fail "expected x86 artifact download by exact name"
+grep -qxF 'producer-run-id=42' <<<"$out" || fail "expected x86 producer-run-id output"
+
+: > "${TMPDIR}/gh-args.log"
+if PATH="${TMPDIR}/bin:${PATH}" \
+  GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
+  FAKE_MANIFEST="${TMPDIR}/manifest.json" \
+  REPO=vm0-ai/vm0 \
+  HEAD_SHA=build-sha \
+  LOOKUP_SHA=head-sha \
+  JOB_REF=pr-123 \
+  METAL_HOSTS=dev-1 \
+  TARGET=powerpc-unknown-linux-musl \
+  PROFILE=vm0/default \
+  OUTPUT_DIR="${TMPDIR}/unsupported-out" \
+  POLL_SECONDS=0 \
+  "$WAIT" >"${TMPDIR}/unsupported.out" 2>"${TMPDIR}/unsupported.err"; then
+  fail "expected unsupported target to fail"
+fi
+[ ! -s "${TMPDIR}/gh-args.log" ] || fail "expected unsupported target to fail before gh calls"
+grep -q -- 'unsupported runner image target: powerpc-unknown-linux-musl' "${TMPDIR}/unsupported.err" || fail "expected unsupported target message"
 
 : > "${TMPDIR}/gh-args.log"
 if PATH="${TMPDIR}/bin:${PATH}" \
   GH_ARGS_LOG="${TMPDIR}/gh-args.log" \
   FAKE_MODE=failed-run \
+  EXPECTED_ARTIFACT_NAME=runner-image-manifest-aarch64-unknown-linux-musl-build-sha-pr-123 \
   REPO=vm0-ai/vm0 \
   HEAD_SHA=build-sha \
   LOOKUP_SHA=head-sha \

--- a/.github/scripts/wait-runner-image.sh
+++ b/.github/scripts/wait-runner-image.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/runner-image-target.sh"
+
 require_env() {
   local name=$1
   if [ -z "${!name:-}" ]; then
@@ -23,12 +26,15 @@ require_env METAL_HOSTS
 require_env TARGET
 require_env PROFILE
 
+runner_image_validate_target "$TARGET"
+
 REPO="${GITHUB_REPOSITORY:-${REPO:-}}"
 WORKFLOW="${WORKFLOW:-runner-image.yml}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1800}"
 POLL_SECONDS="${POLL_SECONDS:-10}"
 OUTPUT_DIR="${OUTPUT_DIR:-/tmp/runner-image-manifest}"
-ARTIFACT_NAME="${ARTIFACT_NAME:-runner-image-manifest-${HEAD_SHA}-${JOB_REF}}"
+DEFAULT_ARTIFACT_NAME=$(runner_image_artifact_name "$TARGET" "$HEAD_SHA" "$JOB_REF")
+ARTIFACT_NAME="${ARTIFACT_NAME:-$DEFAULT_ARTIFACT_NAME}"
 LOOKUP_SHA="${LOOKUP_SHA:-$HEAD_SHA}"
 
 if [ -z "$REPO" ]; then

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -163,7 +163,7 @@ jobs:
           set -euo pipefail
 
           runner_image_ci_changed=false
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/(prepare-runner-image|runner-image-context|runner-image-manifest|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/(prepare-runner-image|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
             runner_image_ci_changed=true
           fi
 
@@ -195,6 +195,7 @@ jobs:
         env:
           HEAD_SHA: ${{ steps.identity.outputs.head-sha }}
           JOB_REF: ${{ steps.identity.outputs.job-ref }}
+          TARGET: aarch64-unknown-linux-musl
         run: .github/scripts/runner-image-context.sh artifact-name
 
   build:


### PR DESCRIPTION
## Summary

- Add a runner-image target helper for supported targets, artifact names, and expected host architectures.
- Include the target triple in runner image manifest artifact names and default wait lookups.
- Validate targets early in runner image scripts and preflight metal host architecture before installing target-specific runners.
- Extend shell coverage for ARM64/x86_64 artifact separation, target mismatch, unsupported targets, and prepare-time validation.

Closes #18483

## Tests

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `for test in .github/scripts/tests/*.sh; do bash "$test"; done`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `git diff --check`