### PR TITLE
fix: update template preview navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1769,7 +1769,7 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(
         within(templateDialog).getByRole("heading", {
-          name: `Template ${template.title}`,
+          name: `Template / ${template.title}`,
         }),
       ).toBeInTheDocument();
     });
@@ -1849,7 +1849,7 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(
         within(templateDialog).getByRole("heading", {
-          name: `Template ${template.title}`,
+          name: `Template / ${template.title}`,
         }),
       ).toBeInTheDocument();
     });
@@ -1898,9 +1898,12 @@ describe("chat composer templates", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(`${String(lastSlideNumber)} of 15`),
-      ).toBeInTheDocument();
+        screen.getByLabelText(`Preview slide ${String(lastSlideNumber)}`),
+      ).toHaveAttribute("aria-pressed", "true");
     });
+    expect(
+      screen.queryByText(`${String(lastSlideNumber)} of 15`),
+    ).not.toBeInTheDocument();
   });
 
   it("resumes presentation template detail preview loading after reopening the same slide", async () => {
@@ -2086,13 +2089,16 @@ describe("chat composer templates", () => {
     const templateDialog = screen.getByRole("dialog");
     expect(
       within(templateDialog).getByRole("heading", {
-        name: `Template ${template.title}`,
+        name: `Template / ${template.title}`,
       }),
     ).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText("1 of 15")).toBeInTheDocument();
+      expect(
+        within(templateDialog).getByLabelText("Preview slide 1"),
+      ).toHaveAttribute("aria-pressed", "true");
     });
+    expect(screen.queryByText("1 of 15")).not.toBeInTheDocument();
     const firstSlidePreviewButton =
       within(templateDialog).getByLabelText("Preview slide 1");
     expect(firstSlidePreviewButton.querySelector("iframe")).toBeNull();
@@ -2174,23 +2180,41 @@ describe("chat composer templates", () => {
     click(screen.getByLabelText(`View template ${template.title}`));
 
     await waitFor(() => {
-      expect(screen.getByText("1 of 15")).toBeInTheDocument();
+      expect(
+        within(templateDialog).getByLabelText("Preview slide 1"),
+      ).toHaveAttribute("aria-pressed", "true");
     });
     expect(screen.getByLabelText("Select style Carnival")).toHaveAttribute(
       "aria-pressed",
       "true",
     );
 
-    fireEvent.click(screen.getByLabelText("Preview next slide"));
+    fireEvent.keyDown(
+      screen.getByLabelText(`${template.title} slide preview`),
+      {
+        key: "ArrowRight",
+      },
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("2 of 15")).toBeInTheDocument();
+      expect(screen.getByLabelText("Preview slide 2")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
     });
 
-    fireEvent.click(screen.getByLabelText("Preview previous slide"));
+    fireEvent.keyDown(
+      screen.getByLabelText(`${template.title} slide preview`),
+      {
+        key: "ArrowLeft",
+      },
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("1 of 15")).toBeInTheDocument();
+      expect(screen.getByLabelText("Preview slide 1")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2092,6 +2092,20 @@ describe("chat composer templates", () => {
         name: `Template / ${template.title}`,
       }),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("Preview previous slide")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByLabelText("Preview previous slide")).not.toHaveClass(
+      "focus-visible:ring-ring",
+    );
+    expect(screen.getByLabelText("Preview next slide")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByLabelText("Preview next slide")).not.toHaveClass(
+      "focus-visible:ring-ring",
+    );
 
     await waitFor(() => {
       expect(
@@ -2209,6 +2223,53 @@ describe("chat composer templates", () => {
         key: "ArrowLeft",
       },
     );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Preview slide 1")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    const themeButton = screen.getByLabelText("Select style Carnival");
+    themeButton.focus();
+    expect(themeButton).toHaveFocus();
+    fireEvent.keyDown(themeButton, {
+      key: "ArrowRight",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Preview slide 2")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    fireEvent.keyDown(themeButton, {
+      key: "ArrowLeft",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Preview slide 1")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    fireEvent.keyDown(screen.getByLabelText("Preview slide 1"), {
+      key: "ArrowRight",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Preview slide 2")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    fireEvent.keyDown(screen.getByLabelText("Preview slide 2"), {
+      key: "ArrowLeft",
+    });
 
     await waitFor(() => {
       expect(screen.getByLabelText("Preview slide 1")).toHaveAttribute(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -3319,6 +3319,97 @@ function TemplatePreview({
   );
 }
 
+interface PresentationTemplateDetailPreviewState {
+  readonly embedUrl: string;
+  readonly failed: boolean;
+  readonly frameUrl: string | null;
+  readonly index: number;
+  readonly loading: boolean;
+  readonly slideCount: number;
+  readonly slug: string;
+  readonly themeId: string;
+}
+
+type SetPresentationTemplateDetailPreview = (
+  value: PresentationTemplateDetailPreviewState | null,
+) => void;
+
+type SetPresentationTemplateDetailSlideIndex = (
+  slug: string,
+  index: number,
+) => void;
+
+function setLoadedPresentationTemplateDetailPreview({
+  draft,
+  index,
+  item,
+  previousFrameUrl,
+  selectedTheme,
+  setDetailPreview,
+}: {
+  readonly draft: PresentationEditDraft;
+  readonly index: number;
+  readonly item: PresentationTemplateItem;
+  readonly previousFrameUrl: string | null;
+  readonly selectedTheme: PresentationTemplateThemeOption;
+  readonly setDetailPreview: SetPresentationTemplateDetailPreview;
+}) {
+  const slide = draft.slides[Math.min(index, draft.slides.length - 1)];
+  if (slide === undefined) {
+    return;
+  }
+  revokePresentationTemplateHtmlPreviewUrl(previousFrameUrl);
+  const frameUrl = createThemedPresentationPreviewUrl({
+    activeSlideId: slide.id,
+    draft,
+    theme: selectedTheme,
+  });
+  setDetailPreview({
+    slug: item.slug,
+    embedUrl: item.embedUrl,
+    themeId: selectedTheme.id,
+    index,
+    loading: false,
+    failed: false,
+    frameUrl,
+    slideCount: draft.slides.length,
+  });
+}
+
+function selectPresentationTemplateDetailSlide({
+  detailPreview,
+  detailSlideCount,
+  index,
+  item,
+  selectedTheme,
+  setDetailPreview,
+  setSlideIndex,
+}: {
+  readonly detailPreview: PresentationTemplateDetailPreviewState | null;
+  readonly detailSlideCount: number;
+  readonly index: number;
+  readonly item: PresentationTemplateItem;
+  readonly selectedTheme: PresentationTemplateThemeOption;
+  readonly setDetailPreview: SetPresentationTemplateDetailPreview;
+  readonly setSlideIndex: SetPresentationTemplateDetailSlideIndex;
+}) {
+  const nextIndex = Math.max(0, Math.min(detailSlideCount - 1, index));
+  setSlideIndex(item.slug, nextIndex);
+  const cachedDraft = presentationTemplateHtmlPreviewCache().drafts.get(
+    item.embedUrl,
+  );
+  if (cachedDraft !== undefined) {
+    setLoadedPresentationTemplateDetailPreview({
+      draft: cachedDraft,
+      index: nextIndex,
+      item,
+      previousFrameUrl: detailPreview?.frameUrl ?? null,
+      selectedTheme,
+      setDetailPreview,
+    });
+  }
+}
+
 function TemplatePreviewPage({
   item,
   onBack,
@@ -3361,28 +3452,13 @@ function TemplatePreviewPage({
     readonly previousFrameUrl: string | null;
     readonly theme: PresentationTemplateThemeOption;
   }) => {
-    const slide =
-      params.draft.slides[
-        Math.min(params.index, params.draft.slides.length - 1)
-      ];
-    if (slide === undefined) {
-      return;
-    }
-    revokePresentationTemplateHtmlPreviewUrl(params.previousFrameUrl);
-    const frameUrl = createThemedPresentationPreviewUrl({
-      activeSlideId: slide.id,
+    setLoadedPresentationTemplateDetailPreview({
       draft: params.draft,
-      theme: params.theme,
-    });
-    setDetailPreview({
-      slug: item.slug,
-      embedUrl: item.embedUrl,
-      themeId: params.theme.id,
       index: params.index,
-      loading: false,
-      failed: false,
-      frameUrl,
-      slideCount: params.draft.slides.length,
+      item,
+      previousFrameUrl: params.previousFrameUrl,
+      selectedTheme: params.theme,
+      setDetailPreview,
     });
   };
 
@@ -3493,19 +3569,15 @@ function TemplatePreviewPage({
   };
 
   const selectDetailSlide = (index: number) => {
-    const nextIndex = Math.max(0, Math.min(detailSlideCount - 1, index));
-    setSlideIndex(item.slug, nextIndex);
-    const cachedDraft = presentationTemplateHtmlPreviewCache().drafts.get(
-      item.embedUrl,
-    );
-    if (cachedDraft !== undefined) {
-      setLoadedDetailPreview({
-        draft: cachedDraft,
-        index: nextIndex,
-        previousFrameUrl: detailPreview?.frameUrl ?? null,
-        theme: selectedTheme,
-      });
-    }
+    selectPresentationTemplateDetailSlide({
+      detailPreview,
+      detailSlideCount,
+      index,
+      item,
+      selectedTheme,
+      setDetailPreview,
+      setSlideIndex,
+    });
   };
 
   const selectDetailTheme = (theme: PresentationTemplateThemeOption) => {
@@ -3522,9 +3594,7 @@ function TemplatePreviewPage({
       });
     }
   };
-  const handleDetailPreviewKeyDown = (
-    event: ReactKeyboardEvent<HTMLDivElement>,
-  ) => {
+  const handleDetailSlideKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.defaultPrevented) {
       return;
     }
@@ -3574,7 +3644,7 @@ function TemplatePreviewPage({
             role="group"
             aria-label={`${item.title} slide preview`}
             tabIndex={0}
-            onKeyDown={handleDetailPreviewKeyDown}
+            onKeyDown={handleDetailSlideKeyDown}
             className="relative overflow-hidden rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <iframe
@@ -3588,19 +3658,21 @@ function TemplatePreviewPage({
               type="button"
               aria-label="Preview previous slide"
               disabled={activeSlideIndex === 0}
+              tabIndex={-1}
               onClick={() => {
                 selectDetailSlide(activeSlideIndex - 1);
               }}
-              className="absolute inset-y-0 left-0 w-1/2 cursor-w-resize bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-default"
+              className="absolute inset-y-0 left-0 w-1/2 cursor-w-resize bg-transparent focus:outline-none disabled:cursor-default"
             />
             <button
               type="button"
               aria-label="Preview next slide"
               disabled={activeSlideIndex >= detailSlideCount - 1}
+              tabIndex={-1}
               onClick={() => {
                 selectDetailSlide(activeSlideIndex + 1);
               }}
-              className="absolute inset-y-0 right-0 w-1/2 cursor-e-resize bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-default"
+              className="absolute inset-y-0 right-0 w-1/2 cursor-e-resize bg-transparent focus:outline-none disabled:cursor-default"
             />
             {visibleDetailPreview?.loading ||
             !visibleDetailPreview?.frameUrl ? (
@@ -3609,7 +3681,10 @@ function TemplatePreviewPage({
               </div>
             ) : null}
           </div>
-          <div className="mt-3 grid grid-cols-8 gap-1.5">
+          <div
+            className="mt-3 grid grid-cols-8 gap-1.5"
+            onKeyDown={handleDetailSlideKeyDown}
+          >
             {Array.from(
               { length: Math.min(detailSlideCount, 15) },
               (_, index) => {
@@ -4843,7 +4918,11 @@ function TemplatePickerDialog({
   const setSearch = useSet(setTemplatePickerSearch$);
   const previewSlug = useGet(templatePickerPreviewSlug$);
   const setPreviewSlug = useSet(setTemplatePickerPreviewSlug$);
+  const detailPreview = useGet(templateDetailHtmlPreview$);
+  const setDetailPreview = useSet(setTemplateDetailHtmlPreview$);
+  const detailThemeIdBySlug = useGet(templateDetailThemeIdBySlug$);
   const setDetailThemeId = useSet(setTemplateDetailThemeId$);
+  const detailSlideIndexBySlug = useGet(templateDetailSlideIndexBySlug$);
   const setDetailSlideIndex = useSet(setTemplateDetailSlideIndex$);
   const cardThemeIdBySlug = useGet(templateCardThemeIdBySlug$);
   const illustrationVariantIndex = useGet(illustrationVariantIndex$);
@@ -4956,6 +5035,75 @@ function TemplatePickerDialog({
     setPreviewSlug(item.slug);
   };
 
+  const previewDetailNavigationState = () => {
+    if (previewItem === null) {
+      return null;
+    }
+    const selectedThemeId =
+      detailThemeIdBySlug[previewItem.slug] ??
+      defaultPresentationTemplateThemeId(previewItem);
+    const selectedTheme = findPresentationTemplateTheme(selectedThemeId);
+    const visibleDetailPreview =
+      detailPreview?.slug === previewItem.slug &&
+      detailPreview.embedUrl === previewItem.embedUrl &&
+      detailPreview.themeId === selectedTheme.id
+        ? detailPreview
+        : null;
+    const detailSlideCount =
+      visibleDetailPreview?.slideCount ??
+      Math.max(presentationTemplateSlideImages(previewItem).length, 1);
+    return {
+      activeSlideIndex: detailSlideIndexBySlug[previewItem.slug] ?? 0,
+      detailSlideCount,
+      selectedTheme,
+      visibleDetailPreview,
+    };
+  };
+
+  const selectPreviewDetailSlide = (index: number) => {
+    if (previewItem === null) {
+      return;
+    }
+    const navigationState = previewDetailNavigationState();
+    if (navigationState === null) {
+      return;
+    }
+    selectPresentationTemplateDetailSlide({
+      detailPreview: navigationState.visibleDetailPreview,
+      detailSlideCount: navigationState.detailSlideCount,
+      index,
+      item: previewItem,
+      selectedTheme: navigationState.selectedTheme,
+      setDetailPreview,
+      setSlideIndex: setDetailSlideIndex,
+    });
+  };
+
+  const handleDialogKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!isPreviewing || event.defaultPrevented) {
+      return;
+    }
+    const navigationState = previewDetailNavigationState();
+    if (navigationState === null) {
+      return;
+    }
+    if (event.key === "ArrowLeft") {
+      if (navigationState.activeSlideIndex > 0) {
+        event.preventDefault();
+        selectPreviewDetailSlide(navigationState.activeSlideIndex - 1);
+      }
+    }
+    if (event.key === "ArrowRight") {
+      if (
+        navigationState.activeSlideIndex <
+        navigationState.detailSlideCount - 1
+      ) {
+        event.preventDefault();
+        selectPreviewDetailSlide(navigationState.activeSlideIndex + 1);
+      }
+    }
+  };
+
   const handleCategoryChange = (nextCategory: string) => {
     setCategory(nextCategory);
     if (!isPreviewing) {
@@ -4986,6 +5134,7 @@ function TemplatePickerDialog({
       <DialogContent
         className={dialogContentClassName}
         aria-describedby={undefined}
+        onKeyDown={handleDialogKeyDown}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           if (!isPreviewing) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -3522,6 +3522,21 @@ function TemplatePreviewPage({
       });
     }
   };
+  const handleDetailPreviewKeyDown = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (event.key === "ArrowLeft" && activeSlideIndex > 0) {
+      event.preventDefault();
+      selectDetailSlide(activeSlideIndex - 1);
+    }
+    if (event.key === "ArrowRight" && activeSlideIndex < detailSlideCount - 1) {
+      event.preventDefault();
+      selectDetailSlide(activeSlideIndex + 1);
+    }
+  };
   const multiAccentThemes = PRESENTATION_TEMPLATE_THEME_OPTIONS.filter(
     (theme) => {
       return theme.group === "multi-accent";
@@ -3544,6 +3559,7 @@ function TemplatePreviewPage({
           >
             Template
           </button>
+          <span className="shrink-0 text-muted-foreground">/</span>
           <span className="block min-w-0 flex-1 truncate leading-none">
             {item.title}
           </span>
@@ -3554,7 +3570,13 @@ function TemplatePreviewPage({
         className="grid max-h-[72vh] gap-4 overflow-y-auto bg-muted/20 p-5 lg:grid-cols-[minmax(0,1fr)_320px] lg:overflow-hidden"
       >
         <div className="rounded-lg border border-border bg-background p-3">
-          <div className="relative overflow-hidden rounded-lg bg-muted">
+          <div
+            role="group"
+            aria-label={`${item.title} slide preview`}
+            tabIndex={0}
+            onKeyDown={handleDetailPreviewKeyDown}
+            className="relative overflow-hidden rounded-lg bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
             <iframe
               title={`${item.title} HTML preview`}
               data-testid={`${item.title} detail HTML preview`}
@@ -3580,10 +3602,6 @@ function TemplatePreviewPage({
               }}
               className="absolute inset-y-0 right-0 w-1/2 cursor-e-resize bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-default"
             />
-            <div className="pointer-events-none absolute left-3 top-3 rounded-full border border-border bg-background/90 px-2.5 py-1 text-xs font-semibold text-foreground shadow-sm backdrop-blur">
-              {Math.min(activeSlideIndex + 1, detailSlideCount)} of{" "}
-              {detailSlideCount}
-            </div>
             {visibleDetailPreview?.loading ||
             !visibleDetailPreview?.frameUrl ? (
               <div className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-muted">


### PR DESCRIPTION
Summary
- Add a slash breadcrumb separator in the presentation template detail title while keeping Template as the back target
- Remove the slide count pill from the large detail preview
- Support ArrowLeft and ArrowRight keyboard navigation for the large preview

Tests
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types

Note
- Did not start a local dev server per vm0 PR verification preference; PR pipeline will cover browser/deploy checks.