### PR TITLE
fix: reveal adjacent illustration thumbnails on selection

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2442,6 +2442,16 @@ describe("chat composer templates", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 112 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
+    // Clicking the active thumbnail at the right edge still reveals the next
+    // two thumbnails.
+    scrollTo.mockClear();
+    click(variant2Thumbnail);
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
+    });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 112 });
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
     // Move to the last thumbnail without scrolling the thumbnail strip, then
     // click left to reveal the two thumbnails before the clicked one.
     scrollTo.mockClear();
@@ -2471,6 +2481,16 @@ describe("chat composer templates", () => {
         return rect({ left: 0, right: 48 });
       },
     });
+    click(variant3Thumbnail);
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(2));
+    });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0 });
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Clicking the active thumbnail at the left edge still reveals the previous
+    // two thumbnails.
+    scrollTo.mockClear();
     click(variant3Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(2));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2478,7 +2478,7 @@ describe("chat composer templates", () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 0 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
-    // Clicking a left-clipped thumbnail nudges the strip back just enough.
+    // Clicking near the left boundary scrolls all the way to the start.
     scrollTo.mockClear();
     Object.defineProperty(thumbnailStrip, "scrollLeft", {
       configurable: true,
@@ -2495,7 +2495,7 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
     });
-    expect(scrollTo).toHaveBeenCalledWith({ left: 48 });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     // Switching away and back to Illustration remounts the active thumbnail but
@@ -2527,6 +2527,52 @@ describe("chat composer templates", () => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
     });
     expect(scrollTo).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Clicking near the right boundary scrolls all the way to the end.
+    const remountedCard = screen
+      .getByAltText(heroAlt)
+      .closest<HTMLElement>("div.group");
+    if (!remountedCard) {
+      throw new Error("Remounted illustration card not found");
+    }
+    const remountedVariant4Thumbnail =
+      within(remountedCard).getByLabelText("Show variant 4");
+    const remountedThumbnailStrip = remountedVariant4Thumbnail.parentElement;
+    if (!remountedThumbnailStrip) {
+      throw new Error("Remounted illustration thumbnail strip not found");
+    }
+    scrollTo.mockClear();
+    Object.defineProperty(remountedThumbnailStrip, "scrollLeft", {
+      configurable: true,
+      value: 120,
+      writable: true,
+    });
+    Object.defineProperty(remountedThumbnailStrip, "scrollWidth", {
+      configurable: true,
+      value: 240,
+    });
+    Object.defineProperty(remountedThumbnailStrip, "clientWidth", {
+      configurable: true,
+      value: 96,
+    });
+    Object.defineProperty(remountedThumbnailStrip, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 0, right: 96 });
+      },
+    });
+    Object.defineProperty(remountedVariant4Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 48, right: 96 });
+      },
+    });
+    click(remountedVariant4Thumbnail);
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(3));
+    });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 144 });
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2323,6 +2323,40 @@ describe("chat composer templates", () => {
         },
       };
     };
+    const mockElementRect = (
+      element: Element,
+      bounds: { left: number; right: number },
+    ) => {
+      Object.defineProperty(element, "getBoundingClientRect", {
+        configurable: true,
+        value: () => {
+          return rect(bounds);
+        },
+      });
+    };
+    const mockScrollLeft = (element: Element, value: number) => {
+      Object.defineProperty(element, "scrollLeft", {
+        configurable: true,
+        value,
+        writable: true,
+      });
+    };
+    const mockScrollSize = (
+      element: Element,
+      {
+        scrollWidth,
+        clientWidth,
+      }: { scrollWidth: number; clientWidth: number },
+    ) => {
+      Object.defineProperty(element, "scrollWidth", {
+        configurable: true,
+        value: scrollWidth,
+      });
+      Object.defineProperty(element, "clientWidth", {
+        configurable: true,
+        value: clientWidth,
+      });
+    };
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
       value: scrollIntoView,
