### PR TITLE
ci: add runner host architecture groups

### DIFF
--- a/.github/scripts/runner-host-architecture-groups.sh
+++ b/.github/scripts/runner-host-architecture-groups.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/runner-image-target.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: runner-host-architecture-groups.sh
+
+Emits compact JSON for configured runner host architecture groups.
+Inputs:
+  AWS_METAL_RUNNER_HOSTS      Existing ARM64 host list.
+  X86_64_METAL_RUNNER_HOSTS   Optional x86_64 host list.
+USAGE
+}
+
+normalize_hosts() {
+  local hosts="${1:-}"
+  printf '%s\n' "$hosts" \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+    | sed '/^$/d' \
+    | paste -sd, -
+}
+
+append_group() {
+  local groups=$1
+  local id=$2
+  local label=$3
+  local hosts=$4
+  local target=$5
+
+  hosts=$(normalize_hosts "$hosts")
+  if [ -z "$hosts" ]; then
+    printf '%s\n' "$groups"
+    return 0
+  fi
+
+  local uname_m cache_suffix asset_suffix
+  uname_m=$(runner_image_expected_uname_m "$target")
+  cache_suffix=$(runner_image_cache_suffix "$target")
+  asset_suffix=$(runner_image_asset_suffix "$target")
+
+  jq -c \
+    --arg id "$id" \
+    --arg label "$label" \
+    --arg hosts "$hosts" \
+    --arg target "$target" \
+    --arg uname_m "$uname_m" \
+    --arg cache_suffix "$cache_suffix" \
+    --arg asset_suffix "$asset_suffix" \
+    '. + [{
+      id: $id,
+      label: $label,
+      hosts: $hosts,
+      target: $target,
+      unameM: $uname_m,
+      cacheSuffix: $cache_suffix,
+      assetSuffix: $asset_suffix
+    }]' <<<"$groups"
+}
+
+emit_groups() {
+  local groups
+  groups=$(jq -n -c '[]')
+  groups=$(append_group "$groups" "arm64" "ARM64" "${AWS_METAL_RUNNER_HOSTS:-}" "aarch64-unknown-linux-musl")
+  groups=$(append_group "$groups" "x86_64" "x86_64" "${X86_64_METAL_RUNNER_HOSTS:-}" "x86_64-unknown-linux-musl")
+  printf '%s\n' "$groups"
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  "")
+    emit_groups
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -44,3 +44,31 @@ runner_image_expected_uname_m() {
       ;;
   esac
 }
+
+runner_image_cache_suffix() {
+  local target="${1:-}"
+
+  runner_image_validate_target "$target" || return $?
+  case "$target" in
+    aarch64-unknown-linux-musl)
+      printf '%s\n' "aarch64-musl"
+      ;;
+    x86_64-unknown-linux-musl)
+      printf '%s\n' "x86_64-musl"
+      ;;
+  esac
+}
+
+runner_image_asset_suffix() {
+  local target="${1:-}"
+
+  runner_image_validate_target "$target" || return $?
+  case "$target" in
+    aarch64-unknown-linux-musl)
+      printf '%s\n' "aarch64-linux"
+      ;;
+    x86_64-unknown-linux-musl)
+      printf '%s\n' "x86_64-linux"
+      ;;
+  esac
+}

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -42,6 +42,10 @@ runner_image_expected_uname_m() {
     x86_64-unknown-linux-musl)
       printf '%s\n' "x86_64"
       ;;
+    *)
+      echo "missing runner image uname metadata for target: ${target}" >&2
+      return 2
+      ;;
   esac
 }
 
@@ -56,6 +60,10 @@ runner_image_cache_suffix() {
     x86_64-unknown-linux-musl)
       printf '%s\n' "x86_64-musl"
       ;;
+    *)
+      echo "missing runner image cache suffix metadata for target: ${target}" >&2
+      return 2
+      ;;
   esac
 }
 
@@ -69,6 +77,10 @@ runner_image_asset_suffix() {
       ;;
     x86_64-unknown-linux-musl)
       printf '%s\n' "x86_64-linux"
+      ;;
+    *)
+      echo "missing runner image asset suffix metadata for target: ${target}" >&2
+      return 2
       ;;
   esac
 }

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -52,10 +52,20 @@ out=$(run_clean "$HOST_GROUPS")
 assert_compact_json "$out"
 assert_json_eq "$out" '[]'
 
+if bash -c '. "$1"; runner_image_cache_suffix ""' bash "$TARGET" >"${TMPDIR}/cache-empty.out" 2>"${TMPDIR}/cache-empty.err"; then
+  fail "expected empty cache suffix target to fail"
+fi
+grep -q "missing runner image target" "${TMPDIR}/cache-empty.err" || fail "expected missing cache suffix target message"
+
 if bash -c '. "$1"; runner_image_cache_suffix powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/cache.out" 2>"${TMPDIR}/cache.err"; then
   fail "expected unsupported cache suffix target to fail"
 fi
 grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/cache.err" || fail "expected unsupported cache suffix message"
