### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2281,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2613,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3254,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3274,9 +3274,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary

- Ran `cargo update --verbose` for the Rust workspace at `crates/`.
- Updated 5 locked packages in `crates/Cargo.lock`:
  - `quinn` 0.11.9 -> 0.11.11
  - `quinn-proto` 0.11.14 -> 0.11.15
  - `rustls` 0.23.40 -> 0.23.41
  - `time` 0.3.49 -> 0.3.51
  - `time-macros` 0.2.29 -> 0.2.30

## Dependencies not updated

- `generic-array` remains at 0.14.7 even though 0.14.9 is available. `cargo update` reports it as unchanged, and `cargo update -p generic-array@0.14.7 --precise 0.14.9` fails because transitive dependency `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`. This is not blocked by a vm0 `Cargo.toml` version constraint.

## Manual version bumps

- None. No safe minor/patch `Cargo.toml` bumps were needed.

## Test status

- Pass: `umask 077; CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target CARGO_BUILD_JOBS=1 cargo test --workspace -j 1`
- Local verification note: the first default workspace run exhausted `/tmp` build space; after moving `CARGO_TARGET_DIR` to `/home/user/workspace`, the default automation umask caused runner tempdir permission failures. Re-running with `umask 077` passed.