@@ -2406,43 +2440,12 @@ describe("chat composer templates", () => {
     if (!thumbnailStrip) {
       throw new Error("Illustration thumbnail strip not found");
     }
-    Object.defineProperty(thumbnailStrip, "scrollLeft", {
-      configurable: true,
-      value: 0,
-      writable: true,
-    });
-    Object.defineProperty(thumbnailStrip, "scrollWidth", {
-      configurable: true,
-      value: 240,
-    });
-    Object.defineProperty(thumbnailStrip, "clientWidth", {
-      configurable: true,
-      value: 96,
-    });
-    Object.defineProperty(thumbnailStrip, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 0, right: 96 });
-      },
-    });
-    Object.defineProperty(variant2Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 48, right: 96 });
-      },
-    });
-    Object.defineProperty(variant3Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 104, right: 152 });
-      },
-    });
-    Object.defineProperty(variant4Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 160, right: 208 });
-      },
-    });
+    mockScrollLeft(thumbnailStrip, 0);
+    mockScrollSize(thumbnailStrip, { scrollWidth: 240, clientWidth: 96 });
+    mockElementRect(thumbnailStrip, { left: 0, right: 96 });
+    mockElementRect(variant2Thumbnail, { left: 48, right: 96 });
+    mockElementRect(variant3Thumbnail, { left: 104, right: 152 });
+    mockElementRect(variant4Thumbnail, { left: 160, right: 208 });
     click(variant2Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
@@ -2472,23 +2475,9 @@ describe("chat composer templates", () => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(3));
     });
     expect(scrollTo).not.toHaveBeenCalled();
-    Object.defineProperty(thumbnailStrip, "scrollLeft", {
-      configurable: true,
-      value: 112,
-      writable: true,
-    });
-    Object.defineProperty(variant1Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: -96, right: -48 });
-      },
-    });
-    Object.defineProperty(variant3Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 0, right: 48 });
-      },
-    });
+    mockScrollLeft(thumbnailStrip, 112);
+    mockElementRect(variant1Thumbnail, { left: -96, right: -48 });
+    mockElementRect(variant3Thumbnail, { left: 0, right: 48 });
     click(variant3Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(2));
@@ -2508,17 +2497,8 @@ describe("chat composer templates", () => {
 
     // Clicking near the left boundary scrolls all the way to the start.
     scrollTo.mockClear();
-    Object.defineProperty(thumbnailStrip, "scrollLeft", {
-      configurable: true,
-      value: 64,
-      writable: true,
-    });
-    Object.defineProperty(variant1Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: -16, right: 32 });
-      },
-    });
+    mockScrollLeft(thumbnailStrip, 64);
+    mockElementRect(variant1Thumbnail, { left: -16, right: 32 });
     click(variant1Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
@@ -2571,31 +2551,13 @@ describe("chat composer templates", () => {
       throw new Error("Remounted illustration thumbnail strip not found");
     }
     scrollTo.mockClear();
-    Object.defineProperty(remountedThumbnailStrip, "scrollLeft", {
-      configurable: true,
-      value: 120,
-      writable: true,
+    mockScrollLeft(remountedThumbnailStrip, 120);
+    mockScrollSize(remountedThumbnailStrip, {
+      scrollWidth: 240,
+      clientWidth: 96,
     });
-    Object.defineProperty(remountedThumbnailStrip, "scrollWidth", {
-      configurable: true,
-      value: 240,
-    });
-    Object.defineProperty(remountedThumbnailStrip, "clientWidth", {
-      configurable: true,
-      value: 96,
-    });
-    Object.defineProperty(remountedThumbnailStrip, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 0, right: 96 });
-      },
-    });
-    Object.defineProperty(remountedVariant4Thumbnail, "getBoundingClientRect", {
-      configurable: true,
-      value: () => {
-        return rect({ left: 48, right: 96 });
-      },
-    });
+    mockElementRect(remountedThumbnailStrip, { left: 0, right: 96 });
+    mockElementRect(remountedVariant4Thumbnail, { left: 48, right: 96 });
     click(remountedVariant4Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(3));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2411,6 +2411,14 @@ describe("chat composer templates", () => {
       value: 0,
       writable: true,
     });
+    Object.defineProperty(thumbnailStrip, "scrollWidth", {
+      configurable: true,
+      value: 240,
+    });
+    Object.defineProperty(thumbnailStrip, "clientWidth", {
+      configurable: true,
+      value: 96,
+    });
     Object.defineProperty(thumbnailStrip, "getBoundingClientRect", {
       configurable: true,
       value: () => {
@@ -2439,7 +2447,7 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
     });
-    expect(scrollTo).toHaveBeenCalledWith({ left: 112 });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 144 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     // Clicking the active thumbnail at the right edge still reveals the next
@@ -2449,7 +2457,7 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
     });
