### PR TITLE
fix: preserve presentation theme in PPTX export

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { buildPresentationHtmlPptxExportHtml } from "../presentation-html-pptx-download.ts";
+
+describe("buildPresentationHtmlPptxExportHtml", () => {
+  it("materializes selected theme switcher defaults before removing deck scripts", async () => {
+    const exportHtml = await buildPresentationHtmlPptxExportHtml({
+      baseUrl: "https://presentation.example.test/index.html",
+      html: `
+        <!doctype html>
+        <html>
+          <head>
+            <style>
+              :root {
+                --bg:#FFFFFF;
+                --accent:#7257E6;
+                --s1:#FF6B4A;
+                --s2:#AEE63E;
+                --s3:#3FA9F5;
+              }
+            </style>
+          </head>
+          <body>
+            <div class="slide" data-slide-id="slide-1">
+              <div class="stage" data-vm0-slide>
+                <h1 style="color:var(--accent)">Slide</h1>
+              </div>
+            </div>
+            <script>
+              var MONO={
+                "Mauve Dusk":["#FAF7FB","#FFFFFF","#2B2533","#635B70","#ECE7F0",["#9C7BB8","#8AA0C9","#E0B6C9","#2B2533"]]
+              };
+              var VIB={
+                "Prism":["#FFFFFF","#F7F7FA","#1A1726","#5C5870","#ECECF2",["#7257E6","#FF6B4A","#AEE63E","#3FA9F5"]]
+              };
+              var FONTS={
+                "Fredoka / Quicksand":["Fredoka","Quicksand"]
+              };
+              var sp=document.getElementById('swPal'),sf=document.getElementById('swFont');
+              sp.value='M:Mauve Dusk';sf.value='Fredoka / Quicksand';
+              sp.onchange();sf.onchange();
+            </script>
+          </body>
+        </html>
+      `,
+      options: {
+        fileName: "deck.pptx",
+        layout: "LAYOUT_WIDE",
+        skipDownload: true,
+        svgAsVector: true,
+      },
+      signal: AbortSignal.any([]),
+    });
+    const doc = new DOMParser().parseFromString(exportHtml, "text/html");
+    const styleText = Array.from(doc.querySelectorAll("style"))
+      .map((style) => {
+        return style.textContent ?? "";
+      })
+      .join("\n");
+    const scriptText = Array.from(doc.querySelectorAll("script"))
+      .map((script) => {
+        return script.textContent ?? "";
+      })
+      .join("\n");
+
+    expect(doc.querySelector("base")?.getAttribute("href")).toBe(
+      "https://presentation.example.test/index.html",
+    );
+    expect(
+      doc.querySelector('[data-vm0-materialized-theme="true"]'),
+    ).not.toBeNull();
+    expect(styleText).toContain("--bg:#FAF7FB");
+    expect(styleText).toContain("--accent:#9C7BB8");
+    expect(styleText).toContain("--s1:#8AA0C9");
+    expect(styleText).toContain("--s2:#E0B6C9");
+    expect(styleText).toContain("--s3:#2B2533");
+    expect(styleText).toContain("--fd:'Fredoka'");
+    expect(styleText).toContain("--fb:'Quicksand'");
+    expect(scriptText).not.toContain("var MONO");
+    expect(scriptText).toContain("vm0-presentation-pptx-export");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -619,7 +619,9 @@ function materializedThemeCss(params: {
   `;
 }
 
-function materializeThemeSwitcherDefaults(doc: Document): void {
+export function materializePresentationThemeSwitcherDefaults(
+  doc: Document,
+): void {
   const scriptText = Array.from(doc.querySelectorAll("script"))
     .map((script) => {
       return script.textContent ?? "";
@@ -702,7 +704,7 @@ export function previewPresentationHtml(params: {
   readonly html: string;
 }): string {
   const doc = new DOMParser().parseFromString(params.html, "text/html");
-  materializeThemeSwitcherDefaults(doc);
+  materializePresentationThemeSwitcherDefaults(doc);
   sanitizePreviewTree(doc);
   const previewDoc = document.implementation.createHTMLDocument(
     doc.title || "Presentation preview",

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -46,7 +46,7 @@ const SLIDE_SELECTORS = [
   "section",
 ] as const;
 
-export type DomToPptxOptions = {
+type DomToPptxOptions = {
   readonly fileName: string;
   readonly layout: "LAYOUT_WIDE";
   readonly skipDownload: boolean;

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -7,6 +7,7 @@ import {
   settle,
   withCleanup,
 } from "../../signals/utils.ts";
+import { materializePresentationThemeSwitcherDefaults } from "./presentation-html-edit-protocol.ts";
 
 const EXPORT_FONT_READY_TIMEOUT_MS = 800;
 const DEV_ARTIFACT_FETCH_PROXY_PATH = "/__vm0-dev-artifact-fetch";
@@ -45,7 +46,7 @@ const SLIDE_SELECTORS = [
   "section",
 ] as const;
 
-type DomToPptxOptions = {
+export type DomToPptxOptions = {
   readonly fileName: string;
   readonly layout: "LAYOUT_WIDE";
   readonly skipDownload: boolean;
@@ -649,6 +650,7 @@ async function htmlWithExportScript(
   options: DomToPptxOptions,
   signal: AbortSignal,
 ): Promise<string> {
+  materializePresentationThemeSwitcherDefaults(doc);
   await inlineFetchableImages(doc, baseUrl, signal);
   for (const script of doc.querySelectorAll("script")) {
     script.remove();
@@ -667,6 +669,20 @@ async function htmlWithExportScript(
   script.textContent = createExportScript(options);
   doc.body.append(script);
   return `<!doctype html>\n${doc.documentElement.outerHTML}`;
+}
+
+export function buildPresentationHtmlPptxExportHtml(params: {
+  readonly baseUrl: string;
+  readonly html: string;
+  readonly options: DomToPptxOptions;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  return htmlWithExportScript(
+    parseHtml(params.html),
+    params.baseUrl,
+    params.options,
+    params.signal,
+  );
 }
 
 function createExportFrame(html: string): HTMLIFrameElement {


### PR DESCRIPTION
## Summary
- Materialize the selected presentation theme switcher palette/font before preparing HTML for PPTX export.
- Reuse the existing preview theme materialization logic so non-default generated themes do not fall back to the deck shell default when scripts are stripped.
- Add a focused exporter test covering a non-default palette/font selection.

## Verification
- pnpm exec prettier --write apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts apps/platform/src/views/zero-page/presentation-html-pptx-download.ts apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts --reporter verbose
- pnpm -F @vm0/app exec oxlint src/views/zero-page/presentation-html-edit-protocol.ts src/views/zero-page/presentation-html-pptx-download.ts src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
- pnpm -F @vm0/app exec eslint src/views/zero-page/presentation-html-edit-protocol.ts src/views/zero-page/presentation-html-pptx-download.ts src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts --max-warnings 0
- pnpm -F @vm0/app check-types