### PR TITLE
fix: keep firewall metadata chunks stable

### DIFF
--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -8,6 +8,13 @@ function isStaticAsset(url) {
   return url.origin === self.location.origin && STATIC_RE.test(url.pathname);
 }
 
+function isRevalidatedStaticAsset(url) {
+  return (
+    url.origin === self.location.origin &&
+    url.pathname.startsWith("/firewall-metadata/")
+  );
+}
+
 function isApiRequest(url) {
   return (
     url.origin === self.location.origin && url.pathname.startsWith("/api/")
@@ -49,6 +56,13 @@ self.addEventListener("fetch", (event) => {
   }
 
   const url = new URL(event.request.url);
+
+  if (isRevalidatedStaticAsset(url)) {
+    // Stable generated metadata URLs must revalidate instead of being served
+    // from Cache Storage like content-hashed Vite assets.
+    event.respondWith(fetch(event.request, { cache: "no-cache" }));
+    return;
+  }
 
   if (isStaticAsset(url)) {
     // Cache-First: Vite content-hashed filenames are immutable.

--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -30,6 +30,23 @@ function isCacheableAssetResponse(response) {
   );
 }
 
+async function fetchRevalidatedStaticAsset(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  try {
+    const response = await fetch(request, { cache: "no-cache" });
+    if (isCacheableAssetResponse(response)) {
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached && isCacheableAssetResponse(cached)) {
+      return cached;
+    }
+    throw error;
+  }
+}
+
 self.addEventListener("install", (_event) => {
   self.skipWaiting();
 });
@@ -59,8 +76,8 @@ self.addEventListener("fetch", (event) => {
 
   if (isRevalidatedStaticAsset(url)) {
     // Stable generated metadata URLs must revalidate instead of being served
-    // from Cache Storage like content-hashed Vite assets.
-    event.respondWith(fetch(event.request, { cache: "no-cache" }));
+    // cache-first like content-hashed Vite assets.
+    event.respondWith(fetchRevalidatedStaticAsset(event.request));
     return;
   }
 

--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -31,17 +31,26 @@ function isCacheableAssetResponse(response) {
 }
 
 async function fetchRevalidatedStaticAsset(request) {
-  const cache = await caches.open(STATIC_CACHE);
   try {
     const response = await fetch(request, { cache: "no-cache" });
     if (isCacheableAssetResponse(response)) {
-      await cache.put(request, response.clone());
+      try {
+        const cache = await caches.open(STATIC_CACHE);
+        await cache.put(request, response.clone());
+      } catch {
+        // The network response is authoritative; Cache Storage is best effort.
+      }
     }
     return response;
   } catch (error) {
-    const cached = await cache.match(request);
-    if (cached && isCacheableAssetResponse(cached)) {
-      return cached;
+    try {
+      const cache = await caches.open(STATIC_CACHE);
+      const cached = await cache.match(request);
+      if (cached && isCacheableAssetResponse(cached)) {
+        return cached;
+      }
+    } catch {
+      // Preserve the original network error if the fallback cache is unusable.
     }
     throw error;
   }

--- a/turbo/apps/platform/src/__tests__/service-worker.test.ts
+++ b/turbo/apps/platform/src/__tests__/service-worker.test.ts
@@ -1,0 +1,187 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+interface FetchListenerEvent {
+  readonly request: Request;
+  respondWith(response: Promise<Response> | Response): void;
+}
+
+type FetchListener = (event: FetchListenerEvent) => void;
+
+interface TestRuntime {
+  readonly cache: TestCache;
+  readonly fetchListener: FetchListener;
+  readonly fetchMock: ReturnType<typeof vi.fn>;
+}
+
+class TestCache {
+  readonly entries = new Map<string, Response>();
+
+  readonly delete = vi.fn((request: Request): Promise<boolean> => {
+    return Promise.resolve(this.entries.delete(request.url));
+  });
+
+  readonly match = vi.fn((request: Request): Promise<Response | undefined> => {
+    return Promise.resolve(this.entries.get(request.url));
+  });
+
+  readonly put = vi.fn(
+    (request: Request, response: Response): Promise<void> => {
+      this.entries.set(request.url, response);
+      return Promise.resolve();
+    },
+  );
+}
+
+function isFetchListener(value: unknown): value is FetchListener {
+  return typeof value === "function";
+}
+
+function createServiceWorkerRuntime(): TestRuntime {
+  const cache = new TestCache();
+  const listeners = new Map<string, unknown[]>();
+  const fetchMock = vi.fn(
+    (_request: Request, _init?: RequestInit): Promise<Response> => {
+      return Promise.resolve(
+        new Response("ok", {
+          headers: { "content-type": "application/javascript" },
+        }),
+      );
+    },
+  );
+  const self = {
+    clients: {
+      claim: vi.fn((): Promise<void> => Promise.resolve()),
+      matchAll: vi.fn((): Promise<readonly unknown[]> => Promise.resolve([])),
+      openWindow: vi.fn((): Promise<null> => Promise.resolve(null)),
+    },
+    location: new URL("https://app.test"),
+    registration: {
+      showNotification: vi.fn((): Promise<void> => Promise.resolve()),
+    },
+    skipWaiting: vi.fn(),
+    addEventListener(type: string, listener: unknown): void {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+  };
+  const context = vm.createContext({
+    Event,
+    Promise,
+    Request,
+    Response,
+    URL,
+    caches: {
+      delete: vi.fn((): Promise<boolean> => Promise.resolve(true)),
+      keys: vi.fn((): Promise<readonly string[]> => Promise.resolve([])),
+      open: vi.fn((): Promise<TestCache> => Promise.resolve(cache)),
+    },
+    clients: self.clients,
+    console,
+    fetch: fetchMock,
+    self,
+  });
+  const swPath = path.resolve(import.meta.dirname, "../../public/sw.js");
+  vm.runInContext(fs.readFileSync(swPath, "utf8"), context, {
+    filename: swPath,
+  });
+
+  const fetchListener = listeners.get("fetch")?.find(isFetchListener);
+  if (!fetchListener) {
+    throw new Error("service worker fetch listener not registered");
+  }
+
+  return { cache, fetchListener, fetchMock };
+}
+
+async function dispatchFetch(
+  runtime: TestRuntime,
+  request: Request,
+): Promise<Response> {
+  let responsePromise: Promise<Response> | null = null;
+  runtime.fetchListener({
+    request,
+    respondWith(response): void {
+      responsePromise = Promise.resolve(response);
+    },
+  });
+
+  if (!responsePromise) {
+    throw new Error("service worker did not handle request");
+  }
+  return await responsePromise;
+}
+
+describe("platform service worker", () => {
+  it("revalidates firewall metadata requests and caches successful responses", async () => {
+    const runtime = createServiceWorkerRuntime();
+    const request = new Request(
+      "https://app.test/firewall-metadata/v1/gmail.generated.js",
+    );
+    runtime.fetchMock.mockResolvedValueOnce(
+      new Response("export const ok = true;", {
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+
+    const response = await dispatchFetch(runtime, request);
+
+    expect(runtime.fetchMock).toHaveBeenCalledWith(request, {
+      cache: "no-cache",
+    });
+    expect(response.ok).toBeTruthy();
+    expect(runtime.cache.put).toHaveBeenCalledTimes(1);
+    const cached = runtime.cache.entries.get(request.url);
+    if (!cached) {
+      throw new Error("metadata response was not cached");
+    }
+    await expect(cached.text()).resolves.toBe("export const ok = true;");
+  });
+
+  it("uses cached firewall metadata only when revalidation cannot reach the network", async () => {
+    const runtime = createServiceWorkerRuntime();
+    const request = new Request(
+      "https://app.test/firewall-metadata/v1/gmail.generated.js",
+    );
+    runtime.cache.entries.set(
+      request.url,
+      new Response("cached", {
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+    runtime.fetchMock.mockRejectedValueOnce(new TypeError("offline"));
+
+    const response = await dispatchFetch(runtime, request);
+
+    expect(runtime.fetchMock).toHaveBeenCalledWith(request, {
+      cache: "no-cache",
+    });
+    await expect(response.text()).resolves.toBe("cached");
+  });
+
+  it("does not hide reachable 404 responses behind cached firewall metadata", async () => {
+    const runtime = createServiceWorkerRuntime();
+    const request = new Request(
+      "https://app.test/firewall-metadata/v1/gmail.generated.js",
+    );
+    runtime.cache.entries.set(
+      request.url,
+      new Response("cached", {
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+    runtime.fetchMock.mockResolvedValueOnce(
+      new Response("missing", {
+        headers: { "content-type": "text/plain" },
+        status: 404,
+      }),
+    );
+
+    const response = await dispatchFetch(runtime, request);
+
+    expect(response.status).toBe(404);
+    expect(runtime.cache.put).not.toHaveBeenCalled();
+    await expect(response.text()).resolves.toBe("missing");
+  });
+});

--- a/turbo/apps/platform/src/__tests__/service-worker.test.ts
+++ b/turbo/apps/platform/src/__tests__/service-worker.test.ts
@@ -160,6 +160,29 @@ describe("platform service worker", () => {
     await expect(response.text()).resolves.toBe("cached");
   });
 
+  it("uses the network response when cache storage cannot be updated", async () => {
+    const runtime = createServiceWorkerRuntime();
+    const request = new Request(
+      "https://app.test/firewall-metadata/v1/gmail.generated.js",
+    );
+    runtime.cache.entries.set(
+      request.url,
+      new Response("stale", {
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+    runtime.fetchMock.mockResolvedValueOnce(
+      new Response("fresh", {
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+    runtime.cache.put.mockRejectedValueOnce(new Error("quota exceeded"));
+
+    const response = await dispatchFetch(runtime, request);
+
+    await expect(response.text()).resolves.toBe("fresh");
+  });
+
   it("does not hide reachable 404 responses behind cached firewall metadata", async () => {
     const runtime = createServiceWorkerRuntime();
     const request = new Request(

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -4,7 +4,6 @@ import {
   loadFirewallPermissionMetadata,
   type FirewallPermissionDetailMetadata,
 } from "@vm0/connectors/firewall-metadata";
-import { retryTransientLoad } from "./utils.ts";
 
 interface FirewallPermissionMetadataParams {
   readonly connectorType: string;
@@ -27,9 +26,7 @@ function createFirewallPermissionMetadataFactory(): (
       if (!isFirewallMetadataConnectorType(params.connectorType)) {
         return null;
       }
-      return await retryTransientLoad(() => {
-        return loadFirewallPermissionMetadata(params.connectorType);
-      });
+      return await loadFirewallPermissionMetadata(params.connectorType);
     });
     cache.set(key, atom$);
     return atom$;

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -163,6 +163,8 @@ export default defineConfig({
     sourcemap: !!process.env.SENTRY_AUTH_TOKEN,
     rolldownOptions: {
       output: {
+        // Stable metadata chunk URLs must also keep stable import contracts.
+        minifyInternalExports: false,
         chunkFileNames(chunkInfo) {
           return (
             firewallMetadataDetailChunkFileName(chunkInfo.name) ??

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -22,6 +22,7 @@ const STATIC_ASSETS_BASE_URL =
     : "https://static.vm7.io");
 const FIREWALL_METADATA_DETAIL_CHUNK_NAME_PREFIX =
   "vm0-firewall-metadata-detail-";
+const FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION = "v1";
 const FIREWALL_METADATA_DETAIL_MODULE_ID_RE =
   /\/packages\/connectors\/src\/firewall-metadata\/details\/([a-z0-9][a-z0-9-]*)\.generated\.ts$/;
 const FIREWALL_METADATA_DETAIL_CHUNK_NAME_RE =
@@ -50,7 +51,7 @@ function firewallMetadataDetailChunkFileName(chunkName: string): string | null {
   if (!match) {
     return null;
   }
-  return `firewall-metadata/${match[1]}.generated.js`;
+  return `firewall-metadata/${FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
 }
 
 function isAllowedDevArtifactFetchUrl(url: URL): boolean {

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -51,7 +51,7 @@ function firewallMetadataDetailChunkFileName(chunkName: string): string | null {
   if (!match) {
     return null;
   }
-  return `firewall-metadata/${FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
+  return `firewall-metadata/details/${FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
 }
 
 function isAllowedDevArtifactFetchUrl(url: URL): boolean {

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -51,7 +51,7 @@ function firewallMetadataDetailChunkFileName(chunkName: string): string | null {
   if (!match) {
     return null;
   }
-  return `firewall-metadata/details/${FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
+  return `firewall-metadata/${FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
 }
 
 function isAllowedDevArtifactFetchUrl(url: URL): boolean {

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -20,8 +20,38 @@ const STATIC_ASSETS_BASE_URL =
   process.env.VERCEL_ENV === "production"
     ? "https://static.vm0.io"
     : "https://static.vm7.io");
+const FIREWALL_METADATA_DETAIL_CHUNK_NAME_PREFIX =
+  "vm0-firewall-metadata-detail-";
+const FIREWALL_METADATA_DETAIL_MODULE_ID_RE =
+  /\/packages\/connectors\/src\/firewall-metadata\/details\/([a-z0-9][a-z0-9-]*)\.generated\.ts$/;
+const FIREWALL_METADATA_DETAIL_CHUNK_NAME_RE =
+  /^vm0-firewall-metadata-detail-([a-z0-9][a-z0-9-]*)\.generated$/;
 
 process.env.VITE_STATIC_ASSETS_BASE_URL = STATIC_ASSETS_BASE_URL;
+
+function normalizedModuleId(id: string): string {
+  const queryIndex = id.indexOf("?");
+  const pathname = queryIndex === -1 ? id : id.slice(0, queryIndex);
+  return pathname.replaceAll("\\", "/");
+}
+
+function firewallMetadataDetailChunkName(moduleId: string): string | null {
+  const match = FIREWALL_METADATA_DETAIL_MODULE_ID_RE.exec(
+    normalizedModuleId(moduleId),
+  );
+  if (!match) {
+    return null;
+  }
+  return `${FIREWALL_METADATA_DETAIL_CHUNK_NAME_PREFIX}${match[1]}.generated`;
+}
+
+function firewallMetadataDetailChunkFileName(chunkName: string): string | null {
+  const match = FIREWALL_METADATA_DETAIL_CHUNK_NAME_RE.exec(chunkName);
+  if (!match) {
+    return null;
+  }
+  return `firewall-metadata/${match[1]}.generated.js`;
+}
 
 function isAllowedDevArtifactFetchUrl(url: URL): boolean {
   if (url.protocol !== "https:") {
@@ -131,5 +161,28 @@ export default defineConfig({
     outDir: "dist",
     // Generate source maps for Sentry (uploaded and removed by plugin)
     sourcemap: !!process.env.SENTRY_AUTH_TOKEN,
+    rolldownOptions: {
+      output: {
+        chunkFileNames(chunkInfo) {
+          return (
+            firewallMetadataDetailChunkFileName(chunkInfo.name) ??
+            "assets/[name]-[hash].js"
+          );
+        },
+        codeSplitting: {
+          groups: [
+            {
+              name(moduleId) {
+                return firewallMetadataDetailChunkName(moduleId);
+              },
+              test(moduleId) {
+                return firewallMetadataDetailChunkName(moduleId) !== null;
+              },
+              priority: 10,
+            },
+          ],
+        },
+      },
+    },
   },
 });

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -174,6 +174,19 @@ function staticImportSpecifiers(source: string): string[] {
   return specifiers;
 }
 
+function runtimeStaticImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of source.matchAll(
+    /^\s*import(?!\s+type\b)[\s\S]*?\sfrom\s+["']([^"']+)["'];?/gm,
+  )) {
+    specifiers.push(match[1]!);
+  }
+  for (const match of source.matchAll(/^\s*import\s+["']([^"']+)["'];?/gm)) {
+    specifiers.push(match[1]!);
+  }
+  return specifiers;
+}
+
 function exportFromSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
   for (const match of source.matchAll(
@@ -300,6 +313,26 @@ describe("firewall metadata", () => {
     expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
     for (const specifier of dynamicSpecifiers) {
       expect(specifier).toMatch(/^\.\/details\/[a-z0-9][a-z0-9-]*\.generated$/);
+    }
+  });
+
+  it("keeps generated permission detail modules runtime-free", () => {
+    const detailsDir = path.resolve(
+      import.meta.dirname,
+      "../firewall-metadata/details",
+    );
+    const files = listTsFiles(detailsDir);
+
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      const source = fs.readFileSync(file, "utf-8");
+      const filename = path.basename(file);
+      expect(runtimeStaticImportSpecifiers(source), filename).toStrictEqual([]);
+      expect(dynamicImportSpecifiers(source), filename).toStrictEqual([]);
+      expect(exportFromSpecifiers(source), filename).toStrictEqual([]);
+      expect(staticImportSpecifiers(source), filename).toStrictEqual([
+        "../types",
+      ]);
     }
   });
 

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -1037,7 +1037,9 @@ function renderLoaderFile(types: readonly FirewallConnectorType[]): string {
     })
     .join("\n");
 
-  return `${generatedHeader()}import type { FirewallPermissionDetailMetadata } from "./types";
+  return `${generatedHeader()}// The platform build serves these dynamic imports from /firewall-metadata/v1/.
+// Bump that URL version to v2 before shipping an incompatible metadata module shape or import contract change.
+import type { FirewallPermissionDetailMetadata } from "./types";
 
 const FIREWALL_PERMISSION_METADATA_LOADERS: Readonly<
   Record<string, () => Promise<FirewallPermissionDetailMetadata>>

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -1038,7 +1038,7 @@ function renderLoaderFile(types: readonly FirewallConnectorType[]): string {
     .join("\n");
 
   return `${generatedHeader()}// The platform build serves these dynamic imports from /firewall-metadata/v1/.
-// Bump that URL version to v2 before shipping an incompatible metadata module shape or import contract change.
+// Bump that URL version before shipping an incompatible metadata module shape or import contract change.
 import type { FirewallPermissionDetailMetadata } from "./types";
 
 const FIREWALL_PERMISSION_METADATA_LOADERS: Readonly<


### PR DESCRIPTION
## Summary

- emit generated firewall metadata detail chunks under stable /firewall-metadata/*.generated.js URLs
- keep normal app chunks content-hashed under /assets
- bypass service worker Cache Storage for stable firewall metadata files so Vercel static-file revalidation is used
- remove the ineffective retry wrapper from firewall permission metadata loading
- add metadata boundary coverage that generated detail modules remain runtime-free

Closes #18622

## Tests

- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-metadata.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app build
- pre-commit: pnpm check-types / knip / prettier