### PR TITLE
fix: deduplicate deel firewall route owners

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/deel_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/deel_0.py
@@ -21,7 +21,6 @@ JSON_PART = r"""{
             "GET /rest/v2/invoices/deel",
             "GET /rest/v2/invoices/{id}/download",
             "GET /rest/v2/invoices/{invoice_id}",
-            "GET /rest/v2/legal-entities",
             "GET /rest/v2/payments",
             "GET /rest/v2/payments/{payment_id}/breakdown",
             "GET /rest/v2/refund-statements",
@@ -100,8 +99,7 @@ JSON_PART = r"""{
             "GET /rest/v2/benefits/legal-entities/{legal_entity_id}/contracts/{contract_id}/plans/{plan_id}",
             "GET /rest/v2/benefits/legal-entities/{legal_entity_id}/paystubs",
             "GET /rest/v2/eor/benefits",
-            "GET /rest/v2/eor/worker/benefits",
-            "POST /rest/v2/workers/amendments/{amendment_id}/sign"
+            "GET /rest/v2/eor/worker/benefits"
           ]
         },
         {
@@ -153,19 +151,10 @@ JSON_PART = r"""{
             "GET /rest/v2/eor/contracts/{contract_id}/offboarding/time-offs",
             "GET /rest/v2/eor/contracts/{contract_id}/project-assignment",
             "GET /rest/v2/eor/contracts/{contract_id}/project-assignment/checkin",
-            "POST /rest/v2/eor/contracts/{contract_id}/project-assignment/checkin",
             "GET /rest/v2/eor/start-date",
             "GET /rest/v2/eor/validations/{country_code}",
             "GET /rest/v2/eor/{contract_id}/benefits",
-            "POST /rest/v2/eor/{oid}/terminations/regular",
-            "POST /rest/v2/eor/{oid}/terminations/resignation",
-            "GET /rest/v2/eor/{oid}/terminations/{terminationId}",
-            "GET /rest/v2/offboarding/tracker",
-            "GET /rest/v2/offboarding/tracker/hris_profile/{oid}",
-            "GET /rest/v2/offboarding/tracker/{id}",
-            "GET /rest/v2/onboarding/tracker",
-            "GET /rest/v2/onboarding/tracker/hris_profile/{hris_profile_id}",
-            "GET /rest/v2/onboarding/tracker/{tracker_id}"
+            "GET /rest/v2/eor/{oid}/terminations/{terminationId}"
           ]
         },
         {
@@ -174,7 +163,6 @@ JSON_PART = r"""{
             "POST /rest/v2/contracts",
             "POST /rest/v2/contracts/gp",
             "PATCH /rest/v2/contracts/{contract_id}",
-            "GET /rest/v2/contracts/{contract_id}/amendments",
             "POST /rest/v2/contracts/{contract_id}/amendments",
             "POST /rest/v2/contracts/{contract_id}/cost-centers",
             "PUT /rest/v2/contracts/{contract_id}/custom_fields",
@@ -248,9 +236,7 @@ JSON_PART = r"""{
         {
           "name": "groups:read",
           "rules": [
-            "GET /rest/v2/groups",
-            "POST /rest/v2/groups",
-            "PATCH /rest/v2/groups/{id}"
+            "GET /rest/v2/groups"
           ]
         },
         {
@@ -329,9 +315,6 @@ JSON_PART = r"""{
           "name": "legal-entity:read",
           "rules": [
             "GET /rest/v2/industries",
-            "POST /rest/v2/legal-entities",
-            "PATCH /rest/v2/legal-entities/{id}",
-            "DELETE /rest/v2/legal-entities/{id}",
             "GET /rest/v2/legal-entities/{legal_entity_id}/cost-centers",
             "GET /rest/v2/legal-entities/{legal_entity_id}/payroll-events",
             "GET /rest/v2/lookups"
@@ -487,8 +470,7 @@ JSON_PART = r"""{
             "GET /rest/v2/hris/positions/profile/{hrisProfileId}",
             "GET /rest/v2/hris/positions/profile/{hris_profile_id}",
             "GET /rest/v2/hris/worker_relations/profile/external/{profile_id}",
-            "GET /rest/v2/hris/worker_relations/profile/{hrisProfileOid}",
-            "PATCH /rest/v2/profiles"
+            "GET /rest/v2/hris/worker_relations/profile/{hrisProfileOid}"
           ]
         },
         {
@@ -631,12 +613,8 @@ JSON_PART = r"""{
         {
           "name": "worker:read",
           "rules": [
-            "GET /rest/v2/contracts/{contract_id}/preview",
             "GET /rest/v2/daas/payslips",
             "GET /rest/v2/engage/learning/actionable-journeys",
-            "GET /rest/v2/eor/contracts/{contract_id}/hrx-documents",
-            "GET /rest/v2/eor/contracts/{contract_id}/hrx-documents/{document_id}",
-            "GET /rest/v2/eor/contracts/{contract_id}/offboarding",
             "GET /rest/v2/eor/workers/banks-guide/country/{country}/currency/{currency}",
             "GET /rest/v2/eor/workers/banks/guide",
             "GET /rest/v2/eor/workers/compliance-documents",
@@ -655,23 +633,13 @@ JSON_PART = r"""{
             "GET /rest/v2/immigration/workers/cases/{case_id}",
             "GET /rest/v2/immigration/workers/{worker_id}/cases/{case_id}/required-document",
             "GET /rest/v2/immigration/workers/{worker_id}/onboarding-case",
-            "GET /rest/v2/invoice-adjustments/{id}",
             "POST /rest/v2/magic-link",
             "GET /rest/v2/payouts/auto-withdrawal-setting",
             "GET /rest/v2/payouts/balances",
             "GET /rest/v2/payouts/contractors/methods",
-            "POST /rest/v2/payouts/contractors/methods",
             "GET /rest/v2/payouts/contractors/methods/bank_transfers/requirements",
             "GET /rest/v2/payouts/contractors/methods/bank_transfers/supported_routes",
-            "PUT /rest/v2/payouts/contractors/methods/{id}",
-            "POST /rest/v2/payouts/contractors/settings/auto_withdraw",
             "GET /rest/v2/payouts/employees/methods",
-            "POST /rest/v2/payouts/employees/methods",
-            "POST /rest/v2/payouts/employees/methods/bank_transfers/requirements",
-            "DELETE /rest/v2/payouts/employees/methods/{id}",
-            "GET /rest/v2/people/me",
-            "GET /rest/v2/screenings/verification-method",
-            "POST /rest/v2/workers/amendments/{amendment_id}/sign",
             "GET /rest/v2/workers/compliance-documents",
             "GET /rest/v2/workers/contracts/{contract_id}/pdf"
           ]
@@ -693,28 +661,18 @@ JSON_PART = r"""{
             "POST /rest/v2/eor/workers/contracts/{contract_id}/project-assignment/acknowledge",
             "POST /rest/v2/eor/workers/contracts/{contract_id}/signatures",
             "POST /rest/v2/immigration/workers/{worker_id}/cases/{case_id}/required-document/{document_request_id}",
-            "POST /rest/v2/invoice-adjustments",
-            "PATCH /rest/v2/invoice-adjustments/{id}",
             "POST /rest/v2/onboarding/workers/individual",
             "POST /rest/v2/onboarding/workers/legal-entity",
             "PATCH /rest/v2/payouts/auto-withdrawal-setting",
-            "GET /rest/v2/payouts/contractors/methods",
             "POST /rest/v2/payouts/contractors/methods",
-            "GET /rest/v2/payouts/contractors/methods/bank_transfers/requirements",
-            "GET /rest/v2/payouts/contractors/methods/bank_transfers/supported_routes",
             "PUT /rest/v2/payouts/contractors/methods/{id}",
             "POST /rest/v2/payouts/contractors/settings/auto_withdraw",
-            "GET /rest/v2/payouts/employees/methods",
             "POST /rest/v2/payouts/employees/methods",
             "POST /rest/v2/payouts/employees/methods/bank_transfers/requirements",
             "DELETE /rest/v2/payouts/employees/methods/{id}",
             "POST /rest/v2/payouts/withdrawals",
             "POST /rest/v2/screenings/kyc/external",
             "POST /rest/v2/screenings/manual-verification",
-            "POST /rest/v2/time_offs",
-            "PATCH /rest/v2/time_offs/{time_off_id}",
-            "DELETE /rest/v2/time_offs/{time_off_id}",
-            "POST /rest/v2/veriff/session",
             "POST /rest/v2/workers/amendments/{amendment_id}/sign",
             "POST /rest/v2/workers/contracts/{contract_id}/reject",
             "POST /rest/v2/workers/contracts/{contract_id}/signatures"

--- a/turbo/packages/connectors/src/__tests__/firewalls/deel.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/deel.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { findMatchingPermissions } from "../../firewall-rule-matcher";
+import { getConnectorFirewall } from "../../firewalls";
+
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+function deelMatches(method: string, path: string): string[] {
+  return findMatchingPermissions(method, path, getConnectorFirewall("deel"));
+}
+
+function expectDeelMatches(
+  method: string,
+  path: string,
+  permissionNames: readonly string[],
+): void {
+  expect([...deelMatches(method, path)].sort()).toStrictEqual(
+    [...permissionNames].sort(),
+  );
+}
+
+function expandRuntimeRules(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+describe("deel firewall", () => {
+  it("assigns one permission owner to every runtime route", () => {
+    const duplicates: string[] = [];
+    for (const api of getConnectorFirewall("deel").apis) {
+      const owners = new Map<string, string>();
+      for (const permission of api.permissions ?? []) {
+        for (const rule of permission.rules) {
+          for (const runtimeRule of expandRuntimeRules(rule)) {
+            const key = `${api.base} ${runtimeRule}`;
+            const existing = owners.get(key);
+            if (existing) {
+              duplicates.push(`${key}: ${existing}, ${permission.name}`);
+              continue;
+            }
+            owners.set(key, permission.name);
+          }
+        }
+      }
+    }
+
+    expect(duplicates).toStrictEqual([]);
+  });
+
+  it("maps legal entity mutations to legal entity write permission", () => {
+    expectDeelMatches("POST", "/rest/v2/legal-entities", [
+      "legal-entity:write",
+    ]);
+    expectDeelMatches("PATCH", "/rest/v2/legal-entities/123", [
+      "legal-entity:write",
+    ]);
+    expectDeelMatches("DELETE", "/rest/v2/legal-entities/123", [
+      "legal-entity:write",
+    ]);
+  });
+
+  it("maps read/write alternatives by method", () => {
+    expectDeelMatches("GET", "/rest/v2/payouts/contractors/methods", [
+      "worker:read",
+    ]);
+    expectDeelMatches("POST", "/rest/v2/payouts/contractors/methods", [
+      "worker:write",
+    ]);
+  });
+
+  it("maps cross-resource alternatives to the route resource owner", () => {
+    expectDeelMatches("GET", "/rest/v2/legal-entities", ["organizations:read"]);
+    expectDeelMatches("GET", "/rest/v2/people/me", ["people:read"]);
+    expectDeelMatches("GET", "/rest/v2/screenings/verification-method", [
+      "screenings:read",
+    ]);
+    expectDeelMatches("POST", "/rest/v2/time_offs", ["time-off:write"]);
+  });
+});

--- a/turbo/packages/firewalls-generator/src/deel.ts
+++ b/turbo/packages/firewalls-generator/src/deel.ts
@@ -36,7 +36,53 @@ interface DeelSpec {
 
 interface DeelOperation {
   description?: string;
+  operationId?: string;
+  tags?: string[];
 }
+
+interface DeelOwnerContext {
+  readonly rule: string;
+  readonly method: string;
+  readonly tags: readonly string[];
+  readonly operationId: string | null;
+}
+
+interface DeelScope {
+  readonly scope: string;
+  readonly family: string;
+  readonly action: string;
+}
+
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+const READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+const DEEL_TAG_OWNER_PREFERENCES = new Map<string, readonly string[]>([
+  ["subpackage_contracts", ["contracts", "worker", "benefits"]],
+  ["subpackage_contractorAmendments", ["contracts"]],
+  ["subpackage_contractorHiring", ["contracts", "worker"]],
+  ["subpackage_eorOffboarding", ["contracts", "worker"]],
+  ["subpackage_eorProjectAssignment", ["contracts"]],
+  ["subpackage_eorTerminations", ["contracts"]],
+  ["subpackage_groups", ["groups"]],
+  ["subpackage_hrxDocuments", ["contracts", "worker"]],
+  ["subpackage_invoiceAdjustments", ["invoice-adjustments", "worker"]],
+  ["subpackage_legalEntities", ["legal-entity", "organizations", "accounting"]],
+  ["subpackage_offboarding", ["people", "contracts"]],
+  ["subpackage_onboarding", ["people", "contracts"]],
+  ["subpackage_payouts", ["worker"]],
+  ["subpackage_people", ["people", "worker"]],
+  ["subpackage_screenings", ["screenings", "worker"]],
+  ["subpackage_timeOff", ["time-off", "worker"]],
+]);
 
 // ── Scope extraction ─────────────────────────────────────────────────────
 
@@ -58,6 +104,165 @@ function extractScopes(description: string): string[] {
     if (scope) scopes.push(scope);
   }
   return scopes;
+}
+
+function parseScope(scope: string): DeelScope {
+  const separatorIndex = scope.lastIndexOf(":");
+  if (separatorIndex === -1) {
+    throw new Error(`Invalid Deel scope "${scope}"`);
+  }
+  return {
+    scope,
+    family: scope.slice(0, separatorIndex),
+    action: scope.slice(separatorIndex + 1),
+  };
+}
+
+function uniqueValues(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function scopeActionRank(method: string, scope: DeelScope): number {
+  if (READ_METHODS.has(method)) {
+    if (scope.action === "read") return 0;
+    if (scope.action === "write") return 1;
+    return 2;
+  }
+  if (scope.action === "write") return 0;
+  if (scope.action === "read") return 1;
+  return 2;
+}
+
+function pickPreferredScopeInSet(
+  scopes: readonly string[],
+  context: DeelOwnerContext,
+): string {
+  const ranked = uniqueValues(scopes)
+    .map((scope) => {
+      return parseScope(scope);
+    })
+    .sort((left, right) => {
+      const actionDifference =
+        scopeActionRank(context.method, left) -
+        scopeActionRank(context.method, right);
+      if (actionDifference !== 0) return actionDifference;
+      return left.scope.localeCompare(right.scope);
+    });
+
+  const first = ranked[0];
+  if (!first) {
+    throw new Error(`No Deel scopes available for ${context.rule}`);
+  }
+
+  return first.scope;
+}
+
+function pickPrimaryDeelScope(
+  scopes: readonly string[],
+  context: DeelOwnerContext,
+): string | null {
+  const candidates = uniqueValues(scopes);
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0]!;
+
+  for (const tag of context.tags) {
+    const preferredFamilies = DEEL_TAG_OWNER_PREFERENCES.get(tag);
+    if (!preferredFamilies) continue;
+    for (const family of preferredFamilies) {
+      const matchingScopes = candidates.filter((scope) => {
+        return parseScope(scope).family === family;
+      });
+      if (matchingScopes.length > 0) {
+        return pickPreferredScopeInSet(matchingScopes, context);
+      }
+    }
+  }
+
+  const families = uniqueValues(
+    candidates.map((scope) => {
+      return parseScope(scope).family;
+    }),
+  );
+  if (families.length === 1) {
+    return pickPreferredScopeInSet(candidates, context);
+  }
+
+  const ranked = candidates
+    .map((scope) => {
+      return parseScope(scope);
+    })
+    .sort((left, right) => {
+      const actionDifference =
+        scopeActionRank(context.method, left) -
+        scopeActionRank(context.method, right);
+      if (actionDifference !== 0) return actionDifference;
+      return left.scope.localeCompare(right.scope);
+    });
+  const first = ranked[0];
+  const second = ranked[1];
+  if (
+    first &&
+    second &&
+    scopeActionRank(context.method, first) !==
+      scopeActionRank(context.method, second)
+  ) {
+    return first.scope;
+  }
+
+  throw new Error(
+    [
+      `Ambiguous Deel scope owner for ${context.rule}`,
+      context.operationId ? `operation: ${context.operationId}` : null,
+      context.tags.length > 0 ? `tags: ${context.tags.join(", ")}` : null,
+      `scopes: ${candidates.join(", ")}`,
+    ]
+      .filter((part) => {
+        return part !== null;
+      })
+      .join("; "),
+  );
+}
+
+function expandRuntimeRule(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+function assertUniqueDeelRules(permissions: readonly PermissionGroup[]): void {
+  const owners = new Map<string, string>();
+  const duplicates: string[] = [];
+
+  for (const permission of permissions) {
+    for (const rule of permission.rules) {
+      for (const runtimeRule of expandRuntimeRule(rule)) {
+        const existing = owners.get(runtimeRule);
+        if (existing) {
+          duplicates.push(`${runtimeRule}: ${existing}, ${permission.name}`);
+          continue;
+        }
+        owners.set(runtimeRule, permission.name);
+      }
+    }
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      "Deel generated duplicate firewall route owners:\n" +
+        duplicates
+          .sort((left, right) => {
+            return left.localeCompare(right);
+          })
+          .map((duplicate) => {
+            return `  - ${duplicate}`;
+          })
+          .join("\n"),
+    );
+  }
 }
 
 // ── Scope overrides ──────────────────────────────────────────────────────
@@ -137,6 +342,13 @@ function buildGroups(spec: DeelSpec): {
       // Apply manual overrides for endpoints missing scopes in spec
       const override = SCOPE_OVERRIDES[rule];
       if (override) {
+        if (scopes.length > 0) {
+          throw new Error(
+            `Stale Deel scope override for ${rule}: official scopes are ${scopes.join(
+              ", ",
+            )}`,
+          );
+        }
         scopes.push(override);
       }
 
@@ -147,14 +359,23 @@ function buildGroups(spec: DeelSpec): {
         continue;
       }
 
-      for (const scope of scopes) {
-        let ruleSet = groups.get(scope);
-        if (!ruleSet) {
-          ruleSet = new Set();
-          groups.set(scope, ruleSet);
-        }
-        ruleSet.add(rule);
+      const primaryScope = pickPrimaryDeelScope(scopes, {
+        rule,
+        method: httpMethod,
+        tags: op.tags ?? [],
+        operationId: op.operationId ?? null,
+      });
+
+      if (!primaryScope) {
+        continue;
       }
+
+      let ruleSet = groups.get(primaryScope);
+      if (!ruleSet) {
+        ruleSet = new Set();
+        groups.set(primaryScope, ruleSet);
+      }
+      ruleSet.add(rule);
     }
   }
 
@@ -166,6 +387,7 @@ function buildGroups(spec: DeelSpec): {
       rules: sanitizeAndSortRules([...ruleSet]),
     }));
 
+  assertUniqueDeelRules(permissions);
   return { permissions, scopeless: unknownScopeless };
 }
 


### PR DESCRIPTION
## Summary
- select one primary Deel firewall permission owner from official Token scopes using operation tags and HTTP method action rank
- fail generation when Deel emits duplicate runtime route owners or when a manual override becomes stale after official scopes appear
- add Deel firewall regression tests and regenerate the Python builtin catalog

## Notes
- No new or removed Deel permission names; the generated catalog still has 55 permissions.
- The change only removes duplicate route ownership from secondary permissions.

## Testing
- cd turbo && pnpm -F @vm0/firewalls-generator generate:deel
- cd turbo && pnpm -F @vm0/api-contracts generate:rust
- cd turbo && pnpm -F @vm0/connectors exec vitest run src/__tests__/firewalls/deel.test.ts
- cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__/builtin-firewall-catalog.test.ts
- cd crates/runner/mitm-addon && python3 -m pytest tests/test_builtin_firewalls_catalog.py
- cd turbo && pnpm -F @vm0/firewalls-generator check-types
- cd turbo && pnpm -F @vm0/connectors check-types
- cd turbo && pnpm -F @vm0/connectors lint
- cd turbo && pnpm lint
- cd turbo && pnpm check-types
- cd turbo && pnpm knip
- cd turbo && pnpm test (full run had two unrelated @vm0/app UI failures; rerunning those two files passed)
- cd turbo && pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- duplicate route script: duplicate runtime routes = 0, permissions added = 0, removed = 0

Closes #18629