-    expect(scrollTo).toHaveBeenCalledWith({ left: 112 });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 144 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     // Move to the last thumbnail without scrolling the thumbnail strip, then
@@ -2472,7 +2480,7 @@ describe("chat composer templates", () => {
     Object.defineProperty(variant1Thumbnail, "getBoundingClientRect", {
       configurable: true,
       value: () => {
-        return rect({ left: -112, right: -64 });
+        return rect({ left: -96, right: -48 });
       },
     });
     Object.defineProperty(variant3Thumbnail, "getBoundingClientRect", {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2294,7 +2294,12 @@ describe("chat composer templates", () => {
   });
 
   it("scrolls illustration thumbnails only after clicking a variant thumbnail", async () => {
-    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS[0]!;
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
+      return item.previewImages.length >= 4;
+    });
+    if (!illustrationTemplate) {
+      throw new Error("Illustration template with four variants not found");
+    }
     const scrollIntoView = vi.fn();
     const scrollTo = vi.fn();
     const rect = ({
@@ -2392,9 +2397,11 @@ describe("chat composer templates", () => {
       throw new Error("Illustration card not found");
     }
 
-    // Clicking the rightmost visible thumbnail reveals the next thumbnail.
+    // Clicking the rightmost visible thumbnail reveals the next two thumbnails.
+    const variant1Thumbnail = within(card).getByLabelText("Show variant 1");
     const variant2Thumbnail = within(card).getByLabelText("Show variant 2");
     const variant3Thumbnail = within(card).getByLabelText("Show variant 3");
+    const variant4Thumbnail = within(card).getByLabelText("Show variant 4");
     const thumbnailStrip = variant2Thumbnail.parentElement;
     if (!thumbnailStrip) {
       throw new Error("Illustration thumbnail strip not found");
@@ -2422,16 +2429,57 @@ describe("chat composer templates", () => {
         return rect({ left: 104, right: 152 });
       },
     });
+    Object.defineProperty(variant4Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 160, right: 208 });
+      },
+    });
     click(variant2Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
     });
-    expect(scrollTo).toHaveBeenCalledWith({ left: 56 });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 112 });
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // Move to the last thumbnail without scrolling the thumbnail strip, then
+    // click left to reveal the two thumbnails before the clicked one.
+    scrollTo.mockClear();
+    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 190 });
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(2));
+    });
+    fireEvent.click(screen.getByAltText(heroAlt), { clientX: 190 });
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(3));
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+    Object.defineProperty(thumbnailStrip, "scrollLeft", {
+      configurable: true,
+      value: 112,
+      writable: true,
+    });
+    Object.defineProperty(variant1Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: -112, right: -64 });
+      },
+    });
+    Object.defineProperty(variant3Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 0, right: 48 });
+      },
+    });
+    click(variant3Thumbnail);
+    await waitFor(() => {
+      expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(2));
+    });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     // Clicking a left-clipped thumbnail nudges the strip back just enough.
     scrollTo.mockClear();
