### PR TITLE
test(runner): assert all encoded secret values

### DIFF
--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -810,23 +810,32 @@ fn build_env_json_empty_artifacts_emits_no_env_var() {
 #[test]
 fn build_env_json_with_secrets() {
     let mut ctx = minimal_context();
-    ctx.secret_values = Some(vec!["secret1".into(), "secret2".into()]);
+    // Raw delimiters in secret values must survive base64 transport.
+    ctx.secret_values = Some(vec!["secret1".into(), "secret,with\nnewline".into()]);
 
     let env = build_env_for_test(&ctx, "http://localhost");
     let val = env.get("VM0_SECRET_VALUES").unwrap();
 
     use base64::Engine as _;
     let parts: Vec<&str> = val.split(',').collect();
-    // sandbox_token ("tok") + secret1 + secret2
     assert_eq!(parts.len(), 3);
-    let decoded0 = base64::engine::general_purpose::STANDARD
-        .decode(parts[0])
-        .unwrap();
-    assert_eq!(decoded0, b"tok");
-    let decoded1 = base64::engine::general_purpose::STANDARD
-        .decode(parts[1])
-        .unwrap();
-    assert_eq!(decoded1, b"secret1");
+    let decoded: Vec<String> = parts
+        .iter()
+        .map(|part| {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(part)
+                .unwrap();
+            String::from_utf8(bytes).unwrap()
+        })
+        .collect();
+    assert_eq!(
+        decoded,
+        vec![
+            "tok".to_string(),
+            "secret1".to_string(),
+            "secret,with\nnewline".to_string(),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- decode every `VM0_SECRET_VALUES` entry in the runner env test
- assert the full ordered payload: sandbox token followed by all user secret values
- include a comma/newline secret fixture to document that raw delimiters survive base64 transport

Closes #18615

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner build_env_json_with_secrets`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`, `commitlint`
