### PR TITLE
fix: use template picker items on presentation page

### DIFF
--- a/turbo/apps/web/app/[locale]/presentation/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/presentation/__tests__/data.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 
-import { buildPresentationRemixHref, type PresentationItem } from "../data";
+import {
+  PRESENTATION_ITEMS,
+  buildPresentationRemixHref,
+  type PresentationItem,
+} from "../data";
 
 const item: PresentationItem = {
   slug: "test-deck",
@@ -12,6 +17,12 @@ const item: PresentationItem = {
   designSystemId: "design-system:test",
   templateId: "template:test",
 };
+
+describe("presentation items", () => {
+  it("uses the shared template picker catalog", () => {
+    expect(PRESENTATION_ITEMS).toBe(PRESENTATION_TEMPLATE_PICKER_ITEMS);
+  });
+});
 
 describe("presentation remix links", () => {
   it("marks presentation try-it links with source attribution", () => {

--- a/turbo/apps/web/app/[locale]/presentation/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation/data.ts
@@ -1,11 +1,11 @@
 import {
-  PRESENTATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_PICKER_ITEMS,
   type PresentationTemplateItem,
 } from "@vm0/core";
 
 export type PresentationItem = PresentationTemplateItem;
 
-export const PRESENTATION_ITEMS = PRESENTATION_TEMPLATE_ITEMS;
+export const PRESENTATION_ITEMS = PRESENTATION_TEMPLATE_PICKER_ITEMS;
 
 const PRESENTATION_ATTRIBUTION_PARAM = "vm0_source";
 const PRESENTATION_ATTRIBUTION_VALUE = "presentation";


### PR DESCRIPTION
## Summary
- switch the presentation landing gallery to `PRESENTATION_TEMPLATE_PICKER_ITEMS`
- add a regression test that locks the page catalog to the picker catalog

## Verification
- `pnpm prettier --check 'apps/web/app/[locale]/presentation/data.ts' 'apps/web/app/[locale]/presentation/__tests__/data.test.ts'`
- `pnpm exec vitest run 'apps/web/app/[locale]/presentation/__tests__/data.test.ts'`
- `pnpm -F web lint`
- `pnpm -F web check-types`