### PR TITLE
fix: deduplicate xero firewall route owners

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/xero_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/xero_0.py
@@ -33,59 +33,26 @@ JSON_PART = r"""{
         {
           "name": "accounting.attachments",
           "rules": [
-            "GET /Accounts/{AccountID}/Attachments",
-            "GET /Accounts/{AccountID}/Attachments/{AttachmentID}",
-            "GET /Accounts/{AccountID}/Attachments/{FileName}",
             "POST /Accounts/{AccountID}/Attachments/{FileName}",
             "PUT /Accounts/{AccountID}/Attachments/{FileName}",
-            "GET /BankTransactions/{BankTransactionID}/Attachments",
-            "GET /BankTransactions/{BankTransactionID}/Attachments/{AttachmentID}",
-            "GET /BankTransactions/{BankTransactionID}/Attachments/{FileName}",
             "POST /BankTransactions/{BankTransactionID}/Attachments/{FileName}",
             "PUT /BankTransactions/{BankTransactionID}/Attachments/{FileName}",
-            "GET /BankTransfers/{BankTransferID}/Attachments",
-            "GET /BankTransfers/{BankTransferID}/Attachments/{AttachmentID}",
-            "GET /BankTransfers/{BankTransferID}/Attachments/{FileName}",
             "POST /BankTransfers/{BankTransferID}/Attachments/{FileName}",
             "PUT /BankTransfers/{BankTransferID}/Attachments/{FileName}",
-            "GET /Contacts/{ContactID}/Attachments",
-            "GET /Contacts/{ContactID}/Attachments/{AttachmentID}",
-            "GET /Contacts/{ContactID}/Attachments/{FileName}",
             "POST /Contacts/{ContactID}/Attachments/{FileName}",
             "PUT /Contacts/{ContactID}/Attachments/{FileName}",
-            "GET /CreditNotes/{CreditNoteID}/Attachments",
-            "GET /CreditNotes/{CreditNoteID}/Attachments/{AttachmentID}",
-            "GET /CreditNotes/{CreditNoteID}/Attachments/{FileName}",
             "POST /CreditNotes/{CreditNoteID}/Attachments/{FileName}",
             "PUT /CreditNotes/{CreditNoteID}/Attachments/{FileName}",
-            "GET /Invoices/{InvoiceID}/Attachments",
-            "GET /Invoices/{InvoiceID}/Attachments/{AttachmentID}",
-            "GET /Invoices/{InvoiceID}/Attachments/{FileName}",
             "POST /Invoices/{InvoiceID}/Attachments/{FileName}",
             "PUT /Invoices/{InvoiceID}/Attachments/{FileName}",
-            "GET /ManualJournals/{ManualJournalID}/Attachments",
-            "GET /ManualJournals/{ManualJournalID}/Attachments/{AttachmentID}",
-            "GET /ManualJournals/{ManualJournalID}/Attachments/{FileName}",
             "POST /ManualJournals/{ManualJournalID}/Attachments/{FileName}",
             "PUT /ManualJournals/{ManualJournalID}/Attachments/{FileName}",
-            "GET /PurchaseOrders/{PurchaseOrderID}/Attachments",
-            "GET /PurchaseOrders/{PurchaseOrderID}/Attachments/{AttachmentID}",
-            "GET /PurchaseOrders/{PurchaseOrderID}/Attachments/{FileName}",
             "POST /PurchaseOrders/{PurchaseOrderID}/Attachments/{FileName}",
             "PUT /PurchaseOrders/{PurchaseOrderID}/Attachments/{FileName}",
-            "GET /Quotes/{QuoteID}/Attachments",
-            "GET /Quotes/{QuoteID}/Attachments/{AttachmentID}",
-            "GET /Quotes/{QuoteID}/Attachments/{FileName}",
             "POST /Quotes/{QuoteID}/Attachments/{FileName}",
             "PUT /Quotes/{QuoteID}/Attachments/{FileName}",
-            "GET /Receipts/{ReceiptID}/Attachments",
-            "GET /Receipts/{ReceiptID}/Attachments/{AttachmentID}",
-            "GET /Receipts/{ReceiptID}/Attachments/{FileName}",
             "POST /Receipts/{ReceiptID}/Attachments/{FileName}",
             "PUT /Receipts/{ReceiptID}/Attachments/{FileName}",
-            "GET /RepeatingInvoices/{RepeatingInvoiceID}/Attachments",
-            "GET /RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{AttachmentID}",
-            "GET /RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{FileName}",
             "POST /RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{FileName}",
             "PUT /RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{FileName}"
           ]
@@ -138,21 +105,15 @@ JSON_PART = r"""{
         {
           "name": "accounting.contacts",
           "rules": [
-            "GET /ContactGroups",
             "PUT /ContactGroups",
-            "GET /ContactGroups/{ContactGroupID}",
             "POST /ContactGroups/{ContactGroupID}",
             "PUT /ContactGroups/{ContactGroupID}/Contacts",
             "DELETE /ContactGroups/{ContactGroupID}/Contacts",
             "DELETE /ContactGroups/{ContactGroupID}/Contacts/{ContactID}",
-            "GET /Contacts",
             "POST /Contacts",
             "PUT /Contacts",
-            "GET /Contacts/{ContactID}",
             "POST /Contacts/{ContactID}",
-            "GET /Contacts/{ContactID}/History",
-            "PUT /Contacts/{ContactID}/History",
-            "GET /Contacts/{ContactNumber}"
+            "PUT /Contacts/{ContactID}/History"
           ]
         },
         {
@@ -185,7 +146,6 @@ JSON_PART = r"""{
             "GET /Reports/BudgetSummary",
             "GET /Reports/ExecutiveSummary",
             "GET /Reports/ProfitAndLoss",
-            "GET /Reports/TenNinetyNine",
             "GET /Reports/TrialBalance",
             "GET /Reports/{ReportID}"
           ]
@@ -199,47 +159,26 @@ JSON_PART = r"""{
         {
           "name": "accounting.settings",
           "rules": [
-            "GET /Accounts",
             "PUT /Accounts",
-            "GET /Accounts/{AccountID}",
             "POST /Accounts/{AccountID}",
             "DELETE /Accounts/{AccountID}",
-            "GET /BrandingThemes",
-            "GET /BrandingThemes/{BrandingThemeID}",
-            "GET /Contacts/{ContactID}/CISSettings",
-            "GET /Currencies",
             "PUT /Currencies",
-            "GET /Employees",
             "POST /Employees",
             "PUT /Employees",
-            "GET /Employees/{EmployeeID}",
-            "GET /InvoiceReminders/Settings",
-            "GET /Items",
             "POST /Items",
             "PUT /Items",
-            "GET /Items/{ItemID}",
             "POST /Items/{ItemID}",
             "DELETE /Items/{ItemID}",
-            "GET /Items/{ItemID}/History",
             "PUT /Items/{ItemID}/History",
-            "GET /Organisation",
-            "GET /Organisation/Actions",
-            "GET /Organisation/{OrganisationID}/CISSettings",
             "POST /Setup",
-            "GET /TaxRates",
             "POST /TaxRates",
             "PUT /TaxRates",
-            "GET /TaxRates/{TaxType}",
-            "GET /TrackingCategories",
             "PUT /TrackingCategories",
-            "GET /TrackingCategories/{TrackingCategoryID}",
             "POST /TrackingCategories/{TrackingCategoryID}",
             "DELETE /TrackingCategories/{TrackingCategoryID}",
             "PUT /TrackingCategories/{TrackingCategoryID}/Options",
             "POST /TrackingCategories/{TrackingCategoryID}/Options/{TrackingOptionID}",
-            "DELETE /TrackingCategories/{TrackingCategoryID}/Options/{TrackingOptionID}",
-            "GET /Users",
-            "GET /Users/{UserID}"
+            "DELETE /TrackingCategories/{TrackingCategoryID}/Options/{TrackingOptionID}"
           ]
         },
         {
@@ -271,111 +210,61 @@ JSON_PART = r"""{
         {
           "name": "accounting.transactions",
           "rules": [
-            "GET /BankTransactions",
             "POST /BankTransactions",
             "PUT /BankTransactions",
-            "GET /BankTransactions/{BankTransactionID}",
             "POST /BankTransactions/{BankTransactionID}",
-            "GET /BankTransactions/{BankTransactionID}/History",
             "PUT /BankTransactions/{BankTransactionID}/History",
-            "GET /BankTransfers",
             "PUT /BankTransfers",
-            "GET /BankTransfers/{BankTransferID}",
-            "GET /BankTransfers/{BankTransferID}/History",
             "PUT /BankTransfers/{BankTransferID}/History",
-            "GET /BatchPayments",
             "POST /BatchPayments",
             "PUT /BatchPayments",
-            "GET /BatchPayments/{BatchPaymentID}",
             "POST /BatchPayments/{BatchPaymentID}",
-            "GET /BatchPayments/{BatchPaymentID}/History",
             "PUT /BatchPayments/{BatchPaymentID}/History",
-            "GET /CreditNotes",
             "POST /CreditNotes",
             "PUT /CreditNotes",
-            "GET /CreditNotes/{CreditNoteID}",
             "POST /CreditNotes/{CreditNoteID}",
             "PUT /CreditNotes/{CreditNoteID}/Allocations",
             "DELETE /CreditNotes/{CreditNoteID}/Allocations/{AllocationID}",
-            "GET /CreditNotes/{CreditNoteID}/History",
             "PUT /CreditNotes/{CreditNoteID}/History",
-            "GET /CreditNotes/{CreditNoteID}/pdf",
-            "GET /ExpenseClaims",
             "PUT /ExpenseClaims",
-            "GET /ExpenseClaims/{ExpenseClaimID}",
             "POST /ExpenseClaims/{ExpenseClaimID}",
-            "GET /ExpenseClaims/{ExpenseClaimID}/History",
             "PUT /ExpenseClaims/{ExpenseClaimID}/History",
-            "GET /Invoices",
             "POST /Invoices",
             "PUT /Invoices",
-            "GET /Invoices/{InvoiceID}",
             "POST /Invoices/{InvoiceID}",
             "POST /Invoices/{InvoiceID}/Email",
-            "GET /Invoices/{InvoiceID}/History",
             "PUT /Invoices/{InvoiceID}/History",
-            "GET /Invoices/{InvoiceID}/OnlineInvoice",
-            "GET /Invoices/{InvoiceID}/pdf",
-            "GET /LinkedTransactions",
             "PUT /LinkedTransactions",
-            "GET /LinkedTransactions/{LinkedTransactionID}",
             "POST /LinkedTransactions/{LinkedTransactionID}",
             "DELETE /LinkedTransactions/{LinkedTransactionID}",
-            "GET /ManualJournals",
             "POST /ManualJournals",
             "PUT /ManualJournals",
-            "GET /ManualJournals/{ManualJournalID}",
             "POST /ManualJournals/{ManualJournalID}",
-            "GET /ManualJournals/{ManualJournalID}/History",
             "PUT /ManualJournals/{ManualJournalID}/History",
-            "GET /Overpayments",
-            "GET /Overpayments/{OverpaymentID}",
             "PUT /Overpayments/{OverpaymentID}/Allocations",
             "DELETE /Overpayments/{OverpaymentID}/Allocations/{AllocationID}",
-            "GET /Overpayments/{OverpaymentID}/History",
             "PUT /Overpayments/{OverpaymentID}/History",
-            "GET /Payments",
             "POST /Payments",
             "PUT /Payments",
-            "GET /Payments/{PaymentID}",
             "POST /Payments/{PaymentID}",
-            "GET /Payments/{PaymentID}/History",
             "PUT /Payments/{PaymentID}/History",
-            "GET /Prepayments",
-            "GET /Prepayments/{PrepaymentID}",
             "PUT /Prepayments/{PrepaymentID}/Allocations",
             "DELETE /Prepayments/{PrepaymentID}/Allocations/{AllocationID}",
-            "GET /Prepayments/{PrepaymentID}/History",
             "PUT /Prepayments/{PrepaymentID}/History",
-            "GET /PurchaseOrders",
             "POST /PurchaseOrders",
             "PUT /PurchaseOrders",
-            "GET /PurchaseOrders/{PurchaseOrderID}",
             "POST /PurchaseOrders/{PurchaseOrderID}",
-            "GET /PurchaseOrders/{PurchaseOrderID}/History",
             "PUT /PurchaseOrders/{PurchaseOrderID}/History",
-            "GET /PurchaseOrders/{PurchaseOrderID}/pdf",
-            "GET /PurchaseOrders/{PurchaseOrderNumber}",
-            "GET /Quotes",
             "POST /Quotes",
             "PUT /Quotes",
-            "GET /Quotes/{QuoteID}",
             "POST /Quotes/{QuoteID}",
-            "GET /Quotes/{QuoteID}/History",
             "PUT /Quotes/{QuoteID}/History",
-            "GET /Quotes/{QuoteID}/pdf",
-            "GET /Receipts",
             "PUT /Receipts",
-            "GET /Receipts/{ReceiptID}",
             "POST /Receipts/{ReceiptID}",
-            "GET /Receipts/{ReceiptID}/History",
             "PUT /Receipts/{ReceiptID}/History",
-            "GET /RepeatingInvoices",
             "POST /RepeatingInvoices",
             "PUT /RepeatingInvoices",
-            "GET /RepeatingInvoices/{RepeatingInvoiceID}",
             "POST /RepeatingInvoices/{RepeatingInvoiceID}",
-            "GET /RepeatingInvoices/{RepeatingInvoiceID}/History",
             "PUT /RepeatingInvoices/{RepeatingInvoiceID}/History"
           ]
         },
@@ -475,12 +364,8 @@ JSON_PART = r"""{
         {
           "name": "assets",
           "rules": [
-            "GET /AssetTypes",
             "POST /AssetTypes",
-            "GET /Assets",
-            "POST /Assets",
-            "GET /Assets/{id}",
-            "GET /Settings"
+            "POST /Assets"
           ]
         },
         {
@@ -527,24 +412,15 @@ JSON_PART = r"""{
         {
           "name": "files",
           "rules": [
-            "GET /Associations/Count",
-            "GET /Associations/{ObjectId}",
-            "GET /Files",
             "POST /Files",
-            "GET /Files/{FileId}",
             "PUT /Files/{FileId}",
             "DELETE /Files/{FileId}",
-            "GET /Files/{FileId}/Associations",
             "POST /Files/{FileId}/Associations",
             "DELETE /Files/{FileId}/Associations/{ObjectId}",
-            "GET /Files/{FileId}/Content",
             "POST /Files/{FolderId}",
-            "GET /Folders",
             "POST /Folders",
-            "GET /Folders/{FolderId}",
             "PUT /Folders/{FolderId}",
-            "DELETE /Folders/{FolderId}",
-            "GET /Inbox"
+            "DELETE /Folders/{FolderId}"
           ]
         },
         {
@@ -607,14 +483,9 @@ JSON_PART = r"""{
         {
           "name": "payroll.employees",
           "rules": [
-            "GET /Employees",
             "POST /Employees",
-            "GET /Employees/{EmployeeID}",
             "POST /Employees/{EmployeeID}",
-            "GET /LeaveApplications",
             "POST /LeaveApplications",
-            "GET /LeaveApplications/v2",
-            "GET /LeaveApplications/{LeaveApplicationID}",
             "POST /LeaveApplications/{LeaveApplicationID}",
             "POST /LeaveApplications/{LeaveApplicationID}/approve",
             "POST /LeaveApplications/{LeaveApplicationID}/reject"
@@ -633,9 +504,7 @@ JSON_PART = r"""{
         {
           "name": "payroll.payruns",
           "rules": [
-            "GET /PayRuns",
             "POST /PayRuns",
-            "GET /PayRuns/{PayRunID}",
             "POST /PayRuns/{PayRunID}"
           ]
         },
@@ -649,7 +518,6 @@ JSON_PART = r"""{
         {
           "name": "payroll.payslip",
           "rules": [
-            "GET /Payslip/{PayslipID}",
             "POST /Payslip/{PayslipID}"
           ]
         },
@@ -662,16 +530,9 @@ JSON_PART = r"""{
         {
           "name": "payroll.settings",
           "rules": [
-            "GET /PayItems",
             "POST /PayItems",
-            "GET /PayrollCalendars",
             "POST /PayrollCalendars",
-            "GET /PayrollCalendars/{PayrollCalendarID}",
-            "GET /Settings",
-            "GET /SuperfundProducts",
-            "GET /Superfunds",
             "POST /Superfunds",
-            "GET /Superfunds/{SuperFundID}",
             "POST /Superfunds/{SuperFundID}"
           ]
         },
@@ -690,9 +551,7 @@ JSON_PART = r"""{
         {
           "name": "payroll.timesheets",
           "rules": [
-            "GET /Timesheets",
             "POST /Timesheets",
-            "GET /Timesheets/{TimesheetID}",
             "POST /Timesheets/{TimesheetID}"
           ]
         },
@@ -716,47 +575,30 @@ JSON_PART = r"""{
         {
           "name": "payroll.employees",
           "rules": [
-            "GET /Employees",
             "POST /Employees",
-            "GET /Employees/{EmployeeID}",
             "PUT /Employees/{EmployeeID}",
             "POST /Employees/{EmployeeID}/Employment",
-            "GET /Employees/{EmployeeID}/Leave",
             "POST /Employees/{EmployeeID}/Leave",
-            "GET /Employees/{EmployeeID}/Leave/{LeaveID}",
             "PUT /Employees/{EmployeeID}/Leave/{LeaveID}",
             "DELETE /Employees/{EmployeeID}/Leave/{LeaveID}",
-            "GET /Employees/{EmployeeID}/LeaveBalances",
-            "GET /Employees/{EmployeeID}/LeavePeriods",
             "POST /Employees/{EmployeeID}/LeaveSetup",
-            "GET /Employees/{EmployeeID}/LeaveTypes",
             "POST /Employees/{EmployeeID}/LeaveTypes",
-            "GET /Employees/{EmployeeID}/OpeningBalances",
             "POST /Employees/{EmployeeID}/OpeningBalances",
             "POST /Employees/{EmployeeID}/PayTemplateEarnings",
-            "GET /Employees/{EmployeeID}/PayTemplates",
             "POST /Employees/{EmployeeID}/PayTemplates/Earnings",
             "PUT /Employees/{EmployeeID}/PayTemplates/Earnings/{PayTemplateEarningID}",
             "DELETE /Employees/{EmployeeID}/PayTemplates/Earnings/{PayTemplateEarningID}",
             "POST /Employees/{EmployeeID}/PayTemplates/earnings",
             "PUT /Employees/{EmployeeID}/PayTemplates/earnings/{PayTemplateEarningID}",
             "DELETE /Employees/{EmployeeID}/PayTemplates/earnings/{PayTemplateEarningID}",
-            "GET /Employees/{EmployeeID}/PaymentMethods",
             "POST /Employees/{EmployeeID}/PaymentMethods",
-            "GET /Employees/{EmployeeID}/SalaryAndWages",
             "POST /Employees/{EmployeeID}/SalaryAndWages",
-            "GET /Employees/{EmployeeID}/SalaryAndWages/{SalaryAndWagesID}",
             "PUT /Employees/{EmployeeID}/SalaryAndWages/{SalaryAndWagesID}",
             "DELETE /Employees/{EmployeeID}/SalaryAndWages/{SalaryAndWagesID}",
-            "GET /Employees/{EmployeeID}/StatutoryLeaveBalance",
-            "GET /Employees/{EmployeeID}/Tax",
             "POST /Employees/{EmployeeID}/Tax",
-            "GET /Employees/{EmployeeID}/Working-Patterns",
             "POST /Employees/{EmployeeID}/Working-Patterns",
-            "GET /Employees/{EmployeeID}/Working-Patterns/{EmployeeWorkingPatternID}",
             "DELETE /Employees/{EmployeeID}/Working-Patterns/{EmployeeWorkingPatternID}",
             "POST /Employees/{EmployeeID}/paytemplateearnings",
-            "GET /Employees/{EmployeeID}/ukopeningbalances",
             "POST /Employees/{EmployeeID}/ukopeningbalances",
             "PUT /Employees/{EmployeeID}/ukopeningbalances"
           ]
@@ -786,9 +628,7 @@ JSON_PART = r"""{
         {
           "name": "payroll.payruns",
           "rules": [
-            "GET /PayRuns",
-            "POST /PayRuns",
-            "GET /PayRuns/{PayRunID}"
+            "POST /PayRuns"
           ]
         },
         {
@@ -801,11 +641,7 @@ JSON_PART = r"""{
         {
           "name": "payroll.payslip",
           "rules": [
-            "GET /PaySlips",
-            "GET /PaySlips/{PaySlipID}",
-            "PUT /PaySlips/{PaySlipID}",
-            "GET /Payslips",
-            "GET /Payslips/{PayslipID}"
+            "PUT /PaySlips/{PaySlipID}"
           ]
         },
         {
@@ -820,38 +656,14 @@ JSON_PART = r"""{
         {
           "name": "payroll.settings",
           "rules": [
-            "GET /Benefits",
             "POST /Benefits",
-            "GET /Benefits/{id}",
-            "GET /Deductions",
             "POST /Deductions",
-            "GET /Deductions/{deductionId}",
-            "GET /EarningsOrders",
-            "GET /EarningsOrders/{id}",
-            "GET /EarningsRates",
             "POST /EarningsRates",
-            "GET /EarningsRates/{EarningsRateID}",
-            "GET /LeaveTypes",
             "POST /LeaveTypes",
-            "GET /LeaveTypes/{LeaveTypeID}",
-            "GET /PayRunCalendars",
             "POST /PayRunCalendars",
-            "GET /PayRunCalendars/{PayRunCalendarID}",
-            "GET /PayRunCalendars/{PayrollCalendarID}",
-            "GET /Reimbursements",
             "POST /Reimbursements",
-            "GET /Reimbursements/{ReimbursementID}",
-            "GET /Settings",
-            "GET /Settings/TrackingCategories",
-            "GET /Settings/trackingCategories",
-            "GET /StatutoryDeductions",
-            "GET /StatutoryDeductions/{id}",
             "POST /StatutoryLeaves/Sick",
-            "GET /StatutoryLeaves/Sick/{StatutorySickLeaveID}",
-            "GET /StatutoryLeaves/Summary/{EmployeeID}",
-            "GET /Superannuations",
-            "POST /Superannuations",
-            "GET /Superannuations/{SuperannuationID}"
+            "POST /Superannuations"
           ]
         },
         {
@@ -886,9 +698,7 @@ JSON_PART = r"""{
         {
           "name": "payroll.timesheets",
           "rules": [
-            "GET /Timesheets",
             "POST /Timesheets",
-            "GET /Timesheets/{TimesheetID}",
             "DELETE /Timesheets/{TimesheetID}",
             "POST /Timesheets/{TimesheetID}/Approve",
             "POST /Timesheets/{TimesheetID}/Lines",
@@ -917,22 +727,15 @@ JSON_PART = r"""{
         {
           "name": "projects",
           "rules": [
-            "GET /Projects",
             "POST /Projects",
-            "GET /Projects/{projectId}",
             "PUT /Projects/{projectId}",
             "PATCH /Projects/{projectId}",
-            "GET /Projects/{projectId}/Tasks",
             "POST /Projects/{projectId}/Tasks",
-            "GET /Projects/{projectId}/Tasks/{taskId}",
             "PUT /Projects/{projectId}/Tasks/{taskId}",
             "DELETE /Projects/{projectId}/Tasks/{taskId}",
-            "GET /Projects/{projectId}/Time",
             "POST /Projects/{projectId}/Time",
-            "GET /Projects/{projectId}/Time/{timeEntryId}",
             "PUT /Projects/{projectId}/Time/{timeEntryId}",
-            "DELETE /Projects/{projectId}/Time/{timeEntryId}",
-            "GET /ProjectsUsers"
+            "DELETE /Projects/{projectId}/Time/{timeEntryId}"
           ]
         },
         {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -940,7 +940,7 @@ describe("zero doctor check-connector command", () => {
       );
       expect(output).toContain("Relative path:    /Accounts");
       expect(output).toContain(
-        "Matched permissions: [accounting.settings, accounting.settings.read]",
+        "Matched permissions: [accounting.settings.read]",
       );
       expect(output).not.toContain("Matched permissions: [connections");
     });

--- a/turbo/packages/connectors/src/__tests__/firewalls/xero.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/xero.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { findMatchingPermissions } from "../../firewall-rule-matcher";
+import { getConnectorFirewall } from "../../firewalls";
+
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+function xeroMatches(apiBase: string, method: string, path: string): string[] {
+  return findMatchingPermissions(method, path, getConnectorFirewall("xero"), {
+    apiBase,
+  });
+}
+
+function expectXeroMatches(
+  apiBase: string,
+  method: string,
+  path: string,
+  permissionNames: readonly string[],
+): void {
+  expect([...xeroMatches(apiBase, method, path)].sort()).toStrictEqual(
+    [...permissionNames].sort(),
+  );
+}
+
+function expandRuntimeRules(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+describe("xero firewall", () => {
+  it("assigns one permission owner to every runtime route", () => {
+    const duplicates: string[] = [];
+    for (const api of getConnectorFirewall("xero").apis) {
+      const owners = new Map<string, string>();
+      for (const permission of api.permissions ?? []) {
+        for (const rule of permission.rules) {
+          for (const runtimeRule of expandRuntimeRules(rule)) {
+            const key = `${api.base} ${runtimeRule}`;
+            const existing = owners.get(key);
+            if (existing) {
+              duplicates.push(`${key}: ${existing}, ${permission.name}`);
+              continue;
+            }
+            owners.set(key, permission.name);
+          }
+        }
+      }
+    }
+
+    expect(duplicates).toStrictEqual([]);
+  });
+
+  it("maps accounting read routes to read permissions", () => {
+    const accountingBase = "https://api.xero.com/api.xro/2.0";
+
+    expectXeroMatches(accountingBase, "GET", "/Accounts", [
+      "accounting.settings.read",
+    ]);
+    expectXeroMatches(
+      accountingBase,
+      "GET",
+      "/Accounts/account-id/Attachments",
+      ["accounting.attachments.read"],
+    );
+    expectXeroMatches(accountingBase, "GET", "/Reports/TenNinetyNine", [
+      "accounting.reports.tenninetynine.read",
+    ]);
+  });
+
+  it("maps mutating routes to write-capable permissions", () => {
+    const accountingBase = "https://api.xero.com/api.xro/2.0";
+
+    expectXeroMatches(accountingBase, "PUT", "/Accounts", [
+      "accounting.settings",
+    ]);
+    expectXeroMatches(
+      accountingBase,
+      "PUT",
+      "/Accounts/account-id/Attachments/file.pdf",
+      ["accounting.attachments"],
+    );
+  });
+
+  it("maps Files API read and mutating routes separately", () => {
+    const filesBase = "https://api.xero.com/files.xro/1.0";
+
+    expectXeroMatches(filesBase, "GET", "/Files", ["files.read"]);
+    expectXeroMatches(filesBase, "POST", "/Files", ["files"]);
+  });
+});

--- a/turbo/packages/firewalls-generator/src/__tests__/xero.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/xero.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { pickPrimaryXeroScope } from "../xero";
+
+describe("pickPrimaryXeroScope", () => {
+  it("uses read scopes as owners for read endpoints", () => {
+    expect(
+      pickPrimaryXeroScope(
+        ["accounting.settings", "accounting.settings.read"],
+        "GET /Accounts",
+      ),
+    ).toBe("accounting.settings.read");
+  });
+
+  it("uses non-read scopes as owners for mutating endpoints", () => {
+    expect(
+      pickPrimaryXeroScope(
+        ["accounting.settings", "accounting.settings.read"],
+        "PUT /Accounts",
+      ),
+    ).toBe("accounting.settings");
+  });
+
+  it("uses the most granular read scope when official scopes overlap", () => {
+    expect(
+      pickPrimaryXeroScope(
+        ["accounting.reports.read", "accounting.reports.tenninetynine.read"],
+        "GET /Reports/TenNinetyNine",
+      ),
+    ).toBe("accounting.reports.tenninetynine.read");
+  });
+
+  it("uses granular non-read scopes over legacy broad scopes", () => {
+    expect(
+      pickPrimaryXeroScope(
+        ["accounting.transactions", "accounting.invoices"],
+        "POST /Invoices",
+      ),
+    ).toBe("accounting.invoices");
+  });
+
+  it("throws when same-priority scopes need an explicit owner", () => {
+    expect(() => {
+      pickPrimaryXeroScope(
+        ["accounting.invoices", "accounting.payments"],
+        "POST /Payments",
+      );
+    }).toThrow("Ambiguous Xero scope owner");
+  });
+});

--- a/turbo/packages/firewalls-generator/src/xero.ts
+++ b/turbo/packages/firewalls-generator/src/xero.ts
@@ -76,6 +76,36 @@ interface NarrowedRule {
   readonly rule: string;
 }
 
+const READ_METHODS = new Set(["GET", "HEAD"]);
+
+const LEGACY_BROAD_SCOPES = new Set([
+  "accounting.attachments",
+  "accounting.attachments.read",
+  "accounting.contacts",
+  "accounting.contacts.read",
+  "accounting.reports.read",
+  "accounting.settings",
+  "accounting.settings.read",
+  "accounting.transactions",
+  "accounting.transactions.read",
+  "assets",
+  "assets.read",
+  "files",
+  "files.read",
+  "payroll.employees",
+  "payroll.employees.read",
+  "payroll.payruns",
+  "payroll.payruns.read",
+  "payroll.payslip",
+  "payroll.payslip.read",
+  "payroll.settings",
+  "payroll.settings.read",
+  "payroll.timesheets",
+  "payroll.timesheets.read",
+  "projects",
+  "projects.read",
+]);
+
 const INCLUDED_SCOPELESS = new Map<string, IncludedScopelessEndpoint>([
   // Identity endpoints use openid scopes (not OAuth2) but still need
   // Bearer token auth. Required to retrieve tenant IDs before any
@@ -117,9 +147,105 @@ function narrowRuleToBasePath(
 
 // ── Grouping ─────────────────────────────────────────────────────────────
 
+interface XeroScopePriority {
+  readonly isGranular: boolean;
+  readonly segmentCount: number;
+}
+
 interface ParsedSpec {
   baseUrl: string;
   paths: Record<string, Record<string, XeroOperation>>;
+}
+
+function isReadScope(scope: string): boolean {
+  return scope.endsWith(".read");
+}
+
+function methodFromRule(rule: string): string {
+  const spaceIndex = rule.indexOf(" ");
+  if (spaceIndex === -1) {
+    throw new Error(`Malformed Xero rule: ${rule}`);
+  }
+  return rule.slice(0, spaceIndex);
+}
+
+function xeroScopePriority(scope: string): XeroScopePriority {
+  return {
+    isGranular: !LEGACY_BROAD_SCOPES.has(scope),
+    segmentCount: scope.split(".").length,
+  };
+}
+
+function compareXeroScopePriority(
+  left: XeroScopePriority,
+  right: XeroScopePriority,
+): number {
+  if (left.isGranular !== right.isGranular) {
+    return left.isGranular ? 1 : -1;
+  }
+  return left.segmentCount - right.segmentCount;
+}
+
+function pickMostSpecificScope(
+  scopes: readonly string[],
+  rule: string,
+): string {
+  const ranked = scopes
+    .map((scope) => {
+      return { scope, priority: xeroScopePriority(scope) };
+    })
+    .sort((left, right) => {
+      const priorityDifference = compareXeroScopePriority(
+        right.priority,
+        left.priority,
+      );
+      if (priorityDifference !== 0) return priorityDifference;
+      return left.scope.localeCompare(right.scope);
+    });
+
+  const first = ranked[0];
+  if (!first) {
+    throw new Error(`No Xero scopes available for ${rule}`);
+  }
+
+  const second = ranked[1];
+  if (
+    second &&
+    compareXeroScopePriority(first.priority, second.priority) === 0
+  ) {
+    throw new Error(
+      `Ambiguous Xero scope owner for ${rule}: ${scopes.join(", ")}`,
+    );
+  }
+
+  return first.scope;
+}
+
+export function pickPrimaryXeroScope(
+  scopes: readonly string[],
+  rule: string,
+): string {
+  const uniqueScopes = [...new Set(scopes)];
+  if (uniqueScopes.length === 0) {
+    throw new Error(`No Xero scopes available for ${rule}`);
+  }
+  if (uniqueScopes.length === 1) {
+    return uniqueScopes[0]!;
+  }
+
+  const method = methodFromRule(rule);
+  const readScopes = uniqueScopes.filter(isReadScope);
+  const nonReadScopes = uniqueScopes.filter((scope) => {
+    return !isReadScope(scope);
+  });
+  const candidates =
+    READ_METHODS.has(method) && readScopes.length > 0
+      ? readScopes
+      : nonReadScopes.length > 0
+        ? nonReadScopes
+        : readScopes;
+
+  return pickMostSpecificScope(candidates, rule);
 }
 
 function addRule(
@@ -139,6 +265,41 @@ function addRule(
     baseMap.set(baseUrl, ruleSet);
   }
   ruleSet.add(rule);
+}
+
+function assertUniqueHostRules(
+  hostGroups: Map<string, PermissionGroup[]>,
+): void {
+  const duplicates: string[] = [];
+  for (const [baseUrl, permissions] of hostGroups) {
+    const owners = new Map<string, string>();
+    for (const permission of permissions) {
+      for (const rule of permission.rules) {
+        const existing = owners.get(rule);
+        if (existing) {
+          duplicates.push(
+            `${baseUrl} ${rule}: ${existing}, ${permission.name}`,
+          );
+          continue;
+        }
+        owners.set(rule, permission.name);
+      }
+    }
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      "Xero generated duplicate firewall route owners:\n" +
+        duplicates
+          .sort((a, b) => {
+            return a.localeCompare(b);
+          })
+          .map((duplicate) => {
+            return `  - ${duplicate}`;
+          })
+          .join("\n"),
+    );
+  }
 }
 
 function buildGroups(specs: ParsedSpec[]): {
@@ -190,12 +351,8 @@ function buildGroups(specs: ParsedSpec[]): {
           continue;
         }
 
-        // Add the rule under every listed scope. Xero lists both write
-        // and read-only scopes for read endpoints (OR semantics), so the
-        // rule must appear in both groups.
-        for (const scope of scopes) {
-          addRule(groups, scope, spec.baseUrl, rule);
-        }
+        const primaryScope = pickPrimaryXeroScope(scopes, rule);
+        addRule(groups, primaryScope, spec.baseUrl, rule);
       }
     }
   }
@@ -230,6 +387,8 @@ function buildGroups(specs: ParsedSpec[]): {
       hostGroups.set(baseUrl, permissions);
     }
   }
+
+  assertUniqueHostRules(hostGroups);
 
   return { hostGroups, scopeless: unknownScopeless };
 }


### PR DESCRIPTION
## Summary

- Assign each generated Xero route to one primary firewall permission instead of emitting the same route under every official OAuth scope.
- Use read scopes for read methods and write-capable scopes for mutating methods, with granular Xero scopes preferred over legacy broad scopes.
- Add generator/runtime regression tests and regenerate the Python built-in firewall catalog.

Closes #18594

## Tests

- pnpm format
- pnpm -F @vm0/firewalls-generator check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm --dir packages/connectors exec oxlint /workspaces/vm9/turbo/packages/firewalls-generator/src/xero.ts /workspaces/vm9/turbo/packages/firewalls-generator/src/__tests__/xero.test.ts
- pnpm -F @vm0/firewalls-generator exec vitest src/__tests__/xero.test.ts
- pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-rule-validation.test.ts src/__tests__/firewalls/xero.test.ts
- pnpm knip --workspace @vm0/firewalls-generator --workspace @vm0/connectors
- pnpm -F @vm0/firewalls-generator generate:xero
- pnpm -F @vm0/api-contracts generate:rust
- .venv/bin/python -m pytest tests/test_builtin_firewalls_catalog.py
- pre-commit: pnpm knip --cache
- pre-commit: pnpm check-types
