### PR TITLE
test: document x billing decode spy

### DIFF
--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -212,7 +212,8 @@ def test_non_refinement_flow_does_not_decode_request_body(x_usage, tmp_path, rea
     # The billing payload cannot prove this negative side effect: the decoder
     # fails closed, so a regression that decodes non-refinement request bodies
     # could still emit `user.read`. Keep this addon-owned call-site spy to guard
-    # the resource boundary fixed in #15705/#17256.
+    # the resource boundary from #15705; #17256 moved the spy off mitmproxy
+    # internals.
     with patch(
         "usage.providers.connectors.x.billing_body.decode_request_body_for_billing"
     ) as decode_request_body:

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -209,6 +209,10 @@ def test_non_refinement_flow_does_not_decode_request_body(x_usage, tmp_path, rea
     )
     flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
 
+    # The billing payload cannot prove this negative side effect: the decoder
+    # fails closed, so a regression that decodes non-refinement request bodies
+    # could still emit `user.read`. Keep this addon-owned call-site spy to guard
+    # the resource boundary fixed in #15705/#17256.
     with patch(
         "usage.providers.connectors.x.billing_body.decode_request_body_for_billing"
     ) as decode_request_body:


### PR DESCRIPTION
## Summary
- document why the X billing non-refinement test intentionally spies on the addon-owned decode call site
- explain that the final billing payload cannot observe accidental request-body decoding because the decoder fails closed

Closes #18553

## Tests
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check tests/x_connector_usage/test_writes.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check tests/x_connector_usage/test_writes.py`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/x_connector_usage/test_writes.py::test_non_refinement_flow_does_not_decode_request_body`