-    const variant1Thumbnail = within(card).getByLabelText("Show variant 1");
     Object.defineProperty(thumbnailStrip, "scrollLeft", {
       configurable: true,
       value: 64,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2392,8 +2392,9 @@ describe("chat composer templates", () => {
       throw new Error("Illustration card not found");
     }
 
-    // Clicking a thumbnail scrolls within the thumbnail strip only.
+    // Clicking the rightmost visible thumbnail reveals the next thumbnail.
     const variant2Thumbnail = within(card).getByLabelText("Show variant 2");
+    const variant3Thumbnail = within(card).getByLabelText("Show variant 3");
     const thumbnailStrip = variant2Thumbnail.parentElement;
     if (!thumbnailStrip) {
       throw new Error("Illustration thumbnail strip not found");
@@ -2412,14 +2413,20 @@ describe("chat composer templates", () => {
     Object.defineProperty(variant2Thumbnail, "getBoundingClientRect", {
       configurable: true,
       value: () => {
-        return rect({ left: 72, right: 120 });
+        return rect({ left: 48, right: 96 });
+      },
+    });
+    Object.defineProperty(variant3Thumbnail, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return rect({ left: 104, right: 152 });
       },
     });
     click(variant2Thumbnail);
     await waitFor(() => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(1));
     });
-    expect(scrollTo).toHaveBeenCalledWith({ left: 24 });
+    expect(scrollTo).toHaveBeenCalledWith({ left: 56 });
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     // Clicking a left-clipped thumbnail nudges the strip back just enough.

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4464,20 +4464,31 @@ function preloadIllustrationVariant(
 
 type IllustrationThumbnailScrollDirection = -1 | 1;
 
+type IllustrationThumbnailScrollTarget = {
+  element: HTMLElement;
+  reachedBoundary: boolean;
+};
+
 function illustrationThumbnailScrollTarget(
   node: HTMLElement,
   direction: IllustrationThumbnailScrollDirection,
-): HTMLElement {
+): IllustrationThumbnailScrollTarget {
   let target = node;
   for (let i = 0; i < 2; i += 1) {
     const sibling =
       direction > 0 ? target.nextElementSibling : target.previousElementSibling;
     if (!(sibling instanceof HTMLElement)) {
-      break;
+      return {
+        element: target,
+        reachedBoundary: true,
+      };
     }
     target = sibling;
   }
-  return target;
+  return {
+    element: target,
+    reachedBoundary: false,
+  };
 }
 
 function scrollIllustrationThumbnailIntoView(
@@ -4496,14 +4507,37 @@ function scrollIllustrationThumbnailIntoView(
   }
 
   const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
-  const target = illustrationThumbnailScrollTarget(node, direction);
+  const { element: target, reachedBoundary } =
+    illustrationThumbnailScrollTarget(node, direction);
   const targetRect = target.getBoundingClientRect();
 
   if (direction < 0) {
+    if (reachedBoundary) {
+      if (thumbnailStrip.scrollLeft > 0) {
+        thumbnailStrip.scrollTo({
+          left: 0,
+        });
+      }
+      return;
+    }
+
     const leftOverflow = thumbnailStripRect.left - targetRect.left;
     if (leftOverflow > 0) {
       thumbnailStrip.scrollTo({
         left: Math.max(0, thumbnailStrip.scrollLeft - leftOverflow),
+      });
+    }
+    return;
+  }
+
+  if (reachedBoundary) {
+    const maxScrollLeft = Math.max(
+      0,
+      thumbnailStrip.scrollWidth - thumbnailStrip.clientWidth,
+    );
+    if (thumbnailStrip.scrollLeft < maxScrollLeft) {
+      thumbnailStrip.scrollTo({
+        left: maxScrollLeft,
       });
     }
     return;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4551,6 +4551,43 @@ function scrollIllustrationThumbnailIntoView(
   }
 }
 
+function activeIllustrationThumbnailScrollDirection(
+  node: HTMLButtonElement,
+): IllustrationThumbnailScrollDirection | null {
+  const thumbnailStrip = node.closest<HTMLElement>(
+    "[data-illustration-variant-strip]",
+  );
+  if (thumbnailStrip === null) {
+    return null;
+  }
+
+  const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
+  const thumbnailRect = node.getBoundingClientRect();
+  const edgeTolerance = 1;
+  const maxScrollLeft = Math.max(
+    0,
+    thumbnailStrip.scrollWidth - thumbnailStrip.clientWidth,
+  );
+
+  if (
+    thumbnailRect.right >= thumbnailStripRect.right - edgeTolerance &&
+    (node.nextElementSibling instanceof HTMLElement ||
+      thumbnailStrip.scrollLeft < maxScrollLeft)
+  ) {
+    return 1;
+  }
+
+  if (
+    thumbnailRect.left <= thumbnailStripRect.left + edgeTolerance &&
+    (node.previousElementSibling instanceof HTMLElement ||
+      thumbnailStrip.scrollLeft > 0)
+  ) {
+    return -1;
+  }
+
+  return null;
+}
+
 function IllustrationTemplateCard({
   item,
   selected,
@@ -4630,10 +4667,17 @@ function IllustrationTemplateCard({
                     item,
                     onVariantChange,
                   });
-                  if (!active) {
+                  const scrollDirection = active
+                    ? activeIllustrationThumbnailScrollDirection(
+                        event.currentTarget,
+                      )
+                    : index > safeIndex
+                      ? 1
+                      : -1;
+                  if (scrollDirection !== null) {
                     scrollIllustrationThumbnailIntoView(
                       event.currentTarget,
-                      index > safeIndex ? 1 : -1,
+                      scrollDirection,
                     );
                   }
                 }}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4462,8 +4462,27 @@ function preloadIllustrationVariant(
   );
 }
 
+type IllustrationThumbnailScrollDirection = -1 | 1;
+
+function illustrationThumbnailScrollTarget(
+  node: HTMLElement,
+  direction: IllustrationThumbnailScrollDirection,
+): HTMLElement {
+  let target = node;
+  for (let i = 0; i < 2; i += 1) {
+    const sibling =
+      direction > 0 ? target.nextElementSibling : target.previousElementSibling;
+    if (!(sibling instanceof HTMLElement)) {
+      break;
+    }
+    target = sibling;
+  }
+  return target;
+}
+
 function scrollIllustrationThumbnailIntoView(
   node: HTMLButtonElement | null,
+  direction: IllustrationThumbnailScrollDirection,
 ): void {
   if (node === null) {
     return;
@@ -4477,21 +4496,20 @@ function scrollIllustrationThumbnailIntoView(
   }
 
   const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
-  const thumbnailRect = node.getBoundingClientRect();
+  const target = illustrationThumbnailScrollTarget(node, direction);
+  const targetRect = target.getBoundingClientRect();
 
-  const leftOverflow = thumbnailStripRect.left - thumbnailRect.left;
-  if (leftOverflow > 0) {
-    thumbnailStrip.scrollTo({
-      left: Math.max(0, thumbnailStrip.scrollLeft - leftOverflow),
-    });
+  if (direction < 0) {
+    const leftOverflow = thumbnailStripRect.left - targetRect.left;
+    if (leftOverflow > 0) {
+      thumbnailStrip.scrollTo({
+        left: Math.max(0, thumbnailStrip.scrollLeft - leftOverflow),
+      });
+    }
     return;
   }
 
-  const nextThumbnail = node.nextElementSibling;
-  const rightTarget =
-    nextThumbnail instanceof HTMLElement ? nextThumbnail : node;
-  const rightTargetRect = rightTarget.getBoundingClientRect();
-  const rightOverflow = rightTargetRect.right - thumbnailStripRect.right;
+  const rightOverflow = targetRect.right - thumbnailStripRect.right;
   if (rightOverflow > 0) {
     thumbnailStrip.scrollTo({
       left: Math.max(0, thumbnailStrip.scrollLeft + rightOverflow),
@@ -4579,7 +4597,10 @@ function IllustrationTemplateCard({
                     onVariantChange,
                   });
                   if (!active) {
-                    scrollIllustrationThumbnailIntoView(event.currentTarget);
+                    scrollIllustrationThumbnailIntoView(
+                      event.currentTarget,
+                      index > safeIndex ? 1 : -1,
+                    );
                   }
                 }}
               >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4464,9 +4464,12 @@ function preloadIllustrationVariant(
 
 type IllustrationThumbnailScrollDirection = -1 | 1;
 
+const ILLUSTRATION_THUMBNAIL_REVEAL_COUNT = 2;
+const ILLUSTRATION_THUMBNAIL_EDGE_TOLERANCE_PX = 1;
+
 type IllustrationThumbnailScrollTarget = {
   element: HTMLElement;
-  reachedBoundary: boolean;
+  targetIsBoundary: boolean;
 };
 
 function illustrationThumbnailScrollTarget(
@@ -4474,13 +4477,13 @@ function illustrationThumbnailScrollTarget(
   direction: IllustrationThumbnailScrollDirection,
 ): IllustrationThumbnailScrollTarget {
   let target = node;
-  for (let i = 0; i < 2; i += 1) {
+  for (let i = 0; i < ILLUSTRATION_THUMBNAIL_REVEAL_COUNT; i += 1) {
     const sibling =
       direction > 0 ? target.nextElementSibling : target.previousElementSibling;
     if (!(sibling instanceof HTMLElement)) {
       return {
         element: target,
-        reachedBoundary: true,
+        targetIsBoundary: true,
       };
     }
     target = sibling;
@@ -4489,8 +4492,14 @@ function illustrationThumbnailScrollTarget(
     direction > 0 ? target.nextElementSibling : target.previousElementSibling;
   return {
     element: target,
-    reachedBoundary: !(boundarySibling instanceof HTMLElement),
+    targetIsBoundary: !(boundarySibling instanceof HTMLElement),
   };
+}
+
+function maxIllustrationThumbnailScrollLeft(
+  thumbnailStrip: HTMLElement,
+): number {
+  return Math.max(0, thumbnailStrip.scrollWidth - thumbnailStrip.clientWidth);
 }
 
 function scrollIllustrationThumbnailIntoView(
@@ -4508,13 +4517,11 @@ function scrollIllustrationThumbnailIntoView(
     return;
   }
 
-  const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
-  const { element: target, reachedBoundary } =
+  const { element: target, targetIsBoundary } =
     illustrationThumbnailScrollTarget(node, direction);
-  const targetRect = target.getBoundingClientRect();
 
   if (direction < 0) {
-    if (reachedBoundary) {
+    if (targetIsBoundary) {
       if (thumbnailStrip.scrollLeft > 0) {
         thumbnailStrip.scrollTo({
           left: 0,
@@ -4523,6 +4530,8 @@ function scrollIllustrationThumbnailIntoView(
       return;
     }
 
+    const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
     const leftOverflow = thumbnailStripRect.left - targetRect.left;
     if (leftOverflow > 0) {
       thumbnailStrip.scrollTo({
@@ -4532,11 +4541,8 @@ function scrollIllustrationThumbnailIntoView(
     return;
   }
 
-  if (reachedBoundary) {
-    const maxScrollLeft = Math.max(
-      0,
-      thumbnailStrip.scrollWidth - thumbnailStrip.clientWidth,
-    );
+  if (targetIsBoundary) {
+    const maxScrollLeft = maxIllustrationThumbnailScrollLeft(thumbnailStrip);
     if (thumbnailStrip.scrollLeft < maxScrollLeft) {
       thumbnailStrip.scrollTo({
         left: maxScrollLeft,
@@ -4545,6 +4551,8 @@ function scrollIllustrationThumbnailIntoView(
     return;
   }
 
+  const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
   const rightOverflow = targetRect.right - thumbnailStripRect.right;
   if (rightOverflow > 0) {
     thumbnailStrip.scrollTo({
@@ -4565,14 +4573,11 @@ function activeIllustrationThumbnailScrollDirection(
 
   const thumbnailStripRect = thumbnailStrip.getBoundingClientRect();
   const thumbnailRect = node.getBoundingClientRect();
-  const edgeTolerance = 1;
-  const maxScrollLeft = Math.max(
-    0,
-    thumbnailStrip.scrollWidth - thumbnailStrip.clientWidth,
-  );
+  const maxScrollLeft = maxIllustrationThumbnailScrollLeft(thumbnailStrip);
 
   if (
-    thumbnailRect.right >= thumbnailStripRect.right - edgeTolerance &&
+    thumbnailRect.right >=
+      thumbnailStripRect.right - ILLUSTRATION_THUMBNAIL_EDGE_TOLERANCE_PX &&
     (node.nextElementSibling instanceof HTMLElement ||
       thumbnailStrip.scrollLeft < maxScrollLeft)
   ) {
@@ -4580,7 +4585,8 @@ function activeIllustrationThumbnailScrollDirection(
   }
 
   if (
-    thumbnailRect.left <= thumbnailStripRect.left + edgeTolerance &&
+    thumbnailRect.left <=
+      thumbnailStripRect.left + ILLUSTRATION_THUMBNAIL_EDGE_TOLERANCE_PX &&
     (node.previousElementSibling instanceof HTMLElement ||
       thumbnailStrip.scrollLeft > 0)
   ) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4485,9 +4485,11 @@ function illustrationThumbnailScrollTarget(
     }
     target = sibling;
   }
+  const boundarySibling =
+    direction > 0 ? target.nextElementSibling : target.previousElementSibling;
   return {
     element: target,
-    reachedBoundary: false,
+    reachedBoundary: !(boundarySibling instanceof HTMLElement),
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4487,7 +4487,11 @@ function scrollIllustrationThumbnailIntoView(
     return;
   }
 
-  const rightOverflow = thumbnailRect.right - thumbnailStripRect.right;
+  const nextThumbnail = node.nextElementSibling;
+  const rightTarget =
+    nextThumbnail instanceof HTMLElement ? nextThumbnail : node;
+  const rightTargetRect = rightTarget.getBoundingClientRect();
+  const rightOverflow = rightTargetRect.right - thumbnailStripRect.right;
   if (rightOverflow > 0) {
     thumbnailStrip.scrollTo({
       left: Math.max(0, thumbnailStrip.scrollLeft + rightOverflow),


### PR DESCRIPTION
## Summary
- Scroll the illustration thumbnail strip toward up to the next two thumbnails in the click direction
- Scroll directly to the start/end when the scroll target reaches that side boundary, including the exactly-two-thumbnails-to-edge case
- Allow clicking an already-active thumbnail at the strip edge to reveal adjacent thumbnails
- Tidy the thumbnail scroll helper naming, constants, layout reads, and test setup helpers
- Update the composer template test to cover rightward, leftward, active-edge, and edge-boundary thumbnail reveal behavior

## Tests
- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx

Closes #18562