### PR TITLE
fix: classify claude output token limits

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -238,6 +238,7 @@ pub enum FailureReason {
     InsufficientCredits,
     InvalidApiKey,
     InvalidCredentials,
+    OutputTokenLimit,
     ProviderOverloaded,
     ReconnectRequired,
     UsageLimit,
@@ -250,6 +251,7 @@ impl FailureReason {
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
             Self::InvalidCredentials => "invalid_credentials",
+            Self::OutputTokenLimit => "output_token_limit",
             Self::ProviderOverloaded => "provider_overloaded",
             Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
@@ -575,6 +577,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "invalid_credentials");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_output_token_limit_reason() {
+        assert_eq!(
+            FailureReason::OutputTokenLimit.as_str(),
+            "output_token_limit"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::OutputTokenLimit);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "output_token_limit");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -493,13 +493,15 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
 }
 
 fn is_claude_output_token_limit_error(normalized: &str) -> bool {
-    let response_exceeded =
-        normalized.contains("response exceeded") || normalized.contains("response has exceeded");
-    response_exceeded
-        && (normalized.contains("output token maximum")
-            || normalized.contains("maximum output tokens")
-            || normalized.contains("max output tokens")
-            || normalized.contains("claude_code_max_output_tokens"))
+    let response_exceeded = normalized.contains("response exceeded")
+        || normalized.contains("response has exceeded")
+        || normalized.contains("response exceeds");
+    let output_token_limit = normalized.contains("output token maximum")
+        || normalized.contains("output token limit")
+        || normalized.contains("maximum output token")
+        || normalized.contains("max output token")
+        || normalized.contains("claude_code_max_output_tokens");
+    response_exceeded && output_token_limit
 }
 
 fn claude_529_error_detail(detail: &str) -> Option<&str> {
@@ -1482,6 +1484,9 @@ mod tests {
             "API Error: Claude's response exceeded the 32000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
             "API Error: Claude's response exceeded the 64000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
             "API Error: Claude's response exceeded the maximum output tokens for this model.",
+            "API Error: Claude's response exceeded the maximum output token limit for this model.",
+            "API Error: Claude's response exceeds the output token limit for this model.",
+            "API Error: Claude's response has exceeded the max output token budget.",
         ] {
             let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, message);
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -433,6 +433,11 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::ProviderOverloaded);
     }
+    if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_output_token_limit_error(&normalized)
+    {
+        return Some(FailureReason::OutputTokenLimit);
+    }
     if matches!(framework, AgentFramework::Codex)
         && (normalized.contains("invalid_api_key")
             || normalized.contains("incorrect api key provided"))
@@ -485,6 +490,16 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
             starts_with_overloaded_word(detail) || contains_overloaded_error_type(detail)
         })
     })
+}
+
+fn is_claude_output_token_limit_error(normalized: &str) -> bool {
+    let response_exceeded =
+        normalized.contains("response exceeded") || normalized.contains("response has exceeded");
+    response_exceeded
+        && (normalized.contains("output token maximum")
+            || normalized.contains("maximum output tokens")
+            || normalized.contains("max output tokens")
+            || normalized.contains("claude_code_max_output_tokens"))
 }
 
 fn claude_529_error_detail(detail: &str) -> Option<&str> {
@@ -1459,6 +1474,75 @@ mod tests {
             diagnostic.failure_detail_source,
             Some(FailureDetailSource::ClaudeResult)
         );
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_output_token_limit() {
+        for message in [
+            "API Error: Claude's response exceeded the 32000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
+            "API Error: Claude's response exceeded the 64000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
+            "API Error: Claude's response exceeded the maximum output tokens for this model.",
+        ] {
+            let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, message);
+
+            assert_eq!(
+                reason,
+                Some(FailureReason::OutputTokenLimit),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_result_output_token_limit_diagnostic() {
+        let message = "API Error: Claude's response exceeded the 64000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.";
+        let msg = cli_failure_message(
+            1,
+            &["background stderr noise".to_string()],
+            Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
+        );
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic =
+            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::OutputTokenLimit)
+        );
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult)
+        );
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_non_claude_output_token_limit() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            "API Error: Claude's response exceeded the 32000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_unrelated_claude_output_token_limit_text() {
+        for message in [
+            "API Error: Claude's context window exceeded the available token budget.",
+            "API Error: Claude's response used 32000 tokens before the request completed.",
+            "Set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable to configure responses.",
+        ] {
+            let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, message);
+
+            assert_eq!(reason, None, "message: {message}");
+        }
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -851,6 +851,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                 FailureReason::InsufficientCredits
                     | FailureReason::InvalidApiKey
                     | FailureReason::InvalidCredentials
+                    | FailureReason::OutputTokenLimit
                     | FailureReason::ProviderOverloaded
                     | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
@@ -1022,16 +1023,15 @@ mod tests {
             FailureReason::InsufficientCredits,
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {
             let diagnostic = job_failure_diagnostic(Some(reason));
-            let failure = executor::ExecutionFailure::new(
-                1,
-                format!("classified failure: {}", reason.as_str()),
-                Some(diagnostic),
-            );
+            let failure_error = format!("classified failure: {}", reason.as_str());
+            let failure =
+                executor::ExecutionFailure::new(1, failure_error.clone(), Some(diagnostic));
 
             let event = capture_job_failure_log(&failure);
 
@@ -1040,6 +1040,7 @@ mod tests {
                 event.fields.get("message").map(String::as_str),
                 Some("job execution failed")
             );
+            assert_field_eq(&event, "error", &failure_error);
             assert_field_eq(&event, "failure_reason", reason.as_str());
             assert_field_eq(&event, "failure_class", "cli_nonzero");
             assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
@@ -1078,6 +1079,7 @@ mod tests {
         for reason in [
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,


### PR DESCRIPTION
## Summary

- add `failure_reason=output_token_limit` for Claude Code output-token maximum failures
- classify Claude output-token-limit messages without hard-coding the observed numeric cap
- log `cli_nonzero` output-token-limit failures at info while preserving the original error field

Closes #18568.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent output_token_limit`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo test --manifest-path crates/Cargo.toml -p runner info_level_reason_on_non_cli_failure_logs_job_execution_failed_at_error`

Pre-commit also ran Rust cargo-fmt, cargo-doc, and cargo-clippy.