### PR TITLE
feat: add gmail workflow trigger cli support

### DIFF
--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/__tests__/trigger.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/__tests__/trigger.test.ts
@@ -10,6 +10,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../../mocks/server";
 import { triggerCommand } from "../index";
@@ -74,6 +77,23 @@ const loopTrigger = {
   scheduleSummary: "Every 900s",
 };
 
+const gmailTrigger = {
+  ...triggerBase,
+  kind: "event",
+  eventType: "gmail-new-message",
+  eventConfig: {
+    provider: "gmail",
+    event: "new_message",
+    match: {
+      from: { contains: "@acme.com" },
+      subject: { contains: "invoice" },
+    },
+  },
+  schedule: null,
+  scheduleSummary: null,
+  nextRunAt: null,
+};
+
 describe("zero workflow trigger commands", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -82,6 +102,7 @@ describe("zero workflow trigger commands", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+  const tempDirs: string[] = [];
 
   beforeEach(() => {
     chalk.level = 0;
@@ -93,8 +114,19 @@ describe("zero workflow trigger commands", () => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
     vi.unstubAllEnvs();
   });
+
+  function writeGmailConfig(config: object): string {
+    const dir = mkdtempSync(join(tmpdir(), "vm0-gmail-trigger-"));
+    tempDirs.push(dir);
+    const path = join(dir, "gmail-trigger.json");
+    writeFileSync(path, JSON.stringify(config), "utf-8");
+    return path;
+  }
 
   function captureCreateTrigger(response: object) {
     const captured: { workflowId?: string; body?: Record<string, unknown> } =
@@ -204,6 +236,135 @@ describe("zero workflow trigger commands", () => {
       });
     });
 
+    it("should add a Gmail new message trigger without match rules", async () => {
+      const captured = captureCreateTrigger({
+        ...gmailTrigger,
+        eventConfig: { provider: "gmail", event: "new_message" },
+      });
+
+      await triggerCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "gmail-new-message",
+      ]);
+
+      expect(captured.workflowId).toBe(WORKFLOW_ID);
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "gmail-new-message",
+        eventConfig: { provider: "gmail", event: "new_message" },
+      });
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Gmail new message");
+      expect(logCalls).toContain("all inbound messages");
+    });
+
+    it("should add a Gmail new message trigger with text match flags", async () => {
+      const captured = captureCreateTrigger(gmailTrigger);
+
+      await triggerCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "gmail-new-message",
+        "--from-contains",
+        "@acme.com",
+        "--subject-contains",
+        "invoice",
+        "--body-not-contains",
+        "unsubscribe",
+      ]);
+
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "gmail-new-message",
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            from: { contains: "@acme.com" },
+            subject: { contains: "invoice" },
+            body: { doesNotContain: "unsubscribe" },
+          },
+        },
+      });
+    });
+
+    it("should add a Gmail new message trigger from a config file", async () => {
+      const configPath = writeGmailConfig({
+        match: {
+          from: { containsAny: ["@acme.com", "@example.com"] },
+          subject: { doesNotContainAny: ["newsletter", "promo"] },
+        },
+      });
+      const captured = captureCreateTrigger(gmailTrigger);
+
+      await triggerCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "gmail-new-message",
+        "--config",
+        configPath,
+      ]);
+
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "gmail-new-message",
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            from: { containsAny: ["@acme.com", "@example.com"] },
+            subject: { doesNotContainAny: ["newsletter", "promo"] },
+          },
+        },
+      });
+    });
+
+    it.each([
+      {
+        field: "hasAttachment",
+        config: { match: { hasAttachment: true } },
+      },
+      {
+        field: "labels",
+        config: { match: { labels: { includeAny: ["INBOX"] } } },
+      },
+      {
+        field: "snippet",
+        config: { match: { snippet: { contains: "preview" } } },
+      },
+    ])(
+      "should reject unsupported Gmail config match field $field",
+      async ({ field, config }) => {
+        const configPath = writeGmailConfig(config);
+
+        await expect(async () => {
+          await triggerCommand.parseAsync([
+            "node",
+            "cli",
+            "add",
+            WORKFLOW_ID,
+            "gmail-new-message",
+            "--config",
+            configPath,
+          ]);
+        }).rejects.toThrow("process.exit called");
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Unsupported Gmail trigger match field "${field}"`,
+          ),
+        );
+        expect(mockExit).toHaveBeenCalledWith(1);
+      },
+    );
+
     it("should reject an unknown trigger kind", async () => {
       await expect(async () => {
         await triggerCommand.parseAsync([
@@ -217,6 +378,46 @@ describe("zero workflow trigger commands", () => {
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('Unknown trigger kind: "webhook"'),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject Gmail match flags on schedule triggers", async () => {
+      await expect(async () => {
+        await triggerCommand.parseAsync([
+          "node",
+          "cli",
+          "add",
+          WORKFLOW_ID,
+          "cron",
+          "--expr",
+          "0 9 * * *",
+          "--from-contains",
+          "@acme.com",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("only apply to gmail-new-message triggers"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject empty Gmail text match flags", async () => {
+      await expect(async () => {
+        await triggerCommand.parseAsync([
+          "node",
+          "cli",
+          "add",
+          WORKFLOW_ID,
+          "gmail-new-message",
+          "--from-contains",
+          "",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("from contains must be non-empty"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -293,7 +494,7 @@ describe("zero workflow trigger commands", () => {
           "http://localhost:3000/api/zero/workflows/:workflowId/triggers",
           ({ params }) => {
             expect(params.workflowId).toBe(WORKFLOW_ID);
-            return HttpResponse.json([cronTrigger, loopTrigger]);
+            return HttpResponse.json([cronTrigger, loopTrigger, gmailTrigger]);
           },
         ),
       );
@@ -304,6 +505,8 @@ describe("zero workflow trigger commands", () => {
       expect(logCalls).toContain(TRIGGER_ID);
       expect(logCalls).toContain("0 9 * * *");
       expect(logCalls).toContain("every 15m");
+      expect(logCalls).toContain("Gmail new message");
+      expect(logCalls).toContain('from contains "@acme.com"');
     });
 
     it("should display an empty state with an add hint", async () => {
@@ -331,7 +534,7 @@ describe("zero workflow trigger commands", () => {
           "http://localhost:3000/api/zero/workflow-triggers/:id",
           ({ params }) => {
             expect(params.id).toBe(TRIGGER_ID);
-            return HttpResponse.json(loopTrigger);
+            return HttpResponse.json(gmailTrigger);
           },
         ),
       );
@@ -340,7 +543,8 @@ describe("zero workflow trigger commands", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(TRIGGER_ID);
-      expect(logCalls).toContain("every 15m");
+      expect(logCalls).toContain("Gmail new message");
+      expect(logCalls).toContain('subject contains "invoice"');
       expect(logCalls).toContain(THREAD_ID);
     });
   });

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/display.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/display.ts
@@ -1,13 +1,77 @@
 import chalk from "chalk";
-import type { ZeroWorkflowTriggerSummary } from "@vm0/api-contracts/contracts/zero-workflows";
+import type {
+  GmailNewMessageEventConfig,
+  ZeroWorkflowTriggerSummary,
+} from "@vm0/api-contracts/contracts/zero-workflows";
 import { formatRelativeTime } from "../../../../lib/domain/schedule-utils";
 import { formatDurationSeconds } from "../../automation/duration";
+
+type GmailMatchRules = NonNullable<GmailNewMessageEventConfig["match"]>;
+type GmailTextMatcher = NonNullable<GmailMatchRules["from"]>;
+type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
+
+const GMAIL_TEXT_FIELDS: readonly GmailTextField[] = [
+  "from",
+  "subject",
+  "body",
+  "to",
+  "cc",
+];
+
+function quote(value: string): string {
+  return `"${value}"`;
+}
+
+function quoteList(values: readonly string[]): string {
+  return values.map(quote).join(", ");
+}
+
+function textMatcherParts(
+  field: GmailTextField,
+  matcher: GmailTextMatcher,
+): string[] {
+  const parts: string[] = [];
+  if (matcher.contains) {
+    parts.push(`${field} contains ${quote(matcher.contains)}`);
+  }
+  if (matcher.containsAny) {
+    parts.push(`${field} contains any of ${quoteList(matcher.containsAny)}`);
+  }
+  if (matcher.doesNotContain) {
+    parts.push(`${field} does not contain ${quote(matcher.doesNotContain)}`);
+  }
+  if (matcher.doesNotContainAny) {
+    parts.push(
+      `${field} does not contain any of ${quoteList(matcher.doesNotContainAny)}`,
+    );
+  }
+  return parts;
+}
+
+function formatGmailMatchSummary(config: GmailNewMessageEventConfig): string {
+  const match = config.match;
+  if (!match) {
+    return "all inbound messages";
+  }
+
+  const parts: string[] = [];
+  for (const field of GMAIL_TEXT_FIELDS) {
+    const matcher = match[field];
+    if (matcher) {
+      parts.push(...textMatcherParts(field, matcher));
+    }
+  }
+  if (match.snippet || match.labels || match.hasAttachment !== undefined) {
+    parts.push("custom match rules");
+  }
+  return parts.length > 0 ? parts.join("; ") : "all inbound messages";
+}
 
 function formatWorkflowTriggerEntry(
   trigger: ZeroWorkflowTriggerSummary,
 ): string {
   if (trigger.kind === "event") {
-    return "Gmail new message";
+    return `Gmail new message: ${formatGmailMatchSummary(trigger.eventConfig)}`;
   }
 
   const { schedule } = trigger;
@@ -81,7 +145,18 @@ export function printWorkflowTriggerDetails(
     console.log(`${"Workflow:".padEnd(14)}${options.workflowRef}`);
   }
   console.log(`${"Status:".padEnd(14)}${status}`);
-  console.log(`${"Trigger:".padEnd(14)}${formatWorkflowTriggerEntry(trigger)}`);
+  console.log(
+    `${"Trigger:".padEnd(14)}${
+      trigger.kind === "event"
+        ? "Gmail new message"
+        : formatWorkflowTriggerEntry(trigger)
+    }`,
+  );
+  if (trigger.kind === "event") {
+    console.log(
+      `${"Match:".padEnd(14)}${formatGmailMatchSummary(trigger.eventConfig)}`,
+    );
+  }
   console.log(`${"Owner:".padEnd(14)}${trigger.ownerUserId}`);
   console.log(
     `${"Chat thread:".padEnd(14)}${trigger.chatThreadId ?? chalk.dim("-")}`,

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/gmail-config.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/gmail-config.ts
@@ -1,0 +1,274 @@
+import { readFileSync } from "node:fs";
+import type { GmailNewMessageEventConfig } from "@vm0/api-contracts/contracts/zero-workflows";
+
+type GmailMatchRules = NonNullable<GmailNewMessageEventConfig["match"]>;
+type GmailTextMatcher = NonNullable<GmailMatchRules["from"]>;
+type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
+
+export interface GmailTriggerOptions {
+  readonly config?: string;
+  readonly fromContains?: string;
+  readonly fromNotContains?: string;
+  readonly subjectContains?: string;
+  readonly subjectNotContains?: string;
+  readonly bodyContains?: string;
+  readonly bodyNotContains?: string;
+  readonly toContains?: string;
+  readonly toNotContains?: string;
+  readonly ccContains?: string;
+  readonly ccNotContains?: string;
+}
+
+interface TextFlagSpec {
+  readonly field: GmailTextField;
+  readonly contains?: string;
+  readonly doesNotContain?: string;
+}
+
+const TEXT_FIELD_LABELS: Record<GmailTextField, string> = {
+  from: "from",
+  subject: "subject",
+  body: "body",
+  to: "to",
+  cc: "cc",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function textFieldFromKey(key: string): GmailTextField | null {
+  switch (key) {
+    case "from":
+    case "subject":
+    case "body":
+    case "to":
+    case "cc":
+      return key;
+    default:
+      return null;
+  }
+}
+
+function formatFieldName(field: GmailTextField): string {
+  return TEXT_FIELD_LABELS[field];
+}
+
+function parseNonEmptyString(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+  return value;
+}
+
+function parseNonEmptyStringArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${path} must be a non-empty string array`);
+  }
+  return value.map((item, index) => {
+    return parseNonEmptyString(item, `${path}[${index}]`);
+  });
+}
+
+function parseTextMatcher(
+  field: GmailTextField,
+  value: unknown,
+): GmailTextMatcher {
+  if (!isRecord(value)) {
+    throw new Error(`${formatFieldName(field)} must be an object`);
+  }
+
+  const matcher: {
+    contains?: string;
+    containsAny?: string[];
+    doesNotContain?: string;
+    doesNotContainAny?: string[];
+  } = {};
+
+  for (const key of Object.keys(value)) {
+    switch (key) {
+      case "contains":
+        matcher.contains = parseNonEmptyString(
+          value[key],
+          `${formatFieldName(field)}.contains`,
+        );
+        break;
+      case "containsAny":
+        matcher.containsAny = parseNonEmptyStringArray(
+          value[key],
+          `${formatFieldName(field)}.containsAny`,
+        );
+        break;
+      case "doesNotContain":
+        matcher.doesNotContain = parseNonEmptyString(
+          value[key],
+          `${formatFieldName(field)}.doesNotContain`,
+        );
+        break;
+      case "doesNotContainAny":
+        matcher.doesNotContainAny = parseNonEmptyStringArray(
+          value[key],
+          `${formatFieldName(field)}.doesNotContainAny`,
+        );
+        break;
+      default:
+        throw new Error(
+          `Unsupported Gmail trigger text matcher "${key}" for ${formatFieldName(field)}`,
+        );
+    }
+  }
+
+  if (
+    matcher.contains === undefined &&
+    matcher.containsAny === undefined &&
+    matcher.doesNotContain === undefined &&
+    matcher.doesNotContainAny === undefined
+  ) {
+    throw new Error(
+      `${formatFieldName(field)} must include at least one text matcher`,
+    );
+  }
+
+  return matcher;
+}
+
+function parseMatch(value: unknown): GmailMatchRules | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new Error("match must be an object");
+  }
+
+  const match: GmailMatchRules = {};
+  for (const key of Object.keys(value)) {
+    const field = textFieldFromKey(key);
+    if (field === null) {
+      throw new Error(
+        `Unsupported Gmail trigger match field "${key}". Supported fields: from, subject, body, to, cc`,
+      );
+    }
+    match[field] = parseTextMatcher(field, value[key]);
+  }
+
+  return Object.keys(match).length > 0 ? match : undefined;
+}
+
+function readConfigMatch(path: string): GmailMatchRules | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to read Gmail trigger config "${path}": ${message}`,
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("Gmail trigger config must be a JSON object");
+  }
+
+  for (const key of Object.keys(parsed)) {
+    if (key !== "match") {
+      throw new Error(
+        `Unsupported Gmail trigger config field "${key}". Use a top-level match object`,
+      );
+    }
+  }
+
+  return parseMatch(parsed.match);
+}
+
+function textFlagSpecs(options: GmailTriggerOptions): readonly TextFlagSpec[] {
+  return [
+    {
+      field: "from",
+      contains: options.fromContains,
+      doesNotContain: options.fromNotContains,
+    },
+    {
+      field: "subject",
+      contains: options.subjectContains,
+      doesNotContain: options.subjectNotContains,
+    },
+    {
+      field: "body",
+      contains: options.bodyContains,
+      doesNotContain: options.bodyNotContains,
+    },
+    {
+      field: "to",
+      contains: options.toContains,
+      doesNotContain: options.toNotContains,
+    },
+    {
+      field: "cc",
+      contains: options.ccContains,
+      doesNotContain: options.ccNotContains,
+    },
+  ];
+}
+
+export function hasGmailTriggerOptions(options: GmailTriggerOptions): boolean {
+  return (
+    options.config !== undefined ||
+    textFlagSpecs(options).some((spec) => {
+      return spec.contains !== undefined || spec.doesNotContain !== undefined;
+    })
+  );
+}
+
+function buildMatchFromFlags(
+  options: GmailTriggerOptions,
+): GmailMatchRules | undefined {
+  const match: GmailMatchRules = {};
+  for (const spec of textFlagSpecs(options)) {
+    const matcher: { contains?: string; doesNotContain?: string } = {};
+    if (spec.contains !== undefined) {
+      if (spec.contains.length === 0) {
+        throw new Error(
+          `${formatFieldName(spec.field)} contains must be non-empty`,
+        );
+      }
+      matcher.contains = spec.contains;
+    }
+    if (spec.doesNotContain !== undefined) {
+      if (spec.doesNotContain.length === 0) {
+        throw new Error(
+          `${formatFieldName(spec.field)} doesNotContain must be non-empty`,
+        );
+      }
+      matcher.doesNotContain = spec.doesNotContain;
+    }
+    if (
+      matcher.contains !== undefined ||
+      matcher.doesNotContain !== undefined
+    ) {
+      match[spec.field] = matcher;
+    }
+  }
+  return Object.keys(match).length > 0 ? match : undefined;
+}
+
+export function buildGmailNewMessageEventConfig(
+  options: GmailTriggerOptions,
+): GmailNewMessageEventConfig {
+  if (
+    options.config !== undefined &&
+    textFlagSpecs(options).some((spec) => {
+      return spec.contains !== undefined || spec.doesNotContain !== undefined;
+    })
+  ) {
+    throw new Error("Use either --config or Gmail text match flags, not both");
+  }
+
+  const match =
+    options.config !== undefined
+      ? readConfigMatch(options.config)
+      : buildMatchFromFlags(options);
+
+  return match
+    ? { provider: "gmail", event: "new_message", match }
+    : { provider: "gmail", event: "new_message" };
+}

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/index.ts
@@ -22,8 +22,13 @@ import {
   printWorkflowTriggerDetails,
   printWorkflowTriggersTable,
 } from "./display";
+import {
+  buildGmailNewMessageEventConfig,
+  hasGmailTriggerOptions,
+  type GmailTriggerOptions,
+} from "./gmail-config";
 
-interface AddOptions {
+interface AddOptions extends GmailTriggerOptions {
   readonly expr?: string;
   readonly at?: string;
   readonly every?: string;
@@ -45,6 +50,8 @@ interface WorkflowRefOptions {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SCHEDULE_KINDS = ["cron", "once", "loop"] as const;
+const EVENT_KINDS = ["gmail-new-message"] as const;
+const TRIGGER_KINDS = [...SCHEDULE_KINDS, ...EVENT_KINDS] as const;
 const EXACTLY_ONE_FLAG_MESSAGE =
   "Provide exactly one of --expr (cron), --at (once), --every (loop)";
 
@@ -206,9 +213,44 @@ function buildSchedule(
       };
     default:
       throw new Error(
-        `Unknown trigger kind: "${kind}". Use one of: ${SCHEDULE_KINDS.join(", ")}`,
+        `Unknown trigger kind: "${kind}". Use one of: ${TRIGGER_KINDS.join(", ")}`,
       );
   }
+}
+
+function hasScheduleAddOptions(options: AddOptions): boolean {
+  return (
+    options.expr !== undefined ||
+    options.at !== undefined ||
+    options.every !== undefined ||
+    options.timezone !== undefined
+  );
+}
+
+function buildCreateRequest(
+  kind: string,
+  options: AddOptions,
+): ZeroWorkflowTriggerCreateRequest {
+  if (kind === "gmail-new-message") {
+    if (hasScheduleAddOptions(options)) {
+      throw new Error(
+        "--expr, --at, --every, and --timezone only apply to schedule triggers",
+      );
+    }
+    return {
+      kind: "event",
+      eventType: "gmail-new-message",
+      eventConfig: buildGmailNewMessageEventConfig(options),
+    };
+  }
+
+  if (hasGmailTriggerOptions(options)) {
+    throw new Error(
+      "Gmail match flags and --config only apply to gmail-new-message triggers",
+    );
+  }
+
+  return { schedule: buildSchedule(kind, options) };
 }
 
 function buildUpdate(options: UpdateOptions): ZeroWorkflowTriggerUpdateRequest {
@@ -261,13 +303,42 @@ async function resolveWorkflowId(
 
 const addCommand = new Command()
   .name("add")
-  .description("Add a schedule trigger to a workflow")
+  .description("Add a trigger to a workflow")
   .argument("<workflow>", "Workflow ID or name")
-  .argument("<kind>", `Trigger kind: ${SCHEDULE_KINDS.join(" | ")}`)
+  .argument("<kind>", `Trigger type: ${TRIGGER_KINDS.join(" | ")}`)
   .option("--expr <expression>", 'Cron expression for kind "cron"')
   .option("--at <iso-time>", 'Fire time for kind "once"')
   .option("--every <duration>", 'Interval for kind "loop" (e.g. 15m, 1h, 90s)')
   .option("-z, --timezone <tz>", "IANA timezone for cron/once (default: UTC)")
+  .option("--config <path>", "Path to a Gmail new message trigger config JSON")
+  .option("--from-contains <text>", "Require the From header to contain text")
+  .option(
+    "--from-not-contains <text>",
+    "Require the From header not to contain text",
+  )
+  .option(
+    "--subject-contains <text>",
+    "Require the Subject header to contain text",
+  )
+  .option(
+    "--subject-not-contains <text>",
+    "Require the Subject header not to contain text",
+  )
+  .option("--body-contains <text>", "Require the message body to contain text")
+  .option(
+    "--body-not-contains <text>",
+    "Require the message body not to contain text",
+  )
+  .option("--to-contains <text>", "Require the To header to contain text")
+  .option(
+    "--to-not-contains <text>",
+    "Require the To header not to contain text",
+  )
+  .option("--cc-contains <text>", "Require the Cc header to contain text")
+  .option(
+    "--cc-not-contains <text>",
+    "Require the Cc header not to contain text",
+  )
   .option("--agent <id>", "Agent ID for resolving a workflow name")
   .addHelpText(
     "after",
@@ -276,21 +347,27 @@ Examples:
   zero workflow trigger add tell-a-joke cron --expr "0 9 * * *" -z Asia/Shanghai
   zero workflow trigger add tell-a-joke once --at "2026-06-10T09:00" -z Asia/Shanghai
   zero workflow trigger add tell-a-joke loop --every 15m
+  zero workflow trigger add triage gmail-new-message --from-contains "@example.com"
+  zero workflow trigger add triage gmail-new-message --config ./gmail-trigger.json
 
 Notes:
   - Workflow names resolve under --agent, then ZERO_AGENT_ID, then all visible workflows
+  - Gmail triggers match all inbound messages when no text match rules are provided
   - Use the workflow ID when a name is ambiguous`,
   )
   .action(
     withErrorHandler(
       async (workflowRef: string, kind: string, options: AddOptions) => {
-        if (options.timezone && kind !== "cron" && kind !== "once") {
+        if (
+          options.timezone &&
+          kind !== "cron" &&
+          kind !== "once" &&
+          kind !== "gmail-new-message"
+        ) {
           throw new Error("--timezone only applies to cron and once triggers");
         }
         const workflowId = await resolveWorkflowId(workflowRef, options);
-        const body: ZeroWorkflowTriggerCreateRequest = {
-          schedule: buildSchedule(kind, options),
-        };
+        const body = buildCreateRequest(kind, options);
         const trigger = await createWorkflowTrigger(workflowId, body);
 
         console.log(
@@ -329,7 +406,7 @@ Examples:
 const listCommand = new Command()
   .name("list")
   .alias("ls")
-  .description("List a workflow's schedule triggers")
+  .description("List a workflow's triggers")
   .argument("<workflow>", "Workflow ID or name")
   .option("--agent <id>", "Agent ID for resolving a workflow name")
   .addHelpText(
@@ -421,7 +498,7 @@ const runCommand = new Command()
 
 export const triggerCommand = new Command()
   .name("trigger")
-  .description("Manage a workflow's schedule triggers")
+  .description("Manage a workflow's triggers")
   .addCommand(addCommand)
   .addCommand(updateCommand)
   .addCommand(listCommand)


### PR DESCRIPTION
## Summary

- Add `zero workflow trigger add <workflow> gmail-new-message` for creating Gmail new message workflow triggers from the CLI
- Support text match flags for from, subject, body, to, and cc, plus `--config` for text-only matcher config
- Keep workflow trigger update and `--json` output unchanged
- Show Gmail trigger match summaries in `list` and `show`

## Non-goals

- No event trigger update support
- No labels, label ids, attachment matching, or snippet matching in the CLI surface
- No action-specific trigger config; the workflow instruction still defines what to do after the trigger fires

## Tests

- `pnpm -F @vm0/cli exec vitest run src/commands/zero/workflow/trigger/__tests__/trigger.test.ts`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`

Closes #18641