### PR TITLE
perf(runner): coalesce network log batch writes

### DIFF
--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -680,6 +680,51 @@ mod tests {
 
     use super::*;
 
+    #[derive(Default)]
+    struct FragmentedWriter {
+        bytes: Vec<u8>,
+        max_chunk: usize,
+        interrupt_once: bool,
+        zero_once: bool,
+    }
+
+    impl Write for FragmentedWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.write_vectored(&[IoSlice::new(buf)])
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+            if self.interrupt_once {
+                self.interrupt_once = false;
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            if self.zero_once {
+                self.zero_once = false;
+                return Ok(0);
+            }
+
+            let mut remaining = self.max_chunk;
+            let mut written = 0;
+            for buf in bufs {
+                if remaining == 0 {
+                    break;
+                }
+                let chunk_len = buf.len().min(remaining);
+                self.bytes.extend_from_slice(&buf[..chunk_len]);
+                written += chunk_len;
+                remaining -= chunk_len;
+                if chunk_len < buf.len() {
+                    break;
+                }
+            }
+            Ok(written)
+        }
+    }
+
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
@@ -740,6 +785,39 @@ mod tests {
         assert_eq!(lines[0]["host"], "example.com");
         assert_eq!(lines[0]["port"], 53);
         assert_eq!(mode(&path), 0o600);
+    }
+
+    #[test]
+    fn write_lines_vectored_completes_partial_and_interrupted_writes() {
+        let lines = vec![
+            "first\n".to_string(),
+            "second\n".to_string(),
+            "third\n".to_string(),
+        ];
+        let mut writer = FragmentedWriter {
+            max_chunk: 3,
+            interrupt_once: true,
+            ..Default::default()
+        };
+
+        write_lines_vectored(&mut writer, &lines).unwrap();
+
+        assert_eq!(writer.bytes, b"first\nsecond\nthird\n");
+    }
+
+    #[test]
+    fn write_lines_vectored_returns_write_zero() {
+        let lines = vec!["first\n".to_string(), "second\n".to_string()];
+        let mut writer = FragmentedWriter {
+            max_chunk: 3,
+            zero_once: true,
+            ..Default::default()
+        };
+
+        let error = write_lines_vectored(&mut writer, &lines).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::WriteZero);
+        assert!(writer.bytes.is_empty());
     }
 
     #[tokio::test]

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::io::Write;
+use std::io::{self, IoSlice, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Weak};
 
@@ -629,11 +629,39 @@ async fn write_path_batch(
     }
 }
 
-fn append_lines(path: &Path, lines: &[String]) -> std::io::Result<()> {
+fn append_lines(path: &Path, lines: &[String]) -> io::Result<()> {
     let mut file = crate::log_file::open_append(path, false)?;
-    for line in lines {
-        file.write_all(line.as_bytes())?;
+
+    match lines {
+        [] => Ok(()),
+        [line] => file.write_all(line.as_bytes()),
+        _ => write_lines_vectored(&mut file, lines),
     }
+}
+
+fn write_lines_vectored(writer: &mut impl Write, lines: &[String]) -> io::Result<()> {
+    let mut bufs: Vec<IoSlice<'_>> = lines
+        .iter()
+        .map(|line| IoSlice::new(line.as_bytes()))
+        .collect();
+    let mut bufs = &mut bufs[..];
+
+    while !bufs.is_empty() {
+        let written = match writer.write_vectored(bufs) {
+            Ok(written) => written,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "failed to write network log batch",
+            ));
+        }
+
+        IoSlice::advance_slices(&mut bufs, written);
+    }
+
     Ok(())
 }
 

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -642,7 +642,9 @@ fn append_lines(path: &Path, lines: &[String]) -> io::Result<()> {
 fn write_lines_vectored(writer: &mut impl Write, lines: &[String]) -> io::Result<()> {
     let mut bufs: Vec<IoSlice<'_>> = lines
         .iter()
-        .map(|line| IoSlice::new(line.as_bytes()))
+        .map(String::as_bytes)
+        .filter(|bytes| !bytes.is_empty())
+        .map(IoSlice::new)
         .collect();
     let mut bufs = &mut bufs[..];
 
@@ -818,6 +820,21 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::WriteZero);
         assert!(writer.bytes.is_empty());
+    }
+
+    #[test]
+    fn write_lines_vectored_accepts_empty_lines() {
+        let lines = vec!["".to_string(), "".to_string()];
+        let mut writer = FragmentedWriter {
+            max_chunk: 3,
+            zero_once: true,
+            ..Default::default()
+        };
+
+        write_lines_vectored(&mut writer, &lines).unwrap();
+
+        assert!(writer.bytes.is_empty());
+        assert!(writer.zero_once);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- coalesce multi-line Rust network log path batches with vectored writes
- keep the existing open_append safety validation and single-line write path
- preserve queue, pending-count, flush, and upload semantics

Closes #18581

## Tests

- cargo test --manifest-path crates/Cargo.toml -p runner network_log_manager
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p runner -- -D warnings
- git diff --check