### PR TITLE
fix: avoid rescheduling disabled automation triggers

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
@@ -1980,6 +1980,60 @@ describe("dispatchRunCallbacks$ trigger internal dispatch", () => {
     await expect(readCallback(callbackId)).resolves.toMatchObject({
       url: null,
       internalKind: "trigger:cron",
+      status: "delivered",
+      attempts: 1,
+      lastError: null,
+    });
+  });
+
+  it("does not reschedule trigger callbacks after the automation is disabled", async () => {
+    mockNow(new Date("2026-05-13T04:00:00.000Z"));
+    const fixture = await seedAgentCallbackRun();
+    const triggerId = await seedAutomationTrigger(fixture, {
+      kind: "cron",
+      consecutiveFailures: 2,
+    });
+    const { callbackId } = await store.set(
+      seedAgentRunCallback$,
+      {
+        runId: fixture.runId,
+        internalKind: "trigger:cron",
+        payload: { triggerId, cronExpression: "0 9 * * *", timezone: "UTC" },
+      },
+      context.signal,
+    );
+    const routeRequests = failIfCallbackRouteIsFetched(
+      TRIGGER_CRON_CALLBACK_URL,
+    );
+    const db = store.set(writeDb$);
+
+    await db
+      .update(automations)
+      .set({ enabled: false })
+      .where(
+        inArray(
+          automations.id,
+          db
+            .select({ id: automationTriggers.automationId })
+            .from(automationTriggers)
+            .where(eq(automationTriggers.id, triggerId)),
+        ),
+      );
+
+    const results = await store.set(
+      dispatchRunCallbacks$,
+      { db, runId: fixture.runId, status: "completed" },
+      context.signal,
+    );
+
+    expect(results).toStrictEqual([{ callbackId, success: true }]);
+    expect(routeRequests()).toBe(0);
+    await expect(readTrigger(triggerId)).resolves.toMatchObject({
+      consecutiveFailures: 2,
+      enabled: true,
+      nextRunAt: null,
+    });
+    await expect(readCallback(callbackId)).resolves.toMatchObject({
       status: "delivered",
       attempts: 1,
       lastError: null,

--- a/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
+++ b/turbo/apps/api/src/signals/services/automations/trigger-poller.ts
@@ -3,7 +3,7 @@ import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { command } from "ccstate";
-import { and, eq, inArray, lte } from "drizzle-orm";
+import { and, eq, exists, inArray, lte } from "drizzle-orm";
 
 import { logger } from "../../../lib/log";
 import { writeDb$, type Db } from "../../external/db";
@@ -284,6 +284,28 @@ async function recordTriggerPreRunFailure(
     failureTime,
     shouldDisable,
   });
+  const parentAutomationIsEnabled = exists(
+    db
+      .select({ id: automations.id })
+      .from(automations)
+      .where(
+        and(
+          eq(automations.id, automationTriggers.automationId),
+          eq(automations.enabled, true),
+        ),
+      ),
+  );
+  const triggerIsStillEligible =
+    due.trigger.kind === "once"
+      ? and(
+          eq(automationTriggers.id, due.trigger.id),
+          parentAutomationIsEnabled,
+        )
+      : and(
+          eq(automationTriggers.id, due.trigger.id),
+          eq(automationTriggers.enabled, true),
+          parentAutomationIsEnabled,
+        );
 
   await db
     .update(automationTriggers)
@@ -293,7 +315,7 @@ async function recordTriggerPreRunFailure(
       nextRunAt,
       updatedAt: failureTime,
     })
-    .where(eq(automationTriggers.id, due.trigger.id));
+    .where(triggerIsStillEligible);
   signal.throwIfAborted();
 
   if (shouldDisable) {

--- a/turbo/apps/api/src/signals/services/internal-trigger-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-trigger-run-callback.service.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
-import { automationTriggers } from "@vm0/db/schema/automation";
-import { eq } from "drizzle-orm";
+import { automations, automationTriggers } from "@vm0/db/schema/automation";
+import { and, eq, exists } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
@@ -96,7 +96,23 @@ export async function handleTriggerInternalCallback(
       nextRunAt,
       updatedAt: completedAt,
     })
-    .where(eq(automationTriggers.id, payload.data.triggerId));
+    .where(
+      and(
+        eq(automationTriggers.id, payload.data.triggerId),
+        eq(automationTriggers.enabled, true),
+        exists(
+          db
+            .select({ id: automations.id })
+            .from(automations)
+            .where(
+              and(
+                eq(automations.id, automationTriggers.automationId),
+                eq(automations.enabled, true),
+              ),
+            ),
+        ),
+      ),
+    );
   signal?.throwIfAborted();
 
   return { success: true };

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-poller.service.ts
@@ -166,6 +166,13 @@ async function recordPreRunFailure(
     failureTime,
     shouldDisable,
   );
+  const triggerIsStillEligible =
+    trigger.scheduleType === "once"
+      ? eq(zeroWorkflowTriggers.id, trigger.id)
+      : and(
+          eq(zeroWorkflowTriggers.id, trigger.id),
+          eq(zeroWorkflowTriggers.enabled, true),
+        );
 
   await db
     .update(zeroWorkflowTriggers)
@@ -175,7 +182,7 @@ async function recordPreRunFailure(
       nextRunAt,
       updatedAt: failureTime,
     })
-    .where(eq(zeroWorkflowTriggers.id, trigger.id));
+    .where(triggerIsStillEligible);
   signal.throwIfAborted();
 
   if (shouldDisable) {

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run-callback.service.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { zeroWorkflowTriggers } from "@vm0/db/schema/zero-workflow";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
 import { nowDate } from "../external/time";
@@ -106,7 +106,12 @@ export async function handleWorkflowTriggerInternalCallback(
       nextRunAt,
       updatedAt: completedAt,
     })
-    .where(eq(zeroWorkflowTriggers.id, payload.data.triggerId));
+    .where(
+      and(
+        eq(zeroWorkflowTriggers.id, payload.data.triggerId),
+        eq(zeroWorkflowTriggers.enabled, true),
+      ),
+    );
   signal?.throwIfAborted();
 
   return { success: true };


### PR DESCRIPTION
## Summary
- keep trigger completion callbacks from writing `nextRunAt` after the trigger or parent automation has been disabled
- add a regression test for completion callbacks arriving after automation suspension

## Testing
- `cd turbo && pnpm -F api exec vitest run src/signals/services/__tests__/agent-run-callback.service.test.ts src/signals/routes/__tests__/org-team.bdd.test.ts`
- `cd turbo && pnpm -F api lint`
- `cd turbo/apps/api && pnpm exec vitest run src/signals/routes/__tests__/*.bdd.test.ts`
- `cd turbo && pnpm check-types`