### PR TITLE
feat: update presentation template gallery

### DIFF
--- a/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
+++ b/turbo/apps/web/app/[locale]/presentation/PresentationClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { IconExternalLink, IconSparkles } from "@tabler/icons-react";
+import { IconCheck, IconExternalLink, IconSparkles } from "@tabler/icons-react";
 import { r2ImageTransformUrl } from "@vm0/core";
 import { CopyablePrompt } from "../../components/CopyablePrompt";
 import { Footer } from "../../components/Footer";
@@ -14,63 +14,172 @@ import {
   type PresentationItem,
 } from "./data";
 
-const MAX_WIDTH = 880;
+const MAX_WIDTH = 1200;
 const PAGE_PADDING = 24;
-const PRESENTATION_PREVIEW_IMAGE_SIZE = { width: 1664, height: 824 } as const;
+const PRESENTATION_PREVIEW_IMAGE_SIZE = { width: 1920, height: 1080 } as const;
+const PRESENTATION_THUMBNAIL_IMAGE_SIZE = {
+  width: 320,
+  height: 180,
+} as const;
+
+function presentationSlideImages(item: PresentationItem): readonly string[] {
+  return item.previewImages.length > 0
+    ? item.previewImages
+    : [item.previewImage];
+}
+
+function formatSlideCounter(index: number, total: number): string {
+  const width = Math.max(2, String(total).length);
+  return `${String(index + 1).padStart(width, "0")} / ${String(total).padStart(
+    width,
+    "0",
+  )}`;
+}
 
 function PresentationCard({
   item,
   appUrl,
   landingSearch,
+  priority,
 }: {
   item: PresentationItem;
   appUrl: string;
   landingSearch: string;
+  priority?: boolean;
 }) {
+  const slides = presentationSlideImages(item);
+  const [activeSlideIndex, setActiveSlideIndex] = useState(0);
+  const [promptOpen, setPromptOpen] = useState(false);
   const remixHref = buildPresentationRemixHref(item, appUrl, landingSearch);
+  const activeSlide = slides[activeSlideIndex] ?? item.previewImage;
+  const slideCounter = formatSlideCounter(activeSlideIndex, slides.length);
 
   return (
     <article
       id={item.slug}
-      className="overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)] transition-all duration-300 hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
+      className="overflow-hidden rounded-[18px] border border-[hsl(var(--gray-200))] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)]"
     >
+      <div className="flex flex-col gap-3 border-b border-[hsl(var(--gray-200))] px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-[#ed4e01]" />
+          <h2 className="truncate text-[18px] font-semibold leading-7 text-[hsl(var(--foreground))] sm:text-[20px]">
+            {item.title}
+          </h2>
+          <span className="shrink-0 font-mono text-[18px] leading-7 text-[hsl(var(--muted-foreground))]">
+            {slideCounter}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setPromptOpen((open) => {
+                return !open;
+              });
+            }}
+            className={`inline-flex h-9 items-center justify-center rounded-[10px] border px-3.5 text-sm font-medium transition-colors ${
+              promptOpen
+                ? "border-[hsl(var(--foreground))] bg-[hsl(var(--foreground))] text-white"
+                : "border-[hsl(var(--gray-200))] bg-white text-[hsl(var(--foreground))] hover:bg-[hsl(var(--gray-50))]"
+            }`}
+            aria-expanded={promptOpen}
+          >
+            Prompt
+          </button>
+          <a
+            href={remixHref}
+            className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[10px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+          >
+            <IconSparkles size={15} stroke={2} />
+            Try it
+          </a>
+          <a
+            href={item.embedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[10px] border border-[hsl(var(--gray-200))] bg-white px-3.5 text-sm font-medium text-[hsl(var(--foreground))] transition-colors hover:bg-[hsl(var(--gray-50))]"
+          >
+            <IconExternalLink size={15} stroke={2} />
+            Open full screen
+          </a>
+        </div>
+      </div>
       <a
         href={item.embedUrl}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={`View ${item.title} in a new tab`}
+        aria-label={`Open ${item.title} in full screen`}
         className="group block"
         style={{ textDecoration: "none" }}
       >
-        <div className="relative aspect-[1280/633] overflow-hidden bg-[hsl(var(--gray-1))]">
+        <div className="relative aspect-video overflow-hidden bg-[#050505]">
           <Image
             src={r2ImageTransformUrl(
-              item.previewImage,
+              activeSlide,
               PRESENTATION_PREVIEW_IMAGE_SIZE,
             )}
-            alt={item.title}
+            alt={`${item.title} slide ${activeSlideIndex + 1}`}
             fill
-            sizes="(min-width: 880px) 832px, calc(100vw - 48px)"
-            className="object-contain transition-transform duration-300 group-hover:scale-[1.03]"
+            priority={priority}
+            sizes="(min-width: 1200px) 1152px, calc(100vw - 48px)"
+            className="object-contain"
           />
-          <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/35 group-hover:opacity-100">
+          <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-200 group-hover:bg-black/25 group-hover:opacity-100">
             <div className="inline-flex items-center gap-2 rounded-full bg-white px-3.5 py-2 text-[13px] font-medium text-[hsl(var(--foreground))] shadow-[0_8px_24px_rgba(0,0,0,0.18)]">
               <IconExternalLink size={16} stroke={2} />
-              View
+              Open full screen
             </div>
           </div>
         </div>
       </a>
-      <div className="flex flex-col gap-3 px-4 py-3">
-        <CopyablePrompt prompt={item.prompt} />
-        <a
-          href={remixHref}
-          className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+      <div className="bg-white px-4 py-4">
+        <div
+          className="flex gap-3 overflow-x-auto pb-3"
+          aria-label={`${item.title} slide thumbnails`}
         >
-          <IconSparkles size={15} stroke={2} />
-          Try it
-        </a>
+          {slides.map((slide, index) => {
+            const active = index === activeSlideIndex;
+
+            return (
+              <button
+                key={slide}
+                type="button"
+                onClick={() => {
+                  setActiveSlideIndex(index);
+                }}
+                aria-label={`Show slide ${index + 1} of ${slides.length}`}
+                aria-pressed={active}
+                className={`relative h-[72px] w-[128px] shrink-0 overflow-hidden rounded-[10px] border bg-[hsl(var(--gray-1))] transition-colors hover:border-[#ed4e01] sm:h-[90px] sm:w-[160px] ${
+                  active
+                    ? "border-[#ed4e01] ring-2 ring-[#ed4e01]/20"
+                    : "border-[hsl(var(--gray-200))]"
+                }`}
+              >
+                <Image
+                  src={r2ImageTransformUrl(
+                    slide,
+                    PRESENTATION_THUMBNAIL_IMAGE_SIZE,
+                  )}
+                  alt=""
+                  fill
+                  sizes="160px"
+                  className="object-cover"
+                />
+                {active ? (
+                  <span className="absolute right-2 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-[#ed4e01] text-white">
+                    <IconCheck size={13} stroke={2.4} />
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
       </div>
+      {promptOpen ? (
+        <div className="border-t border-[hsl(var(--gray-200))] bg-[hsl(var(--gray-0))] px-4 py-4">
+          <CopyablePrompt prompt={item.prompt} />
+        </div>
+      ) : null}
     </article>
   );
 }
@@ -87,7 +196,12 @@ export function PresentationClient() {
     <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
       <Particles />
 
-      <section className="hero-section" style={{ paddingBottom: 32 }}>
+      <section
+        className="hero-section"
+        style={{
+          paddingBottom: 32,
+        }}
+      >
         <div
           style={{
             maxWidth: MAX_WIDTH,
@@ -97,8 +211,8 @@ export function PresentationClient() {
         >
           <h1 className="hero-title">Presentation</h1>
           <p className="hero-description">
-            Get a polished deck from a single, short prompt. Focus on your
-            content and leave the design and creative work to VM0.
+            Browse default HTML presentation templates, inspect their slides,
+            and remix the prompt in Zero.
           </p>
         </div>
       </section>
@@ -112,13 +226,14 @@ export function PresentationClient() {
           }}
           className="flex flex-col items-stretch gap-6"
         >
-          {PRESENTATION_ITEMS.map((item) => {
+          {PRESENTATION_ITEMS.map((item, index) => {
             return (
               <PresentationCard
                 key={item.slug}
                 item={item}
                 appUrl={appUrl}
                 landingSearch={landingSearch}
+                priority={index === 0}
               />
             );
           })}

--- a/turbo/apps/web/app/[locale]/presentation/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/presentation/__tests__/data.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 
-import { buildPresentationRemixHref, type PresentationItem } from "../data";
+import {
+  PRESENTATION_ITEMS,
+  buildPresentationRemixHref,
+  type PresentationItem,
+} from "../data";
 
 const item: PresentationItem = {
   slug: "test-deck",
@@ -14,6 +19,21 @@ const item: PresentationItem = {
 };
 
 describe("presentation remix links", () => {
+  it("shows default picker templates with CDN slide images", () => {
+    expect(PRESENTATION_ITEMS).toBe(PRESENTATION_TEMPLATE_PICKER_ITEMS);
+
+    for (const item of PRESENTATION_ITEMS) {
+      expect(item.previewImages.length, item.slug).toBeGreaterThan(0);
+      expect(item.previewImage, item.slug).toBe(item.previewImages[0]);
+
+      for (const image of item.previewImages) {
+        expect(image, item.slug).toMatch(
+          /^https:\/\/cdn\.vm0\.io\/artifacts\/.+\.(png|jpg|jpeg)$/u,
+        );
+      }
+    }
+  });
+
   it("marks presentation try-it links with source attribution", () => {
     const href = buildPresentationRemixHref(item, "https://app.vm0.ai");
     const url = new URL(href);

--- a/turbo/apps/web/app/[locale]/presentation/data.ts
+++ b/turbo/apps/web/app/[locale]/presentation/data.ts
@@ -1,11 +1,11 @@
 import {
-  PRESENTATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_PICKER_ITEMS,
   type PresentationTemplateItem,
 } from "@vm0/core";
 
 export type PresentationItem = PresentationTemplateItem;
 
-export const PRESENTATION_ITEMS = PRESENTATION_TEMPLATE_ITEMS;
+export const PRESENTATION_ITEMS = PRESENTATION_TEMPLATE_PICKER_ITEMS;
 
 const PRESENTATION_ATTRIBUTION_PARAM = "vm0_source";
 const PRESENTATION_ATTRIBUTION_VALUE = "presentation";


### PR DESCRIPTION
## Summary
- Redesign the public presentation template gallery cards into a deck viewer with slide navigation thumbnails and a horizontal thumbnail scroller.
- Remove hover zoom from presentation cover previews.
- Use default picker templates only and verify each template exposes CDN-backed slide preview images.

## Testing
- pnpm -C turbo exec prettier --check apps/web/app/[locale]/presentation/PresentationClient.tsx apps/web/app/[locale]/presentation/data.ts apps/web/app/[locale]/presentation/__tests__/data.test.ts
- pnpm -C turbo -F web lint
- pnpm -C turbo -F web check-types
- pnpm -C turbo -F web test app/[locale]/presentation/__tests__/data.test.ts
- git diff --check