### PR TITLE
Fix so frontend POST proxy requests

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -107,8 +107,11 @@ describe("proxy middleware: public routes", () => {
     const request = new NextRequest("https://www.vm0.ai/en?from=signout", {
       method: "POST",
       headers: {
+        connection: "keep-alive",
         "content-type": "text/plain;charset=UTF-8",
         cookie: "__session=test",
+        origin: "https://www.vm0.ai",
+        referer: "https://www.vm0.ai/en?from=signout",
       },
       body: "payload",
     });
@@ -120,7 +123,14 @@ describe("proxy middleware: public routes", () => {
     expect(String(targetUrl)).toBe("https://so.vm0.ai/en?from=signout");
     expect(init?.method).toBe("POST");
     expect(init?.headers).toBeInstanceOf(Headers);
+    expect((init as RequestInit & { duplex?: string })?.duplex).toBe("half");
     const proxiedHeaders = init?.headers as Headers;
+    expect(proxiedHeaders.get("connection")).toBeNull();
+    expect(proxiedHeaders.get("content-length")).toBeNull();
+    expect(proxiedHeaders.get("origin")).toBe("https://so.vm0.ai");
+    expect(proxiedHeaders.get("referer")).toBe(
+      "https://so.vm0.ai/en?from=signout",
+    );
     expect(proxiedHeaders.get("x-forwarded-host")).toBe("www.vm0.ai");
     expect(proxiedHeaders.get("x-forwarded-proto")).toBe("https");
     expect(response).toBeDefined();
@@ -131,6 +141,38 @@ describe("proxy middleware: public routes", () => {
     expect(response.headers.get("x-so-frontend")).toBe("1");
     await expect(response.text()).resolves.toBe("proxied");
     expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("proxies bodyless so frontend POST requests without a request body stream", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("proxied", { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("https://www.vm0.ai/en", {
+      method: "POST",
+      headers: {
+        origin: "https://www.vm0.ai",
+        referer: "https://www.vm0.ai/en",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("Expected fetch init");
+    }
+    expect("body" in init).toBe(false);
+    expect((init as RequestInit & { duplex?: string }).duplex).toBeUndefined();
+    const proxiedHeaders = init.headers as Headers;
+    expect(proxiedHeaders.get("origin")).toBe("https://so.vm0.ai");
+    expect(proxiedHeaders.get("referer")).toBe("https://so.vm0.ai/en");
+    expect(response?.status).toBe(202);
   });
 
   it("does not proxy non-GET requests when so frontend forwarding is disabled", async () => {

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -101,6 +101,18 @@ const PAT_TOKEN_PREFIX = "vm0_pat_";
 const TEST_ENDPOINT_BYPASS_HEADER = "x-vm0-test-endpoint-bypass";
 const OAUTH_WEB_ORIGIN_HEADER = "x-vm0-web-origin";
 const SO_FRONTEND_PAGE_METHODS = new Set(["GET", "HEAD"]);
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
@@ -158,20 +170,37 @@ async function proxySoFrontendRequest(
   targetUrl: URL,
 ): Promise<Response> {
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.delete("host");
-  requestHeaders.delete("content-length");
+  for (const header of HOP_BY_HOP_HEADERS) {
+    requestHeaders.delete(header);
+  }
   requestHeaders.set("x-forwarded-host", request.nextUrl.host);
   requestHeaders.set(
     "x-forwarded-proto",
     request.nextUrl.protocol.slice(0, -1),
   );
 
-  return fetch(targetUrl, {
+  if (requestHeaders.get("origin") === request.nextUrl.origin) {
+    requestHeaders.set("origin", targetUrl.origin);
+  }
+  const referer = requestHeaders.get("referer");
+  if (referer?.startsWith(request.nextUrl.origin)) {
+    requestHeaders.set(
+      "referer",
+      `${targetUrl.origin}${referer.slice(request.nextUrl.origin.length)}`,
+    );
+  }
+
+  const proxyRequestInit: RequestInit & { duplex?: "half" } = {
     method: request.method,
     headers: requestHeaders,
-    body: request.body,
     redirect: "manual",
-  });
+  };
+  if (request.body) {
+    proxyRequestInit.body = request.body;
+    proxyRequestInit.duplex = "half";
+  }
+
+  return fetch(targetUrl, proxyRequestInit);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- sanitize hop-by-hop headers before proxying non-GET so frontend page requests
- rewrite same-origin origin/referer headers to the so frontend target origin
- only attach a request body stream when one exists and set duplex for streamed POST bodies

## Verification
- pnpm --filter web test -- __tests__/proxy.public-routes.test.ts
- pnpm --filter web lint