### PR TITLE
refactor: centralize guest-agent process group signaling

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -173,7 +173,7 @@ impl CodexAppServerClient {
 
         let mut child = cmd.spawn().map_err(CodexAppServerError::Spawn)?;
         let process_id = child.id();
-        let process_group = ChildProcessGroup::from_child_id(process_id);
+        let process_group = ChildProcessGroup::from_group_leader_child_id(process_id);
         let stdin = child.stdin.take().ok_or_else(|| {
             CodexAppServerError::Protocol("app-server stdin was not piped".to_string())
         })?;

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -21,7 +21,7 @@ use tokio::task::JoinHandle;
 
 use crate::error::AgentError;
 
-use super::{child_env, diagnostics};
+use super::{child_env, diagnostics, process_group::ChildProcessGroup};
 
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
@@ -135,7 +135,7 @@ pub struct CodexAppServerClient {
     stdin: Option<ChildStdin>,
     stdout_reader: Option<BufReader<ChildStdout>>,
     process_id: Option<u32>,
-    process_group_id: Option<i32>,
+    process_group: Option<ChildProcessGroup>,
     wait_rx: Option<oneshot::Receiver<std::io::Result<ExitStatus>>>,
     stderr_handle: Option<JoinHandle<Vec<String>>>,
     stderr_tail: Vec<String>,
@@ -173,7 +173,7 @@ impl CodexAppServerClient {
 
         let mut child = cmd.spawn().map_err(CodexAppServerError::Spawn)?;
         let process_id = child.id();
-        let process_group_id = process_id.map(|pid| pid as i32);
+        let process_group = ChildProcessGroup::from_child_id(process_id);
         let stdin = child.stdin.take().ok_or_else(|| {
             CodexAppServerError::Protocol("app-server stdin was not piped".to_string())
         })?;
@@ -194,7 +194,7 @@ impl CodexAppServerClient {
             stdin: Some(stdin),
             stdout_reader: Some(BufReader::new(stdout)),
             process_id,
-            process_group_id,
+            process_group,
             wait_rx: Some(wait_rx),
             stderr_handle: Some(stderr_handle),
             stderr_tail: Vec::new(),
@@ -349,9 +349,9 @@ impl CodexAppServerClient {
             self.try_finish_child_wait()?.is_some()
         };
         if self.wait_rx.is_some() && !child_exited {
-            self.signal_process_group(libc::SIGTERM);
+            self.sigterm_process_group();
             if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
-                self.signal_process_group(libc::SIGKILL);
+                self.sigkill_process_group();
                 if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
                     return Err(CodexAppServerError::ShutdownTimeout);
                 }
@@ -593,7 +593,7 @@ impl CodexAppServerClient {
         self.mark_stream_unusable(message);
         self.close_io_handles();
         if self.process_group_signal_needed() {
-            self.signal_process_group(libc::SIGKILL);
+            self.sigkill_process_group();
         }
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
@@ -606,7 +606,7 @@ impl CodexAppServerClient {
         self.mark_stream_unusable(message.clone());
         self.close_io_handles();
         if self.process_group_signal_needed() {
-            self.signal_process_group(libc::SIGKILL);
+            self.sigkill_process_group();
         }
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
@@ -632,7 +632,7 @@ impl CodexAppServerClient {
             return;
         };
         if !stderr_handle.is_finished() {
-            self.signal_process_group(libc::SIGKILL);
+            self.sigkill_process_group();
         }
 
         let Some(stderr_handle) = self.stderr_handle.as_mut() else {
@@ -656,21 +656,21 @@ impl CodexAppServerClient {
         }
     }
 
-    fn signal_process_group(&mut self, signal: libc::c_int) {
-        if let Some(pgid) = self.process_group_id {
-            unsafe {
-                libc::kill(-pgid, signal);
-            }
-        } else if let Some(pid) = self.process_id {
-            unsafe {
-                libc::kill(pid as libc::pid_t, signal);
-            }
+    fn sigterm_process_group(&self) {
+        if let Some(process_group) = self.process_group {
+            process_group.sigterm();
+        }
+    }
+
+    fn sigkill_process_group(&self) {
+        if let Some(process_group) = self.process_group {
+            process_group.sigkill();
         }
     }
 
     fn clear_child_process_handles(&mut self) {
         self.process_id = None;
-        self.process_group_id = None;
+        self.process_group = None;
     }
 
     fn close_io_handles(&mut self) {
@@ -679,7 +679,7 @@ impl CodexAppServerClient {
     }
 
     fn kill_and_clear_child_process_handles(&mut self) {
-        self.signal_process_group(libc::SIGKILL);
+        self.sigkill_process_group();
         self.clear_child_process_handles();
     }
 
@@ -694,7 +694,7 @@ impl CodexAppServerClient {
     fn kill_unusable_stream_process_if_needed(&mut self) {
         let _ = self.try_finish_child_wait();
         if self.process_group_signal_needed() {
-            self.signal_process_group(libc::SIGKILL);
+            self.sigkill_process_group();
         }
         if self.wait_rx.is_none() {
             self.clear_child_process_handles();
@@ -708,7 +708,7 @@ impl Drop for CodexAppServerClient {
             self.close_io_handles();
             let _ = self.try_finish_child_wait();
             if self.process_group_signal_needed() {
-                self.signal_process_group(libc::SIGKILL);
+                self.sigkill_process_group();
             }
         }
         if let Some(stderr_handle) = self.stderr_handle.take() {

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -16,7 +16,10 @@ use crate::env;
 use crate::error::AgentError;
 use crate::masker::SecretMasker;
 
-use super::{child_env, diagnostics};
+use super::{
+    child_env, diagnostics,
+    process_group::{ChildProcessGroup, ProcessGroupKillGuard},
+};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -66,8 +69,8 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
         .spawn();
     let result = match result {
         Ok(mut child) => {
-            let pgid = child.id().map(|pid| pid as i32);
-            let mut process_group = SetupProcessGroupGuard::new(pgid);
+            let process_group = ChildProcessGroup::from_child_id(child.id());
+            let mut process_group_guard = ProcessGroupKillGuard::new(process_group);
             let stderr = child.stderr.take();
             let stderr_handle = tokio::spawn(async move {
                 match stderr {
@@ -82,8 +85,9 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
 
             match child.wait().await {
                 Ok(status) => {
-                    let stderr_lines = drain_setup_stderr_after_wait(stderr_handle, pgid).await;
-                    process_group.disarm();
+                    let stderr_lines =
+                        drain_setup_stderr_after_wait(stderr_handle, process_group).await;
+                    process_group_guard.disarm();
                     Ok((status, stderr_lines))
                 }
                 Err(e) => {
@@ -123,48 +127,23 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
     Ok(())
 }
 
-struct SetupProcessGroupGuard {
-    pgid: Option<i32>,
-}
-
-impl SetupProcessGroupGuard {
-    fn new(pgid: Option<i32>) -> Self {
-        Self { pgid }
-    }
-
-    fn disarm(&mut self) {
-        self.pgid = None;
-    }
-}
-
-impl Drop for SetupProcessGroupGuard {
-    fn drop(&mut self) {
-        if let Some(pid) = self.pgid {
-            unsafe {
-                libc::kill(-pid, libc::SIGKILL);
-            }
-        }
-    }
-}
-
 async fn drain_setup_stderr_after_wait(
     mut stderr_handle: tokio::task::JoinHandle<Vec<String>>,
-    pgid: Option<i32>,
+    process_group: Option<ChildProcessGroup>,
 ) -> Vec<String> {
     if !stderr_handle.is_finished() {
         tokio::task::yield_now().await;
     }
 
     if !stderr_handle.is_finished()
-        && let Some(pid) = pgid
+        && let Some(process_group) = process_group
     {
+        let pgid = process_group.raw_pgid();
         log_warn!(
             LOG_TAG,
-            "codex login stderr still open after exit, SIGKILL pgid={pid}"
+            "codex login stderr still open after exit, SIGKILL pgid={pgid}"
         );
-        unsafe {
-            libc::kill(-pid, libc::SIGKILL);
-        }
+        process_group.sigkill();
     }
 
     let stderr_timeout =

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -69,7 +69,7 @@ pub async fn setup_codex(masker: &SecretMasker) -> Result<(), AgentError> {
         .spawn();
     let result = match result {
         Ok(mut child) => {
-            let process_group = ChildProcessGroup::from_child_id(child.id());
+            let process_group = ChildProcessGroup::from_group_leader_child_id(child.id());
             let mut process_group_guard = ProcessGroupKillGuard::new(process_group);
             let stderr = child.stderr.take();
             let stderr_handle = tokio::spawn(async move {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -22,6 +22,7 @@ mod command;
 mod diagnostics;
 mod event_delivery;
 mod framework;
+mod process_group;
 mod termination;
 
 pub use codex_setup::setup_codex;
@@ -45,6 +46,7 @@ use event_delivery::{AckedEventPrefix, PreparedEvent};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
+use process_group::ChildProcessGroup;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
@@ -382,7 +384,8 @@ async fn execute_cli_inner(
 
     // Capture the process group ID before wait() reaps the child, since
     // child.id() returns None after the process has been reaped.
-    let pgid = child.id().map(|pid| pid as i32);
+    let process_group = ChildProcessGroup::from_child_id(child.id());
+    let pgid = process_group.map(ChildProcessGroup::raw_pgid);
 
     let mut cli_status: Option<std::process::ExitStatus> = None;
 
@@ -486,8 +489,8 @@ async fn execute_cli_inner(
                             pgid,
                             Duration::from_secs(env::post_result_sigkill_grace_secs()),
                         );
-                        if let Some(pid) = pgid {
-                            unsafe { libc::kill(-pid, libc::SIGTERM); }
+                        if let Some(process_group) = process_group {
+                            process_group.sigterm();
                         }
                         termination_error = Some(error);
                         post_result_cleanup = None;
@@ -516,8 +519,8 @@ async fn execute_cli_inner(
                             pgid,
                             Duration::from_secs(env::post_result_sigkill_grace_secs()),
                         );
-                        if let Some(pid) = pgid {
-                            unsafe { libc::kill(-pid, libc::SIGTERM); }
+                        if let Some(process_group) = process_group {
+                            process_group.sigterm();
                         }
                         termination_error = Some(AgentError::Execution(format!(
                             "Claude stdin writer task failed: {error}"
@@ -755,10 +758,10 @@ async fn execute_cli_inner(
                 }
             }
             () = &mut termination_deadline, if termination_state.is_pending() && cli_status.is_none() => {
-                // `libc::kill` return value is intentionally discarded in
-                // both arms: ESRCH (child reaped since the is_pending()
-                // / is_none() check) is racy-but-harmless, and every
-                // other error would be unrecoverable from userspace.
+                // Process-group signal results are intentionally discarded in
+                // both arms: ESRCH (child reaped since the is_pending() /
+                // is_none() check) is racy-but-harmless, and every other
+                // error would be unrecoverable from userspace.
                 // The sigkill_grace deadline is the escalation path if
                 // the signal fails to take effect in time.
                 match termination_state {
@@ -818,7 +821,9 @@ async fn execute_cli_inner(
                                 pgid,
                                 grace,
                             );
-                            unsafe { libc::kill(-pid, libc::SIGTERM); }
+                            if let Some(process_group) = process_group {
+                                process_group.sigterm();
+                            }
                         }
                         termination_state = TerminationState::SigkillPending { reason };
                         termination_deadline.as_mut().reset(
@@ -860,7 +865,9 @@ async fn execute_cli_inner(
                                 pgid,
                                 grace,
                             );
-                            unsafe { libc::kill(-pid, libc::SIGKILL); }
+                            if let Some(process_group) = process_group {
+                                process_group.sigkill();
+                            }
                         }
                         post_result_cleanup = None;
                         termination_state = TerminationState::Done;
@@ -919,8 +926,8 @@ async fn execute_cli_inner(
                         pgid,
                         Duration::from_secs(env::post_result_sigkill_grace_secs()),
                     );
-                    if let Some(pid) = pgid {
-                        unsafe { libc::kill(-pid, libc::SIGTERM); }
+                    if let Some(process_group) = process_group {
+                        process_group.sigterm();
                     }
                     termination_error = Some(timeout_error);
                     post_result_cleanup = None;
@@ -959,8 +966,8 @@ async fn execute_cli_inner(
                                 pgid,
                                 Duration::from_secs(env::post_result_sigkill_grace_secs()),
                             );
-                            if let Some(pid) = pgid {
-                                unsafe { libc::kill(-pid, libc::SIGTERM); }
+                            if let Some(process_group) = process_group {
+                                process_group.sigterm();
                             }
                             termination_error = Some(e);
                             post_result_cleanup = None;
@@ -992,8 +999,8 @@ async fn execute_cli_inner(
                                 pgid,
                                 Duration::from_secs(env::post_result_sigkill_grace_secs()),
                             );
-                            if let Some(pid) = pgid {
-                                unsafe { libc::kill(-pid, libc::SIGTERM); }
+                            if let Some(process_group) = process_group {
+                                process_group.sigterm();
                             }
                             termination_error = Some(error);
                             post_result_cleanup = None;
@@ -1021,8 +1028,8 @@ async fn execute_cli_inner(
                                 pgid,
                                 Duration::from_secs(env::post_result_sigkill_grace_secs()),
                             );
-                            if let Some(pid) = pgid {
-                                unsafe { libc::kill(-pid, libc::SIGTERM); }
+                            if let Some(process_group) = process_group {
+                                process_group.sigterm();
                             }
                             termination_error = Some(error);
                             post_result_cleanup = None;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -384,7 +384,7 @@ async fn execute_cli_inner(
 
     // Capture the process group ID before wait() reaps the child, since
     // child.id() returns None after the process has been reaped.
-    let process_group = ChildProcessGroup::from_child_id(child.id());
+    let process_group = ChildProcessGroup::from_group_leader_child_id(child.id());
     let pgid = process_group.map(ChildProcessGroup::raw_pgid);
 
     let mut cli_status: Option<std::process::ExitStatus> = None;

--- a/crates/guest-agent/src/cli/process_group.rs
+++ b/crates/guest-agent/src/cli/process_group.rs
@@ -11,7 +11,7 @@ pub(super) struct ChildProcessGroup {
 }
 
 impl ChildProcessGroup {
-    pub(super) fn from_child_id(child_id: Option<u32>) -> Option<Self> {
+    pub(super) fn from_group_leader_child_id(child_id: Option<u32>) -> Option<Self> {
         child_id.and_then(Self::from_raw_child_id)
     }
 
@@ -110,7 +110,7 @@ mod tests {
         let overflowing_child_id = (i32::MAX as u32).saturating_add(1);
 
         assert_eq!(
-            ChildProcessGroup::from_child_id(Some(overflowing_child_id)),
+            ChildProcessGroup::from_group_leader_child_id(Some(overflowing_child_id)),
             None
         );
     }

--- a/crates/guest-agent/src/cli/process_group.rs
+++ b/crates/guest-agent/src/cli/process_group.rs
@@ -1,0 +1,117 @@
+//! Process-group signaling for guest-agent CLI children.
+//!
+//! Callers construct these values only for children spawned with
+//! `Command::process_group(0)`, where the child PID is also the process-group
+//! ID. This module owns the unsafe `kill(-pgid, signal)` boundary; it does not
+//! own child lifecycle, wait, drain, or termination policy.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ChildProcessGroup {
+    pgid: i32,
+}
+
+impl ChildProcessGroup {
+    pub(super) fn from_child_id(child_id: Option<u32>) -> Option<Self> {
+        child_id.and_then(Self::from_raw_child_id)
+    }
+
+    fn from_raw_child_id(child_id: u32) -> Option<Self> {
+        let pgid = i32::try_from(child_id).ok()?;
+        Self::from_raw_pgid(pgid)
+    }
+
+    fn from_raw_pgid(pgid: i32) -> Option<Self> {
+        is_signalable_child_pgid(pgid).then_some(Self { pgid })
+    }
+
+    pub(super) fn raw_pgid(self) -> i32 {
+        self.pgid
+    }
+
+    pub(super) fn sigterm(self) {
+        self.signal(libc::SIGTERM);
+    }
+
+    pub(super) fn sigkill(self) {
+        self.signal(libc::SIGKILL);
+    }
+
+    fn signal(self, signal: libc::c_int) {
+        // Best-effort by design: ESRCH is expected if the child exits between
+        // the caller's state check and this signal, and other failures are not
+        // recoverable inside guest-agent.
+        unsafe {
+            libc::kill(-self.pgid, signal);
+        }
+    }
+}
+
+pub(super) struct ProcessGroupKillGuard {
+    process_group: Option<ChildProcessGroup>,
+}
+
+impl ProcessGroupKillGuard {
+    pub(super) fn new(process_group: Option<ChildProcessGroup>) -> Self {
+        Self { process_group }
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.process_group = None;
+    }
+}
+
+impl Drop for ProcessGroupKillGuard {
+    fn drop(&mut self) {
+        if let Some(process_group) = self.process_group {
+            process_group.sigkill();
+        }
+    }
+}
+
+fn is_signalable_child_pgid(pgid: i32) -> bool {
+    pgid > 1 && pgid != current_process_group()
+}
+
+fn current_process_group() -> i32 {
+    unsafe { libc::getpgrp() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChildProcessGroup;
+
+    #[test]
+    fn child_process_group_rejects_dangerous_pgids() {
+        assert_eq!(ChildProcessGroup::from_raw_pgid(-1), None);
+        assert_eq!(ChildProcessGroup::from_raw_pgid(0), None);
+        assert_eq!(ChildProcessGroup::from_raw_pgid(1), None);
+    }
+
+    #[test]
+    fn child_process_group_rejects_current_process_group() {
+        let current_pgid = super::current_process_group();
+
+        assert_eq!(ChildProcessGroup::from_raw_pgid(current_pgid), None);
+    }
+
+    #[test]
+    fn child_process_group_preserves_signalable_child_id() {
+        let current_pgid = super::current_process_group();
+        let child_id = if current_pgid == 42 { 43 } else { 42 };
+
+        let process_group =
+            ChildProcessGroup::from_raw_pgid(child_id).expect("signalable process group");
+
+        assert_eq!(process_group.raw_pgid(), child_id);
+    }
+
+    #[test]
+    fn child_process_group_rejects_child_id_overflow() {
+        let overflowing_child_id = (i32::MAX as u32).saturating_add(1);
+
+        assert_eq!(
+            ChildProcessGroup::from_child_id(Some(overflowing_child_id)),
+            None
+        );
+    }
+}

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -4,7 +4,7 @@
 //! never reaches (default SIGTERM handler terminates its mock).
 //!
 //! This is the only coverage for the SigkillPending match arm and the
-//! `libc::kill(-pid, SIGKILL)` call in `cli.rs`.
+//! process-group SIGKILL escalation path in `cli`.
 //!
 //! See: https://github.com/vm0-ai/vm0/issues/10879
 


### PR DESCRIPTION
## Summary
- Add a small guest-agent CLI process-group primitive that owns the unsafe `kill(-pgid, signal)` boundary.
- Reuse it from execute_cli, Codex setup, and Codex app-server shutdown paths.
- Replace the setup-only kill guard with a shared process-group kill guard while keeping lifecycle and wait/drain policy at each call site.
- Remove the app-server single-PID fallback from the signaling helper; it was unreachable because both the old process-group id and process id came from the same spawned child id, and all call sites spawn with `.process_group(0)`.

Closes #18549

## Verification
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent process_group`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_setup_stderr_masking`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_client`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test post_result_reap --test post_result_reap_sigkill --test post_result_reap_refresh --test post_result_reap_total_cap --test post_result_reap_error_result --test initial_prompt_stdin_reap_sigkill --test heartbeat_reap_sigkill --test heartbeat_panic_reap_sigkill --test stuck_tool_reap_sigkill --test stuck_tool_stdout_eof_reap_sigkill`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test post_result_reap_happy --test cli_stdin_unread --test cli_stdin_early_exit --test cli_setup_failure --test no_api_mode`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
