### PR TITLE
fix: remove presentation template eye control

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -401,7 +401,7 @@ async function openTemplatePicker(
     expect(screen.getByText(template.title)).toBeInTheDocument();
   });
 
-  click(screen.getByLabelText(`View template ${template.title}`));
+  click(screen.getByLabelText(`Preview ${template.title} at current slide`));
   await waitFor(() => {
     expect(
       screen.getByTestId(`${template.title} detail HTML preview`),
@@ -1618,6 +1618,9 @@ describe("chat composer templates", () => {
         }),
       );
       await fill(screen.getByLabelText("Search templates"), template.title);
+      expect(
+        screen.queryByLabelText(`View template ${template.title}`),
+      ).not.toBeInTheDocument();
       const currentPreviewFrame = () => {
         return screen.getByTestId(`${template.title} card HTML preview`);
       };
@@ -1764,7 +1767,9 @@ describe("chat composer templates", () => {
       ),
     ).toMatchObject({ [template.slug]: "prism" });
 
-    await user.click(screen.getByLabelText(`View template ${template.title}`));
+    await user.click(
+      screen.getByLabelText(`Preview ${template.title} at current slide`),
+    );
     const templateDialog = screen.getByRole("dialog");
     await waitFor(() => {
       expect(
@@ -1964,7 +1969,9 @@ describe("chat composer templates", () => {
         }),
       );
       await fill(screen.getByLabelText("Search templates"), template.title);
-      click(screen.getByLabelText(`View template ${template.title}`));
+      click(
+        screen.getByLabelText(`Preview ${template.title} at current slide`),
+      );
 
       await waitFor(() => {
         expect(previewFetchCount).toBe(1);
@@ -1982,7 +1989,9 @@ describe("chat composer templates", () => {
         throw new Error("Template button not found");
       }
       click(templateButton);
-      click(screen.getByLabelText(`View template ${template.title}`));
+      click(
+        screen.getByLabelText(`Preview ${template.title} at current slide`),
+      );
 
       previewFetch.resolve(
         new Response(
@@ -2081,7 +2090,7 @@ describe("chat composer templates", () => {
       }),
     );
     await fill(screen.getByLabelText("Search templates"), template.title);
-    click(screen.getByLabelText(`View template ${template.title}`));
+    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
 
     const templateDialog = screen.getByRole("dialog");
     expect(
@@ -2171,7 +2180,7 @@ describe("chat composer templates", () => {
       throw new Error("Template button not found");
     }
     click(templateButton);
-    click(screen.getByLabelText(`View template ${template.title}`));
+    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
 
     await waitFor(() => {
       expect(screen.getByText("1 of 15")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4039,7 +4039,9 @@ describe("chat lifecycle", () => {
 
     await user.click(await screen.findByLabelText("Template"));
     await user.click(
-      await screen.findByLabelText(`View template ${template.title}`),
+      await screen.findByLabelText(
+        `Preview ${template.title} at current slide`,
+      ),
     );
     await user.click(await screen.findByLabelText("Select style Gold Luxe"));
     await user.click(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -23,7 +23,6 @@ import {
   IconDeviceDesktop,
   IconDownload,
   IconPresentation,
-  IconEye,
   IconLoader2,
   IconMicrophone,
   IconPaperclip,
@@ -2963,7 +2962,6 @@ function TemplatePreview({
   const setDefaultHtmlPreview = useSet(setTemplateCardDefaultHtmlPreview$);
   const loadedHtmlFrameUrls = useGet(templateCardLoadedHtmlFrameUrls$);
   const setLoadedHtmlFrameUrl = useSet(setTemplateCardLoadedHtmlFrameUrl$);
-  const setThemePopoverOpenSlug = useSet(setTemplateCardThemePopoverOpenSlug$);
   const slideImages = presentationTemplateSlideImages(item);
   const fallbackSlideCount = Math.max(slideImages.length, 1);
   const hoverSlideIndex = Math.max(
@@ -3303,18 +3301,6 @@ function TemplatePreview({
         className="absolute inset-0 z-10 cursor-zoom-in bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         onClick={openPreview}
       />
-      <button
-        type="button"
-        aria-label={`View template ${item.title}`}
-        className="absolute right-2 top-2 z-30 flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background/85 text-foreground opacity-0 shadow-sm backdrop-blur transition-colors hover:bg-background group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        onClick={(event) => {
-          event.stopPropagation();
-          setThemePopoverOpenSlug(null);
-          openPreview();
-        }}
-      >
-        <IconEye size={16} stroke={1.8} />
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the inactive top-right eye control from presentation template preview cards.
- Keep the existing full-card preview action for opening template detail previews.
- Update template and chat lifecycle tests to use the remaining preview action and assert the old eye control is absent.

Closes #18565

## Tests
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- git diff --check
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types