### PR TITLE
perf(mitm-addon): cache compiled builtin firewall cores

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -237,8 +237,8 @@ class _CompiledPermission(NamedTuple):
     rules: tuple[_CompiledRule, ...]
 
 
-class _CompiledApi(NamedTuple):
-    raw_api_entry: dict
+class _CompiledApiCore(NamedTuple):
+    raw_api_index: int
     base: _CompiledBase
     permissions: tuple[_CompiledPermission, ...]
     base_malformed: bool
@@ -247,10 +247,48 @@ class _CompiledApi(NamedTuple):
     has_malformed_rules: bool
 
 
-class _CompiledFirewall(NamedTuple):
+class _CompiledApi(NamedTuple):
+    raw_api_entry: dict
+    core: _CompiledApiCore
+
+    @property
+    def base(self) -> _CompiledBase:
+        return self.core.base
+
+    @property
+    def permissions(self) -> tuple[_CompiledPermission, ...]:
+        return self.core.permissions
+
+    @property
+    def base_malformed(self) -> bool:
+        return self.core.base_malformed
+
+    @property
+    def auth_malformed(self) -> bool:
+        return self.core.auth_malformed
+
+    @property
+    def has_malformed_rules(self) -> bool:
+        return self.core.has_malformed_rules
+
+
+class CompiledFirewallCore(NamedTuple):
     name: str
-    apis: tuple[_CompiledApi, ...]
+    api_cores: tuple[_CompiledApiCore, ...]
     name_malformed: bool
+
+
+class _CompiledFirewall(NamedTuple):
+    core: CompiledFirewallCore
+    apis: tuple[_CompiledApi, ...]
+
+    @property
+    def name(self) -> str:
+        return self.core.name
+
+    @property
+    def name_malformed(self) -> bool:
+        return self.core.name_malformed
 
 
 class CompiledFirewallSet(NamedTuple):
@@ -1303,6 +1341,122 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # no allow/deny resolved, malformed network policy resolves before malformed
 # firewall config; malformed unknownPolicy only affects unknown-endpoint
 # resolution.
