### PR TITLE
perf: avoid active input validation allocation

### DIFF
--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use crate::ids::RunId;
@@ -27,10 +28,35 @@ impl<'a> ActiveInputPayload<'a> {
     }
 }
 
+#[derive(Default)]
+struct CountingWriter {
+    len: usize,
+}
+
+impl CountingWriter {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.len = self
+            .len
+            .checked_add(buf.len())
+            .ok_or_else(|| io::Error::other("serialized active-input payload length overflow"))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 pub(crate) fn active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {
-    ActiveInputPayload::new(text)
-        .to_vec()
-        .map(|payload| payload.len())
+    let mut counter = CountingWriter::default();
+    serde_json::to_writer(&mut counter, &ActiveInputPayload::new(text))?;
+    Ok(counter.len())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -56,6 +82,27 @@ impl ActiveInputSource {
         match self {
             Self::LocalQueue(source) => LocalQueue::new(source.group_dir.clone())
                 .read_active_input_entries_from_sequence_sync(source.run_id, min_sequence),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_input_payload_len_matches_serialized_payload_len() {
+        let texts = [
+            "plain ascii".to_string(),
+            "quotes \" backslash \\ newline \n tab \t carriage \r".to_string(),
+            "unicode café 你好 🚀".to_string(),
+            "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - 128),
+        ];
+
+        for text in texts {
+            let counted = active_input_payload_len(&text).unwrap();
+            let serialized = ActiveInputPayload::new(&text).to_vec().unwrap();
+            assert_eq!(counted, serialized.len(), "text len={}", text.len());
         }
     }
 }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -1310,6 +1310,27 @@ mod tests {
     }
 
     #[test]
+    fn accepts_active_input_payload_at_serialized_limit() {
+        let job_id = RunId::nil();
+        let payload_overhead = active_input_payload_len("").unwrap();
+        let exact_limit_text =
+            "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - payload_overhead);
+
+        let parsed = SubmitPlan::parse_active_inputs(
+            &[format!("after=1s,text={exact_limit_text}")],
+            Duration::from_secs(5),
+            job_id,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(
+            active_input_payload_len(&parsed[0].text).unwrap(),
+            ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES
+        );
+    }
+
+    #[test]
     fn rejects_active_input_for_non_claude_agent() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -655,8 +655,8 @@ impl SubmitPlan {
         Ok(())
     }
 
-    fn start_active_input_producer(&self) -> Option<ActiveInputProducer> {
-        ActiveInputProducer::start(self.queue.clone(), self.active_inputs.clone())
+    fn start_active_input_producer(&mut self) -> Option<ActiveInputProducer> {
+        ActiveInputProducer::start(self.queue.clone(), std::mem::take(&mut self.active_inputs))
     }
 
     async fn wait_for_result(&self) -> RunnerResult<SubmitOutcome> {
@@ -740,7 +740,7 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
 }
 
 async fn run_submit_with_home(args: SubmitArgs, home: HomePaths) -> RunnerResult<ExitCode> {
-    let plan = SubmitPlan::from_args(args, home)?;
+    let mut plan = SubmitPlan::from_args(args, home)?;
     plan.write_job_file()?;
     let producer = plan.start_active_input_producer();
     let outcome = plan.wait_for_result().await;


### PR DESCRIPTION
## Summary

- count serialized active-input payload bytes with a `std::io::Write` sink instead of allocating a validation-only `Vec<u8>`
- move local submit active inputs into the producer task instead of cloning large text values
- add serializer parity coverage for ASCII, escaped, Unicode, and large active-input text

Fixes #18612

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner active_input`
- `cargo test --manifest-path crates/Cargo.toml -p runner active_inputs_are_written_after_job_publication_and_cleaned_on_completion`
- `cargo test --manifest-path crates/Cargo.toml -p runner rejects_invalid_active_input_specs`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
