### PR TITLE
perf(runner): reduce procfs stat parsing overhead

### DIFF
--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -1020,6 +1020,7 @@ mod tests {
     fn process_stat(identity: &FirecrackerProcessIdentity) -> ProcessStat {
         ProcessStat {
             state: 'S',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime,
         }
@@ -1391,6 +1392,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'S',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime + 1,
         };
@@ -1410,6 +1412,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'S',
+            ppid: 7,
             pgid: identity.pgid + 1,
             starttime: identity.starttime,
         };
@@ -1430,16 +1433,25 @@ mod tests {
         let matching = process_stat(identity);
         let changed_starttime = ProcessStat {
             state: 'S',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime + 1,
         };
         let changed_pgid = ProcessStat {
             state: 'S',
+            ppid: 7,
             pgid: identity.pgid + 1,
+            starttime: identity.starttime,
+        };
+        let changed_ppid = ProcessStat {
+            state: 'S',
+            ppid: 9,
+            pgid: identity.pgid,
             starttime: identity.starttime,
         };
 
         assert!(process_stat_matches_identity(identity, &matching));
+        assert!(process_stat_matches_identity(identity, &changed_ppid));
         assert!(!process_stat_matches_identity(identity, &changed_starttime));
         assert!(!process_stat_matches_identity(identity, &changed_pgid));
     }
@@ -1491,6 +1503,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let zombie = ProcessStat {
             state: 'Z',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime,
         };
@@ -1505,6 +1518,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let dead = ProcessStat {
             state: 'X',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime,
         };
@@ -1527,6 +1541,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'Z',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime,
         };
@@ -1540,6 +1555,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'x',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime,
         };