+def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
+    """Compile one firewall into VM-independent matcher data."""
+    if not isinstance(fw_entry, dict):
+        return None
+
+    raw_name = fw_entry.get("name")
+    name_malformed = not isinstance(raw_name, str) or raw_name == ""
+    firewall_name = raw_name if isinstance(raw_name, str) else ""
+
+    raw_apis = fw_entry.get("apis", [])
+    if not isinstance(raw_apis, list):
+        return None
+
+    api_cores: list[_CompiledApiCore] = []
+    for api_index, api_entry in enumerate(raw_apis):
+        if not isinstance(api_entry, dict):
+            continue
+        raw_base = api_entry.get("base", "")
+        if not isinstance(raw_base, str):
+            continue
+        base = _compile_base(raw_base)
+        if base is None:
+            continue
+        base_malformed = (
+            base.has_query_or_fragment
+            or base.raw_syntax_malformed
+            or base.param_parse_malformed
+            or base.parts.host_malformed
+            or base.parts.has_userinfo
+            or base.parts.port_malformed
+            or not _compiled_base_params_are_valid(base)
+        )
+        auth_malformed = not _auth_config_is_valid(api_entry)
+
+        compiled_permissions: list[_CompiledPermission] = []
+        has_malformed_rules = name_malformed
+        seen_permission_names: set[str] = set()
+        permissions = api_entry.get("permissions")
+        permissions_present = "permissions" in api_entry
+        if isinstance(permissions, list):
+            for perm in permissions:
+                if not isinstance(perm, dict):
+                    has_malformed_rules = True
+                    continue
+                raw_name = perm.get("name")
+                if not isinstance(raw_name, str):
+                    has_malformed_rules = True
+                    continue
+                if raw_name in ("", "all"):
+                    has_malformed_rules = True
+                    continue
+                if raw_name in seen_permission_names:
+                    has_malformed_rules = True
+                    continue
+                seen_permission_names.add(raw_name)
+                raw_rules = perm.get("rules", [])
+                if not isinstance(raw_rules, list):
+                    raw_rules = []
+                    has_malformed_rules = True
+                if len(raw_rules) == 0:
+                    has_malformed_rules = True
+
+                compiled_rules: list[_CompiledRule] = []
+                for rule_str in raw_rules:
+                    if not isinstance(rule_str, str):
+                        has_malformed_rules = True
+                        continue
+                    rule = _compile_rule(rule_str)
+                    if rule is None:
+                        has_malformed_rules = True
+                        continue
+                    compiled_rules.append(rule)
+
+                compiled_permissions.append(_CompiledPermission(raw_name, tuple(compiled_rules)))
+        elif permissions_present:
+            has_malformed_rules = True
+
+        api_cores.append(
+            _CompiledApiCore(
+                api_index,
+                base,
+                tuple(compiled_permissions),
+                base_malformed,
+                auth_malformed,
+                has_malformed_rules,
+            )
+        )
+
+    if not api_cores:
+        return None
+    return CompiledFirewallCore(firewall_name, tuple(api_cores), name_malformed)
+
+
+def bind_compiled_firewall_core(
+    fw_entry: dict,
+    core: CompiledFirewallCore,
+) -> _CompiledFirewall | None:
+    """Bind VM-specific raw API entries to reusable compiled firewall core data."""
+    raw_apis = fw_entry.get("apis", [])
+    if not isinstance(raw_apis, list):
+        return None
+
+    compiled_apis: list[_CompiledApi] = []
+    for api_core in core.api_cores:
+        if api_core.raw_api_index >= len(raw_apis):
+            return None
+        api_entry = raw_apis[api_core.raw_api_index]
+        if not isinstance(api_entry, dict):
+            return None
+        compiled_apis.append(_CompiledApi(api_entry, api_core))
+
+    if not compiled_apis:
+        return None
+    return _CompiledFirewall(core, tuple(compiled_apis))
+
+
 def compile_firewalls(vm_firewalls: object | None) -> CompiledFirewallSet | None:
     """Compile firewall data and retain selected malformed state.
 
@@ -1313,98 +1467,12 @@ def compile_firewalls(vm_firewalls: object | None) -> CompiledFirewallSet | None
 
     compiled_firewalls: list[_CompiledFirewall] = []
     for fw_entry in vm_firewalls:
-        if not isinstance(fw_entry, dict):
+        core = compile_firewall_core(fw_entry)
+        if core is None or not isinstance(fw_entry, dict):
             continue
-
-        raw_name = fw_entry.get("name")
-        name_malformed = not isinstance(raw_name, str) or raw_name == ""
-        firewall_name = raw_name if isinstance(raw_name, str) else ""
-
-        raw_apis = fw_entry.get("apis", [])
-        if not isinstance(raw_apis, list):
-            continue
-
-        compiled_apis: list[_CompiledApi] = []
-        for api_entry in raw_apis:
-            if not isinstance(api_entry, dict):
-                continue
-            raw_base = api_entry.get("base", "")
-            if not isinstance(raw_base, str):
-                continue
-            base = _compile_base(raw_base)
-            if base is None:
-                continue
-            base_malformed = (
-                base.has_query_or_fragment
-                or base.raw_syntax_malformed
-                or base.param_parse_malformed
-                or base.parts.host_malformed
-                or base.parts.has_userinfo
-                or base.parts.port_malformed
-                or not _compiled_base_params_are_valid(base)
-            )
-            auth_malformed = not _auth_config_is_valid(api_entry)
-
-            compiled_permissions: list[_CompiledPermission] = []
-            has_malformed_rules = name_malformed
-            seen_permission_names: set[str] = set()
-            permissions = api_entry.get("permissions")
-            permissions_present = "permissions" in api_entry
-            if isinstance(permissions, list):
-                for perm in permissions:
-                    if not isinstance(perm, dict):
-                        has_malformed_rules = True
-                        continue
-                    raw_name = perm.get("name")
-                    if not isinstance(raw_name, str):
-                        has_malformed_rules = True
-                        continue
-                    if raw_name in ("", "all"):
-                        has_malformed_rules = True
-                        continue
-                    if raw_name in seen_permission_names:
-                        has_malformed_rules = True
-                        continue
-                    seen_permission_names.add(raw_name)
-                    raw_rules = perm.get("rules", [])
-                    if not isinstance(raw_rules, list):
-                        raw_rules = []
-                        has_malformed_rules = True
-                    if len(raw_rules) == 0:
-                        has_malformed_rules = True
-
-                    compiled_rules: list[_CompiledRule] = []
-                    for rule_str in raw_rules:
-                        if not isinstance(rule_str, str):
-                            has_malformed_rules = True
-                            continue
-                        rule = _compile_rule(rule_str)
-                        if rule is None:
-                            has_malformed_rules = True
-                            continue
-                        compiled_rules.append(rule)
-
-                    compiled_permissions.append(
-                        _CompiledPermission(raw_name, tuple(compiled_rules))
-                    )
-            elif permissions_present:
-                has_malformed_rules = True
-
-            compiled_apis.append(
-                _CompiledApi(
-                    api_entry,
-                    base,
-                    tuple(compiled_permissions),
-                    base_malformed,
-                    auth_malformed,
-                    has_malformed_rules,
-                )
-            )
-
-        if compiled_apis:
-            compiled_firewalls.append(
-                _CompiledFirewall(firewall_name, tuple(compiled_apis), name_malformed)
-            )
+        compiled_firewall = bind_compiled_firewall_core(fw_entry, core)
+        if compiled_firewall is not None:
+            compiled_firewalls.append(compiled_firewall)
 
     if not compiled_firewalls:
         return None

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -25,6 +25,7 @@ VmContext = tuple[
     matching.CompiledNetworkPolicies,
 ]
 _RegistryCacheKey = tuple[str, int, int, int, int]
+_BuiltinFirewallCoreCacheKey = tuple[str, int, tuple[tuple[str, str], ...], tuple[str, ...]]
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
 _READ_CHUNK_BYTES = 1024 * 1024
 _BASE_URL_VAR_PATTERN = re.compile(r"\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
@@ -64,6 +65,18 @@ class _RegistrySnapshot:
 
 
 @dataclass(frozen=True)
+class _ResolvedBuiltinFirewallEntry:
+    firewall: dict
+    cache_key: _BuiltinFirewallCoreCacheKey
+
+
+@dataclass(frozen=True)
+class _ResolvedFirewallEntries:
+    firewalls: list[dict] | None
+    builtin_cache_keys: tuple[_BuiltinFirewallCoreCacheKey | None, ...] | None
+
+
+@dataclass(frozen=True)
 class RegistryUnavailable:
     """Current registry file cannot be trusted as an enforcement source."""
 
@@ -94,6 +107,10 @@ class _RegistryCacheState:
     # key only to avoid request-path log spam without poisoning the file state.
     stat_error_logged: bool = False
     read_error_key: _RegistryCacheKey | None = None
+    builtin_firewall_core_cache: dict[
+        _BuiltinFirewallCoreCacheKey,
+        matching.CompiledFirewallCore,
+    ] = field(default_factory=dict)
 
     def reset(self, registry_path: str | None = None) -> None:
         self.registry_path = registry_path
@@ -102,6 +119,7 @@ class _RegistryCacheState:
         self.failed_key = None
         self.stat_error_logged = False
         self.read_error_key = None
+        self.builtin_firewall_core_cache = {}
 
 
 _registry_state = _RegistryCacheState()
@@ -126,6 +144,11 @@ def _state_for_path(path_key: str) -> _RegistryCacheState:
 
 def _compile_registry(
     new_registry: dict,
+    builtin_cache_keys: dict[str, tuple[_BuiltinFirewallCoreCacheKey | None, ...]],
+    builtin_firewall_core_cache: dict[
+        _BuiltinFirewallCoreCacheKey,
+        matching.CompiledFirewallCore,
+    ],
 ) -> tuple[
     dict[str, matching.CompiledFirewallSet],
     dict[str, matching.CompiledNetworkPolicies],
@@ -134,12 +157,54 @@ def _compile_registry(
     compiled_policy_registry: dict[str, matching.CompiledNetworkPolicies] = {}
     for client_ip, vm in new_registry.items():
         firewalls = vm.get("firewalls")
-        compiled_firewalls = matching.compile_firewalls(firewalls)
+        compiled_firewalls = _compile_firewalls_with_builtin_cache(
+            firewalls,
+            builtin_cache_keys.get(client_ip),
+            builtin_firewall_core_cache,
+        )
         if compiled_firewalls is not None:
             compiled_firewall_registry[client_ip] = compiled_firewalls
         network_policies = vm.get("networkPolicies")
         compiled_policy_registry[client_ip] = matching.compile_network_policies(network_policies)
     return compiled_firewall_registry, compiled_policy_registry
+
+
+def _compile_firewalls_with_builtin_cache(
+    firewalls: object | None,
+    builtin_cache_keys: tuple[_BuiltinFirewallCoreCacheKey | None, ...] | None,
+    builtin_firewall_core_cache: dict[
+        _BuiltinFirewallCoreCacheKey,
+        matching.CompiledFirewallCore,
+    ],
+) -> matching.CompiledFirewallSet | None:
+    if not isinstance(firewalls, list) or not firewalls:
+        return None
+    if builtin_cache_keys is None or len(builtin_cache_keys) != len(firewalls):
+        return matching.compile_firewalls(firewalls)
+
+    compiled_firewalls = []
+    for firewall, cache_key in zip(firewalls, builtin_cache_keys, strict=False):
+        if not isinstance(firewall, dict):
+            continue
+        if cache_key is None:
+            inline_compiled = matching.compile_firewalls([firewall])
+            if inline_compiled is not None:
+                compiled_firewalls.extend(inline_compiled.firewalls)
+            continue
+
+        compiled_core = builtin_firewall_core_cache.get(cache_key)
+        if compiled_core is None:
+            compiled_core = matching.compile_firewall_core(firewall)
+            if compiled_core is None:
+                continue
+            builtin_firewall_core_cache[cache_key] = compiled_core
+        compiled_firewall = matching.bind_compiled_firewall_core(firewall, compiled_core)
+        if compiled_firewall is not None:
+            compiled_firewalls.append(compiled_firewall)
+
+    if not compiled_firewalls:
+        return None
+    return matching.CompiledFirewallSet(tuple(compiled_firewalls))
 
 
 def _string_record(value: object, field_name: str) -> dict[str, str]:
@@ -546,7 +611,7 @@ def _validate_credentialed_builtin_base(
         )
 
 
-def _resolve_builtin_firewall_entry(entry: dict) -> dict:
+def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntry:
     raw_name = entry.get("name")
     if not isinstance(raw_name, str) or raw_name == "":
         raise _FirewallEntryResolutionError(
@@ -563,6 +628,7 @@ def _resolve_builtin_firewall_entry(entry: dict) -> dict:
         raise _FirewallEntryResolutionError(f'builtin firewall "{raw_name}" apis must be a list')
 
     vars_map = _base_url_vars_for_entry(entry)
+    resolved_bases: list[str] = []
     for api in raw_apis:
         if not isinstance(api, dict):
             raise _FirewallEntryResolutionError(
@@ -584,8 +650,17 @@ def _resolve_builtin_firewall_entry(entry: dict) -> dict:
             auth_config=api.get("auth"),
         )
         api["base"] = resolved_base
+        resolved_bases.append(resolved_base)
 
-    return firewall
+    return _ResolvedBuiltinFirewallEntry(
+        firewall=firewall,
+        cache_key=(
+            raw_name,
+            id(catalog_firewall),
+            tuple(sorted(vars_map.items())),
+            tuple(resolved_bases),
+        ),
+    )
 
 
 def _assign_firewall_api_ids(firewalls: list[dict], run_id: str) -> None:
@@ -603,21 +678,24 @@ def _assign_firewall_api_ids(firewalls: list[dict], run_id: str) -> None:
             index += 1
 
 
-def _resolve_firewall_entries(vm: dict) -> list[dict] | None:
+def _resolve_firewall_entries(vm: dict) -> _ResolvedFirewallEntries:
     raw_firewalls = vm.get("firewalls")
     if raw_firewalls is None:
-        return None
+        return _ResolvedFirewallEntries(None, None)
     if not isinstance(raw_firewalls, list):
         raise _FirewallEntryResolutionError("firewalls must be a list")
 
     resolved: list[dict] = []
+    builtin_cache_keys: list[_BuiltinFirewallCoreCacheKey | None] = []
     for entry in raw_firewalls:
         if not isinstance(entry, dict):
             raise _FirewallEntryResolutionError("firewall entries must be objects")
 
         kind = entry.get("kind")
         if kind == "builtin":
-            resolved.append(_resolve_builtin_firewall_entry(entry))
+            resolved_builtin = _resolve_builtin_firewall_entry(entry)
+            resolved.append(resolved_builtin.firewall)
+            builtin_cache_keys.append(resolved_builtin.cache_key)
             continue
         if kind == "inline":
             firewall = entry.get("firewall")
@@ -626,16 +704,27 @@ def _resolve_firewall_entries(vm: dict) -> list[dict] | None:
                     "inline firewall entry firewall must be an object"
                 )
             resolved.append(copy.deepcopy(firewall))
+            builtin_cache_keys.append(None)
             continue
         raise _FirewallEntryResolutionError("firewall entries must use a supported kind")
 
     _assign_firewall_api_ids(resolved, vm["runId"])
-    return resolved
+    return _ResolvedFirewallEntries(resolved, tuple(builtin_cache_keys))
 
 
-def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidVmEntry]]:
+def _classify_registry_vms(
+    raw_registry: dict,
+) -> tuple[
+    dict,
+    dict[str, InvalidVmEntry],
+    dict[str, tuple[_BuiltinFirewallCoreCacheKey | None, ...]],
+]:
     new_registry: dict = {}
     invalid_vms: dict[str, InvalidVmEntry] = {}
+    builtin_cache_keys_by_client_ip: dict[
+        str,
+        tuple[_BuiltinFirewallCoreCacheKey | None, ...],
+    ] = {}
     for client_ip, vm in raw_registry.items():
         if not isinstance(vm, dict):
             invalid_vms[client_ip] = InvalidVmEntry(
@@ -689,12 +778,14 @@ def _classify_registry_vms(raw_registry: dict) -> tuple[dict, dict[str, InvalidV
             continue
 
         vm = dict(vm)
-        if resolved_firewalls is not None:
-            vm["firewalls"] = resolved_firewalls
+        if resolved_firewalls.firewalls is not None:
+            vm["firewalls"] = resolved_firewalls.firewalls
+            if resolved_firewalls.builtin_cache_keys is not None:
+                builtin_cache_keys_by_client_ip[client_ip] = resolved_firewalls.builtin_cache_keys
 
         new_registry[client_ip] = vm
 
-    return new_registry, invalid_vms
+    return new_registry, invalid_vms, builtin_cache_keys_by_client_ip
 
 
 def _open_registry_for_read(path: Path) -> tuple[int, os.stat_result]:
@@ -811,10 +902,14 @@ def load_registry_state(registry_path: str) -> RegistryState:
     finally:
         os.close(fd)
 
-    new_registry, invalid_vms = _classify_registry_vms(raw_registry)
+    new_registry, invalid_vms, builtin_cache_keys = _classify_registry_vms(raw_registry)
     if invalid_vms:
         ctx.log.warn(f"Rejected {len(invalid_vms)} invalid proxy registry VM entries")
-    new_compiled_registry, new_compiled_policy_registry = _compile_registry(new_registry)
+    new_compiled_registry, new_compiled_policy_registry = _compile_registry(
+        new_registry,
+        builtin_cache_keys,
+        state.builtin_firewall_core_cache,
+    )
 
     # Evict cache entries for runs no longer in the registry.
     active_run_ids = {vm["runId"] for vm in new_registry.values()}

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -6,6 +6,7 @@ import os
 import re
 import stat
 import urllib.parse
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -166,7 +167,26 @@ def _compile_registry(
             compiled_firewall_registry[client_ip] = compiled_firewalls
         network_policies = vm.get("networkPolicies")
         compiled_policy_registry[client_ip] = matching.compile_network_policies(network_policies)
+    _prune_builtin_firewall_core_cache(builtin_firewall_core_cache, builtin_cache_keys.values())
     return compiled_firewall_registry, compiled_policy_registry
+
+
+def _prune_builtin_firewall_core_cache(
+    builtin_firewall_core_cache: dict[
+        _BuiltinFirewallCoreCacheKey,
+        matching.CompiledFirewallCore,
+    ],
+    active_key_groups: Iterable[tuple[_BuiltinFirewallCoreCacheKey | None, ...]],
+) -> None:
+    active_keys = {
+        cache_key
+        for cache_keys in active_key_groups
+        for cache_key in cache_keys
+        if cache_key is not None
+    }
+    stale_keys = set(builtin_firewall_core_cache) - active_keys
+    for cache_key in stale_keys:
+        del builtin_firewall_core_cache[cache_key]
 
 
 def _compile_firewalls_with_builtin_cache(

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -57,6 +57,42 @@ def _install_test_builtin_firewall(monkeypatch, *, name: str, base: str) -> None
     )
 
 
+def _write_multi_vm_registry(path, vms: dict) -> None:
+    path.write_text(json.dumps({"vms": vms, "updatedAt": 0}))
+
+
+def _builtin_vm(run_id: str, name: str, base_url_vars: dict[str, str] | None = None) -> dict:
+    entry: dict[str, object] = {"kind": "builtin", "name": name}
+    if base_url_vars is not None:
+        entry["baseUrlVars"] = base_url_vars
+    return {"runId": run_id, "firewalls": [entry]}
+
+
+def _inline_vm(run_id: str) -> dict:
+    return {
+        "runId": run_id,
+        "firewalls": [
+            {
+                "kind": "inline",
+                "firewall": {
+                    "name": "example",
+                    "apis": [
+                        {
+                            "base": "https://api.example.com",
+                            "auth": {"headers": {"Authorization": "Bearer token"}},
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+
+def _first_firewall_core(compiled_firewalls: matching.CompiledFirewallSet):
+    return compiled_firewalls.firewalls[0].core
+
+
 class TestGetVmInfo:
     def test_known_ip(self, registry_file):
         info = registry.get_vm_info("10.200.0.1", str(registry_file))
@@ -171,6 +207,47 @@ class TestGetVmContext:
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://api.github.com"
         assert vm_info["firewalls"][0]["apis"][0]["id"] == "run-github:0"
 
+    def test_repeated_builtin_firewall_refs_share_core_but_keep_vm_api_ids(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": _builtin_vm("run-github-a", "github"),
+                "10.200.0.2": _builtin_vm("run-github-b", "github"),
+            },
+        )
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        second_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert first_context is not None
+        assert second_context is not None
+        first_vm_info, first_compiled, first_policies = first_context
+        second_vm_info, second_compiled, second_policies = second_context
+        assert first_compiled is not None
+        assert second_compiled is not None
+        assert _first_firewall_core(first_compiled) is _first_firewall_core(second_compiled)
+
+        first_result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/vm0-ai/vm0",
+            "GET",
+            first_compiled,
+            first_policies,
+        )
+        second_result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/vm0-ai/vm0",
+            "GET",
+            second_compiled,
+            second_policies,
+        )
+
+        assert isinstance(first_result, matching.FirewallAllow)
+        assert isinstance(second_result, matching.FirewallAllow)
+        assert first_result.api_entry is first_vm_info["firewalls"][0]["apis"][0]
+        assert second_result.api_entry is second_vm_info["firewalls"][0]["apis"][0]
+        assert first_result.api_entry["id"] == "run-github-a:0"
+        assert second_result.api_entry["id"] == "run-github-b:0"
+
     def test_builtin_firewall_entry_resolves_dynamic_base_url_vars(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(
@@ -199,6 +276,141 @@ class TestGetVmContext:
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.zendesk.com"
+
+    def test_builtin_refs_with_different_base_url_vars_do_not_share_core(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": _builtin_vm(
+                    "run-zendesk-a",
+                    "zendesk",
+                    {"ZENDESK_SUBDOMAIN": "acme"},
+                ),
+                "10.200.0.2": _builtin_vm(
+                    "run-zendesk-b",
+                    "zendesk",
+                    {"ZENDESK_SUBDOMAIN": "beta"},
+                ),
+            },
+        )
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        second_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert first_context is not None
+        assert second_context is not None
+        first_vm_info, first_compiled, first_policies = first_context
+        second_vm_info, second_compiled, second_policies = second_context
+        assert first_compiled is not None
+        assert second_compiled is not None
+        assert _first_firewall_core(first_compiled) is not _first_firewall_core(second_compiled)
+        assert first_vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.zendesk.com"
+        assert second_vm_info["firewalls"][0]["apis"][0]["base"] == "https://beta.zendesk.com"
+
+        first_result = matching.match_compiled_firewall_request(
+            "https://acme.zendesk.com/api/v2/tickets",
+            "GET",
+            first_compiled,
+            first_policies,
+        )
+        second_result = matching.match_compiled_firewall_request(
+            "https://beta.zendesk.com/api/v2/tickets",
+            "GET",
+            second_compiled,
+            second_policies,
+        )
+
+        assert isinstance(first_result, matching.FirewallAllow)
+        assert isinstance(second_result, matching.FirewallAllow)
+        assert first_result.api_entry is first_vm_info["firewalls"][0]["apis"][0]
+        assert second_result.api_entry is second_vm_info["firewalls"][0]["apis"][0]
+
+    def test_builtin_compile_cache_is_scoped_to_registry_path(self, tmp_path):
+        path_a = tmp_path / "registry-a.json"
+        path_b = tmp_path / "registry-b.json"
+        data = {"10.200.0.1": _builtin_vm("run-github", "github")}
+        _write_multi_vm_registry(path_a, data)
+        _write_multi_vm_registry(path_b, data)
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path_a))
+        second_context = registry.get_vm_context("10.200.0.1", str(path_b))
+
+        assert first_context is not None
+        assert second_context is not None
+        _, first_compiled, _ = first_context
+        _, second_compiled, _ = second_context
+        assert first_compiled is not None
+        assert second_compiled is not None
+        assert _first_firewall_core(first_compiled) is not _first_firewall_core(second_compiled)
+
+    def test_invalid_builtin_entry_does_not_poison_valid_vm_core_cache(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": _builtin_vm("run-github", "github"),
+                "10.200.0.2": _builtin_vm("run-missing", "missing-firewall"),
+            },
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            valid_context = registry.get_vm_context("10.200.0.1", str(path))
+            invalid_context = registry.get_vm_context("10.200.0.2", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert valid_context is not None
+        assert invalid_context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert state.invalid_vms["10.200.0.2"].reason == "invalid_firewalls"
+        _, compiled_firewalls, compiled_policies = valid_context
+        assert compiled_firewalls is not None
+        result = matching.match_compiled_firewall_request(
+            "https://api.github.com/repos/vm0-ai/vm0",
+            "GET",
+            compiled_firewalls,
+            compiled_policies,
+        )
+        assert isinstance(result, matching.FirewallAllow)
+
+    def test_inline_firewalls_do_not_share_compiled_core(self, tmp_path):
+        path = tmp_path / "registry.json"
+        _write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": _inline_vm("run-inline-a"),
+                "10.200.0.2": _inline_vm("run-inline-b"),
+            },
+        )
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        second_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert first_context is not None
+        assert second_context is not None
+        first_vm_info, first_compiled, first_policies = first_context
+        second_vm_info, second_compiled, second_policies = second_context
+        assert first_compiled is not None
+        assert second_compiled is not None
+        assert _first_firewall_core(first_compiled) is not _first_firewall_core(second_compiled)
+
+        first_result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            first_compiled,
+            first_policies,
+        )
+        second_result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            second_compiled,
+            second_policies,
+        )
+
+        assert isinstance(first_result, matching.FirewallAllow)
+        assert isinstance(second_result, matching.FirewallAllow)
+        assert first_result.api_entry is first_vm_info["firewalls"][0]["apis"][0]
+        assert second_result.api_entry is second_vm_info["firewalls"][0]["apis"][0]
 
     def test_builtin_fixed_provider_suffix_rejects_authority_escape(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -1,6 +1,7 @@
 """Tests for registry VM lookup and compiled context behavior."""
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -372,6 +373,55 @@ class TestGetVmContext:
             compiled_policies,
         )
         assert isinstance(result, matching.FirewallAllow)
+
+    def test_builtin_core_cache_prunes_inactive_keys_on_registry_reload(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            registry,
+            "BUILTIN_FIREWALLS",
+            {
+                "cache-a": {
+                    "name": "cache-a",
+                    "apis": [
+                        {
+                            "base": "https://api-a.example.com",
+                            "auth": {"headers": {"Authorization": "Bearer token"}},
+                            "permissions": [],
+                        }
+                    ],
+                },
+                "cache-b": {
+                    "name": "cache-b",
+                    "apis": [
+                        {
+                            "base": "https://api-b.example.com",
+                            "auth": {"headers": {"Authorization": "Bearer token"}},
+                            "permissions": [],
+                        }
+                    ],
+                },
+            },
+        )
+        path = tmp_path / "registry.json"
+        _write_multi_vm_registry(path, {"10.200.0.1": _builtin_vm("run-cache-a", "cache-a")})
+        os.utime(path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert first_context is not None
+        assert len(registry._registry_state.builtin_firewall_core_cache) == 1
+        first_cache_key = next(iter(registry._registry_state.builtin_firewall_core_cache))
+        assert first_cache_key[0] == "cache-a"
+
+        _write_multi_vm_registry(path, {"10.200.0.1": _builtin_vm("run-cache-b", "cache-b")})
+        os.utime(path, ns=(1_700_000_000_000_000_001, 1_700_000_000_000_000_001))
+        second_context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert second_context is not None
+        assert len(registry._registry_state.builtin_firewall_core_cache) == 1
+        second_cache_key = next(iter(registry._registry_state.builtin_firewall_core_cache))
+        assert second_cache_key[0] == "cache-b"
 
     def test_inline_firewalls_do_not_share_compiled_core(self, tmp_path):
         path = tmp_path / "registry.json"


### PR DESCRIPTION
## Summary
- split compiled firewall data into reusable builtin cores plus per-VM raw API bindings
- cache builtin compiled cores in path-scoped registry state without sharing per-run API ids
- add registry tests for shared cores, baseUrlVars separation, path reset, invalid VM isolation, and inline firewall non-caching

## Tests
- python3 -m ruff check src tests
- python3 -m ruff format --check src tests
- python3 -m basedpyright
- python3 -m pytest tests/test_registry_context.py tests/test_registry_loading.py tests/test_request_handler_firewall_dispatch.py
- python3 -m pytest tests/

Closes #18083