+
+if bash -c '. "$1"; runner_image_asset_suffix ""' bash "$TARGET" >"${TMPDIR}/asset-empty.out" 2>"${TMPDIR}/asset-empty.err"; then
+  fail "expected empty asset suffix target to fail"
+fi
+grep -q "missing runner image target" "${TMPDIR}/asset-empty.err" || fail "expected missing asset suffix target message"
 
 if bash -c '. "$1"; runner_image_asset_suffix powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset.out" 2>"${TMPDIR}/asset.err"; then
   fail "expected unsupported asset suffix target to fail"

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST_GROUPS="${SCRIPT_DIR}/runner-host-architecture-groups.sh"
+TARGET="${SCRIPT_DIR}/runner-image-target.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+run_clean() {
+  env -i PATH="$PATH" HOME="${HOME:-/tmp}" "$@"
+}
+
+assert_json_eq() {
+  local actual=$1 expected=$2
+  local actual_canonical expected_canonical
+  actual_canonical=$(jq -cS . <<<"$actual")
+  expected_canonical=$(jq -cS . <<<"$expected")
+  [ "$actual_canonical" = "$expected_canonical" ] || fail "expected ${expected_canonical}, got ${actual_canonical}"
+}
+
+assert_compact_json() {
+  local output=$1
+  jq -e 'type == "array"' >/dev/null <<<"$output" || fail "expected JSON array: ${output}"
+  if [[ "$output" == *$'\n'* ]]; then
+    fail "expected compact single-line JSON: ${output}"
+  fi
+}
+
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS")
+assert_compact_json "$out"
+assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","hosts":"arm-1,arm-2","target":"aarch64-unknown-linux-musl","unameM":"aarch64","cacheSuffix":"aarch64-musl","assetSuffix":"aarch64-linux"}]'
+
+out=$(run_clean X86_64_METAL_RUNNER_HOSTS='x86-1' "$HOST_GROUPS")
+assert_compact_json "$out"
+assert_json_eq "$out" '[{"id":"x86_64","label":"x86_64","hosts":"x86-1","target":"x86_64-unknown-linux-musl","unameM":"x86_64","cacheSuffix":"x86_64-musl","assetSuffix":"x86_64-linux"}]'
+
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1' X86_64_METAL_RUNNER_HOSTS='x86-1,x86-2' "$HOST_GROUPS")
+assert_compact_json "$out"
+assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","hosts":"arm-1","target":"aarch64-unknown-linux-musl","unameM":"aarch64","cacheSuffix":"aarch64-musl","assetSuffix":"aarch64-linux"},{"id":"x86_64","label":"x86_64","hosts":"x86-1,x86-2","target":"x86_64-unknown-linux-musl","unameM":"x86_64","cacheSuffix":"x86_64-musl","assetSuffix":"x86_64-linux"}]'
+
+out=$(run_clean AWS_METAL_RUNNER_HOSTS=' arm-1 , , arm-2 ' X86_64_METAL_RUNNER_HOSTS=' , ' "$HOST_GROUPS")
+assert_compact_json "$out"
+assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","hosts":"arm-1,arm-2","target":"aarch64-unknown-linux-musl","unameM":"aarch64","cacheSuffix":"aarch64-musl","assetSuffix":"aarch64-linux"}]'
+
+out=$(run_clean "$HOST_GROUPS")
+assert_compact_json "$out"
+assert_json_eq "$out" '[]'
+
+if bash -c '. "$1"; runner_image_cache_suffix powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/cache.out" 2>"${TMPDIR}/cache.err"; then
+  fail "expected unsupported cache suffix target to fail"
+fi
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/cache.err" || fail "expected unsupported cache suffix message"
+
+if bash -c '. "$1"; runner_image_asset_suffix powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset.out" 2>"${TMPDIR}/asset.err"; then
+  fail "expected unsupported asset suffix target to fail"
+fi
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/asset.err" || fail "expected unsupported asset suffix message"
+
+echo "runner-host-architecture-groups-test: ok"


### PR DESCRIPTION
## Summary

- Add runner image target metadata helpers for cache and release asset suffixes.
- Add a runner host architecture group helper that emits compact JSON for configured ARM64 and x86_64 host groups.
- Add shell tests for ARM-only, x86-only, mixed, empty optional group, all-empty groups, compact JSON, and unsupported target metadata.

## Validation

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- `bash .github/scripts/tests/runner-host-architecture-groups-test.sh`
- `for test in .github/scripts/tests/*.sh; do bash "$test"; done`
- `git diff --check`

Closes #18570