@@ -1553,6 +1569,7 @@ mod tests {
         let identity = target.identity.as_ref().unwrap();
         let stat = ProcessStat {
             state: 'S',
+            ppid: 7,
             pgid: identity.pgid,
             starttime: identity.starttime + 1,
         };

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -198,7 +198,7 @@ async fn unresolved_firecracker_resolution_if_present(pid: u32) -> FirecrackerCa
     if should_keep_unidentified_firecracker_candidate(&stat, argv.as_deref()) {
         FirecrackerCandidateResolution::UnidentifiedLive {
             pid,
-            ppid: read_ppid(pid).await,
+            ppid: Some(stat.ppid),
         }
     } else {
         FirecrackerCandidateResolution::NotPresent
@@ -207,7 +207,6 @@ async fn unresolved_firecracker_resolution_if_present(pid: u32) -> FirecrackerCa
 
 fn stable_firecracker_resolution(
     pid: u32,
-    ppid: Option<u32>,
     cwd_info: Option<(String, PathBuf)>,
     initial_stat: ProcessStat,
     process_stat: ProcessStat,
@@ -216,8 +215,10 @@ fn stable_firecracker_resolution(
         return FirecrackerCandidateResolution::NotPresent;
     }
     if !process_stat_identity_matches(&initial_stat, &process_stat) {
+        let ppid = Some(process_stat.ppid);
         return FirecrackerCandidateResolution::UnidentifiedLive { pid, ppid };
     }
+    let ppid = Some(process_stat.ppid);
     match cwd_info {
         Some((sandbox_id, base_dir)) => FirecrackerCandidateResolution::StableKnownWorkspace {
             pid,
@@ -241,11 +242,10 @@ async fn resolve_firecracker_candidate(pid: u32) -> FirecrackerCandidateResoluti
     let cwd_info = read_cwd(pid)
         .await
         .and_then(|cwd| parse_workspace_cwd(&cwd));
-    let ppid = read_ppid(pid).await;
     let Some(process_stat) = read_stable_firecracker_stat(pid).await else {
         return unresolved_firecracker_resolution_if_present(pid).await;
     };
-    stable_firecracker_resolution(pid, ppid, cwd_info, initial_stat, process_stat)
+    stable_firecracker_resolution(pid, cwd_info, initial_stat, process_stat)
 }
 
 /// Scan `/proc` once for sandbox child process facts.
@@ -312,8 +312,13 @@ mod tests {
     }
 
     fn stat(state: char, pgid: u32, starttime: u64) -> ProcessStat {
+        stat_with_ppid(state, 7, pgid, starttime)
+    }
+
+    fn stat_with_ppid(state: char, ppid: u32, pgid: u32, starttime: u64) -> ProcessStat {
         ProcessStat {
             state,
+            ppid,
             pgid,
             starttime,
         }
@@ -460,28 +465,14 @@ mod tests {
 
     #[test]
     fn process_stat_identity_ignores_state_changes() {
-        let sleeping = ProcessStat {
-            state: 'S',
-            pgid: 1100,
-            starttime: 123456,
-        };
-        let running = ProcessStat {
-            state: 'R',
-            pgid: 1100,
-            starttime: 123456,
-        };
-        let different_group = ProcessStat {
-            state: 'S',
-            pgid: 2200,
-            starttime: 123456,
-        };
-        let different_start = ProcessStat {
-            state: 'S',
-            pgid: 1100,
-            starttime: 654321,
-        };
+        let sleeping = stat('S', 1100, 123456);
+        let running = stat('R', 1100, 123456);
+        let different_group = stat('S', 2200, 123456);
+        let different_start = stat('S', 1100, 654321);
+        let different_parent = stat_with_ppid('S', 9, 1100, 123456);
 
         assert!(process_stat_identity_matches(&sleeping, &running));
+        assert!(process_stat_identity_matches(&sleeping, &different_parent));
         assert!(!process_stat_identity_matches(&sleeping, &different_group));
         assert!(!process_stat_identity_matches(&sleeping, &different_start));
     }
@@ -492,7 +483,6 @@ mod tests {
         let base_dir = PathBuf::from("/data/runner-01");
         let resolution = stable_firecracker_resolution(
             42,
-            Some(7),
             Some(("sandbox-a".to_string(), base_dir.clone())),
             stat('S', 1100, 123456),
             process_stat.clone(),
@@ -529,13 +519,8 @@ mod tests {
     #[test]
     fn firecracker_resolution_unknown_workspace_keeps_stable_process_identity() {
         let process_stat = stat('R', 1100, 123456);
-        let resolution = stable_firecracker_resolution(
-            42,
-            Some(7),
-            None,
-            stat('S', 1100, 123456),
-            process_stat.clone(),
-        );
+        let resolution =
+            stable_firecracker_resolution(42, None, stat('S', 1100, 123456), process_stat.clone());
 
         assert_eq!(
             resolution,
@@ -568,7 +553,6 @@ mod tests {
     fn firecracker_resolution_identity_drift_becomes_unidentified() {
         let resolution = stable_firecracker_resolution(
             42,
-            Some(7),
             Some(("sandbox-a".to_string(), PathBuf::from("/data/runner-01"))),
             stat('S', 1100, 123456),
             stat('R', 2200, 123456),
@@ -595,7 +579,6 @@ mod tests {
     fn firecracker_resolution_rejects_dead_process_states() {
         let resolution = stable_firecracker_resolution(
             42,
-            Some(7),
             Some(("sandbox-a".to_string(), PathBuf::from("/data/runner-01"))),
             stat('Z', 1100, 123456),
             stat('R', 1100, 123456),
@@ -607,16 +590,8 @@ mod tests {
 
     #[test]
     fn stable_live_firecracker_stat_accepts_live_stable_firecracker() {
-        let before = ProcessStat {
-            state: 'S',
-            pgid: 1100,
-            starttime: 123456,
-        };
-        let after = ProcessStat {
-            state: 'R',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let before = stat('S', 1100, 123456);
+        let after = stat('R', 1100, 123456);
 
         assert_eq!(
             stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after.clone()),
@@ -626,16 +601,8 @@ mod tests {
 
     #[test]
     fn stable_live_firecracker_stat_rejects_zombie_firecracker() {
-        let before = ProcessStat {
-            state: 'Z',
-            pgid: 1100,
-            starttime: 123456,
-        };
-        let after = ProcessStat {
-            state: 'Z',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let before = stat('Z', 1100, 123456);
+        let after = stat('Z', 1100, 123456);
 
         assert_eq!(
             stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after),
@@ -645,16 +612,8 @@ mod tests {
 
     #[test]
     fn stable_live_firecracker_stat_rejects_dead_firecracker() {
-        let before = ProcessStat {
-            state: 'X',
-            pgid: 1100,
-            starttime: 123456,
-        };
-        let after = ProcessStat {
-            state: 'x',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let before = stat('X', 1100, 123456);
+        let after = stat('x', 1100, 123456);
 
         assert_eq!(
             stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after),
@@ -664,16 +623,8 @@ mod tests {
 
     #[test]
     fn stable_live_firecracker_stat_rejects_exit_during_read() {
-        let before = ProcessStat {
-            state: 'S',
-            pgid: 1100,
-            starttime: 123456,
-        };
-        let after = ProcessStat {
-            state: 'Z',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let before = stat('S', 1100, 123456);
+        let after = stat('Z', 1100, 123456);
 
         assert_eq!(
             stable_live_firecracker_stat(&before, &argv(&["firecracker"]), after),
@@ -683,11 +634,7 @@ mod tests {
 
     #[test]
     fn unidentified_firecracker_candidate_keeps_uncertain_live_processes() {
-        let stat = ProcessStat {
-            state: 'S',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let stat = stat('S', 1100, 123456);
 
         assert!(should_keep_unidentified_firecracker_candidate(&stat, None));
         assert!(should_keep_unidentified_firecracker_candidate(
@@ -698,11 +645,7 @@ mod tests {
 
     #[test]
     fn unidentified_firecracker_candidate_rejects_known_non_firecracker() {
-        let stat = ProcessStat {
-            state: 'S',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let stat = stat('S', 1100, 123456);
 
         assert!(!should_keep_unidentified_firecracker_candidate(
             &stat,
@@ -712,11 +655,7 @@ mod tests {
 
     #[test]
     fn unidentified_firecracker_candidate_rejects_zombie_processes() {
-        let stat = ProcessStat {
-            state: 'Z',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let stat = stat('Z', 1100, 123456);
 
         assert!(!should_keep_unidentified_firecracker_candidate(&stat, None));
         assert!(!should_keep_unidentified_firecracker_candidate(
@@ -727,11 +666,7 @@ mod tests {
 
     #[test]
     fn unidentified_firecracker_candidate_rejects_dead_processes() {
-        let stat = ProcessStat {
-            state: 'X',
-            pgid: 1100,
-            starttime: 123456,
-        };
+        let stat = stat('X', 1100, 123456);
 
         assert!(!should_keep_unidentified_firecracker_candidate(&stat, None));
         assert!(!should_keep_unidentified_firecracker_candidate(

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -25,37 +25,54 @@ pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
 /// Read `/proc/{pid}/stat` and extract the PPid field.
 pub(super) async fn read_ppid(pid: u32) -> Option<u32> {
     let path = format!("/proc/{pid}/stat");
-    let content = tokio::fs::read_to_string(&path).await.ok()?;
+    let content = tokio::fs::read(&path).await.ok()?;
     parse_process_ppid(&content)
 }
 
-/// Return the fields after the `/proc/{pid}/stat` comm field.
+/// Return the byte fields after the `/proc/{pid}/stat` comm field.
 ///
 /// Format: `pid (comm) state ppid pgrp ...`
 /// The comm field may contain spaces and parentheses, so we find the
 /// last `)` to skip past it reliably.
-fn stat_fields_after_comm(content: &str) -> Option<std::str::SplitWhitespace<'_>> {
-    let after_comm = content.rsplit_once(')')?.1;
-    Some(after_comm.split_whitespace())
+fn stat_fields_after_comm(content: &[u8]) -> Option<impl Iterator<Item = &[u8]> + '_> {
+    let close_paren = content.iter().rposition(|byte| *byte == b')')?;
+    let after_comm = content.get(close_paren + 1..)?;
+    Some(
+        after_comm
+            .split(|byte| byte.is_ascii_whitespace())
+            .filter(|field| !field.is_empty()),
+    )
 }
 
-fn parse_process_ppid(content: &str) -> Option<u32> {
+fn parse_char_field(field: &[u8]) -> Option<char> {
+    std::str::from_utf8(field).ok()?.chars().next()
+}
+
+fn parse_u32_field(field: &[u8]) -> Option<u32> {
+    std::str::from_utf8(field).ok()?.parse().ok()
+}
+
+fn parse_u64_field(field: &[u8]) -> Option<u64> {
+    std::str::from_utf8(field).ok()?.parse().ok()
+}
+
+fn parse_process_ppid(content: &[u8]) -> Option<u32> {
     let mut fields = stat_fields_after_comm(content)?;
     let _state = fields.next()?;
-    fields.next()?.parse().ok()
+    parse_u32_field(fields.next()?)
 }
 
 /// Parse process facts from `/proc/{pid}/stat` content.
-fn parse_process_stat(content: &str) -> Option<ProcessStat> {
+fn parse_process_stat(content: &[u8]) -> Option<ProcessStat> {
     let mut fields = stat_fields_after_comm(content)?;
 
     // After the comm field, index 0 is stat field 3 (`state`), index 1 is
     // field 4 (`ppid`), index 2 is field 5 (`pgrp`), and index 19 is field
     // 22 (`starttime`).
-    let state = fields.next()?.chars().next()?;
-    let ppid = fields.next()?.parse().ok()?;
-    let pgid = fields.next()?.parse().ok()?;
-    let starttime = fields.nth(16)?.parse().ok()?;
+    let state = parse_char_field(fields.next()?)?;
+    let ppid = parse_u32_field(fields.next()?)?;
+    let pgid = parse_u32_field(fields.next()?)?;
+    let starttime = parse_u64_field(fields.nth(16)?)?;
 
     Some(ProcessStat {
         state,
@@ -68,7 +85,7 @@ fn parse_process_stat(content: &str) -> Option<ProcessStat> {
 /// Read `/proc/{pid}/stat` and extract process facts.
 pub(crate) async fn read_process_stat(pid: u32) -> Option<ProcessStat> {
     let path = format!("/proc/{pid}/stat");
-    let content = tokio::fs::read_to_string(&path).await.ok()?;
+    let content = tokio::fs::read(&path).await.ok()?;
     parse_process_stat(&content)
 }
 
@@ -144,12 +161,24 @@ mod tests {
         format!("1234 ({comm}) {}", fields.join(" "))
     }
 
+    fn stat_bytes_with_comm(comm: &[u8], state: &str, pgid: &str, starttime: &str) -> Vec<u8> {
+        let fields = [
+            state, "1200", pgid, "1100", "0", "-1", "4194560", "2100", "0", "0", "0", "12", "8",
+            "0", "0", "20", "0", "1", "0", starttime,
+        ];
+        let mut stat = b"1234 (".to_vec();
+        stat.extend_from_slice(comm);
+        stat.extend_from_slice(b") ");
+        stat.extend_from_slice(fields.join(" ").as_bytes());
+        stat
+    }
+
     #[test]
     fn parse_process_stat_simple() {
         // Real /proc/pid/stat: "1234 (firecracker) S 1200 1100 1100 ..."
         let stat = stat_with_comm("firecracker", "S", "1100", "123456");
         assert_eq!(
-            parse_process_stat(&stat),
+            parse_process_stat(stat.as_bytes()),
             Some(ProcessStat {
                 state: 'S',
                 ppid: 1200,
@@ -164,7 +193,7 @@ mod tests {
         // comm can contain spaces
         let stat = stat_with_comm("Web Content", "S", "200", "999");
         assert_eq!(
-            parse_process_stat(&stat),
+            parse_process_stat(stat.as_bytes()),
             Some(ProcessStat {
                 state: 'S',
                 ppid: 1200,
@@ -179,7 +208,7 @@ mod tests {
         // comm can contain parentheses — last ')' is the delimiter
         let stat = stat_with_comm("foo (bar)", "S", "600", "888");
         assert_eq!(
-            parse_process_stat(&stat),
+            parse_process_stat(stat.as_bytes()),
             Some(ProcessStat {
                 state: 'S',
                 ppid: 1200,
@@ -193,7 +222,7 @@ mod tests {
     fn parse_process_stat_zombie_state() {
         let stat = stat_with_comm("firecracker", "Z", "1100", "123456");
         assert_eq!(
-            parse_process_stat(&stat),
+            parse_process_stat(stat.as_bytes()),
             Some(ProcessStat {
                 state: 'Z',
                 ppid: 1200,
@@ -205,13 +234,13 @@ mod tests {
 
     #[test]
     fn parse_process_stat_empty() {
-        assert!(parse_process_stat("").is_none());
+        assert!(parse_process_stat(b"").is_none());
     }
 
     #[test]
     fn parse_process_stat_truncated_before_starttime() {
         let stat = "1234 (cmd) S 100 200 200 0 0 0";
-        assert!(parse_process_stat(stat).is_none());
+        assert!(parse_process_stat(stat.as_bytes()).is_none());
     }
 
     #[test]
@@ -239,36 +268,56 @@ mod tests {
             "123456",
         ];
         let stat = format!("1234 (firecracker) {}", fields.join(" "));
-        assert!(parse_process_stat(&stat).is_none());
+        assert!(parse_process_stat(stat.as_bytes()).is_none());
     }
 
     #[test]
     fn parse_process_stat_rejects_invalid_pgid() {
         let stat = stat_with_comm("firecracker", "S", "not-a-number", "123456");
-        assert!(parse_process_stat(&stat).is_none());
+        assert!(parse_process_stat(stat.as_bytes()).is_none());
     }
 
     #[test]
     fn parse_process_stat_rejects_invalid_starttime() {
         let stat = stat_with_comm("firecracker", "S", "1100", "not-a-number");
-        assert!(parse_process_stat(&stat).is_none());
+        assert!(parse_process_stat(stat.as_bytes()).is_none());
     }
 
     #[test]
     fn parse_process_ppid_does_not_require_starttime() {
         let stat = stat_with_comm("firecracker", "S", "1100", "not-a-number");
-        assert_eq!(parse_process_ppid(&stat), Some(1200));
+        assert_eq!(parse_process_ppid(stat.as_bytes()), Some(1200));
     }
 
     #[test]
     fn parse_process_ppid_rejects_invalid_ppid() {
         let stat = "1234 (firecracker) S not-a-number 1100";
-        assert!(parse_process_ppid(stat).is_none());
+        assert!(parse_process_ppid(stat.as_bytes()).is_none());
     }
 
     #[test]
     fn parse_process_ppid_rejects_missing_ppid() {
         let stat = "1234 (firecracker) S";
-        assert!(parse_process_ppid(stat).is_none());
+        assert!(parse_process_ppid(stat.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn parse_process_stat_accepts_non_utf8_comm() {
+        let stat = stat_bytes_with_comm(b"bad \xff ) name", "S", "1100", "123456");
+        assert_eq!(
+            parse_process_stat(&stat),
+            Some(ProcessStat {
+                state: 'S',
+                ppid: 1200,
+                pgid: 1100,
+                starttime: 123456
+            })
+        );
+    }
+
+    #[test]
+    fn parse_process_ppid_accepts_non_utf8_comm() {
+        let stat = stat_bytes_with_comm(b"bad \xff ) name", "S", "1100", "not-a-number");
+        assert_eq!(parse_process_ppid(&stat), Some(1200));
     }
 }

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -29,7 +29,7 @@ pub(super) async fn read_ppid(pid: u32) -> Option<u32> {
     parse_process_ppid(&content)
 }
 
-/// Parse process facts from `/proc/{pid}/stat` content.
+/// Return the fields after the `/proc/{pid}/stat` comm field.
 ///
 /// Format: `pid (comm) state ppid pgrp ...`
 /// The comm field may contain spaces and parentheses, so we find the
@@ -45,6 +45,7 @@ fn parse_process_ppid(content: &str) -> Option<u32> {
     fields.next()?.parse().ok()
 }
 
+/// Parse process facts from `/proc/{pid}/stat` content.
 fn parse_process_stat(content: &str) -> Option<ProcessStat> {
     let mut fields = stat_fields_after_comm(content)?;
 

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -22,41 +22,49 @@ pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
     if argv.is_empty() { None } else { Some(argv) }
 }
 
-/// Read `/proc/{pid}/status` and extract the PPid field.
+/// Read `/proc/{pid}/stat` and extract the PPid field.
 pub(super) async fn read_ppid(pid: u32) -> Option<u32> {
-    let path = format!("/proc/{pid}/status");
+    let path = format!("/proc/{pid}/stat");
     let content = tokio::fs::read_to_string(&path).await.ok()?;
-    for line in content.lines() {
-        if let Some(val) = line.strip_prefix("PPid:\t") {
-            return val.trim().parse().ok();
-        }
-    }
-    None
+    parse_process_ppid(&content)
 }
 
-/// Parse stable process facts from `/proc/{pid}/stat` content.
+/// Parse process facts from `/proc/{pid}/stat` content.
 ///
 /// Format: `pid (comm) state ppid pgrp ...`
 /// The comm field may contain spaces and parentheses, so we find the
 /// last `)` to skip past it reliably.
-fn parse_process_stat(content: &str) -> Option<ProcessStat> {
+fn stat_fields_after_comm(content: &str) -> Option<std::str::SplitWhitespace<'_>> {
     let after_comm = content.rsplit_once(')')?.1;
-    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    Some(after_comm.split_whitespace())
+}
 
-    // After the comm field, index 0 is stat field 3 (`state`), index 2 is
-    // field 5 (`pgrp`), and index 19 is field 22 (`starttime`).
-    let state = fields.first()?.chars().next()?;
-    let pgid = fields.get(2)?.parse().ok()?;
-    let starttime = fields.get(19)?.parse().ok()?;
+fn parse_process_ppid(content: &str) -> Option<u32> {
+    let mut fields = stat_fields_after_comm(content)?;
+    let _state = fields.next()?;
+    fields.next()?.parse().ok()
+}
+
+fn parse_process_stat(content: &str) -> Option<ProcessStat> {
+    let mut fields = stat_fields_after_comm(content)?;
+
+    // After the comm field, index 0 is stat field 3 (`state`), index 1 is
+    // field 4 (`ppid`), index 2 is field 5 (`pgrp`), and index 19 is field
+    // 22 (`starttime`).
+    let state = fields.next()?.chars().next()?;
+    let ppid = fields.next()?.parse().ok()?;
+    let pgid = fields.next()?.parse().ok()?;
+    let starttime = fields.nth(16)?.parse().ok()?;
 
     Some(ProcessStat {
         state,
+        ppid,
         pgid,
         starttime,
     })
 }
 
-/// Read `/proc/{pid}/stat` and extract stable process facts.
+/// Read `/proc/{pid}/stat` and extract process facts.
 pub(crate) async fn read_process_stat(pid: u32) -> Option<ProcessStat> {
     let path = format!("/proc/{pid}/stat");
     let content = tokio::fs::read_to_string(&path).await.ok()?;
@@ -143,6 +151,7 @@ mod tests {
             parse_process_stat(&stat),
             Some(ProcessStat {
                 state: 'S',
+                ppid: 1200,
                 pgid: 1100,
                 starttime: 123456
             })
@@ -157,6 +166,7 @@ mod tests {
             parse_process_stat(&stat),
             Some(ProcessStat {
                 state: 'S',
+                ppid: 1200,
                 pgid: 200,
                 starttime: 999
             })
@@ -171,6 +181,7 @@ mod tests {
             parse_process_stat(&stat),
             Some(ProcessStat {
                 state: 'S',
+                ppid: 1200,
                 pgid: 600,
                 starttime: 888
             })
@@ -184,6 +195,7 @@ mod tests {
             parse_process_stat(&stat),
             Some(ProcessStat {
                 state: 'Z',
+                ppid: 1200,
                 pgid: 1100,
                 starttime: 123456
             })
@@ -202,6 +214,34 @@ mod tests {
     }
 
     #[test]
+    fn parse_process_stat_rejects_invalid_ppid() {
+        let fields = [
+            "S",
+            "not-a-number",
+            "1100",
+            "1100",
+            "0",
+            "-1",
+            "4194560",
+            "2100",
+            "0",
+            "0",
+            "0",
+            "12",
+            "8",
+            "0",
+            "0",
+            "20",
+            "0",
+            "1",
+            "0",
+            "123456",
+        ];
+        let stat = format!("1234 (firecracker) {}", fields.join(" "));
+        assert!(parse_process_stat(&stat).is_none());
+    }
+
+    #[test]
     fn parse_process_stat_rejects_invalid_pgid() {
         let stat = stat_with_comm("firecracker", "S", "not-a-number", "123456");
         assert!(parse_process_stat(&stat).is_none());
@@ -211,5 +251,23 @@ mod tests {
     fn parse_process_stat_rejects_invalid_starttime() {
         let stat = stat_with_comm("firecracker", "S", "1100", "not-a-number");
         assert!(parse_process_stat(&stat).is_none());
+    }
+
+    #[test]
+    fn parse_process_ppid_does_not_require_starttime() {
+        let stat = stat_with_comm("firecracker", "S", "1100", "not-a-number");
+        assert_eq!(parse_process_ppid(&stat), Some(1200));
+    }
+
+    #[test]
+    fn parse_process_ppid_rejects_invalid_ppid() {
+        let stat = "1234 (firecracker) S not-a-number 1100";
+        assert!(parse_process_ppid(stat).is_none());
+    }
+
+    #[test]
+    fn parse_process_ppid_rejects_missing_ppid() {
+        let stat = "1234 (firecracker) S";
+        assert!(parse_process_ppid(stat).is_none());
     }
 }

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -1,9 +1,13 @@
 use std::path::PathBuf;
 
-/// Stable facts read from `/proc/{pid}/stat`.
+/// Process facts read from `/proc/{pid}/stat`.
+///
+/// Only `pgid` and `starttime` are used as stable process identity; `ppid`
+/// is the parent relationship observed at read time.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessStat {
     pub state: char,
+    pub ppid: u32,
     pub pgid: u32,
     pub starttime: u64,
 }


### PR DESCRIPTION
## Summary

- Parse `/proc/{pid}/stat` fields directly without collecting the suffix into a `Vec<&str>`.
- Add PPid to `ProcessStat` and use stat-backed PPid parsing for `read_ppid`.
- Reuse parsed PPid in firecracker discovery while keeping process identity based on `pgid + starttime`.

Closes #18613

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner process::procfs`
- `cargo test --manifest-path crates/Cargo.toml -p runner process::discovery`
- `cargo test --manifest-path crates/Cargo.toml -p runner process::ancestry`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --all --check --manifest-path crates/Cargo.toml`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`