### PR TITLE
fix: show goal briefs in continuation chat

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -537,6 +537,10 @@ describe("zero goals", () => {
     expect(workflowMarkerContent).not.toBe(objective);
     expect(workflowMarkerContent?.length ?? 0).toBeLessThanOrEqual(140);
     expect(workflowMarkerContent).toMatch(/\.\.\.$/);
+    expect(goalRows?.preference).toMatchObject({
+      objective,
+      objectiveBrief: workflowMarkerContent,
+    });
     expect(markerContent(afterCreate, "goal-trigger:active")).toStrictEqual([
       goalRows!.triggerId,
     ]);
@@ -605,6 +609,10 @@ describe("zero goals", () => {
     expect(editedMarkerContent).not.toBe(objective);
     expect(editedMarkerContent?.length ?? 0).toBeLessThanOrEqual(140);
     expect(editedMarkerContent).toMatch(/\.\.\.$/);
+    expect((await loadGoalRows(fixture))?.preference).toMatchObject({
+      objective,
+      objectiveBrief: editedMarkerContent,
+    });
   });
 
   it("auto-resumes a blocked goal when edited and clears stopReason", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
@@ -250,11 +250,14 @@ async function seedGoalTrigger(
   scenario: Scenario,
   args: {
     readonly threadId: string;
+    readonly objective?: string;
+    readonly objectiveBrief?: string;
     readonly consecutiveFailures?: number;
     readonly enabled?: boolean;
   },
 ): Promise<{ workflowId: string; triggerId: string }> {
   const db = store.set(writeDb$);
+  const objective = args.objective ?? "Ship the goal workflow";
   const [workflow] = await db
     .insert(zeroWorkflows)
     .values({
@@ -264,7 +267,11 @@ async function seedGoalTrigger(
       visibility: "private",
       type: "goal",
       active: true,
-      preference: { version: 1, objective: "Ship the goal workflow" },
+      preference: {
+        version: 1,
+        objective,
+        ...(args.objectiveBrief ? { objectiveBrief: args.objectiveBrief } : {}),
+      },
       ownerUserId: scenario.fixture.userId,
       displayName: "Goal",
       createdBy: scenario.fixture.userId,
@@ -540,8 +547,13 @@ describe("zero workflow trigger scheduler", () => {
     const scenario = await setup();
     await enableGoalFeature(scenario);
     const terminal = await seedThreadRun(scenario, { status: "completed" });
+    const objective =
+      "Ship the goal workflow by checking every backend transition, fixing any failed CI jobs, coordinating release timing, and continuing until the external rollout is verified.";
+    const objectiveBrief = "Ship the goal workflow";
     const { triggerId } = await seedGoalTrigger(scenario, {
       threadId: terminal.threadId,
+      objective,
+      objectiveBrief,
       consecutiveFailures: 2,
     });
 
@@ -557,6 +569,7 @@ describe("zero workflow trigger scheduler", () => {
         id: zeroRuns.id,
         triggerSource: zeroRuns.triggerSource,
         prompt: agentRuns.prompt,
+        appendSystemPrompt: agentRuns.appendSystemPrompt,
         continuedFromSessionId: agentRuns.continuedFromSessionId,
       })
       .from(zeroRuns)
@@ -567,9 +580,12 @@ describe("zero workflow trigger scheduler", () => {
       triggerSource: "workflow-event",
       continuedFromSessionId: terminal.sessionId,
     });
-    // The continuation prompt is the rendered Codex-style template carrying the
-    // objective, not a `/goal` slash command (which the harness would intercept).
-    expect(runs[0]!.prompt).toContain("Ship the goal workflow");
+    // The continuation prompt is chat-visible, so it carries only the objective
+    // brief. The full objective is hidden in the appended system prompt so it
+    // remains available to the agent without becoming chat-visible copy.
+    expect(runs[0]!.prompt).toBe(objectiveBrief);
+    expect(runs[0]!.prompt).not.toContain(objective);
+    expect(runs[0]!.appendSystemPrompt).toContain(objective);
     expect(runs[0]!.prompt).not.toBe("/goal");
 
     const callbacks = await db
@@ -593,9 +609,14 @@ describe("zero workflow trigger scheduler", () => {
       .where(eq(chatMessages.chatThreadId, terminal.threadId));
     expect(
       messages.some((message) => {
-        return message.content?.includes("Ship the goal workflow");
+        return message.content === objectiveBrief;
       }),
     ).toBeTruthy();
+    expect(
+      messages.some((message) => {
+        return message.content?.includes(objective);
+      }),
+    ).toBeFalsy();
   });
 
   it("does not continue a goal when another run is already queued on the thread", async () => {

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -104,43 +104,42 @@ function failureMessage(error: unknown): string {
   return error.message;
 }
 
-function buildGoalContinuationSystemPrompt(): string {
-  return [
+function buildGoalContinuationSystemPrompt(
+  preference: ZeroGoalPreference,
+): string {
+  const lines = [
     "# Current context",
     "You are autonomously continuing a persistent goal on this web chat thread.",
     "Everything you output is shown to the user in this thread.",
-  ].join("\n");
-}
-
-/**
- * The continuation user prompt — vm0's analog of Codex's `continuation.md`.
- * Rendered in code each turn with the goal's objective (and optional token
- * budget) from `zero_workflows.preference`, then injected as the run's user
- * prompt. Plain instruction text, not a `/goal` slash command, so the harness
- * never intercepts it.
- */
-function buildGoalContinuationPrompt(preference: ZeroGoalPreference): string {
-  const lines = [
+    "",
     "# Active thread goal",
     "",
-    "You are autonomously continuing a persistent goal. Make concrete progress this turn, then end the turn — the goal automatically continues on the next idle.",
-    "",
-    "## Objective",
-    "",
     preference.objective,
-    "",
   ];
+  if (
+    preference.objectiveBrief &&
+    preference.objectiveBrief !== preference.objective
+  ) {
+    lines.push(
+      "",
+      "# User-visible objective brief",
+      "",
+      preference.objectiveBrief,
+    );
+  }
   if (preference.tokenBudget) {
     lines.push(
-      "## Token budget",
+      "",
+      "# Token budget",
       "",
       `Soft budget: about ${preference.tokenBudget} tokens across the whole goal. Be economical; if you have clearly exhausted it without completing, run \`zero goal block\` and explain.`,
-      "",
     );
   }
   lines.push(
-    "## How to operate",
     "",
+    "# How to operate",
+    "",
+    "- Make concrete progress this turn, then end the turn. The goal automatically continues on the next idle.",
     "- Persist all progress to durable external state (commits, PRs, uploaded artifacts, connectors).",
     "- When the objective is verifiably done, audit it requirement-by-requirement against the current external state (not your assumptions); only then run `zero goal complete`.",
     "- If the same blocker stops you for 3 consecutive turns, run `zero goal block` and explain why.",
@@ -148,6 +147,15 @@ function buildGoalContinuationPrompt(preference: ZeroGoalPreference): string {
     "- Do not stop to ask the user and wait — this is an autonomous continuation; act on the best available information.",
   );
   return lines.join("\n");
+}
+
+/**
+ * The continuation user prompt shown in the chat. Keep it short and focused on
+ * what the goal is trying to accomplish; the full objective and operating rules
+ * are carried in the appended system prompt.
+ */
+function buildGoalContinuationPrompt(preference: ZeroGoalPreference): string {
+  return preference.objectiveBrief ?? preference.objective;
 }
 
 async function loadTerminatingRun(
@@ -516,7 +524,7 @@ export const continueGoalIfIdle$ = command(
         ...(sessionId ? { sessionId } : {}),
         prompt: buildGoalContinuationPrompt(goal.preference),
         triggerSource: "workflow-event",
-        appendSystemPrompt: buildGoalContinuationSystemPrompt(),
+        appendSystemPrompt: buildGoalContinuationSystemPrompt(goal.preference),
         callbacks: buildChatOnlyWorkflowTriggerCallbacks(
           trigger,
           goal.agentId,
@@ -617,7 +625,7 @@ export const bootstrapGoalRun$ = command(
         apiStartTime: now(),
         prompt: buildGoalContinuationPrompt(goal.preference),
         triggerSource: "workflow-event",
-        appendSystemPrompt: buildGoalContinuationSystemPrompt(),
+        appendSystemPrompt: buildGoalContinuationSystemPrompt(goal.preference),
         callbacks: buildChatOnlyWorkflowTriggerCallbacks(
           args.trigger,
           goal.agentId,

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -123,6 +123,7 @@ function mergeGoalPreference(
   current: unknown,
   update: {
     readonly objective?: string;
+    readonly objectiveBrief?: string;
     readonly tokenBudget?: number;
     readonly stopReason?: ZeroGoalStopReason | null;
   },
@@ -132,6 +133,10 @@ function mergeGoalPreference(
     version: 1,
     objective: update.objective ?? preference.objective,
   };
+  const objectiveBrief = update.objectiveBrief ?? preference.objectiveBrief;
+  if (objectiveBrief !== undefined) {
+    merged.objectiveBrief = objectiveBrief;
+  }
   const tokenBudget = update.tokenBudget ?? preference.tokenBudget;
   if (tokenBudget !== undefined) {
     merged.tokenBudget = tokenBudget;
@@ -230,6 +235,7 @@ export async function createGoalForCurrentThread(
   const preference = {
     version: 1 as const,
     objective: args.objective,
+    objectiveBrief,
     ...(args.tokenBudget ? { tokenBudget: args.tokenBudget } : {}),
   };
   const isNewThread = context.threadId === null;
@@ -556,6 +562,7 @@ export async function editCurrentGoal(
       : await generateGoalObjectiveBrief(args.objective);
   const nextPreference = mergeGoalPreference(goal.row.preference, {
     ...(args.objective !== undefined ? { objective: args.objective } : {}),
+    ...(objectiveBrief !== null ? { objectiveBrief } : {}),
     ...(args.tokenBudget !== undefined
       ? { tokenBudget: args.tokenBudget }
       : {}),

--- a/turbo/packages/api-contracts/src/contracts/zero-goals.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-goals.ts
@@ -13,6 +13,7 @@ export type ZeroGoalStopReason = z.infer<typeof zeroGoalStopReasonSchema>;
 export const zeroGoalPreferenceSchema = z.object({
   version: z.literal(1),
   objective: z.string().min(1),
+  objectiveBrief: z.string().min(1).optional(),
   tokenBudget: z.number().int().positive().optional(),
   stopReason: zeroGoalStopReasonSchema.optional(),
 });


### PR DESCRIPTION
## Summary\n- persist generated goal objective briefs in the goal workflow preference\n- make goal continuation chat messages show only the brief while moving the full objective and operating rules into the appended system prompt\n- cover marker persistence and continuation prompt behavior in goal tests\n\n## Tests\n- pnpm -w exec prettier --write packages/api-contracts/src/contracts/zero-goals.ts apps/api/src/signals/services/zero-goal.service.ts apps/api/src/signals/services/zero-goal-continuation.service.ts apps/api/src/signals/routes/__tests__/zero-goals.test.ts apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts\n- pnpm -F api exec oxlint src/signals/services/zero-goal.service.ts src/signals/services/zero-goal-continuation.service.ts src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts\n- pnpm -F api exec eslint src/signals/services/zero-goal.service.ts src/signals/services/zero-goal-continuation.service.ts src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts\n- pnpm -F api exec oxlint --type-aware src/signals/services/zero-goal.service.ts src/signals/services/zero-goal-continuation.service.ts src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts\n- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm vitest --run apps/api/src/signals/routes/__tests__/zero-goals.test.ts apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts\n\n## Notes\n- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types is currently blocked by unrelated generated firewall export errors in packages/connectors/src/firewalls/index.ts for google-search-console and youtube.