### PR TITLE
fix: reject exec-control requests after sink failure

### DIFF
--- a/crates/vsock-guest/src/exec_control/forward.rs
+++ b/crates/vsock-guest/src/exec_control/forward.rs
@@ -80,7 +80,7 @@ pub(super) fn forward_control_request(
         match sink.wait_for_stream(deadline) {
             Ok(stream) => match stream.lock_until(deadline, &sink.active) {
                 Ok(mut stream) => {
-                    if !sink.active.load(Ordering::Acquire) {
+                    let outcome = if !sink.active.load(Ordering::Acquire) {
                         ControlForwardOutcome {
                             status: ExecControlStatus::Inactive,
                             diagnostic: EXEC_OPERATION_INACTIVE_MESSAGE.to_owned(),
@@ -94,7 +94,11 @@ pub(super) fn forward_control_request(
                         }
                     } else {
                         forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
+                    };
+                    if matches!(outcome.sink_disposition, ControlSinkDisposition::Fail) {
+                        sink.fail(outcome.diagnostic.clone());
                     }
+                    outcome
                 }
                 Err(ControlStreamLockError::Inactive) => ControlForwardOutcome {
                     status: ExecControlStatus::Inactive,
@@ -121,15 +125,8 @@ pub(super) fn forward_control_request(
     };
 
     let ControlForwardOutcome {
-        status,
-        diagnostic,
-        sink_disposition,
+        status, diagnostic, ..
     } = outcome;
-
-    match sink_disposition {
-        ControlSinkDisposition::Keep => {}
-        ControlSinkDisposition::Fail => sink.fail(diagnostic.clone()),
-    }
 
     let result = writer.write_generated_frame_after_lock(|| {
         let (status, diagnostic) = if sink.active.load(Ordering::Acquire) {

--- a/crates/vsock-guest/src/exec_control/forward.rs
+++ b/crates/vsock-guest/src/exec_control/forward.rs
@@ -12,7 +12,7 @@ use crate::error::to_io_error;
 use crate::log::log;
 use crate::writer::GuestWriter;
 
-use super::sink::{ControlSinkState, PendingControlSlot};
+use super::sink::{ControlSinkState, ControlStreamLockError, PendingControlSlot};
 use super::{
     CONTROL_SINK_IO_TIMEOUT, EXEC_CONTROL_LOG_NAME, EXEC_CONTROL_MESSAGE_ID_MISMATCH_PREFIX,
     EXEC_CONTROL_WORKER_START_ERROR_PREFIX, EXEC_OPERATION_INACTIVE_MESSAGE,
@@ -96,14 +96,19 @@ pub(super) fn forward_control_request(
                         forward_to_connected_sink(&mut stream, &message_id, payload, deadline)
                     }
                 }
-                Err(error) if is_timeout(&error) => ControlForwardOutcome {
-                    status: ExecControlStatus::SinkTimeout,
-                    diagnostic: error.to_string(),
+                Err(ControlStreamLockError::Inactive) => ControlForwardOutcome {
+                    status: ExecControlStatus::Inactive,
+                    diagnostic: EXEC_OPERATION_INACTIVE_MESSAGE.to_owned(),
                     sink_disposition: ControlSinkDisposition::Keep,
                 },
-                Err(error) => ControlForwardOutcome {
+                Err(ControlStreamLockError::Timeout) => ControlForwardOutcome {
+                    status: ExecControlStatus::SinkTimeout,
+                    diagnostic: EXEC_REQUEST_TIMEOUT_DIAGNOSTIC.to_owned(),
+                    sink_disposition: ControlSinkDisposition::Keep,
+                },
+                Err(ControlStreamLockError::SinkError(diagnostic)) => ControlForwardOutcome {
                     status: ExecControlStatus::SinkError,
-                    diagnostic: error.to_string(),
+                    diagnostic,
                     sink_disposition: ControlSinkDisposition::Keep,
                 },
             },

--- a/crates/vsock-guest/src/exec_control/sink.rs
+++ b/crates/vsock-guest/src/exec_control/sink.rs
@@ -38,7 +38,7 @@ use vsock_proto::ExecControlStatus;
 use super::{
     EXEC_CONTROL_CLONE_SINK_ERROR_PREFIX, EXEC_CONTROL_QUEUE_FULL_MESSAGE,
     EXEC_OPERATION_INACTIVE_MESSAGE, EXEC_REQUEST_TIMEOUT_DIAGNOSTIC, MAX_PENDING_CONTROL_REQUESTS,
-    duration_until, request_timeout_error,
+    duration_until,
 };
 
 pub(super) struct ControlSinkState {
@@ -68,7 +68,7 @@ pub(super) struct ConnectedControlSink {
 /// stream mutex.
 pub(super) struct ControlStreamState {
     stream: Mutex<UnixStream>,
-    locked: Mutex<bool>,
+    gate: Mutex<ControlStreamGate>,
     ready: Condvar,
 }
 
@@ -76,6 +76,13 @@ pub(super) struct ControlStreamState {
 pub(super) struct ControlStreamGuard<'a> {
     state: &'a ControlStreamState,
     stream: MutexGuard<'a, UnixStream>,
+}
+
+#[derive(Debug)]
+pub(super) enum ControlStreamLockError {
+    Inactive,
+    Timeout,
+    SinkError(String),
 }
 
 pub(super) enum ControlSinkInner {
@@ -89,6 +96,12 @@ pub(super) enum ControlSinkInner {
     Failed(String),
     /// Operation cleanup completed; subsequent requests resolve inactive.
     Closed,
+}
+
+enum ControlStreamGate {
+    Available,
+    Locked,
+    Failed(String),
 }
 
 /// Reserved pending capacity for one forwarding worker.
@@ -180,13 +193,20 @@ impl ControlSinkState {
             return;
         }
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        shutdown_sink_stream(&guard);
-        {
-            if !matches!(*guard, ControlSinkInner::Closed) {
-                *guard = ControlSinkInner::Failed(message);
+        match &*guard {
+            ControlSinkInner::Connected(connected) => connected.fail(&message),
+            ControlSinkInner::Waiting | ControlSinkInner::Handshaking(_) => {
+                shutdown_sink_stream(&guard);
             }
-            self.ready.notify_all();
+            ControlSinkInner::Failed(_) | ControlSinkInner::Closed => {}
         }
+        if !matches!(
+            *guard,
+            ControlSinkInner::Closed | ControlSinkInner::Failed(_)
+        ) {
+            *guard = ControlSinkInner::Failed(message);
+        }
+        self.ready.notify_all();
     }
 
     pub(super) fn close(&self) {
@@ -291,13 +311,18 @@ impl ConnectedControlSink {
         let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
         self.stream.notify_waiters();
     }
+
+    fn fail(&self, message: &str) {
+        let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+        self.stream.mark_failed(message);
+    }
 }
 
 impl ControlStreamState {
     fn new(stream: UnixStream) -> Self {
         Self {
             stream: Mutex::new(stream),
-            locked: Mutex::new(false),
+            gate: Mutex::new(ControlStreamGate::Available),
             ready: Condvar::new(),
         }
     }
@@ -306,42 +331,53 @@ impl ControlStreamState {
         &self,
         deadline: Instant,
         active: &AtomicBool,
-    ) -> io::Result<ControlStreamGuard<'_>> {
-        let mut locked = self.locked.lock().unwrap_or_else(|e| e.into_inner());
+    ) -> Result<ControlStreamGuard<'_>, ControlStreamLockError> {
+        let mut gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
         loop {
             if !active.load(Ordering::Acquire) {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    EXEC_OPERATION_INACTIVE_MESSAGE,
-                ));
+                return Err(ControlStreamLockError::Inactive);
             }
-            if !*locked {
-                *locked = true;
-                drop(locked);
-                let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
-                return Ok(ControlStreamGuard {
-                    state: self,
-                    stream,
-                });
+            match &*gate {
+                ControlStreamGate::Available => {
+                    *gate = ControlStreamGate::Locked;
+                    drop(gate);
+                    let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+                    return Ok(ControlStreamGuard {
+                        state: self,
+                        stream,
+                    });
+                }
+                ControlStreamGate::Failed(message) => {
+                    return Err(ControlStreamLockError::SinkError(message.clone()));
+                }
+                ControlStreamGate::Locked => {}
             }
             let Some(wait) = duration_until(deadline) else {
-                return Err(request_timeout_error());
+                return Err(ControlStreamLockError::Timeout);
             };
-            let (next_locked, wait_result) = self
+            let (next_gate, wait_result) = self
                 .ready
-                .wait_timeout(locked, wait)
+                .wait_timeout(gate, wait)
                 .unwrap_or_else(|e| e.into_inner());
-            locked = next_locked;
+            gate = next_gate;
             // A timeout can race with unlock notification; re-check the locked
             // flag unless the request deadline has actually elapsed.
             if wait_result.timed_out() && duration_until(deadline).is_none() {
-                return Err(request_timeout_error());
+                return Err(ControlStreamLockError::Timeout);
             }
         }
     }
 
     fn notify_waiters(&self) {
-        let _locked = self.locked.lock().unwrap_or_else(|e| e.into_inner());
+        let _gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
+        self.ready.notify_all();
+    }
+
+    fn mark_failed(&self, message: &str) {
+        let mut gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
+        if !matches!(*gate, ControlStreamGate::Failed(_)) {
+            *gate = ControlStreamGate::Failed(message.to_owned());
+        }
         self.ready.notify_all();
     }
 }
@@ -362,8 +398,10 @@ impl std::ops::DerefMut for ControlStreamGuard<'_> {
 
 impl Drop for ControlStreamGuard<'_> {
     fn drop(&mut self) {
-        let mut locked = self.state.locked.lock().unwrap_or_else(|e| e.into_inner());
-        *locked = false;
+        let mut gate = self.state.gate.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(*gate, ControlStreamGate::Locked) {
+            *gate = ControlStreamGate::Available;
+        }
         self.state.ready.notify_one();
     }
 }

--- a/crates/vsock-guest/src/exec_control/sink.rs
+++ b/crates/vsock-guest/src/exec_control/sink.rs
@@ -74,8 +74,14 @@ pub(super) struct ControlStreamState {
 
 /// RAII guard for the forwarder that owns the connected-stream gate.
 pub(super) struct ControlStreamGuard<'a> {
-    state: &'a ControlStreamState,
+    /// This field must be declared before `_gate` so the stream mutex is
+    /// released before the serialization gate is reopened.
     stream: MutexGuard<'a, UnixStream>,
+    _gate: ControlStreamGateGuard<'a>,
+}
+
+struct ControlStreamGateGuard<'a> {
+    state: &'a ControlStreamState,
 }
 
 #[derive(Debug)]
@@ -343,8 +349,8 @@ impl ControlStreamState {
                     drop(gate);
                     let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
                     return Ok(ControlStreamGuard {
-                        state: self,
                         stream,
+                        _gate: ControlStreamGateGuard { state: self },
                     });
                 }
                 ControlStreamGate::Failed(message) => {
@@ -396,7 +402,7 @@ impl std::ops::DerefMut for ControlStreamGuard<'_> {
     }
 }
 
-impl Drop for ControlStreamGuard<'_> {
+impl Drop for ControlStreamGateGuard<'_> {
     fn drop(&mut self) {
         let mut gate = self.state.gate.lock().unwrap_or_else(|e| e.into_inner());
         if matches!(*gate, ControlStreamGate::Locked) {

--- a/crates/vsock-guest/src/exec_control/sink.rs
+++ b/crates/vsock-guest/src/exec_control/sink.rs
@@ -350,12 +350,15 @@ impl ControlStreamState {
                     let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
                     let mut gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
                     if !active.load(Ordering::Acquire) {
+                        drop(stream);
                         self.release_locked_gate(&mut gate);
                         return Err(ControlStreamLockError::Inactive);
                     }
                     match &*gate {
                         ControlStreamGate::Failed(message) => {
-                            return Err(ControlStreamLockError::SinkError(message.clone()));
+                            let message = message.clone();
+                            drop(stream);
+                            return Err(ControlStreamLockError::SinkError(message));
                         }
                         ControlStreamGate::Available => {
                             *gate = ControlStreamGate::Locked;
@@ -405,8 +408,8 @@ impl ControlStreamState {
     fn release_locked_gate(&self, gate: &mut ControlStreamGate) {
         if matches!(*gate, ControlStreamGate::Locked) {
             *gate = ControlStreamGate::Available;
+            self.ready.notify_one();
         }
-        self.ready.notify_one();
     }
 }
 

--- a/crates/vsock-guest/src/exec_control/sink.rs
+++ b/crates/vsock-guest/src/exec_control/sink.rs
@@ -348,6 +348,21 @@ impl ControlStreamState {
                     *gate = ControlStreamGate::Locked;
                     drop(gate);
                     let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+                    let mut gate = self.gate.lock().unwrap_or_else(|e| e.into_inner());
+                    if !active.load(Ordering::Acquire) {
+                        self.release_locked_gate(&mut gate);
+                        return Err(ControlStreamLockError::Inactive);
+                    }
+                    match &*gate {
+                        ControlStreamGate::Failed(message) => {
+                            return Err(ControlStreamLockError::SinkError(message.clone()));
+                        }
+                        ControlStreamGate::Available => {
+                            *gate = ControlStreamGate::Locked;
+                        }
+                        ControlStreamGate::Locked => {}
+                    }
+                    drop(gate);
                     return Ok(ControlStreamGuard {
                         stream,
                         _gate: ControlStreamGateGuard { state: self },
@@ -386,6 +401,13 @@ impl ControlStreamState {
         }
         self.ready.notify_all();
     }
+
+    fn release_locked_gate(&self, gate: &mut ControlStreamGate) {
+        if matches!(*gate, ControlStreamGate::Locked) {
+            *gate = ControlStreamGate::Available;
+        }
+        self.ready.notify_one();
+    }
 }
 
 impl std::ops::Deref for ControlStreamGuard<'_> {
@@ -405,9 +427,6 @@ impl std::ops::DerefMut for ControlStreamGuard<'_> {
 impl Drop for ControlStreamGateGuard<'_> {
     fn drop(&mut self) {
         let mut gate = self.state.gate.lock().unwrap_or_else(|e| e.into_inner());
-        if matches!(*gate, ControlStreamGate::Locked) {
-            *gate = ControlStreamGate::Available;
-        }
-        self.state.ready.notify_one();
+        self.state.release_locked_gate(&mut gate);
     }
 }

--- a/crates/vsock-guest/src/exec_control/sink.rs
+++ b/crates/vsock-guest/src/exec_control/sink.rs
@@ -20,8 +20,8 @@
 //! `inner` and `ready` own connection-state changes and wake waiting forwarders.
 //! `active` is the operation-lifetime gate, so close/drop can stop queued or
 //! in-flight forwarding even when a connected stream guard is busy. The
-//! connected stream has a separate `locked` gate so waiters can keep their
-//! request deadlines and be woken by close/fail before taking the stream mutex.
+//! connected stream has a separate gate so waiters can keep their request
+//! deadlines and be woken by close/fail before taking the stream mutex.
 //! `pending` limits outstanding forwarding work; when it is full, new requests
 //! release their transient count and return `QueueFull`. `PendingControlSlot`
 //! releases reserved work. The shutdown stream clones let close/fail interrupt
@@ -63,9 +63,9 @@ pub(super) struct ConnectedControlSink {
 
 /// Shared connected stream plus a waitable serialization gate.
 ///
-/// `locked` is separate from `stream` so waiting forwarders can wait with their
-/// request deadline and can be woken by close/fail without contending on a busy
-/// stream mutex.
+/// `gate` is separate from `stream` so waiting forwarders can wait with their
+/// request deadline, observe terminal failure, and be woken by close/fail
+/// without contending on a busy stream mutex.
 pub(super) struct ControlStreamState {
     stream: Mutex<UnixStream>,
     gate: Mutex<ControlStreamGate>,
@@ -360,8 +360,8 @@ impl ControlStreamState {
                 .wait_timeout(gate, wait)
                 .unwrap_or_else(|e| e.into_inner());
             gate = next_gate;
-            // A timeout can race with unlock notification; re-check the locked
-            // flag unless the request deadline has actually elapsed.
+            // A timeout can race with gate notification; re-check the gate
+            // unless the request deadline has actually elapsed.
             if wait_result.timed_out() && duration_until(deadline).is_none() {
                 return Err(ControlStreamLockError::Timeout);
             }

--- a/crates/vsock-guest/src/exec_control/tests.rs
+++ b/crates/vsock-guest/src/exec_control/tests.rs
@@ -979,6 +979,38 @@ fn failed_control_sink_rejects_existing_connected_stream_handle() {
 }
 
 #[test]
+fn control_sink_failure_preserves_first_diagnostic() {
+    let sink = Arc::new(ControlSinkState::new());
+    let (stream, _peer) = UnixStream::pair().unwrap();
+    sink.connect(stream);
+    let stream = match &*sink.inner.lock().unwrap_or_else(|e| e.into_inner()) {
+        ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
+        _ => panic!("sink should be connected"),
+    };
+
+    sink.fail("first failure".to_owned());
+    sink.fail("second failure".to_owned());
+
+    let error = match sink.wait_for_stream(request_deadline(5000)) {
+        Ok(_) => panic!("failed sink should reject future stream lookups"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error,
+        (ExecControlStatus::SinkError, "first failure".to_owned())
+    );
+
+    let error = match stream.lock_until(request_deadline(5000), &sink.active) {
+        Ok(_) => panic!("failed stream gate should preserve the first failure"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        ControlStreamLockError::SinkError(message) if message == "first failure"
+    ));
+}
+
+#[test]
 fn queued_control_request_is_not_delivered_after_close() {
     let sink = Arc::new(ControlSinkState::new());
     let (stream, mut peer) = UnixStream::pair().unwrap();

--- a/crates/vsock-guest/src/exec_control/tests.rs
+++ b/crates/vsock-guest/src/exec_control/tests.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use vsock_proto::{ExecControlNonce, ExecControlStatus, MSG_EXEC_CONTROL_RESULT};
 
 use super::forward::{OwnedExecControlRequest, forward_control_request, try_forward};
-use super::sink::{ControlSinkInner, ControlSinkState};
+use super::sink::{ControlSinkInner, ControlSinkState, ControlStreamLockError};
 use super::*;
 
 const NONCE: ExecControlNonce = *b"0123456789abcdef";
@@ -953,6 +953,32 @@ fn fail_does_not_wait_for_busy_control_stream_lock() {
 }
 
 #[test]
+fn failed_control_sink_rejects_existing_connected_stream_handle() {
+    let sink = Arc::new(ControlSinkState::new());
+    let (stream, _peer) = UnixStream::pair().unwrap();
+    sink.connect(stream);
+    let stream = match &*sink.inner.lock().unwrap_or_else(|e| e.into_inner()) {
+        ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
+        _ => panic!("sink should be connected"),
+    };
+    let stream_guard = stream
+        .lock_until(request_deadline(5000), &sink.active)
+        .unwrap();
+
+    sink.fail("failed".to_owned());
+
+    let error = match stream.lock_until(request_deadline(5000), &sink.active) {
+        Ok(_) => panic!("failed sink should reject existing connected stream handles"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        ControlStreamLockError::SinkError(message) if message == "failed"
+    ));
+    drop(stream_guard);
+}
+
+#[test]
 fn queued_control_request_is_not_delivered_after_close() {
     let sink = Arc::new(ControlSinkState::new());
     let (stream, mut peer) = UnixStream::pair().unwrap();
@@ -1005,6 +1031,61 @@ fn queued_control_request_is_not_delivered_after_close() {
         err.kind(),
         io::ErrorKind::WouldBlock | io::ErrorKind::UnexpectedEof | io::ErrorKind::ConnectionReset
     ));
+}
+
+#[test]
+fn queued_control_request_is_not_delivered_after_fail() {
+    let sink = Arc::new(ControlSinkState::new());
+    let (stream, mut peer) = UnixStream::pair().unwrap();
+    peer.set_nonblocking(true).unwrap();
+    sink.connect(stream);
+    let stream = match &*sink.inner.lock().unwrap_or_else(|e| e.into_inner()) {
+        ControlSinkInner::Connected(connected) => Arc::clone(&connected.stream),
+        _ => panic!("sink should be connected"),
+    };
+    let stream_guard = stream
+        .lock_until(request_deadline(5000), &sink.active)
+        .unwrap();
+    let (guest, mut host) = UnixStream::pair().unwrap();
+    host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+
+    let pending_slot = sink.reserve_pending_slot().unwrap();
+    let worker = std::thread::spawn({
+        let sink = Arc::clone(&sink);
+        move || {
+            forward_control_request(
+                sink,
+                pending_slot,
+                OwnedExecControlRequest {
+                    response_seq: 23,
+                    target_seq: 9,
+                    deadline: request_deadline(5000),
+                    control_nonce: NONCE,
+                    message_id: "msg-after-fail".to_owned(),
+                    payload: b"payload".to_vec(),
+                },
+                GuestWriter::new(guest),
+            );
+        }
+    });
+
+    sink.fail("failed".to_owned());
+
+    let (msg_type, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
+    assert_eq!(msg_type, MSG_EXEC_CONTROL_RESULT);
+    assert_eq!(seq, 23);
+    assert_eq!(status, ExecControlStatus::SinkError);
+    assert_eq!(message_id, "msg-after-fail");
+    assert_eq!(diagnostic, "failed");
+    worker.join().unwrap();
+    assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+
+    let err = process_control_ipc::read_request(&mut peer).unwrap_err();
+    assert!(matches!(
+        err.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::UnexpectedEof | io::ErrorKind::ConnectionReset
+    ));
+    drop(stream_guard);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #18618.

This changes the connected exec-control stream gate so terminal sink failure is visible to forwarders that already passed `wait_for_stream()` and are waiting in `lock_until()`.

Key changes:

- Replace the connected stream `locked: bool` gate with explicit `Available`, `Locked`, and `Failed(diagnostic)` states.
- Have `ControlSinkState::fail()` mark the connected stream gate failed and wake stream waiters while preserving `Closed`/`Inactive` semantics.
- Return structured lock failures so queued requests map sink failure to `SinkError` with the original diagnostic instead of touching the failed stream.
- Add regression coverage for queued requests after `fail()` and existing connected stream handles after failure.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest queued_control_request`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest failed_control_sink_rejects_existing_connected_stream_handle`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest control_sink`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec_control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings`
- `git diff --check`
